### PR TITLE
Upgrade to `optparse-applicative-fork-0.18.1.0`

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -13,8 +13,8 @@ repository cardano-haskell-packages
 -- See CONTRIBUTING for information about these, including some Nix commands
 -- you need to run if you change them
 index-state:
-  , hackage.haskell.org 2023-07-03T00:00:00Z
-  , cardano-haskell-packages 2023-07-08T06:00:00Z
+  , hackage.haskell.org 2023-07-05T20:00:33Z
+  , cardano-haskell-packages 2023-07-12T13:59:36Z
 
 packages:
     cardano-cli

--- a/cardano-cli/src/Cardano/CLI/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Parsers.hs
@@ -19,6 +19,7 @@ import           Cardano.CLI.Shelley.Parsers (parseShelleyCommands)
 import           Data.Foldable
 import           Options.Applicative
 import qualified Options.Applicative as Opt
+import qualified Prettyprinter as PP
 
 
 opts :: EnvCli -> ParserInfo ClientCommand
@@ -33,11 +34,12 @@ opts envCli =
     ]
 
 pref :: ParserPrefs
-pref = Opt.prefs $ mconcat
-         [ showHelpOnEmpty
-         , helpHangUsageOverflow 10
-         , helpRenderHelp customRenderHelp
-         ]
+pref =
+  Opt.prefs $ mconcat
+    [ showHelpOnEmpty
+    , helpEmbedBriefDesc $ PP.align
+    , helpRenderHelp customRenderHelp
+    ]
 
 parseClientCommand :: EnvCli -> Parser ClientCommand
 parseClientCommand envCli =

--- a/cardano-cli/src/Cardano/CLI/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Run.hs
@@ -119,9 +119,8 @@ helpAll pprefs progn rnames parserInfo = do
         go p = case p of
           NilP _ -> return ()
           OptP optP -> case optMain optP of
-            CmdReader _ cs f -> do
-              forM_ cs $ \c ->
-                forM_ (f c) $ \subParserInfo ->
+            CmdReader _ cs -> do
+              forM_ cs $ \(c, subParserInfo) ->
                   helpAll pprefs progn (c:rnames) subParserInfo
             _ -> return ()
           AltP pa pb -> go pa >> go pb

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -10,152 +10,160 @@ Usage: cardano-cli text-view decode-cbor --in-file FILE [--out-file FILE]
   Print a TextView file as decoded CBOR.
 
 Usage: cardano-cli governance 
-            ( create-mir-certificate
-            | create-genesis-key-delegation-certificate
-            | create-update-proposal
-            | create-poll
-            | answer-poll
-            | verify-poll
-            | vote
-            | action
-            )
+                                ( create-mir-certificate
+                                | create-genesis-key-delegation-certificate
+                                | create-update-proposal
+                                | create-poll
+                                | answer-poll
+                                | verify-poll
+                                | vote
+                                | action
+                                )
 
   Governance commands
 
 Usage: cardano-cli governance create-mir-certificate 
-            ( ( --shelley-era
-              | --allegra-era
-              | --mary-era
-              | --alonzo-era
-              | --babbage-era
-              | --conway-era
-              )
-              (--reserves | --treasury)
-              (--stake-address ADDRESS)
-              (--reward LOVELACE)
-              --out-file FILE
-            | stake-addresses
-            | transfer-to-treasury
-            | transfer-to-rewards
-            )
+                                                       ( ( --shelley-era
+                                                         | --allegra-era
+                                                         | --mary-era
+                                                         | --alonzo-era
+                                                         | --babbage-era
+                                                         | --conway-era
+                                                         )
+                                                         ( --reserves
+                                                         | --treasury
+                                                         )
+                                                         (--stake-address ADDRESS)
+                                                         (--reward LOVELACE)
+                                                         --out-file FILE
+                                                       | stake-addresses
+                                                       | transfer-to-treasury
+                                                       | transfer-to-rewards
+                                                       )
 
   Create an MIR (Move Instantaneous Rewards) certificate
 
 Usage: cardano-cli governance create-mir-certificate stake-addresses 
-            ( --shelley-era
-            | --allegra-era
-            | --mary-era
-            | --alonzo-era
-            | --babbage-era
-            | --conway-era
-            )
-            (--reserves | --treasury)
-            (--stake-address ADDRESS)
-            (--reward LOVELACE)
-            --out-file FILE
+                                                                       ( --shelley-era
+                                                                       | --allegra-era
+                                                                       | --mary-era
+                                                                       | --alonzo-era
+                                                                       | --babbage-era
+                                                                       | --conway-era
+                                                                       )
+                                                                       ( --reserves
+                                                                       | --treasury
+                                                                       )
+                                                                       (--stake-address ADDRESS)
+                                                                       (--reward LOVELACE)
+                                                                       --out-file FILE
 
   Create an MIR certificate to pay stake addresses
 
 Usage: cardano-cli governance create-mir-certificate transfer-to-treasury 
-            ( --shelley-era
-            | --allegra-era
-            | --mary-era
-            | --alonzo-era
-            | --babbage-era
-            | --conway-era
-            )
-            --transfer LOVELACE
-            --out-file FILE
+                                                                            ( --shelley-era
+                                                                            | --allegra-era
+                                                                            | --mary-era
+                                                                            | --alonzo-era
+                                                                            | --babbage-era
+                                                                            | --conway-era
+                                                                            )
+                                                                            --transfer LOVELACE
+                                                                            --out-file FILE
 
   Create an MIR certificate to transfer from the reserves pot to the treasury
   pot
 
 Usage: cardano-cli governance create-mir-certificate transfer-to-rewards 
-            ( --shelley-era
-            | --allegra-era
-            | --mary-era
-            | --alonzo-era
-            | --babbage-era
-            | --conway-era
-            )
-            --transfer LOVELACE
-            --out-file FILE
+                                                                           ( --shelley-era
+                                                                           | --allegra-era
+                                                                           | --mary-era
+                                                                           | --alonzo-era
+                                                                           | --babbage-era
+                                                                           | --conway-era
+                                                                           )
+                                                                           --transfer LOVELACE
+                                                                           --out-file FILE
 
   Create an MIR certificate to transfer from the treasury pot to the reserves
   pot
 
 Usage: cardano-cli governance create-genesis-key-delegation-certificate 
-            ( --shelley-era
-            | --allegra-era
-            | --mary-era
-            | --alonzo-era
-            | --babbage-era
-            | --conway-era
-            )
-            ( --genesis-verification-key STRING
-            | --genesis-verification-key-file FILE
-            | --genesis-verification-key-hash STRING
-            )
-            ( --genesis-delegate-verification-key STRING
-            | --genesis-delegate-verification-key-file FILE
-            | --genesis-delegate-verification-key-hash STRING
-            )
-            ( --vrf-verification-key STRING
-            | --vrf-verification-key-file FILE
-            | --vrf-verification-key-hash STRING
-            )
-            --out-file FILE
+                                                                          ( --shelley-era
+                                                                          | --allegra-era
+                                                                          | --mary-era
+                                                                          | --alonzo-era
+                                                                          | --babbage-era
+                                                                          | --conway-era
+                                                                          )
+                                                                          ( --genesis-verification-key STRING
+                                                                          | --genesis-verification-key-file FILE
+                                                                          | --genesis-verification-key-hash STRING
+                                                                          )
+                                                                          ( --genesis-delegate-verification-key STRING
+                                                                          | --genesis-delegate-verification-key-file FILE
+                                                                          | --genesis-delegate-verification-key-hash STRING
+                                                                          )
+                                                                          ( --vrf-verification-key STRING
+                                                                          | --vrf-verification-key-file FILE
+                                                                          | --vrf-verification-key-hash STRING
+                                                                          )
+                                                                          --out-file FILE
 
   Create a genesis key delegation certificate
 
 Usage: cardano-cli governance create-update-proposal --out-file FILE
-            --epoch EPOCH
-            (--genesis-verification-key-file FILE)
-            [--protocol-major-version NATURAL --protocol-minor-version NATURAL]
-            [--decentralization-parameter RATIONAL]
-            [--extra-entropy HEX | --reset-extra-entropy]
-            [--max-block-header-size NATURAL]
-            [--max-block-body-size NATURAL]
-            [--max-tx-size NATURAL]
-            [--min-fee-constant LOVELACE]
-            [--min-fee-linear LOVELACE]
-            [--min-utxo-value NATURAL]
-            [--key-reg-deposit-amt NATURAL]
-            [--pool-reg-deposit NATURAL]
-            [--min-pool-cost NATURAL]
-            [--pool-retirement-epoch-boundary EPOCH_BOUNDARY]
-            [--number-of-pools NATURAL]
-            [--pool-influence RATIONAL]
-            [--monetary-expansion RATIONAL]
-            [--treasury-expansion RATIONAL]
-            [--utxo-cost-per-word LOVELACE]
-            [--price-execution-steps RATIONAL --price-execution-memory RATIONAL]
-            [--max-tx-execution-units (INT, INT)]
-            [--max-block-execution-units (INT, INT)]
-            [--max-value-size INT]
-            [--collateral-percent INT]
-            [--max-collateral-inputs INT]
-            [--utxo-cost-per-byte LOVELACE]
-            [--cost-model-file FILE]
+                                                       --epoch EPOCH
+                                                       (--genesis-verification-key-file FILE)
+                                                       [--protocol-major-version NATURAL
+                                                         --protocol-minor-version NATURAL]
+                                                       [--decentralization-parameter RATIONAL]
+                                                       [ --extra-entropy HEX
+                                                       | --reset-extra-entropy
+                                                       ]
+                                                       [--max-block-header-size NATURAL]
+                                                       [--max-block-body-size NATURAL]
+                                                       [--max-tx-size NATURAL]
+                                                       [--min-fee-constant LOVELACE]
+                                                       [--min-fee-linear LOVELACE]
+                                                       [--min-utxo-value NATURAL]
+                                                       [--key-reg-deposit-amt NATURAL]
+                                                       [--pool-reg-deposit NATURAL]
+                                                       [--min-pool-cost NATURAL]
+                                                       [--pool-retirement-epoch-boundary EPOCH_BOUNDARY]
+                                                       [--number-of-pools NATURAL]
+                                                       [--pool-influence RATIONAL]
+                                                       [--monetary-expansion RATIONAL]
+                                                       [--treasury-expansion RATIONAL]
+                                                       [--utxo-cost-per-word LOVELACE]
+                                                       [--price-execution-steps RATIONAL
+                                                         --price-execution-memory RATIONAL]
+                                                       [--max-tx-execution-units (INT, INT)]
+                                                       [--max-block-execution-units (INT, INT)]
+                                                       [--max-value-size INT]
+                                                       [--collateral-percent INT]
+                                                       [--max-collateral-inputs INT]
+                                                       [--utxo-cost-per-byte LOVELACE]
+                                                       [--cost-model-file FILE]
 
   Create an update proposal
 
 Usage: cardano-cli governance create-poll --question STRING
-            (--answer STRING)
-            [--nonce UINT]
-            --out-file FILE
+                                            (--answer STRING)
+                                            [--nonce UINT]
+                                            --out-file FILE
 
   Create an SPO poll
 
 Usage: cardano-cli governance answer-poll --poll-file FILE
-            [--answer INT]
-            [--out-file FILE]
+                                            [--answer INT]
+                                            [--out-file FILE]
 
   Answer an SPO poll
 
 Usage: cardano-cli governance verify-poll --poll-file FILE
-            --tx-file FILE
-            [--out-file FILE]
+                                            --tx-file FILE
+                                            [--out-file FILE]
 
   Verify an answer to a given SPO poll
 
@@ -164,13 +172,16 @@ Usage: cardano-cli governance vote create-vote
   Vote related commands.
 
 Usage: cardano-cli governance vote create-vote (--yes | --no | --abstain)
-            (--constitutional-committee-member | --drep | --spo)
-            --tx-in TX-IN
-            ( --stake-pool-verification-key STRING
-            | --cold-verification-key-file FILE
-            )
-            [--conway-era]
-            --out-file FILE
+                                                 ( --constitutional-committee-member
+                                                 | --drep
+                                                 | --spo
+                                                 )
+                                                 --tx-in TX-IN
+                                                 ( --stake-pool-verification-key STRING
+                                                 | --cold-verification-key-file FILE
+                                                 )
+                                                 [--conway-era]
+                                                 --out-file FILE
 
   Create a vote for a proposed governance action.
 
@@ -183,45 +194,47 @@ Usage: cardano-cli governance action create-action create-constitution
   Create a governance action.
 
 Usage: cardano-cli governance action create-action create-constitution 
-            [--conway-era]
-            --governance-action-deposit NATURAL
-            ( --stake-pool-verification-key STRING
-            | --cold-verification-key-file FILE
-            )
-            (--constitution TEXT | --constitution-file FILE)
-            --out-file FILE
+                                                                         [--conway-era]
+                                                                         --governance-action-deposit NATURAL
+                                                                         ( --stake-pool-verification-key STRING
+                                                                         | --cold-verification-key-file FILE
+                                                                         )
+                                                                         ( --constitution TEXT
+                                                                         | --constitution-file FILE
+                                                                         )
+                                                                         --out-file FILE
 
   Create a constitution.
 
 Usage: cardano-cli genesis 
-            ( key-gen-genesis
-            | key-gen-delegate
-            | key-gen-utxo
-            | key-hash
-            | get-ver-key
-            | initial-addr
-            | initial-txin
-            | create-cardano
-            | create
-            | create-staked
-            | hash
-            )
+                             ( key-gen-genesis
+                             | key-gen-delegate
+                             | key-gen-utxo
+                             | key-hash
+                             | get-ver-key
+                             | initial-addr
+                             | initial-txin
+                             | create-cardano
+                             | create
+                             | create-staked
+                             | hash
+                             )
 
   Genesis block commands
 
 Usage: cardano-cli genesis key-gen-genesis --verification-key-file FILE
-            --signing-key-file FILE
+                                             --signing-key-file FILE
 
   Create a Shelley genesis key pair
 
 Usage: cardano-cli genesis key-gen-delegate --verification-key-file FILE
-            --signing-key-file FILE
-            --operational-certificate-issue-counter-file FILE
+                                              --signing-key-file FILE
+                                              --operational-certificate-issue-counter-file FILE
 
   Create a Shelley genesis delegate key pair
 
 Usage: cardano-cli genesis key-gen-utxo --verification-key-file FILE
-            --signing-key-file FILE
+                                          --signing-key-file FILE
 
   Create a Shelley genesis UTxO key pair
 
@@ -230,65 +243,67 @@ Usage: cardano-cli genesis key-hash --verification-key-file FILE
   Print the identifier (hash) of a public key
 
 Usage: cardano-cli genesis get-ver-key --verification-key-file FILE
-            --signing-key-file FILE
+                                         --signing-key-file FILE
 
   Derive the verification key from a signing key
 
 Usage: cardano-cli genesis initial-addr --verification-key-file FILE
-            (--mainnet | --testnet-magic NATURAL)
-            [--out-file FILE]
+                                          (--mainnet | --testnet-magic NATURAL)
+                                          [--out-file FILE]
 
   Get the address for an initial UTxO based on the verification key
 
 Usage: cardano-cli genesis initial-txin --verification-key-file FILE
-            (--mainnet | --testnet-magic NATURAL)
-            [--out-file FILE]
+                                          (--mainnet | --testnet-magic NATURAL)
+                                          [--out-file FILE]
 
   Get the TxIn for an initial UTxO based on the verification key
 
 Usage: cardano-cli genesis create-cardano --genesis-dir DIR
-            [--gen-genesis-keys INT]
-            [--gen-utxo-keys INT]
-            [--start-time UTC-TIME]
-            [--supply LOVELACE]
-            [--security-param INT]
-            [--slot-length INT]
-            [--slot-coefficient RATIONAL]
-            (--mainnet | --testnet-magic NATURAL)
-            --byron-template FILEPATH
-            --shelley-template FILEPATH
-            --alonzo-template FILEPATH
-            --conway-template FILEPATH
-            [--node-config-template FILEPATH]
+                                            [--gen-genesis-keys INT]
+                                            [--gen-utxo-keys INT]
+                                            [--start-time UTC-TIME]
+                                            [--supply LOVELACE]
+                                            [--security-param INT]
+                                            [--slot-length INT]
+                                            [--slot-coefficient RATIONAL]
+                                            ( --mainnet
+                                            | --testnet-magic NATURAL
+                                            )
+                                            --byron-template FILEPATH
+                                            --shelley-template FILEPATH
+                                            --alonzo-template FILEPATH
+                                            --conway-template FILEPATH
+                                            [--node-config-template FILEPATH]
 
   Create a Byron and Shelley genesis file from a genesis template and
   genesis/delegation/spending keys.
 
 Usage: cardano-cli genesis create [--key-output-format STRING]
-            --genesis-dir DIR
-            [--gen-genesis-keys INT]
-            [--gen-utxo-keys INT]
-            [--start-time UTC-TIME]
-            [--supply LOVELACE]
-            (--mainnet | --testnet-magic NATURAL)
+                                    --genesis-dir DIR
+                                    [--gen-genesis-keys INT]
+                                    [--gen-utxo-keys INT]
+                                    [--start-time UTC-TIME]
+                                    [--supply LOVELACE]
+                                    (--mainnet | --testnet-magic NATURAL)
 
   Create a Shelley genesis file from a genesis template and
   genesis/delegation/spending keys.
 
 Usage: cardano-cli genesis create-staked [--key-output-format STRING]
-            --genesis-dir DIR
-            [--gen-genesis-keys INT]
-            [--gen-utxo-keys INT]
-            [--gen-pools INT]
-            [--gen-stake-delegs INT]
-            [--start-time UTC-TIME]
-            [--supply LOVELACE]
-            [--supply-delegated LOVELACE]
-            (--mainnet | --testnet-magic NATURAL)
-            [--bulk-pool-cred-files INT]
-            [--bulk-pools-per-file INT]
-            [--num-stuffed-utxo INT]
-            [--relay-specification-file FILE]
+                                           --genesis-dir DIR
+                                           [--gen-genesis-keys INT]
+                                           [--gen-utxo-keys INT]
+                                           [--gen-pools INT]
+                                           [--gen-stake-delegs INT]
+                                           [--start-time UTC-TIME]
+                                           [--supply LOVELACE]
+                                           [--supply-delegated LOVELACE]
+                                           (--mainnet | --testnet-magic NATURAL)
+                                           [--bulk-pool-cred-files INT]
+                                           [--bulk-pools-per-file INT]
+                                           [--num-stuffed-utxo INT]
+                                           [--relay-specification-file FILE]
 
   Create a staked Shelley genesis file from a genesis template and
   genesis/delegation/spending keys.
@@ -298,191 +313,217 @@ Usage: cardano-cli genesis hash --genesis FILE
   Compute the hash of a genesis file
 
 Usage: cardano-cli query 
-            ( protocol-parameters
-            | constitution-hash
-            | tip
-            | stake-pools
-            | stake-distribution
-            | stake-address-info
-            | utxo
-            | ledger-state
-            | protocol-state
-            | stake-snapshot
-            | leadership-schedule
-            | kes-period-info
-            | pool-state
-            | tx-mempool
-            | slot-number
-            )
+                           ( protocol-parameters
+                           | constitution-hash
+                           | tip
+                           | stake-pools
+                           | stake-distribution
+                           | stake-address-info
+                           | utxo
+                           | ledger-state
+                           | protocol-state
+                           | stake-snapshot
+                           | leadership-schedule
+                           | kes-period-info
+                           | pool-state
+                           | tx-mempool
+                           | slot-number
+                           )
 
   Node query commands. Will query the local node whose Unix domain socket is
   obtained from the CARDANO_NODE_SOCKET_PATH environment variable.
 
 Usage: cardano-cli query protocol-parameters --socket-path SOCKET_PATH
-            [ --shelley-mode
-            | --byron-mode [--epoch-slots SLOTS]
-            | --cardano-mode [--epoch-slots SLOTS]
-            ]
-            (--mainnet | --testnet-magic NATURAL)
-            [--out-file FILE]
+                                               [ --shelley-mode
+                                               | --byron-mode
+                                                 [--epoch-slots SLOTS]
+                                               | --cardano-mode
+                                                 [--epoch-slots SLOTS]
+                                               ]
+                                               ( --mainnet
+                                               | --testnet-magic NATURAL
+                                               )
+                                               [--out-file FILE]
 
   Get the node's current protocol parameters
 
 Usage: cardano-cli query constitution-hash --socket-path SOCKET_PATH
-            [ --shelley-mode
-            | --byron-mode [--epoch-slots SLOTS]
-            | --cardano-mode [--epoch-slots SLOTS]
-            ]
-            (--mainnet | --testnet-magic NATURAL)
-            [--out-file FILE]
+                                             [ --shelley-mode
+                                             | --byron-mode
+                                               [--epoch-slots SLOTS]
+                                             | --cardano-mode
+                                               [--epoch-slots SLOTS]
+                                             ]
+                                             ( --mainnet
+                                             | --testnet-magic NATURAL
+                                             )
+                                             [--out-file FILE]
 
   Get the constitution hash
 
 Usage: cardano-cli query tip --socket-path SOCKET_PATH
-            [ --shelley-mode
-            | --byron-mode [--epoch-slots SLOTS]
-            | --cardano-mode [--epoch-slots SLOTS]
-            ]
-            (--mainnet | --testnet-magic NATURAL)
-            [--out-file FILE]
+                               [ --shelley-mode
+                               | --byron-mode [--epoch-slots SLOTS]
+                               | --cardano-mode [--epoch-slots SLOTS]
+                               ]
+                               (--mainnet | --testnet-magic NATURAL)
+                               [--out-file FILE]
 
   Get the node's current tip (slot no, hash, block no)
 
 Usage: cardano-cli query stake-pools --socket-path SOCKET_PATH
-            [ --shelley-mode
-            | --byron-mode [--epoch-slots SLOTS]
-            | --cardano-mode [--epoch-slots SLOTS]
-            ]
-            (--mainnet | --testnet-magic NATURAL)
-            [--out-file FILE]
+                                       [ --shelley-mode
+                                       | --byron-mode [--epoch-slots SLOTS]
+                                       | --cardano-mode [--epoch-slots SLOTS]
+                                       ]
+                                       (--mainnet | --testnet-magic NATURAL)
+                                       [--out-file FILE]
 
   Get the node's current set of stake pool ids
 
 Usage: cardano-cli query stake-distribution --socket-path SOCKET_PATH
-            [ --shelley-mode
-            | --byron-mode [--epoch-slots SLOTS]
-            | --cardano-mode [--epoch-slots SLOTS]
-            ]
-            (--mainnet | --testnet-magic NATURAL)
-            [--out-file FILE]
+                                              [ --shelley-mode
+                                              | --byron-mode
+                                                [--epoch-slots SLOTS]
+                                              | --cardano-mode
+                                                [--epoch-slots SLOTS]
+                                              ]
+                                              ( --mainnet
+                                              | --testnet-magic NATURAL
+                                              )
+                                              [--out-file FILE]
 
   Get the node's current aggregated stake distribution
 
 Usage: cardano-cli query stake-address-info --socket-path SOCKET_PATH
-            [ --shelley-mode
-            | --byron-mode [--epoch-slots SLOTS]
-            | --cardano-mode [--epoch-slots SLOTS]
-            ]
-            --address ADDRESS
-            (--mainnet | --testnet-magic NATURAL)
-            [--out-file FILE]
+                                              [ --shelley-mode
+                                              | --byron-mode
+                                                [--epoch-slots SLOTS]
+                                              | --cardano-mode
+                                                [--epoch-slots SLOTS]
+                                              ]
+                                              --address ADDRESS
+                                              ( --mainnet
+                                              | --testnet-magic NATURAL
+                                              )
+                                              [--out-file FILE]
 
   Get the current delegations and reward accounts filtered by stake address.
 
 Usage: cardano-cli query utxo --socket-path SOCKET_PATH
-            [ --shelley-mode
-            | --byron-mode [--epoch-slots SLOTS]
-            | --cardano-mode [--epoch-slots SLOTS]
-            ]
-            (--whole-utxo | (--address ADDRESS) | (--tx-in TX-IN))
-            (--mainnet | --testnet-magic NATURAL)
-            [--out-file FILE]
+                                [ --shelley-mode
+                                | --byron-mode [--epoch-slots SLOTS]
+                                | --cardano-mode [--epoch-slots SLOTS]
+                                ]
+                                ( --whole-utxo
+                                | (--address ADDRESS)
+                                | (--tx-in TX-IN)
+                                )
+                                (--mainnet | --testnet-magic NATURAL)
+                                [--out-file FILE]
 
   Get a portion of the current UTxO: by tx in, by address or the whole.
 
 Usage: cardano-cli query ledger-state --socket-path SOCKET_PATH
-            [ --shelley-mode
-            | --byron-mode [--epoch-slots SLOTS]
-            | --cardano-mode [--epoch-slots SLOTS]
-            ]
-            (--mainnet | --testnet-magic NATURAL)
-            [--out-file FILE]
+                                        [ --shelley-mode
+                                        | --byron-mode [--epoch-slots SLOTS]
+                                        | --cardano-mode [--epoch-slots SLOTS]
+                                        ]
+                                        (--mainnet | --testnet-magic NATURAL)
+                                        [--out-file FILE]
 
   Dump the current ledger state of the node (Ledger.NewEpochState -- advanced
   command)
 
 Usage: cardano-cli query protocol-state --socket-path SOCKET_PATH
-            [ --shelley-mode
-            | --byron-mode [--epoch-slots SLOTS]
-            | --cardano-mode [--epoch-slots SLOTS]
-            ]
-            (--mainnet | --testnet-magic NATURAL)
-            [--out-file FILE]
+                                          [ --shelley-mode
+                                          | --byron-mode [--epoch-slots SLOTS]
+                                          | --cardano-mode [--epoch-slots SLOTS]
+                                          ]
+                                          (--mainnet | --testnet-magic NATURAL)
+                                          [--out-file FILE]
 
   Dump the current protocol state of the node (Ledger.ChainDepState -- advanced
   command)
 
 Usage: cardano-cli query stake-snapshot --socket-path SOCKET_PATH
