### PR TITLE
Refactoring to merge queries to share the same connection

### DIFF
--- a/cardano-cli/src/Cardano/CLI/Run/Legacy/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Run/Legacy/Query.hs
@@ -448,28 +448,37 @@ runQueryKesPeriodInfo socketPath (AnyConsensusModeParams cModeParams) network no
     CardanoMode -> do
       join $ lift
         ( executeLocalStateQueryExpr localNodeConnInfo Nothing $ runExceptT $ do
+            anyE@(AnyCardanoEra era) <- lift (determineEraExpr cModeParams)
+              & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
+
+            sbe <- requireShelleyBasedEra era
+              & onNothing (left ShelleyQueryCmdByronEra)
+
+            eInMode <- toEraInMode era cMode
+              & hoistMaybe (ShelleyQueryCmdEraConsensusModeMismatch (AnyConsensusMode cMode) anyE)
+
+            -- We check that the KES period specified in the operational certificate is correct
+            -- based on the KES period defined in the genesis parameters and the current slot number
+            eraInMode <- calcEraInMode era $ consensusModeOnly cModeParams
+
+            requireNotByronEraInByronMode eraInMode
+
+            gParams <- lift (queryGenesisParameters eInMode sbe)
+              & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
+              & onLeft (left . ShelleyQueryCmdLocalStateQueryError . EraMismatchError)
+
+            eraHistory <- lift queryEraHistory
+              & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
+
+            let eInfo = toTentativeEpochInfo eraHistory
+
+            -- We get the operational certificate counter from the protocol state and check that
+            -- it is equivalent to what we have on disk.
+            ptclState <- lift (queryProtocolState eInMode sbe)
+              & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
+              & onLeft (left . ShelleyQueryCmdLocalStateQueryError . EraMismatchError)
+
             pure $ do
-              anyE@(AnyCardanoEra era) <- lift (executeLocalStateQueryExpr localNodeConnInfo Nothing (determineEraExpr cModeParams))
-                & onLeft (left . ShelleyQueryCmdAcquireFailure)
-                & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
-
-              sbe <- requireShelleyBasedEra era
-                & onNothing (left ShelleyQueryCmdByronEra)
-
-              eInMode <- toEraInMode era cMode
-                & hoistMaybe (ShelleyQueryCmdEraConsensusModeMismatch (AnyConsensusMode cMode) anyE)
-
-              -- We check that the KES period specified in the operational certificate is correct
-              -- based on the KES period defined in the genesis parameters and the current slot number
-              eraInMode <- calcEraInMode era $ consensusModeOnly cModeParams
-
-              requireNotByronEraInByronMode eraInMode
-
-              gParams <- lift (executeLocalStateQueryExpr localNodeConnInfo Nothing $ queryGenesisParameters eInMode sbe)
-                & onLeft (left . ShelleyQueryCmdAcquireFailure)
-                & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
-                & onLeft (left . ShelleyQueryCmdLocalStateQueryError . EraMismatchError)
-
               chainTip <- liftIO $ getLocalChainTip localNodeConnInfo
 
               let curKesPeriod = currentKesPeriod chainTip gParams
@@ -477,20 +486,8 @@ runQueryKesPeriodInfo socketPath (AnyConsensusModeParams cModeParams) network no
                   oCertEndKesPeriod = opCertEndKesPeriod gParams opCert
                   opCertIntervalInformation = opCertIntervalInfo gParams chainTip curKesPeriod oCertStartKesPeriod oCertEndKesPeriod
 
-              eraHistory <- lift (executeLocalStateQueryExpr localNodeConnInfo Nothing queryEraHistory)
-                & onLeft (left . ShelleyQueryCmdAcquireFailure)
-                & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
-
-              let eInfo = toTentativeEpochInfo eraHistory
-
-              -- We get the operational certificate counter from the protocol state and check that
-              -- it is equivalent to what we have on disk.
-              ptclState <- lift (executeLocalStateQueryExpr localNodeConnInfo Nothing $ queryProtocolState eInMode sbe)
-                & onLeft (left . ShelleyQueryCmdAcquireFailure)
-                & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
-                & onLeft (left . ShelleyQueryCmdLocalStateQueryError . EraMismatchError)
-
               (onDiskC, stateC) <- shelleyBasedEraConstraints sbe $ opCertOnDiskAndStateCounters ptclState opCert
+
               let counterInformation = opCertNodeAndOnDiskCounters onDiskC stateC
 
               -- Always render diagnostic information

--- a/cardano-cli/src/Cardano/CLI/Run/Legacy/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Run/Legacy/Query.hs
@@ -1363,9 +1363,9 @@ runQueryLeadershipSchedule
 
         let cMode = consensusModeOnly cModeParams
 
-        pure $ do
-          case cMode of
-            CardanoMode -> do
+        case cMode of
+          CardanoMode -> do
+            pure $ do
               eInMode <- toEraInMode era cMode
                   & hoistMaybe (ShelleyQueryCmdEraConsensusModeMismatch (AnyConsensusMode cMode) anyE)
 
@@ -1436,7 +1436,9 @@ runQueryLeadershipSchedule
                 Just (File jsonOutputFile) ->
                   liftIO $ LBS.writeFile jsonOutputFile $
                     printLeadershipScheduleAsJson schedule eInfo (SystemStart $ sgSystemStart shelleyGenesis)
-            mode -> left . ShelleyQueryCmdUnsupportedMode $ AnyConsensusMode mode
+          mode ->
+            pure $ do
+              left . ShelleyQueryCmdUnsupportedMode $ AnyConsensusMode mode
     )
     & onLeft (left . ShelleyQueryCmdAcquireFailure)
     & onLeft left

--- a/cardano-cli/src/Cardano/CLI/Run/Legacy/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Run/Legacy/Query.hs
@@ -1426,12 +1426,7 @@ runQueryLeadershipSchedule
                     $ nextEpochEligibleLeadershipSlots sbe shelleyGenesis
                       serCurrentEpochState ptclState poolid vrkSkey bpp
                       eInfo (tip, curentEpoch)
