### PR TITLE
Use new function-based API instead of using query data types directly

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -14,7 +14,7 @@ repository cardano-haskell-packages
 -- you need to run if you change them
 index-state:
   , hackage.haskell.org 2023-06-05T00:00:00Z
-  , cardano-haskell-packages 2023-06-15T12:05:43Z
+  , cardano-haskell-packages 2023-06-20T00:00:00Z
 
 packages:
     cardano-cli

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -110,7 +110,7 @@ library
                       , binary
                       , bytestring
                       , canonical-json
-                      , cardano-api ^>= 8.4
+                      , cardano-api ^>= 8.5.2
                       , cardano-binary
                       , cardano-crypto
                       , cardano-crypto-class >= 2.1.1
@@ -198,8 +198,8 @@ test-suite cardano-cli-test
                       , base16-bytestring
                       , bech32 >= 1.1.0
                       , bytestring
-                      , cardano-api ^>= 8.4
-                      , cardano-api:internal ^>= 8.4
+                      , cardano-api ^>= 8.5.2
+                      , cardano-api:internal ^>= 8.5.2
                       , cardano-api-gen ^>= 8.1.0.2
                       , cardano-cli
                       , cardano-cli:cardano-cli-test-lib
@@ -240,7 +240,7 @@ test-suite cardano-cli-golden
   build-depends:        aeson >= 1.5.6.0
                       , base16-bytestring
                       , bytestring
-                      , cardano-api ^>= 8.4
+                      , cardano-api ^>= 8.5.2
                       , cardano-cli
                       , cardano-cli:cardano-cli-test-lib
                       , cardano-crypto-class ^>= 2.1

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
@@ -363,8 +363,9 @@ runQueryUTxO socketPath (AnyConsensusModeParams cModeParams)
              qfilter network mOutFile = do
   let localNodeConnInfo = LocalNodeConnectInfo cModeParams network socketPath
 
-  anyE@(AnyCardanoEra era) <- lift (determineEra cModeParams localNodeConnInfo)
+  anyE@(AnyCardanoEra era) <- lift (executeLocalStateQueryExpr localNodeConnInfo Nothing (determineEraExpr cModeParams))
     & onLeft (left . ShelleyQueryCmdAcquireFailure)
+    & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
 
   let cMode = consensusModeOnly cModeParams
   sbe <- getSbe $ cardanoEraStyle era
@@ -392,8 +393,9 @@ runQueryKesPeriodInfo socketPath (AnyConsensusModeParams cModeParams) network no
 
   let localNodeConnInfo = LocalNodeConnectInfo cModeParams network socketPath
 
-  anyE@(AnyCardanoEra era) <- lift (determineEra cModeParams localNodeConnInfo)
+  anyE@(AnyCardanoEra era) <- lift (executeLocalStateQueryExpr localNodeConnInfo Nothing (determineEraExpr cModeParams))
     & onLeft (left . ShelleyQueryCmdAcquireFailure)
+    & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
 
   let cMode = consensusModeOnly cModeParams
   sbe <- getSbe $ cardanoEraStyle era
@@ -652,8 +654,9 @@ runQueryPoolState
 runQueryPoolState socketPath (AnyConsensusModeParams cModeParams) network poolIds = do
   let localNodeConnInfo = LocalNodeConnectInfo cModeParams network socketPath
 
-  anyE@(AnyCardanoEra era) <- lift (determineEra cModeParams localNodeConnInfo)
+  anyE@(AnyCardanoEra era) <- lift (executeLocalStateQueryExpr localNodeConnInfo Nothing (determineEraExpr cModeParams))
     & onLeft (left . ShelleyQueryCmdAcquireFailure)
+    & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
 
   let cMode = consensusModeOnly cModeParams
   sbe <- getSbe $ cardanoEraStyle era
@@ -678,8 +681,9 @@ runQueryTxMempool socketPath (AnyConsensusModeParams cModeParams) network query 
 
   localQuery <- case query of
       TxMempoolQueryTxExists tx -> do
-        anyE@(AnyCardanoEra era) <- lift (determineEra cModeParams localNodeConnInfo)
+        anyE@(AnyCardanoEra era) <- lift (executeLocalStateQueryExpr localNodeConnInfo Nothing (determineEraExpr cModeParams))
           & onLeft (left . ShelleyQueryCmdAcquireFailure)
