### PR TITLE
Fix Windows CI issues

### DIFF
--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -293,11 +293,11 @@ test-suite cardano-cli-golden
                         Test.Golden.Shelley.StakeAddress.KeyGen
                         Test.Golden.Shelley.StakeAddress.RegistrationCertificate
                         Test.Golden.Shelley.StakePool.RegistrationCertificate
-                        Test.Golden.Shelley.TextEnvelope.Certificates.GenesisKeyDelegationCertificate
-                        Test.Golden.Shelley.TextEnvelope.Certificates.MIRCertificate
-                        Test.Golden.Shelley.TextEnvelope.Certificates.OperationalCertificate
-                        Test.Golden.Shelley.TextEnvelope.Certificates.StakeAddressCertificates
-                        Test.Golden.Shelley.TextEnvelope.Certificates.StakePoolCertificates
+                        Test.Golden.Shelley.TextEnvelope.Certificates.GenesisKeyDelegation
+                        Test.Golden.Shelley.TextEnvelope.Certificates.MIR
+                        Test.Golden.Shelley.TextEnvelope.Certificates.Operational
+                        Test.Golden.Shelley.TextEnvelope.Certificates.StakeAddress
+                        Test.Golden.Shelley.TextEnvelope.Certificates.StakePool
                         Test.Golden.Shelley.TextEnvelope.Keys.ExtendedPaymentKeys
                         Test.Golden.Shelley.TextEnvelope.Keys.GenesisDelegateKeys
                         Test.Golden.Shelley.TextEnvelope.Keys.GenesisKeys

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley.hs
@@ -10,6 +10,7 @@ module Test.Golden.Shelley
   , txTests
   ) where
 