-            [ --shelley-mode
-            | --byron-mode [--epoch-slots SLOTS]
-            | --cardano-mode [--epoch-slots SLOTS]
-            ]
-            (--mainnet | --testnet-magic NATURAL)
-            [--all-stake-pools | [--stake-pool-id STAKE_POOL_ID]]
-            [--out-file FILE]
+                                          [ --shelley-mode
+                                          | --byron-mode [--epoch-slots SLOTS]
+                                          | --cardano-mode [--epoch-slots SLOTS]
+                                          ]
+                                          (--mainnet | --testnet-magic NATURAL)
+                                          [ --all-stake-pools
+                                          | [--stake-pool-id STAKE_POOL_ID]
+                                          ]
+                                          [--out-file FILE]
 
   Obtain the three stake snapshots for a pool, plus the total active stake
   (advanced command)
 
 Usage: cardano-cli query pool-params --socket-path SOCKET_PATH
-            [ --shelley-mode
-            | --byron-mode [--epoch-slots SLOTS]
-            | --cardano-mode [--epoch-slots SLOTS]
-            ]
-            (--mainnet | --testnet-magic NATURAL)
-            [--stake-pool-id STAKE_POOL_ID]
+                                       [ --shelley-mode
+                                       | --byron-mode [--epoch-slots SLOTS]
+                                       | --cardano-mode [--epoch-slots SLOTS]
+                                       ]
+                                       (--mainnet | --testnet-magic NATURAL)
+                                       [--stake-pool-id STAKE_POOL_ID]
 
   DEPRECATED. Use query pool-state instead. Dump the pool parameters
   (Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced
   command)
 
 Usage: cardano-cli query leadership-schedule --socket-path SOCKET_PATH
-            [ --shelley-mode
-            | --byron-mode [--epoch-slots SLOTS]
-            | --cardano-mode [--epoch-slots SLOTS]
-            ]
-            (--mainnet | --testnet-magic NATURAL)
-            --genesis FILE
-            ( --stake-pool-verification-key STRING
-            | --cold-verification-key-file FILE
-            | --stake-pool-id STAKE_POOL_ID
-            )
-            --vrf-signing-key-file FILE
-            (--current | --next)
-            [--out-file FILE]
+                                               [ --shelley-mode
+                                               | --byron-mode
+                                                 [--epoch-slots SLOTS]
+                                               | --cardano-mode
+                                                 [--epoch-slots SLOTS]
+                                               ]
+                                               ( --mainnet
+                                               | --testnet-magic NATURAL
+                                               )
+                                               --genesis FILE
+                                               ( --stake-pool-verification-key STRING
+                                               | --cold-verification-key-file FILE
+                                               | --stake-pool-id STAKE_POOL_ID
+                                               )
+                                               --vrf-signing-key-file FILE
+                                               (--current | --next)
+                                               [--out-file FILE]
 
   Get the slots the node is expected to mint a block in (advanced command)
 
 Usage: cardano-cli query kes-period-info --socket-path SOCKET_PATH
-            [ --shelley-mode
-            | --byron-mode [--epoch-slots SLOTS]
-            | --cardano-mode [--epoch-slots SLOTS]
-            ]
-            (--mainnet | --testnet-magic NATURAL)
-            --op-cert-file FILE
-            [--out-file FILE]
+                                           [ --shelley-mode
+                                           | --byron-mode [--epoch-slots SLOTS]
+                                           | --cardano-mode
+                                             [--epoch-slots SLOTS]
+                                           ]
+                                           (--mainnet | --testnet-magic NATURAL)
+                                           --op-cert-file FILE
+                                           [--out-file FILE]
 
   Get information about the current KES period and your node's operational
   certificate.
 
 Usage: cardano-cli query pool-state --socket-path SOCKET_PATH
-            [ --shelley-mode
-            | --byron-mode [--epoch-slots SLOTS]
-            | --cardano-mode [--epoch-slots SLOTS]
-            ]
-            (--mainnet | --testnet-magic NATURAL)
-            [--stake-pool-id STAKE_POOL_ID]
+                                      [ --shelley-mode
+                                      | --byron-mode [--epoch-slots SLOTS]
+                                      | --cardano-mode [--epoch-slots SLOTS]
+                                      ]
+                                      (--mainnet | --testnet-magic NATURAL)
+                                      [--stake-pool-id STAKE_POOL_ID]
 
   Dump the pool state
 
 Usage: cardano-cli query tx-mempool --socket-path SOCKET_PATH
-            [ --shelley-mode
-            | --byron-mode [--epoch-slots SLOTS]
-            | --cardano-mode [--epoch-slots SLOTS]
-            ]
-            (--mainnet | --testnet-magic NATURAL)
-            (info | next-tx | tx-exists)
-            [--out-file FILE]
+                                      [ --shelley-mode
+                                      | --byron-mode [--epoch-slots SLOTS]
+                                      | --cardano-mode [--epoch-slots SLOTS]
+                                      ]
+                                      (--mainnet | --testnet-magic NATURAL)
+                                      (info | next-tx | tx-exists)
+                                      [--out-file FILE]
 
   Local Mempool info
 
@@ -499,429 +540,456 @@ Usage: cardano-cli query tx-mempool tx-exists TX_ID
   Query if a particular transaction exists in the mempool
 
 Usage: cardano-cli query slot-number --socket-path SOCKET_PATH
-            [ --shelley-mode
-            | --byron-mode [--epoch-slots SLOTS]
-            | --cardano-mode [--epoch-slots SLOTS]
-            ]
-            (--mainnet | --testnet-magic NATURAL)
-            TIMESTAMP
+                                       [ --shelley-mode
+                                       | --byron-mode [--epoch-slots SLOTS]
+                                       | --cardano-mode [--epoch-slots SLOTS]
+                                       ]
+                                       (--mainnet | --testnet-magic NATURAL)
+                                       TIMESTAMP
 
   Query slot number for UTC timestamp
 
 Usage: cardano-cli stake-pool 
-            ( registration-certificate
-            | deregistration-certificate
-            | id
-            | metadata-hash
-            )
+                                ( registration-certificate
+                                | deregistration-certificate
+                                | id
+                                | metadata-hash
+                                )
 
   Stake pool commands
 
 Usage: cardano-cli stake-pool registration-certificate 
-            ( --shelley-era
-            | --allegra-era
-            | --mary-era
-            | --alonzo-era
-            | --babbage-era
-            | --conway-era
-            )
-            ( --stake-pool-verification-key STRING
-            | --cold-verification-key-file FILE
-            )
-            (--vrf-verification-key STRING | --vrf-verification-key-file FILE)
-            --pool-pledge LOVELACE
-            --pool-cost LOVELACE
-            --pool-margin RATIONAL
-            ( --pool-reward-account-verification-key STRING
-            | --pool-reward-account-verification-key-file FILE
-            )
-            ( --pool-owner-verification-key STRING
-            | --pool-owner-stake-verification-key-file FILE
-            )
-            [ [--pool-relay-ipv4 STRING]
-              [--pool-relay-ipv6 STRING]
-              --pool-relay-port INT
-            | --single-host-pool-relay STRING [--pool-relay-port INT]
-            | --multi-host-pool-relay STRING
-            ]
-            [--metadata-url URL --metadata-hash HASH]
-            (--mainnet | --testnet-magic NATURAL)
-            --out-file FILE
+                                                         ( --shelley-era
+                                                         | --allegra-era
+                                                         | --mary-era
+                                                         | --alonzo-era
+                                                         | --babbage-era
+                                                         | --conway-era
+                                                         )
+                                                         ( --stake-pool-verification-key STRING
+                                                         | --cold-verification-key-file FILE
+                                                         )
+                                                         ( --vrf-verification-key STRING
+                                                         | --vrf-verification-key-file FILE
+                                                         )
+                                                         --pool-pledge LOVELACE
+                                                         --pool-cost LOVELACE
+                                                         --pool-margin RATIONAL
+                                                         ( --pool-reward-account-verification-key STRING
+                                                         | --pool-reward-account-verification-key-file FILE
+                                                         )
+                                                         ( --pool-owner-verification-key STRING
+                                                         | --pool-owner-stake-verification-key-file FILE
+                                                         )
+                                                         [ [--pool-relay-ipv4 STRING]
+                                                           [--pool-relay-ipv6 STRING]
+                                                           --pool-relay-port INT
+                                                         | --single-host-pool-relay STRING
+                                                           [--pool-relay-port INT]
+                                                         | --multi-host-pool-relay STRING
+                                                         ]
+                                                         [--metadata-url URL
+                                                           --metadata-hash HASH]
+                                                         ( --mainnet
+                                                         | --testnet-magic NATURAL
+                                                         )
+                                                         --out-file FILE
 
   Create a stake pool registration certificate
 
 Usage: cardano-cli stake-pool deregistration-certificate 
-            ( --shelley-era
-            | --allegra-era
-            | --mary-era
-            | --alonzo-era
-            | --babbage-era
-            | --conway-era
-            )
-            ( --stake-pool-verification-key STRING
-            | --cold-verification-key-file FILE
-            )
-            --epoch NATURAL
-            --out-file FILE
+                                                           ( --shelley-era
+                                                           | --allegra-era
+                                                           | --mary-era
+                                                           | --alonzo-era
+                                                           | --babbage-era
+                                                           | --conway-era
+                                                           )
+                                                           ( --stake-pool-verification-key STRING
+                                                           | --cold-verification-key-file FILE
+                                                           )
+                                                           --epoch NATURAL
+                                                           --out-file FILE
 
   Create a stake pool deregistration certificate
 
 Usage: cardano-cli stake-pool id 
-            ( --stake-pool-verification-key STRING
-            | --cold-verification-key-file FILE
-            )
-            [--output-format STRING]
-            [--out-file FILE]
+                                   ( --stake-pool-verification-key STRING
+                                   | --cold-verification-key-file FILE
+                                   )
+                                   [--output-format STRING]
+                                   [--out-file FILE]
 
   Build pool id from the offline key
 
 Usage: cardano-cli stake-pool metadata-hash --pool-metadata-file FILE
-            [--out-file FILE]
+                                              [--out-file FILE]
 
   Print the hash of pool metadata.
 
 Usage: cardano-cli node 
-            ( key-gen
-            | key-gen-KES
-            | key-gen-VRF
-            | key-hash-VRF
-            | new-counter
-            | issue-op-cert
-            )
+                          ( key-gen
+                          | key-gen-KES
+                          | key-gen-VRF
+                          | key-hash-VRF
+                          | new-counter
+                          | issue-op-cert
+                          )
 
   Node operation commands
 
 Usage: cardano-cli node key-gen [--key-output-format STRING]
-            --cold-verification-key-file FILE
-            --cold-signing-key-file FILE
-            --operational-certificate-issue-counter-file FILE
+                                  --cold-verification-key-file FILE
+                                  --cold-signing-key-file FILE
+                                  --operational-certificate-issue-counter-file FILE
 
   Create a key pair for a node operator's offline key and a new certificate
   issue counter
 
 Usage: cardano-cli node key-gen-KES [--key-output-format STRING]
-            --verification-key-file FILE
-            --signing-key-file FILE
+                                      --verification-key-file FILE
+                                      --signing-key-file FILE
 
   Create a key pair for a node KES operational key
 
 Usage: cardano-cli node key-gen-VRF [--key-output-format STRING]
-            --verification-key-file FILE
-            --signing-key-file FILE
+                                      --verification-key-file FILE
+                                      --signing-key-file FILE
 
   Create a key pair for a node VRF operational key
 
 Usage: cardano-cli node key-hash-VRF 
-            (--verification-key STRING | --verification-key-file FILE)
-            [--out-file FILE]
+                                       ( --verification-key STRING
+                                       | --verification-key-file FILE
+                                       )
+                                       [--out-file FILE]
 
   Print hash of a node's operational VRF key.
 
 Usage: cardano-cli node new-counter 
-            ( --stake-pool-verification-key STRING
-            | --genesis-delegate-verification-key STRING
-            | --cold-verification-key-file FILE
-            )
-            --counter-value INT
-            --operational-certificate-issue-counter-file FILE
+                                      ( --stake-pool-verification-key STRING
+                                      | --genesis-delegate-verification-key STRING
+                                      | --cold-verification-key-file FILE
+                                      )
+                                      --counter-value INT
+                                      --operational-certificate-issue-counter-file FILE
 
   Create a new certificate issue counter
 
 Usage: cardano-cli node issue-op-cert 
-            (--kes-verification-key STRING | --kes-verification-key-file FILE)
-            --cold-signing-key-file FILE
-            --operational-certificate-issue-counter-file FILE
-            --kes-period NATURAL
-            --out-file FILE
+                                        ( --kes-verification-key STRING
+                                        | --kes-verification-key-file FILE
+                                        )
+                                        --cold-signing-key-file FILE
+                                        --operational-certificate-issue-counter-file FILE
+                                        --kes-period NATURAL
+                                        --out-file FILE
 
   Issue a node operational certificate
 
 Usage: cardano-cli transaction 
-            ( build-raw
-            | build
-            | sign
-            | witness
-            | assemble
-            | submit
-            | policyid
-            | calculate-min-fee
-            | calculate-min-required-utxo
-            | hash-script-data
-            | txid
-            | view
-            )
+                                 ( build-raw
+                                 | build
+                                 | sign
+                                 | witness
+                                 | assemble
+                                 | submit
+                                 | policyid
+                                 | calculate-min-fee
+                                 | calculate-min-required-utxo
+                                 | hash-script-data
+                                 | txid
+                                 | view
+                                 )
 
   Transaction commands
 
 Usage: cardano-cli transaction build-raw 