+          & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
         let cMode = consensusModeOnly cModeParams
         eInMode <- toEraInMode era cMode
           & hoistMaybe (ShelleyQueryCmdEraConsensusModeMismatch (AnyConsensusMode cMode) anyE)
@@ -717,8 +721,9 @@ runQueryStakeSnapshot
 runQueryStakeSnapshot socketPath (AnyConsensusModeParams cModeParams) network allOrOnlyPoolIds mOutFile = do
   let localNodeConnInfo = LocalNodeConnectInfo cModeParams network socketPath
 
-  anyE@(AnyCardanoEra era) <- lift (determineEra cModeParams localNodeConnInfo)
+  anyE@(AnyCardanoEra era) <- lift (executeLocalStateQueryExpr localNodeConnInfo Nothing (determineEraExpr cModeParams))
     & onLeft (left . ShelleyQueryCmdAcquireFailure)
+    & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
 
   let cMode = consensusModeOnly cModeParams
   sbe <- getSbe $ cardanoEraStyle era
@@ -743,8 +748,9 @@ runQueryLedgerState
 runQueryLedgerState socketPath (AnyConsensusModeParams cModeParams) network mOutFile = do
   let localNodeConnInfo = LocalNodeConnectInfo cModeParams network socketPath
 
-  anyE@(AnyCardanoEra era) <- lift (determineEra cModeParams localNodeConnInfo)
+  anyE@(AnyCardanoEra era) <- lift (executeLocalStateQueryExpr localNodeConnInfo Nothing (determineEraExpr cModeParams))
     & onLeft (left . ShelleyQueryCmdAcquireFailure)
+    & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
 
   let cMode = consensusModeOnly cModeParams
   sbe <- getSbe $ cardanoEraStyle era
@@ -767,8 +773,9 @@ runQueryProtocolState
 runQueryProtocolState socketPath (AnyConsensusModeParams cModeParams) network mOutFile = do
   let localNodeConnInfo = LocalNodeConnectInfo cModeParams network socketPath
 
-  anyE@(AnyCardanoEra era) <- lift (determineEra cModeParams localNodeConnInfo)
+  anyE@(AnyCardanoEra era) <- lift (executeLocalStateQueryExpr localNodeConnInfo Nothing (determineEraExpr cModeParams))
     & onLeft (left . ShelleyQueryCmdAcquireFailure)
+    & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
 
   let cMode = consensusModeOnly cModeParams
   sbe <- getSbe $ cardanoEraStyle era
@@ -797,8 +804,9 @@ runQueryStakeAddressInfo
 runQueryStakeAddressInfo socketPath (AnyConsensusModeParams cModeParams) (StakeAddress _ addr) network mOutFile = do
   let localNodeConnInfo = LocalNodeConnectInfo cModeParams network socketPath
 
-  anyE@(AnyCardanoEra era) <- lift (determineEra cModeParams localNodeConnInfo)
+  anyE@(AnyCardanoEra era) <- lift (executeLocalStateQueryExpr localNodeConnInfo Nothing (determineEraExpr cModeParams))
     & onLeft (left . ShelleyQueryCmdAcquireFailure)
+    & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
 
   let cMode = consensusModeOnly cModeParams
   sbe <- getSbe $ cardanoEraStyle era
@@ -1075,8 +1083,9 @@ runQueryStakeDistribution
 runQueryStakeDistribution socketPath (AnyConsensusModeParams cModeParams) network mOutFile = do
   let localNodeConnInfo = LocalNodeConnectInfo cModeParams network socketPath
 
-  anyE@(AnyCardanoEra era) <- lift (determineEra cModeParams localNodeConnInfo)
+  anyE@(AnyCardanoEra era) <- lift (executeLocalStateQueryExpr localNodeConnInfo Nothing (determineEraExpr cModeParams))
     & onLeft (left . ShelleyQueryCmdAcquireFailure)
+    & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
 
   let cMode = consensusModeOnly cModeParams
   sbe <- getSbe $ cardanoEraStyle era
@@ -1197,8 +1206,9 @@ runQueryLeadershipSchedule
     whichSchedule mJsonOutputFile = do
   let localNodeConnInfo = LocalNodeConnectInfo cModeParams network socketPath
 
