### PR TITLE
Add alonzo era to `Parser AnyShelleyBasedEra`

### DIFF
--- a/cardano-cli/src/Cardano/CLI/Common/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Common/Parsers.hs
@@ -66,6 +66,7 @@ pCardanoEra = asum
     -- Default for now:
   , pure (AnyCardanoEra BabbageEra)
   ]
+
 command' :: String -> String -> Parser a -> Mod CommandFields a
 command' c descr p =
   mconcat
@@ -294,6 +295,7 @@ pAnyShelleyBasedEra = asum
   , pShelleyBasedMary
   , pShelleyBasedAlonzo
   , pShelleyBasedBabbage
+  , pShelleyBasedConway
   ]
 
 pShelleyBasedShelley :: Parser AnyShelleyBasedEra
@@ -313,8 +315,8 @@ pShelleyBasedMary =
 
 pShelleyBasedAlonzo :: Parser AnyShelleyBasedEra
 pShelleyBasedAlonzo =
-  Opt.flag' (AnyShelleyBasedEra ShelleyBasedEraAllegra)
-   $ mconcat [Opt.long "allegra-era", Opt.help "Specify the Allegra era"]
+  Opt.flag' (AnyShelleyBasedEra ShelleyBasedEraAlonzo)
+   $ mconcat [Opt.long "alonzo-era", Opt.help "Specify the Alonzo era"]
 
 pShelleyBasedBabbage :: Parser AnyShelleyBasedEra
 pShelleyBasedBabbage =

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -26,8 +26,9 @@ Usage: cardano-cli governance create-mir-certificate
             ( ( --shelley-era
               | --allegra-era
               | --mary-era
-              | --allegra-era
+              | --alonzo-era
               | --babbage-era
+              | --conway-era
               )
               (--reserves | --treasury)
               (--stake-address ADDRESS)
@@ -44,8 +45,9 @@ Usage: cardano-cli governance create-mir-certificate stake-addresses
             ( --shelley-era
             | --allegra-era
             | --mary-era
-            | --allegra-era
+            | --alonzo-era
             | --babbage-era
+            | --conway-era
             )
             (--reserves | --treasury)
             (--stake-address ADDRESS)
@@ -58,8 +60,9 @@ Usage: cardano-cli governance create-mir-certificate transfer-to-treasury
             ( --shelley-era
             | --allegra-era
             | --mary-era
-            | --allegra-era
+            | --alonzo-era
             | --babbage-era
+            | --conway-era
             )
             --transfer LOVELACE
             --out-file FILE
@@ -71,8 +74,9 @@ Usage: cardano-cli governance create-mir-certificate transfer-to-rewards
             ( --shelley-era
             | --allegra-era
             | --mary-era
-            | --allegra-era
+            | --alonzo-era
             | --babbage-era
+            | --conway-era
             )
             --transfer LOVELACE
             --out-file FILE
@@ -84,8 +88,9 @@ Usage: cardano-cli governance create-genesis-key-delegation-certificate
             ( --shelley-era
             | --allegra-era
             | --mary-era
-            | --allegra-era
+            | --alonzo-era
             | --babbage-era
+            | --conway-era
             )
             ( --genesis-verification-key STRING
             | --genesis-verification-key-file FILE
@@ -516,8 +521,9 @@ Usage: cardano-cli stake-pool registration-certificate
             ( --shelley-era
             | --allegra-era
             | --mary-era
-            | --allegra-era
+            | --alonzo-era
             | --babbage-era
+            | --conway-era
             )
             ( --stake-pool-verification-key STRING
             | --cold-verification-key-file FILE
@@ -548,8 +554,9 @@ Usage: cardano-cli stake-pool deregistration-certificate
             ( --shelley-era
             | --allegra-era
             | --mary-era
-            | --allegra-era
+            | --alonzo-era
             | --babbage-era
+            | --conway-era
             )
             ( --stake-pool-verification-key STRING
             | --cold-verification-key-file FILE
@@ -1115,8 +1122,9 @@ Usage: cardano-cli stake-address registration-certificate
             ( --shelley-era
             | --allegra-era
             | --mary-era
-            | --allegra-era
+            | --alonzo-era
             | --babbage-era
+            | --conway-era
             )
             ( --stake-verification-key STRING
             | --stake-verification-key-file FILE
@@ -1131,8 +1139,9 @@ Usage: cardano-cli stake-address deregistration-certificate
             ( --shelley-era
             | --allegra-era
             | --mary-era
-            | --allegra-era
+            | --alonzo-era
             | --babbage-era
+            | --conway-era
             )
             ( --stake-verification-key STRING
             | --stake-verification-key-file FILE
@@ -1147,8 +1156,9 @@ Usage: cardano-cli stake-address delegation-certificate
             ( --shelley-era
             | --allegra-era
             | --mary-era
-            | --allegra-era
+            | --alonzo-era
             | --babbage-era
+            | --conway-era
             )
             ( --stake-verification-key STRING
             | --stake-verification-key-file FILE

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_create-genesis-key-delegation-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_create-genesis-key-delegation-certificate.cli
@@ -2,8 +2,9 @@ Usage: cardano-cli governance create-genesis-key-delegation-certificate
             ( --shelley-era
             | --allegra-era
             | --mary-era
-            | --allegra-era
+            | --alonzo-era
             | --babbage-era
+            | --conway-era
             )
             ( --genesis-verification-key STRING
             | --genesis-verification-key-file FILE
@@ -25,8 +26,9 @@ Available options:
   --shelley-era            Specify the Shelley era
   --allegra-era            Specify the Allegra era
   --mary-era               Specify the Mary era
-  --allegra-era            Specify the Allegra era
+  --alonzo-era             Specify the Alonzo era
   --babbage-era            Specify the Babbage era
+  --conway-era             Specify the Conway era
   --genesis-verification-key STRING
                            Genesis verification key (hex-encoded).
   --genesis-verification-key-file FILE

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_create-mir-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_create-mir-certificate.cli
@@ -2,8 +2,9 @@ Usage: cardano-cli governance create-mir-certificate
             ( ( --shelley-era
               | --allegra-era
               | --mary-era
-              | --allegra-era
+              | --alonzo-era
               | --babbage-era
+              | --conway-era
               )
               (--reserves | --treasury)
               (--stake-address ADDRESS)
@@ -20,8 +21,9 @@ Available options:
   --shelley-era            Specify the Shelley era
   --allegra-era            Specify the Allegra era
   --mary-era               Specify the Mary era
-  --allegra-era            Specify the Allegra era
+  --alonzo-era             Specify the Alonzo era
   --babbage-era            Specify the Babbage era
+  --conway-era             Specify the Conway era
   --reserves               Use the reserves pot.
   --treasury               Use the treasury pot.
   --stake-address ADDRESS  Target stake address (bech32 format).

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_create-mir-certificate_stake-addresses.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_create-mir-certificate_stake-addresses.cli
@@ -2,8 +2,9 @@ Usage: cardano-cli governance create-mir-certificate stake-addresses
             ( --shelley-era
             | --allegra-era
             | --mary-era
-            | --allegra-era
+            | --alonzo-era
             | --babbage-era
+            | --conway-era
             )
             (--reserves | --treasury)
             (--stake-address ADDRESS)
@@ -16,8 +17,9 @@ Available options:
   --shelley-era            Specify the Shelley era
   --allegra-era            Specify the Allegra era
   --mary-era               Specify the Mary era
-  --allegra-era            Specify the Allegra era
+  --alonzo-era             Specify the Alonzo era
   --babbage-era            Specify the Babbage era
+  --conway-era             Specify the Conway era
   --reserves               Use the reserves pot.
   --treasury               Use the treasury pot.
   --stake-address ADDRESS  Target stake address (bech32 format).

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_create-mir-certificate_transfer-to-rewards.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_create-mir-certificate_transfer-to-rewards.cli
@@ -2,8 +2,9 @@ Usage: cardano-cli governance create-mir-certificate transfer-to-rewards
             ( --shelley-era
             | --allegra-era
             | --mary-era
-            | --allegra-era
+            | --alonzo-era
             | --babbage-era
+            | --conway-era
             )
             --transfer LOVELACE
             --out-file FILE
@@ -15,8 +16,9 @@ Available options:
   --shelley-era            Specify the Shelley era
   --allegra-era            Specify the Allegra era
   --mary-era               Specify the Mary era
-  --allegra-era            Specify the Allegra era
+  --alonzo-era             Specify the Alonzo era
   --babbage-era            Specify the Babbage era
+  --conway-era             Specify the Conway era
   --transfer LOVELACE      The amount to transfer.
   --out-file FILE          The output file.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_create-mir-certificate_transfer-to-treasury.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_create-mir-certificate_transfer-to-treasury.cli
@@ -2,8 +2,9 @@ Usage: cardano-cli governance create-mir-certificate transfer-to-treasury
             ( --shelley-era
             | --allegra-era
             | --mary-era
-            | --allegra-era
+            | --alonzo-era
             | --babbage-era
+            | --conway-era
             )
             --transfer LOVELACE
             --out-file FILE
@@ -15,8 +16,9 @@ Available options:
   --shelley-era            Specify the Shelley era
   --allegra-era            Specify the Allegra era
   --mary-era               Specify the Mary era
-  --allegra-era            Specify the Allegra era
+  --alonzo-era             Specify the Alonzo era
   --babbage-era            Specify the Babbage era
+  --conway-era             Specify the Conway era
   --transfer LOVELACE      The amount to transfer.
   --out-file FILE          The output file.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/stake-address_delegation-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/stake-address_delegation-certificate.cli
@@ -2,8 +2,9 @@ Usage: cardano-cli stake-address delegation-certificate
             ( --shelley-era
             | --allegra-era
             | --mary-era
-            | --allegra-era
+            | --alonzo-era
             | --babbage-era
+            | --conway-era
             )
             ( --stake-verification-key STRING
             | --stake-verification-key-file FILE
@@ -22,8 +23,9 @@ Available options:
   --shelley-era            Specify the Shelley era
   --allegra-era            Specify the Allegra era
   --mary-era               Specify the Mary era
-  --allegra-era            Specify the Allegra era
+  --alonzo-era             Specify the Alonzo era
   --babbage-era            Specify the Babbage era
+  --conway-era             Specify the Conway era
   --stake-verification-key STRING
                            Stake verification key (Bech32 or hex-encoded).
   --stake-verification-key-file FILE

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/stake-address_deregistration-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/stake-address_deregistration-certificate.cli
@@ -2,8 +2,9 @@ Usage: cardano-cli stake-address deregistration-certificate
             ( --shelley-era
             | --allegra-era
             | --mary-era
-            | --allegra-era
+            | --alonzo-era
             | --babbage-era
+            | --conway-era
             )
             ( --stake-verification-key STRING
             | --stake-verification-key-file FILE
@@ -18,8 +19,9 @@ Available options:
   --shelley-era            Specify the Shelley era
   --allegra-era            Specify the Allegra era
   --mary-era               Specify the Mary era
-  --allegra-era            Specify the Allegra era
+  --alonzo-era             Specify the Alonzo era
   --babbage-era            Specify the Babbage era
+  --conway-era             Specify the Conway era
   --stake-verification-key STRING
                            Stake verification key (Bech32 or hex-encoded).
   --stake-verification-key-file FILE

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/stake-address_registration-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/stake-address_registration-certificate.cli
@@ -2,8 +2,9 @@ Usage: cardano-cli stake-address registration-certificate
             ( --shelley-era
             | --allegra-era
             | --mary-era
-            | --allegra-era
+            | --alonzo-era
             | --babbage-era
+            | --conway-era
             )
             ( --stake-verification-key STRING
             | --stake-verification-key-file FILE
@@ -18,8 +19,9 @@ Available options:
   --shelley-era            Specify the Shelley era
   --allegra-era            Specify the Allegra era
   --mary-era               Specify the Mary era
-  --allegra-era            Specify the Allegra era
+  --alonzo-era             Specify the Alonzo era
   --babbage-era            Specify the Babbage era
+  --conway-era             Specify the Conway era
   --stake-verification-key STRING
                            Stake verification key (Bech32 or hex-encoded).
   --stake-verification-key-file FILE

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/stake-pool_deregistration-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/stake-pool_deregistration-certificate.cli
@@ -2,8 +2,9 @@ Usage: cardano-cli stake-pool deregistration-certificate
             ( --shelley-era
             | --allegra-era
             | --mary-era
-            | --allegra-era
+            | --alonzo-era
             | --babbage-era
+            | --conway-era
             )
             ( --stake-pool-verification-key STRING
             | --cold-verification-key-file FILE
@@ -17,8 +18,9 @@ Available options:
   --shelley-era            Specify the Shelley era
   --allegra-era            Specify the Allegra era
   --mary-era               Specify the Mary era
-  --allegra-era            Specify the Allegra era
+  --alonzo-era             Specify the Alonzo era
   --babbage-era            Specify the Babbage era
+  --conway-era             Specify the Conway era
   --stake-pool-verification-key STRING
                            Stake pool verification key (Bech32 or hex-encoded).
   --cold-verification-key-file FILE

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/stake-pool_registration-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/stake-pool_registration-certificate.cli
@@ -2,8 +2,9 @@ Usage: cardano-cli stake-pool registration-certificate
             ( --shelley-era
             | --allegra-era
             | --mary-era
-            | --allegra-era
+            | --alonzo-era
             | --babbage-era
+            | --conway-era
             )
             ( --stake-pool-verification-key STRING
             | --cold-verification-key-file FILE
@@ -34,8 +35,9 @@ Available options:
   --shelley-era            Specify the Shelley era
   --allegra-era            Specify the Allegra era
   --mary-era               Specify the Mary era
-  --allegra-era            Specify the Allegra era
+  --alonzo-era             Specify the Alonzo era
   --babbage-era            Specify the Babbage era
+  --conway-era             Specify the Conway era
   --stake-pool-verification-key STRING
                            Stake pool verification key (Bech32 or hex-encoded).
   --cold-verification-key-file FILE


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Add alonzo era to `Parser AnyShelleyBasedEra`
  compatibility: no-api-changes
  type: bugfix
```

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