+import qualified Hedgehog as H
 import           Test.Golden.Shelley.Address.Build (golden_shelleyAddressBuild)
 import           Test.Golden.Shelley.Address.Info (golden_shelleyAddressInfo)
 import           Test.Golden.Shelley.Address.KeyGen (golden_shelleyAddressExtendedKeyGen,
@@ -20,7 +21,6 @@ import           Test.Golden.Shelley.Genesis.KeyGenDelegate (golden_shelleyGenes
 import           Test.Golden.Shelley.Genesis.KeyGenGenesis (golden_shelleyGenesisKeyGenGenesis)
 import           Test.Golden.Shelley.Genesis.KeyGenUtxo (golden_shelleyGenesisKeyGenUtxo)
 import           Test.Golden.Shelley.Genesis.KeyHash (golden_shelleyGenesisKeyHash)
-
 import           Test.Golden.Shelley.Governance.AnswerPoll (golden_shelleyGovernanceAnswerPoll0,
                    golden_shelleyGovernanceAnswerPollNeg1Invalid,
                    golden_shelleyGovernanceAnswerPollPos1,
@@ -32,12 +32,14 @@ import           Test.Golden.Shelley.Governance.VerifyPoll (golden_shelleyGovern
                    golden_shelleyGovernanceVerifyPollMalformedAnswer,
                    golden_shelleyGovernanceVerifyPollMismatch,
                    golden_shelleyGovernanceVerifyPollNoAnswer)
-
 import           Test.Golden.Shelley.Key.ConvertCardanoAddressKey
                    (golden_convertCardanoAddressByronSigningKey,
                    golden_convertCardanoAddressIcarusSigningKey,
                    golden_convertCardanoAddressShelleyPaymentSigningKey,
                    golden_convertCardanoAddressShelleyStakeSigningKey)
+import           Test.Golden.Shelley.Metadata.StakePoolMetadata (golden_stakePoolMetadataHash)
+import           Test.Golden.Shelley.MultiSig.Address (golden_shelleyAllMultiSigAddressBuild,
+                   golden_shelleyAnyMultiSigAddressBuild, golden_shelleyAtLeastMultiSigAddressBuild)
 import           Test.Golden.Shelley.Node.IssueOpCert (golden_shelleyNodeIssueOpCert)
 import           Test.Golden.Shelley.Node.KeyGen (golden_shelleyNodeKeyGen,
                    golden_shelleyNodeKeyGen_bech32, golden_shelleyNodeKeyGen_te)
@@ -53,20 +55,15 @@ import           Test.Golden.Shelley.StakeAddress.RegistrationCertificate
                    (golden_shelleyStakeAddressRegistrationCertificate)
 import           Test.Golden.Shelley.StakePool.RegistrationCertificate
                    (golden_shelleyStakePoolRegistrationCertificate)
-import           Test.Golden.Shelley.TextEnvelope.Certificates.GenesisKeyDelegationCertificate
+import           Test.Golden.Shelley.TextEnvelope.Certificates.GenesisKeyDelegation
                    (golden_shelleyGenesisKeyDelegationCertificate)
-import           Test.Golden.Shelley.TextEnvelope.Certificates.MIRCertificate
-                   (golden_shelleyMIRCertificate)
-import           Test.Golden.Shelley.TextEnvelope.Certificates.OperationalCertificate
+import           Test.Golden.Shelley.TextEnvelope.Certificates.MIR (golden_shelleyMIRCertificate)
+import           Test.Golden.Shelley.TextEnvelope.Certificates.Operational
                    (golden_shelleyOperationalCertificate)
-import           Test.Golden.Shelley.TextEnvelope.Certificates.StakeAddressCertificates
+import           Test.Golden.Shelley.TextEnvelope.Certificates.StakeAddress
                    (golden_shelleyStakeAddressCertificates)
-import           Test.Golden.Shelley.TextEnvelope.Certificates.StakePoolCertificates
+import           Test.Golden.Shelley.TextEnvelope.Certificates.StakePool
                    (golden_shelleyStakePoolCertificates)
-
-import           Test.Golden.Shelley.Metadata.StakePoolMetadata (golden_stakePoolMetadataHash)
-import           Test.Golden.Shelley.MultiSig.Address (golden_shelleyAllMultiSigAddressBuild,
-                   golden_shelleyAnyMultiSigAddressBuild, golden_shelleyAtLeastMultiSigAddressBuild)
 import           Test.Golden.Shelley.TextEnvelope.Keys.ExtendedPaymentKeys
                    (golden_shelleyExtendedPaymentKeys, golden_shelleyExtendedPaymentKeys_bech32,
                    golden_shelleyExtendedPaymentKeys_te)
@@ -82,6 +79,8 @@ import           Test.Golden.Shelley.TextEnvelope.Keys.StakeKeys (golden_shelley
                    golden_shelleyStakeKeys_bech32, golden_shelleyStakeKeys_te)
 import           Test.Golden.Shelley.TextEnvelope.Keys.VRFKeys (golden_shelleyVRFKeys,
                    golden_shelleyVRFKeys_bech32, golden_shelleyVRFKeys_te)
+import           Test.Golden.Shelley.TextEnvelope.Tx.Tx (golden_shelleyTx)
+import           Test.Golden.Shelley.TextEnvelope.Tx.TxBody (golden_shelleyTxBody)
 import           Test.Golden.Shelley.TextView.DecodeCbor (golden_shelleyTextViewDecodeCbor)
 import           Test.Golden.Shelley.Transaction.Assemble
                    (golden_shelleyTransactionAssembleWitness_SigningKey)
@@ -95,13 +94,7 @@ import           Test.Golden.Shelley.Transaction.CalculateMinFee
 import           Test.Golden.Shelley.Transaction.CreateWitness
                    (golden_shelleyTransactionSigningKeyWitness)
 import           Test.Golden.Shelley.Transaction.Sign (golden_shelleyTransactionSign)
-
-import           Test.Golden.Shelley.TextEnvelope.Tx.Tx (golden_shelleyTx)
-import           Test.Golden.Shelley.TextEnvelope.Tx.TxBody (golden_shelleyTxBody)
-
 import           Test.Golden.Version (golden_version)
-
-import qualified Hedgehog as H
 
 keyTests :: IO Bool
 keyTests =

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Certificates/GenesisKeyDelegation.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Certificates/GenesisKeyDelegation.hs
@@ -1,14 +1,16 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-module Test.Golden.Shelley.TextEnvelope.Certificates.GenesisKeyDelegationCertificate
+module Test.Golden.Shelley.TextEnvelope.Certificates.GenesisKeyDelegation
   ( golden_shelleyGenesisKeyDelegationCertificate
   ) where
 
 import           Cardano.Api (AsType (..), HasTextEnvelope (..))
+
 import           Control.Monad (void)
-import           Hedgehog (Property)
+
 import           Test.Cardano.CLI.Util
 
+import           Hedgehog (Property)
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Certificates/MIR.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Certificates/MIR.hs
@@ -1,14 +1,16 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-module Test.Golden.Shelley.TextEnvelope.Certificates.MIRCertificate
+module Test.Golden.Shelley.TextEnvelope.Certificates.MIR
   ( golden_shelleyMIRCertificate
   ) where
 
 import           Cardano.Api (AsType (..), HasTextEnvelope (..))
+
 import           Control.Monad (void)
-import           Hedgehog (Property)
+
 import           Test.Cardano.CLI.Util
 
+import           Hedgehog (Property)
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Certificates/Operational.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Certificates/Operational.hs
@@ -1,14 +1,16 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-module Test.Golden.Shelley.TextEnvelope.Certificates.OperationalCertificate
+module Test.Golden.Shelley.TextEnvelope.Certificates.Operational
   ( golden_shelleyOperationalCertificate
   ) where
 
 import           Cardano.Api (AsType (..), HasTextEnvelope (..))
+
 import           Control.Monad (void)
-import           Hedgehog (Property)
+
 import           Test.Cardano.CLI.Util
 
+import           Hedgehog (Property)
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Certificates/StakeAddress.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Certificates/StakeAddress.hs
@@ -1,14 +1,16 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-module Test.Golden.Shelley.TextEnvelope.Certificates.StakeAddressCertificates
+module Test.Golden.Shelley.TextEnvelope.Certificates.StakeAddress
   ( golden_shelleyStakeAddressCertificates
   ) where
 
 import           Cardano.Api (AsType (..), HasTextEnvelope (..))
+
 import           Control.Monad (void)
-import           Hedgehog (Property)
+
 import           Test.Cardano.CLI.Util
 
+import           Hedgehog (Property)
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Certificates/StakePool.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Certificates/StakePool.hs
@@ -1,14 +1,16 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-module Test.Golden.Shelley.TextEnvelope.Certificates.StakePoolCertificates
+module Test.Golden.Shelley.TextEnvelope.Certificates.StakePool
   ( golden_shelleyStakePoolCertificates
   ) where
 
 import           Cardano.Api (AsType (..), HasTextEnvelope (..))
+
 import           Control.Monad (void)
-import           Hedgehog (Property)
+
 import           Test.Cardano.CLI.Util
 
+import           Hedgehog (Property)
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 


### PR DESCRIPTION
# Description

Shorten module names to fix Windows CI issues due to filename length limitations on Windows.

# Changelog

```yaml
- description: |
    Shorten module names to fix Windows CI issues due to filename length limitations on Windows.
  compatibility: no-api-changes
  type: test
```

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
