### PR TITLE
Apply `stylish-haskell` to project

### DIFF
--- a/.github/workflows/check-stylish-haskell.yml
+++ b/.github/workflows/check-stylish-haskell.yml
@@ -55,7 +55,11 @@ jobs:
 
         for x in $(git ls-tree --full-tree --name-only -r HEAD ${{ env.STYLISH_HASKELL_PATHS }}); do
           if [ "${x##*.}" == "hs" ]; then
-            stylish-haskell -i $x
+            if grep -qE '^#' $x; then
+              echo "$x contains CPP.  Skipping."
+            else
+              stylish-haskell -i $x
+            fi
           fi
         done
 
@@ -68,7 +72,11 @@ jobs:
         git fetch origin ${{ github.base_ref }} --unshallow
         for x in $(git diff --name-only origin/${{ github.base_ref }}..HEAD ${{ env.STYLISH_HASKELL_PATHS }}); do
           if [ "${x##*.}" == "hs" ]; then
-            stylish-haskell -i $x
+            if grep -qE '^#' $x; then
+              echo "$x contains CPP.  Skipping."
+            else
+              stylish-haskell -i $x
+            fi
           fi
         done
 

--- a/.github/workflows/github-page.yml
+++ b/.github/workflows/github-page.yml
@@ -22,7 +22,7 @@ jobs:
 
     env:
       # Modify this value to "invalidate" the cabal cache.
-      CABAL_CACHE_VERSION: "2022-12-30"
+      CABAL_CACHE_VERSION: "2023-07-11"
 
       # Modify this value to "invalidate" the secp cache.
       SECP_CACHE_VERSION: "2022-12-30"

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -17,7 +17,7 @@ jobs:
 
     env:
       # Modify this value to "invalidate" the cabal cache.
-      CABAL_CACHE_VERSION: "2023-07-08"
+      CABAL_CACHE_VERSION: "2023-07-11"
 
     concurrency:
       group: >

--- a/cardano-cli/src/Cardano/CLI/Byron/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Commands.hs
@@ -10,20 +10,18 @@ module Cardano.CLI.Byron.Commands
   , NewCertificateFile (..)
   ) where
 
-import           Data.String (IsString)
-
-import           Cardano.Chain.Update (InstallerHash (..), ProtocolVersion (..),
-                   SoftwareVersion (..), SystemTag (..))
-
 import           Cardano.Api hiding (GenesisParameters)
 import           Cardano.Api.Byron hiding (GenesisParameters)
 
+import           Cardano.Chain.Update (InstallerHash (..), ProtocolVersion (..),
+                   SoftwareVersion (..), SystemTag (..))
 import           Cardano.CLI.Byron.Genesis
 import           Cardano.CLI.Byron.Key
 import           Cardano.CLI.Byron.Tx
+import           Cardano.CLI.Shelley.Commands (ByronKeyFormat)
 import           Cardano.CLI.Types
 
-import           Cardano.CLI.Shelley.Commands (ByronKeyFormat)
+import           Data.String (IsString)
 
 data ByronCommand =
 

--- a/cardano-cli/src/Cardano/CLI/Byron/Delegation.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Delegation.hs
@@ -12,29 +12,28 @@ module Cardano.CLI.Byron.Delegation
   )
 where
 
+import           Cardano.Api.Byron
+
+import qualified Cardano.Chain.Delegation as Dlg
+import           Cardano.Chain.Slotting (EpochNumber)
+import           Cardano.CLI.Byron.Key (ByronKeyFailure, renderByronKeyFailure)
+import           Cardano.CLI.Types (CertificateFile (..))
+import           Cardano.Crypto (ProtocolMagicId)
+import qualified Cardano.Crypto as Crypto
+import           Cardano.Ledger.Binary (Annotated (..), byronProtVer, serialize')
+import           Cardano.Prelude (canonicalDecodePretty, canonicalEncodePretty)
+
 import           Prelude hiding ((.))
 
 import           Control.Category
-import           Control.Monad.Trans.Except.Extra (left)
-import qualified Data.ByteString.Lazy as LB
-import           Formatting (Format, sformat)
-
-import           Cardano.Api.Byron
-
-import           Cardano.Ledger.Binary (Annotated (..), serialize', byronProtVer)
-import qualified Cardano.Chain.Delegation as Dlg
-import           Cardano.Chain.Slotting (EpochNumber)
-import           Cardano.Crypto (ProtocolMagicId)
-import qualified Cardano.Crypto as Crypto
-
-import           Cardano.CLI.Byron.Key (ByronKeyFailure, renderByronKeyFailure)
-import           Cardano.CLI.Types (CertificateFile (..))
-import           Cardano.Prelude (canonicalDecodePretty, canonicalEncodePretty)
 import           Control.Monad (unless)
 import           Control.Monad.IO.Class (MonadIO (..))
 import           Control.Monad.Trans.Except (ExceptT)
+import           Control.Monad.Trans.Except.Extra (left)
 import           Data.ByteString (ByteString)
+import qualified Data.ByteString.Lazy as LB
 import           Data.Text (Text)
+import           Formatting (Format, sformat)
 
 data ByronDelegationError
   = CertificateValidationErrors !FilePath ![Text]

--- a/cardano-cli/src/Cardano/CLI/Byron/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Genesis.hs
@@ -12,6 +12,19 @@ module Cardano.CLI.Byron.Genesis
   )
 where
 
+import           Cardano.Api (Key (..), NetworkId, textShow, writeSecrets)
+import           Cardano.Api.Byron (ByronKey, SerialiseAsRawBytes (..), SigningKey (..),
+                   toByronRequiresNetworkMagic)
+
+import qualified Cardano.Chain.Common as Common
+import           Cardano.Chain.Delegation hiding (Map, epoch)
+import           Cardano.Chain.Genesis (GeneratedSecrets (..))
+import qualified Cardano.Chain.Genesis as Genesis
+import qualified Cardano.Chain.UTxO as UTxO
+import           Cardano.CLI.Byron.Delegation
+import           Cardano.CLI.Byron.Key
+import           Cardano.CLI.Types (GenesisFile (..))
+import qualified Cardano.Crypto as Crypto
 import           Cardano.Prelude (canonicalDecodePretty, canonicalEncodePretty)
 
 import           Control.Monad.IO.Class (MonadIO (..))
@@ -30,24 +43,7 @@ import           Data.Text.Lazy (toStrict)
 import           Data.Text.Lazy.Builder (toLazyText)
 import           Data.Time (UTCTime)
 import           Formatting.Buildable
-
-import           Cardano.Api (Key (..), NetworkId, textShow, writeSecrets)
-
-import           Cardano.Api.Byron (ByronKey, SerialiseAsRawBytes (..), SigningKey (..),
-                   toByronRequiresNetworkMagic)
 import           System.Directory (createDirectory, doesPathExist)
-
-import qualified Cardano.Chain.Common as Common
-import           Cardano.Chain.Delegation hiding (Map, epoch)
-import           Cardano.Chain.Genesis (GeneratedSecrets (..))
-import qualified Cardano.Chain.Genesis as Genesis
-import qualified Cardano.Chain.UTxO as UTxO
-
-import qualified Cardano.Crypto as Crypto
-
-import           Cardano.CLI.Byron.Delegation
-import           Cardano.CLI.Byron.Key
-import           Cardano.CLI.Types (GenesisFile (..))
 
 data ByronGenesisError
   = ByronDelegationCertSerializationError !ByronDelegationError

--- a/cardano-cli/src/Cardano/CLI/Byron/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Key.hs
@@ -15,6 +15,13 @@ module Cardano.CLI.Byron.Key
   )
 where
 
+import           Cardano.Api.Byron
+
+import qualified Cardano.Chain.Common as Common
+import           Cardano.CLI.Shelley.Commands (ByronKeyFormat (..))
+import           Cardano.CLI.Types
+import qualified Cardano.Crypto.Signing as Crypto
+
 import           Control.Exception (Exception (..))
 import           Control.Monad.Trans.Except (ExceptT)
 import           Control.Monad.Trans.Except.Extra (firstExceptT, handleIOExceptT, hoistEither, left,
@@ -25,13 +32,6 @@ import           Data.String (IsString, fromString)
 import           Data.Text (Text)
 import qualified Data.Text as T
 import           Formatting (build, sformat, (%))
-
-import           Cardano.Api.Byron
-
-import qualified Cardano.Chain.Common as Common
-import           Cardano.CLI.Shelley.Commands (ByronKeyFormat (..))
-import           Cardano.CLI.Types
-import qualified Cardano.Crypto.Signing as Crypto
 
 
 data ByronKeyFailure

--- a/cardano-cli/src/Cardano/CLI/Byron/Legacy.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Legacy.hs
@@ -9,18 +9,17 @@ module Cardano.CLI.Byron.Legacy (
     , decodeLegacyDelegateKey
     ) where
 
-import           Cardano.Prelude (cborError)
+import           Cardano.Api (textShow)
 
-import           Control.Monad (when)
-import           Formatting (build, formatToString)
+import           Cardano.Crypto.Signing (SigningKey (..))
+import qualified Cardano.Crypto.Wallet as Wallet
+import           Cardano.Prelude (cborError)
 
 import qualified Codec.CBOR.Decoding as D
 import qualified Codec.CBOR.Encoding as E
-
-import           Cardano.Api (textShow)
-import           Cardano.Crypto.Signing (SigningKey (..))
-import qualified Cardano.Crypto.Wallet as Wallet
+import           Control.Monad (when)
 import           Data.Text (Text)
+import           Formatting (build, formatToString)
 
 
 -- | LegacyDelegateKey is a subset of the UserSecret's from the legacy codebase:

--- a/cardano-cli/src/Cardano/CLI/Byron/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Query.hs
@@ -10,7 +10,6 @@ module Cardano.CLI.Byron.Query
 import           Cardano.Api
 
 import           Data.Aeson.Encode.Pretty (encodePretty)
-
 import qualified Data.ByteString.Lazy as LB
 import qualified Data.Text.Encoding as Text
 import qualified Data.Text.IO as Text

--- a/cardano-cli/src/Cardano/CLI/Byron/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Run.hs
@@ -7,29 +7,10 @@ module Cardano.CLI.Byron.Run
   , runByronClientCommand
   ) where
 