-
-              case mJsonOutputFile of
-                Nothing -> liftIO $ printLeadershipScheduleAsText schedule eInfo (SystemStart $ sgSystemStart shelleyGenesis)
-                Just (File jsonOutputFile) ->
-                  liftIO $ LBS.writeFile jsonOutputFile $
-                    printLeadershipScheduleAsJson schedule eInfo (SystemStart $ sgSystemStart shelleyGenesis)
+              writeSchedule mJsonOutputFile eInfo shelleyGenesis schedule
           mode ->
             pure $ do
               left . ShelleyQueryCmdUnsupportedMode $ AnyConsensusMode mode
@@ -1439,6 +1434,13 @@ runQueryLeadershipSchedule
     & onLeft (left . ShelleyQueryCmdAcquireFailure)
     & onLeft left
   where
+    writeSchedule mOutFile eInfo shelleyGenesis schedule =
+      case mOutFile of
+        Nothing -> liftIO $ printLeadershipScheduleAsText schedule eInfo (SystemStart $ sgSystemStart shelleyGenesis)
+        Just (File jsonOutputFile) ->
+          liftIO $ LBS.writeFile jsonOutputFile $
+            printLeadershipScheduleAsJson schedule eInfo (SystemStart $ sgSystemStart shelleyGenesis)
+
     printLeadershipScheduleAsText
       :: Set SlotNo
       -> EpochInfo (Either Text)

--- a/cardano-cli/src/Cardano/CLI/Run/Legacy/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Run/Legacy/Query.hs
@@ -449,66 +449,65 @@ runQueryKesPeriodInfo socketPath (AnyConsensusModeParams cModeParams) network no
       join $ lift
         ( executeLocalStateQueryExpr localNodeConnInfo Nothing $ runExceptT $ do
             pure $ do
-              pure ()
+              anyE@(AnyCardanoEra era) <- lift (executeLocalStateQueryExpr localNodeConnInfo Nothing (determineEraExpr cModeParams))
+                & onLeft (left . ShelleyQueryCmdAcquireFailure)
+                & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
+
+              sbe <- requireShelleyBasedEra era
+                & onNothing (left ShelleyQueryCmdByronEra)
+
+              eInMode <- toEraInMode era cMode
+                & hoistMaybe (ShelleyQueryCmdEraConsensusModeMismatch (AnyConsensusMode cMode) anyE)
+
+              -- We check that the KES period specified in the operational certificate is correct
+              -- based on the KES period defined in the genesis parameters and the current slot number
+              eraInMode <- calcEraInMode era $ consensusModeOnly cModeParams
+
+              requireNotByronEraInByronMode eraInMode
+
+              gParams <- lift (executeLocalStateQueryExpr localNodeConnInfo Nothing $ queryGenesisParameters eInMode sbe)
+                & onLeft (left . ShelleyQueryCmdAcquireFailure)
+                & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
+                & onLeft (left . ShelleyQueryCmdLocalStateQueryError . EraMismatchError)
+
+              chainTip <- liftIO $ getLocalChainTip localNodeConnInfo
+
+              let curKesPeriod = currentKesPeriod chainTip gParams
+                  oCertStartKesPeriod = opCertStartingKesPeriod opCert
+                  oCertEndKesPeriod = opCertEndKesPeriod gParams opCert
+                  opCertIntervalInformation = opCertIntervalInfo gParams chainTip curKesPeriod oCertStartKesPeriod oCertEndKesPeriod
+
+              eraHistory <- lift (executeLocalStateQueryExpr localNodeConnInfo Nothing queryEraHistory)
+                & onLeft (left . ShelleyQueryCmdAcquireFailure)
+                & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
+
+              let eInfo = toTentativeEpochInfo eraHistory
+
+              -- We get the operational certificate counter from the protocol state and check that
+              -- it is equivalent to what we have on disk.
+              ptclState <- lift (executeLocalStateQueryExpr localNodeConnInfo Nothing $ queryProtocolState eInMode sbe)
+                & onLeft (left . ShelleyQueryCmdAcquireFailure)
+                & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
+                & onLeft (left . ShelleyQueryCmdLocalStateQueryError . EraMismatchError)
+
+              (onDiskC, stateC) <- shelleyBasedEraConstraints sbe $ opCertOnDiskAndStateCounters ptclState opCert
+              let counterInformation = opCertNodeAndOnDiskCounters onDiskC stateC
+
+              -- Always render diagnostic information
+              liftIO . putStrLn $ renderOpCertIntervalInformation (unFile nodeOpCertFile) opCertIntervalInformation
+              liftIO . putStrLn $ renderOpCertNodeAndOnDiskCounterInformation (unFile nodeOpCertFile) counterInformation
+
+              let qKesInfoOutput = createQueryKesPeriodInfoOutput opCertIntervalInformation counterInformation eInfo gParams
+                  kesPeriodInfoJSON = encodePretty qKesInfoOutput
+
+              liftIO $ LBS.putStrLn kesPeriodInfoJSON
+              forM_ mOutFile (\(File oFp) ->
+                handleIOExceptT (ShelleyQueryCmdWriteFileError . FileIOError oFp)
+                  $ LBS.writeFile oFp kesPeriodInfoJSON)
         )
         & onLeft (left . ShelleyQueryCmdAcquireFailure)
         & onLeft left
 
