### PR TITLE
Run `check-pr-changelog` in `merge_group` but skip steps

### DIFF
--- a/.github/workflows/check-pr-changelog.yml
+++ b/.github/workflows/check-pr-changelog.yml
@@ -1,17 +1,23 @@
 name: Check if PR changelog was filled correctly
 on:
-    pull_request:
-      types: [opened, edited, synchronize, ready_for_review]
+  merge_group:
+  pull_request:
+    types: [opened, edited, synchronize, ready_for_review]
 
 jobs:
   check-changelog:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/setup-node@v3
+        if: ${{ github.event_name != 'merge_group' }}
         with:
           node-version: 16
+
       - run: npm install js-yaml@4.1.0
+        if: ${{ github.event_name != 'merge_group' }}
+
       - name: Fail if PR changelog is not correct
+        if: ${{ github.event_name != 'merge_group' }}
         uses: actions/github-script@v6
         id: check-changelog
         with:


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Run check-pr-changelog in merge_group but skip steps
  compatibility: breaking
  type: maintenance
```

# Context

The workflow must run if used as a required-check with merge queues because if the merge queue can't find the job, it won't merge the PR.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