-import           Control.Monad.IO.Class (MonadIO (liftIO))
-import           Control.Monad.Trans.Except (ExceptT)
-import           Control.Monad.Trans.Except.Extra (firstExceptT, hoistEither, left)
-import           Data.Bifunctor (Bifunctor (..))
-import qualified Data.ByteString.Char8 as BS
-import           Data.Text (Text)
-import qualified Data.Text as Text
-import qualified Data.Text.IO as Text
-import qualified Data.Text.Lazy.Builder as Builder
-import qualified Data.Text.Lazy.IO as TL
-import qualified Formatting as F
-
-import qualified Cardano.Chain.Genesis as Genesis
-
-import qualified Cardano.Crypto.Hashing as Crypto
-import qualified Cardano.Crypto.Signing as Crypto
-
 import           Cardano.Api hiding (GenesisParameters, UpdateProposal)
 import           Cardano.Api.Byron (SomeByronSigningKey (..), Tx (..))
 
-import           Ouroboros.Consensus.Byron.Ledger (ByronBlock)
-import           Ouroboros.Consensus.Ledger.SupportsMempool (ApplyTxErr)
-
+import qualified Cardano.Chain.Genesis as Genesis
 import           Cardano.CLI.Byron.Commands
 import           Cardano.CLI.Byron.Delegation
 import           Cardano.CLI.Byron.Genesis
@@ -41,6 +22,22 @@ import           Cardano.CLI.Byron.Vote
 import           Cardano.CLI.Helpers
 import           Cardano.CLI.Shelley.Commands (ByronKeyFormat (..))
 import           Cardano.CLI.Types
+import qualified Cardano.Crypto.Hashing as Crypto
+import qualified Cardano.Crypto.Signing as Crypto
+import           Ouroboros.Consensus.Byron.Ledger (ByronBlock)
+import           Ouroboros.Consensus.Ledger.SupportsMempool (ApplyTxErr)
+
+import           Control.Monad.IO.Class (MonadIO (liftIO))
+import           Control.Monad.Trans.Except (ExceptT)
+import           Control.Monad.Trans.Except.Extra (firstExceptT, hoistEither, left)
+import           Data.Bifunctor (Bifunctor (..))
+import qualified Data.ByteString.Char8 as BS
+import           Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.IO as Text
+import qualified Data.Text.Lazy.Builder as Builder
+import qualified Data.Text.Lazy.IO as TL
+import qualified Formatting as F
 
 -- | Data type that encompasses all the possible errors of the
 -- Byron client.

--- a/cardano-cli/src/Cardano/CLI/Byron/UpdateProposal.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/UpdateProposal.hs
@@ -9,7 +9,21 @@ module Cardano.CLI.Byron.UpdateProposal
   , submitByronUpdateProposal
   ) where
 
+import           Cardano.Api (NetworkId, SerialiseAsRawBytes (..), SocketPath, textShow)
+import           Cardano.Api.Byron (AsType (AsByronUpdateProposal), ByronProtocolParametersUpdate,
+                   ByronUpdateProposal, makeByronUpdateProposal, toByronLedgerUpdateProposal)
+
+import           Cardano.Chain.Update (InstallerHash (..), ProtocolVersion (..),
+                   SoftwareVersion (..), SystemTag (..))
+import           Cardano.CLI.Byron.Genesis (ByronGenesisError)
+import           Cardano.CLI.Byron.Key (ByronKeyFailure, readByronSigningKey)
+import           Cardano.CLI.Byron.Tx (ByronTxError, nodeSubmitTx)
+import           Cardano.CLI.Helpers (HelpersError, ensureNewFileLBS, renderHelpersError)
+import           Cardano.CLI.Shelley.Commands (ByronKeyFormat (..))
+import           Cardano.CLI.Types
 import           Cardano.Prelude (ConvertText (..))
+import           Ouroboros.Consensus.Ledger.SupportsMempool (txId)
+import           Ouroboros.Consensus.Util.Condense (condense)
 
 import           Control.Exception (Exception (..))
 import           Control.Monad.Trans.Except (ExceptT)
@@ -18,23 +32,6 @@ import           Control.Tracer (stdoutTracer, traceWith)
 import           Data.Bifunctor (Bifunctor (..))
 import qualified Data.ByteString as BS
 import           Data.Text (Text)
-
-import           Cardano.Chain.Update (InstallerHash (..), ProtocolVersion (..),
-                   SoftwareVersion (..), SystemTag (..))
-
-import           Ouroboros.Consensus.Ledger.SupportsMempool (txId)
-import           Ouroboros.Consensus.Util.Condense (condense)
-
-import           Cardano.Api (NetworkId, SerialiseAsRawBytes (..), SocketPath, textShow)
-import           Cardano.Api.Byron (AsType (AsByronUpdateProposal), ByronProtocolParametersUpdate,
-                   ByronUpdateProposal, makeByronUpdateProposal, toByronLedgerUpdateProposal)
-
-import           Cardano.CLI.Byron.Genesis (ByronGenesisError)
-import           Cardano.CLI.Byron.Key (ByronKeyFailure, readByronSigningKey)
-import           Cardano.CLI.Byron.Tx (ByronTxError, nodeSubmitTx)
-import           Cardano.CLI.Helpers (HelpersError, ensureNewFileLBS, renderHelpersError)
-import           Cardano.CLI.Shelley.Commands (ByronKeyFormat (..))
-import           Cardano.CLI.Types
 
 data ByronUpdateProposalError
   = ByronReadUpdateProposalFileFailure !FilePath !Text

--- a/cardano-cli/src/Cardano/CLI/Byron/Vote.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Vote.hs
@@ -9,29 +9,28 @@ module Cardano.CLI.Byron.Vote
   , submitByronVote
   ) where
 
-import           Control.Monad.Trans.Except (ExceptT)
-import           Control.Monad.Trans.Except.Extra (firstExceptT, hoistEither)
-import           Control.Tracer (stdoutTracer, traceWith)
-import qualified Data.ByteString as BS
-import           Data.Text (Text)
-import qualified Data.Text as Text
-
-import qualified Cardano.Binary as Binary
-import           Cardano.CLI.Byron.UpdateProposal (ByronUpdateProposalError,
-                   readByronUpdateProposal)
-import           Ouroboros.Consensus.Ledger.SupportsMempool (txId)
-import           Ouroboros.Consensus.Util.Condense (condense)
-
 import           Cardano.Api.Byron
 
+import qualified Cardano.Binary as Binary
 import           Cardano.CLI.Byron.Genesis (ByronGenesisError)
 import           Cardano.CLI.Byron.Key (ByronKeyFailure, readByronSigningKey)
 import           Cardano.CLI.Byron.Tx (ByronTxError, nodeSubmitTx)
+import           Cardano.CLI.Byron.UpdateProposal (ByronUpdateProposalError,
+                   readByronUpdateProposal)
 import           Cardano.CLI.Helpers (HelpersError, ensureNewFileLBS)
 import           Cardano.CLI.Shelley.Commands (ByronKeyFormat (..))
 import           Cardano.CLI.Types
+import           Ouroboros.Consensus.Ledger.SupportsMempool (txId)
+import           Ouroboros.Consensus.Util.Condense (condense)
+
 import           Control.Monad.IO.Class (MonadIO (..))
+import           Control.Monad.Trans.Except (ExceptT)
+import           Control.Monad.Trans.Except.Extra (firstExceptT, hoistEither)
+import           Control.Tracer (stdoutTracer, traceWith)
 import           Data.Bifunctor (first)
+import qualified Data.ByteString as BS
+import           Data.Text (Text)
+import qualified Data.Text as Text
 
 
 data ByronVoteError

--- a/cardano-cli/src/Cardano/CLI/Conway/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Conway/Commands.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
 
 module Cardano.CLI.Conway.Commands where
 
@@ -10,6 +10,7 @@ import           Cardano.Api.Shelley
 import           Cardano.Binary (DecoderError)
 import           Cardano.CLI.Conway.Types
 import           Cardano.CLI.Shelley.Key
+import           Cardano.CLI.Shelley.Run.Read (CddlError)
 import           Cardano.CLI.Shelley.Run.StakeAddress
 
 import           Control.Monad.IO.Class
@@ -17,11 +18,9 @@ import           Control.Monad.Trans.Except (ExceptT)
 import           Control.Monad.Trans.Except.Extra (firstExceptT, hoistEither, newExceptT)
 import           Data.Bifunctor
 import qualified Data.ByteString as BS
+import           Data.Text (Text)
 import qualified Data.Text.Encoding as Text
 import           Data.Text.Encoding.Error
-import           Data.Text(Text)
-
-import           Cardano.CLI.Shelley.Run.Read (CddlError)
 
 data GovernanceCmdError
   = -- Voting related
@@ -125,7 +124,7 @@ runGovernanceCreateActionCmd
 runGovernanceCreateActionCmd anyEra deposit depositReturnAddr govAction oFp = do
   AnyShelleyBasedEra sbe <- pure anyEra
   let proposal = createProposalProcedure sbe deposit depositReturnAddr govAction
-  
+
   firstExceptT WriteFileError . newExceptT
     $ obtainEraPParamsConstraint sbe
     $ writeFileTextEnvelope oFp Nothing proposal

--- a/cardano-cli/src/Cardano/CLI/Helpers.hs
+++ b/cardano-cli/src/Cardano/CLI/Helpers.hs
@@ -15,6 +15,13 @@ module Cardano.CLI.Helpers
   , hushM
   ) where
 
+import           Cardano.Chain.Block (decCBORABlockOrBoundary)
+import qualified Cardano.Chain.Delegation as Delegation
+import qualified Cardano.Chain.Update as Update
+import qualified Cardano.Chain.UTxO as UTxO
+import           Cardano.CLI.Types
+import           Cardano.Ledger.Binary (byronProtVer, toPlainDecoder)
+import           Cardano.Ledger.Binary.Plain (Decoder, fromCBOR)
 import           Cardano.Prelude (ConvertText (..))
 
 import           Codec.CBOR.Pretty (prettyHexEnc)