-            [ --byron-era
-            | --shelley-era
-            | --allegra-era
-            | --mary-era
-            | --alonzo-era
-            | --babbage-era
-            | --conway-era
-            ]
-            [--script-valid | --script-invalid]
-            (--tx-in TX-IN
-              [ --spending-tx-in-reference TX-IN
-                --spending-plutus-script-v2
-                ( --spending-reference-tx-in-datum-cbor-file CBOR FILE
-                | --spending-reference-tx-in-datum-file JSON FILE
-                | --spending-reference-tx-in-datum-value JSON VALUE
-                | --spending-reference-tx-in-inline-datum-present
-                )
-                ( --spending-reference-tx-in-redeemer-cbor-file CBOR FILE
-                | --spending-reference-tx-in-redeemer-file JSON FILE
-                | --spending-reference-tx-in-redeemer-value JSON VALUE
-                )
-                --spending-reference-tx-in-execution-units (INT, INT)
-              | --simple-script-tx-in-reference TX-IN
-              | --tx-in-script-file FILE
-                [
-                  ( --tx-in-datum-cbor-file CBOR FILE
-                  | --tx-in-datum-file JSON FILE
-                  | --tx-in-datum-value JSON VALUE
-                  | --tx-in-inline-datum-present
-                  )
-                  ( --tx-in-redeemer-cbor-file CBOR FILE
-                  | --tx-in-redeemer-file JSON FILE
-                  | --tx-in-redeemer-value JSON VALUE
-                  )
-                  --tx-in-execution-units (INT, INT)]
-              ])
-            [--read-only-tx-in-reference TX-IN]
-            [--tx-in-collateral TX-IN]
-            [--tx-out-return-collateral ADDRESS VALUE]
-            [--tx-total-collateral INTEGER]
-            [--required-signer FILE | --required-signer-hash HASH]
-            [--tx-out ADDRESS VALUE
-              [ --tx-out-datum-hash HASH
-              | --tx-out-datum-hash-cbor-file CBOR FILE
-              | --tx-out-datum-hash-file JSON FILE
-              | --tx-out-datum-hash-value JSON VALUE
-              | --tx-out-datum-embed-cbor-file CBOR FILE
-              | --tx-out-datum-embed-file JSON FILE
-              | --tx-out-datum-embed-value JSON VALUE
-              | --tx-out-inline-datum-cbor-file CBOR FILE
-              | --tx-out-inline-datum-file JSON FILE
-              | --tx-out-inline-datum-value JSON VALUE
-              ]
-              [--tx-out-reference-script-file FILE]]
-            [--mint VALUE
-              ( --mint-script-file FILE
-                [
-                  ( --mint-redeemer-cbor-file CBOR FILE
-                  | --mint-redeemer-file JSON FILE
-                  | --mint-redeemer-value JSON VALUE
-                  )
-                  --mint-execution-units (INT, INT)]
-              | --simple-minting-script-tx-in-reference TX-IN --policy-id HASH
-              | --mint-tx-in-reference TX-IN
-                --mint-plutus-script-v2
-                ( --mint-reference-tx-in-redeemer-cbor-file CBOR FILE
-                | --mint-reference-tx-in-redeemer-file JSON FILE
-                | --mint-reference-tx-in-redeemer-value JSON VALUE
-                )
-                --mint-reference-tx-in-execution-units (INT, INT)
-                --policy-id HASH
-              )]
-            [--invalid-before SLOT]
-            [--invalid-hereafter SLOT]
-            [--fee LOVELACE]
-            [--certificate-file CERTIFICATEFILE
-              [ --certificate-script-file FILE
-                [
-                  ( --certificate-redeemer-cbor-file CBOR FILE
-                  | --certificate-redeemer-file JSON FILE
-                  | --certificate-redeemer-value JSON VALUE
-                  )
-                  --certificate-execution-units (INT, INT)]
-              | --certificate-tx-in-reference TX-IN
-                --certificate-plutus-script-v2
-                ( --certificate-reference-tx-in-redeemer-cbor-file CBOR FILE
-                | --certificate-reference-tx-in-redeemer-file JSON FILE
-                | --certificate-reference-tx-in-redeemer-value JSON VALUE
-                )
-                --certificate-reference-tx-in-execution-units (INT, INT)
-              ]]
-            [--withdrawal WITHDRAWAL
-              [ --withdrawal-script-file FILE
-                [
-                  ( --withdrawal-redeemer-cbor-file CBOR FILE
-                  | --withdrawal-redeemer-file JSON FILE
-                  | --withdrawal-redeemer-value JSON VALUE
-                  )
-                  --withdrawal-execution-units (INT, INT)]
-              | --withdrawal-tx-in-reference TX-IN
-                --withdrawal-plutus-script-v2
-                ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR FILE
-                | --withdrawal-reference-tx-in-redeemer-file JSON FILE
-                | --withdrawal-reference-tx-in-redeemer-value JSON VALUE
-                )
-                --withdrawal-reference-tx-in-execution-units (INT, INT)
-              ]]
-            [--json-metadata-no-schema | --json-metadata-detailed-schema]
-            [--auxiliary-script-file FILE]
-            [--metadata-json-file FILE | --metadata-cbor-file FILE]
-            [--protocol-params-file FILE]
-            [--update-proposal-file FILE]
-            --out-file FILE
+                                           [ --byron-era
+                                           | --shelley-era
+                                           | --allegra-era
+                                           | --mary-era
+                                           | --alonzo-era
+                                           | --babbage-era
+                                           | --conway-era
+                                           ]
+                                           [--script-valid | --script-invalid]
+                                           (--tx-in TX-IN
+                                             [ --spending-tx-in-reference TX-IN
+                                               --spending-plutus-script-v2
+                                               ( --spending-reference-tx-in-datum-cbor-file CBOR FILE
+                                               | --spending-reference-tx-in-datum-file JSON FILE
+                                               | --spending-reference-tx-in-datum-value JSON VALUE
+                                               | --spending-reference-tx-in-inline-datum-present
+                                               )
+                                               ( --spending-reference-tx-in-redeemer-cbor-file CBOR FILE
+                                               | --spending-reference-tx-in-redeemer-file JSON FILE
+                                               | --spending-reference-tx-in-redeemer-value JSON VALUE
+                                               )
+                                               --spending-reference-tx-in-execution-units (INT, INT)
+                                             | --simple-script-tx-in-reference TX-IN
+                                             | --tx-in-script-file FILE
+                                               [
+                                                 ( --tx-in-datum-cbor-file CBOR FILE
+                                                 | --tx-in-datum-file JSON FILE
+                                                 | --tx-in-datum-value JSON VALUE
+                                                 | --tx-in-inline-datum-present
+                                                 )
+                                                 ( --tx-in-redeemer-cbor-file CBOR FILE
+                                                 | --tx-in-redeemer-file JSON FILE
+                                                 | --tx-in-redeemer-value JSON VALUE
+                                                 )
+                                                 --tx-in-execution-units (INT, INT)]
+                                             ])
+                                           [--read-only-tx-in-reference TX-IN]
+                                           [--tx-in-collateral TX-IN]
+                                           [--tx-out-return-collateral ADDRESS VALUE]
+                                           [--tx-total-collateral INTEGER]
+                                           [ --required-signer FILE
+                                           | --required-signer-hash HASH
+                                           ]
+                                           [--tx-out ADDRESS VALUE
+                                             [ --tx-out-datum-hash HASH
+                                             | --tx-out-datum-hash-cbor-file CBOR FILE
+                                             | --tx-out-datum-hash-file JSON FILE
+                                             | --tx-out-datum-hash-value JSON VALUE
+                                             | --tx-out-datum-embed-cbor-file CBOR FILE
+                                             | --tx-out-datum-embed-file JSON FILE
+                                             | --tx-out-datum-embed-value JSON VALUE
+                                             | --tx-out-inline-datum-cbor-file CBOR FILE
+                                             | --tx-out-inline-datum-file JSON FILE
+                                             | --tx-out-inline-datum-value JSON VALUE
+                                             ]
+                                             [--tx-out-reference-script-file FILE]]
+                                           [--mint VALUE
+                                             ( --mint-script-file FILE
+                                               [
+                                                 ( --mint-redeemer-cbor-file CBOR FILE
+                                                 | --mint-redeemer-file JSON FILE
+                                                 | --mint-redeemer-value JSON VALUE
+                                                 )
+                                                 --mint-execution-units (INT, INT)]
+                                             | --simple-minting-script-tx-in-reference TX-IN
+                                               --policy-id HASH
+                                             | --mint-tx-in-reference TX-IN
+                                               --mint-plutus-script-v2
+                                               ( --mint-reference-tx-in-redeemer-cbor-file CBOR FILE
+                                               | --mint-reference-tx-in-redeemer-file JSON FILE
+                                               | --mint-reference-tx-in-redeemer-value JSON VALUE
+                                               )
+                                               --mint-reference-tx-in-execution-units (INT, INT)
+                                               --policy-id HASH
+                                             )]
+                                           [--invalid-before SLOT]
+                                           [--invalid-hereafter SLOT]
+                                           [--fee LOVELACE]
+                                           [--certificate-file CERTIFICATEFILE
+                                             [ --certificate-script-file FILE
+                                               [
+                                                 ( --certificate-redeemer-cbor-file CBOR FILE
+                                                 | --certificate-redeemer-file JSON FILE
+                                                 | --certificate-redeemer-value JSON VALUE
+                                                 )
+                                                 --certificate-execution-units (INT, INT)]
+                                             | --certificate-tx-in-reference TX-IN
+                                               --certificate-plutus-script-v2
+                                               ( --certificate-reference-tx-in-redeemer-cbor-file CBOR FILE
+                                               | --certificate-reference-tx-in-redeemer-file JSON FILE
+                                               | --certificate-reference-tx-in-redeemer-value JSON VALUE
+                                               )
+                                               --certificate-reference-tx-in-execution-units (INT, INT)
+                                             ]]
+                                           [--withdrawal WITHDRAWAL
+                                             [ --withdrawal-script-file FILE
+                                               [
+                                                 ( --withdrawal-redeemer-cbor-file CBOR FILE
+                                                 | --withdrawal-redeemer-file JSON FILE
+                                                 | --withdrawal-redeemer-value JSON VALUE
+                                                 )
+                                                 --withdrawal-execution-units (INT, INT)]
+                                             | --withdrawal-tx-in-reference TX-IN
+                                               --withdrawal-plutus-script-v2
+                                               ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR FILE
+                                               | --withdrawal-reference-tx-in-redeemer-file JSON FILE
+                                               | --withdrawal-reference-tx-in-redeemer-value JSON VALUE
+                                               )
+                                               --withdrawal-reference-tx-in-execution-units (INT, INT)
+                                             ]]
+                                           [ --json-metadata-no-schema
+                                           | --json-metadata-detailed-schema
+                                           ]
+                                           [--auxiliary-script-file FILE]
+                                           [ --metadata-json-file FILE
+                                           | --metadata-cbor-file FILE
+                                           ]
+                                           [--protocol-params-file FILE]
+                                           [--update-proposal-file FILE]
+                                           --out-file FILE
 
   Build a transaction (low-level, inconvenient)
 
   Please note the order of some cmd options is crucial. If used incorrectly may produce undesired tx body. See nested [] notation above for details.[0;22;23;24m
 
 Usage: cardano-cli transaction build --socket-path SOCKET_PATH
-            [ --byron-era
-            | --shelley-era
-            | --allegra-era
-            | --mary-era
-            | --alonzo-era
-            | --babbage-era
-            | --conway-era
-            ]
-            [ --shelley-mode
-            | --byron-mode [--epoch-slots SLOTS]
-            | --cardano-mode [--epoch-slots SLOTS]
-            ]
-            (--mainnet | --testnet-magic NATURAL)
-            [--script-valid | --script-invalid]
-            [--witness-override WORD]
-            (--tx-in TX-IN
-              [ --spending-tx-in-reference TX-IN
-                --spending-plutus-script-v2
-                ( --spending-reference-tx-in-datum-cbor-file CBOR FILE
-                | --spending-reference-tx-in-datum-file JSON FILE
-                | --spending-reference-tx-in-datum-value JSON VALUE
-                | --spending-reference-tx-in-inline-datum-present
-                )
-                ( --spending-reference-tx-in-redeemer-cbor-file CBOR FILE
-                | --spending-reference-tx-in-redeemer-file JSON FILE
-                | --spending-reference-tx-in-redeemer-value JSON VALUE
-                )
-              | --simple-script-tx-in-reference TX-IN
-              | --tx-in-script-file FILE
-                [
-                  ( --tx-in-datum-cbor-file CBOR FILE
-                  | --tx-in-datum-file JSON FILE
-                  | --tx-in-datum-value JSON VALUE
-                  | --tx-in-inline-datum-present
-                  )
-                  ( --tx-in-redeemer-cbor-file CBOR FILE
-                  | --tx-in-redeemer-file JSON FILE
-                  | --tx-in-redeemer-value JSON VALUE
-                  )]
-              ])
-            [--read-only-tx-in-reference TX-IN]
-            [--required-signer FILE | --required-signer-hash HASH]
-            [--tx-in-collateral TX-IN]
-            [--tx-out-return-collateral ADDRESS VALUE]
-            [--tx-total-collateral INTEGER]
-            [--tx-out ADDRESS VALUE
-              [ --tx-out-datum-hash HASH
-              | --tx-out-datum-hash-cbor-file CBOR FILE
-              | --tx-out-datum-hash-file JSON FILE
-              | --tx-out-datum-hash-value JSON VALUE
-              | --tx-out-datum-embed-cbor-file CBOR FILE
-              | --tx-out-datum-embed-file JSON FILE
-              | --tx-out-datum-embed-value JSON VALUE
-              | --tx-out-inline-datum-cbor-file CBOR FILE
-              | --tx-out-inline-datum-file JSON FILE
-              | --tx-out-inline-datum-value JSON VALUE
-              ]
-              [--tx-out-reference-script-file FILE]]
-            --change-address ADDRESS
-            [--mint VALUE
-              ( --mint-script-file FILE
-                [ --mint-redeemer-cbor-file CBOR FILE
-                | --mint-redeemer-file JSON FILE
-                | --mint-redeemer-value JSON VALUE
-                ]
-              | --simple-minting-script-tx-in-reference TX-IN --policy-id HASH
-              | --mint-tx-in-reference TX-IN
-                --mint-plutus-script-v2
-                ( --mint-reference-tx-in-redeemer-cbor-file CBOR FILE
-                | --mint-reference-tx-in-redeemer-file JSON FILE
-                | --mint-reference-tx-in-redeemer-value JSON VALUE
-                )
-                --policy-id HASH
-              )]
-            [--invalid-before SLOT]
-            [--invalid-hereafter SLOT]
-            [--certificate-file CERTIFICATEFILE
-              [ --certificate-script-file FILE
-                [ --certificate-redeemer-cbor-file CBOR FILE
-                | --certificate-redeemer-file JSON FILE
-                | --certificate-redeemer-value JSON VALUE
-                ]
-              | --certificate-tx-in-reference TX-IN
-                --certificate-plutus-script-v2
-                ( --certificate-reference-tx-in-redeemer-cbor-file CBOR FILE
-                | --certificate-reference-tx-in-redeemer-file JSON FILE
-                | --certificate-reference-tx-in-redeemer-value JSON VALUE
-                )
-              ]]
-            [--withdrawal WITHDRAWAL
-              [ --withdrawal-script-file FILE
-                [ --withdrawal-redeemer-cbor-file CBOR FILE
-                | --withdrawal-redeemer-file JSON FILE
-                | --withdrawal-redeemer-value JSON VALUE
-                ]
-              | --withdrawal-tx-in-reference TX-IN
-                --withdrawal-plutus-script-v2
-                ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR FILE
-                | --withdrawal-reference-tx-in-redeemer-file JSON FILE
-                | --withdrawal-reference-tx-in-redeemer-value JSON VALUE
-                )
-              ]]
-            [--json-metadata-no-schema | --json-metadata-detailed-schema]
-            [--auxiliary-script-file FILE]
-            [--metadata-json-file FILE | --metadata-cbor-file FILE]
-            [--protocol-params-file FILE]
-            [--update-proposal-file FILE]
-            [--vote-file FILE]
-            [--constitution-file FILE]
-            (--out-file FILE | --calculate-plutus-script-cost FILE)
+                                       [ --byron-era
+                                       | --shelley-era
+                                       | --allegra-era
+                                       | --mary-era
+                                       | --alonzo-era
+                                       | --babbage-era
+                                       | --conway-era
+                                       ]
+                                       [ --shelley-mode
+                                       | --byron-mode [--epoch-slots SLOTS]
+                                       | --cardano-mode [--epoch-slots SLOTS]
+                                       ]
+                                       (--mainnet | --testnet-magic NATURAL)
+                                       [--script-valid | --script-invalid]
+                                       [--witness-override WORD]
+                                       (--tx-in TX-IN
+                                         [ --spending-tx-in-reference TX-IN
+                                           --spending-plutus-script-v2
+                                           ( --spending-reference-tx-in-datum-cbor-file CBOR FILE
+                                           | --spending-reference-tx-in-datum-file JSON FILE
+                                           | --spending-reference-tx-in-datum-value JSON VALUE
+                                           | --spending-reference-tx-in-inline-datum-present
+                                           )
+                                           ( --spending-reference-tx-in-redeemer-cbor-file CBOR FILE
+                                           | --spending-reference-tx-in-redeemer-file JSON FILE
+                                           | --spending-reference-tx-in-redeemer-value JSON VALUE
+                                           )
+                                         | --simple-script-tx-in-reference TX-IN
+                                         | --tx-in-script-file FILE
+                                           [
+                                             ( --tx-in-datum-cbor-file CBOR FILE
+                                             | --tx-in-datum-file JSON FILE
+                                             | --tx-in-datum-value JSON VALUE
+                                             | --tx-in-inline-datum-present
+                                             )
+                                             ( --tx-in-redeemer-cbor-file CBOR FILE
+                                             | --tx-in-redeemer-file JSON FILE
+                                             | --tx-in-redeemer-value JSON VALUE
+                                             )]
+                                         ])
+                                       [--read-only-tx-in-reference TX-IN]
+                                       [ --required-signer FILE
+                                       | --required-signer-hash HASH
+                                       ]
+                                       [--tx-in-collateral TX-IN]
+                                       [--tx-out-return-collateral ADDRESS VALUE]
+                                       [--tx-total-collateral INTEGER]
+                                       [--tx-out ADDRESS VALUE
+                                         [ --tx-out-datum-hash HASH
+                                         | --tx-out-datum-hash-cbor-file CBOR FILE
+                                         | --tx-out-datum-hash-file JSON FILE
+                                         | --tx-out-datum-hash-value JSON VALUE
+                                         | --tx-out-datum-embed-cbor-file CBOR FILE
+                                         | --tx-out-datum-embed-file JSON FILE
+                                         | --tx-out-datum-embed-value JSON VALUE
+                                         | --tx-out-inline-datum-cbor-file CBOR FILE
+                                         | --tx-out-inline-datum-file JSON FILE
+                                         | --tx-out-inline-datum-value JSON VALUE
+                                         ]
+                                         [--tx-out-reference-script-file FILE]]
+                                       --change-address ADDRESS
+                                       [--mint VALUE
+                                         ( --mint-script-file FILE
+                                           [ --mint-redeemer-cbor-file CBOR FILE
+                                           | --mint-redeemer-file JSON FILE
+                                           | --mint-redeemer-value JSON VALUE
+                                           ]
+                                         | --simple-minting-script-tx-in-reference TX-IN
+                                           --policy-id HASH
+                                         | --mint-tx-in-reference TX-IN
+                                           --mint-plutus-script-v2
+                                           ( --mint-reference-tx-in-redeemer-cbor-file CBOR FILE
+                                           | --mint-reference-tx-in-redeemer-file JSON FILE
+                                           | --mint-reference-tx-in-redeemer-value JSON VALUE
+                                           )
+                                           --policy-id HASH
+                                         )]
+                                       [--invalid-before SLOT]
+                                       [--invalid-hereafter SLOT]
+                                       [--certificate-file CERTIFICATEFILE
+                                         [ --certificate-script-file FILE
+                                           [ --certificate-redeemer-cbor-file CBOR FILE
+                                           | --certificate-redeemer-file JSON FILE
+                                           | --certificate-redeemer-value JSON VALUE
+                                           ]
+                                         | --certificate-tx-in-reference TX-IN
+                                           --certificate-plutus-script-v2
+                                           ( --certificate-reference-tx-in-redeemer-cbor-file CBOR FILE
+                                           | --certificate-reference-tx-in-redeemer-file JSON FILE
+                                           | --certificate-reference-tx-in-redeemer-value JSON VALUE
+                                           )
+                                         ]]
+                                       [--withdrawal WITHDRAWAL
+                                         [ --withdrawal-script-file FILE
+                                           [ --withdrawal-redeemer-cbor-file CBOR FILE
+                                           | --withdrawal-redeemer-file JSON FILE
+                                           | --withdrawal-redeemer-value JSON VALUE
+                                           ]
+                                         | --withdrawal-tx-in-reference TX-IN
+                                           --withdrawal-plutus-script-v2
+                                           ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR FILE
+                                           | --withdrawal-reference-tx-in-redeemer-file JSON FILE
+                                           | --withdrawal-reference-tx-in-redeemer-value JSON VALUE
+                                           )
+                                         ]]
+                                       [ --json-metadata-no-schema
+                                       | --json-metadata-detailed-schema
+                                       ]
+                                       [--auxiliary-script-file FILE]
+                                       [ --metadata-json-file FILE
+                                       | --metadata-cbor-file FILE
+                                       ]
+                                       [--protocol-params-file FILE]
+                                       [--update-proposal-file FILE]
+                                       [--vote-file FILE]
+                                       [--constitution-file FILE]
+                                       ( --out-file FILE
+                                       | --calculate-plutus-script-cost FILE
+                                       )
 
   Build a balanced transaction (automatically calculates fees)
 
   Please note the order[93;22;23;24m of some cmd options is crucial. If used incorrectly may produce undesired tx body. See nested [] notation above for details.[0;22;23;24m
 
 Usage: cardano-cli transaction sign (--tx-body-file FILE | --tx-file FILE)
-            [--signing-key-file FILE [--address STRING]]
-            [--mainnet | --testnet-magic NATURAL]
-            --out-file FILE
+                                      [--signing-key-file FILE
+                                        [--address STRING]]
+                                      [--mainnet | --testnet-magic NATURAL]
+                                      --out-file FILE
 
   Sign a transaction
 
 Usage: cardano-cli transaction witness --tx-body-file FILE
-            --signing-key-file FILE
-            [--address STRING]
-            [--mainnet | --testnet-magic NATURAL]
-            --out-file FILE
+                                         --signing-key-file FILE
+                                         [--address STRING]
+                                         [--mainnet | --testnet-magic NATURAL]
+                                         --out-file FILE
 
   Create a transaction witness
 
 Usage: cardano-cli transaction assemble --tx-body-file FILE
-            [--witness-file FILE]
-            --out-file FILE
+                                          [--witness-file FILE]
+                                          --out-file FILE
 
   Assemble a tx body and witness(es) to form a transaction
 
 Usage: cardano-cli transaction sign-witness --tx-body-file FILE
-            [--witness-file FILE]
-            --out-file FILE
+                                              [--witness-file FILE]
+                                              --out-file FILE
 
   Assemble a tx body and witness(es) to form a transaction
 
 Usage: cardano-cli transaction submit --socket-path SOCKET_PATH
-            [ --shelley-mode
-            | --byron-mode [--epoch-slots SLOTS]
-            | --cardano-mode [--epoch-slots SLOTS]
-            ]
-            (--mainnet | --testnet-magic NATURAL)
-            --tx-file FILE
+                                        [ --shelley-mode
+                                        | --byron-mode [--epoch-slots SLOTS]
+                                        | --cardano-mode [--epoch-slots SLOTS]
+                                        ]
+                                        (--mainnet | --testnet-magic NATURAL)
+                                        --tx-file FILE
 
   Submit a transaction to the local node whose Unix domain socket is obtained
   from the CARDANO_NODE_SOCKET_PATH environment variable.
@@ -931,72 +999,74 @@ Usage: cardano-cli transaction policyid --script-file FILE
   Calculate the PolicyId from the monetary policy script.
 
 Usage: cardano-cli transaction calculate-min-fee --tx-body-file FILE
-            (--mainnet | --testnet-magic NATURAL)
-            --protocol-params-file FILE
-            --tx-in-count NATURAL
-            --tx-out-count NATURAL
-            --witness-count NATURAL
-            [--byron-witness-count NATURAL]
+                                                   ( --mainnet
+                                                   | --testnet-magic NATURAL
+                                                   )
+                                                   --protocol-params-file FILE
+                                                   --tx-in-count NATURAL
+                                                   --tx-out-count NATURAL
+                                                   --witness-count NATURAL
+                                                   [--byron-witness-count NATURAL]
 
   Calculate the minimum fee for a transaction.
 
 Usage: cardano-cli transaction calculate-min-required-utxo 
-            [ --byron-era
-            | --shelley-era
-            | --allegra-era
-            | --mary-era
-            | --alonzo-era
-            | --babbage-era
-            | --conway-era
-            ]
-            --protocol-params-file FILE
-            --tx-out ADDRESS VALUE
-            [ --tx-out-datum-hash HASH
-            | --tx-out-datum-hash-cbor-file CBOR FILE
-            | --tx-out-datum-hash-file JSON FILE
-            | --tx-out-datum-hash-value JSON VALUE
-            | --tx-out-datum-embed-cbor-file CBOR FILE
-            | --tx-out-datum-embed-file JSON FILE
-            | --tx-out-datum-embed-value JSON VALUE
-            | --tx-out-inline-datum-cbor-file CBOR FILE
-            | --tx-out-inline-datum-file JSON FILE
-            | --tx-out-inline-datum-value JSON VALUE
-            ]
-            [--tx-out-reference-script-file FILE]
+                                                             [ --byron-era
+                                                             | --shelley-era
+                                                             | --allegra-era
+                                                             | --mary-era
+                                                             | --alonzo-era
+                                                             | --babbage-era
+                                                             | --conway-era
+                                                             ]
+                                                             --protocol-params-file FILE
+                                                             --tx-out ADDRESS VALUE
+                                                             [ --tx-out-datum-hash HASH
+                                                             | --tx-out-datum-hash-cbor-file CBOR FILE
+                                                             | --tx-out-datum-hash-file JSON FILE
+                                                             | --tx-out-datum-hash-value JSON VALUE
+                                                             | --tx-out-datum-embed-cbor-file CBOR FILE
+                                                             | --tx-out-datum-embed-file JSON FILE
+                                                             | --tx-out-datum-embed-value JSON VALUE
+                                                             | --tx-out-inline-datum-cbor-file CBOR FILE
+                                                             | --tx-out-inline-datum-file JSON FILE
+                                                             | --tx-out-inline-datum-value JSON VALUE
+                                                             ]
+                                                             [--tx-out-reference-script-file FILE]
 
   Calculate the minimum required UTxO for a transaction output.
 
 Usage: cardano-cli transaction calculate-min-value 
-            [ --byron-era
-            | --shelley-era
-            | --allegra-era
-            | --mary-era
-            | --alonzo-era
-            | --babbage-era
-            | --conway-era
-            ]
-            --protocol-params-file FILE
-            --tx-out ADDRESS VALUE
-            [ --tx-out-datum-hash HASH
-            | --tx-out-datum-hash-cbor-file CBOR FILE
-            | --tx-out-datum-hash-file JSON FILE
-            | --tx-out-datum-hash-value JSON VALUE
-            | --tx-out-datum-embed-cbor-file CBOR FILE
-            | --tx-out-datum-embed-file JSON FILE
-            | --tx-out-datum-embed-value JSON VALUE
-            | --tx-out-inline-datum-cbor-file CBOR FILE
-            | --tx-out-inline-datum-file JSON FILE
-            | --tx-out-inline-datum-value JSON VALUE
-            ]
-            [--tx-out-reference-script-file FILE]
+                                                     [ --byron-era
+                                                     | --shelley-era
+                                                     | --allegra-era
+                                                     | --mary-era
+                                                     | --alonzo-era
+                                                     | --babbage-era
+                                                     | --conway-era
+                                                     ]
+                                                     --protocol-params-file FILE
+                                                     --tx-out ADDRESS VALUE
+                                                     [ --tx-out-datum-hash HASH
+                                                     | --tx-out-datum-hash-cbor-file CBOR FILE
+                                                     | --tx-out-datum-hash-file JSON FILE
+                                                     | --tx-out-datum-hash-value JSON VALUE
+                                                     | --tx-out-datum-embed-cbor-file CBOR FILE
+                                                     | --tx-out-datum-embed-file JSON FILE
+                                                     | --tx-out-datum-embed-value JSON VALUE
+                                                     | --tx-out-inline-datum-cbor-file CBOR FILE
+                                                     | --tx-out-inline-datum-file JSON FILE
+                                                     | --tx-out-inline-datum-value JSON VALUE
+                                                     ]
+                                                     [--tx-out-reference-script-file FILE]
 
   DEPRECATED: Use 'calculate-min-required-utxo' instead.
 
 Usage: cardano-cli transaction hash-script-data 
-            ( --script-data-cbor-file CBOR FILE
-            | --script-data-file JSON FILE
-            | --script-data-value JSON VALUE
-            )
+                                                  ( --script-data-cbor-file CBOR FILE
+                                                  | --script-data-file JSON FILE
+                                                  | --script-data-value JSON VALUE
+                                                  )
 
   Calculate the hash of script data.
 
@@ -1009,167 +1079,171 @@ Usage: cardano-cli transaction view (--tx-body-file FILE | --tx-file FILE)
   Print a transaction.
 
 Usage: cardano-cli key 
-            ( verification-key
-            | non-extended-key
-            | convert-byron-key
-            | convert-byron-genesis-vkey
-            | convert-itn-key
-            | convert-itn-extended-key
-            | convert-itn-bip32-key
-            | convert-cardano-address-key
-            )
+                         ( verification-key
+                         | non-extended-key
+                         | convert-byron-key
+                         | convert-byron-genesis-vkey
+                         | convert-itn-key
+                         | convert-itn-extended-key
+                         | convert-itn-bip32-key
+                         | convert-cardano-address-key
+                         )
 
   Key utility commands
 
 Usage: cardano-cli key verification-key --signing-key-file FILE
-            --verification-key-file FILE
+                                          --verification-key-file FILE
 
   Get a verification key from a signing key. This supports all key types.
 
 Usage: cardano-cli key non-extended-key --extended-verification-key-file FILE
-            --verification-key-file FILE
+                                          --verification-key-file FILE
 
   Get a non-extended verification key from an extended verification key. This
   supports all extended key types.
 
 Usage: cardano-cli key convert-byron-key [--password TEXT]
-            ( --byron-payment-key-type
-            | --legacy-byron-payment-key-type
-            | --byron-genesis-key-type
-            | --legacy-byron-genesis-key-type
-            | --byron-genesis-delegate-key-type
-            | --legacy-byron-genesis-delegate-key-type
-            )
-            (--byron-signing-key-file FILE | --byron-verification-key-file FILE)
-            --out-file FILE
+                                           ( --byron-payment-key-type
+                                           | --legacy-byron-payment-key-type
+                                           | --byron-genesis-key-type
+                                           | --legacy-byron-genesis-key-type
+                                           | --byron-genesis-delegate-key-type
+                                           | --legacy-byron-genesis-delegate-key-type
+                                           )
+                                           ( --byron-signing-key-file FILE
+                                           | --byron-verification-key-file FILE
+                                           )
+                                           --out-file FILE
 
   Convert a Byron payment, genesis or genesis delegate key (signing or
   verification) to a corresponding Shelley-format key.
 
 Usage: cardano-cli key convert-byron-genesis-vkey --byron-genesis-verification-key BASE64
-            --out-file FILE
+                                                    --out-file FILE
 
   Convert a Base64-encoded Byron genesis verification key to a Shelley genesis
   verification key
 
 Usage: cardano-cli key convert-itn-key 
-            (--itn-signing-key-file FILE | --itn-verification-key-file FILE)
-            --out-file FILE
+                                         ( --itn-signing-key-file FILE
+                                         | --itn-verification-key-file FILE
+                                         )
+                                         --out-file FILE
 
   Convert an Incentivized Testnet (ITN) non-extended (Ed25519) signing or
   verification key to a corresponding Shelley stake key
 
 Usage: cardano-cli key convert-itn-extended-key --itn-signing-key-file FILE
-            --out-file FILE
+                                                  --out-file FILE
 
   Convert an Incentivized Testnet (ITN) extended (Ed25519Extended) signing key
   to a corresponding Shelley stake signing key
 
 Usage: cardano-cli key convert-itn-bip32-key --itn-signing-key-file FILE
-            --out-file FILE
+                                               --out-file FILE
 
   Convert an Incentivized Testnet (ITN) BIP32 (Ed25519Bip32) signing key to a
   corresponding Shelley stake signing key
 
 Usage: cardano-cli key convert-cardano-address-key 
-            ( --shelley-payment-key
-            | --shelley-stake-key
-            | --icarus-payment-key
-            | --byron-payment-key
-            )
-            --signing-key-file FILE
-            --out-file FILE
+                                                     ( --shelley-payment-key
+                                                     | --shelley-stake-key
+                                                     | --icarus-payment-key
+                                                     | --byron-payment-key
+                                                     )
+                                                     --signing-key-file FILE
+                                                     --out-file FILE
 
   Convert a cardano-address extended signing key to a corresponding
   Shelley-format key.
 
 Usage: cardano-cli stake-address 
-            ( key-gen
-            | build
-            | key-hash
-            | registration-certificate
-            | deregistration-certificate
-            | delegation-certificate
-            )
+                                   ( key-gen
+                                   | build
+                                   | key-hash
+                                   | registration-certificate
+                                   | deregistration-certificate
+                                   | delegation-certificate
+                                   )
 
   Stake address commands
 
 Usage: cardano-cli stake-address key-gen [--key-output-format STRING]
-            --verification-key-file FILE
-            --signing-key-file FILE
+                                           --verification-key-file FILE
+                                           --signing-key-file FILE
 
   Create a stake address key pair
 
 Usage: cardano-cli stake-address build 
-            ( --stake-verification-key STRING
-            | --stake-verification-key-file FILE
-            | --stake-script-file FILE
-            )
-            (--mainnet | --testnet-magic NATURAL)
-            [--out-file FILE]
+                                         ( --stake-verification-key STRING
+                                         | --stake-verification-key-file FILE
+                                         | --stake-script-file FILE
+                                         )
+                                         (--mainnet | --testnet-magic NATURAL)
+                                         [--out-file FILE]
 
   Build a stake address
 
 Usage: cardano-cli stake-address key-hash 
-            ( --stake-verification-key STRING
-            | --stake-verification-key-file FILE
-            )
-            [--out-file FILE]
+                                            ( --stake-verification-key STRING
+                                            | --stake-verification-key-file FILE
+                                            )
+                                            [--out-file FILE]
 
   Print the hash of a stake address key.
 
 Usage: cardano-cli stake-address registration-certificate 
-            ( --shelley-era
-            | --allegra-era
-            | --mary-era
-            | --alonzo-era
-            | --babbage-era
-            | --conway-era
-            )
-            ( --stake-verification-key STRING
-            | --stake-verification-key-file FILE
-            | --stake-script-file FILE
-            | --stake-address ADDRESS
-            )
-            --out-file FILE
+                                                            ( --shelley-era
+                                                            | --allegra-era
+                                                            | --mary-era
+                                                            | --alonzo-era
+                                                            | --babbage-era
+                                                            | --conway-era
+                                                            )
+                                                            ( --stake-verification-key STRING
+                                                            | --stake-verification-key-file FILE
+                                                            | --stake-script-file FILE
+                                                            | --stake-address ADDRESS
+                                                            )
+                                                            --out-file FILE
 
   Create a stake address registration certificate
 
 Usage: cardano-cli stake-address deregistration-certificate 
-            ( --shelley-era
-            | --allegra-era
-            | --mary-era
-            | --alonzo-era
-            | --babbage-era
-            | --conway-era
-            )
-            ( --stake-verification-key STRING
-            | --stake-verification-key-file FILE
-            | --stake-script-file FILE
-            | --stake-address ADDRESS
-            )
-            --out-file FILE
+                                                              ( --shelley-era
+                                                              | --allegra-era
+                                                              | --mary-era
+                                                              | --alonzo-era
+                                                              | --babbage-era
+                                                              | --conway-era
+                                                              )
+                                                              ( --stake-verification-key STRING
+                                                              | --stake-verification-key-file FILE
+                                                              | --stake-script-file FILE
+                                                              | --stake-address ADDRESS
+                                                              )
+                                                              --out-file FILE
 
   Create a stake address deregistration certificate
 
 Usage: cardano-cli stake-address delegation-certificate 
-            ( --shelley-era
-            | --allegra-era
-            | --mary-era
-            | --alonzo-era
-            | --babbage-era
-            | --conway-era
-            )
-            ( --stake-verification-key STRING
-            | --stake-verification-key-file FILE
-            | --stake-script-file FILE
-            | --stake-address ADDRESS
-            )
-            ( --stake-pool-verification-key STRING
-            | --cold-verification-key-file FILE
-            | --stake-pool-id STAKE_POOL_ID
-            )
-            --out-file FILE
+                                                          ( --shelley-era
+                                                          | --allegra-era
+                                                          | --mary-era
+                                                          | --alonzo-era
+                                                          | --babbage-era
+                                                          | --conway-era
+                                                          )
+                                                          ( --stake-verification-key STRING
+                                                          | --stake-verification-key-file FILE
+                                                          | --stake-script-file FILE
+                                                          | --stake-address ADDRESS
+                                                          )
+                                                          ( --stake-pool-verification-key STRING
+                                                          | --cold-verification-key-file FILE
+                                                          | --stake-pool-id STAKE_POOL_ID
+                                                          )
+                                                          --out-file FILE
 
   Create a stake address pool delegation certificate
 
@@ -1178,32 +1252,35 @@ Usage: cardano-cli address (key-gen | key-hash | build | info)
   Payment address commands
 
 Usage: cardano-cli address key-gen [--key-output-format STRING]
-            [--normal-key | --extended-key | --byron-key]
-            --verification-key-file FILE
-            --signing-key-file FILE
+                                     [ --normal-key
+                                     | --extended-key
+                                     | --byron-key
+                                     ]
+                                     --verification-key-file FILE
+                                     --signing-key-file FILE
 
   Create an address key pair.
 
 Usage: cardano-cli address key-hash 
-            ( --payment-verification-key STRING
-            | --payment-verification-key-file FILE
-            )
-            [--out-file FILE]
+                                      ( --payment-verification-key STRING
+                                      | --payment-verification-key-file FILE
+                                      )
+                                      [--out-file FILE]
 
   Print the hash of an address key.
 
 Usage: cardano-cli address build 
-            ( --payment-verification-key STRING
-            | --payment-verification-key-file FILE
-            | --payment-script-file FILE
-            )
-            [ --stake-verification-key STRING
-            | --stake-verification-key-file FILE
-            | --stake-script-file FILE
-            | --stake-address ADDRESS
-            ]
-            (--mainnet | --testnet-magic NATURAL)
-            [--out-file FILE]
+                                   ( --payment-verification-key STRING
+                                   | --payment-verification-key-file FILE
+                                   | --payment-script-file FILE
+                                   )
+                                   [ --stake-verification-key STRING
+                                   | --stake-verification-key-file FILE
+                                   | --stake-script-file FILE
+                                   | --stake-address ADDRESS
+                                   ]
+                                   (--mainnet | --testnet-magic NATURAL)
+                                   [--out-file FILE]
 
   Build a Shelley payment address, with optional delegation to a stake address.
 
@@ -1212,17 +1289,22 @@ Usage: cardano-cli address info --address ADDRESS [--out-file FILE]
   Print information about an address.
 
 Usage: cardano-cli byron 
-            (key | transaction | query | genesis | governance | miscellaneous)
+                           ( key
+                           | transaction
+                           | query
+                           | genesis
+                           | governance
+                           | miscellaneous
+                           )
 
   Byron specific commands
 
-Usage: cardano-cli byron key 
-          ( keygen
-          | to-verification
-          | signing-key-public
-          | signing-key-address
-          | migrate-delegate-key-from
-          )
+Usage: cardano-cli byron key ( keygen
+                             | to-verification
+                             | signing-key-public
+                             | signing-key-address
+                             | migrate-delegate-key-from
+                             )
 
   Byron key utility commands
 
@@ -1231,62 +1313,79 @@ Usage: cardano-cli byron key keygen --secret FILEPATH
   Generate a signing key.
 
 Usage: cardano-cli byron key to-verification 
-            [--byron-legacy-formats | --byron-formats]
-            --secret FILEPATH
-            --to FILEPATH
+                                               [ --byron-legacy-formats
+                                               | --byron-formats
+                                               ]
+                                               --secret FILEPATH
+                                               --to FILEPATH
 
   Extract a verification key in its base64 form.
 
 Usage: cardano-cli byron key signing-key-public 
-            [--byron-legacy-formats | --byron-formats]
-            --secret FILEPATH
+                                                  [ --byron-legacy-formats
+                                                  | --byron-formats
+                                                  ]
+                                                  --secret FILEPATH
 
   Pretty-print a signing key's verification key (not a secret).
 
 Usage: cardano-cli byron key signing-key-address 
-            [--byron-legacy-formats | --byron-formats]
-            (--mainnet | --testnet-magic NATURAL)
-            --secret FILEPATH
+                                                   [ --byron-legacy-formats
+                                                   | --byron-formats
+                                                   ]
+                                                   ( --mainnet
+                                                   | --testnet-magic NATURAL
+                                                   )
+                                                   --secret FILEPATH
 
   Print address of a signing key.
 
 Usage: cardano-cli byron key migrate-delegate-key-from --from FILEPATH
-            --to FILEPATH
+                                                         --to FILEPATH
 
   Migrate a delegate key from an older version.
 
-Usage: cardano-cli byron transaction 
-          ( submit-tx
-          | issue-genesis-utxo-expenditure
-          | issue-utxo-expenditure
-          | txid
-          )
+Usage: cardano-cli byron transaction ( submit-tx
+                                     | issue-genesis-utxo-expenditure
+                                     | issue-utxo-expenditure
+                                     | txid
+                                     )
 
   Byron transaction commands
 
 Usage: cardano-cli byron transaction submit-tx --socket-path SOCKET_PATH
-            (--mainnet | --testnet-magic NATURAL)
-            --tx FILEPATH
+                                                 ( --mainnet
+                                                 | --testnet-magic NATURAL
+                                                 )
+                                                 --tx FILEPATH
 
   Submit a raw, signed transaction, in its on-wire representation.
 
 Usage: cardano-cli byron transaction issue-genesis-utxo-expenditure --genesis-json FILEPATH
-            (--mainnet | --testnet-magic NATURAL)
-            [--byron-legacy-formats | --byron-formats]
-            --tx FILEPATH
-            --wallet-key FILEPATH
-            --rich-addr-from ADDR
-            (--txout '("ADDR", LOVELACE)')
+                                                                      ( --mainnet
+                                                                      | --testnet-magic NATURAL
+                                                                      )
+                                                                      [ --byron-legacy-formats
+                                                                      | --byron-formats
+                                                                      ]
+                                                                      --tx FILEPATH
+                                                                      --wallet-key FILEPATH
+                                                                      --rich-addr-from ADDR
+                                                                      (--txout '("ADDR", LOVELACE)')
 
   Write a file with a signed transaction, spending genesis UTxO.
 
 Usage: cardano-cli byron transaction issue-utxo-expenditure 
-            (--mainnet | --testnet-magic NATURAL)
-            [--byron-legacy-formats | --byron-formats]
-            --tx FILEPATH
-            --wallet-key FILEPATH
-            (--txin (TXID,INDEX))
-            (--txout '("ADDR", LOVELACE)')
+                                                              ( --mainnet
+                                                              | --testnet-magic NATURAL
+                                                              )
+                                                              [ --byron-legacy-formats
+                                                              | --byron-formats
+                                                              ]
+                                                              --tx FILEPATH
+                                                              --wallet-key FILEPATH
+                                                              (--txin (TXID,INDEX))
+                                                              (--txout '("ADDR", LOVELACE)')
 
   Write a file with a signed transaction, spending normal UTxO.
 
@@ -1299,7 +1398,7 @@ Usage: cardano-cli byron query get-tip
   Byron node query commands.
 
 Usage: cardano-cli byron query get-tip --socket-path SOCKET_PATH
-            (--mainnet | --testnet-magic NATURAL)
+                                         (--mainnet | --testnet-magic NATURAL)
 
   Get the tip of your local node's blockchain
 
@@ -1308,18 +1407,18 @@ Usage: cardano-cli byron genesis (genesis | print-genesis-hash)
   Byron genesis block commands
 
 Usage: cardano-cli byron genesis genesis --genesis-output-dir FILEPATH
-            --start-time POSIXSECONDS
-            --protocol-parameters-file FILEPATH
-            --k INT
-            --protocol-magic INT
-            --n-poor-addresses INT
-            --n-delegate-addresses INT
-            --total-balance INT
-            --delegate-share DOUBLE
-            --avvm-entry-count INT
-            --avvm-entry-balance INT
-            [--avvm-balance-factor DOUBLE]
-            [--secret-seed INT]
+                                           --start-time POSIXSECONDS
+                                           --protocol-parameters-file FILEPATH
+                                           --k INT
+                                           --protocol-magic INT
+                                           --n-poor-addresses INT
+                                           --n-delegate-addresses INT
+                                           --total-balance INT
+                                           --delegate-share DOUBLE
+                                           --avvm-entry-count INT
+                                           --avvm-entry-balance INT
+                                           [--avvm-balance-factor DOUBLE]
+                                           [--secret-seed INT]
 
   Create genesis.
 
@@ -1332,55 +1431,66 @@ Usage: cardano-cli byron governance COMMAND
   Byron governance commands
 
 Usage: cardano-cli byron governance submit-proposal-vote 
-            --socket-path SOCKET_PATH
-            (--mainnet | --testnet-magic NATURAL)
-            --filepath FILEPATH
+                                                           --socket-path SOCKET_PATH
+                                                           ( --mainnet
+                                                           | --testnet-magic NATURAL
+                                                           )
+                                                           --filepath FILEPATH
 
   Submit a proposal vote.
 
 Usage: cardano-cli byron governance submit-update-proposal 
-            --socket-path SOCKET_PATH
-            (--mainnet | --testnet-magic NATURAL)
-            --filepath FILEPATH
+                                                             --socket-path SOCKET_PATH
+                                                             ( --mainnet
+                                                             | --testnet-magic NATURAL
+                                                             )
+                                                             --filepath FILEPATH
 
   Submit an update proposal.
 
 Usage: cardano-cli byron governance create-proposal-vote 
-            (--mainnet | --testnet-magic NATURAL)
-            --signing-key FILEPATH
-            --proposal-filepath FILEPATH
-            (--vote-yes | --vote-no)
-            --output-filepath FILEPATH
+                                                           ( --mainnet
+                                                           | --testnet-magic NATURAL
+                                                           )
+                                                           --signing-key FILEPATH
+                                                           --proposal-filepath FILEPATH
+                                                           ( --vote-yes
+                                                           | --vote-no
+                                                           )
+                                                           --output-filepath FILEPATH
 
   Create an update proposal vote.
 
 Usage: cardano-cli byron governance create-update-proposal 
-            (--mainnet | --testnet-magic NATURAL)
-            --signing-key FILEPATH
-            --protocol-version-major WORD16
-            --protocol-version-minor WORD16
-            --protocol-version-alt WORD8
-            --application-name STRING
-            --software-version-num WORD32
-            --system-tag STRING
-            --installer-hash HASH
-            --filepath FILEPATH
-            [--script-version WORD16]
-            [--slot-duration NATURAL]
-            [--max-block-size NATURAL]
-            [--max-header-size NATURAL]
-            [--max-tx-size NATURAL]
-            [--max-proposal-size NATURAL]
-            [--max-mpc-thd DOUBLE]
-            [--heavy-del-thd DOUBLE]
-            [--update-vote-thd DOUBLE]
-            [--update-proposal-thd DOUBLE]
-            [--time-to-live WORD64]
-            [--softfork-init-thd DOUBLE
-              --softfork-min-thd DOUBLE
-              --softfork-thd-dec DOUBLE]
-            [--tx-fee-a-constant INT --tx-fee-b-constant DOUBLE]
-            [--unlock-stake-epoch WORD64]
+                                                             ( --mainnet
+                                                             | --testnet-magic NATURAL
+                                                             )
+                                                             --signing-key FILEPATH
+                                                             --protocol-version-major WORD16
+                                                             --protocol-version-minor WORD16
+                                                             --protocol-version-alt WORD8
+                                                             --application-name STRING
+                                                             --software-version-num WORD32
+                                                             --system-tag STRING
+                                                             --installer-hash HASH
+                                                             --filepath FILEPATH
+                                                             [--script-version WORD16]
+                                                             [--slot-duration NATURAL]
+                                                             [--max-block-size NATURAL]
+                                                             [--max-header-size NATURAL]
+                                                             [--max-tx-size NATURAL]
+                                                             [--max-proposal-size NATURAL]
+                                                             [--max-mpc-thd DOUBLE]
+                                                             [--heavy-del-thd DOUBLE]
+                                                             [--update-vote-thd DOUBLE]
+                                                             [--update-proposal-thd DOUBLE]
+                                                             [--time-to-live WORD64]
+                                                             [--softfork-init-thd DOUBLE
+                                                               --softfork-min-thd DOUBLE
+                                                               --softfork-thd-dec DOUBLE]
+                                                             [--tx-fee-a-constant INT
+                                                               --tx-fee-b-constant DOUBLE]
+                                                             [--unlock-stake-epoch WORD64]
 
   Create an update proposal.
 
@@ -1389,13 +1499,13 @@ Usage: cardano-cli byron miscellaneous (validate-cbor | pretty-print-cbor)
   Byron miscellaneous commands
 
 Usage: cardano-cli byron miscellaneous validate-cbor 
-            [ --byron-block INT
-            | --byron-delegation-certificate
-            | --byron-tx
-            | --byron-update-proposal
-            | --byron-vote
-            ]
-            --filepath FILEPATH
+                                                       [ --byron-block INT
+                                                       | --byron-delegation-certificate
+                                                       | --byron-tx
+                                                       | --byron-update-proposal
+                                                       | --byron-vote
+                                                       ]
+                                                       --filepath FILEPATH
 
   Validate a CBOR blockchain object.
 
@@ -1404,79 +1514,88 @@ Usage: cardano-cli byron miscellaneous pretty-print-cbor --filepath FILEPATH
   Pretty print a CBOR file.
 
 Usage: cardano-cli byron submit-proposal-vote --socket-path SOCKET_PATH
-            (--mainnet | --testnet-magic NATURAL)
-            --filepath FILEPATH
+                                                ( --mainnet
+                                                | --testnet-magic NATURAL
+                                                )
+                                                --filepath FILEPATH
 
   Submit a proposal vote.
 
 Usage: cardano-cli byron submit-update-proposal --socket-path SOCKET_PATH
-            (--mainnet | --testnet-magic NATURAL)
-            --filepath FILEPATH
+                                                  ( --mainnet
+                                                  | --testnet-magic NATURAL
+                                                  )
+                                                  --filepath FILEPATH
 
   Submit an update proposal.
 
 Usage: cardano-cli byron create-proposal-vote 
-            (--mainnet | --testnet-magic NATURAL)
-            --signing-key FILEPATH
-            --proposal-filepath FILEPATH
-            (--vote-yes | --vote-no)
-            --output-filepath FILEPATH
+                                                ( --mainnet
+                                                | --testnet-magic NATURAL
+                                                )
+                                                --signing-key FILEPATH
+                                                --proposal-filepath FILEPATH
+                                                (--vote-yes | --vote-no)
+                                                --output-filepath FILEPATH
 
   Create an update proposal vote.
 
 Usage: cardano-cli byron create-update-proposal 
-            (--mainnet | --testnet-magic NATURAL)
-            --signing-key FILEPATH
-            --protocol-version-major WORD16
-            --protocol-version-minor WORD16
-            --protocol-version-alt WORD8
-            --application-name STRING
-            --software-version-num WORD32
-            --system-tag STRING
-            --installer-hash HASH
-            --filepath FILEPATH
-            [--script-version WORD16]
-            [--slot-duration NATURAL]
-            [--max-block-size NATURAL]
-            [--max-header-size NATURAL]
-            [--max-tx-size NATURAL]
-            [--max-proposal-size NATURAL]
-            [--max-mpc-thd DOUBLE]
-            [--heavy-del-thd DOUBLE]
-            [--update-vote-thd DOUBLE]
-            [--update-proposal-thd DOUBLE]
-            [--time-to-live WORD64]
-            [--softfork-init-thd DOUBLE
-              --softfork-min-thd DOUBLE
-              --softfork-thd-dec DOUBLE]
-            [--tx-fee-a-constant INT --tx-fee-b-constant DOUBLE]
-            [--unlock-stake-epoch WORD64]
+                                                  ( --mainnet
+                                                  | --testnet-magic NATURAL
+                                                  )
+                                                  --signing-key FILEPATH
+                                                  --protocol-version-major WORD16
+                                                  --protocol-version-minor WORD16
+                                                  --protocol-version-alt WORD8
+                                                  --application-name STRING
+                                                  --software-version-num WORD32
+                                                  --system-tag STRING
+                                                  --installer-hash HASH
+                                                  --filepath FILEPATH
+                                                  [--script-version WORD16]
+                                                  [--slot-duration NATURAL]
+                                                  [--max-block-size NATURAL]
+                                                  [--max-header-size NATURAL]
+                                                  [--max-tx-size NATURAL]
+                                                  [--max-proposal-size NATURAL]
+                                                  [--max-mpc-thd DOUBLE]
+                                                  [--heavy-del-thd DOUBLE]
+                                                  [--update-vote-thd DOUBLE]
+                                                  [--update-proposal-thd DOUBLE]
+                                                  [--time-to-live WORD64]
+                                                  [--softfork-init-thd DOUBLE
+                                                    --softfork-min-thd DOUBLE
+                                                    --softfork-thd-dec DOUBLE]
+                                                  [--tx-fee-a-constant INT
+                                                    --tx-fee-b-constant DOUBLE]
+                                                  [--unlock-stake-epoch WORD64]
 
   Create an update proposal.
 
 Usage: cardano-cli ping [-c|--count COUNT]
-            ((-h|--host HOST) | (-u|--unixsock SOCKET))
-            [-p|--port PORT]
-            [-m|--magic MAGIC]
-            [-j|--json]
-            [-q|--quiet]
-            [-Q|--query-versions]
+                          ((-h|--host HOST) | (-u|--unixsock SOCKET))
+                          [-p|--port PORT]
+                          [-m|--magic MAGIC]
+                          [-j|--json]
+                          [-q|--quiet]
+                          [-Q|--query-versions]
 
   Ping a cardano node either using node-to-node or node-to-client protocol. It negotiates a handshake and keeps sending keep alive messages.
 
 Usage: cardano-cli genesis --genesis-output-dir FILEPATH
-            --start-time POSIXSECONDS
-            --protocol-parameters-file FILEPATH
-            --k INT
-            --protocol-magic INT
-            --n-poor-addresses INT
-            --n-delegate-addresses INT
-            --total-balance INT
-            --delegate-share DOUBLE
-            --avvm-entry-count INT
-            --avvm-entry-balance INT
-            [--avvm-balance-factor DOUBLE]
-            [--secret-seed INT]
+                             --start-time POSIXSECONDS
+                             --protocol-parameters-file FILEPATH
+                             --k INT
+                             --protocol-magic INT
+                             --n-poor-addresses INT
+                             --n-delegate-addresses INT
+                             --total-balance INT
+                             --delegate-share DOUBLE
+                             --avvm-entry-count INT
+                             --avvm-entry-balance INT
+                             [--avvm-balance-factor DOUBLE]
+                             [--secret-seed INT]
 
   Create genesis.
 
@@ -1489,20 +1608,22 @@ Usage: cardano-cli keygen --secret FILEPATH
   Generate a signing key.
 
 Usage: cardano-cli to-verification [--byron-legacy-formats | --byron-formats]
-            --secret FILEPATH
-            --to FILEPATH
+                                     --secret FILEPATH
+                                     --to FILEPATH
 
   Extract a verification key in its base64 form.
 
 Usage: cardano-cli signing-key-public [--byron-legacy-formats | --byron-formats]
-            --secret FILEPATH
+                                        --secret FILEPATH
 
   Pretty-print a signing key's verification key (not a secret).
 
 Usage: cardano-cli signing-key-address 
-            [--byron-legacy-formats | --byron-formats]
-            (--mainnet | --testnet-magic NATURAL)
-            --secret FILEPATH
+                                         [ --byron-legacy-formats
+                                         | --byron-formats
+                                         ]
+                                         (--mainnet | --testnet-magic NATURAL)
+                                         --secret FILEPATH
 
   Print address of a signing key.
 
@@ -1511,27 +1632,33 @@ Usage: cardano-cli migrate-delegate-key-from --from FILEPATH --to FILEPATH
   Migrate a delegate key from an older version.
 
 Usage: cardano-cli submit-tx --socket-path SOCKET_PATH
-            (--mainnet | --testnet-magic NATURAL)
-            --tx FILEPATH
+                               (--mainnet | --testnet-magic NATURAL)
+                               --tx FILEPATH
 
   Submit a raw, signed transaction, in its on-wire representation.
 
 Usage: cardano-cli issue-genesis-utxo-expenditure --genesis-json FILEPATH
-            (--mainnet | --testnet-magic NATURAL)
-            [--byron-legacy-formats | --byron-formats]
-            --tx FILEPATH
-            --wallet-key FILEPATH
-            --rich-addr-from ADDR
-            (--txout '("ADDR", LOVELACE)')
+                                                    ( --mainnet
+                                                    | --testnet-magic NATURAL
+                                                    )
+                                                    [ --byron-legacy-formats
+                                                    | --byron-formats
+                                                    ]
+                                                    --tx FILEPATH
+                                                    --wallet-key FILEPATH
+                                                    --rich-addr-from ADDR
+                                                    (--txout '("ADDR", LOVELACE)')
 
   Write a file with a signed transaction, spending genesis UTxO.
 
 Usage: cardano-cli issue-utxo-expenditure (--mainnet | --testnet-magic NATURAL)
-            [--byron-legacy-formats | --byron-formats]
-            --tx FILEPATH
-            --wallet-key FILEPATH
-            (--txin (TXID,INDEX))
-            (--txout '("ADDR", LOVELACE)')
+                                            [ --byron-legacy-formats
+                                            | --byron-formats
+                                            ]
+                                            --tx FILEPATH
+                                            --wallet-key FILEPATH
+                                            (--txin (TXID,INDEX))
+                                            (--txout '("ADDR", LOVELACE)')
 
   Write a file with a signed transaction, spending normal UTxO.
 
@@ -1540,18 +1667,18 @@ Usage: cardano-cli txid --tx FILEPATH
   Print the txid of a raw, signed transaction.
 
 Usage: cardano-cli get-tip --socket-path SOCKET_PATH
-            (--mainnet | --testnet-magic NATURAL)
+                             (--mainnet | --testnet-magic NATURAL)
 
   Get the tip of your local node's blockchain
 
 Usage: cardano-cli validate-cbor 
-            [ --byron-block INT
-            | --byron-delegation-certificate
-            | --byron-tx
-            | --byron-update-proposal
-            | --byron-vote
-            ]
-            --filepath FILEPATH
+                                   [ --byron-block INT
+                                   | --byron-delegation-certificate
+                                   | --byron-tx
+                                   | --byron-update-proposal
+                                   | --byron-vote
+                                   ]
+                                   --filepath FILEPATH
 
   Validate a CBOR blockchain object.
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/address_build.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/address_build.cli
@@ -1,15 +1,15 @@
 Usage: cardano-cli address build 
-            ( --payment-verification-key STRING
-            | --payment-verification-key-file FILE
-            | --payment-script-file FILE
-            )
-            [ --stake-verification-key STRING
-            | --stake-verification-key-file FILE
-            | --stake-script-file FILE
-            | --stake-address ADDRESS
-            ]
-            (--mainnet | --testnet-magic NATURAL)
-            [--out-file FILE]
+                                   ( --payment-verification-key STRING
+                                   | --payment-verification-key-file FILE
+                                   | --payment-script-file FILE
+                                   )
+                                   [ --stake-verification-key STRING
+                                   | --stake-verification-key-file FILE
+                                   | --stake-script-file FILE
+                                   | --stake-address ADDRESS
+                                   ]
+                                   (--mainnet | --testnet-magic NATURAL)
+                                   [--out-file FILE]
 
   Build a Shelley payment address, with optional delegation to a stake address.
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/address_key-gen.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/address_key-gen.cli
@@ -1,7 +1,10 @@
 Usage: cardano-cli address key-gen [--key-output-format STRING]
-            [--normal-key | --extended-key | --byron-key]
-            --verification-key-file FILE
-            --signing-key-file FILE
+                                     [ --normal-key
+                                     | --extended-key
+                                     | --byron-key
+                                     ]
+                                     --verification-key-file FILE
+                                     --signing-key-file FILE
 
   Create an address key pair.
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/address_key-hash.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/address_key-hash.cli
@@ -1,8 +1,8 @@
 Usage: cardano-cli address key-hash 
-            ( --payment-verification-key STRING
-            | --payment-verification-key-file FILE
-            )
-            [--out-file FILE]
+                                      ( --payment-verification-key STRING
+                                      | --payment-verification-key-file FILE
+                                      )
+                                      [--out-file FILE]
 
   Print the hash of an address key.
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/byron.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/byron.cli
@@ -1,5 +1,11 @@
 Usage: cardano-cli byron 
-            (key | transaction | query | genesis | governance | miscellaneous)
+                           ( key
+                           | transaction
+                           | query
+                           | genesis
+                           | governance
+                           | miscellaneous
+                           )
 
   Byron specific commands
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/byron_create-proposal-vote.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/byron_create-proposal-vote.cli
@@ -1,9 +1,11 @@
 Usage: cardano-cli byron create-proposal-vote 
-            (--mainnet | --testnet-magic NATURAL)
-            --signing-key FILEPATH
-            --proposal-filepath FILEPATH
-            (--vote-yes | --vote-no)
-            --output-filepath FILEPATH
+                                                ( --mainnet
+                                                | --testnet-magic NATURAL
+                                                )
+                                                --signing-key FILEPATH
+                                                --proposal-filepath FILEPATH
+                                                (--vote-yes | --vote-no)
+                                                --output-filepath FILEPATH
 
   Create an update proposal vote.
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/byron_create-update-proposal.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/byron_create-update-proposal.cli
@@ -1,30 +1,33 @@
 Usage: cardano-cli byron create-update-proposal 
-            (--mainnet | --testnet-magic NATURAL)
-            --signing-key FILEPATH
-            --protocol-version-major WORD16
-            --protocol-version-minor WORD16
-            --protocol-version-alt WORD8
-            --application-name STRING
-            --software-version-num WORD32
-            --system-tag STRING
-            --installer-hash HASH
-            --filepath FILEPATH
-            [--script-version WORD16]
-            [--slot-duration NATURAL]
-            [--max-block-size NATURAL]
-            [--max-header-size NATURAL]
-            [--max-tx-size NATURAL]
-            [--max-proposal-size NATURAL]
-            [--max-mpc-thd DOUBLE]
-            [--heavy-del-thd DOUBLE]
-            [--update-vote-thd DOUBLE]
-            [--update-proposal-thd DOUBLE]
-            [--time-to-live WORD64]
-            [--softfork-init-thd DOUBLE
-              --softfork-min-thd DOUBLE
-              --softfork-thd-dec DOUBLE]
-            [--tx-fee-a-constant INT --tx-fee-b-constant DOUBLE]
-            [--unlock-stake-epoch WORD64]
+                                                  ( --mainnet
+                                                  | --testnet-magic NATURAL
+                                                  )
+                                                  --signing-key FILEPATH
+                                                  --protocol-version-major WORD16
+                                                  --protocol-version-minor WORD16
+                                                  --protocol-version-alt WORD8
+                                                  --application-name STRING
+                                                  --software-version-num WORD32
+                                                  --system-tag STRING
+                                                  --installer-hash HASH
+                                                  --filepath FILEPATH
+                                                  [--script-version WORD16]
+                                                  [--slot-duration NATURAL]
+                                                  [--max-block-size NATURAL]
+                                                  [--max-header-size NATURAL]
+                                                  [--max-tx-size NATURAL]
+                                                  [--max-proposal-size NATURAL]
+                                                  [--max-mpc-thd DOUBLE]
+                                                  [--heavy-del-thd DOUBLE]
+                                                  [--update-vote-thd DOUBLE]
+                                                  [--update-proposal-thd DOUBLE]
+                                                  [--time-to-live WORD64]
+                                                  [--softfork-init-thd DOUBLE
+                                                    --softfork-min-thd DOUBLE
+                                                    --softfork-thd-dec DOUBLE]
+                                                  [--tx-fee-a-constant INT
+                                                    --tx-fee-b-constant DOUBLE]
+                                                  [--unlock-stake-epoch WORD64]
 
   Create an update proposal.
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/byron_genesis_genesis.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/byron_genesis_genesis.cli
@@ -1,16 +1,16 @@
 Usage: cardano-cli byron genesis genesis --genesis-output-dir FILEPATH
-            --start-time POSIXSECONDS
-            --protocol-parameters-file FILEPATH
-            --k INT
-            --protocol-magic INT
-            --n-poor-addresses INT
-            --n-delegate-addresses INT
-            --total-balance INT
-            --delegate-share DOUBLE
-            --avvm-entry-count INT
-            --avvm-entry-balance INT
-            [--avvm-balance-factor DOUBLE]
-            [--secret-seed INT]
+                                           --start-time POSIXSECONDS
+                                           --protocol-parameters-file FILEPATH
+                                           --k INT
+                                           --protocol-magic INT
+                                           --n-poor-addresses INT
+                                           --n-delegate-addresses INT
+                                           --total-balance INT
+                                           --delegate-share DOUBLE
+                                           --avvm-entry-count INT
+                                           --avvm-entry-balance INT
+                                           [--avvm-balance-factor DOUBLE]
+                                           [--secret-seed INT]
 
   Create genesis.
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/byron_governance_create-proposal-vote.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/byron_governance_create-proposal-vote.cli
@@ -1,9 +1,13 @@
 Usage: cardano-cli byron governance create-proposal-vote 
-            (--mainnet | --testnet-magic NATURAL)
-            --signing-key FILEPATH
-            --proposal-filepath FILEPATH
-            (--vote-yes | --vote-no)
-            --output-filepath FILEPATH
+                                                           ( --mainnet
+                                                           | --testnet-magic NATURAL
+                                                           )
+                                                           --signing-key FILEPATH
+                                                           --proposal-filepath FILEPATH
+                                                           ( --vote-yes
+                                                           | --vote-no
+                                                           )
+                                                           --output-filepath FILEPATH
 
   Create an update proposal vote.
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/byron_governance_create-update-proposal.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/byron_governance_create-update-proposal.cli
@@ -1,30 +1,33 @@
 Usage: cardano-cli byron governance create-update-proposal 
-            (--mainnet | --testnet-magic NATURAL)
-            --signing-key FILEPATH
-            --protocol-version-major WORD16
-            --protocol-version-minor WORD16
-            --protocol-version-alt WORD8
-            --application-name STRING
-            --software-version-num WORD32
-            --system-tag STRING
-            --installer-hash HASH
-            --filepath FILEPATH
-            [--script-version WORD16]
-            [--slot-duration NATURAL]
-            [--max-block-size NATURAL]
-            [--max-header-size NATURAL]
-            [--max-tx-size NATURAL]
-            [--max-proposal-size NATURAL]
-            [--max-mpc-thd DOUBLE]
-            [--heavy-del-thd DOUBLE]
-            [--update-vote-thd DOUBLE]
-            [--update-proposal-thd DOUBLE]
-            [--time-to-live WORD64]
-            [--softfork-init-thd DOUBLE
-              --softfork-min-thd DOUBLE
-              --softfork-thd-dec DOUBLE]
-            [--tx-fee-a-constant INT --tx-fee-b-constant DOUBLE]
-            [--unlock-stake-epoch WORD64]
+                                                             ( --mainnet
+                                                             | --testnet-magic NATURAL
+                                                             )
+                                                             --signing-key FILEPATH
+                                                             --protocol-version-major WORD16
+                                                             --protocol-version-minor WORD16
+                                                             --protocol-version-alt WORD8
+                                                             --application-name STRING
+                                                             --software-version-num WORD32
+                                                             --system-tag STRING
+                                                             --installer-hash HASH
+                                                             --filepath FILEPATH
+                                                             [--script-version WORD16]
+                                                             [--slot-duration NATURAL]
+                                                             [--max-block-size NATURAL]
+                                                             [--max-header-size NATURAL]
+                                                             [--max-tx-size NATURAL]
+                                                             [--max-proposal-size NATURAL]
+                                                             [--max-mpc-thd DOUBLE]
+                                                             [--heavy-del-thd DOUBLE]
+                                                             [--update-vote-thd DOUBLE]
+                                                             [--update-proposal-thd DOUBLE]
+                                                             [--time-to-live WORD64]
+                                                             [--softfork-init-thd DOUBLE
+                                                               --softfork-min-thd DOUBLE
+                                                               --softfork-thd-dec DOUBLE]
+                                                             [--tx-fee-a-constant INT
+                                                               --tx-fee-b-constant DOUBLE]
+                                                             [--unlock-stake-epoch WORD64]
 
   Create an update proposal.
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/byron_governance_submit-proposal-vote.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/byron_governance_submit-proposal-vote.cli
@@ -1,7 +1,9 @@
 Usage: cardano-cli byron governance submit-proposal-vote 
-            --socket-path SOCKET_PATH
-            (--mainnet | --testnet-magic NATURAL)
-            --filepath FILEPATH
+                                                           --socket-path SOCKET_PATH
+                                                           ( --mainnet
+                                                           | --testnet-magic NATURAL
+                                                           )
+                                                           --filepath FILEPATH
 
   Submit a proposal vote.
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/byron_governance_submit-update-proposal.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/byron_governance_submit-update-proposal.cli
@@ -1,7 +1,9 @@
 Usage: cardano-cli byron governance submit-update-proposal 
-            --socket-path SOCKET_PATH
-            (--mainnet | --testnet-magic NATURAL)
-            --filepath FILEPATH
+                                                             --socket-path SOCKET_PATH
+                                                             ( --mainnet
+                                                             | --testnet-magic NATURAL
+                                                             )
+                                                             --filepath FILEPATH
 
   Submit an update proposal.
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/byron_key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/byron_key.cli
@@ -1,10 +1,9 @@
-Usage: cardano-cli byron key 
-          ( keygen
-          | to-verification
-          | signing-key-public
-          | signing-key-address
-          | migrate-delegate-key-from
-          )
+Usage: cardano-cli byron key ( keygen
+                             | to-verification
+                             | signing-key-public
+                             | signing-key-address
+                             | migrate-delegate-key-from
+                             )
 
   Byron key utility commands
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/byron_key_migrate-delegate-key-from.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/byron_key_migrate-delegate-key-from.cli
@@ -1,5 +1,5 @@
 Usage: cardano-cli byron key migrate-delegate-key-from --from FILEPATH
-            --to FILEPATH
+                                                         --to FILEPATH
 
   Migrate a delegate key from an older version.
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/byron_key_signing-key-address.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/byron_key_signing-key-address.cli
@@ -1,7 +1,11 @@
 Usage: cardano-cli byron key signing-key-address 
-            [--byron-legacy-formats | --byron-formats]
-            (--mainnet | --testnet-magic NATURAL)
-            --secret FILEPATH
+                                                   [ --byron-legacy-formats
+                                                   | --byron-formats
+                                                   ]
+                                                   ( --mainnet
+                                                   | --testnet-magic NATURAL
+                                                   )
+                                                   --secret FILEPATH
 
   Print address of a signing key.
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/byron_key_signing-key-public.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/byron_key_signing-key-public.cli
@@ -1,6 +1,8 @@
 Usage: cardano-cli byron key signing-key-public 
-            [--byron-legacy-formats | --byron-formats]
-            --secret FILEPATH
+                                                  [ --byron-legacy-formats
+                                                  | --byron-formats
+                                                  ]
+                                                  --secret FILEPATH
 
   Pretty-print a signing key's verification key (not a secret).
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/byron_key_to-verification.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/byron_key_to-verification.cli
@@ -1,7 +1,9 @@
 Usage: cardano-cli byron key to-verification 
-            [--byron-legacy-formats | --byron-formats]
-            --secret FILEPATH
-            --to FILEPATH
+                                               [ --byron-legacy-formats
+                                               | --byron-formats
+                                               ]
+                                               --secret FILEPATH
+                                               --to FILEPATH
 
   Extract a verification key in its base64 form.
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/byron_miscellaneous_validate-cbor.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/byron_miscellaneous_validate-cbor.cli
@@ -1,11 +1,11 @@
 Usage: cardano-cli byron miscellaneous validate-cbor 
-            [ --byron-block INT
-            | --byron-delegation-certificate
-            | --byron-tx
-            | --byron-update-proposal
-            | --byron-vote
-            ]
-            --filepath FILEPATH
+                                                       [ --byron-block INT
+                                                       | --byron-delegation-certificate
+                                                       | --byron-tx
+                                                       | --byron-update-proposal
+                                                       | --byron-vote
+                                                       ]
+                                                       --filepath FILEPATH
 
   Validate a CBOR blockchain object.
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/byron_query_get-tip.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/byron_query_get-tip.cli
@@ -1,5 +1,5 @@
 Usage: cardano-cli byron query get-tip --socket-path SOCKET_PATH
-            (--mainnet | --testnet-magic NATURAL)
+                                         (--mainnet | --testnet-magic NATURAL)
 
   Get the tip of your local node's blockchain
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/byron_submit-proposal-vote.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/byron_submit-proposal-vote.cli
@@ -1,6 +1,8 @@
 Usage: cardano-cli byron submit-proposal-vote --socket-path SOCKET_PATH
-            (--mainnet | --testnet-magic NATURAL)
-            --filepath FILEPATH
+                                                ( --mainnet
+                                                | --testnet-magic NATURAL
+                                                )
+                                                --filepath FILEPATH
 
   Submit a proposal vote.
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/byron_submit-update-proposal.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/byron_submit-update-proposal.cli
@@ -1,6 +1,8 @@
 Usage: cardano-cli byron submit-update-proposal --socket-path SOCKET_PATH
-            (--mainnet | --testnet-magic NATURAL)
-            --filepath FILEPATH
+                                                  ( --mainnet
+                                                  | --testnet-magic NATURAL
+                                                  )
+                                                  --filepath FILEPATH
 
   Submit an update proposal.
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/byron_transaction.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/byron_transaction.cli
@@ -1,9 +1,8 @@
-Usage: cardano-cli byron transaction 
-          ( submit-tx
-          | issue-genesis-utxo-expenditure
-          | issue-utxo-expenditure
-          | txid
-          )
+Usage: cardano-cli byron transaction ( submit-tx
+                                     | issue-genesis-utxo-expenditure
+                                     | issue-utxo-expenditure
+                                     | txid
+                                     )
 
   Byron transaction commands
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/byron_transaction_issue-genesis-utxo-expenditure.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/byron_transaction_issue-genesis-utxo-expenditure.cli
@@ -1,10 +1,14 @@
 Usage: cardano-cli byron transaction issue-genesis-utxo-expenditure --genesis-json FILEPATH
-            (--mainnet | --testnet-magic NATURAL)
-            [--byron-legacy-formats | --byron-formats]
-            --tx FILEPATH
-            --wallet-key FILEPATH
-            --rich-addr-from ADDR
-            (--txout '("ADDR", LOVELACE)')
+                                                                      ( --mainnet
+                                                                      | --testnet-magic NATURAL
+                                                                      )
+                                                                      [ --byron-legacy-formats
+                                                                      | --byron-formats
+                                                                      ]
+                                                                      --tx FILEPATH
+                                                                      --wallet-key FILEPATH
+                                                                      --rich-addr-from ADDR
+                                                                      (--txout '("ADDR", LOVELACE)')
 
   Write a file with a signed transaction, spending genesis UTxO.
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/byron_transaction_issue-utxo-expenditure.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/byron_transaction_issue-utxo-expenditure.cli
@@ -1,10 +1,14 @@
 Usage: cardano-cli byron transaction issue-utxo-expenditure 
-            (--mainnet | --testnet-magic NATURAL)
-            [--byron-legacy-formats | --byron-formats]
-            --tx FILEPATH
-            --wallet-key FILEPATH
-            (--txin (TXID,INDEX))
-            (--txout '("ADDR", LOVELACE)')
+                                                              ( --mainnet
+                                                              | --testnet-magic NATURAL
+                                                              )
+                                                              [ --byron-legacy-formats
+                                                              | --byron-formats
+                                                              ]
+                                                              --tx FILEPATH
+                                                              --wallet-key FILEPATH
+                                                              (--txin (TXID,INDEX))
+                                                              (--txout '("ADDR", LOVELACE)')
 
   Write a file with a signed transaction, spending normal UTxO.
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/byron_transaction_submit-tx.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/byron_transaction_submit-tx.cli
@@ -1,6 +1,8 @@
 Usage: cardano-cli byron transaction submit-tx --socket-path SOCKET_PATH
-            (--mainnet | --testnet-magic NATURAL)
-            --tx FILEPATH
+                                                 ( --mainnet
+                                                 | --testnet-magic NATURAL
+                                                 )
+                                                 --tx FILEPATH
 
   Submit a raw, signed transaction, in its on-wire representation.
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/genesis.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/genesis.cli
@@ -1,16 +1,16 @@
 Usage: cardano-cli genesis 
-            ( key-gen-genesis
-            | key-gen-delegate
-            | key-gen-utxo
-            | key-hash
-            | get-ver-key
-            | initial-addr
-            | initial-txin
-            | create-cardano
-            | create
-            | create-staked
-            | hash
-            )
+                             ( key-gen-genesis
+                             | key-gen-delegate
+                             | key-gen-utxo
+                             | key-hash
+                             | get-ver-key
+                             | initial-addr
+                             | initial-txin
+                             | create-cardano
+                             | create
+                             | create-staked
+                             | hash
+                             )
 
   Genesis block commands
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/genesis_create-cardano.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/genesis_create-cardano.cli
@@ -1,17 +1,19 @@
 Usage: cardano-cli genesis create-cardano --genesis-dir DIR
-            [--gen-genesis-keys INT]
-            [--gen-utxo-keys INT]
-            [--start-time UTC-TIME]
-            [--supply LOVELACE]
-            [--security-param INT]
-            [--slot-length INT]
-            [--slot-coefficient RATIONAL]
-            (--mainnet | --testnet-magic NATURAL)
-            --byron-template FILEPATH
-            --shelley-template FILEPATH
-            --alonzo-template FILEPATH
-            --conway-template FILEPATH
-            [--node-config-template FILEPATH]
+                                            [--gen-genesis-keys INT]
+                                            [--gen-utxo-keys INT]
+                                            [--start-time UTC-TIME]
+                                            [--supply LOVELACE]
+                                            [--security-param INT]
+                                            [--slot-length INT]
+                                            [--slot-coefficient RATIONAL]
+                                            ( --mainnet
+                                            | --testnet-magic NATURAL
+                                            )
+                                            --byron-template FILEPATH
+                                            --shelley-template FILEPATH
+                                            --alonzo-template FILEPATH
+                                            --conway-template FILEPATH
+                                            [--node-config-template FILEPATH]
 
   Create a Byron and Shelley genesis file from a genesis template and
   genesis/delegation/spending keys.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/genesis_create-staked.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/genesis_create-staked.cli
@@ -1,17 +1,17 @@
 Usage: cardano-cli genesis create-staked [--key-output-format STRING]
-            --genesis-dir DIR
-            [--gen-genesis-keys INT]
-            [--gen-utxo-keys INT]
-            [--gen-pools INT]
-            [--gen-stake-delegs INT]
-            [--start-time UTC-TIME]
-            [--supply LOVELACE]
-            [--supply-delegated LOVELACE]
-            (--mainnet | --testnet-magic NATURAL)
-            [--bulk-pool-cred-files INT]
-            [--bulk-pools-per-file INT]
-            [--num-stuffed-utxo INT]
-            [--relay-specification-file FILE]
+                                           --genesis-dir DIR
+                                           [--gen-genesis-keys INT]
+                                           [--gen-utxo-keys INT]
+                                           [--gen-pools INT]
+                                           [--gen-stake-delegs INT]
+                                           [--start-time UTC-TIME]
+                                           [--supply LOVELACE]
+                                           [--supply-delegated LOVELACE]
+                                           (--mainnet | --testnet-magic NATURAL)
+                                           [--bulk-pool-cred-files INT]
+                                           [--bulk-pools-per-file INT]
+                                           [--num-stuffed-utxo INT]
+                                           [--relay-specification-file FILE]
 
   Create a staked Shelley genesis file from a genesis template and
   genesis/delegation/spending keys.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/genesis_create.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/genesis_create.cli
@@ -1,10 +1,10 @@
 Usage: cardano-cli genesis create [--key-output-format STRING]
-            --genesis-dir DIR
-            [--gen-genesis-keys INT]
-            [--gen-utxo-keys INT]
-            [--start-time UTC-TIME]
-            [--supply LOVELACE]
-            (--mainnet | --testnet-magic NATURAL)
+                                    --genesis-dir DIR
+                                    [--gen-genesis-keys INT]
+                                    [--gen-utxo-keys INT]
+                                    [--start-time UTC-TIME]
+                                    [--supply LOVELACE]
+                                    (--mainnet | --testnet-magic NATURAL)
 
   Create a Shelley genesis file from a genesis template and
   genesis/delegation/spending keys.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/genesis_get-ver-key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/genesis_get-ver-key.cli
@@ -1,5 +1,5 @@
 Usage: cardano-cli genesis get-ver-key --verification-key-file FILE
-            --signing-key-file FILE
+                                         --signing-key-file FILE
 
   Derive the verification key from a signing key
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/genesis_initial-addr.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/genesis_initial-addr.cli
@@ -1,6 +1,6 @@
 Usage: cardano-cli genesis initial-addr --verification-key-file FILE
-            (--mainnet | --testnet-magic NATURAL)
-            [--out-file FILE]
+                                          (--mainnet | --testnet-magic NATURAL)
+                                          [--out-file FILE]
 
   Get the address for an initial UTxO based on the verification key
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/genesis_initial-txin.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/genesis_initial-txin.cli
@@ -1,6 +1,6 @@
 Usage: cardano-cli genesis initial-txin --verification-key-file FILE
-            (--mainnet | --testnet-magic NATURAL)
-            [--out-file FILE]
+                                          (--mainnet | --testnet-magic NATURAL)
+                                          [--out-file FILE]
 
   Get the TxIn for an initial UTxO based on the verification key
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/genesis_key-gen-delegate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/genesis_key-gen-delegate.cli
@@ -1,6 +1,6 @@
 Usage: cardano-cli genesis key-gen-delegate --verification-key-file FILE
-            --signing-key-file FILE
-            --operational-certificate-issue-counter-file FILE
+                                              --signing-key-file FILE
+                                              --operational-certificate-issue-counter-file FILE
 
   Create a Shelley genesis delegate key pair
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/genesis_key-gen-genesis.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/genesis_key-gen-genesis.cli
@@ -1,5 +1,5 @@
 Usage: cardano-cli genesis key-gen-genesis --verification-key-file FILE
-            --signing-key-file FILE
+                                             --signing-key-file FILE
 
   Create a Shelley genesis key pair
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/genesis_key-gen-utxo.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/genesis_key-gen-utxo.cli
@@ -1,5 +1,5 @@
 Usage: cardano-cli genesis key-gen-utxo --verification-key-file FILE
-            --signing-key-file FILE
+                                          --signing-key-file FILE
 
   Create a Shelley genesis UTxO key pair
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/get-tip.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/get-tip.cli
@@ -1,5 +1,5 @@
 Usage: cardano-cli get-tip --socket-path SOCKET_PATH
-            (--mainnet | --testnet-magic NATURAL)
+                             (--mainnet | --testnet-magic NATURAL)
 
   Get the tip of your local node's blockchain
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/governance.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/governance.cli
@@ -1,13 +1,13 @@
 Usage: cardano-cli governance 
-            ( create-mir-certificate
-            | create-genesis-key-delegation-certificate
-            | create-update-proposal
-            | create-poll
-            | answer-poll
-            | verify-poll
-            | vote
-            | action
-            )
+                                ( create-mir-certificate
+                                | create-genesis-key-delegation-certificate
+                                | create-update-proposal
+                                | create-poll
+                                | answer-poll
+                                | verify-poll
+                                | vote
+                                | action
+                                )
 
   Governance commands
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_action_create-action_create-constitution.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_action_create-action_create-constitution.cli
@@ -1,11 +1,13 @@
 Usage: cardano-cli governance action create-action create-constitution 
-            [--conway-era]
-            --governance-action-deposit NATURAL
-            ( --stake-pool-verification-key STRING
-            | --cold-verification-key-file FILE
-            )
-            (--constitution TEXT | --constitution-file FILE)
-            --out-file FILE
+                                                                         [--conway-era]
+                                                                         --governance-action-deposit NATURAL
+                                                                         ( --stake-pool-verification-key STRING
+                                                                         | --cold-verification-key-file FILE
+                                                                         )
+                                                                         ( --constitution TEXT
+                                                                         | --constitution-file FILE
+                                                                         )
+                                                                         --out-file FILE
 
   Create a constitution.
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_answer-poll.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_answer-poll.cli
@@ -1,6 +1,6 @@
 Usage: cardano-cli governance answer-poll --poll-file FILE
-            [--answer INT]
-            [--out-file FILE]
+                                            [--answer INT]
+                                            [--out-file FILE]
 
   Answer an SPO poll
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_create-genesis-key-delegation-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_create-genesis-key-delegation-certificate.cli
@@ -1,24 +1,24 @@
 Usage: cardano-cli governance create-genesis-key-delegation-certificate 
-            ( --shelley-era
-            | --allegra-era
-            | --mary-era
-            | --alonzo-era
-            | --babbage-era
-            | --conway-era
-            )
-            ( --genesis-verification-key STRING
-            | --genesis-verification-key-file FILE
-            | --genesis-verification-key-hash STRING
-            )
-            ( --genesis-delegate-verification-key STRING
-            | --genesis-delegate-verification-key-file FILE
-            | --genesis-delegate-verification-key-hash STRING
-            )
-            ( --vrf-verification-key STRING
-            | --vrf-verification-key-file FILE
-            | --vrf-verification-key-hash STRING
-            )
-            --out-file FILE
+                                                                          ( --shelley-era
+                                                                          | --allegra-era
+                                                                          | --mary-era
+                                                                          | --alonzo-era
+                                                                          | --babbage-era
+                                                                          | --conway-era
+                                                                          )
+                                                                          ( --genesis-verification-key STRING
+                                                                          | --genesis-verification-key-file FILE
+                                                                          | --genesis-verification-key-hash STRING
+                                                                          )
+                                                                          ( --genesis-delegate-verification-key STRING
+                                                                          | --genesis-delegate-verification-key-file FILE
+                                                                          | --genesis-delegate-verification-key-hash STRING
+                                                                          )
+                                                                          ( --vrf-verification-key STRING
+                                                                          | --vrf-verification-key-file FILE
+                                                                          | --vrf-verification-key-hash STRING
+                                                                          )
+                                                                          --out-file FILE
 
   Create a genesis key delegation certificate
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_create-mir-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_create-mir-certificate.cli
@@ -1,19 +1,21 @@
 Usage: cardano-cli governance create-mir-certificate 
-            ( ( --shelley-era
-              | --allegra-era
-              | --mary-era
-              | --alonzo-era
-              | --babbage-era
-              | --conway-era
-              )
-              (--reserves | --treasury)
-              (--stake-address ADDRESS)
-              (--reward LOVELACE)
-              --out-file FILE
-            | stake-addresses
-            | transfer-to-treasury
-            | transfer-to-rewards
-            )
+                                                       ( ( --shelley-era
+                                                         | --allegra-era
+                                                         | --mary-era
+                                                         | --alonzo-era
+                                                         | --babbage-era
+                                                         | --conway-era
+                                                         )
+                                                         ( --reserves
+                                                         | --treasury
+                                                         )
+                                                         (--stake-address ADDRESS)
+                                                         (--reward LOVELACE)
+                                                         --out-file FILE
+                                                       | stake-addresses
+                                                       | transfer-to-treasury
+                                                       | transfer-to-rewards
+                                                       )
 
   Create an MIR (Move Instantaneous Rewards) certificate
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_create-mir-certificate_stake-addresses.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_create-mir-certificate_stake-addresses.cli
@@ -1,15 +1,17 @@
 Usage: cardano-cli governance create-mir-certificate stake-addresses 
-            ( --shelley-era
-            | --allegra-era
-            | --mary-era
-            | --alonzo-era
-            | --babbage-era
-            | --conway-era
-            )
-            (--reserves | --treasury)
-            (--stake-address ADDRESS)
-            (--reward LOVELACE)
-            --out-file FILE
+                                                                       ( --shelley-era
+                                                                       | --allegra-era
+                                                                       | --mary-era
+                                                                       | --alonzo-era
+                                                                       | --babbage-era
+                                                                       | --conway-era
+                                                                       )
+                                                                       ( --reserves
+                                                                       | --treasury
+                                                                       )
+                                                                       (--stake-address ADDRESS)
+                                                                       (--reward LOVELACE)
+                                                                       --out-file FILE
 
   Create an MIR certificate to pay stake addresses
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_create-mir-certificate_transfer-to-rewards.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_create-mir-certificate_transfer-to-rewards.cli
@@ -1,13 +1,13 @@
 Usage: cardano-cli governance create-mir-certificate transfer-to-rewards 
-            ( --shelley-era
-            | --allegra-era
-            | --mary-era
-            | --alonzo-era
-            | --babbage-era
-            | --conway-era
-            )
-            --transfer LOVELACE
-            --out-file FILE
+                                                                           ( --shelley-era
+                                                                           | --allegra-era
+                                                                           | --mary-era
+                                                                           | --alonzo-era
+                                                                           | --babbage-era
+                                                                           | --conway-era
+                                                                           )
+                                                                           --transfer LOVELACE
+                                                                           --out-file FILE
 
   Create an MIR certificate to transfer from the treasury pot to the reserves
   pot

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_create-mir-certificate_transfer-to-treasury.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_create-mir-certificate_transfer-to-treasury.cli
@@ -1,13 +1,13 @@
 Usage: cardano-cli governance create-mir-certificate transfer-to-treasury 
-            ( --shelley-era
-            | --allegra-era
-            | --mary-era
-            | --alonzo-era
-            | --babbage-era
-            | --conway-era
-            )
-            --transfer LOVELACE
-            --out-file FILE
+                                                                            ( --shelley-era
+                                                                            | --allegra-era
+                                                                            | --mary-era
+                                                                            | --alonzo-era
+                                                                            | --babbage-era
+                                                                            | --conway-era
+                                                                            )
+                                                                            --transfer LOVELACE
+                                                                            --out-file FILE
 
   Create an MIR certificate to transfer from the reserves pot to the treasury
   pot

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_create-poll.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_create-poll.cli
@@ -1,7 +1,7 @@
 Usage: cardano-cli governance create-poll --question STRING
-            (--answer STRING)
-            [--nonce UINT]
-            --out-file FILE
+                                            (--answer STRING)
+                                            [--nonce UINT]
+                                            --out-file FILE
 
   Create an SPO poll
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_create-update-proposal.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_create-update-proposal.cli
@@ -1,32 +1,36 @@
 Usage: cardano-cli governance create-update-proposal --out-file FILE
-            --epoch EPOCH
-            (--genesis-verification-key-file FILE)
-            [--protocol-major-version NATURAL --protocol-minor-version NATURAL]
-            [--decentralization-parameter RATIONAL]
-            [--extra-entropy HEX | --reset-extra-entropy]
-            [--max-block-header-size NATURAL]
-            [--max-block-body-size NATURAL]
-            [--max-tx-size NATURAL]
-            [--min-fee-constant LOVELACE]
-            [--min-fee-linear LOVELACE]
-            [--min-utxo-value NATURAL]
-            [--key-reg-deposit-amt NATURAL]
-            [--pool-reg-deposit NATURAL]
-            [--min-pool-cost NATURAL]
-            [--pool-retirement-epoch-boundary EPOCH_BOUNDARY]
-            [--number-of-pools NATURAL]
-            [--pool-influence RATIONAL]
-            [--monetary-expansion RATIONAL]
-            [--treasury-expansion RATIONAL]
-            [--utxo-cost-per-word LOVELACE]
-            [--price-execution-steps RATIONAL --price-execution-memory RATIONAL]
-            [--max-tx-execution-units (INT, INT)]
-            [--max-block-execution-units (INT, INT)]
-            [--max-value-size INT]
-            [--collateral-percent INT]
-            [--max-collateral-inputs INT]
-            [--utxo-cost-per-byte LOVELACE]
-            [--cost-model-file FILE]
+                                                       --epoch EPOCH
+                                                       (--genesis-verification-key-file FILE)
+                                                       [--protocol-major-version NATURAL
+                                                         --protocol-minor-version NATURAL]
+                                                       [--decentralization-parameter RATIONAL]
+                                                       [ --extra-entropy HEX
+                                                       | --reset-extra-entropy
+                                                       ]
+                                                       [--max-block-header-size NATURAL]
+                                                       [--max-block-body-size NATURAL]
+                                                       [--max-tx-size NATURAL]
+                                                       [--min-fee-constant LOVELACE]
+                                                       [--min-fee-linear LOVELACE]
+                                                       [--min-utxo-value NATURAL]
+                                                       [--key-reg-deposit-amt NATURAL]
+                                                       [--pool-reg-deposit NATURAL]
+                                                       [--min-pool-cost NATURAL]
+                                                       [--pool-retirement-epoch-boundary EPOCH_BOUNDARY]
+                                                       [--number-of-pools NATURAL]
+                                                       [--pool-influence RATIONAL]
+                                                       [--monetary-expansion RATIONAL]
+                                                       [--treasury-expansion RATIONAL]
+                                                       [--utxo-cost-per-word LOVELACE]
+                                                       [--price-execution-steps RATIONAL
+                                                         --price-execution-memory RATIONAL]
+                                                       [--max-tx-execution-units (INT, INT)]
+                                                       [--max-block-execution-units (INT, INT)]
+                                                       [--max-value-size INT]
+                                                       [--collateral-percent INT]
+                                                       [--max-collateral-inputs INT]
+                                                       [--utxo-cost-per-byte LOVELACE]
+                                                       [--cost-model-file FILE]
 
   Create an update proposal
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_verify-poll.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_verify-poll.cli
@@ -1,6 +1,6 @@
 Usage: cardano-cli governance verify-poll --poll-file FILE
-            --tx-file FILE
-            [--out-file FILE]
+                                            --tx-file FILE
+                                            [--out-file FILE]
 
   Verify an answer to a given SPO poll
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_vote_create-vote.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_vote_create-vote.cli
@@ -1,11 +1,14 @@
 Usage: cardano-cli governance vote create-vote (--yes | --no | --abstain)
-            (--constitutional-committee-member | --drep | --spo)
-            --tx-in TX-IN
-            ( --stake-pool-verification-key STRING
-            | --cold-verification-key-file FILE
-            )
-            [--conway-era]
-            --out-file FILE
+                                                 ( --constitutional-committee-member
+                                                 | --drep
+                                                 | --spo
+                                                 )
+                                                 --tx-in TX-IN
+                                                 ( --stake-pool-verification-key STRING
+                                                 | --cold-verification-key-file FILE
+                                                 )
+                                                 [--conway-era]
+                                                 --out-file FILE
 
   Create a vote for a proposed governance action.
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/issue-genesis-utxo-expenditure.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/issue-genesis-utxo-expenditure.cli
@@ -1,10 +1,14 @@
 Usage: cardano-cli issue-genesis-utxo-expenditure --genesis-json FILEPATH
-            (--mainnet | --testnet-magic NATURAL)
-            [--byron-legacy-formats | --byron-formats]
-            --tx FILEPATH
-            --wallet-key FILEPATH
-            --rich-addr-from ADDR
-            (--txout '("ADDR", LOVELACE)')
+                                                    ( --mainnet
+                                                    | --testnet-magic NATURAL
+                                                    )
+                                                    [ --byron-legacy-formats
+                                                    | --byron-formats
+                                                    ]
+                                                    --tx FILEPATH
+                                                    --wallet-key FILEPATH
+                                                    --rich-addr-from ADDR
+                                                    (--txout '("ADDR", LOVELACE)')
 
   Write a file with a signed transaction, spending genesis UTxO.
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/issue-utxo-expenditure.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/issue-utxo-expenditure.cli
@@ -1,9 +1,11 @@
 Usage: cardano-cli issue-utxo-expenditure (--mainnet | --testnet-magic NATURAL)
-            [--byron-legacy-formats | --byron-formats]
-            --tx FILEPATH
-            --wallet-key FILEPATH
-            (--txin (TXID,INDEX))
-            (--txout '("ADDR", LOVELACE)')
+                                            [ --byron-legacy-formats
+                                            | --byron-formats
+                                            ]
+                                            --tx FILEPATH
+                                            --wallet-key FILEPATH
+                                            (--txin (TXID,INDEX))
+                                            (--txout '("ADDR", LOVELACE)')
 
   Write a file with a signed transaction, spending normal UTxO.
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/key.cli
@@ -1,13 +1,13 @@
 Usage: cardano-cli key 
-            ( verification-key
-            | non-extended-key
-            | convert-byron-key
-            | convert-byron-genesis-vkey
-            | convert-itn-key
-            | convert-itn-extended-key
-            | convert-itn-bip32-key
-            | convert-cardano-address-key
-            )
+                         ( verification-key
+                         | non-extended-key
+                         | convert-byron-key
+                         | convert-byron-genesis-vkey
+                         | convert-itn-key
+                         | convert-itn-extended-key
+                         | convert-itn-bip32-key
+                         | convert-cardano-address-key
+                         )
 
   Key utility commands
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/key_convert-byron-genesis-vkey.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/key_convert-byron-genesis-vkey.cli
@@ -1,5 +1,5 @@
 Usage: cardano-cli key convert-byron-genesis-vkey --byron-genesis-verification-key BASE64
-            --out-file FILE
+                                                    --out-file FILE
 
   Convert a Base64-encoded Byron genesis verification key to a Shelley genesis
   verification key

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/key_convert-byron-key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/key_convert-byron-key.cli
@@ -1,13 +1,15 @@
 Usage: cardano-cli key convert-byron-key [--password TEXT]
-            ( --byron-payment-key-type
-            | --legacy-byron-payment-key-type
-            | --byron-genesis-key-type
-            | --legacy-byron-genesis-key-type
-            | --byron-genesis-delegate-key-type
-            | --legacy-byron-genesis-delegate-key-type
-            )
-            (--byron-signing-key-file FILE | --byron-verification-key-file FILE)
-            --out-file FILE
+                                           ( --byron-payment-key-type
+                                           | --legacy-byron-payment-key-type
+                                           | --byron-genesis-key-type
+                                           | --legacy-byron-genesis-key-type
+                                           | --byron-genesis-delegate-key-type
+                                           | --legacy-byron-genesis-delegate-key-type
+                                           )
+                                           ( --byron-signing-key-file FILE
+                                           | --byron-verification-key-file FILE
+                                           )
+                                           --out-file FILE
 
   Convert a Byron payment, genesis or genesis delegate key (signing or
   verification) to a corresponding Shelley-format key.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/key_convert-cardano-address-key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/key_convert-cardano-address-key.cli
@@ -1,11 +1,11 @@
 Usage: cardano-cli key convert-cardano-address-key 
-            ( --shelley-payment-key
-            | --shelley-stake-key
-            | --icarus-payment-key
-            | --byron-payment-key
-            )
-            --signing-key-file FILE
-            --out-file FILE
+                                                     ( --shelley-payment-key
+                                                     | --shelley-stake-key
+                                                     | --icarus-payment-key
+                                                     | --byron-payment-key
+                                                     )
+                                                     --signing-key-file FILE
+                                                     --out-file FILE
 
   Convert a cardano-address extended signing key to a corresponding
   Shelley-format key.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/key_convert-itn-bip32-key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/key_convert-itn-bip32-key.cli
@@ -1,5 +1,5 @@
 Usage: cardano-cli key convert-itn-bip32-key --itn-signing-key-file FILE
-            --out-file FILE
+                                               --out-file FILE
 
   Convert an Incentivized Testnet (ITN) BIP32 (Ed25519Bip32) signing key to a
   corresponding Shelley stake signing key

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/key_convert-itn-extended-key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/key_convert-itn-extended-key.cli
@@ -1,5 +1,5 @@
 Usage: cardano-cli key convert-itn-extended-key --itn-signing-key-file FILE
-            --out-file FILE
+                                                  --out-file FILE
 
   Convert an Incentivized Testnet (ITN) extended (Ed25519Extended) signing key
   to a corresponding Shelley stake signing key

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/key_convert-itn-key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/key_convert-itn-key.cli
@@ -1,6 +1,8 @@
 Usage: cardano-cli key convert-itn-key 
-            (--itn-signing-key-file FILE | --itn-verification-key-file FILE)
-            --out-file FILE
+                                         ( --itn-signing-key-file FILE
+                                         | --itn-verification-key-file FILE
+                                         )
+                                         --out-file FILE
 
   Convert an Incentivized Testnet (ITN) non-extended (Ed25519) signing or
   verification key to a corresponding Shelley stake key

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/key_non-extended-key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/key_non-extended-key.cli
@@ -1,5 +1,5 @@
 Usage: cardano-cli key non-extended-key --extended-verification-key-file FILE
-            --verification-key-file FILE
+                                          --verification-key-file FILE
 
   Get a non-extended verification key from an extended verification key. This
   supports all extended key types.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/key_verification-key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/key_verification-key.cli
@@ -1,5 +1,5 @@
 Usage: cardano-cli key verification-key --signing-key-file FILE
-            --verification-key-file FILE
+                                          --verification-key-file FILE
 
   Get a verification key from a signing key. This supports all key types.
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/node.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/node.cli
@@ -1,11 +1,11 @@
 Usage: cardano-cli node 
-            ( key-gen
-            | key-gen-KES
-            | key-gen-VRF
-            | key-hash-VRF
-            | new-counter
-            | issue-op-cert
-            )
+                          ( key-gen
+                          | key-gen-KES
+                          | key-gen-VRF
+                          | key-hash-VRF
+                          | new-counter
+                          | issue-op-cert
+                          )
 
   Node operation commands
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/node_issue-op-cert.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/node_issue-op-cert.cli
@@ -1,9 +1,11 @@
 Usage: cardano-cli node issue-op-cert 
-            (--kes-verification-key STRING | --kes-verification-key-file FILE)
-            --cold-signing-key-file FILE
-            --operational-certificate-issue-counter-file FILE
-            --kes-period NATURAL
-            --out-file FILE
+                                        ( --kes-verification-key STRING
+                                        | --kes-verification-key-file FILE
+                                        )
+                                        --cold-signing-key-file FILE
+                                        --operational-certificate-issue-counter-file FILE
+                                        --kes-period NATURAL
+                                        --out-file FILE
 
   Issue a node operational certificate
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/node_key-gen-KES.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/node_key-gen-KES.cli
@@ -1,6 +1,6 @@
 Usage: cardano-cli node key-gen-KES [--key-output-format STRING]
-            --verification-key-file FILE
-            --signing-key-file FILE
+                                      --verification-key-file FILE
+                                      --signing-key-file FILE
 
   Create a key pair for a node KES operational key
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/node_key-gen-VRF.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/node_key-gen-VRF.cli
@@ -1,6 +1,6 @@
 Usage: cardano-cli node key-gen-VRF [--key-output-format STRING]
-            --verification-key-file FILE
-            --signing-key-file FILE
+                                      --verification-key-file FILE
+                                      --signing-key-file FILE
 
   Create a key pair for a node VRF operational key
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/node_key-gen.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/node_key-gen.cli
@@ -1,7 +1,7 @@
 Usage: cardano-cli node key-gen [--key-output-format STRING]
-            --cold-verification-key-file FILE
-            --cold-signing-key-file FILE
-            --operational-certificate-issue-counter-file FILE
+                                  --cold-verification-key-file FILE
+                                  --cold-signing-key-file FILE
+                                  --operational-certificate-issue-counter-file FILE
 
   Create a key pair for a node operator's offline key and a new certificate
   issue counter

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/node_key-hash-VRF.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/node_key-hash-VRF.cli
@@ -1,6 +1,8 @@
 Usage: cardano-cli node key-hash-VRF 
-            (--verification-key STRING | --verification-key-file FILE)
-            [--out-file FILE]
+                                       ( --verification-key STRING
+                                       | --verification-key-file FILE
+                                       )
+                                       [--out-file FILE]
 
   Print hash of a node's operational VRF key.
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/node_new-counter.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/node_new-counter.cli
@@ -1,10 +1,10 @@
 Usage: cardano-cli node new-counter 
-            ( --stake-pool-verification-key STRING
-            | --genesis-delegate-verification-key STRING
-            | --cold-verification-key-file FILE
-            )
-            --counter-value INT
-            --operational-certificate-issue-counter-file FILE
+                                      ( --stake-pool-verification-key STRING
+                                      | --genesis-delegate-verification-key STRING
+                                      | --cold-verification-key-file FILE
+                                      )
+                                      --counter-value INT
+                                      --operational-certificate-issue-counter-file FILE
 
   Create a new certificate issue counter
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/ping.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/ping.cli
@@ -1,10 +1,10 @@
 Usage: cardano-cli ping [-c|--count COUNT]
-            ((-h|--host HOST) | (-u|--unixsock SOCKET))
-            [-p|--port PORT]
-            [-m|--magic MAGIC]
-            [-j|--json]
-            [-q|--quiet]
-            [-Q|--query-versions]
+                          ((-h|--host HOST) | (-u|--unixsock SOCKET))
+                          [-p|--port PORT]
+                          [-m|--magic MAGIC]
+                          [-j|--json]
+                          [-q|--quiet]
+                          [-Q|--query-versions]
 
   Ping a cardano node either using node-to-node or node-to-client protocol. It negotiates a handshake and keeps sending keep alive messages.
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/query.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/query.cli
@@ -1,20 +1,20 @@
 Usage: cardano-cli query 
-            ( protocol-parameters
-            | constitution-hash
-            | tip
-            | stake-pools
-            | stake-distribution
-            | stake-address-info
-            | utxo
-            | ledger-state
-            | protocol-state
-            | stake-snapshot
-            | leadership-schedule
-            | kes-period-info
-            | pool-state
-            | tx-mempool
-            | slot-number
-            )
+                           ( protocol-parameters
+                           | constitution-hash
+                           | tip
+                           | stake-pools
+                           | stake-distribution
+                           | stake-address-info
+                           | utxo
+                           | ledger-state
+                           | protocol-state
+                           | stake-snapshot
+                           | leadership-schedule
+                           | kes-period-info
+                           | pool-state
+                           | tx-mempool
+                           | slot-number
+                           )
 
   Node query commands. Will query the local node whose Unix domain socket is
   obtained from the CARDANO_NODE_SOCKET_PATH environment variable.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/query_constitution-hash.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/query_constitution-hash.cli
@@ -1,10 +1,14 @@
 Usage: cardano-cli query constitution-hash --socket-path SOCKET_PATH
-            [ --shelley-mode
-            | --byron-mode [--epoch-slots SLOTS]
-            | --cardano-mode [--epoch-slots SLOTS]
-            ]
-            (--mainnet | --testnet-magic NATURAL)
-            [--out-file FILE]
+                                             [ --shelley-mode
+                                             | --byron-mode
+                                               [--epoch-slots SLOTS]
+                                             | --cardano-mode
+                                               [--epoch-slots SLOTS]
+                                             ]
+                                             ( --mainnet
+                                             | --testnet-magic NATURAL
+                                             )
+                                             [--out-file FILE]
 
   Get the constitution hash
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/query_kes-period-info.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/query_kes-period-info.cli
@@ -1,11 +1,12 @@
 Usage: cardano-cli query kes-period-info --socket-path SOCKET_PATH
-            [ --shelley-mode
-            | --byron-mode [--epoch-slots SLOTS]
-            | --cardano-mode [--epoch-slots SLOTS]
-            ]
-            (--mainnet | --testnet-magic NATURAL)
-            --op-cert-file FILE
-            [--out-file FILE]
+                                           [ --shelley-mode
+                                           | --byron-mode [--epoch-slots SLOTS]
+                                           | --cardano-mode
+                                             [--epoch-slots SLOTS]
+                                           ]
+                                           (--mainnet | --testnet-magic NATURAL)
+                                           --op-cert-file FILE
+                                           [--out-file FILE]
 
   Get information about the current KES period and your node's operational
   certificate.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/query_leadership-schedule.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/query_leadership-schedule.cli
@@ -1,17 +1,21 @@
 Usage: cardano-cli query leadership-schedule --socket-path SOCKET_PATH
-            [ --shelley-mode
-            | --byron-mode [--epoch-slots SLOTS]
-            | --cardano-mode [--epoch-slots SLOTS]
-            ]
-            (--mainnet | --testnet-magic NATURAL)
-            --genesis FILE
-            ( --stake-pool-verification-key STRING
-            | --cold-verification-key-file FILE
-            | --stake-pool-id STAKE_POOL_ID
-            )
-            --vrf-signing-key-file FILE
-            (--current | --next)
-            [--out-file FILE]
+                                               [ --shelley-mode
+                                               | --byron-mode
+                                                 [--epoch-slots SLOTS]
+                                               | --cardano-mode
+                                                 [--epoch-slots SLOTS]
+                                               ]
+                                               ( --mainnet
+                                               | --testnet-magic NATURAL
+                                               )
+                                               --genesis FILE
+                                               ( --stake-pool-verification-key STRING
+                                               | --cold-verification-key-file FILE
+                                               | --stake-pool-id STAKE_POOL_ID
+                                               )
+                                               --vrf-signing-key-file FILE
+                                               (--current | --next)
+                                               [--out-file FILE]
 
   Get the slots the node is expected to mint a block in (advanced command)
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/query_ledger-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/query_ledger-state.cli
@@ -1,10 +1,10 @@
 Usage: cardano-cli query ledger-state --socket-path SOCKET_PATH
-            [ --shelley-mode
-            | --byron-mode [--epoch-slots SLOTS]
-            | --cardano-mode [--epoch-slots SLOTS]
-            ]
-            (--mainnet | --testnet-magic NATURAL)
-            [--out-file FILE]
+                                        [ --shelley-mode
+                                        | --byron-mode [--epoch-slots SLOTS]
+                                        | --cardano-mode [--epoch-slots SLOTS]
+                                        ]
+                                        (--mainnet | --testnet-magic NATURAL)
+                                        [--out-file FILE]
 
   Dump the current ledger state of the node (Ledger.NewEpochState -- advanced
   command)

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/query_pool-params.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/query_pool-params.cli
@@ -1,10 +1,10 @@
 Usage: cardano-cli query pool-params --socket-path SOCKET_PATH
-            [ --shelley-mode
-            | --byron-mode [--epoch-slots SLOTS]
-            | --cardano-mode [--epoch-slots SLOTS]
-            ]
-            (--mainnet | --testnet-magic NATURAL)
-            [--stake-pool-id STAKE_POOL_ID]
+                                       [ --shelley-mode
+                                       | --byron-mode [--epoch-slots SLOTS]
+                                       | --cardano-mode [--epoch-slots SLOTS]
+                                       ]
+                                       (--mainnet | --testnet-magic NATURAL)
+                                       [--stake-pool-id STAKE_POOL_ID]
 
   DEPRECATED. Use query pool-state instead. Dump the pool parameters
   (Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/query_pool-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/query_pool-state.cli
@@ -1,10 +1,10 @@
 Usage: cardano-cli query pool-state --socket-path SOCKET_PATH
-            [ --shelley-mode
-            | --byron-mode [--epoch-slots SLOTS]
-            | --cardano-mode [--epoch-slots SLOTS]
-            ]
-            (--mainnet | --testnet-magic NATURAL)
-            [--stake-pool-id STAKE_POOL_ID]
+                                      [ --shelley-mode
+                                      | --byron-mode [--epoch-slots SLOTS]
+                                      | --cardano-mode [--epoch-slots SLOTS]
+                                      ]
+                                      (--mainnet | --testnet-magic NATURAL)
+                                      [--stake-pool-id STAKE_POOL_ID]
 
   Dump the pool state
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/query_protocol-parameters.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/query_protocol-parameters.cli
@@ -1,10 +1,14 @@
 Usage: cardano-cli query protocol-parameters --socket-path SOCKET_PATH
-            [ --shelley-mode
-            | --byron-mode [--epoch-slots SLOTS]
-            | --cardano-mode [--epoch-slots SLOTS]
-            ]
-            (--mainnet | --testnet-magic NATURAL)
-            [--out-file FILE]
+                                               [ --shelley-mode
+                                               | --byron-mode
+                                                 [--epoch-slots SLOTS]
+                                               | --cardano-mode
+                                                 [--epoch-slots SLOTS]
+                                               ]
+                                               ( --mainnet
+                                               | --testnet-magic NATURAL
+                                               )
+                                               [--out-file FILE]
 
   Get the node's current protocol parameters
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/query_protocol-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/query_protocol-state.cli
@@ -1,10 +1,10 @@
 Usage: cardano-cli query protocol-state --socket-path SOCKET_PATH
-            [ --shelley-mode
-            | --byron-mode [--epoch-slots SLOTS]
-            | --cardano-mode [--epoch-slots SLOTS]
-            ]
-            (--mainnet | --testnet-magic NATURAL)
-            [--out-file FILE]
+                                          [ --shelley-mode
+                                          | --byron-mode [--epoch-slots SLOTS]
+                                          | --cardano-mode [--epoch-slots SLOTS]
+                                          ]
+                                          (--mainnet | --testnet-magic NATURAL)
+                                          [--out-file FILE]
 
   Dump the current protocol state of the node (Ledger.ChainDepState -- advanced
   command)

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/query_slot-number.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/query_slot-number.cli
@@ -1,10 +1,10 @@
 Usage: cardano-cli query slot-number --socket-path SOCKET_PATH
-            [ --shelley-mode
-            | --byron-mode [--epoch-slots SLOTS]
-            | --cardano-mode [--epoch-slots SLOTS]
-            ]
-            (--mainnet | --testnet-magic NATURAL)
-            TIMESTAMP
+                                       [ --shelley-mode
+                                       | --byron-mode [--epoch-slots SLOTS]
+                                       | --cardano-mode [--epoch-slots SLOTS]
+                                       ]
+                                       (--mainnet | --testnet-magic NATURAL)
+                                       TIMESTAMP
 
   Query slot number for UTC timestamp
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/query_stake-address-info.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/query_stake-address-info.cli
@@ -1,11 +1,15 @@
 Usage: cardano-cli query stake-address-info --socket-path SOCKET_PATH
-            [ --shelley-mode
-            | --byron-mode [--epoch-slots SLOTS]
-            | --cardano-mode [--epoch-slots SLOTS]
-            ]
-            --address ADDRESS
-            (--mainnet | --testnet-magic NATURAL)
-            [--out-file FILE]
+                                              [ --shelley-mode
+                                              | --byron-mode
+                                                [--epoch-slots SLOTS]
+                                              | --cardano-mode
+                                                [--epoch-slots SLOTS]
+                                              ]
+                                              --address ADDRESS
+                                              ( --mainnet
+                                              | --testnet-magic NATURAL
+                                              )
+                                              [--out-file FILE]
 
   Get the current delegations and reward accounts filtered by stake address.
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/query_stake-distribution.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/query_stake-distribution.cli
@@ -1,10 +1,14 @@
 Usage: cardano-cli query stake-distribution --socket-path SOCKET_PATH
-            [ --shelley-mode
-            | --byron-mode [--epoch-slots SLOTS]
-            | --cardano-mode [--epoch-slots SLOTS]
-            ]
-            (--mainnet | --testnet-magic NATURAL)
-            [--out-file FILE]
+                                              [ --shelley-mode
+                                              | --byron-mode
+                                                [--epoch-slots SLOTS]
+                                              | --cardano-mode
+                                                [--epoch-slots SLOTS]
+                                              ]
+                                              ( --mainnet
+                                              | --testnet-magic NATURAL
+                                              )
+                                              [--out-file FILE]
 
   Get the node's current aggregated stake distribution
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/query_stake-pools.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/query_stake-pools.cli
@@ -1,10 +1,10 @@
 Usage: cardano-cli query stake-pools --socket-path SOCKET_PATH
-            [ --shelley-mode
-            | --byron-mode [--epoch-slots SLOTS]
-            | --cardano-mode [--epoch-slots SLOTS]
-            ]
-            (--mainnet | --testnet-magic NATURAL)
-            [--out-file FILE]
+                                       [ --shelley-mode
+                                       | --byron-mode [--epoch-slots SLOTS]
+                                       | --cardano-mode [--epoch-slots SLOTS]
+                                       ]
+                                       (--mainnet | --testnet-magic NATURAL)
+                                       [--out-file FILE]
 
   Get the node's current set of stake pool ids
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/query_stake-snapshot.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/query_stake-snapshot.cli
@@ -1,11 +1,13 @@
 Usage: cardano-cli query stake-snapshot --socket-path SOCKET_PATH
-            [ --shelley-mode
-            | --byron-mode [--epoch-slots SLOTS]
-            | --cardano-mode [--epoch-slots SLOTS]
-            ]
-            (--mainnet | --testnet-magic NATURAL)
-            [--all-stake-pools | [--stake-pool-id STAKE_POOL_ID]]
-            [--out-file FILE]
+                                          [ --shelley-mode
+                                          | --byron-mode [--epoch-slots SLOTS]
+                                          | --cardano-mode [--epoch-slots SLOTS]
+                                          ]
+                                          (--mainnet | --testnet-magic NATURAL)
+                                          [ --all-stake-pools
+                                          | [--stake-pool-id STAKE_POOL_ID]
+                                          ]
+                                          [--out-file FILE]
 
   Obtain the three stake snapshots for a pool, plus the total active stake
   (advanced command)

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/query_tip.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/query_tip.cli
@@ -1,10 +1,10 @@
 Usage: cardano-cli query tip --socket-path SOCKET_PATH
-            [ --shelley-mode
-            | --byron-mode [--epoch-slots SLOTS]
-            | --cardano-mode [--epoch-slots SLOTS]
-            ]
-            (--mainnet | --testnet-magic NATURAL)
-            [--out-file FILE]
+                               [ --shelley-mode
+                               | --byron-mode [--epoch-slots SLOTS]
+                               | --cardano-mode [--epoch-slots SLOTS]
+                               ]
+                               (--mainnet | --testnet-magic NATURAL)
+                               [--out-file FILE]
 
   Get the node's current tip (slot no, hash, block no)
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/query_tx-mempool.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/query_tx-mempool.cli
@@ -1,11 +1,11 @@
 Usage: cardano-cli query tx-mempool --socket-path SOCKET_PATH
-            [ --shelley-mode
-            | --byron-mode [--epoch-slots SLOTS]
-            | --cardano-mode [--epoch-slots SLOTS]
-            ]
-            (--mainnet | --testnet-magic NATURAL)
-            (info | next-tx | tx-exists)
-            [--out-file FILE]
+                                      [ --shelley-mode
+                                      | --byron-mode [--epoch-slots SLOTS]
+                                      | --cardano-mode [--epoch-slots SLOTS]
+                                      ]
+                                      (--mainnet | --testnet-magic NATURAL)
+                                      (info | next-tx | tx-exists)
+                                      [--out-file FILE]
 
   Local Mempool info
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/query_tx-mempool_info.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/query_tx-mempool_info.cli
@@ -1,12 +1,12 @@
 Missing: --socket-path SOCKET_PATH (--mainnet | --testnet-magic NATURAL)
 
 Usage: cardano-cli query tx-mempool --socket-path SOCKET_PATH
-            [ --shelley-mode
-            | --byron-mode [--epoch-slots SLOTS]
-            | --cardano-mode [--epoch-slots SLOTS]
-            ]
-            (--mainnet | --testnet-magic NATURAL)
-            (info | next-tx | tx-exists)
-            [--out-file FILE]
+                                      [ --shelley-mode
+                                      | --byron-mode [--epoch-slots SLOTS]
+                                      | --cardano-mode [--epoch-slots SLOTS]
+                                      ]
+                                      (--mainnet | --testnet-magic NATURAL)
+                                      (info | next-tx | tx-exists)
+                                      [--out-file FILE]
 
   Local Mempool info

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/query_tx-mempool_next-tx.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/query_tx-mempool_next-tx.cli
@@ -1,12 +1,12 @@
 Missing: --socket-path SOCKET_PATH (--mainnet | --testnet-magic NATURAL)
 
 Usage: cardano-cli query tx-mempool --socket-path SOCKET_PATH
-            [ --shelley-mode
-            | --byron-mode [--epoch-slots SLOTS]
-            | --cardano-mode [--epoch-slots SLOTS]
-            ]
-            (--mainnet | --testnet-magic NATURAL)
-            (info | next-tx | tx-exists)
-            [--out-file FILE]
+                                      [ --shelley-mode
+                                      | --byron-mode [--epoch-slots SLOTS]
+                                      | --cardano-mode [--epoch-slots SLOTS]
+                                      ]
+                                      (--mainnet | --testnet-magic NATURAL)
+                                      (info | next-tx | tx-exists)
+                                      [--out-file FILE]
 
   Local Mempool info

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/query_tx-mempool_tx-exists_TX_ID.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/query_tx-mempool_tx-exists_TX_ID.cli
@@ -1,12 +1,12 @@
 Missing: --socket-path SOCKET_PATH (--mainnet | --testnet-magic NATURAL)
 
 Usage: cardano-cli query tx-mempool --socket-path SOCKET_PATH
-            [ --shelley-mode
-            | --byron-mode [--epoch-slots SLOTS]
-            | --cardano-mode [--epoch-slots SLOTS]
-            ]
-            (--mainnet | --testnet-magic NATURAL)
-            (info | next-tx | tx-exists)
-            [--out-file FILE]
+                                      [ --shelley-mode
+                                      | --byron-mode [--epoch-slots SLOTS]
+                                      | --cardano-mode [--epoch-slots SLOTS]
+                                      ]
+                                      (--mainnet | --testnet-magic NATURAL)
+                                      (info | next-tx | tx-exists)
+                                      [--out-file FILE]
 
   Local Mempool info

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/query_utxo.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/query_utxo.cli
@@ -1,11 +1,14 @@
 Usage: cardano-cli query utxo --socket-path SOCKET_PATH
-            [ --shelley-mode
-            | --byron-mode [--epoch-slots SLOTS]
-            | --cardano-mode [--epoch-slots SLOTS]
-            ]
-            (--whole-utxo | (--address ADDRESS) | (--tx-in TX-IN))
-            (--mainnet | --testnet-magic NATURAL)
-            [--out-file FILE]
+                                [ --shelley-mode
+                                | --byron-mode [--epoch-slots SLOTS]
+                                | --cardano-mode [--epoch-slots SLOTS]
+                                ]
+                                ( --whole-utxo
+                                | (--address ADDRESS)
+                                | (--tx-in TX-IN)
+                                )
+                                (--mainnet | --testnet-magic NATURAL)
+                                [--out-file FILE]
 
   Get a portion of the current UTxO: by tx in, by address or the whole.
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/signing-key-address.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/signing-key-address.cli
@@ -1,7 +1,9 @@
 Usage: cardano-cli signing-key-address 
-            [--byron-legacy-formats | --byron-formats]
-            (--mainnet | --testnet-magic NATURAL)
-            --secret FILEPATH
+                                         [ --byron-legacy-formats
+                                         | --byron-formats
+                                         ]
+                                         (--mainnet | --testnet-magic NATURAL)
+                                         --secret FILEPATH
 
   Print address of a signing key.
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/signing-key-public.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/signing-key-public.cli
@@ -1,5 +1,5 @@
 Usage: cardano-cli signing-key-public [--byron-legacy-formats | --byron-formats]
-            --secret FILEPATH
+                                        --secret FILEPATH
 
   Pretty-print a signing key's verification key (not a secret).
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/stake-address.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/stake-address.cli
@@ -1,11 +1,11 @@
 Usage: cardano-cli stake-address 
-            ( key-gen
-            | build
-            | key-hash
-            | registration-certificate
-            | deregistration-certificate
-            | delegation-certificate
-            )
+                                   ( key-gen
+                                   | build
+                                   | key-hash
+                                   | registration-certificate
+                                   | deregistration-certificate
+                                   | delegation-certificate
+                                   )
 
   Stake address commands
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/stake-address_build.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/stake-address_build.cli
@@ -1,10 +1,10 @@
 Usage: cardano-cli stake-address build 
-            ( --stake-verification-key STRING
-            | --stake-verification-key-file FILE
-            | --stake-script-file FILE
-            )
-            (--mainnet | --testnet-magic NATURAL)
-            [--out-file FILE]
+                                         ( --stake-verification-key STRING
+                                         | --stake-verification-key-file FILE
+                                         | --stake-script-file FILE
+                                         )
+                                         (--mainnet | --testnet-magic NATURAL)
+                                         [--out-file FILE]
 
   Build a stake address
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/stake-address_delegation-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/stake-address_delegation-certificate.cli
@@ -1,21 +1,21 @@
 Usage: cardano-cli stake-address delegation-certificate 
-            ( --shelley-era
-            | --allegra-era
-            | --mary-era
-            | --alonzo-era
-            | --babbage-era
-            | --conway-era
-            )
-            ( --stake-verification-key STRING
-            | --stake-verification-key-file FILE
-            | --stake-script-file FILE
-            | --stake-address ADDRESS
-            )
-            ( --stake-pool-verification-key STRING
-            | --cold-verification-key-file FILE
-            | --stake-pool-id STAKE_POOL_ID
-            )
-            --out-file FILE
+                                                          ( --shelley-era
+                                                          | --allegra-era
+                                                          | --mary-era
+                                                          | --alonzo-era
+                                                          | --babbage-era
+                                                          | --conway-era
+                                                          )
+                                                          ( --stake-verification-key STRING
+                                                          | --stake-verification-key-file FILE
+                                                          | --stake-script-file FILE
+                                                          | --stake-address ADDRESS
+                                                          )
+                                                          ( --stake-pool-verification-key STRING
+                                                          | --cold-verification-key-file FILE
+                                                          | --stake-pool-id STAKE_POOL_ID
+                                                          )
+                                                          --out-file FILE
 
   Create a stake address pool delegation certificate
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/stake-address_deregistration-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/stake-address_deregistration-certificate.cli
@@ -1,17 +1,17 @@
 Usage: cardano-cli stake-address deregistration-certificate 
-            ( --shelley-era
-            | --allegra-era
-            | --mary-era
-            | --alonzo-era
-            | --babbage-era
-            | --conway-era
-            )
-            ( --stake-verification-key STRING
-            | --stake-verification-key-file FILE
-            | --stake-script-file FILE
-            | --stake-address ADDRESS
-            )
-            --out-file FILE
+                                                              ( --shelley-era
+                                                              | --allegra-era
+                                                              | --mary-era
+                                                              | --alonzo-era
+                                                              | --babbage-era
+                                                              | --conway-era
+                                                              )
+                                                              ( --stake-verification-key STRING
+                                                              | --stake-verification-key-file FILE
+                                                              | --stake-script-file FILE
+                                                              | --stake-address ADDRESS
+                                                              )
+                                                              --out-file FILE
 
   Create a stake address deregistration certificate
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/stake-address_key-gen.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/stake-address_key-gen.cli
@@ -1,6 +1,6 @@
 Usage: cardano-cli stake-address key-gen [--key-output-format STRING]
-            --verification-key-file FILE
-            --signing-key-file FILE
+                                           --verification-key-file FILE
+                                           --signing-key-file FILE
 
   Create a stake address key pair
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/stake-address_key-hash.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/stake-address_key-hash.cli
@@ -1,8 +1,8 @@
 Usage: cardano-cli stake-address key-hash 
-            ( --stake-verification-key STRING
-            | --stake-verification-key-file FILE
-            )
-            [--out-file FILE]
+                                            ( --stake-verification-key STRING
+                                            | --stake-verification-key-file FILE
+                                            )
+                                            [--out-file FILE]
 
   Print the hash of a stake address key.
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/stake-address_registration-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/stake-address_registration-certificate.cli
@@ -1,17 +1,17 @@
 Usage: cardano-cli stake-address registration-certificate 
-            ( --shelley-era
-            | --allegra-era
-            | --mary-era
-            | --alonzo-era
-            | --babbage-era
-            | --conway-era
-            )
-            ( --stake-verification-key STRING
-            | --stake-verification-key-file FILE
-            | --stake-script-file FILE
-            | --stake-address ADDRESS
-            )
-            --out-file FILE
+                                                            ( --shelley-era
+                                                            | --allegra-era
+                                                            | --mary-era
+                                                            | --alonzo-era
+                                                            | --babbage-era
+                                                            | --conway-era
+                                                            )
+                                                            ( --stake-verification-key STRING
+                                                            | --stake-verification-key-file FILE
+                                                            | --stake-script-file FILE
+                                                            | --stake-address ADDRESS
+                                                            )
+                                                            --out-file FILE
 
   Create a stake address registration certificate
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/stake-pool.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/stake-pool.cli
@@ -1,9 +1,9 @@
 Usage: cardano-cli stake-pool 
-            ( registration-certificate
-            | deregistration-certificate
-            | id
-            | metadata-hash
-            )
+                                ( registration-certificate
+                                | deregistration-certificate
+                                | id
+                                | metadata-hash
+                                )
 
   Stake pool commands
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/stake-pool_deregistration-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/stake-pool_deregistration-certificate.cli
@@ -1,16 +1,16 @@
 Usage: cardano-cli stake-pool deregistration-certificate 
-            ( --shelley-era
-            | --allegra-era
-            | --mary-era
-            | --alonzo-era
-            | --babbage-era
-            | --conway-era
-            )
-            ( --stake-pool-verification-key STRING
-            | --cold-verification-key-file FILE
-            )
-            --epoch NATURAL
-            --out-file FILE
+                                                           ( --shelley-era
+                                                           | --allegra-era
+                                                           | --mary-era
+                                                           | --alonzo-era
+                                                           | --babbage-era
+                                                           | --conway-era
+                                                           )
+                                                           ( --stake-pool-verification-key STRING
+                                                           | --cold-verification-key-file FILE
+                                                           )
+                                                           --epoch NATURAL
+                                                           --out-file FILE
 
   Create a stake pool deregistration certificate
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/stake-pool_id.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/stake-pool_id.cli
@@ -1,9 +1,9 @@
 Usage: cardano-cli stake-pool id 
-            ( --stake-pool-verification-key STRING
-            | --cold-verification-key-file FILE
-            )
-            [--output-format STRING]
-            [--out-file FILE]
+                                   ( --stake-pool-verification-key STRING
+                                   | --cold-verification-key-file FILE
+                                   )
+                                   [--output-format STRING]
+                                   [--out-file FILE]
 
   Build pool id from the offline key
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/stake-pool_metadata-hash.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/stake-pool_metadata-hash.cli
@@ -1,5 +1,5 @@
 Usage: cardano-cli stake-pool metadata-hash --pool-metadata-file FILE
-            [--out-file FILE]
+                                              [--out-file FILE]
 
   Print the hash of pool metadata.
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/stake-pool_registration-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/stake-pool_registration-certificate.cli
@@ -1,33 +1,39 @@
 Usage: cardano-cli stake-pool registration-certificate 
-            ( --shelley-era
-            | --allegra-era
-            | --mary-era
-            | --alonzo-era
-            | --babbage-era
-            | --conway-era
-            )
-            ( --stake-pool-verification-key STRING
-            | --cold-verification-key-file FILE
-            )
-            (--vrf-verification-key STRING | --vrf-verification-key-file FILE)
-            --pool-pledge LOVELACE
-            --pool-cost LOVELACE
-            --pool-margin RATIONAL
-            ( --pool-reward-account-verification-key STRING
-            | --pool-reward-account-verification-key-file FILE
-            )
-            ( --pool-owner-verification-key STRING
-            | --pool-owner-stake-verification-key-file FILE
-            )
-            [ [--pool-relay-ipv4 STRING]
-              [--pool-relay-ipv6 STRING]
-              --pool-relay-port INT
-            | --single-host-pool-relay STRING [--pool-relay-port INT]
-            | --multi-host-pool-relay STRING
-            ]
-            [--metadata-url URL --metadata-hash HASH]
-            (--mainnet | --testnet-magic NATURAL)
-            --out-file FILE
+                                                         ( --shelley-era
+                                                         | --allegra-era
+                                                         | --mary-era
+                                                         | --alonzo-era
+                                                         | --babbage-era
+                                                         | --conway-era
+                                                         )
+                                                         ( --stake-pool-verification-key STRING
+                                                         | --cold-verification-key-file FILE
+                                                         )
+                                                         ( --vrf-verification-key STRING
+                                                         | --vrf-verification-key-file FILE
+                                                         )
+                                                         --pool-pledge LOVELACE
+                                                         --pool-cost LOVELACE
+                                                         --pool-margin RATIONAL
+                                                         ( --pool-reward-account-verification-key STRING
+                                                         | --pool-reward-account-verification-key-file FILE
+                                                         )
+                                                         ( --pool-owner-verification-key STRING
+                                                         | --pool-owner-stake-verification-key-file FILE
+                                                         )
+                                                         [ [--pool-relay-ipv4 STRING]
+                                                           [--pool-relay-ipv6 STRING]
+                                                           --pool-relay-port INT
+                                                         | --single-host-pool-relay STRING
+                                                           [--pool-relay-port INT]
+                                                         | --multi-host-pool-relay STRING
+                                                         ]
+                                                         [--metadata-url URL
+                                                           --metadata-hash HASH]
+                                                         ( --mainnet
+                                                         | --testnet-magic NATURAL
+                                                         )
+                                                         --out-file FILE
 
   Create a stake pool registration certificate
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/submit-tx.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/submit-tx.cli
@@ -1,6 +1,6 @@
 Usage: cardano-cli submit-tx --socket-path SOCKET_PATH
-            (--mainnet | --testnet-magic NATURAL)
-            --tx FILEPATH
+                               (--mainnet | --testnet-magic NATURAL)
+                               --tx FILEPATH
 
   Submit a raw, signed transaction, in its on-wire representation.
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/to-verification.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/to-verification.cli
@@ -1,6 +1,6 @@
 Usage: cardano-cli to-verification [--byron-legacy-formats | --byron-formats]
-            --secret FILEPATH
-            --to FILEPATH
+                                     --secret FILEPATH
+                                     --to FILEPATH
 
   Extract a verification key in its base64 form.
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/transaction.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/transaction.cli
@@ -1,17 +1,17 @@
 Usage: cardano-cli transaction 
-            ( build-raw
-            | build
-            | sign
-            | witness
-            | assemble
-            | submit
-            | policyid
-            | calculate-min-fee
-            | calculate-min-required-utxo
-            | hash-script-data
-            | txid
-            | view
-            )
+                                 ( build-raw
+                                 | build
+                                 | sign
+                                 | witness
+                                 | assemble
+                                 | submit
+                                 | policyid
+                                 | calculate-min-fee
+                                 | calculate-min-required-utxo
+                                 | hash-script-data
+                                 | txid
+                                 | view
+                                 )
 
   Transaction commands
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/transaction_assemble.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/transaction_assemble.cli
@@ -1,6 +1,6 @@
 Usage: cardano-cli transaction assemble --tx-body-file FILE
-            [--witness-file FILE]
-            --out-file FILE
+                                          [--witness-file FILE]
+                                          --out-file FILE
 
   Assemble a tx body and witness(es) to form a transaction
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/transaction_build-raw.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/transaction_build-raw.cli
@@ -1,117 +1,124 @@
 Usage: cardano-cli transaction build-raw 
-            [ --byron-era
-            | --shelley-era
-            | --allegra-era
-            | --mary-era
-            | --alonzo-era
-            | --babbage-era
-            | --conway-era
-            ]
-            [--script-valid | --script-invalid]
-            (--tx-in TX-IN
-              [ --spending-tx-in-reference TX-IN
-                --spending-plutus-script-v2
-                ( --spending-reference-tx-in-datum-cbor-file CBOR FILE
-                | --spending-reference-tx-in-datum-file JSON FILE
-                | --spending-reference-tx-in-datum-value JSON VALUE
-                | --spending-reference-tx-in-inline-datum-present
-                )
-                ( --spending-reference-tx-in-redeemer-cbor-file CBOR FILE
-                | --spending-reference-tx-in-redeemer-file JSON FILE
-                | --spending-reference-tx-in-redeemer-value JSON VALUE
-                )
-                --spending-reference-tx-in-execution-units (INT, INT)
-              | --simple-script-tx-in-reference TX-IN
-              | --tx-in-script-file FILE
-                [
-                  ( --tx-in-datum-cbor-file CBOR FILE
-                  | --tx-in-datum-file JSON FILE
-                  | --tx-in-datum-value JSON VALUE
-                  | --tx-in-inline-datum-present
-                  )
-                  ( --tx-in-redeemer-cbor-file CBOR FILE
-                  | --tx-in-redeemer-file JSON FILE
-                  | --tx-in-redeemer-value JSON VALUE
-                  )
-                  --tx-in-execution-units (INT, INT)]
-              ])
-            [--read-only-tx-in-reference TX-IN]
-            [--tx-in-collateral TX-IN]
-            [--tx-out-return-collateral ADDRESS VALUE]
-            [--tx-total-collateral INTEGER]
-            [--required-signer FILE | --required-signer-hash HASH]
-            [--tx-out ADDRESS VALUE
-              [ --tx-out-datum-hash HASH
-              | --tx-out-datum-hash-cbor-file CBOR FILE
-              | --tx-out-datum-hash-file JSON FILE
-              | --tx-out-datum-hash-value JSON VALUE
-              | --tx-out-datum-embed-cbor-file CBOR FILE
-              | --tx-out-datum-embed-file JSON FILE
-              | --tx-out-datum-embed-value JSON VALUE
-              | --tx-out-inline-datum-cbor-file CBOR FILE
-              | --tx-out-inline-datum-file JSON FILE
-              | --tx-out-inline-datum-value JSON VALUE
-              ]
-              [--tx-out-reference-script-file FILE]]
-            [--mint VALUE
-              ( --mint-script-file FILE
-                [
-                  ( --mint-redeemer-cbor-file CBOR FILE
-                  | --mint-redeemer-file JSON FILE
-                  | --mint-redeemer-value JSON VALUE
-                  )
-                  --mint-execution-units (INT, INT)]
-              | --simple-minting-script-tx-in-reference TX-IN --policy-id HASH
-              | --mint-tx-in-reference TX-IN
-                --mint-plutus-script-v2
-                ( --mint-reference-tx-in-redeemer-cbor-file CBOR FILE
-                | --mint-reference-tx-in-redeemer-file JSON FILE
-                | --mint-reference-tx-in-redeemer-value JSON VALUE
-                )
-                --mint-reference-tx-in-execution-units (INT, INT)
-                --policy-id HASH
-              )]
-            [--invalid-before SLOT]
-            [--invalid-hereafter SLOT]
-            [--fee LOVELACE]
-            [--certificate-file CERTIFICATEFILE
-              [ --certificate-script-file FILE
-                [
-                  ( --certificate-redeemer-cbor-file CBOR FILE
-                  | --certificate-redeemer-file JSON FILE
-                  | --certificate-redeemer-value JSON VALUE
-                  )
-                  --certificate-execution-units (INT, INT)]
-              | --certificate-tx-in-reference TX-IN
-                --certificate-plutus-script-v2
-                ( --certificate-reference-tx-in-redeemer-cbor-file CBOR FILE
-                | --certificate-reference-tx-in-redeemer-file JSON FILE
-                | --certificate-reference-tx-in-redeemer-value JSON VALUE
-                )
-                --certificate-reference-tx-in-execution-units (INT, INT)
-              ]]
-            [--withdrawal WITHDRAWAL
-              [ --withdrawal-script-file FILE
-                [
-                  ( --withdrawal-redeemer-cbor-file CBOR FILE
-                  | --withdrawal-redeemer-file JSON FILE
-                  | --withdrawal-redeemer-value JSON VALUE
-                  )
-                  --withdrawal-execution-units (INT, INT)]
-              | --withdrawal-tx-in-reference TX-IN
-                --withdrawal-plutus-script-v2
-                ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR FILE
-                | --withdrawal-reference-tx-in-redeemer-file JSON FILE
-                | --withdrawal-reference-tx-in-redeemer-value JSON VALUE
-                )
-                --withdrawal-reference-tx-in-execution-units (INT, INT)
-              ]]
-            [--json-metadata-no-schema | --json-metadata-detailed-schema]
-            [--auxiliary-script-file FILE]
-            [--metadata-json-file FILE | --metadata-cbor-file FILE]
-            [--protocol-params-file FILE]
-            [--update-proposal-file FILE]
-            --out-file FILE
+                                           [ --byron-era
+                                           | --shelley-era
+                                           | --allegra-era
+                                           | --mary-era
+                                           | --alonzo-era
+                                           | --babbage-era
+                                           | --conway-era
+                                           ]
+                                           [--script-valid | --script-invalid]
+                                           (--tx-in TX-IN
+                                             [ --spending-tx-in-reference TX-IN
+                                               --spending-plutus-script-v2
+                                               ( --spending-reference-tx-in-datum-cbor-file CBOR FILE
+                                               | --spending-reference-tx-in-datum-file JSON FILE
+                                               | --spending-reference-tx-in-datum-value JSON VALUE
+                                               | --spending-reference-tx-in-inline-datum-present
+                                               )
+                                               ( --spending-reference-tx-in-redeemer-cbor-file CBOR FILE
+                                               | --spending-reference-tx-in-redeemer-file JSON FILE
+                                               | --spending-reference-tx-in-redeemer-value JSON VALUE
+                                               )
+                                               --spending-reference-tx-in-execution-units (INT, INT)
+                                             | --simple-script-tx-in-reference TX-IN
+                                             | --tx-in-script-file FILE
+                                               [
+                                                 ( --tx-in-datum-cbor-file CBOR FILE
+                                                 | --tx-in-datum-file JSON FILE
+                                                 | --tx-in-datum-value JSON VALUE
+                                                 | --tx-in-inline-datum-present
+                                                 )
+                                                 ( --tx-in-redeemer-cbor-file CBOR FILE
+                                                 | --tx-in-redeemer-file JSON FILE
+                                                 | --tx-in-redeemer-value JSON VALUE
+                                                 )
+                                                 --tx-in-execution-units (INT, INT)]
+                                             ])
+                                           [--read-only-tx-in-reference TX-IN]
+                                           [--tx-in-collateral TX-IN]
+                                           [--tx-out-return-collateral ADDRESS VALUE]
+                                           [--tx-total-collateral INTEGER]
+                                           [ --required-signer FILE
+                                           | --required-signer-hash HASH
+                                           ]
+                                           [--tx-out ADDRESS VALUE
+                                             [ --tx-out-datum-hash HASH
+                                             | --tx-out-datum-hash-cbor-file CBOR FILE
+                                             | --tx-out-datum-hash-file JSON FILE
+                                             | --tx-out-datum-hash-value JSON VALUE
+                                             | --tx-out-datum-embed-cbor-file CBOR FILE
+                                             | --tx-out-datum-embed-file JSON FILE
+                                             | --tx-out-datum-embed-value JSON VALUE
+                                             | --tx-out-inline-datum-cbor-file CBOR FILE
+                                             | --tx-out-inline-datum-file JSON FILE
+                                             | --tx-out-inline-datum-value JSON VALUE
+                                             ]
+                                             [--tx-out-reference-script-file FILE]]
+                                           [--mint VALUE
+                                             ( --mint-script-file FILE
+                                               [
+                                                 ( --mint-redeemer-cbor-file CBOR FILE
+                                                 | --mint-redeemer-file JSON FILE
+                                                 | --mint-redeemer-value JSON VALUE
+                                                 )
+                                                 --mint-execution-units (INT, INT)]
+                                             | --simple-minting-script-tx-in-reference TX-IN
+                                               --policy-id HASH
+                                             | --mint-tx-in-reference TX-IN
+                                               --mint-plutus-script-v2
+                                               ( --mint-reference-tx-in-redeemer-cbor-file CBOR FILE
+                                               | --mint-reference-tx-in-redeemer-file JSON FILE
+                                               | --mint-reference-tx-in-redeemer-value JSON VALUE
+                                               )
+                                               --mint-reference-tx-in-execution-units (INT, INT)
+                                               --policy-id HASH
+                                             )]
+                                           [--invalid-before SLOT]
+                                           [--invalid-hereafter SLOT]
+                                           [--fee LOVELACE]
+                                           [--certificate-file CERTIFICATEFILE
+                                             [ --certificate-script-file FILE
+                                               [
+                                                 ( --certificate-redeemer-cbor-file CBOR FILE
+                                                 | --certificate-redeemer-file JSON FILE
+                                                 | --certificate-redeemer-value JSON VALUE
+                                                 )
+                                                 --certificate-execution-units (INT, INT)]
+                                             | --certificate-tx-in-reference TX-IN
+                                               --certificate-plutus-script-v2
+                                               ( --certificate-reference-tx-in-redeemer-cbor-file CBOR FILE
+                                               | --certificate-reference-tx-in-redeemer-file JSON FILE
+                                               | --certificate-reference-tx-in-redeemer-value JSON VALUE
+                                               )
+                                               --certificate-reference-tx-in-execution-units (INT, INT)
+                                             ]]
+                                           [--withdrawal WITHDRAWAL
+                                             [ --withdrawal-script-file FILE
+                                               [
+                                                 ( --withdrawal-redeemer-cbor-file CBOR FILE
+                                                 | --withdrawal-redeemer-file JSON FILE
+                                                 | --withdrawal-redeemer-value JSON VALUE
+                                                 )
+                                                 --withdrawal-execution-units (INT, INT)]
+                                             | --withdrawal-tx-in-reference TX-IN
+                                               --withdrawal-plutus-script-v2
+                                               ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR FILE
+                                               | --withdrawal-reference-tx-in-redeemer-file JSON FILE
+                                               | --withdrawal-reference-tx-in-redeemer-value JSON VALUE
+                                               )
+                                               --withdrawal-reference-tx-in-execution-units (INT, INT)
+                                             ]]
+                                           [ --json-metadata-no-schema
+                                           | --json-metadata-detailed-schema
+                                           ]
+                                           [--auxiliary-script-file FILE]
+                                           [ --metadata-json-file FILE
+                                           | --metadata-cbor-file FILE
+                                           ]
+                                           [--protocol-params-file FILE]
+                                           [--update-proposal-file FILE]
+                                           --out-file FILE
 
   Build a transaction (low-level, inconvenient)
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/transaction_build.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/transaction_build.cli
@@ -1,114 +1,123 @@
 Usage: cardano-cli transaction build --socket-path SOCKET_PATH
-            [ --byron-era
-            | --shelley-era
-            | --allegra-era
-            | --mary-era
-            | --alonzo-era
-            | --babbage-era
-            | --conway-era
-            ]
-            [ --shelley-mode
-            | --byron-mode [--epoch-slots SLOTS]
-            | --cardano-mode [--epoch-slots SLOTS]
-            ]
-            (--mainnet | --testnet-magic NATURAL)
-            [--script-valid | --script-invalid]
-            [--witness-override WORD]
-            (--tx-in TX-IN
-              [ --spending-tx-in-reference TX-IN
-                --spending-plutus-script-v2
-                ( --spending-reference-tx-in-datum-cbor-file CBOR FILE
-                | --spending-reference-tx-in-datum-file JSON FILE
-                | --spending-reference-tx-in-datum-value JSON VALUE
-                | --spending-reference-tx-in-inline-datum-present
-                )
-                ( --spending-reference-tx-in-redeemer-cbor-file CBOR FILE
-                | --spending-reference-tx-in-redeemer-file JSON FILE
-                | --spending-reference-tx-in-redeemer-value JSON VALUE
-                )
-              | --simple-script-tx-in-reference TX-IN
-              | --tx-in-script-file FILE
-                [
-                  ( --tx-in-datum-cbor-file CBOR FILE
-                  | --tx-in-datum-file JSON FILE
-                  | --tx-in-datum-value JSON VALUE
-                  | --tx-in-inline-datum-present
-                  )
-                  ( --tx-in-redeemer-cbor-file CBOR FILE
-                  | --tx-in-redeemer-file JSON FILE
-                  | --tx-in-redeemer-value JSON VALUE
-                  )]
-              ])
-            [--read-only-tx-in-reference TX-IN]
-            [--required-signer FILE | --required-signer-hash HASH]
-            [--tx-in-collateral TX-IN]
-            [--tx-out-return-collateral ADDRESS VALUE]
-            [--tx-total-collateral INTEGER]
-            [--tx-out ADDRESS VALUE
-              [ --tx-out-datum-hash HASH
-              | --tx-out-datum-hash-cbor-file CBOR FILE
-              | --tx-out-datum-hash-file JSON FILE
-              | --tx-out-datum-hash-value JSON VALUE
-              | --tx-out-datum-embed-cbor-file CBOR FILE
-              | --tx-out-datum-embed-file JSON FILE
-              | --tx-out-datum-embed-value JSON VALUE
-              | --tx-out-inline-datum-cbor-file CBOR FILE
-              | --tx-out-inline-datum-file JSON FILE
-              | --tx-out-inline-datum-value JSON VALUE
-              ]
-              [--tx-out-reference-script-file FILE]]
-            --change-address ADDRESS
-            [--mint VALUE
-              ( --mint-script-file FILE
-                [ --mint-redeemer-cbor-file CBOR FILE
-                | --mint-redeemer-file JSON FILE
-                | --mint-redeemer-value JSON VALUE
-                ]
-              | --simple-minting-script-tx-in-reference TX-IN --policy-id HASH
-              | --mint-tx-in-reference TX-IN
-                --mint-plutus-script-v2
-                ( --mint-reference-tx-in-redeemer-cbor-file CBOR FILE
-                | --mint-reference-tx-in-redeemer-file JSON FILE
-                | --mint-reference-tx-in-redeemer-value JSON VALUE
-                )
-                --policy-id HASH
-              )]
-            [--invalid-before SLOT]
-            [--invalid-hereafter SLOT]
-            [--certificate-file CERTIFICATEFILE
-              [ --certificate-script-file FILE
-                [ --certificate-redeemer-cbor-file CBOR FILE
-                | --certificate-redeemer-file JSON FILE
-                | --certificate-redeemer-value JSON VALUE
-                ]
-              | --certificate-tx-in-reference TX-IN
-                --certificate-plutus-script-v2
-                ( --certificate-reference-tx-in-redeemer-cbor-file CBOR FILE
-                | --certificate-reference-tx-in-redeemer-file JSON FILE
-                | --certificate-reference-tx-in-redeemer-value JSON VALUE
-                )
-              ]]
-            [--withdrawal WITHDRAWAL
-              [ --withdrawal-script-file FILE
-                [ --withdrawal-redeemer-cbor-file CBOR FILE
-                | --withdrawal-redeemer-file JSON FILE
-                | --withdrawal-redeemer-value JSON VALUE
-                ]
-              | --withdrawal-tx-in-reference TX-IN
-                --withdrawal-plutus-script-v2
-                ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR FILE
-                | --withdrawal-reference-tx-in-redeemer-file JSON FILE
-                | --withdrawal-reference-tx-in-redeemer-value JSON VALUE
-                )
-              ]]
-            [--json-metadata-no-schema | --json-metadata-detailed-schema]
-            [--auxiliary-script-file FILE]
-            [--metadata-json-file FILE | --metadata-cbor-file FILE]
-            [--protocol-params-file FILE]
-            [--update-proposal-file FILE]
-            [--vote-file FILE]
-            [--constitution-file FILE]
-            (--out-file FILE | --calculate-plutus-script-cost FILE)
+                                       [ --byron-era
+                                       | --shelley-era
+                                       | --allegra-era
+                                       | --mary-era
+                                       | --alonzo-era
+                                       | --babbage-era
+                                       | --conway-era
+                                       ]
+                                       [ --shelley-mode
+                                       | --byron-mode [--epoch-slots SLOTS]
+                                       | --cardano-mode [--epoch-slots SLOTS]
+                                       ]
+                                       (--mainnet | --testnet-magic NATURAL)
+                                       [--script-valid | --script-invalid]
+                                       [--witness-override WORD]
+                                       (--tx-in TX-IN
+                                         [ --spending-tx-in-reference TX-IN
+                                           --spending-plutus-script-v2
+                                           ( --spending-reference-tx-in-datum-cbor-file CBOR FILE
+                                           | --spending-reference-tx-in-datum-file JSON FILE
+                                           | --spending-reference-tx-in-datum-value JSON VALUE
+                                           | --spending-reference-tx-in-inline-datum-present
+                                           )
+                                           ( --spending-reference-tx-in-redeemer-cbor-file CBOR FILE
+                                           | --spending-reference-tx-in-redeemer-file JSON FILE
+                                           | --spending-reference-tx-in-redeemer-value JSON VALUE
+                                           )
+                                         | --simple-script-tx-in-reference TX-IN
+                                         | --tx-in-script-file FILE
+                                           [
+                                             ( --tx-in-datum-cbor-file CBOR FILE
+                                             | --tx-in-datum-file JSON FILE
+                                             | --tx-in-datum-value JSON VALUE
+                                             | --tx-in-inline-datum-present
+                                             )
+                                             ( --tx-in-redeemer-cbor-file CBOR FILE
+                                             | --tx-in-redeemer-file JSON FILE
+                                             | --tx-in-redeemer-value JSON VALUE
+                                             )]
+                                         ])
+                                       [--read-only-tx-in-reference TX-IN]
+                                       [ --required-signer FILE
+                                       | --required-signer-hash HASH
+                                       ]
+                                       [--tx-in-collateral TX-IN]
+                                       [--tx-out-return-collateral ADDRESS VALUE]
+                                       [--tx-total-collateral INTEGER]
+                                       [--tx-out ADDRESS VALUE
+                                         [ --tx-out-datum-hash HASH
+                                         | --tx-out-datum-hash-cbor-file CBOR FILE
+                                         | --tx-out-datum-hash-file JSON FILE
+                                         | --tx-out-datum-hash-value JSON VALUE
+                                         | --tx-out-datum-embed-cbor-file CBOR FILE
+                                         | --tx-out-datum-embed-file JSON FILE
+                                         | --tx-out-datum-embed-value JSON VALUE
+                                         | --tx-out-inline-datum-cbor-file CBOR FILE
+                                         | --tx-out-inline-datum-file JSON FILE
+                                         | --tx-out-inline-datum-value JSON VALUE
+                                         ]
+                                         [--tx-out-reference-script-file FILE]]
+                                       --change-address ADDRESS
+                                       [--mint VALUE
+                                         ( --mint-script-file FILE
+                                           [ --mint-redeemer-cbor-file CBOR FILE
+                                           | --mint-redeemer-file JSON FILE
+                                           | --mint-redeemer-value JSON VALUE
+                                           ]
+                                         | --simple-minting-script-tx-in-reference TX-IN
+                                           --policy-id HASH
+                                         | --mint-tx-in-reference TX-IN
+                                           --mint-plutus-script-v2
+                                           ( --mint-reference-tx-in-redeemer-cbor-file CBOR FILE
+                                           | --mint-reference-tx-in-redeemer-file JSON FILE
+                                           | --mint-reference-tx-in-redeemer-value JSON VALUE
+                                           )
+                                           --policy-id HASH
+                                         )]
+                                       [--invalid-before SLOT]
+                                       [--invalid-hereafter SLOT]
+                                       [--certificate-file CERTIFICATEFILE
+                                         [ --certificate-script-file FILE
+                                           [ --certificate-redeemer-cbor-file CBOR FILE
+                                           | --certificate-redeemer-file JSON FILE
+                                           | --certificate-redeemer-value JSON VALUE
+                                           ]
+                                         | --certificate-tx-in-reference TX-IN
+                                           --certificate-plutus-script-v2
+                                           ( --certificate-reference-tx-in-redeemer-cbor-file CBOR FILE
+                                           | --certificate-reference-tx-in-redeemer-file JSON FILE
+                                           | --certificate-reference-tx-in-redeemer-value JSON VALUE
+                                           )
+                                         ]]
+                                       [--withdrawal WITHDRAWAL
+                                         [ --withdrawal-script-file FILE
+                                           [ --withdrawal-redeemer-cbor-file CBOR FILE
+                                           | --withdrawal-redeemer-file JSON FILE
+                                           | --withdrawal-redeemer-value JSON VALUE
+                                           ]
+                                         | --withdrawal-tx-in-reference TX-IN
+                                           --withdrawal-plutus-script-v2
+                                           ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR FILE
+                                           | --withdrawal-reference-tx-in-redeemer-file JSON FILE
+                                           | --withdrawal-reference-tx-in-redeemer-value JSON VALUE
+                                           )
+                                         ]]
+                                       [ --json-metadata-no-schema
+                                       | --json-metadata-detailed-schema
+                                       ]
+                                       [--auxiliary-script-file FILE]
+                                       [ --metadata-json-file FILE
+                                       | --metadata-cbor-file FILE
+                                       ]
+                                       [--protocol-params-file FILE]
+                                       [--update-proposal-file FILE]
+                                       [--vote-file FILE]
+                                       [--constitution-file FILE]
+                                       ( --out-file FILE
+                                       | --calculate-plutus-script-cost FILE
+                                       )
 
   Build a balanced transaction (automatically calculates fees)
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/transaction_calculate-min-fee.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/transaction_calculate-min-fee.cli
@@ -1,10 +1,12 @@
 Usage: cardano-cli transaction calculate-min-fee --tx-body-file FILE
