### PR TITLE
flake fixes

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,0 +1,35 @@
+********************************************
+Contributing to the ``cardano-cli`` project
+********************************************
+
+Updating dependencies
+====
+
+... from Hackage
+----
+
+Updating package dependencies from Hackage should work like normal in a Haskell project.
+The most important thing to note is that we pin the ``index-state`` of the Hackage package index in ``cabal.project``.
+This means that cabal will always see Hackage “as if” it was that time, ensuring reproducibility.
+But it also means that if you need a package version that was released *after* that time, you need to bump the ``index-state`` (and to run ``cabal update`` locally).
+
+Because of how we use Nix to manage our Haskell build, whenever you do this you will also need to pull in the Nix equivalent of the newer ``index-state``.
+You can do this by running ``nix flake lock --update-input haskellNix/hackage``.
+
+... from the Cardano package repository
+----
+
+Many Cardano packages are not on Hackage and are instead in the `Cardano package repository <https://github.com/input-output-hk/cardano-haskell-packages>`__, see the README for (lots) more information.
+Getting new packages from there works much like getting them from Hackage.
+The differences are that it has an independent ``index-state``, and that there is a different Nix command you need to run afterwards: ``nix flake lock --update-input CHaP``.
+
+Using unreleased versions of dependencies
+~~~~
+
+Sometimes we need to use an unreleased version of one of our dependencies, either to fix an issue in a package that is not under our control, or to experiment with a pre-release version of one of our own packages.
+You can use a ``source-repository-package`` stanza to pull in the unreleased version.
+Try only to do this for a short time, as it does not play very well with tooling, and will interfere with the ability to release the node itself.
+
+For packages that we do not control, we can end up in a situation where we have a fork that looks like it will be long-lived or permanent (e.g. the maintainer is unresponsive, or the change has been merged but not released).
+In that case, release a patched version to the `Cardano package repository <https://github.com/input-output-hk/cardano-haskell-packages>`__, which allows us to remove the ``source-repository-package`` stanza.
+See the README for instructions.

--- a/flake.lock
+++ b/flake.lock
@@ -101,22 +101,6 @@
         "type": "github"
       }
     },