@@ -37,14 +44,6 @@ import qualified System.Console.ANSI as ANSI
 import           System.Console.ANSI
 import qualified System.Directory as IO
 import qualified System.IO as IO
-
-import           Cardano.Chain.Block (decCBORABlockOrBoundary)
-import qualified Cardano.Chain.Delegation as Delegation
-import qualified Cardano.Chain.Update as Update
-import qualified Cardano.Chain.UTxO as UTxO
-import           Cardano.CLI.Types
-import           Cardano.Ledger.Binary (byronProtVer, toPlainDecoder)
-import           Cardano.Ledger.Binary.Plain (Decoder, fromCBOR)
 
 data HelpersError
   = CBORPrettyPrintError !DeserialiseFailure

--- a/cardano-cli/src/Cardano/CLI/IO/Compat.hs
+++ b/cardano-cli/src/Cardano/CLI/IO/Compat.hs
@@ -1,0 +1,21 @@
+{-# LANGUAGE CPP #-}
+
+module Cardano.CLI.IO.Compat
+  ( posixSetOtherAndGroupModes
+  ) where
+
+#if !defined(mingw32_HOST_OS)
+#define UNIX
+#endif
+
+#ifdef UNIX
+import           System.Posix.Files
+#endif
+
+posixSetOtherAndGroupModes :: IO ()
+posixSetOtherAndGroupModes = do
+#ifdef UNIX
+  _ <- setFileCreationMask (otherModes `unionFileModes` groupModes)
+#endif
+
+  pure ()

--- a/cardano-cli/src/Cardano/CLI/IO/Lazy.hs
+++ b/cardano-cli/src/Cardano/CLI/IO/Lazy.hs
@@ -12,7 +12,6 @@ module Cardano.CLI.IO.Lazy
 
 import           Control.Monad.IO.Unlift (MonadIO (liftIO), MonadUnliftIO, UnliftIO (unliftIO),
                    askUnliftIO)
-
 import qualified Data.List as L
 import qualified System.IO.Unsafe as IO
 

--- a/cardano-cli/src/Cardano/CLI/OS/Unix.hs
+++ b/cardano-cli/src/Cardano/CLI/OS/Unix.hs
@@ -1,0 +1,8 @@
+{-# LANGUAGE CPP #-}
+
+module Cardano.CLI.OS.Unix where
+
+#if !defined(mingw32_HOST_OS)
+import           System.Posix.Files
+import           System.Posix.IO
+#endif

--- a/cardano-cli/src/Cardano/CLI/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Parsers.hs
@@ -18,7 +18,6 @@ import           Cardano.CLI.Shelley.Parsers (parseShelleyCommands)
 
 import           Data.Foldable
 import           Options.Applicative
-
 import qualified Options.Applicative as Opt
 
 

--- a/cardano-cli/src/Cardano/CLI/Ping.hs
+++ b/cardano-cli/src/Cardano/CLI/Ping.hs
@@ -11,6 +11,8 @@ module Cardano.CLI.Ping
   , parsePingCmd
   ) where
 
+import qualified Cardano.Network.Ping as CNP
+
 import           Control.Applicative ((<|>))
 import           Control.Concurrent.Class.MonadSTM.Strict (StrictTMVar)
 import qualified Control.Concurrent.Class.MonadSTM.Strict as STM
@@ -32,8 +34,6 @@ import qualified Options.Applicative as Opt
 import qualified Prettyprinter as PP
 import qualified System.Exit as IO
 import qualified System.IO as IO
-
-import qualified Cardano.Network.Ping as CNP
 
 newtype PingClientCmdError = PingClientCmdError [(AddrInfo, SomeException)]
 

--- a/cardano-cli/src/Cardano/CLI/Pretty.hs
+++ b/cardano-cli/src/Cardano/CLI/Pretty.hs
@@ -15,14 +15,13 @@ module Cardano.CLI.Pretty
     white,
   ) where
 
+import qualified Control.Concurrent.QSem as IO
 import           Control.Exception (bracket_)
 import           Control.Monad.IO.Class (MonadIO, liftIO)
-import           Prettyprinter
-import           Prettyprinter.Render.Terminal
-
-import qualified Control.Concurrent.QSem as IO
 import qualified Data.Text.Lazy as TextLazy
 import qualified Data.Text.Lazy.IO as TextLazy
+import           Prettyprinter
+import           Prettyprinter.Render.Terminal
 import qualified System.IO as IO
 import qualified System.IO.Unsafe as IO
 

--- a/cardano-cli/src/Cardano/CLI/Render.hs
+++ b/cardano-cli/src/Cardano/CLI/Render.hs
@@ -4,18 +4,17 @@ module Cardano.CLI.Render
   ( customRenderHelp
   ) where
 
+import           Cardano.Api (textShow)
+
 import           Data.Text (Text)
+import qualified Data.Text as T
 import           Options.Applicative
 import           Options.Applicative.Help.Ann
 import           Options.Applicative.Help.Types (helpText, renderHelp)
 import           Prettyprinter
 import           Prettyprinter.Render.Util.SimpleDocTree
-
-import qualified Data.Text as T
 import qualified System.Environment as IO
 import qualified System.IO.Unsafe as IO
-
-import           Cardano.Api (textShow)
 
 cliHelpTraceEnabled :: Bool
 cliHelpTraceEnabled = IO.unsafePerformIO $ do

--- a/cardano-cli/src/Cardano/CLI/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Run.hs
@@ -8,6 +8,17 @@ module Cardano.CLI.Run
   , runClientCommand
   ) where
 
+import           Cardano.CLI.Byron.Commands (ByronCommand)
+import           Cardano.CLI.Byron.Run (ByronClientCmdError, renderByronClientCmdError,
+                   runByronClientCommand)
+import           Cardano.CLI.Ping (PingClientCmdError (..), PingCmd (..), renderPingClientCmdError,
+                   runPingCmd)
+import           Cardano.CLI.Render (customRenderHelp)
+import           Cardano.CLI.Shelley.Commands (ShelleyCommand)
+import           Cardano.CLI.Shelley.Run (ShelleyClientCmdError, renderShelleyClientCmdError,
+                   runShelleyClientCommand)
+import           Cardano.Git.Rev (gitRev)
+
 import           Control.Monad (forM_)
 import           Control.Monad.IO.Unlift (MonadIO (..))
 import           Control.Monad.Trans.Except (ExceptT)
@@ -16,25 +27,14 @@ import qualified Data.List as L
 import           Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
-import qualified System.IO as IO
-
-import           Cardano.CLI.Byron.Commands (ByronCommand)
-import           Cardano.CLI.Byron.Run (ByronClientCmdError, renderByronClientCmdError,
-                   runByronClientCommand)
-import           Cardano.CLI.Ping (PingCmd (..), PingClientCmdError (..), renderPingClientCmdError, runPingCmd)
-import           Cardano.CLI.Shelley.Commands (ShelleyCommand)
-import           Cardano.CLI.Shelley.Run (ShelleyClientCmdError, renderShelleyClientCmdError,
-                   runShelleyClientCommand)
-
-import           Cardano.CLI.Render (customRenderHelp)
-
-import           Cardano.Git.Rev (gitRev)
 import           Data.Version (showVersion)
 import           Options.Applicative.Help.Core
 import           Options.Applicative.Types (OptReader (..), Option (..), Parser (..),
                    ParserInfo (..), ParserPrefs (..))
-import           Paths_cardano_cli (version)
 import           System.Info (arch, compilerName, compilerVersion, os)
+import qualified System.IO as IO
+
+import           Paths_cardano_cli (version)
 
 -- | Sub-commands of 'cardano-cli'.
 data ClientCommand =

--- a/cardano-cli/src/Cardano/CLI/Run/Friendly.hs
+++ b/cardano-cli/src/Cardano/CLI/Run/Friendly.hs
@@ -10,6 +10,15 @@
 -- | User-friendly pretty-printing for textual user interfaces (TUI)
 module Cardano.CLI.Run.Friendly (friendlyTxBS, friendlyTxBodyBS) where
 
+import           Cardano.Api as Api
+import           Cardano.Api.Byron (KeyWitness (ByronKeyWitness))
+import           Cardano.Api.Shelley (Address (ShelleyAddress),
+                   KeyWitness (ShelleyBootstrapWitness, ShelleyKeyWitness), StakeAddress (..),
+                   StakeCredential (..), StakePoolParameters (..), fromShelleyPaymentCredential,
+                   fromShelleyStakeCredential, fromShelleyStakeReference)
+
+import qualified Cardano.Ledger.Shelley.API as Shelley
+
 import           Data.Aeson (Value (..), object, toJSON, (.=))
 import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Key as Aeson
@@ -28,14 +37,6 @@ import           Data.Yaml.Pretty (setConfCompare)
 import qualified Data.Yaml.Pretty as Yaml
 import           GHC.Real (denominator)
 import           GHC.Unicode (isAlphaNum)
-
-import           Cardano.Api as Api
-import           Cardano.Api.Byron (KeyWitness (ByronKeyWitness))
-import           Cardano.Api.Shelley (Address (ShelleyAddress),
-                   KeyWitness (ShelleyBootstrapWitness, ShelleyKeyWitness), StakeAddress (..),
-                   StakeCredential (..), StakePoolParameters (..), fromShelleyPaymentCredential,
-                   fromShelleyStakeCredential, fromShelleyStakeReference)
-import qualified Cardano.Ledger.Shelley.API as Shelley
 
 yamlConfig :: Yaml.Config
 yamlConfig = Yaml.defConfig & setConfCompare compare

--- a/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Commands.hs
@@ -50,7 +50,7 @@ module Cardano.CLI.Shelley.Commands
   , Deprecated (..)
   ) where
 
-import           Cardano.Api.Shelley hiding (QueryInShelleyBasedEra(..))
+import           Cardano.Api.Shelley hiding (QueryInShelleyBasedEra (..))
 
 import           Cardano.Chain.Common (BlockCount)
 import           Cardano.CLI.Conway.Parsers

