### PR TITLE
Remove merge_group trigger from changelog check CI

### DIFF
--- a/.github/workflows/check-pr-changelog.yml
+++ b/.github/workflows/check-pr-changelog.yml
@@ -1,6 +1,5 @@
 name: Check if PR changelog was filled correctly
 on:
-    merge_group:
     pull_request:
       types: [opened, edited, synchronize, ready_for_review]
 


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Remove merge_group trigger from changelog check CI
  compatibility: no-api-changes
  type: maintenance
```

# Context

`merge_group` does not make sense for the changelog check because that check only ensures the changelog section in the PR is well formed and doesn't relate to any committed code.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
