### PR TITLE
Fix finding files with getProjectBase

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -135,12 +135,13 @@
                  let
                    # This define files included in the directory that will be passed to `H.getProjectBase` for this test:
                    filteredProjectBase = inputs.incl ./. [
+                     "cabal.project"
                      "scripts/plutus/scripts/v1/custom-guess-42-datum-42.plutus"
                    ];
                  in
                  ''
                    ${exportCliPath}
-                   export CARDANO_CLI_SRC=${filteredProjectBase}
+                   cp -r ${filteredProjectBase}/* ..
                  '';
                packages.cardano-cli.components.tests.cardano-cli-test.preCheck =
                  let
@@ -149,7 +150,7 @@
                  in
                  ''
                    ${exportCliPath}
-                   export CARDANO_CLI_SRC=${filteredProjectBase}
+                   cp -r ${filteredProjectBase}/* ..
                  '';
             })
             ({pkgs, ...}:


### PR DESCRIPTION
The tests use `getProjectBase` to find the `cabal.project` file.  They then look for files based on that.  This change makes that work in nix by copying the `cabal.project` file and required `scripts` file into the parent directory of the component build dir (component build dir will be a subdir `cardano-cli` because we mirror the directory structure of the project for component builds).