--- a/cardano-cli/src/Cardano/CLI/Shelley/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Key.hs
@@ -30,6 +30,9 @@ module Cardano.CLI.Shelley.Key
   ) where
 
 import           Cardano.Api
+import           Cardano.Api.Shelley (StakePoolKey)
+
+import           Cardano.CLI.Types
 
 import           Control.Monad.IO.Class (MonadIO (..))
 import           Data.Bifunctor (Bifunctor (..))
@@ -38,9 +41,6 @@ import qualified Data.List.NonEmpty as NE
 import           Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
-
-import           Cardano.Api.Shelley (StakePoolKey)
-import           Cardano.CLI.Types
 
 
 ------------------------------------------------------------------------------

--- a/cardano-cli/src/Cardano/CLI/Shelley/Orphans.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Orphans.hs
@@ -18,11 +18,6 @@ import qualified Cardano.Protocol.TPraos.API as Ledger
 import           Cardano.Protocol.TPraos.BHeader (HashHeader (..))
 import qualified Cardano.Protocol.TPraos.Rules.Prtcl as Ledger
 import qualified Cardano.Protocol.TPraos.Rules.Tickn as Ledger
-import           Data.Aeson (KeyValue ((.=)), ToJSON (..))
-import qualified Data.Aeson as Aeson
-import qualified Data.ByteString.Base16 as Base16
-import qualified Data.ByteString.Short as SBS
-import qualified Data.Text.Encoding as Text
 import           Ouroboros.Consensus.Byron.Ledger.Block (ByronHash (..))
 import           Ouroboros.Consensus.HardFork.Combinator (OneEraHash (..))
 import           Ouroboros.Consensus.Protocol.Praos (PraosState)
@@ -32,6 +27,12 @@ import qualified Ouroboros.Consensus.Protocol.TPraos as Consensus
 import           Ouroboros.Consensus.Shelley.Eras (StandardCrypto)
 import           Ouroboros.Consensus.Shelley.Ledger.Block (ShelleyHash (..))
 import           Ouroboros.Network.Block (HeaderHash, Tip (..))
+
+import           Data.Aeson (KeyValue ((.=)), ToJSON (..))
+import qualified Data.Aeson as Aeson
+import qualified Data.ByteString.Base16 as Base16
+import qualified Data.ByteString.Short as SBS
+import qualified Data.Text.Encoding as Text
 
 instance ToJSON (OneEraHash xs) where
   toJSON = toJSON

--- a/cardano-cli/src/Cardano/CLI/Shelley/Output.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Output.hs
@@ -11,10 +11,15 @@ module Cardano.CLI.Shelley.Output
   , renderScriptCosts
   ) where
 
-import           Prelude
-
 import           Cardano.Api
 import           Cardano.Api.Shelley
+
+import           Cardano.CLI.Shelley.Orphans ()
+import           Cardano.CLI.Types
+import           Cardano.Ledger.Shelley.Scripts ()
+
+import           Prelude
+
 import           Data.Aeson
 import qualified Data.Aeson.Key as Aeson
 import qualified Data.List as List
@@ -24,10 +29,6 @@ import           Data.Text (Text)
 import qualified Data.Text as Text
 import           Data.Time.Clock (UTCTime)
 import           Data.Word
-
-import           Cardano.CLI.Shelley.Orphans ()
-import           Cardano.CLI.Types
-import           Cardano.Ledger.Shelley.Scripts ()
 
 data QueryKesPeriodInfoOutput =
   QueryKesPeriodInfoOutput

--- a/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Parsers.hs
@@ -15,8 +15,8 @@ module Cardano.CLI.Shelley.Parsers
   , parseTxIn
   ) where
 
-import           Cardano.Api hiding (QueryInShelleyBasedEra(..))
-import           Cardano.Api.Shelley hiding (QueryInShelleyBasedEra(..))
+import           Cardano.Api hiding (QueryInShelleyBasedEra (..))
+import           Cardano.Api.Shelley hiding (QueryInShelleyBasedEra (..))
 
 import           Cardano.Chain.Common (BlockCount (BlockCount))
 import           Cardano.CLI.Common.Parsers

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Address.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Address.hs
@@ -13,14 +13,6 @@ module Cardano.CLI.Shelley.Run.Address
   , makeStakeAddressRef
   ) where
 
-import           Control.Monad.IO.Class (MonadIO (..))
-import           Control.Monad.Trans.Except (ExceptT)
-import           Control.Monad.Trans.Except.Extra (firstExceptT, left, newExceptT)
-import qualified Data.ByteString.Char8 as BS
-import           Data.Text (Text)
-import qualified Data.Text as Text
-import qualified Data.Text.IO as Text
-
 import           Cardano.Api
 import           Cardano.Api.Shelley
 
@@ -32,6 +24,14 @@ import           Cardano.CLI.Shelley.Parsers (AddressCmd (..), AddressKeyType (.
 import           Cardano.CLI.Shelley.Run.Address.Info (ShelleyAddressInfoError, runAddressInfo)
 import           Cardano.CLI.Shelley.Run.Read
 import           Cardano.CLI.Types
+
+import           Control.Monad.IO.Class (MonadIO (..))
+import           Control.Monad.Trans.Except (ExceptT)
+import           Control.Monad.Trans.Except.Extra (firstExceptT, left, newExceptT)
+import qualified Data.ByteString.Char8 as BS
+import           Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.IO as Text
 
 data ShelleyAddressCmdError
   = ShelleyAddressCmdAddressInfoError !ShelleyAddressInfoError

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Governance.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Governance.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Cardano.CLI.Shelley.Run.Governance

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Key.hs
@@ -14,30 +14,6 @@ module Cardano.CLI.Shelley.Run.Key
   , decodeBech32
   ) where
 
-import           Control.Exception (Exception (..), IOException)
-import           Control.Monad.IO.Class (MonadIO (..))
-import           Control.Monad.Trans.Except (ExceptT)
-import           Data.Bifunctor (Bifunctor (..))
-import           Data.ByteString (ByteString)
-import qualified Data.ByteString as BS
-import qualified Data.ByteString.Char8 as BSC
-import           Data.Text (Text)
-import qualified Data.Text as Text
-import qualified Data.Text.Encoding as Text
-import           System.Exit (exitFailure)
-
-import qualified Control.Exception as Exception
-import           Control.Monad.Trans.Except.Extra (firstExceptT, hoistEither, left, newExceptT)
-
-import qualified Codec.Binary.Bech32 as Bech32
-
-import qualified Cardano.Crypto.DSIGN as DSIGN
-import qualified Cardano.Crypto.Signing as Byron
-import qualified Cardano.Crypto.Signing as Byron.Crypto
-import qualified Cardano.Crypto.Signing as Crypto
-import qualified Cardano.Crypto.Wallet as Crypto
-import qualified Cardano.Ledger.Keys as Shelley
-
 import           Cardano.Api
 import qualified Cardano.Api.Byron as ByronApi
 import           Cardano.Api.Crypto.Ed25519Bip32 (xPrvFromBytes)
@@ -49,6 +25,27 @@ import           Cardano.CLI.Shelley.Key (VerificationKeyTextOrFile (..),
                    VerificationKeyTextOrFileError, readVerificationKeyTextOrFileAnyOf,
                    renderVerificationKeyTextOrFileError)
 import           Cardano.CLI.Types (SigningKeyFile, VerificationKeyFile)
+import qualified Cardano.Crypto.DSIGN as DSIGN
+import qualified Cardano.Crypto.Signing as Byron
+import qualified Cardano.Crypto.Signing as Byron.Crypto
+import qualified Cardano.Crypto.Signing as Crypto
+import qualified Cardano.Crypto.Wallet as Crypto
+import qualified Cardano.Ledger.Keys as Shelley
+
+import qualified Codec.Binary.Bech32 as Bech32
+import           Control.Exception (Exception (..), IOException)
+import qualified Control.Exception as Exception
+import           Control.Monad.IO.Class (MonadIO (..))
+import           Control.Monad.Trans.Except (ExceptT)
+import           Control.Monad.Trans.Except.Extra (firstExceptT, hoistEither, left, newExceptT)
+import           Data.Bifunctor (Bifunctor (..))
+import           Data.ByteString (ByteString)
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as BSC
+import           Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text
+import           System.Exit (exitFailure)
 
 
 data ShelleyKeyCmdError

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Node.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Node.hs
@@ -11,6 +11,13 @@ module Cardano.CLI.Shelley.Run.Node
   , readColdVerificationKeyOrFile
   ) where
 
+import           Cardano.Api
+import           Cardano.Api.Shelley
+
+import           Cardano.CLI.Shelley.Commands
+import           Cardano.CLI.Shelley.Key (VerificationKeyOrFile, readVerificationKeyOrFile)
+import           Cardano.CLI.Types (KeyOutputFormat (..), SigningKeyFile, VerificationKeyFile)
+
 import           Control.Monad.IO.Class (MonadIO (..))
 import           Control.Monad.Trans.Except (ExceptT)
 import           Control.Monad.Trans.Except.Extra (firstExceptT, hoistEither, newExceptT)
@@ -19,13 +26,6 @@ import           Data.String (fromString)
 import           Data.Text (Text)
 import qualified Data.Text as Text
 import           Data.Word (Word64)
-
-import           Cardano.Api
-import           Cardano.Api.Shelley
-
-import           Cardano.CLI.Shelley.Commands
-import           Cardano.CLI.Shelley.Key (VerificationKeyOrFile, readVerificationKeyOrFile)
-import           Cardano.CLI.Types (KeyOutputFormat (..), SigningKeyFile, VerificationKeyFile)
 
 {- HLINT ignore "Reduce duplication" -}
 

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/TextView.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/TextView.hs
@@ -6,18 +6,17 @@ module Cardano.CLI.Shelley.Run.TextView
   , runTextViewCmd
   ) where
 
-import           Control.Monad.Trans.Except (ExceptT)
-import qualified Data.ByteString.Lazy.Char8 as LBS
-import           Data.Text (Text)
-import qualified Data.Text as Text
+import           Cardano.Api
 
 import           Cardano.CLI.Helpers (HelpersError, pPrintCBOR, renderHelpersError)
 import           Cardano.CLI.Shelley.Parsers
 