-  anyE@(AnyCardanoEra era) <- lift (determineEra cModeParams localNodeConnInfo)
+  anyE@(AnyCardanoEra era) <- lift (executeLocalStateQueryExpr localNodeConnInfo Nothing (determineEraExpr cModeParams))
     & onLeft (left . ShelleyQueryCmdAcquireFailure)
+    & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
 
   sbe <- getSbe (cardanoEraStyle era)
 

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
@@ -376,7 +376,7 @@ runQueryUTxO socketPath (AnyConsensusModeParams cModeParams)
 
   requireNotByronEraInByronMode eraInMode
 
-  result <- lift (executeLocalStateQueryExpr localNodeConnInfo Nothing $ queryExpr $ QueryInEra eInMode $ QueryInShelleyBasedEra sbe (QueryUTxO qfilter))
+  result <- lift (executeLocalStateQueryExpr localNodeConnInfo Nothing $ queryUtxo eInMode sbe qfilter)
     & onLeft (left . ShelleyQueryCmdAcquireFailure)
     & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
     & onLeft (left . ShelleyQueryCmdLocalStateQueryError . EraMismatchError)
@@ -413,7 +413,7 @@ runQueryKesPeriodInfo socketPath (AnyConsensusModeParams cModeParams) network no
 
       requireNotByronEraInByronMode eraInMode
 
-      gParams <- lift (executeLocalStateQueryExpr localNodeConnInfo Nothing $ queryExpr $ QueryInEra eInMode . QueryInShelleyBasedEra sbe $ QueryGenesisParameters)
+      gParams <- lift (executeLocalStateQueryExpr localNodeConnInfo Nothing $ queryGenesisParameters eInMode sbe)
         & onLeft (left . ShelleyQueryCmdAcquireFailure)
         & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
         & onLeft (left . ShelleyQueryCmdLocalStateQueryError . EraMismatchError)
@@ -433,7 +433,7 @@ runQueryKesPeriodInfo socketPath (AnyConsensusModeParams cModeParams) network no
 
       -- We get the operational certificate counter from the protocol state and check that
       -- it is equivalent to what we have on disk.
-      ptclState <- lift (executeLocalStateQueryExpr localNodeConnInfo Nothing $ queryExpr $ QueryInEra eInMode . QueryInShelleyBasedEra sbe $ QueryProtocolState)
+      ptclState <- lift (executeLocalStateQueryExpr localNodeConnInfo Nothing $ queryProtocolState eInMode sbe)
         & onLeft (left . ShelleyQueryCmdAcquireFailure)
         & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
         & onLeft (left . ShelleyQueryCmdLocalStateQueryError . EraMismatchError)
@@ -679,7 +679,7 @@ runQueryPoolState socketPath (AnyConsensusModeParams cModeParams) network poolId
 
   requireNotByronEraInByronMode eraInMode
 
-  result <- lift (executeLocalStateQueryExpr localNodeConnInfo Nothing $ queryExpr $ QueryInEra eInMode . QueryInShelleyBasedEra sbe $ QueryPoolState $ Just $ Set.fromList poolIds)
+  result <- lift (executeLocalStateQueryExpr localNodeConnInfo Nothing $ queryPoolState eInMode sbe $ Just $ Set.fromList poolIds)
     & onLeft (left . ShelleyQueryCmdAcquireFailure)
     & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
     & onLeft (left . ShelleyQueryCmdLocalStateQueryError . EraMismatchError)
@@ -749,7 +749,7 @@ runQueryStakeSnapshot socketPath (AnyConsensusModeParams cModeParams) network al
   eInMode <- toEraInMode era cMode
     & hoistMaybe (ShelleyQueryCmdEraConsensusModeMismatch (AnyConsensusMode cMode) anyE)
 
-  let qInMode = QueryInEra eInMode . QueryInShelleyBasedEra sbe $ QueryStakeSnapshot $ case allOrOnlyPoolIds of
+  let poolFilter = case allOrOnlyPoolIds of
         All -> Nothing
         Only poolIds -> Just $ Set.fromList poolIds
 