-            (--mainnet | --testnet-magic NATURAL)
-            --protocol-params-file FILE
-            --tx-in-count NATURAL
-            --tx-out-count NATURAL
-            --witness-count NATURAL
-            [--byron-witness-count NATURAL]
+                                                   ( --mainnet
+                                                   | --testnet-magic NATURAL
+                                                   )
+                                                   --protocol-params-file FILE
+                                                   --tx-in-count NATURAL
+                                                   --tx-out-count NATURAL
+                                                   --witness-count NATURAL
+                                                   [--byron-witness-count NATURAL]
 
   Calculate the minimum fee for a transaction.
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/transaction_calculate-min-required-utxo.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/transaction_calculate-min-required-utxo.cli
@@ -1,26 +1,26 @@
 Usage: cardano-cli transaction calculate-min-required-utxo 
-            [ --byron-era
-            | --shelley-era
-            | --allegra-era
-            | --mary-era
-            | --alonzo-era
-            | --babbage-era
-            | --conway-era
-            ]
-            --protocol-params-file FILE
-            --tx-out ADDRESS VALUE
-            [ --tx-out-datum-hash HASH
-            | --tx-out-datum-hash-cbor-file CBOR FILE
-            | --tx-out-datum-hash-file JSON FILE
-            | --tx-out-datum-hash-value JSON VALUE
-            | --tx-out-datum-embed-cbor-file CBOR FILE
-            | --tx-out-datum-embed-file JSON FILE
-            | --tx-out-datum-embed-value JSON VALUE
-            | --tx-out-inline-datum-cbor-file CBOR FILE
-            | --tx-out-inline-datum-file JSON FILE
-            | --tx-out-inline-datum-value JSON VALUE
-            ]
-            [--tx-out-reference-script-file FILE]
+                                                             [ --byron-era
+                                                             | --shelley-era
+                                                             | --allegra-era
+                                                             | --mary-era
+                                                             | --alonzo-era
+                                                             | --babbage-era
+                                                             | --conway-era
+                                                             ]
+                                                             --protocol-params-file FILE
+                                                             --tx-out ADDRESS VALUE
+                                                             [ --tx-out-datum-hash HASH
+                                                             | --tx-out-datum-hash-cbor-file CBOR FILE
+                                                             | --tx-out-datum-hash-file JSON FILE
+                                                             | --tx-out-datum-hash-value JSON VALUE
+                                                             | --tx-out-datum-embed-cbor-file CBOR FILE
+                                                             | --tx-out-datum-embed-file JSON FILE
+                                                             | --tx-out-datum-embed-value JSON VALUE
+                                                             | --tx-out-inline-datum-cbor-file CBOR FILE
+                                                             | --tx-out-inline-datum-file JSON FILE
+                                                             | --tx-out-inline-datum-value JSON VALUE
+                                                             ]
+                                                             [--tx-out-reference-script-file FILE]
 
   Calculate the minimum required UTxO for a transaction output.
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/transaction_calculate-min-value.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/transaction_calculate-min-value.cli
@@ -1,26 +1,26 @@
 Usage: cardano-cli transaction calculate-min-value 