-import           Cardano.Api
-
 import           Control.Monad.IO.Class (MonadIO (..))
+import           Control.Monad.Trans.Except (ExceptT)
 import           Control.Monad.Trans.Except.Extra (firstExceptT, newExceptT)
+import qualified Data.ByteString.Lazy.Char8 as LBS
+import           Data.Text (Text)
+import qualified Data.Text as Text
 
 data ShelleyTextViewFileError
   = TextViewReadFileError (FileError TextEnvelopeError)

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Validate.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Validate.hs
@@ -34,10 +34,10 @@ module Cardano.CLI.Shelley.Run.Validate
   , validateTxWithdrawals
   ) where
 
-import           Prelude
-
 import           Cardano.Api
 import           Cardano.Api.Shelley
+
+import           Prelude
 
 import           Data.Bifunctor (first)
 import qualified Data.Map.Strict as Map

--- a/cardano-cli/src/Cardano/CLI/TopHandler.hs
+++ b/cardano-cli/src/Cardano/CLI/TopHandler.hs
@@ -47,7 +47,6 @@ module Cardano.CLI.TopHandler
 import           Prelude
 
 import           Control.Exception
-
 import           System.Environment
 import           System.Exit
 import           System.IO

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Byron/SigningKeys.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Byron/SigningKeys.hs
@@ -4,24 +4,24 @@ module Test.Golden.Byron.SigningKeys
   ( tests
   ) where
 
-import           Codec.CBOR.Read (deserialiseFromBytes)
-import           Control.Monad (void)
-import           Control.Monad.Trans.Except (runExceptT)
-import qualified Data.ByteString.Lazy as LB
-
-import qualified Cardano.Crypto.Signing as Crypto
-
 import           Cardano.Api.Byron
 
 import           Cardano.CLI.Byron.Key (readByronSigningKey)
 import           Cardano.CLI.Byron.Legacy (decodeLegacyDelegateKey)
 import           Cardano.CLI.Shelley.Commands
+import qualified Cardano.Crypto.Signing as Crypto
+
+import           Codec.CBOR.Read (deserialiseFromBytes)
+import           Control.Monad (void)
+import           Control.Monad.Trans.Except (runExceptT)
+import qualified Data.ByteString.Lazy as LB
+
+import           Test.Cardano.CLI.Util
 
 import           Hedgehog (Group (..), Property, checkSequential, property, success)
 import qualified Hedgehog as H
 import qualified Hedgehog.Extras.Test.Base as H
 import           Hedgehog.Internal.Property (failWith)
-import           Test.Cardano.CLI.Util
 
 prop_deserialise_legacy_signing_Key :: Property
 prop_deserialise_legacy_signing_Key = propertyOnce $ do

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Byron/Tx.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Byron/Tx.hs
@@ -5,6 +5,7 @@ module Test.Golden.Byron.Tx
   ) where
 
 import           Cardano.Api
+
 import           Cardano.Chain.UTxO (ATxAux)
 import           Cardano.CLI.Byron.Tx
 
@@ -14,12 +15,12 @@ import           Control.Monad.Trans.Except (runExceptT)
 import           Data.ByteString (ByteString)
 import qualified Data.Text as Text
 
-import           Hedgehog (Property, (===))
-import qualified Hedgehog as H
-import           Hedgehog.Internal.Property (failWith)
 import           Test.Cardano.CLI.Util
 
+import           Hedgehog (Property, (===))
+import qualified Hedgehog as H
 import qualified Hedgehog.Extras.Test.Base as H
+import           Hedgehog.Internal.Property (failWith)
 
 {- HLINT ignore "Use camelCase" -}
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Byron/UpdateProposal.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Byron/UpdateProposal.hs
@@ -4,19 +4,19 @@ module Test.Golden.Byron.UpdateProposal
   ( updateProposalTest
   ) where
 
+import           Cardano.CLI.Byron.UpdateProposal
+
 import           Control.Monad (void)
 import           Control.Monad.IO.Class (MonadIO (..))
 import           Control.Monad.Trans.Except (runExceptT)
 import qualified Data.Text as Text
 
-import           Cardano.CLI.Byron.UpdateProposal
+import           Test.Cardano.CLI.Util
 
 import           Hedgehog (Property, (===))
 import qualified Hedgehog as H
-import           Hedgehog.Internal.Property (failWith)
-import           Test.Cardano.CLI.Util
-
 import qualified Hedgehog.Extras.Test.Base as H
+import           Hedgehog.Internal.Property (failWith)
 
 {- HLINT ignore "Use camelCase" -}
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Byron/Vote.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Byron/Vote.hs
@@ -10,12 +10,13 @@ import           Control.Monad (void)
 import           Control.Monad.IO.Class (MonadIO (..))
 import           Control.Monad.Trans.Except (runExceptT)
 import qualified Data.Text as Text
-import qualified Hedgehog.Extras.Test.Base as H
+
+import           Test.Cardano.CLI.Util
 
 import           Hedgehog (Property, (===))
 import qualified Hedgehog as H
+import qualified Hedgehog.Extras.Test.Base as H
 import           Hedgehog.Internal.Property (failWith)
-import           Test.Cardano.CLI.Util
 
 {- HLINT ignore "Use camelCase" -}
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Help.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Help.hs
@@ -9,21 +9,22 @@ module Test.Golden.Help
 import           Prelude hiding (lines)
 
 import           Control.Monad (forM_, unless, (<=<))
-import           Data.Maybe (maybeToList)
-import           Data.Text (Text)
-import           Hedgehog (Property)
-import           Hedgehog.Extras.Stock.OS (isWin32)
-import           System.FilePath ((</>))
-import           Test.Cardano.CLI.Util (execCardanoCLI, propertyOnce)
-import           Text.Regex (Regex, mkRegex, subRegex)
-
 import qualified Data.Char as Char
 import qualified Data.List as List
+import           Data.Maybe (maybeToList)
+import           Data.Text (Text)
 import qualified Data.Text as Text
+import           System.FilePath ((</>))
+import           Text.Regex (Regex, mkRegex, subRegex)
+
+import qualified Test.Cardano.CLI.Util as H
+import           Test.Cardano.CLI.Util (execCardanoCLI, propertyOnce)
+
+import           Hedgehog (Property)
 import qualified Hedgehog as H
+import           Hedgehog.Extras.Stock.OS (isWin32)
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.Golden as H
-import qualified Test.Cardano.CLI.Util as H
 
 ansiRegex :: Regex
 ansiRegex = mkRegex "\\[[0-9]+m"

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Key.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Key.hs
@@ -4,9 +4,8 @@ module Test.Golden.Key
   ( keyTests
   ) where
 
-import qualified Test.Golden.Key.NonExtendedKey
-
 import qualified Hedgehog as H
+import qualified Test.Golden.Key.NonExtendedKey
 
 keyTests :: IO Bool
 keyTests =

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Key/NonExtendedKey.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Key/NonExtendedKey.hs
@@ -6,12 +6,14 @@ module Test.Golden.Key.NonExtendedKey
   ) where
 
 import           Control.Monad (void)
+import           System.FilePath ((</>))
+
+import           Test.Cardano.CLI.Util (execCardanoCLI, propertyOnce)
+
 import           Hedgehog (Property)
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 import qualified Hedgehog.Extras.Test.Golden as H
-import           System.FilePath ((</>))
-import           Test.Cardano.CLI.Util (execCardanoCLI, propertyOnce)
 
 {- HLINT ignore "Use camelCase" -}
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Address/Build.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Address/Build.hs
@@ -5,9 +5,10 @@ module Test.Golden.Shelley.Address.Build
   ) where
 
 import           Control.Monad (void)
-import           Hedgehog (Property)
+
 import           Test.Cardano.CLI.Util as OP
 
+import           Hedgehog (Property)
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Address/Info.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Address/Info.hs
@@ -5,11 +5,11 @@ module Test.Golden.Shelley.Address.Info
   ) where
 
 import           Control.Monad (when)
+import qualified Data.List as L
 
-import           Hedgehog (Property)
 import           Test.Cardano.CLI.Util
 
-import qualified Data.List as L
+import           Hedgehog (Property)
 import qualified Hedgehog as H
 
 {- HLINT ignore "Use camelCase" -}

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Address/KeyGen.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Address/KeyGen.hs
@@ -6,9 +6,10 @@ module Test.Golden.Shelley.Address.KeyGen
   ) where
 
 import           Control.Monad (void)
-import           Hedgehog (Property)
+
 import           Test.Cardano.CLI.Util
 
+import           Hedgehog (Property)
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Genesis/Create.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Genesis/Create.hs
@@ -6,20 +6,20 @@ module Test.Golden.Shelley.Genesis.Create
   ) where
 
 import           Control.Monad (void)
-import           Data.Bifunctor (Bifunctor (..))
-import           Data.Foldable (for_)
-
-import           Hedgehog (Property, forAll, (===))
-import           Test.Cardano.CLI.Util as OP
-
 import qualified Data.Aeson as J
 import qualified Data.Aeson.Key as J
 import qualified Data.Aeson.KeyMap as KeyMap
 import qualified Data.Aeson.Types as J
+import           Data.Bifunctor (Bifunctor (..))
 import qualified Data.ByteString.Lazy as LBS
+import           Data.Foldable (for_)
 import qualified Data.HashMap.Lazy as HM
 import qualified Data.Set as S
 import qualified Data.Time.Clock as DT
+
+import           Test.Cardano.CLI.Util as OP
+
+import           Hedgehog (Property, forAll, (===))
 import qualified Hedgehog as H
 import qualified Hedgehog.Extras.Stock.Time as H
 import qualified Hedgehog.Extras.Test.Base as H

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Genesis/InitialTxIn.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Genesis/InitialTxIn.hs
@@ -4,9 +4,9 @@ module Test.Golden.Shelley.Genesis.InitialTxIn
   ( golden_shelleyGenesisInitialTxIn
   ) where
 
-import           Hedgehog (Property)
 import           Test.Cardano.CLI.Util
 
+import           Hedgehog (Property)
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Genesis/KeyGenDelegate.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Genesis/KeyGenDelegate.hs
@@ -5,9 +5,10 @@ module Test.Golden.Shelley.Genesis.KeyGenDelegate
   ) where
 
 import           Control.Monad (void)