@@ -757,7 +757,7 @@ runQueryStakeSnapshot socketPath (AnyConsensusModeParams cModeParams) network al
 
   requireNotByronEraInByronMode eraInMode2
 
-  result <- lift (executeLocalStateQueryExpr localNodeConnInfo Nothing $ queryExpr qInMode)
+  result <- lift (executeLocalStateQueryExpr localNodeConnInfo Nothing $ queryStakeSnapshot eInMode sbe poolFilter)
     & onLeft (left . ShelleyQueryCmdAcquireFailure)
     & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
     & onLeft (left . ShelleyQueryCmdLocalStateQueryError . EraMismatchError)
@@ -788,7 +788,7 @@ runQueryLedgerState socketPath (AnyConsensusModeParams cModeParams) network mOut
 
   requireNotByronEraInByronMode eraInMode
 
-  result <- lift (executeLocalStateQueryExpr localNodeConnInfo Nothing $ queryExpr $ QueryInEra eInMode . QueryInShelleyBasedEra sbe $ QueryDebugLedgerState)
+  result <- lift (executeLocalStateQueryExpr localNodeConnInfo Nothing $ queryDebugLedgerState eInMode sbe)
     & onLeft (left . ShelleyQueryCmdAcquireFailure)
     & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
     & onLeft (left . ShelleyQueryCmdLocalStateQueryError . EraMismatchError)
@@ -818,7 +818,7 @@ runQueryProtocolState socketPath (AnyConsensusModeParams cModeParams) network mO
 
   requireNotByronEraInByronMode eraInMode
 
-  result <- lift (executeLocalStateQueryExpr localNodeConnInfo Nothing $ queryExpr $ QueryInEra eInMode . QueryInShelleyBasedEra sbe $ QueryProtocolState)
+  result <- lift (executeLocalStateQueryExpr localNodeConnInfo Nothing $ queryProtocolState eInMode sbe)
     & onLeft (left . ShelleyQueryCmdAcquireFailure)
     & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
     & onLeft (left . ShelleyQueryCmdLocalStateQueryError . EraMismatchError)