-    "cardano-mainnet-mirror": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1557232434,
-        "narHash": "sha256-2rclcOjIVq0lFCdYAa8S9imzZZHqySn2LZ/O48hUofw=",
-        "owner": "input-output-hk",
-        "repo": "cardano-mainnet-mirror",
-        "rev": "a31ac7534ec855b715b9a6bb6a06861ee94935d9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "repo": "cardano-mainnet-mirror",
-        "type": "github"
-      }
-    },
     "cardano-shell": {
       "flake": false,
       "locked": {
@@ -623,7 +607,6 @@
     "root": {
       "inputs": {
         "CHaP": "CHaP",
-        "cardano-mainnet-mirror": "cardano-mainnet-mirror",
         "flake-utils": "flake-utils",
         "haskellNix": "haskellNix",
         "incl": "incl",

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1685707241,
-        "narHash": "sha256-3vwY0mo8lf+0n+H6g3giXtVLQeXt/l9+FlsOpfi7CwM=",
+        "lastModified": 1686832558,
+        "narHash": "sha256-ShN++GEuj09VR2Q4zGNM9IGTKk+xfXnl8BXQG7tGQOA=",
         "owner": "input-output-hk",
         "repo": "cardano-haskell-packages",
-        "rev": "2baceb51b8f3175e05e94fdd4780cc717aeb2a6f",
+        "rev": "bc32b60d563860e2dab2a66ea558699ce72c7c29",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -10,9 +10,6 @@
 
     CHaP.url = "github:input-output-hk/cardano-haskell-packages?ref=repo";
     CHaP.flake = false;
-
-    cardano-mainnet-mirror.url = "github:input-output-hk/cardano-mainnet-mirror";
-    cardano-mainnet-mirror.flake = false;
   };
 
   outputs = inputs: let
@@ -78,7 +75,6 @@
             };
           # and from nixpkgs or other inputs
           shell.nativeBuildInputs = with nixpkgs; [
-            haskellPackages.implicit-hie
           ];
           # disable Hoogle until someone request it
           shell.withHoogle = false;
@@ -89,26 +85,7 @@
           # specific enough, or doesn't allow setting these.
           modules = [
             ({pkgs, ...}: {
-              packages.byron-spec-chain.configureFlags = ["--ghc-option=-Werror"];
-              packages.byron-spec-ledger.configureFlags = ["--ghc-option=-Werror"];
-              packages.delegation.configureFlags = ["--ghc-option=-Werror"];
-              packages.non-integral.configureFlags = ["--ghc-option=-Werror"];
-              packages.cardano-cli-shelley.configureFlags = ["--ghc-option=-Werror"];
-              packages.cardano-cli-shelley-ma.configureFlags = ["--ghc-option=-Werror"];
-              packages.cardano-cli-shelley-ma-test.configureFlags = ["--ghc-option=-Werror"];
-              packages.small-steps.configureFlags = ["--ghc-option=-Werror"];
-              packages.cardano-cli-byron = {
-                configureFlags = ["--ghc-option=-Werror"];
-                components = {
-                  tests.cardano-cli-byron-test = {
-                    preCheck = ''
-                      export CARDANO_MAINNET_MIRROR="${inputs.cardano-mainnet-mirror}/epochs"
-                      cp ${./eras/byron/ledger/impl/mainnet-genesis.json} ./mainnet-genesis.json
-                    '';
-                    testFlags = ["--scenario=ContinuousIntegration"];
-                  };
-                };
-              };
+              packages.cardano-cli.configureFlags = ["--ghc-option=-Werror"];
               packages.cardano-cli.components.tests.cardano-cli-test.build-tools =
                 lib.mkForce (with pkgs.buildPackages; [ jq coreutils shellcheck ]);
               packages.cardano-cli.components.tests.cardano-cli-golden.build-tools =
@@ -124,10 +101,6 @@
                  "configuration/cardano/mainnet-shelley-genesis.json"
                  "configuration/cardano/mainnet-alonzo-genesis.json"
                  "configuration/cardano/mainnet-conway-genesis.json"
-               ];
-               goldenConfigFiles = [
-                 "cardano-cli/test/cardano-cli-golden/files/golden/alonzo/genesis.alonzo.spec.json"
-                 "cardano-cli/test/cardano-cli-golden/files/golden/conway/genesis.conway.spec.json"
                ];
              in
              {
@@ -153,25 +126,6 @@
                    ${exportCliPath}
                    cp -r ${filteredProjectBase}/* ..
                  '';
-            })
-            ({pkgs, ...}:
-            lib.mkIf pkgs.stdenv.hostPlatform.isUnix {
-              packages.cardano-cli-shelley-ma-test.components.tests.cardano-ledger-shelley-ma-test.build-tools = [pkgs.cddl pkgs.cbor-diag];
-              packages.cardano-cli-shelley-test.components.tests.cardano-ledger-shelley-test.build-tools = [pkgs.cddl pkgs.cbor-diag];
-              packages.cardano-cli-alonzo-test.components.tests.cardano-ledger-alonzo-test.build-tools = [pkgs.cddl pkgs.cbor-diag];
-              packages.cardano-cli-babbage-test.components.tests.cardano-ledger-babbage-test.build-tools = [pkgs.cddl pkgs.cbor-diag];
-              packages.cardano-cli-conway-test.components.tests.cardano-ledger-conway-test.build-tools = [pkgs.cddl pkgs.cbor-diag];
-            })
-            ({pkgs, ...}:
-            lib.mkIf pkgs.stdenv.hostPlatform.isWindows {
-              packages.set-algebra.components.tests.tests.buildable = lib.mkForce false;
-              packages.plutus-preprocessor.package.buildable = lib.mkForce false;
-              packages.cardano-cli-test.package.buildable = lib.mkForce false;
-              packages.cardano-cli-shelley-ma-test.package.buildable = lib.mkForce false;
-              packages.cardano-cli-shelley-test.package.buildable = lib.mkForce false;
-              packages.cardano-cli-alonzo-test.package.buildable = lib.mkForce false;
-              packages.cardano-cli-babbage-test.package.buildable = lib.mkForce false;
-              packages.cardano-cli-conway-test.package.buildable = lib.mkForce false;
             })
           ];
         });

--- a/flake.nix
+++ b/flake.nix
@@ -70,7 +70,7 @@
             }
             // lib.optionalAttrs (config.compiler-nix-name == defaultCompiler) {
               # tools that work only with default compiler
-              fourmolu = "0.10.1.0";
+              stylish-haskell = "0.14.4.0";
               hlint = "3.5";
               #haskell-language-server = "2.0.0.0";
             };


### PR DESCRIPTION
# Description

see commits (to be reviewed individually to skip `nix fmt` noise).

# Changelog
```yaml
- description: |
    nix-related changes: 
    - Bump CHaP nix pin to sync with cabal.projet. Document this in CONTRIBUTING (copy-pasted section fromm cardano-node)
    - flake.nix: nix fmt
    - flake.nix: clean-up unnecessary config
    - nix develop: provide stylish-haskell instead of formolu.
  compatibility: no-api-changes
  type: maintenance
```