-import           Hedgehog (Property)
+
 import           Test.Cardano.CLI.Util
 
+import           Hedgehog (Property)
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Genesis/KeyGenGenesis.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Genesis/KeyGenGenesis.hs
@@ -5,9 +5,10 @@ module Test.Golden.Shelley.Genesis.KeyGenGenesis
   ) where
 
 import           Control.Monad (void)
-import           Hedgehog (Property)
+
 import           Test.Cardano.CLI.Util
 
+import           Hedgehog (Property)
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Genesis/KeyGenUtxo.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Genesis/KeyGenUtxo.hs
@@ -5,9 +5,10 @@ module Test.Golden.Shelley.Genesis.KeyGenUtxo
   ) where
 
 import           Control.Monad (void)
-import           Hedgehog (Property)
+
 import           Test.Cardano.CLI.Util
 
+import           Hedgehog (Property)
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Genesis/KeyHash.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Genesis/KeyHash.hs
@@ -4,9 +4,9 @@ module Test.Golden.Shelley.Genesis.KeyHash
   ( golden_shelleyGenesisKeyHash
   ) where
 
-import           Hedgehog (Property, (===))
 import           Test.Cardano.CLI.Util as OP
 
+import           Hedgehog (Property, (===))
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Governance/AnswerPoll.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Governance/AnswerPoll.hs
@@ -7,10 +7,11 @@ module Test.Golden.Shelley.Governance.AnswerPoll
   , golden_shelleyGovernanceAnswerPollPos2Invalid
   ) where
 
-import           Hedgehog (Property)
+import           Control.Monad (void)
+
 import           Test.Cardano.CLI.Util
 
-import           Control.Monad (void)
+import           Hedgehog (Property)
 import qualified Hedgehog as H
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Governance/CreatePoll.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Governance/CreatePoll.hs
@@ -6,9 +6,10 @@ module Test.Golden.Shelley.Governance.CreatePoll
   ) where
 
 import           Control.Monad (void)
-import           Hedgehog (Property)
+
 import           Test.Cardano.CLI.Util
 
+import           Hedgehog (Property)
 import qualified Hedgehog as H
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Governance/VerifyPoll.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Governance/VerifyPoll.hs
@@ -9,15 +9,17 @@ module Test.Golden.Shelley.Governance.VerifyPoll
   , golden_shelleyGovernanceVerifyPollInvalidAnswer
   ) where
 
-import           Control.Monad.IO.Class (liftIO)
-import           Hedgehog (Property)
-import           Test.Cardano.CLI.Util
-
 import           Cardano.Api
+
 import           Cardano.CLI.Shelley.Key (VerificationKeyOrFile (..),
                    readVerificationKeyOrTextEnvFile)
 
+import           Control.Monad.IO.Class (liftIO)
 import qualified Data.ByteString.Char8 as BSC
+
+import           Test.Cardano.CLI.Util
+
+import           Hedgehog (Property)
 import qualified Hedgehog as H
 import qualified Hedgehog.Internal.Property as H
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Key/ConvertCardanoAddressKey.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Key/ConvertCardanoAddressKey.hs
@@ -9,9 +9,10 @@ module Test.Golden.Shelley.Key.ConvertCardanoAddressKey
 
 import           Control.Monad (void)
 import           Data.Text (Text)
-import           Hedgehog (Property, (===))
+
 import           Test.Cardano.CLI.Util
 
+import           Hedgehog (Property, (===))
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Metadata/StakePoolMetadata.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Metadata/StakePoolMetadata.hs
@@ -7,9 +7,10 @@ module Test.Golden.Shelley.Metadata.StakePoolMetadata
 import           Control.Monad (void)
 import           Data.Text (Text)
 import qualified Data.Text.IO as Text
-import           Hedgehog (Property)
+
 import           Test.Cardano.CLI.Util as OP
 
+import           Hedgehog (Property)
 import qualified Hedgehog as H
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/MultiSig/Address.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/MultiSig/Address.hs
@@ -6,9 +6,9 @@ module Test.Golden.Shelley.MultiSig.Address
   , golden_shelleyAtLeastMultiSigAddressBuild
   ) where
 
-import           Hedgehog (Property)
 import           Test.Cardano.CLI.Util as OP
 
+import           Hedgehog (Property)
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Node/IssueOpCert.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Node/IssueOpCert.hs
@@ -5,9 +5,10 @@ module Test.Golden.Shelley.Node.IssueOpCert
   ) where
 
 import           Control.Monad (void)
-import           Hedgehog (Property)
+
 import           Test.Cardano.CLI.Util
 
+import           Hedgehog (Property)
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Node/KeyGen.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Node/KeyGen.hs
@@ -7,9 +7,10 @@ module Test.Golden.Shelley.Node.KeyGen
   ) where
 
 import           Control.Monad (void)
-import           Hedgehog (Property)
+
 import           Test.Cardano.CLI.Util
 
+import           Hedgehog (Property)
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Node/KeyGenKes.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Node/KeyGenKes.hs
@@ -7,9 +7,10 @@ module Test.Golden.Shelley.Node.KeyGenKes
   ) where
 
 import           Control.Monad (void)
-import           Hedgehog (Property)
+
 import           Test.Cardano.CLI.Util
 
+import           Hedgehog (Property)
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Node/KeyGenVrf.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Node/KeyGenVrf.hs
@@ -7,9 +7,10 @@ module Test.Golden.Shelley.Node.KeyGenVrf
   ) where
 
 import           Control.Monad (void)
-import           Hedgehog (Property)
+
 import           Test.Cardano.CLI.Util
 
+import           Hedgehog (Property)
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/StakeAddress/Build.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/StakeAddress/Build.hs
@@ -4,9 +4,9 @@ module Test.Golden.Shelley.StakeAddress.Build
   ( golden_shelleyStakeAddressBuild
   ) where
 
-import           Hedgehog (Property)
 import           Test.Cardano.CLI.Util as OP
 
+import           Hedgehog (Property)
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/StakeAddress/DeregistrationCertificate.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/StakeAddress/DeregistrationCertificate.hs
@@ -5,10 +5,11 @@ module Test.Golden.Shelley.StakeAddress.DeregistrationCertificate
   ) where
 
 import           Control.Monad (void)
-import           Hedgehog (Property)
 import           System.FilePath ((</>))
+
 import           Test.Cardano.CLI.Util
 
+import           Hedgehog (Property)
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 import qualified Hedgehog.Extras.Test.Process as H

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/StakeAddress/KeyGen.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/StakeAddress/KeyGen.hs
@@ -4,10 +4,11 @@ module Test.Golden.Shelley.StakeAddress.KeyGen
   ( golden_shelleyStakeAddressKeyGen
   ) where
 
-import           Hedgehog (Property)
+import           Control.Monad (void)
+
 import           Test.Cardano.CLI.Util
 
-import           Control.Monad (void)
+import           Hedgehog (Property)
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/StakeAddress/RegistrationCertificate.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/StakeAddress/RegistrationCertificate.hs
@@ -5,10 +5,11 @@ module Test.Golden.Shelley.StakeAddress.RegistrationCertificate
   ) where
 
 import           Control.Monad (void)
-import           Hedgehog (Property)
 import           System.FilePath ((</>))
+
 import           Test.Cardano.CLI.Util
 
+import           Hedgehog (Property)
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 import qualified Hedgehog.Extras.Test.Process as H

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/StakePool/RegistrationCertificate.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/StakePool/RegistrationCertificate.hs
@@ -4,10 +4,11 @@ module Test.Golden.Shelley.StakePool.RegistrationCertificate
   ( golden_shelleyStakePoolRegistrationCertificate
   ) where
 
-import           Hedgehog (Property)
+import           Control.Monad (void)
+
 import           Test.Cardano.CLI.Util
 
-import           Control.Monad (void)
+import           Hedgehog (Property)
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/ExtendedPaymentKeys.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/ExtendedPaymentKeys.hs
@@ -10,10 +10,11 @@ module Test.Golden.Shelley.TextEnvelope.Keys.ExtendedPaymentKeys
 import           Cardano.Api (AsType (..), HasTextEnvelope (..))
 
 import           Control.Monad (void)
-import           Hedgehog (Property)
-import           Test.Cardano.CLI.Util
 import           Text.Regex.TDFA ((=~))
 
+import           Test.Cardano.CLI.Util
+
+import           Hedgehog (Property)
 import qualified Hedgehog as H
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/GenesisDelegateKeys.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/GenesisDelegateKeys.hs
@@ -5,10 +5,12 @@ module Test.Golden.Shelley.TextEnvelope.Keys.GenesisDelegateKeys
   ) where
 
 import           Cardano.Api (AsType (..), HasTextEnvelope (..))
+
 import           Control.Monad (void)
-import           Hedgehog (Property)
+
 import           Test.Cardano.CLI.Util
 
+import           Hedgehog (Property)
 import qualified Hedgehog.Extras.Test.Base as H
 
 {- HLINT ignore "Use camelCase" -}

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/GenesisKeys.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/GenesisKeys.hs
@@ -5,10 +5,12 @@ module Test.Golden.Shelley.TextEnvelope.Keys.GenesisKeys
   ) where
 
 import           Cardano.Api (AsType (..), HasTextEnvelope (..))
+
 import           Control.Monad (void)
-import           Hedgehog (Property)
+
 import           Test.Cardano.CLI.Util
 
+import           Hedgehog (Property)
 import qualified Hedgehog.Extras.Test.Base as H
 
 {- HLINT ignore "Use camelCase" -}

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/GenesisUTxOKeys.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/GenesisUTxOKeys.hs
@@ -5,10 +5,12 @@ module Test.Golden.Shelley.TextEnvelope.Keys.GenesisUTxOKeys
   ) where
 
 import           Cardano.Api (AsType (..), HasTextEnvelope (..))
+
 import           Control.Monad (void)
-import           Hedgehog (Property)
+
 import           Test.Cardano.CLI.Util
 