@@ -856,7 +856,7 @@ runQueryStakeAddressInfo socketPath (AnyConsensusModeParams cModeParams) (StakeA
 
   requireNotByronEraInByronMode eraInMode
 
-  result <- lift (executeLocalStateQueryExpr localNodeConnInfo Nothing $ queryExpr $ QueryInEra eInMode . QueryInShelleyBasedEra sbe $ QueryStakeAddresses stakeAddr network)
+  result <- lift (executeLocalStateQueryExpr localNodeConnInfo Nothing $ queryStakeAddresses eInMode sbe stakeAddr network)
     & onLeft (left . ShelleyQueryCmdAcquireFailure)
     & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
     & onLeft (left . ShelleyQueryCmdLocalStateQueryError . EraMismatchError)
@@ -1139,7 +1139,7 @@ runQueryStakeDistribution socketPath (AnyConsensusModeParams cModeParams) networ
 
   requireNotByronEraInByronMode eraInMode
 
-  result <- lift (executeLocalStateQueryExpr localNodeConnInfo Nothing $ queryExpr $ QueryInEra eInMode . QueryInShelleyBasedEra sbe $ QueryStakeDistribution)
+  result <- lift (executeLocalStateQueryExpr localNodeConnInfo Nothing $ queryStakeDistribution eInMode sbe)
     & onLeft (left . ShelleyQueryCmdAcquireFailure)
     & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
     & onLeft (left . ShelleyQueryCmdLocalStateQueryError . EraMismatchError)
@@ -1279,12 +1279,12 @@ runQueryLeadershipSchedule
 
       requireNotByronEraInByronMode eraInMode
 
-      pparams <- lift (executeLocalStateQueryExpr localNodeConnInfo Nothing $ queryExpr $ QueryInEra eInMode $ QueryInShelleyBasedEra sbe QueryProtocolParameters)
+      pparams <- lift (executeLocalStateQueryExpr localNodeConnInfo Nothing $ queryProtocolParameters eInMode sbe)
         & onLeft (left . ShelleyQueryCmdAcquireFailure)
         & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
         & onLeft (left . ShelleyQueryCmdLocalStateQueryError . EraMismatchError)
 
-      ptclState <- lift (executeLocalStateQueryExpr localNodeConnInfo Nothing $ queryExpr $ QueryInEra eInMode . QueryInShelleyBasedEra sbe $ QueryProtocolState)
+      ptclState <- lift (executeLocalStateQueryExpr localNodeConnInfo Nothing $ queryProtocolState eInMode sbe)
         & onLeft (left . ShelleyQueryCmdAcquireFailure)
         & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
         & onLeft (left . ShelleyQueryCmdLocalStateQueryError . EraMismatchError)
@@ -1295,7 +1295,7 @@ runQueryLeadershipSchedule
 
       let eInfo = toEpochInfo eraHistory
 
-      curentEpoch <- lift (executeLocalStateQueryExpr localNodeConnInfo Nothing $ queryExpr $ QueryInEra eInMode $ QueryInShelleyBasedEra sbe QueryEpoch)
+      curentEpoch <- lift (executeLocalStateQueryExpr localNodeConnInfo Nothing $ queryEpoch eInMode sbe)
         & onLeft (left . ShelleyQueryCmdAcquireFailure)
         & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
         & onLeft (left . ShelleyQueryCmdLocalStateQueryError . EraMismatchError)
@@ -1305,7 +1305,7 @@ runQueryLeadershipSchedule
 
       schedule <- case whichSchedule of
         CurrentEpoch -> do
-          serCurrentEpochState <- lift (executeLocalStateQueryExpr localNodeConnInfo Nothing $ queryExpr $ QueryInEra eInMode $ QueryInShelleyBasedEra sbe (QueryPoolDistribution (Just (Set.singleton poolid))))
+          serCurrentEpochState <- lift (executeLocalStateQueryExpr localNodeConnInfo Nothing $ queryPoolDistribution eInMode sbe (Just (Set.singleton poolid)))
             & onLeft (left . ShelleyQueryCmdAcquireFailure)
             & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
             & onLeft (left . ShelleyQueryCmdLocalStateQueryError . EraMismatchError)
@@ -1326,7 +1326,7 @@ runQueryLeadershipSchedule
         NextEpoch -> do
           tip <- liftIO $ getLocalChainTip localNodeConnInfo
 
-          serCurrentEpochState <- lift (executeLocalStateQueryExpr localNodeConnInfo Nothing $ queryExpr $ QueryInEra eInMode $ QueryInShelleyBasedEra sbe QueryCurrentEpochState)
+          serCurrentEpochState <- lift (executeLocalStateQueryExpr localNodeConnInfo Nothing $ queryCurrentEpochState eInMode sbe)
             & onLeft (left . ShelleyQueryCmdAcquireFailure)
             & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
             & onLeft (left . ShelleyQueryCmdLocalStateQueryError . EraMismatchError)

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
@@ -215,7 +215,7 @@ runQueryProtocolParameters socketPath (AnyConsensusModeParams cModeParams) netwo
         eInMode <- toEraInMode era cMode
           & hoistMaybe (ShelleyQueryCmdEraConsensusModeMismatch (AnyConsensusMode cMode) anyE)
 
-        lift (queryPparams eInMode sbe)
+        lift (queryProtocolParameters eInMode sbe)
           & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
           & onLeft (left . ShelleyQueryCmdEraMismatch)
 
@@ -1412,8 +1412,9 @@ utcTimeToSlotNo socketPath (AnyConsensusModeParams cModeParams) network utcTime 
 
             pure (Api.getSlotForRelativeTime relTime eraHistory)
               & onLeft (left . ShelleyQueryCmdPastHorizon)
-        ) & onLeft (left . ShelleyQueryCmdAcquireFailure)
-          & onLeft left
+        )
+        & onLeft (left . ShelleyQueryCmdAcquireFailure)
+        & onLeft left
 
     mode -> left . ShelleyQueryCmdUnsupportedMode $ AnyConsensusMode mode
 

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Query.hs
@@ -207,17 +207,17 @@ runQueryProtocolParameters socketPath (AnyConsensusModeParams cModeParams) netwo
     anyE@(AnyCardanoEra era) <- lift (determineEraExpr cModeParams)
       & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
 
-    case cardanoEraStyle era of
-      LegacyByronEra -> left ShelleyQueryCmdByronEra
-      ShelleyBasedEra sbe -> do
-        let cMode = consensusModeOnly cModeParams
+    sbe <- requireShelleyBasedEra era
+      & onNothing (left ShelleyQueryCmdByronEra)
 