-      anyE@(AnyCardanoEra era) <- lift (executeLocalStateQueryExpr localNodeConnInfo Nothing (determineEraExpr cModeParams))
-        & onLeft (left . ShelleyQueryCmdAcquireFailure)
-        & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
-
-      sbe <- requireShelleyBasedEra era
-        & onNothing (left ShelleyQueryCmdByronEra)
-
-      eInMode <- toEraInMode era cMode
-        & hoistMaybe (ShelleyQueryCmdEraConsensusModeMismatch (AnyConsensusMode cMode) anyE)
-
-      -- We check that the KES period specified in the operational certificate is correct
-      -- based on the KES period defined in the genesis parameters and the current slot number
-      eraInMode <- calcEraInMode era $ consensusModeOnly cModeParams
-
-      requireNotByronEraInByronMode eraInMode
-
-      gParams <- lift (executeLocalStateQueryExpr localNodeConnInfo Nothing $ queryGenesisParameters eInMode sbe)
-        & onLeft (left . ShelleyQueryCmdAcquireFailure)
-        & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
-        & onLeft (left . ShelleyQueryCmdLocalStateQueryError . EraMismatchError)
-
-      chainTip <- liftIO $ getLocalChainTip localNodeConnInfo
-
-      let curKesPeriod = currentKesPeriod chainTip gParams
-          oCertStartKesPeriod = opCertStartingKesPeriod opCert
-          oCertEndKesPeriod = opCertEndKesPeriod gParams opCert
-          opCertIntervalInformation = opCertIntervalInfo gParams chainTip curKesPeriod oCertStartKesPeriod oCertEndKesPeriod
-
-      eraHistory <- lift (executeLocalStateQueryExpr localNodeConnInfo Nothing queryEraHistory)
-        & onLeft (left . ShelleyQueryCmdAcquireFailure)
-        & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
-
-      let eInfo = toTentativeEpochInfo eraHistory
-
-      -- We get the operational certificate counter from the protocol state and check that
-      -- it is equivalent to what we have on disk.
-      ptclState <- lift (executeLocalStateQueryExpr localNodeConnInfo Nothing $ queryProtocolState eInMode sbe)
-        & onLeft (left . ShelleyQueryCmdAcquireFailure)
-        & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
-        & onLeft (left . ShelleyQueryCmdLocalStateQueryError . EraMismatchError)
-
-      (onDiskC, stateC) <- shelleyBasedEraConstraints sbe $ opCertOnDiskAndStateCounters ptclState opCert
-      let counterInformation = opCertNodeAndOnDiskCounters onDiskC stateC
-
-      -- Always render diagnostic information
-      liftIO . putStrLn $ renderOpCertIntervalInformation (unFile nodeOpCertFile) opCertIntervalInformation
-      liftIO . putStrLn $ renderOpCertNodeAndOnDiskCounterInformation (unFile nodeOpCertFile) counterInformation
-
-      let qKesInfoOutput = createQueryKesPeriodInfoOutput opCertIntervalInformation counterInformation eInfo gParams
-          kesPeriodInfoJSON = encodePretty qKesInfoOutput
-
-      liftIO $ LBS.putStrLn kesPeriodInfoJSON
-      forM_ mOutFile (\(File oFp) ->
-        handleIOExceptT (ShelleyQueryCmdWriteFileError . FileIOError oFp)
-          $ LBS.writeFile oFp kesPeriodInfoJSON)
     mode -> left . ShelleyQueryCmdUnsupportedMode $ AnyConsensusMode mode
 
  where

--- a/cardano-cli/src/Cardano/CLI/Run/Legacy/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Run/Legacy/Query.hs
@@ -446,6 +446,14 @@ runQueryKesPeriodInfo socketPath (AnyConsensusModeParams cModeParams) network no
 
   case cMode of
     CardanoMode -> do
+      join $ lift
+        ( executeLocalStateQueryExpr localNodeConnInfo Nothing $ runExceptT $ do
+            pure $ do
+              pure ()
+        )
+        & onLeft (left . ShelleyQueryCmdAcquireFailure)
+        & onLeft left
+
       anyE@(AnyCardanoEra era) <- lift (executeLocalStateQueryExpr localNodeConnInfo Nothing (determineEraExpr cModeParams))
         & onLeft (left . ShelleyQueryCmdAcquireFailure)
         & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)

--- a/cardano-cli/src/Cardano/CLI/Run/Legacy/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Run/Legacy/Query.hs
@@ -1394,12 +1394,11 @@ runQueryLeadershipSchedule
 
             case whichSchedule of
               CurrentEpoch -> do
-                pure $ do
-                  serCurrentEpochState <- lift (executeLocalStateQueryExpr localNodeConnInfo Nothing $ queryPoolDistribution eInMode sbe (Just (Set.singleton poolid)))
-                    & onLeft (left . ShelleyQueryCmdAcquireFailure)
-                    & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
-                    & onLeft (left . ShelleyQueryCmdLocalStateQueryError . EraMismatchError)
+                serCurrentEpochState <- lift (queryPoolDistribution eInMode sbe (Just (Set.singleton poolid)))
+                  & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
+                  & onLeft (left . ShelleyQueryCmdLocalStateQueryError . EraMismatchError)
 
+                pure $ do
                   schedule <- firstExceptT ShelleyQueryCmdLeaderShipError $ hoistEither
                     $ shelleyBasedEraConstraints sbe
                     $ currentEpochEligibleLeadershipSlots
@@ -1416,12 +1415,11 @@ runQueryLeadershipSchedule
                   writeSchedule mJsonOutputFile eInfo shelleyGenesis schedule
 
               NextEpoch -> do
-                pure $ do
-                  serCurrentEpochState <- lift (executeLocalStateQueryExpr localNodeConnInfo Nothing $ queryCurrentEpochState eInMode sbe)
-                    & onLeft (left . ShelleyQueryCmdAcquireFailure)
-                    & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
-                    & onLeft (left . ShelleyQueryCmdLocalStateQueryError . EraMismatchError)
+                serCurrentEpochState <- lift (queryCurrentEpochState eInMode sbe)
+                  & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
+                  & onLeft (left . ShelleyQueryCmdLocalStateQueryError . EraMismatchError)
 
+                pure $ do
                   tip <- liftIO $ getLocalChainTip localNodeConnInfo
 
                   schedule <- firstExceptT ShelleyQueryCmdLeaderShipError $ hoistEither