+import           Hedgehog (Property)
 import qualified Hedgehog.Extras.Test.Base as H
 
 {- HLINT ignore "Use camelCase" -}

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/KESKeys.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/KESKeys.hs
@@ -10,13 +10,14 @@ module Test.Golden.Shelley.TextEnvelope.Keys.KESKeys
 import           Cardano.Api (AsType (..), HasTextEnvelope (..))
 
 import           Control.Monad (void)
-import           Hedgehog (Property)
+import           Text.Regex.TDFA ((=~))
+
 import           Test.Cardano.CLI.Util
 
+import           Hedgehog (Property)
 import qualified Hedgehog as H
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
-import           Text.Regex.TDFA ((=~))
 
 {- HLINT ignore "Use camelCase" -}
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/PaymentKeys.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/PaymentKeys.hs
@@ -8,14 +8,16 @@ module Test.Golden.Shelley.TextEnvelope.Keys.PaymentKeys
   ) where
 
 import           Cardano.Api (AsType (..), HasTextEnvelope (..))
+
 import           Control.Monad (void)
-import           Hedgehog (Property)
+import           Text.Regex.TDFA ((=~))
+
 import           Test.Cardano.CLI.Util
 
+import           Hedgehog (Property)
 import qualified Hedgehog as H
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
-import           Text.Regex.TDFA ((=~))
 
 {- HLINT ignore "Use camelCase" -}
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/StakeKeys.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/StakeKeys.hs
@@ -8,14 +8,16 @@ module Test.Golden.Shelley.TextEnvelope.Keys.StakeKeys
   ) where
 
 import           Cardano.Api (AsType (..), HasTextEnvelope (..))
+
 import           Control.Monad (void)
-import           Hedgehog (Property)
+import           Text.Regex.TDFA ((=~))
+
 import           Test.Cardano.CLI.Util
 
+import           Hedgehog (Property)
 import qualified Hedgehog as H
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
-import           Text.Regex.TDFA ((=~))
 
 {- HLINT ignore "Use camelCase" -}
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/VRFKeys.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/VRFKeys.hs
@@ -10,13 +10,14 @@ module Test.Golden.Shelley.TextEnvelope.Keys.VRFKeys
 import           Cardano.Api (AsType (..), HasTextEnvelope (..))
 
 import           Control.Monad (void)
-import           Hedgehog (Property)
+import           Text.Regex.TDFA ((=~))
+
 import           Test.Cardano.CLI.Util
 
+import           Hedgehog (Property)
 import qualified Hedgehog as H
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
-import           Text.Regex.TDFA ((=~))
 
 {- HLINT ignore "Use camelCase" -}
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Tx/Tx.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Tx/Tx.hs
@@ -5,9 +5,10 @@ module Test.Golden.Shelley.TextEnvelope.Tx.Tx
   ) where
 
 import           Control.Monad (void)
-import           Hedgehog (Property)
+
 import           Test.Cardano.CLI.Util
 
+import           Hedgehog (Property)
 import qualified Hedgehog.Extras.Test.Base as H
 
 {- HLINT ignore "Use camelCase" -}

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Tx/TxBody.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Tx/TxBody.hs
@@ -4,10 +4,11 @@ module Test.Golden.Shelley.TextEnvelope.Tx.TxBody
   ( golden_shelleyTxBody
   ) where
 
-import           Hedgehog (Property)
+import           Control.Monad (void)
+
 import           Test.Cardano.CLI.Util
 
-import           Control.Monad (void)
+import           Hedgehog (Property)
 import qualified Hedgehog.Extras.Test.Base as H
 
 {- HLINT ignore "Use camelCase" -}

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextView/DecodeCbor.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextView/DecodeCbor.hs
@@ -4,9 +4,9 @@ module Test.Golden.Shelley.TextView.DecodeCbor
   ( golden_shelleyTextViewDecodeCbor
   ) where
 
-import           Hedgehog (Property)
 import           Test.Cardano.CLI.Util
 
+import           Hedgehog (Property)
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Transaction/Assemble.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Transaction/Assemble.hs
@@ -6,9 +6,9 @@ module Test.Golden.Shelley.Transaction.Assemble
 
 import           Control.Monad (void)
 
-import           Hedgehog (Property)
 import           Test.Cardano.CLI.Util
 
+import           Hedgehog (Property)
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Transaction/Build.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Transaction/Build.hs
@@ -9,12 +9,12 @@ module Test.Golden.Shelley.Transaction.Build
   ) where
 
 import           Control.Monad (void)
-
 import qualified Data.ByteString.Base16 as Base16
 import qualified Data.ByteString.Char8 as BSC
-import           Hedgehog (Property)
+
 import           Test.Cardano.CLI.Util
 
+import           Hedgehog (Property)
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Transaction/CalculateMinFee.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Transaction/CalculateMinFee.hs
@@ -4,9 +4,9 @@ module Test.Golden.Shelley.Transaction.CalculateMinFee
   ( golden_shelleyTransactionCalculateMinFee
   ) where
 
-import           Hedgehog (Property)
 import           Test.Cardano.CLI.Util
 
+import           Hedgehog (Property)
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Transaction/CreateWitness.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Transaction/CreateWitness.hs
@@ -5,9 +5,10 @@ module Test.Golden.Shelley.Transaction.CreateWitness
   ) where
 
 import           Control.Monad (void)
-import           Hedgehog (Property)
+
 import           Test.Cardano.CLI.Util
 
+import           Hedgehog (Property)
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Transaction/Sign.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Transaction/Sign.hs
@@ -5,9 +5,10 @@ module Test.Golden.Shelley.Transaction.Sign
   ) where
 
 import           Control.Monad (void)
-import           Hedgehog (Property)
+
 import           Test.Cardano.CLI.Util
 
+import           Hedgehog (Property)
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/TxView.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/TxView.hs
@@ -3,12 +3,13 @@
 module Test.Golden.TxView (txViewTests) where
 
 import           Control.Monad (void)
+import           System.FilePath ((</>))
+
+import           Test.Cardano.CLI.Util (execCardanoCLI, noteTempFile)
 
 import           Hedgehog (Group (..), Property, checkSequential)
 import           Hedgehog.Extras (Integration, moduleWorkspace, note_, propertyOnce)
 import qualified Hedgehog.Extras.Test.Golden as H
-import           System.FilePath ((</>))
-import           Test.Cardano.CLI.Util (execCardanoCLI, noteTempFile)
 
 {- HLINT ignore "Use camelCase" -}
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Version.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Version.hs
@@ -6,8 +6,9 @@ module Test.Golden.Version
 
 import           Control.Monad (void)
 
-import           Hedgehog (Property)
 import           Test.Cardano.CLI.Util
+
+import           Hedgehog (Property)
 
 {- HLINT ignore "Use camelCase" -}
 

--- a/cardano-cli/test/cardano-cli-golden/cardano-cli-golden.hs
+++ b/cardano-cli/test/cardano-cli-golden/cardano-cli-golden.hs
@@ -1,7 +1,8 @@
-import           Hedgehog.Main (defaultMain)
+import qualified Cardano.Crypto.Init as Crypto
 
 import           System.IO (BufferMode (LineBuffering), hSetBuffering, hSetEncoding, stdout, utf8)
 
+import           Hedgehog.Main (defaultMain)
 import qualified Test.Golden.Byron.SigningKeys
 import qualified Test.Golden.Byron.Tx
 import qualified Test.Golden.Byron.UpdateProposal
@@ -10,8 +11,6 @@ import qualified Test.Golden.Help
 import qualified Test.Golden.Key
 import qualified Test.Golden.Shelley
 import qualified Test.Golden.TxView
-
-import qualified Cardano.Crypto.Init as Crypto
 
 main :: IO ()
 main = do

--- a/cardano-cli/test/cardano-cli-test-lib/Test/Cardano/CLI/Util.hs
+++ b/cardano-cli/test/cardano-cli-test-lib/Test/Cardano/CLI/Util.hs
@@ -20,22 +20,22 @@ import           Control.Monad.IO.Class (MonadIO (..))
 import           Control.Monad.Trans.Class (lift)
 import           Control.Monad.Trans.Except (runExceptT)
 import           Data.Function ((&))
-import           GHC.Stack (CallStack, HasCallStack)
-import           Hedgehog.Extras (ExecConfig)
-import           Hedgehog.Internal.Property (Diff, MonadTest, liftTest, mkTest)
-import           Hedgehog.Internal.Show (ValueDiff (ValueSame), mkValue, showPretty, valueDiff)
-import           Hedgehog.Internal.Source (getCaller)
-
 import qualified Data.List as List
 import           Data.Monoid (Last (..))
+import           GHC.Stack (CallStack, HasCallStack)
 import qualified GHC.Stack as GHC
-import qualified Hedgehog as H
-import qualified Hedgehog.Extras as H
-import           Hedgehog.Extras.Test (ExecConfig (..))
-import qualified Hedgehog.Internal.Property as H
 import qualified System.Exit as IO
 import qualified System.Process as IO
 import           System.Process (CreateProcess)
+
+import qualified Hedgehog as H
+import           Hedgehog.Extras (ExecConfig)
+import qualified Hedgehog.Extras as H
+import           Hedgehog.Extras.Test (ExecConfig (..))
+import           Hedgehog.Internal.Property (Diff, MonadTest, liftTest, mkTest)
+import qualified Hedgehog.Internal.Property as H
+import           Hedgehog.Internal.Show (ValueDiff (ValueSame), mkValue, showPretty, valueDiff)
+import           Hedgehog.Internal.Source (getCaller)
 
 -- | Execute cardano-cli via the command line.
 --

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/CliIntermediateFormat.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/CliIntermediateFormat.hs
@@ -7,9 +7,9 @@ module Test.Cli.CliIntermediateFormat
 
 import           Control.Monad (void)
 
-import           Hedgehog (Property, discover)
 import           Test.Cardano.CLI.Util
 