-        eInMode <- toEraInMode era cMode
-          & hoistMaybe (ShelleyQueryCmdEraConsensusModeMismatch (AnyConsensusMode cMode) anyE)
+    let cMode = consensusModeOnly cModeParams
 
-        lift (queryProtocolParameters eInMode sbe)
-          & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
-          & onLeft (left . ShelleyQueryCmdEraMismatch)
+    eInMode <- toEraInMode era cMode
+      & hoistMaybe (ShelleyQueryCmdEraConsensusModeMismatch (AnyConsensusMode cMode) anyE)
+
+    lift (queryProtocolParameters eInMode sbe)
+      & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
+      & onLeft (left . ShelleyQueryCmdEraMismatch)
 
   writeProtocolParameters mOutFile =<< except (join (first ShelleyQueryCmdAcquireFailure result))
 
@@ -367,7 +367,9 @@ runQueryUTxO socketPath (AnyConsensusModeParams cModeParams)
     & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
 
   let cMode = consensusModeOnly cModeParams
-  sbe <- getSbe $ cardanoEraStyle era
+
+  sbe <- requireShelleyBasedEra era
+    & onNothing (left ShelleyQueryCmdByronEra)
 
   eInMode <- pure (toEraInMode era cMode)
     & onNothing (left (ShelleyQueryCmdEraConsensusModeMismatch (AnyConsensusMode cMode) anyE))
@@ -401,7 +403,10 @@ runQueryKesPeriodInfo socketPath (AnyConsensusModeParams cModeParams) network no
     & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
 
   let cMode = consensusModeOnly cModeParams
-  sbe <- getSbe $ cardanoEraStyle era
+
+  sbe <- requireShelleyBasedEra era
+    & onNothing (left ShelleyQueryCmdByronEra)
+
   case cMode of
     CardanoMode -> do
       eInMode <- toEraInMode era cMode
@@ -670,7 +675,9 @@ runQueryPoolState socketPath (AnyConsensusModeParams cModeParams) network poolId
     & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
 
   let cMode = consensusModeOnly cModeParams
-  sbe <- getSbe $ cardanoEraStyle era
+
+  sbe <- requireShelleyBasedEra era
+    & onNothing (left ShelleyQueryCmdByronEra)
 
   eInMode <- toEraInMode era cMode
     & hoistMaybe (ShelleyQueryCmdEraConsensusModeMismatch (AnyConsensusMode cMode) anyE)
@@ -744,7 +751,9 @@ runQueryStakeSnapshot socketPath (AnyConsensusModeParams cModeParams) network al
     & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
 
   let cMode = consensusModeOnly cModeParams
-  sbe <- getSbe $ cardanoEraStyle era
+
+  sbe <- requireShelleyBasedEra era
+    & onNothing (left ShelleyQueryCmdByronEra)
 
   eInMode <- toEraInMode era cMode
     & hoistMaybe (ShelleyQueryCmdEraConsensusModeMismatch (AnyConsensusMode cMode) anyE)
@@ -779,7 +788,9 @@ runQueryLedgerState socketPath (AnyConsensusModeParams cModeParams) network mOut
     & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
 
   let cMode = consensusModeOnly cModeParams
-  sbe <- getSbe $ cardanoEraStyle era
+
+  sbe <- requireShelleyBasedEra era
+    & onNothing (left ShelleyQueryCmdByronEra)
 
   eInMode <- pure (toEraInMode era cMode)
     & onNothing (left (ShelleyQueryCmdEraConsensusModeMismatch (AnyConsensusMode cMode) anyE))
@@ -809,7 +820,9 @@ runQueryProtocolState socketPath (AnyConsensusModeParams cModeParams) network mO
     & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
 
   let cMode = consensusModeOnly cModeParams
-  sbe <- getSbe $ cardanoEraStyle era
+
+  sbe <- requireShelleyBasedEra era
+    & onNothing (left ShelleyQueryCmdByronEra)
 
   eInMode <- pure (toEraInMode era cMode)
     & onNothing (left (ShelleyQueryCmdEraConsensusModeMismatch (AnyConsensusMode cMode) anyE))