--- a/cardano-cli/src/Cardano/CLI/Run/Legacy/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Run/Legacy/Query.hs
@@ -1365,38 +1365,34 @@ runQueryLeadershipSchedule
 
         case cMode of
           CardanoMode -> do
+            eInMode <- toEraInMode era cMode
+                & hoistMaybe (ShelleyQueryCmdEraConsensusModeMismatch (AnyConsensusMode cMode) anyE)
+
+            eraInMode <- calcEraInMode era $ consensusModeOnly cModeParams
+
+            requireNotByronEraInByronMode eraInMode
+
+            pparams <- lift (queryProtocolParameters eInMode sbe)
+              & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
+              & onLeft (left . ShelleyQueryCmdLocalStateQueryError . EraMismatchError)
+
+            ptclState <- lift (queryProtocolState eInMode sbe)
+              & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
+              & onLeft (left . ShelleyQueryCmdLocalStateQueryError . EraMismatchError)
+
+            eraHistory <- lift queryEraHistory
+              & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
+
+            let eInfo = toEpochInfo eraHistory
+
+            curentEpoch <- lift (queryEpoch eInMode sbe)
+              & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
+              & onLeft (left . ShelleyQueryCmdLocalStateQueryError . EraMismatchError)
+
+            bpp <- hoistEither . first ShelleyQueryCmdProtocolParameterConversionError $
+              bundleProtocolParams era pparams
+
             pure $ do
-              eInMode <- toEraInMode era cMode
-                  & hoistMaybe (ShelleyQueryCmdEraConsensusModeMismatch (AnyConsensusMode cMode) anyE)
-
-              eraInMode <- calcEraInMode era $ consensusModeOnly cModeParams
-
-              requireNotByronEraInByronMode eraInMode
-
-              pparams <- lift (executeLocalStateQueryExpr localNodeConnInfo Nothing $ queryProtocolParameters eInMode sbe)
-                & onLeft (left . ShelleyQueryCmdAcquireFailure)
-                & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
-                & onLeft (left . ShelleyQueryCmdLocalStateQueryError . EraMismatchError)
-
-              ptclState <- lift (executeLocalStateQueryExpr localNodeConnInfo Nothing $ queryProtocolState eInMode sbe)
-                & onLeft (left . ShelleyQueryCmdAcquireFailure)
-                & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
-                & onLeft (left . ShelleyQueryCmdLocalStateQueryError . EraMismatchError)
-
-              eraHistory <- lift (executeLocalStateQueryExpr localNodeConnInfo Nothing queryEraHistory)
-                & onLeft (left . ShelleyQueryCmdAcquireFailure)
-                & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
-
-              let eInfo = toEpochInfo eraHistory
-
-              curentEpoch <- lift (executeLocalStateQueryExpr localNodeConnInfo Nothing $ queryEpoch eInMode sbe)
-                & onLeft (left . ShelleyQueryCmdAcquireFailure)
-                & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
-                & onLeft (left . ShelleyQueryCmdLocalStateQueryError . EraMismatchError)
-
-              bpp <- hoistEither . first ShelleyQueryCmdProtocolParameterConversionError $
-                bundleProtocolParams era pparams
-
               schedule <- case whichSchedule of
                 CurrentEpoch -> do
                   serCurrentEpochState <- lift (executeLocalStateQueryExpr localNodeConnInfo Nothing $ queryPoolDistribution eInMode sbe (Just (Set.singleton poolid)))
@@ -1418,12 +1414,12 @@ runQueryLeadershipSchedule
                       curentEpoch
 
                 NextEpoch -> do
-                  tip <- liftIO $ getLocalChainTip localNodeConnInfo
-
                   serCurrentEpochState <- lift (executeLocalStateQueryExpr localNodeConnInfo Nothing $ queryCurrentEpochState eInMode sbe)
                     & onLeft (left . ShelleyQueryCmdAcquireFailure)
                     & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
                     & onLeft (left . ShelleyQueryCmdLocalStateQueryError . EraMismatchError)
+
+                  tip <- liftIO $ getLocalChainTip localNodeConnInfo
 
                   firstExceptT ShelleyQueryCmdLeaderShipError $ hoistEither
                     $ shelleyBasedEraConstraints sbe
@@ -1442,65 +1438,65 @@ runQueryLeadershipSchedule
     )
     & onLeft (left . ShelleyQueryCmdAcquireFailure)
     & onLeft left
- where
-  printLeadershipScheduleAsText
-    :: Set SlotNo
-    -> EpochInfo (Either Text)
-    -> SystemStart
-    -> IO ()
-  printLeadershipScheduleAsText leadershipSlots eInfo sStart = do
-    Text.putStrLn title
-    putStrLn $ replicate (Text.length title + 2) '-'
-    sequence_
-      [ putStrLn $ showLeadershipSlot slot eInfo sStart
-      | slot <- Set.toList leadershipSlots ]
-   where
-     title :: Text
-     title =
-       "     SlotNo                          UTC Time              "
+  where
+    printLeadershipScheduleAsText
+      :: Set SlotNo
+      -> EpochInfo (Either Text)
+      -> SystemStart
+      -> IO ()
+    printLeadershipScheduleAsText leadershipSlots eInfo sStart = do
+      Text.putStrLn title
+      putStrLn $ replicate (Text.length title + 2) '-'
+      sequence_
+        [ putStrLn $ showLeadershipSlot slot eInfo sStart
+        | slot <- Set.toList leadershipSlots ]
+      where
+        title :: Text
+        title =
+          "     SlotNo                          UTC Time              "
 