+import           Hedgehog (Property, discover)
 import qualified Hedgehog
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/FilePermissions.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/FilePermissions.hs
@@ -1,22 +1,23 @@
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TemplateHaskell   #-}
+{-# LANGUAGE TemplateHaskell #-}
 
 module Test.Cli.FilePermissions
   ( tests
   ) where
 
 import           Cardano.Api
-import           Cardano.Api.IO             (checkVrfFilePermissions)
+import           Cardano.Api.IO (checkVrfFilePermissions)
 
-import           Hedgehog                   (Property, discover, success)
-import qualified Hedgehog
-import qualified Hedgehog.Extras.Test.Base  as H
-import           Hedgehog.Internal.Property (failWith)
-
-import           Control.Monad              (void)
-import           Control.Monad.IO.Class     (MonadIO (..))
+import           Control.Monad (void)
+import           Control.Monad.IO.Class (MonadIO (..))
 import           Control.Monad.Trans.Except (runExceptT)
-import           Test.Cardano.CLI.Util      (execCardanoCLI)
+
+import           Test.Cardano.CLI.Util (execCardanoCLI)
+
+import           Hedgehog (Property, discover, success)
+import qualified Hedgehog
+import qualified Hedgehog.Extras.Test.Base as H
+import           Hedgehog.Internal.Property (failWith)
 
 -- | This property ensures that the VRF signing key file is created only with owner permissions
 prop_createVRFSigningKeyFilePermissions :: Property

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/ITN.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/ITN.hs
@@ -12,11 +12,13 @@ import           Data.ByteString (ByteString)
 import qualified Data.ByteString.Base16 as Base16
 import           Data.Text (Text)
 import qualified Data.Text.IO as Text
+
+import           Test.Cardano.CLI.Util
+
 import           Hedgehog (Property, (===))
 import qualified Hedgehog as H
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
-import           Test.Cardano.CLI.Util
 
 {- HLINT ignore "Reduce duplication" -}
 

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/JSON.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/JSON.hs
@@ -5,8 +5,11 @@
 module Test.Cli.JSON where
 
 import           Cardano.Api.Shelley
-import           Test.Gen.Cardano.Api.Typed (genLovelace, genSlotNo, genStakeAddress,
-                   genVerificationKeyHash)
+
+import           Cardano.CLI.Shelley.Output (QueryKesPeriodInfoOutput (..),
+                   createOpCertIntervalInfo)
+import           Cardano.CLI.Shelley.Run.Query
+import           Cardano.CLI.Types
 
 import           Data.Aeson
 import qualified Data.Map.Strict as Map
@@ -14,10 +17,8 @@ import           Data.Time
 import           Data.Time.Clock.POSIX (posixSecondsToUTCTime)
 import           Data.Word (Word64)
 
-import           Cardano.CLI.Shelley.Output (QueryKesPeriodInfoOutput (..),
-                   createOpCertIntervalInfo)
-import           Cardano.CLI.Shelley.Run.Query
-import           Cardano.CLI.Types
+import           Test.Gen.Cardano.Api.Typed (genLovelace, genSlotNo, genStakeAddress,
+                   genVerificationKeyHash)
 
 import           Hedgehog (Gen, Property, checkSequential, discover, forAll, property, tripping)
 import           Hedgehog.Gen as Gen

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/MultiAssetParsing.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/MultiAssetParsing.hs
@@ -3,15 +3,15 @@
 
 module Test.Cli.MultiAssetParsing where
 
+import           Cardano.Api (parseValue, renderValue, renderValuePretty, valueToList)
+
 import qualified Data.Text as Text
 import qualified Text.Parsec as Parsec (parse)
 
+import           Test.Gen.Cardano.Api.Typed (genValueDefault)
+
 import           Hedgehog (Property, checkSequential, discover, forAll, property, tripping)
 import qualified Hedgehog.Gen as Gen
-
-import           Cardano.Api (parseValue, renderValue, renderValuePretty, valueToList)
-
-import           Test.Gen.Cardano.Api.Typed (genValueDefault)
 
 prop_roundtrip_Value_parse_render :: Property
 prop_roundtrip_Value_parse_render =

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/Pioneers/Exercise1.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/Pioneers/Exercise1.hs
@@ -5,9 +5,10 @@ module Test.Cli.Pioneers.Exercise1
   ) where
 
 import           Control.Monad (void)
-import           Hedgehog (Property)
+
 import           Test.Cardano.CLI.Util
 
+import           Hedgehog (Property)
 import qualified Hedgehog as H
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/Pioneers/Exercise2.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/Pioneers/Exercise2.hs
@@ -5,9 +5,10 @@ module Test.Cli.Pioneers.Exercise2
   ) where
 
 import           Control.Monad (void)
-import           Hedgehog (Property)
+
 import           Test.Cardano.CLI.Util
 
+import           Hedgehog (Property)
 import qualified Hedgehog as H
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/Pioneers/Exercise3.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/Pioneers/Exercise3.hs
@@ -5,9 +5,10 @@ module Test.Cli.Pioneers.Exercise3
   ) where
 
 import           Control.Monad (void)
-import           Hedgehog (Property)
+
 import           Test.Cardano.CLI.Util
 
+import           Hedgehog (Property)
 import qualified Hedgehog as H
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/Pioneers/Exercise4.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/Pioneers/Exercise4.hs
@@ -5,9 +5,10 @@ module Test.Cli.Pioneers.Exercise4
   ) where
 
 import           Control.Monad (void)
-import           Hedgehog (Property)
+
 import           Test.Cardano.CLI.Util
 
+import           Hedgehog (Property)
 import qualified Hedgehog as H
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/Pioneers/Exercise5.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/Pioneers/Exercise5.hs
@@ -5,9 +5,10 @@ module Test.Cli.Pioneers.Exercise5
   ) where
 
 import           Control.Monad (void)
-import           Hedgehog (Property)
+
 import           Test.Cardano.CLI.Util
 
+import           Hedgehog (Property)
 import qualified Hedgehog as H
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/Pioneers/Exercise6.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/Pioneers/Exercise6.hs
@@ -5,9 +5,10 @@ module Test.Cli.Pioneers.Exercise6
   ) where
 
 import           Control.Monad (void)
-import           Hedgehog (Property)
+
 import           Test.Cardano.CLI.Util
 
+import           Hedgehog (Property)
 import qualified Hedgehog as H
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/Shelley/Run/Query.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/Shelley/Run/Query.hs
@@ -2,10 +2,10 @@ module Test.Cli.Shelley.Run.Query
   ( tests
   ) where
 
-import           Cardano.Slotting.Time (RelativeTime (..))
-import           Hedgehog (Property, (===))
-
 import qualified Cardano.CLI.Shelley.Run.Query as Q
+import           Cardano.Slotting.Time (RelativeTime (..))
+
+import           Hedgehog (Property, (===))
 import qualified Hedgehog as H
 import qualified Hedgehog.Extras.Test.Base as H
 

--- a/cardano-cli/test/cardano-cli-test/Test/Config/Mainnet.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Config/Mainnet.hs
@@ -7,18 +7,19 @@ module Test.Config.Mainnet
   ) where
 
 import           Cardano.Api (File (..), initialLedgerState, renderInitialLedgerStateError)
-import           Control.Monad.Trans.Except
-import           Hedgehog (Property, (===))
-import           System.FilePath ((</>))
 
+import           Control.Monad.Trans.Except
 import qualified Data.Aeson as J
 import qualified Data.Text as T
 import qualified Data.Yaml as Y
 import qualified GHC.Stack as GHC
+import qualified System.Directory as IO
+import           System.FilePath ((</>))
+
+import           Hedgehog (Property, (===))
 import qualified Hedgehog as H
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.Process as H
-import qualified System.Directory as IO
 
 hprop_configMainnetHash :: Property
 hprop_configMainnetHash = H.propertyOnce $ do

--- a/cardano-cli/test/cardano-cli-test/cardano-cli-test.hs
+++ b/cardano-cli/test/cardano-cli-test/cardano-cli-test.hs
@@ -1,7 +1,13 @@
 module Main where
 
+import qualified Cardano.Crypto.Init as Crypto
+
 import           System.IO (BufferMode (LineBuffering), hSetBuffering, hSetEncoding, stdout, utf8)
 
+import           Test.Gen.Cardano.Api.Empty ()
+
+import           Hedgehog.Extras.Stock.OS (isWin32)
+import           Hedgehog.Main (defaultMain)
 import qualified Test.Cli.CliIntermediateFormat
 import qualified Test.Cli.FilePermissions
 import qualified Test.Cli.ITN
@@ -13,13 +19,6 @@ import qualified Test.Cli.Pioneers.Exercise3
 import qualified Test.Cli.Pioneers.Exercise4
 import qualified Test.Cli.Pipes
 import qualified Test.Cli.Shelley.Run.Query
-
-import           Hedgehog.Extras.Stock.OS (isWin32)
-import           Hedgehog.Main (defaultMain)
-
-import           Test.Gen.Cardano.Api.Empty ()
-
-import qualified Cardano.Crypto.Init as Crypto
 
 main :: IO ()
 main = do

--- a/scripts/githooks/haskell-style-lint
+++ b/scripts/githooks/haskell-style-lint
@@ -4,12 +4,16 @@
 #
 # To set this script as your pre-commit hook, use the following command:
 #
-# ln -s $(git-root)/scripts/githooks/haskell-style-lint $(git-root)/.git/hooks/pre-commit
+# ln -s $(git-root)/scripts/githooks/haskell-style-lint $(git rev-parse --git-dir)/hooks/pre-commit
 #
 
 for x in $(git diff --staged --name-only --diff-filter=ACM | tr '\n' ' '); do
   if [ "${x##*.}" = "hs" ]; then
-    stylish-haskell -i "$x"
+    if grep -qE '^#' "$x"; then
+      echo "$x contains CPP.  Skipping."
+    else
+      stylish-haskell -i "$x"
+    fi
     # fail on linting issues
     hlint "$x"
   fi


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Apply `stylish-haskell` to project
  compatibility: no-api-changes
  type: maintenance
```

# Context

PRs tend to be a lot bigger than they need to be because`stylish-haskell` rules as to fix imports and the code is full of imports that haven't been fixed yet.

We only use `stylish-haskell` to format imports.  It's probably better to get all the pain out of the way by applying the `stylish-haskell` rules across the entire project so that future PRs can be smaller.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Any changes are noted in the `CHANGELOG.md` for affected package
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