@@ -845,7 +858,9 @@ runQueryStakeAddressInfo socketPath (AnyConsensusModeParams cModeParams) (StakeA
     & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
 
   let cMode = consensusModeOnly cModeParams
-  sbe <- getSbe $ cardanoEraStyle era
+
+  sbe <- requireShelleyBasedEra era
+    & onNothing (left ShelleyQueryCmdByronEra)
 
   eInMode <- pure (toEraInMode era cMode)
     & onNothing (left (ShelleyQueryCmdEraConsensusModeMismatch (AnyConsensusMode cMode) anyE))
@@ -1094,7 +1109,8 @@ runQueryStakePools socketPath (AnyConsensusModeParams cModeParams) network mOutF
         eInMode <- toEraInMode era cMode
           & hoistMaybe (ShelleyQueryCmdEraConsensusModeMismatch (AnyConsensusMode cMode) anyE)
 
-        sbe <- getSbe $ cardanoEraStyle era
+        sbe <- requireShelleyBasedEra era
+          & onNothing (left ShelleyQueryCmdByronEra)
 
         lift (queryStakePools eInMode sbe)
           & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
@@ -1130,7 +1146,9 @@ runQueryStakeDistribution socketPath (AnyConsensusModeParams cModeParams) networ
     & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
 
   let cMode = consensusModeOnly cModeParams
-  sbe <- getSbe $ cardanoEraStyle era
+
+  sbe <- requireShelleyBasedEra era
+    & onNothing (left ShelleyQueryCmdByronEra)
 
   eInMode <- pure (toEraInMode era cMode)
     & onNothing (left (ShelleyQueryCmdEraConsensusModeMismatch (AnyConsensusMode cMode) anyE))
@@ -1257,7 +1275,8 @@ runQueryLeadershipSchedule
     & onLeft (left . ShelleyQueryCmdAcquireFailure)
     & onLeft (left . ShelleyQueryCmdUnsupportedNtcVersion)
 
-  sbe <- getSbe (cardanoEraStyle era)
+  sbe <- requireShelleyBasedEra era
+    & onNothing (left ShelleyQueryCmdByronEra)
 
   let cMode = consensusModeOnly cModeParams
 
@@ -1418,10 +1437,6 @@ requireNotByronEraInByronMode :: EraInMode era mode -> ExceptT ShelleyQueryCmdEr
 requireNotByronEraInByronMode = \case
   ByronEraInByronMode -> left ShelleyQueryCmdByronEra
   _ -> pure ()
-
-getSbe :: Monad m => CardanoEraStyle era -> ExceptT ShelleyQueryCmdError m (Api.ShelleyBasedEra era)
-getSbe LegacyByronEra = left ShelleyQueryCmdByronEra
-getSbe (Api.ShelleyBasedEra sbe) = return sbe
 
 toEpochInfo :: EraHistory CardanoMode -> EpochInfo (Either Text)
 toEpochInfo (EraHistory _ interpreter) =

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Transaction.hs
@@ -342,8 +342,9 @@ runTxBuildCmd
                             , localNodeSocketPath = socketPath
                             }
 
-  AnyCardanoEra nodeEra <- lift (determineEra cModeParams localNodeConnInfo)
+  AnyCardanoEra nodeEra <- lift (executeLocalStateQueryExpr localNodeConnInfo Nothing (determineEraExpr cModeParams))
     & onLeft (left . ShelleyTxCmdQueryConvenienceError . AcqFailure)
+    & onLeft (left . ShelleyTxCmdQueryConvenienceError . QceUnsupportedNtcVersion)
 
   inputsAndMaybeScriptWits <- firstExceptT ShelleyTxCmdScriptWitnessError $ readScriptWitnessFiles cEra txins
   certFilesAndMaybeScriptWits <- firstExceptT ShelleyTxCmdScriptWitnessError $ readScriptWitnessFiles cEra certs
@@ -686,8 +687,10 @@ runTxBuild
                                      , localNodeNetworkId = networkId
                                      , localNodeSocketPath = socketPath
                                      }