-     showLeadershipSlot
-       :: SlotNo
-       -> EpochInfo (Either Text)
-       -> SystemStart
-       -> String
-     showLeadershipSlot lSlot@(SlotNo sn) eInfo' sStart' =
-       case epochInfoSlotToUTCTime eInfo' sStart' lSlot of
-         Right slotTime ->
-          concat
-           [ "     "
-           , show sn
-           , "                   "
-           , show slotTime
-           ]
-         Left err ->
-          concat
-           [ "     "
-           , show sn
-           , "                   "
-           , Text.unpack err
-           ]
-  printLeadershipScheduleAsJson
-    :: Set SlotNo
-    -> EpochInfo (Either Text)
-    -> SystemStart
-    -> LBS.ByteString
-  printLeadershipScheduleAsJson leadershipSlots eInfo sStart =
-    encodePretty $ showLeadershipSlot <$> List.sort (Set.toList leadershipSlots)
-    where
-      showLeadershipSlot :: SlotNo -> Aeson.Value
-      showLeadershipSlot lSlot@(SlotNo sn) =
-        case epochInfoSlotToUTCTime eInfo sStart lSlot of
-          Right slotTime ->
-            Aeson.object
-              [ "slotNumber" Aeson..= sn
-              , "slotTime" Aeson..= slotTime
+        showLeadershipSlot
+          :: SlotNo
+          -> EpochInfo (Either Text)
+          -> SystemStart
+          -> String
+        showLeadershipSlot lSlot@(SlotNo sn) eInfo' sStart' =
+          case epochInfoSlotToUTCTime eInfo' sStart' lSlot of
+            Right slotTime ->
+              concat
+              [ "     "
+              , show sn
+              , "                   "
+              , show slotTime
               ]
-          Left err ->
-            Aeson.object
-              [ "slotNumber" Aeson..= sn
-              , "error" Aeson..= Text.unpack err
+            Left err ->
+              concat
+              [ "     "
+              , show sn
+              , "                   "
+              , Text.unpack err
               ]
+    printLeadershipScheduleAsJson
+      :: Set SlotNo
+      -> EpochInfo (Either Text)
+      -> SystemStart
+      -> LBS.ByteString
+    printLeadershipScheduleAsJson leadershipSlots eInfo sStart =
+      encodePretty $ showLeadershipSlot <$> List.sort (Set.toList leadershipSlots)
+      where
+        showLeadershipSlot :: SlotNo -> Aeson.Value
+        showLeadershipSlot lSlot@(SlotNo sn) =
+          case epochInfoSlotToUTCTime eInfo sStart lSlot of
+            Right slotTime ->
+              Aeson.object
+                [ "slotNumber" Aeson..= sn
+                , "slotTime" Aeson..= slotTime
+                ]
+            Left err ->
+              Aeson.object
+                [ "slotNumber" Aeson..= sn
+                , "error" Aeson..= Text.unpack err
+                ]
 
 
 -- Helpers

--- a/cardano-cli/src/Cardano/CLI/Run/Legacy/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Run/Legacy/Query.hs
@@ -1344,15 +1344,6 @@ runQueryLeadershipSchedule
     whichSchedule mJsonOutputFile = do
   let localNodeConnInfo = LocalNodeConnectInfo cModeParams network socketPath
 
-  anyE@(AnyCardanoEra era) <- lift (executeLocalStateQueryExpr localNodeConnInfo Nothing (determineEraExpr cModeParams))
-    & onLeft (left . ShelleyQueryCmdAcquireFailure)
-    & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
-
-  sbe <- requireShelleyBasedEra era
-    & onNothing (left ShelleyQueryCmdByronEra)
-
-  let cMode = consensusModeOnly cModeParams
-
   poolid <- lift (readVerificationKeyOrHashOrFile AsStakePoolKey coldVerKeyFile)
     & onLeft (left . ShelleyQueryCmdTextReadError)
 
@@ -1362,79 +1353,93 @@ runQueryLeadershipSchedule
   shelleyGenesis <- lift (readAndDecodeShelleyGenesis genFile)
     & onLeft (left . ShelleyQueryCmdGenesisReadError)
 
-  case cMode of
-    CardanoMode -> do
-      eInMode <- toEraInMode era cMode
-          & hoistMaybe (ShelleyQueryCmdEraConsensusModeMismatch (AnyConsensusMode cMode) anyE)
+  join $ lift
+    ( executeLocalStateQueryExpr localNodeConnInfo Nothing $ runExceptT $ do
+        anyE@(AnyCardanoEra era) <- lift (determineEraExpr cModeParams)
+          & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
 
-      eraInMode <- calcEraInMode era $ consensusModeOnly cModeParams
+        sbe <- requireShelleyBasedEra era
+          & onNothing (left ShelleyQueryCmdByronEra)
 
-      requireNotByronEraInByronMode eraInMode
+        let cMode = consensusModeOnly cModeParams
 
-      pparams <- lift (executeLocalStateQueryExpr localNodeConnInfo Nothing $ queryProtocolParameters eInMode sbe)
-        & onLeft (left . ShelleyQueryCmdAcquireFailure)
-        & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
-        & onLeft (left . ShelleyQueryCmdLocalStateQueryError . EraMismatchError)
+        pure $ do
+          case cMode of
+            CardanoMode -> do
+              eInMode <- toEraInMode era cMode
+                  & hoistMaybe (ShelleyQueryCmdEraConsensusModeMismatch (AnyConsensusMode cMode) anyE)
 
-      ptclState <- lift (executeLocalStateQueryExpr localNodeConnInfo Nothing $ queryProtocolState eInMode sbe)
-        & onLeft (left . ShelleyQueryCmdAcquireFailure)
-        & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
-        & onLeft (left . ShelleyQueryCmdLocalStateQueryError . EraMismatchError)
+              eraInMode <- calcEraInMode era $ consensusModeOnly cModeParams
 
-      eraHistory <- lift (executeLocalStateQueryExpr localNodeConnInfo Nothing queryEraHistory)
-        & onLeft (left . ShelleyQueryCmdAcquireFailure)
-        & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
+              requireNotByronEraInByronMode eraInMode
 
-      let eInfo = toEpochInfo eraHistory
+              pparams <- lift (executeLocalStateQueryExpr localNodeConnInfo Nothing $ queryProtocolParameters eInMode sbe)
+                & onLeft (left . ShelleyQueryCmdAcquireFailure)
+                & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
+                & onLeft (left . ShelleyQueryCmdLocalStateQueryError . EraMismatchError)
 
-      curentEpoch <- lift (executeLocalStateQueryExpr localNodeConnInfo Nothing $ queryEpoch eInMode sbe)
-        & onLeft (left . ShelleyQueryCmdAcquireFailure)
-        & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
-        & onLeft (left . ShelleyQueryCmdLocalStateQueryError . EraMismatchError)
+              ptclState <- lift (executeLocalStateQueryExpr localNodeConnInfo Nothing $ queryProtocolState eInMode sbe)
+                & onLeft (left . ShelleyQueryCmdAcquireFailure)
+                & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
+                & onLeft (left . ShelleyQueryCmdLocalStateQueryError . EraMismatchError)
 
-      bpp <- hoistEither . first ShelleyQueryCmdProtocolParameterConversionError $
-        bundleProtocolParams era pparams
+              eraHistory <- lift (executeLocalStateQueryExpr localNodeConnInfo Nothing queryEraHistory)
+                & onLeft (left . ShelleyQueryCmdAcquireFailure)
+                & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
 
-      schedule <- case whichSchedule of
-        CurrentEpoch -> do
-          serCurrentEpochState <- lift (executeLocalStateQueryExpr localNodeConnInfo Nothing $ queryPoolDistribution eInMode sbe (Just (Set.singleton poolid)))
-            & onLeft (left . ShelleyQueryCmdAcquireFailure)
-            & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
-            & onLeft (left . ShelleyQueryCmdLocalStateQueryError . EraMismatchError)
+              let eInfo = toEpochInfo eraHistory
 
-          firstExceptT ShelleyQueryCmdLeaderShipError $ hoistEither
-            $ shelleyBasedEraConstraints sbe
-            $ currentEpochEligibleLeadershipSlots
-              sbe
-              shelleyGenesis
-              eInfo
-              bpp
-              ptclState
-              poolid
-              vrkSkey
-              serCurrentEpochState
-              curentEpoch
+              curentEpoch <- lift (executeLocalStateQueryExpr localNodeConnInfo Nothing $ queryEpoch eInMode sbe)
+                & onLeft (left . ShelleyQueryCmdAcquireFailure)
+                & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
+                & onLeft (left . ShelleyQueryCmdLocalStateQueryError . EraMismatchError)
 
-        NextEpoch -> do
-          tip <- liftIO $ getLocalChainTip localNodeConnInfo
+              bpp <- hoistEither . first ShelleyQueryCmdProtocolParameterConversionError $
+                bundleProtocolParams era pparams
 
-          serCurrentEpochState <- lift (executeLocalStateQueryExpr localNodeConnInfo Nothing $ queryCurrentEpochState eInMode sbe)
-            & onLeft (left . ShelleyQueryCmdAcquireFailure)
-            & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
-            & onLeft (left . ShelleyQueryCmdLocalStateQueryError . EraMismatchError)
+              schedule <- case whichSchedule of
+                CurrentEpoch -> do
+                  serCurrentEpochState <- lift (executeLocalStateQueryExpr localNodeConnInfo Nothing $ queryPoolDistribution eInMode sbe (Just (Set.singleton poolid)))
+                    & onLeft (left . ShelleyQueryCmdAcquireFailure)
+                    & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
+                    & onLeft (left . ShelleyQueryCmdLocalStateQueryError . EraMismatchError)
 
-          firstExceptT ShelleyQueryCmdLeaderShipError $ hoistEither
-            $ shelleyBasedEraConstraints sbe
-            $ nextEpochEligibleLeadershipSlots sbe shelleyGenesis
-              serCurrentEpochState ptclState poolid vrkSkey bpp
-              eInfo (tip, curentEpoch)
+                  firstExceptT ShelleyQueryCmdLeaderShipError $ hoistEither
+                    $ shelleyBasedEraConstraints sbe
+                    $ currentEpochEligibleLeadershipSlots
+                      sbe
+                      shelleyGenesis
+                      eInfo
+                      bpp
+                      ptclState
+                      poolid
+                      vrkSkey
+                      serCurrentEpochState
+                      curentEpoch
 
-      case mJsonOutputFile of
-        Nothing -> liftIO $ printLeadershipScheduleAsText schedule eInfo (SystemStart $ sgSystemStart shelleyGenesis)
-        Just (File jsonOutputFile) ->
-          liftIO $ LBS.writeFile jsonOutputFile $
-            printLeadershipScheduleAsJson schedule eInfo (SystemStart $ sgSystemStart shelleyGenesis)
-    mode -> left . ShelleyQueryCmdUnsupportedMode $ AnyConsensusMode mode
+                NextEpoch -> do
+                  tip <- liftIO $ getLocalChainTip localNodeConnInfo
+
+                  serCurrentEpochState <- lift (executeLocalStateQueryExpr localNodeConnInfo Nothing $ queryCurrentEpochState eInMode sbe)
+                    & onLeft (left . ShelleyQueryCmdAcquireFailure)
+                    & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
+                    & onLeft (left . ShelleyQueryCmdLocalStateQueryError . EraMismatchError)
+
+                  firstExceptT ShelleyQueryCmdLeaderShipError $ hoistEither
+                    $ shelleyBasedEraConstraints sbe
+                    $ nextEpochEligibleLeadershipSlots sbe shelleyGenesis
+                      serCurrentEpochState ptclState poolid vrkSkey bpp
+                      eInfo (tip, curentEpoch)
+
+              case mJsonOutputFile of
+                Nothing -> liftIO $ printLeadershipScheduleAsText schedule eInfo (SystemStart $ sgSystemStart shelleyGenesis)
+                Just (File jsonOutputFile) ->
+                  liftIO $ LBS.writeFile jsonOutputFile $
+                    printLeadershipScheduleAsJson schedule eInfo (SystemStart $ sgSystemStart shelleyGenesis)
+            mode -> left . ShelleyQueryCmdUnsupportedMode $ AnyConsensusMode mode
+    )
+    & onLeft (left . ShelleyQueryCmdAcquireFailure)
+    & onLeft left
  where
   printLeadershipScheduleAsText
     :: Set SlotNo

--- a/cardano-cli/src/Cardano/CLI/Run/Legacy/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Run/Legacy/Query.hs
@@ -799,33 +799,36 @@ runQueryStakeSnapshot
 runQueryStakeSnapshot socketPath (AnyConsensusModeParams cModeParams) network allOrOnlyPoolIds mOutFile = do
   let localNodeConnInfo = LocalNodeConnectInfo cModeParams network socketPath
 
-  anyE@(AnyCardanoEra era) <- lift (executeLocalStateQueryExpr localNodeConnInfo Nothing (determineEraExpr cModeParams))
+  join $ lift
+    ( executeLocalStateQueryExpr localNodeConnInfo Nothing $ runExceptT $ do
+        anyE@(AnyCardanoEra era) <- lift (determineEraExpr cModeParams)
+          & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
+
+        let cMode = consensusModeOnly cModeParams
+
+        sbe <- requireShelleyBasedEra era
+          & onNothing (left ShelleyQueryCmdByronEra)
+
+        eInMode <- toEraInMode era cMode
+          & hoistMaybe (ShelleyQueryCmdEraConsensusModeMismatch (AnyConsensusMode cMode) anyE)
+
+        let poolFilter = case allOrOnlyPoolIds of
+              All -> Nothing
+              Only poolIds -> Just $ Set.fromList poolIds
+
+        eraInMode2 <- calcEraInMode era $ consensusModeOnly cModeParams
+
+        requireNotByronEraInByronMode eraInMode2
+
+        result <- lift (queryStakeSnapshot eInMode sbe poolFilter)
+          & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
+          & onLeft (left . ShelleyQueryCmdLocalStateQueryError . EraMismatchError)
+
+        pure $ do
+          shelleyBasedEraConstraints sbe (writeStakeSnapshots mOutFile) result
+    )
     & onLeft (left . ShelleyQueryCmdAcquireFailure)
-    & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
-
-  let cMode = consensusModeOnly cModeParams
-
-  sbe <- requireShelleyBasedEra era
-    & onNothing (left ShelleyQueryCmdByronEra)
-
-  eInMode <- toEraInMode era cMode
-    & hoistMaybe (ShelleyQueryCmdEraConsensusModeMismatch (AnyConsensusMode cMode) anyE)
-
-  let poolFilter = case allOrOnlyPoolIds of
-        All -> Nothing
-        Only poolIds -> Just $ Set.fromList poolIds
-
-  eraInMode2 <- calcEraInMode era $ consensusModeOnly cModeParams
-
-  requireNotByronEraInByronMode eraInMode2
-
-  result <- lift (executeLocalStateQueryExpr localNodeConnInfo Nothing $ queryStakeSnapshot eInMode sbe poolFilter)
-    & onLeft (left . ShelleyQueryCmdAcquireFailure)
-    & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
-    & onLeft (left . ShelleyQueryCmdLocalStateQueryError . EraMismatchError)
-
-  shelleyBasedEraConstraints sbe $ writeStakeSnapshots mOutFile result
-
+    & onLeft left
 
 runQueryLedgerState
   :: SocketPath
@@ -836,28 +839,32 @@ runQueryLedgerState
 runQueryLedgerState socketPath (AnyConsensusModeParams cModeParams) network mOutFile = do
   let localNodeConnInfo = LocalNodeConnectInfo cModeParams network socketPath
 
-  anyE@(AnyCardanoEra era) <- lift (executeLocalStateQueryExpr localNodeConnInfo Nothing (determineEraExpr cModeParams))
+  join $ lift
+    ( executeLocalStateQueryExpr localNodeConnInfo Nothing $ runExceptT $ do
+        anyE@(AnyCardanoEra era) <- lift (determineEraExpr cModeParams)
+          & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
+
+        let cMode = consensusModeOnly cModeParams
+
+        sbe <- requireShelleyBasedEra era
+          & onNothing (left ShelleyQueryCmdByronEra)
+
+        eInMode <- pure (toEraInMode era cMode)
+          & onNothing (left (ShelleyQueryCmdEraConsensusModeMismatch (AnyConsensusMode cMode) anyE))
+
+        eraInMode <- calcEraInMode era $ consensusModeOnly cModeParams
+
+        requireNotByronEraInByronMode eraInMode
+
+        result <- lift (queryDebugLedgerState eInMode sbe)
+          & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
+          & onLeft (left . ShelleyQueryCmdLocalStateQueryError . EraMismatchError)
+
+        pure $ do
+          shelleyBasedEraConstraints sbe (writeLedgerState mOutFile) result
+    )
     & onLeft (left . ShelleyQueryCmdAcquireFailure)
-    & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
-
-  let cMode = consensusModeOnly cModeParams
-
-  sbe <- requireShelleyBasedEra era
-    & onNothing (left ShelleyQueryCmdByronEra)
-
-  eInMode <- pure (toEraInMode era cMode)
-    & onNothing (left (ShelleyQueryCmdEraConsensusModeMismatch (AnyConsensusMode cMode) anyE))
-
-  eraInMode <- calcEraInMode era $ consensusModeOnly cModeParams
-
-  requireNotByronEraInByronMode eraInMode
-
-  result <- lift (executeLocalStateQueryExpr localNodeConnInfo Nothing $ queryDebugLedgerState eInMode sbe)
-    & onLeft (left . ShelleyQueryCmdAcquireFailure)
-    & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
-    & onLeft (left . ShelleyQueryCmdLocalStateQueryError . EraMismatchError)
-
-  shelleyBasedEraConstraints sbe $ writeLedgerState mOutFile result
+    & onLeft left
 
 runQueryProtocolState
   :: SocketPath

--- a/cardano-cli/src/Cardano/CLI/Run/Legacy/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Run/Legacy/Query.hs
@@ -1210,28 +1210,32 @@ runQueryStakeDistribution
 runQueryStakeDistribution socketPath (AnyConsensusModeParams cModeParams) network mOutFile = do
   let localNodeConnInfo = LocalNodeConnectInfo cModeParams network socketPath
 
-  anyE@(AnyCardanoEra era) <- lift (executeLocalStateQueryExpr localNodeConnInfo Nothing (determineEraExpr cModeParams))
+  join $ lift
+    ( executeLocalStateQueryExpr localNodeConnInfo Nothing $ runExceptT $ do
+        anyE@(AnyCardanoEra era) <- lift (determineEraExpr cModeParams)
+          & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
+
+        let cMode = consensusModeOnly cModeParams
+
+        sbe <- requireShelleyBasedEra era
+          & onNothing (left ShelleyQueryCmdByronEra)
+
+        eInMode <- pure (toEraInMode era cMode)
+          & onNothing (left (ShelleyQueryCmdEraConsensusModeMismatch (AnyConsensusMode cMode) anyE))
+
+        eraInMode <- calcEraInMode era $ consensusModeOnly cModeParams
+
+        requireNotByronEraInByronMode eraInMode
+
+        result <- lift (queryStakeDistribution eInMode sbe)
+          & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
+          & onLeft (left . ShelleyQueryCmdLocalStateQueryError . EraMismatchError)
+
+        pure $ do
+          writeStakeDistribution mOutFile result
+    )
     & onLeft (left . ShelleyQueryCmdAcquireFailure)
-    & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
-
-  let cMode = consensusModeOnly cModeParams
-
-  sbe <- requireShelleyBasedEra era
-    & onNothing (left ShelleyQueryCmdByronEra)
-
-  eInMode <- pure (toEraInMode era cMode)
-    & onNothing (left (ShelleyQueryCmdEraConsensusModeMismatch (AnyConsensusMode cMode) anyE))
-
-  eraInMode <- calcEraInMode era $ consensusModeOnly cModeParams
-
-  requireNotByronEraInByronMode eraInMode
-
-  result <- lift (executeLocalStateQueryExpr localNodeConnInfo Nothing $ queryStakeDistribution eInMode sbe)
-    & onLeft (left . ShelleyQueryCmdAcquireFailure)
-    & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
-    & onLeft (left . ShelleyQueryCmdLocalStateQueryError . EraMismatchError)
-
-  writeStakeDistribution mOutFile result
+    & onLeft left
 
 writeStakeDistribution
   :: Maybe (File () Out)

--- a/cardano-cli/src/Cardano/CLI/Run/Legacy/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Run/Legacy/Query.hs
@@ -402,7 +402,7 @@ runQueryUTxO socketPath (AnyConsensusModeParams cModeParams)
              qfilter network mOutFile = do
   let localNodeConnInfo = LocalNodeConnectInfo cModeParams network socketPath
 
-  InAnyShelleyBasedEra sbe utxo <- lift
+  join $ lift
     ( executeLocalStateQueryExpr localNodeConnInfo Nothing $ runExceptT $ do
         anyE@(AnyCardanoEra era) <- lift (determineEraExpr cModeParams)
           & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
@@ -423,12 +423,11 @@ runQueryUTxO socketPath (AnyConsensusModeParams cModeParams)
           & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
           & onLeft (left . ShelleyQueryCmdLocalStateQueryError . EraMismatchError)
 
-        pure $ inAnyShelleyBasedEra sbe utxo
+        pure $ do
+          writeFilteredUTxOs sbe mOutFile utxo
     )
     & onLeft (left . ShelleyQueryCmdAcquireFailure)
     & onLeft left
-
-  writeFilteredUTxOs sbe mOutFile utxo
 
 runQueryKesPeriodInfo
   :: SocketPath

--- a/cardano-cli/src/Cardano/CLI/Run/Legacy/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/Run/Legacy/Transaction.hs
@@ -351,10 +351,6 @@ runTxBuildCmd
                             , localNodeSocketPath = socketPath
                             }
 
-  AnyCardanoEra nodeEra <- lift (executeLocalStateQueryExpr localNodeConnInfo Nothing (determineEraExpr cModeParams))
-    & onLeft (left . ShelleyTxCmdQueryConvenienceError . AcqFailure)
-    & onLeft (left . ShelleyTxCmdQueryConvenienceError . QceUnsupportedNtcVersion)
-
   inputsAndMaybeScriptWits <- firstExceptT ShelleyTxCmdScriptWitnessError $ readScriptWitnessFiles cEra txins
   certFilesAndMaybeScriptWits <- firstExceptT ShelleyTxCmdScriptWitnessError $ readScriptWitnessFiles cEra certs
 
@@ -435,6 +431,10 @@ runTxBuildCmd
 
       case consensusMode of
         CardanoMode -> do
+          AnyCardanoEra nodeEra <- lift (executeLocalStateQueryExpr localNodeConnInfo Nothing (determineEraExpr cModeParams))
+            & onLeft (left . ShelleyTxCmdQueryConvenienceError . AcqFailure)
+            & onLeft (left . ShelleyTxCmdQueryConvenienceError . QceUnsupportedNtcVersion)
+
           (nodeEraUTxO, _, eraHistory, systemStart, _, _) <-
             lift (executeLocalStateQueryExpr localNodeConnInfo Nothing (queryStateForBalancedTx nodeEra allTxInputs []))
               & onLeft (left . ShelleyTxCmdQueryConvenienceError . AcqFailure)


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Refactoring to merge queries to share the same connection
  compatibility: no-api-changes
  type: feature
```

# Context

Previously many of the commands were implemented in such a way as to open a new connection to the node for each query.  These can cause multiple connections to opened and closed during the execution of a single command.

This change greatly reduces the number of connections used by having the queries share the same connection instead.

This PR is carefully split into may smaller commits that shows the refactoring changes incrementally.  Each commit should compile on its own.

This draft PR confirms that integration tests still pass: https://github.com/input-output-hk/cardano-node/pull/5392

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
