### PR TITLE
Deprecate `--protocol-params-file` option of the `transaction build` command more thoroughly

### DIFF
--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -44,6 +44,8 @@ module Cardano.CLI.Shelley.Commands
   , BlockId (..)
   , WitnessSigningData (..)
   , ColdVerificationKeyOrFile (..)
+
+  , Deprecated (..)
   ) where
 
 import           Prelude
@@ -232,7 +234,7 @@ data TransactionCmd
       [ScriptFile]
       -- ^ Auxiliary scripts
       [MetadataFile]
-      (Maybe ProtocolParamsFile)
+      (Maybe (Deprecated ProtocolParamsFile))
       (Maybe UpdateProposalFile)
       TxBuildOutputOptions
   | TxSign InputTxBodyOrTxFile [WitnessSigningData] (Maybe NetworkId) (TxFile Out)
@@ -615,3 +617,6 @@ data ColdVerificationKeyOrFile
   | ColdGenesisDelegateVerificationKey !(VerificationKey GenesisDelegateKey)
   | ColdVerificationKeyFile !(VerificationKeyFile In)
   deriving Show
+
+-- | Marks a value as being deprecated.
+newtype Deprecated a = Deprecated a

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -737,7 +737,7 @@ pTransaction envCli =
                         Nothing
                         "Filepath of auxiliary script(s)")
             <*> many pMetadataFile
-            <*> optional pProtocolParamsFile
+            <*> optional pDeprecatedProtocolParamsFile
             <*> optional pUpdateProposalFile
             <*> (OutputTxBodyOnly <$> pTxBodyFileOut <|> pCalculatePlutusScriptCost)
 
@@ -1598,15 +1598,27 @@ pAddressKeyType =
   <|>
     pure AddressKeyShelley
 
+pDeprecatedProtocolParamsFile :: Parser (Deprecated ProtocolParamsFile)
+pDeprecatedProtocolParamsFile =
+  fmap (Deprecated . ProtocolParamsFile) $ Opt.strOption $ mconcat
+    [ Opt.long "protocol-params-file"
+    , Opt.metavar "FILE"
+    , Opt.help $ mconcat
+        [ "Filepath of the JSON-encoded protocol parameters file. "
+        , "DEPRECATED The option is ignored and protocol parameters are "
+        , "retrieved from the node."
+        ]
+    , Opt.completer (Opt.bashCompleter "file")
+    ]
+
 pProtocolParamsFile :: Parser ProtocolParamsFile
 pProtocolParamsFile =
-  ProtocolParamsFile <$>
-    Opt.strOption
-      (  Opt.long "protocol-params-file"
-      <> Opt.metavar "FILE"
-      <> Opt.help "Filepath of the JSON-encoded protocol parameters file"
-      <> Opt.completer (Opt.bashCompleter "file")
-      )
+  fmap ProtocolParamsFile $ Opt.strOption $ mconcat
+    [ Opt.long "protocol-params-file"
+    , Opt.metavar "FILE"
+    , Opt.help "Filepath of the JSON-encoded protocol parameters file"
+    , Opt.completer (Opt.bashCompleter "file")
+    ]
 
 pCalculatePlutusScriptCost :: Parser TxBuildOutputOptions
 pCalculatePlutusScriptCost =

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/transaction_build.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/transaction_build.cli
@@ -381,7 +381,9 @@ Available options:
   --metadata-cbor-file FILE
                            Filepath of the metadata, in raw CBOR format.
   --protocol-params-file FILE
-                           Filepath of the JSON-encoded protocol parameters file
+                           Filepath of the JSON-encoded protocol parameters
+                           file. DEPRECATED The option is ignored and protocol
+                           parameters are retrieved from the node.
   --update-proposal-file FILE
                            Filepath of the update proposal.
   --out-file FILE          Output filepath of the JSON TxBody.


### PR DESCRIPTION
# Description

# Changelog

```yaml
- description: |
    The `--protocol-params-file` option of the `transaction build` command is
    now marked as deprecated in Usage help.  The option was already deprecated
    and ignored.
  compatibility: compatible
  type: bugfix
```

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
