### PR TITLE
Remove protocol params file from `transaction build`

### DIFF
--- a/cardano-cli/src/Cardano/CLI/Commands/Legacy.hs
+++ b/cardano-cli/src/Cardano/CLI/Commands/Legacy.hs
@@ -46,8 +46,6 @@ module Cardano.CLI.Commands.Legacy
   , BlockId (..)
   , WitnessSigningData (..)
   , ColdVerificationKeyOrFile (..)
-
-  , Deprecated (..)
   ) where
 
 import           Cardano.Api.Shelley hiding (QueryInShelleyBasedEra (..))
@@ -243,7 +241,6 @@ data TransactionCmd
       [ScriptFile]
       -- ^ Auxiliary scripts
       [MetadataFile]
-      (Maybe (Deprecated ProtocolParamsFile))
       (Maybe UpdateProposalFile)
       [VoteFile In]
       [NewConstitutionFile In]
@@ -590,6 +587,3 @@ data ColdVerificationKeyOrFile
   | ColdGenesisDelegateVerificationKey !(VerificationKey GenesisDelegateKey)
   | ColdVerificationKeyFile !(VerificationKeyFile In)
   deriving Show
-
--- | Marks a value as being deprecated.
-newtype Deprecated a = Deprecated a

--- a/cardano-cli/src/Cardano/CLI/EraBased/Legacy.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Legacy.hs
@@ -764,7 +764,6 @@ pTransaction envCli =
                   Nothing
                   "Filepath of auxiliary script(s)")
       <*> many pMetadataFile
-      <*> optional pDeprecatedProtocolParamsFile
       <*> optional pUpdateProposalFile
       <*> many (pFileInDirection "vote-file" "Filepath of the vote.")
       <*> many (pFileInDirection "constitution-file" "Filepath of the constitution.")
@@ -1664,19 +1663,6 @@ pAddressKeyType =
         , Opt.help "Use a Byron-era key."
         ]
     , pure AddressKeyShelley
-    ]
-
-pDeprecatedProtocolParamsFile :: Parser (Deprecated ProtocolParamsFile)
-pDeprecatedProtocolParamsFile =
-  fmap (Deprecated . ProtocolParamsFile) $ Opt.strOption $ mconcat
-    [ Opt.long "protocol-params-file"
-    , Opt.metavar "FILE"
-    , Opt.help $ mconcat
-        [ "Filepath of the JSON-encoded protocol parameters file. "
-        , "DEPRECATED The option is ignored and protocol parameters are "
-        , "retrieved from the node."
-        ]
-    , Opt.completer (Opt.bashCompleter "file")
     ]
 
 pProtocolParamsFile :: Parser ProtocolParamsFile

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -1422,7 +1422,6 @@ Usage: cardano-cli legacy transaction build --socket-path SOCKET_PATH
                                               [ --metadata-json-file FILE
                                               | --metadata-cbor-file FILE
                                               ]
-                                              [--protocol-params-file FILE]
                                               [--update-proposal-file FILE]
                                               [--vote-file FILE]
                                               [--constitution-file FILE]
@@ -2781,7 +2780,6 @@ Usage: cardano-cli transaction build --socket-path SOCKET_PATH
                                        [ --metadata-json-file FILE
                                        | --metadata-cbor-file FILE
                                        ]
-                                       [--protocol-params-file FILE]
                                        [--update-proposal-file FILE]
                                        [--vote-file FILE]
                                        [--constitution-file FILE]

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_transaction_build.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_transaction_build.cli
@@ -118,7 +118,6 @@ Usage: cardano-cli legacy transaction build --socket-path SOCKET_PATH
                                               [ --metadata-json-file FILE
                                               | --metadata-cbor-file FILE
                                               ]
-                                              [--protocol-params-file FILE]
                                               [--update-proposal-file FILE]
                                               [--vote-file FILE]
                                               [--constitution-file FILE]
@@ -398,10 +397,6 @@ Available options:
                            Filepath of the metadata file, in JSON format.
   --metadata-cbor-file FILE
                            Filepath of the metadata, in raw CBOR format.
-  --protocol-params-file FILE
-                           Filepath of the JSON-encoded protocol parameters
-                           file. DEPRECATED The option is ignored and protocol
-                           parameters are retrieved from the node.
   --update-proposal-file FILE
                            Filepath of the update proposal.
   --vote-file FILE         Filepath of the vote.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/transaction_build.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/transaction_build.cli
@@ -111,7 +111,6 @@ Usage: cardano-cli transaction build --socket-path SOCKET_PATH
                                        [ --metadata-json-file FILE
                                        | --metadata-cbor-file FILE
                                        ]
-                                       [--protocol-params-file FILE]
                                        [--update-proposal-file FILE]
                                        [--vote-file FILE]
                                        [--constitution-file FILE]
@@ -391,10 +390,6 @@ Available options:
                            Filepath of the metadata file, in JSON format.
   --metadata-cbor-file FILE
                            Filepath of the metadata, in raw CBOR format.
-  --protocol-params-file FILE
-                           Filepath of the JSON-encoded protocol parameters
-                           file. DEPRECATED The option is ignored and protocol
-                           parameters are retrieved from the node.
   --update-proposal-file FILE
                            Filepath of the update proposal.
   --vote-file FILE         Filepath of the vote.


### PR DESCRIPTION
# Description

Remove `--protocol-params-file`  from `transaction build`  command.

# Changelog

```yaml
- description: |
    Remove `--protocol-params-file`  from `transaction build`  command.
  # no-changes: the API has not changed
  # compatible: the API has changed but is non-breaking
  # breaking: the API has changed in a breaking way
  compatibility: breaking
  # feature: the change implements a new feature in the API
  # bugfix: the change fixes a bug in the API
  # test: the change fixes modifies tests
  # maintenance: the change involves something other than the API
  # If more than one is applicable, it may be put into a list.
  type: feature
```

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [x] CI passes. See note on CI.  The following CI checks are required:
  - [x] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [x] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [x] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [x] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