-            [ --byron-era
-            | --shelley-era
-            | --allegra-era
-            | --mary-era
-            | --alonzo-era
-            | --babbage-era
-            | --conway-era
-            ]
-            --protocol-params-file FILE
-            --tx-out ADDRESS VALUE
-            [ --tx-out-datum-hash HASH
-            | --tx-out-datum-hash-cbor-file CBOR FILE
-            | --tx-out-datum-hash-file JSON FILE
-            | --tx-out-datum-hash-value JSON VALUE
-            | --tx-out-datum-embed-cbor-file CBOR FILE
-            | --tx-out-datum-embed-file JSON FILE
-            | --tx-out-datum-embed-value JSON VALUE
-            | --tx-out-inline-datum-cbor-file CBOR FILE
-            | --tx-out-inline-datum-file JSON FILE
-            | --tx-out-inline-datum-value JSON VALUE
-            ]
-            [--tx-out-reference-script-file FILE]
+                                                     [ --byron-era
+                                                     | --shelley-era
+                                                     | --allegra-era
+                                                     | --mary-era
+                                                     | --alonzo-era
+                                                     | --babbage-era
+                                                     | --conway-era
+                                                     ]
+                                                     --protocol-params-file FILE
+                                                     --tx-out ADDRESS VALUE
+                                                     [ --tx-out-datum-hash HASH
+                                                     | --tx-out-datum-hash-cbor-file CBOR FILE
+                                                     | --tx-out-datum-hash-file JSON FILE
+                                                     | --tx-out-datum-hash-value JSON VALUE
+                                                     | --tx-out-datum-embed-cbor-file CBOR FILE
+                                                     | --tx-out-datum-embed-file JSON FILE
+                                                     | --tx-out-datum-embed-value JSON VALUE
+                                                     | --tx-out-inline-datum-cbor-file CBOR FILE
+                                                     | --tx-out-inline-datum-file JSON FILE
+                                                     | --tx-out-inline-datum-value JSON VALUE
+                                                     ]
+                                                     [--tx-out-reference-script-file FILE]
 
   DEPRECATED: Use 'calculate-min-required-utxo' instead.
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/transaction_hash-script-data.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/transaction_hash-script-data.cli
@@ -1,8 +1,8 @@
 Usage: cardano-cli transaction hash-script-data 
