### PR TITLE
Update to `cardano-api-8.7.0.0`

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -17,7 +17,7 @@ jobs:
 
     env:
       # Modify this value to "invalidate" the cabal cache.
-      CABAL_CACHE_VERSION: "2023-04-30"
+      CABAL_CACHE_VERSION: "2023-07-02"
 
     concurrency:
       group: >

--- a/cabal.project
+++ b/cabal.project
@@ -14,7 +14,7 @@ repository cardano-haskell-packages
 -- you need to run if you change them
 index-state:
   , hackage.haskell.org 2023-06-05T00:00:00Z
-  , cardano-haskell-packages 2023-06-20T00:00:00Z
+  , cardano-haskell-packages 2023-07-02T00:00:00Z
 
 packages:
     cardano-cli
@@ -40,4 +40,3 @@ write-ghc-environment-files: always
 -- IMPORTANT
 -- Do NOT add more source-repository-package stanzas here unless they are strictly
 -- temporary! Please read the section in CONTRIBUTING about updating dependencies.
-

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -110,7 +110,7 @@ library
                       , binary
                       , bytestring
                       , canonical-json
-                      , cardano-api ^>= 8.5.2
+                      , cardano-api ^>= 8.7
                       , cardano-binary
                       , cardano-crypto
                       , cardano-crypto-class >= 2.1.1
@@ -198,8 +198,8 @@ test-suite cardano-cli-test
                       , base16-bytestring
                       , bech32 >= 1.1.0
                       , bytestring
-                      , cardano-api ^>= 8.5.2
-                      , cardano-api:internal ^>= 8.5.2
+                      , cardano-api ^>= 8.7
+                      , cardano-api:internal ^>= 8.7
                       , cardano-api-gen ^>= 8.1.0.2
                       , cardano-cli
                       , cardano-cli:cardano-cli-test-lib
@@ -240,7 +240,7 @@ test-suite cardano-cli-golden
   build-depends:        aeson >= 1.5.6.0
                       , base16-bytestring
                       , bytestring
-                      , cardano-api ^>= 8.5.2
+                      , cardano-api ^>= 8.7
                       , cardano-cli
                       , cardano-cli:cardano-cli-test-lib
                       , cardano-crypto-class ^>= 2.1

--- a/cardano-cli/src/Cardano/CLI/Run/Friendly.hs
+++ b/cardano-cli/src/Cardano/CLI/Run/Friendly.hs
@@ -341,6 +341,12 @@ friendlyCertificate =
       MIRCertificate pot target ->
         "MIR" .= object ["pot" .= friendlyMirPot pot, friendlyMirTarget target]
 
+      CommitteeDelegationCertificate {} ->
+        error "TODO CIP-1694 implement CommitteeDelegationCertificate case"
+
+      CommitteeHotKeyDeregistrationCertificate {} ->
+        error "TODO CIP-1694 implement CommitteeHotKeyDeregistrationCertificate case"
+
 friendlyMirTarget :: MIRTarget -> Aeson.Pair
 friendlyMirTarget = \case
   StakeAddressesMIR addresses ->

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Transaction.hs
@@ -581,7 +581,8 @@ runTxBuildRaw era
       <- createTxMintValue era valuesWithScriptWits
     validatedTxScriptValidity
       <- first ShelleyTxCmdScriptValidityValidationError $ validateTxScriptValidity era mScriptValidity
-
+    let validatedTxGovernanceActions = TxGovernanceActionsNone -- TODO: Conwary era
+        validatedTxVotes = TxVotesNone -- TODO: Conwary era
     let txBodyContent = TxBodyContent
                           (validateTxIns inputsAndMaybeScriptWits)
                           validatedCollateralTxIns
@@ -600,6 +601,8 @@ runTxBuildRaw era
                           validatedTxUpProp
                           validatedMintValue
                           validatedTxScriptValidity
+                          validatedTxGovernanceActions
+                          validatedTxVotes
 
     first ShelleyTxCmdTxBodyError $
       getIsCardanoEraConstraint era $ createAndValidateTransactionBody txBodyContent
@@ -705,8 +708,9 @@ runTxBuild
 
       validatedPParams <- hoistEither $ first ShelleyTxCmdProtocolParametersValidationError
                                       $ validateProtocolParameters era (Just pparams)
-
-      let txBodyContent = TxBodyContent
+      let validatedTxGovernanceActions = TxGovernanceActionsNone -- TODO: Conwary era
+          validatedTxVotes = TxVotesNone -- TODO: Conwary era
+          txBodyContent = TxBodyContent
                           (validateTxIns inputsAndMaybeScriptWits)
                           validatedCollateralTxIns
                           validatedRefInputs
@@ -724,6 +728,8 @@ runTxBuild
                           validatedTxUpProp
                           validatedMintValue
                           validatedTxScriptValidity
+                          validatedTxGovernanceActions
+                          validatedTxVotes
 
       firstExceptT ShelleyTxCmdTxInsDoNotExist
         . hoistEither $ txInsExistInUTxO allTxInputs nodeEraUTxO

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1687312611,
-        "narHash": "sha256-Tvq04QEK/Kkj977GM3p7KxGtOrl15ef2y6OagSS5gtM=",
+        "lastModified": 1688152461,
+        "narHash": "sha256-p25nWq+0nnCiny9B06rnmCzBZ/H7Amlw1XAODO/M8Ho=",
         "owner": "input-output-hk",
         "repo": "cardano-haskell-packages",
-        "rev": "42e80e6600314053b7e0db2cb71725b9a1c8cdcf",
+        "rev": "0018f17c65472f5e8b39883917958ef775e3c324",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
# Description

Minimal changes to update to `cardano-api-8.7.0.0`

# Changelog

```yaml
- description: |
    Update to `cardano-api-8.7.0.0` with minimal changes.
  compatibility: no-api-changes
  type: maintenance
```

# Context

Allows an interm version of `cardano-cli` to be released so that `cardano-node` can upgrade to latest `cardano-api` (and hence `cardano-ledger`).

The change is intentionally minimal to not impact feature work for `CIP-1694`.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
