### PR TITLE
Accomodate ouroboros-api changes due to the BF PR

### DIFF
--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -53,7 +53,7 @@ library
   exposed-modules:      Cardano.CLI.Conway.Commands
                         Cardano.CLI.Conway.Parsers
                         Cardano.CLI.Conway.Types
-  
+
                         Cardano.CLI.Environment
                         Cardano.CLI.Helpers
                         Cardano.CLI.Parsers
@@ -147,8 +147,8 @@ library
                       , microlens
                       , network
                       , optparse-applicative-fork
-                      , ouroboros-consensus >= 0.7
-                      , ouroboros-consensus-cardano >= 0.6
+                      , ouroboros-consensus >= 0.9
+                      , ouroboros-consensus-cardano >= 0.7
                       , ouroboros-consensus-protocol >= 0.5
                       , ouroboros-network-api
                       , ouroboros-network-protocols

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Read.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Read.hs
@@ -497,6 +497,7 @@ acceptTxCDDLSerialisation file err =
    e@(FileError _ (TextEnvelopeTypeError _ _)) ->
       first (CddlErrorTextEnv e) <$> readCddlTx file
    e@FileErrorTempFile{} -> return . Left $ CddlIOError e
+   e@FileDoesNotExistError{} -> return . Left $ CddlIOError e
    e@FileIOError{} -> return . Left $ CddlIOError e
    e@FileDoesNotExistError{} -> return . Left $ CddlIOError e
 
@@ -562,6 +563,7 @@ acceptKeyWitnessCDDLSerialisation err =
     e@(FileError fp (TextEnvelopeTypeError _ _)) ->
       first (CddlWitnessErrorTextEnv e) <$> readCddlWitness fp
     e@FileErrorTempFile{} -> return . Left $ CddlWitnessIOError e
+    e@FileDoesNotExistError{} -> return . Left $ CddlWitnessIOError e
     e@FileIOError{} -> return . Left $ CddlWitnessIOError e
     e@FileDoesNotExistError{} -> return . Left $ CddlWitnessIOError e
 


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Accomodate ouroboros-consensus API changes
    Accomodate ouroboros-api API changes
  compatibility: no-api-changes
  type: feature
```

# Context

This PR is related to https://github.com/input-output-hk/ouroboros-consensus/pull/140 & https://github.com/input-output-hk/cardano-api/pull/45 and is needed in order for https://github.com/input-output-hk/cardano-node/pull/4024 to compile.

SRP needs to be removed once we get a release from `ouroboros-consensus`, `io-sim` and `cardano-api`