-            ( --script-data-cbor-file CBOR FILE
-            | --script-data-file JSON FILE
-            | --script-data-value JSON VALUE
-            )
+                                                  ( --script-data-cbor-file CBOR FILE
+                                                  | --script-data-file JSON FILE
+                                                  | --script-data-value JSON VALUE
+                                                  )
 
   Calculate the hash of script data.
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/transaction_sign-witness.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/transaction_sign-witness.cli
@@ -1,6 +1,6 @@
 Usage: cardano-cli transaction sign-witness --tx-body-file FILE
-            [--witness-file FILE]
-            --out-file FILE
+                                              [--witness-file FILE]
+                                              --out-file FILE
 
   Assemble a tx body and witness(es) to form a transaction
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/transaction_sign.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/transaction_sign.cli
@@ -1,7 +1,8 @@
 Usage: cardano-cli transaction sign (--tx-body-file FILE | --tx-file FILE)
-            [--signing-key-file FILE [--address STRING]]
-            [--mainnet | --testnet-magic NATURAL]
-            --out-file FILE
+                                      [--signing-key-file FILE
+                                        [--address STRING]]
+                                      [--mainnet | --testnet-magic NATURAL]
+                                      --out-file FILE
 
   Sign a transaction
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/transaction_submit.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/transaction_submit.cli
@@ -1,10 +1,10 @@
 Usage: cardano-cli transaction submit --socket-path SOCKET_PATH