-      AnyCardanoEra nodeEra <- lift (determineEra cModeParams localNodeConnInfo)
+
+      AnyCardanoEra nodeEra <- lift (executeLocalStateQueryExpr localNodeConnInfo Nothing (determineEraExpr cModeParams))
         & onLeft (left . ShelleyTxCmdQueryConvenienceError . AcqFailure)
+        & onLeft (left . ShelleyTxCmdQueryConvenienceError . QceUnsupportedNtcVersion)
 
       let certs =
             case validatedTxCerts of

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Transaction.hs
@@ -32,10 +32,10 @@ import           Cardano.CLI.Types
 import           Ouroboros.Consensus.Cardano.Block (EraMismatch (..))
 import qualified Ouroboros.Network.Protocol.LocalTxSubmission.Client as Net.Tx
 
-import           Control.Monad (forM, forM_, void)
+import           Control.Monad (forM, forM_)
 import           Control.Monad.IO.Class (MonadIO (..))
 import           Control.Monad.Trans (MonadTrans (..))
-import           Control.Monad.Trans.Except (ExceptT)
+import           Control.Monad.Trans.Except
 import           Control.Monad.Trans.Except.Extra (firstExceptT, hoistEither, hoistMaybe, left,
                    newExceptT, onLeft, onNothing)
 import           Data.Aeson.Encode.Pretty (encodePretty)
@@ -45,6 +45,7 @@ import qualified Data.ByteString.Lazy.Char8 as LBS
 import           Data.Data ((:~:) (..))
 import           Data.Foldable (Foldable (..))
 import           Data.Function ((&))
+import           Data.Functor
 import qualified Data.List as List
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
@@ -784,9 +785,11 @@ data TxFeature = TxFeatureShelleyAddresses
                | TxFeatureReturnCollateral
   deriving Show
 
-txFeatureMismatch :: CardanoEra era
-                  -> TxFeature
-                  -> ExceptT ShelleyTxCmdError IO a
+txFeatureMismatch :: ()
+  => Monad m
+  => CardanoEra era
+  -> TxFeature
+  -> ExceptT ShelleyTxCmdError m a
 txFeatureMismatch era feature =
     hoistEither . Left $ ShelleyTxCmdTxFeatureMismatch (anyCardanoEra era) feature
 
@@ -866,14 +869,14 @@ toAddressInAnyEra
   :: CardanoEra era
   -> AddressAny
   -> Either ShelleyTxCmdError (AddressInEra era)
-toAddressInAnyEra era addrAny =
+toAddressInAnyEra era addrAny = runExcept $ do
   case addrAny of
-    AddressByron   bAddr -> return (AddressInEra ByronAddressInAnyEra bAddr)
-    AddressShelley sAddr ->
-      case cardanoEraStyle era of
-        LegacyByronEra -> txFeatureMismatchPure era TxFeatureShelleyAddresses
-        ShelleyBasedEra era' ->
-          return (AddressInEra (ShelleyAddressInEra era') sAddr)
+    AddressByron   bAddr -> pure (AddressInEra ByronAddressInAnyEra bAddr)
+    AddressShelley sAddr -> do
+      sbe <- requireShelleyBasedEra era
+        & onNothing (txFeatureMismatch era TxFeatureShelleyAddresses)
+
+      pure (AddressInEra (ShelleyAddressInEra sbe) sAddr)
 
 toTxOutValueInAnyEra
   :: CardanoEra era

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1686832558,
-        "narHash": "sha256-ShN++GEuj09VR2Q4zGNM9IGTKk+xfXnl8BXQG7tGQOA=",
+        "lastModified": 1687312611,
+        "narHash": "sha256-Tvq04QEK/Kkj977GM3p7KxGtOrl15ef2y6OagSS5gtM=",
         "owner": "input-output-hk",
         "repo": "cardano-haskell-packages",
-        "rev": "bc32b60d563860e2dab2a66ea558699ce72c7c29",
+        "rev": "42e80e6600314053b7e0db2cb71725b9a1c8cdcf",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Also use `executeLocalStateQueryExpr` in place of other functions where possible.

A future PR will combined nearby invocations of `executeLocalStateQueryExpr` into a single query.

# Changelog

```yaml
- description: |
    Use new function-based API instead of using query data types directly.  Also use `executeLocalStateQueryExpr` in place of other functions where possible.
  compatibility: no-api-changes
  type: maintenance
```

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