-            [ --shelley-mode
-            | --byron-mode [--epoch-slots SLOTS]
-            | --cardano-mode [--epoch-slots SLOTS]
-            ]
-            (--mainnet | --testnet-magic NATURAL)
-            --tx-file FILE
+                                        [ --shelley-mode
+                                        | --byron-mode [--epoch-slots SLOTS]
+                                        | --cardano-mode [--epoch-slots SLOTS]
+                                        ]
+                                        (--mainnet | --testnet-magic NATURAL)
+                                        --tx-file FILE
 
   Submit a transaction to the local node whose Unix domain socket is obtained
   from the CARDANO_NODE_SOCKET_PATH environment variable.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/transaction_witness.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/transaction_witness.cli
@@ -1,8 +1,8 @@
 Usage: cardano-cli transaction witness --tx-body-file FILE
-            --signing-key-file FILE
-            [--address STRING]
-            [--mainnet | --testnet-magic NATURAL]
-            --out-file FILE
+                                         --signing-key-file FILE
+                                         [--address STRING]
+                                         [--mainnet | --testnet-magic NATURAL]
+                                         --out-file FILE
 
   Create a transaction witness
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/validate-cbor.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/validate-cbor.cli
@@ -1,11 +1,11 @@
 Usage: cardano-cli validate-cbor 
-            [ --byron-block INT
-            | --byron-delegation-certificate
-            | --byron-tx
-            | --byron-update-proposal
-            | --byron-vote
-            ]
-            --filepath FILEPATH
+                                   [ --byron-block INT
+                                   | --byron-delegation-certificate
+                                   | --byron-tx
+                                   | --byron-update-proposal
+                                   | --byron-vote
+                                   ]
+                                   --filepath FILEPATH
 
   Validate a CBOR blockchain object.
 

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1688793078,
-        "narHash": "sha256-HfOVYupLwcxzOmdaW2XFDGOXhZ242To2YG0w/Km3lmM=",
+        "lastModified": 1689000650,
+        "narHash": "sha256-HreklCNRaQ2kb2BRz+8B3dOhgMOnehHV9/wtL6gAW80=",
         "owner": "input-output-hk",
         "repo": "cardano-haskell-packages",
-        "rev": "2735cffa7fdca54aab57a2d08d0a85ccaf8de440",
+        "rev": "ffefef95f1d21d3a3d85d751b3283a999842a38b",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1689000650,
-        "narHash": "sha256-HreklCNRaQ2kb2BRz+8B3dOhgMOnehHV9/wtL6gAW80=",
+        "lastModified": 1689173980,
+        "narHash": "sha256-+0lVuJn8kDn2eERBvnrskBfwHpR0kl/VT3LuZlsnNUI=",
         "owner": "input-output-hk",
         "repo": "cardano-haskell-packages",
-        "rev": "ffefef95f1d21d3a3d85d751b3283a999842a38b",
+        "rev": "0222c8c03ef4fe542f4292306b7eec481cbafea1",
         "type": "github"
       },
       "original": {
@@ -189,11 +189,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1688776114,
-        "narHash": "sha256-6X2pwv1elnE6FSvESUL+VERGnVFhfkdxmyCBlMU5cZA=",
+        "lastModified": 1689208161,
+        "narHash": "sha256-qh5bnqYDhEhm9V5u6Z3eiYC5Dy9CAVKxQnSC3tHhO4A=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "135146a67666cd23018ce22bd5fa2b66206fc23d",
+        "rev": "521fbfc52df1ef8df4af20e75ca92e874a33b6b2",
         "type": "github"
       },
       "original": {
@@ -233,11 +233,11 @@
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1685926350,
-        "narHash": "sha256-d6uK8/U7zYGrFbW3bd/lWupYTygsIa/cf/ECQ/3KSt0=",
+        "lastModified": 1689209503,
+        "narHash": "sha256-9U73sWQ/JKbBhOcij8/2/M/7MfoNZxTtek5Zws840Bs=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "ebef98fdd98b173f336bb7889feb11e2915eca34",
+        "rev": "50e7b671ca73ea9ab350d7f18ba434bf8393051a",
         "type": "github"
       },
       "original": {
@@ -266,16 +266,16 @@
     "hls-2.0": {
       "flake": false,
       "locked": {
-        "lastModified": 1684398654,
-        "narHash": "sha256-RW44up2BIyBBYN6tZur5f9kDDR3kr0Rd+TgPbLTfwB4=",
+        "lastModified": 1687698105,
+        "narHash": "sha256-OHXlgRzs/kuJH8q7Sxh507H+0Rb8b7VOiPAjcY9sM1k=",
         "owner": "haskell",
         "repo": "haskell-language-server",
-        "rev": "20c6d1e731cd9c0beef7338e2fc7a8126ba9b6fb",
+        "rev": "783905f211ac63edf982dd1889c671653327e441",
         "type": "github"
       },
       "original": {
         "owner": "haskell",
-        "ref": "2.0.0.0",
+        "ref": "2.0.0.1",
         "repo": "haskell-language-server",
         "type": "github"
       }
@@ -345,11 +345,11 @@
         "sodium": "sodium"
       },
       "locked": {
-        "lastModified": 1685727458,
-        "narHash": "sha256-c/pkFYCfzpRb6W2OOKE+EOzOlcw+96vwJGGg8Ir9Qfk=",
+        "lastModified": 1687951625,
+        "narHash": "sha256-jwUD9tyGAvcuIl4TZYc+qGFTCEwIMriim+whXO+fiE4=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "02f42375ee5c2bab1640f14c6389b7e91bbfec8b",
+        "rev": "7bb42e5de0c1318e57017eedbe206751d58b78b3",
         "type": "github"
       },
       "original": {
@@ -654,11 +654,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1685923834,
-        "narHash": "sha256-5oTnK+dXt1elpbLwVUYiyKroFcCMvRzEPz/PBKRtIIA=",
+        "lastModified": 1689034277,
+        "narHash": "sha256-Ido3tEL8bQKsHFlZa5X8lv+RW8ntplVV1Dcmdt5z3ww=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "fe1d92917a72ec690dbe61a81318931052be6179",
+        "rev": "7a999b71591f8d357d7c838d38ad787d171f3b1f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Upgrade to `optparse-applicative-fork-0.18.1.0`
  compatibility: compatible
  type: maintenance
```

# Context

Upgrade to `optparse-applicative-fork-0.18.1.0` to unblock `ghc-9.6` work.  This will affect the formatting of how the CLI usage is rendered so there will be a lot of formatting changes in the golden files.

`optparse-applicative-fork-0.18.1.0` is already published to CHaP, however, there is currently an SRP which will be removed once the CHaP index includes the `optparse-applicative-fork-0.18.1.0`  package version.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
