### PR TITLE
Conway error messages

### DIFF
--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -203,8 +203,7 @@ test-suite cardano-cli-test
                       , base16-bytestring
                       , bech32 >= 1.1.0
                       , bytestring
-                      , cardano-api ^>= 8.10.2
-                      , cardano-api:internal ^>= 8.10.2
+                      , cardano-api:{cardano-api, internal, gen} ^>= 8.10.2
                       , cardano-api-gen ^>= 8.1.1.0
                       , cardano-cli
                       , cardano-cli:cardano-cli-test-lib
@@ -247,7 +246,8 @@ test-suite cardano-cli-golden
   build-depends:        aeson >= 1.5.6.0
                       , base16-bytestring
                       , bytestring
-                      , cardano-api ^>= 8.10.2
+                      , cardano-api:{cardano-api, gen} ^>= 8.10.2
+                      , cardano-binary
                       , cardano-cli
                       , cardano-cli:cardano-cli-test-lib
                       , cardano-crypto-class ^>= 2.1
@@ -260,6 +260,7 @@ test-suite cardano-cli-golden
                       , hedgehog-extras ^>= 0.4.7.0
                       , regex-compat
                       , regex-tdfa
+                      , tasty
                       , text
                       , time
                       , transformers
@@ -272,6 +273,7 @@ test-suite cardano-cli-golden
                         Test.Golden.Byron.UpdateProposal
                         Test.Golden.Byron.Vote
                         Test.Golden.Byron.Witness
+                        Test.Golden.ErrorsSpec
                         Test.Golden.Help
                         Test.Golden.Key
                         Test.Golden.Key.NonExtendedKey

--- a/cardano-cli/src/Cardano/CLI/Run/Legacy.hs
+++ b/cardano-cli/src/Cardano/CLI/Run/Legacy.hs
@@ -45,9 +45,8 @@ renderLegacyClientCmdError cmd err =
        renderError cmd renderShelleyAddressCmdError addrCmdErr
     LegacyCmdGenesisError genesisCmdErr ->
        renderError cmd (Text.pack . displayError) genesisCmdErr
-    LegacyCmdGovernanceError govCmdErr -> Text.pack $ show govCmdErr
-       -- TODO: Conway era
-       -- renderError cmd renderShelleyGovernanceError govCmdErr
+    LegacyCmdGovernanceError govCmdErr ->
+       renderError cmd (Text.pack . displayError) govCmdErr
     LegacyCmdNodeError nodeCmdErr ->
        renderError cmd renderShelleyNodeCmdError nodeCmdErr
     LegacyCmdPoolError poolCmdErr ->

--- a/cardano-cli/src/Cardano/CLI/Run/Legacy/Read.hs
+++ b/cardano-cli/src/Cardano/CLI/Run/Legacy/Read.hs
@@ -31,7 +31,7 @@ module Cardano.CLI.Run.Legacy.Read
   , renderScriptDataError
 
   -- * Tx
-  , CddlError
+  , CddlError(..)
   , CddlTx(..)
   , IncompleteTx(..)
   , readFileTx

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/ErrorsSpec.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/ErrorsSpec.hs
@@ -1,0 +1,94 @@
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+
+module Test.Golden.ErrorsSpec (messagesTests) where
+
+import           Cardano.Api
+import           Cardano.Api.Shelley
+
+import           Cardano.Binary
+import           Cardano.CLI.Commands.Governance
+import           Cardano.CLI.Run.Legacy.Read
+import           Cardano.CLI.Run.Legacy.StakeAddress
+
+import           Control.Exception (try)
+import           Data.Text.Encoding.Error
+import           GHC.Stack (HasCallStack)
+import           System.Exit
+
+import qualified Test.Hedgehog.Golden.ErrorMessage as ErrorMessage
+import           Test.Tasty
+
+test_GovernanceCmdError :: TestTree
+test_GovernanceCmdError =
+  testErrorMessagesRendering "Cardano.CLI.Commands.Governance" "GovernanceCmdError"
+    [ ("StakeCredGovCmdError"
+      , StakeCredGovCmdError
+        . ShelleyStakeAddressCmdReadKeyFileError
+        $ FileError "path/file.txt" InputInvalidError)
+    , ("VotingCredentialDecodeGovCmdEror"
+      , VotingCredentialDecodeGovCmdEror $ DecoderErrorEmptyList "emptylist")
+    , ("WriteFileError"
+      , WriteFileError $ FileError "path/file.txt" ())
+    , ("ReadFileError"
+      , ReadFileError $ FileError "path/file.txt" InputInvalidError)
+    , ("NonUtf8EncodedConstitution"
+      , NonUtf8EncodedConstitution $ DecodeError "seq" Nothing)
+    , ("GovernanceCmdTextEnvReadError"
+      , GovernanceCmdTextEnvReadError
+        . FileError  "path/file.txt"
+        $ TextEnvelopeAesonDecodeError "cannot decode json")
+    , ("GovernanceCmdCddlError"
+      , GovernanceCmdCddlError
+        $ CddlErrorTextEnv
+          (FileError "path/file.txt" . TextEnvelopeDecodeError $ DecoderErrorCustom "todecode" "decodeerr")
+          (FileError "path/file.txt" TextEnvelopeCddlUnknownKeyWitness))
+    , ("GovernanceCmdKeyReadError"
+      , GovernanceCmdKeyReadError $ FileError "path/file.txt" InputInvalidError)
+    , ("GovernanceCmdCostModelReadError"
+      , GovernanceCmdCostModelReadError $ FileError "path/file.txt" ())
+    , ("GovernanceCmdTextEnvWriteError"
+      , GovernanceCmdTextEnvWriteError $ FileError "path/file.txt" ())
+    , ("GovernanceCmdEmptyUpdateProposalError"
+      , GovernanceCmdEmptyUpdateProposalError)
+    , ("GovernanceCmdMIRCertificateKeyRewardMistmach"
+       ,GovernanceCmdMIRCertificateKeyRewardMistmach "path/file.txt" 1 2)
+    , ("GovernanceCmdCostModelsJsonDecodeErr"
+      , GovernanceCmdCostModelsJsonDecodeErr "path/file.txt" "jsonerr")
+    , ("GovernanceCmdEmptyCostModel"
+      , GovernanceCmdEmptyCostModel "path/file.txt")
+    , ("GovernanceCmdUnexpectedKeyType"
+      , GovernanceCmdUnexpectedKeyType (TextEnvelopeType <$> ["env1", "env2"]))
+    , ("GovernanceCmdPollOutOfBoundAnswer"
+      , GovernanceCmdPollOutOfBoundAnswer 4)
+    , ("GovernanceCmdPollInvalidChoice"
+      , GovernanceCmdPollInvalidChoice)
+    , ("GovernanceCmdDecoderError"
+      , GovernanceCmdDecoderError $ DecoderErrorEmptyList "empty")
+    , ("GovernanceCmdVerifyPollError"
+      , GovernanceCmdVerifyPollError ErrGovernancePollNoAnswer)
+    , ("GovernanceCmdWriteFileError"
+      , GovernanceCmdWriteFileError $ FileError "path/file.txt" ())
+    , ("ShelleyGovernanceCmdMIRCertNotSupportedInConway"
+      , ShelleyGovernanceCmdMIRCertNotSupportedInConway)
+    , ("ShelleyGovernanceCmdGenesisDelegationNotSupportedInConway"
+      , ShelleyGovernanceCmdGenesisDelegationNotSupportedInConway)
+    ]
+
+
+goldenFilesPath :: FilePath
+goldenFilesPath = "test/cardano-cli-golden/files/golden/errors"
+
+testErrorMessagesRendering :: forall a. (HasCallStack, Error a)
+                      => String -- ^ module name
+                      -> String -- ^ type name
+                      -> [(String, a)]  -- ^ list of constructor names and values
+                      -> TestTree
+testErrorMessagesRendering = ErrorMessage.testAllErrorMessages_ goldenFilesPath
+
+messagesTests :: IO Bool
+messagesTests = do
+  exitCode <- try @ExitCode $ defaultMain test_GovernanceCmdError
+  pure $ exitCode == Left ExitSuccess

--- a/cardano-cli/test/cardano-cli-golden/cardano-cli-golden.hs
+++ b/cardano-cli/test/cardano-cli-golden/cardano-cli-golden.hs
@@ -7,6 +7,7 @@ import qualified Test.Golden.Byron.SigningKeys
 import qualified Test.Golden.Byron.Tx
 import qualified Test.Golden.Byron.UpdateProposal
 import qualified Test.Golden.Byron.Vote
+import qualified Test.Golden.ErrorsSpec
 import qualified Test.Golden.Help
 import qualified Test.Golden.Key
 import qualified Test.Golden.Shelley
@@ -23,6 +24,7 @@ main = do
     , Test.Golden.Byron.Tx.txTests
     , Test.Golden.Byron.UpdateProposal.updateProposalTest
     , Test.Golden.Byron.Vote.voteTests
+    , Test.Golden.ErrorsSpec.messagesTests
     , Test.Golden.Help.helpTests
     , Test.Golden.Key.keyTests
     , Test.Golden.Shelley.keyTests

--- a/cardano-cli/test/cardano-cli-golden/files/golden/errors/Cardano.CLI.Commands.Governance.GovernanceCmdError/GovernanceCmdCddlError.txt
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/errors/Cardano.CLI.Commands.Governance.GovernanceCmdError/GovernanceCmdCddlError.txt
@@ -1,0 +1,2 @@
+Reading transaction CDDL file error: Failed to decode neither the cli's serialisation format nor the ledger's CDDL serialisation format. TextEnvelope error: path/file.txt: TextEnvelope decode error: DecoderErrorCustom "todecode" "decodeerr"
+TextEnvelopeCddl error: path/file.txt: Unknown key witness specified

--- a/cardano-cli/test/cardano-cli-golden/files/golden/errors/Cardano.CLI.Commands.Governance.GovernanceCmdError/GovernanceCmdCostModelReadError.txt
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/errors/Cardano.CLI.Commands.Governance.GovernanceCmdError/GovernanceCmdCostModelReadError.txt
@@ -1,0 +1,1 @@
+Cannot read cost model: path/file.txt: 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/errors/Cardano.CLI.Commands.Governance.GovernanceCmdError/GovernanceCmdCostModelsJsonDecodeErr.txt
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/errors/Cardano.CLI.Commands.Governance.GovernanceCmdError/GovernanceCmdCostModelsJsonDecodeErr.txt
@@ -1,0 +1,1 @@
+Error decoding cost model: jsonerr at: path/file.txt

--- a/cardano-cli/test/cardano-cli-golden/files/golden/errors/Cardano.CLI.Commands.Governance.GovernanceCmdError/GovernanceCmdDecoderError.txt
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/errors/Cardano.CLI.Commands.Governance.GovernanceCmdError/GovernanceCmdDecoderError.txt
@@ -1,0 +1,1 @@
+Unable to decode metadata: Found unexpected empty list while decoding empty

--- a/cardano-cli/test/cardano-cli-golden/files/golden/errors/Cardano.CLI.Commands.Governance.GovernanceCmdError/GovernanceCmdEmptyCostModel.txt
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/errors/Cardano.CLI.Commands.Governance.GovernanceCmdError/GovernanceCmdEmptyCostModel.txt
@@ -1,0 +1,1 @@
+The decoded cost model was empty at: path/file.txt

--- a/cardano-cli/test/cardano-cli-golden/files/golden/errors/Cardano.CLI.Commands.Governance.GovernanceCmdError/GovernanceCmdEmptyUpdateProposalError.txt
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/errors/Cardano.CLI.Commands.Governance.GovernanceCmdError/GovernanceCmdEmptyUpdateProposalError.txt
@@ -1,0 +1,1 @@
+Empty update proposals are not allowed.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/errors/Cardano.CLI.Commands.Governance.GovernanceCmdError/GovernanceCmdKeyReadError.txt
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/errors/Cardano.CLI.Commands.Governance.GovernanceCmdError/GovernanceCmdKeyReadError.txt
@@ -1,0 +1,1 @@
+Cannot read key: path/file.txt: Invalid key.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/errors/Cardano.CLI.Commands.Governance.GovernanceCmdError/GovernanceCmdMIRCertificateKeyRewardMistmach.txt
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/errors/Cardano.CLI.Commands.Governance.GovernanceCmdError/GovernanceCmdMIRCertificateKeyRewardMistmach.txt
@@ -1,0 +1,1 @@
+Error creating the MIR certificate at: path/file.txt The number of staking keys: 1 and the number of reward amounts: 2 are not equivalent.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/errors/Cardano.CLI.Commands.Governance.GovernanceCmdError/GovernanceCmdPollInvalidChoice.txt
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/errors/Cardano.CLI.Commands.Governance.GovernanceCmdError/GovernanceCmdPollInvalidChoice.txt
@@ -1,0 +1,1 @@
+Invalid choice. Please choose from the available answers.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/errors/Cardano.CLI.Commands.Governance.GovernanceCmdError/GovernanceCmdPollOutOfBoundAnswer.txt
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/errors/Cardano.CLI.Commands.Governance.GovernanceCmdError/GovernanceCmdPollOutOfBoundAnswer.txt
@@ -1,0 +1,1 @@
+Poll answer out of bounds. Choices are between 0 and 4

--- a/cardano-cli/test/cardano-cli-golden/files/golden/errors/Cardano.CLI.Commands.Governance.GovernanceCmdError/GovernanceCmdTextEnvReadError.txt
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/errors/Cardano.CLI.Commands.Governance.GovernanceCmdError/GovernanceCmdTextEnvReadError.txt
@@ -1,0 +1,1 @@
+Cannot read text envelope: path/file.txt: TextEnvelope aeson decode error: cannot decode json

--- a/cardano-cli/test/cardano-cli-golden/files/golden/errors/Cardano.CLI.Commands.Governance.GovernanceCmdError/GovernanceCmdTextEnvWriteError.txt
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/errors/Cardano.CLI.Commands.Governance.GovernanceCmdError/GovernanceCmdTextEnvWriteError.txt
@@ -1,0 +1,1 @@
+path/file.txt: 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/errors/Cardano.CLI.Commands.Governance.GovernanceCmdError/GovernanceCmdUnexpectedKeyType.txt
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/errors/Cardano.CLI.Commands.Governance.GovernanceCmdError/GovernanceCmdUnexpectedKeyType.txt
@@ -1,0 +1,1 @@
+Unexpected poll key type; expected one of: TextEnvelopeType "env1", TextEnvelopeType "env2"

--- a/cardano-cli/test/cardano-cli-golden/files/golden/errors/Cardano.CLI.Commands.Governance.GovernanceCmdError/GovernanceCmdVerifyPollError.txt
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/errors/Cardano.CLI.Commands.Governance.GovernanceCmdError/GovernanceCmdVerifyPollError.txt
@@ -1,0 +1,1 @@
+No answer found in the provided transaction's metadata.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/errors/Cardano.CLI.Commands.Governance.GovernanceCmdError/GovernanceCmdWriteFileError.txt
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/errors/Cardano.CLI.Commands.Governance.GovernanceCmdError/GovernanceCmdWriteFileError.txt
@@ -1,0 +1,1 @@
+Cannot write file: path/file.txt: 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/errors/Cardano.CLI.Commands.Governance.GovernanceCmdError/NonUtf8EncodedConstitution.txt
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/errors/Cardano.CLI.Commands.Governance.GovernanceCmdError/NonUtf8EncodedConstitution.txt
@@ -1,0 +1,1 @@
+Constitution encoded in a format different than UTF-8: Cannot decode input: seq

--- a/cardano-cli/test/cardano-cli-golden/files/golden/errors/Cardano.CLI.Commands.Governance.GovernanceCmdError/ReadFileError.txt
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/errors/Cardano.CLI.Commands.Governance.GovernanceCmdError/ReadFileError.txt
@@ -1,0 +1,1 @@
+path/file.txt: Invalid key.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/errors/Cardano.CLI.Commands.Governance.GovernanceCmdError/ShelleyGovernanceCmdGenesisDelegationNotSupportedInConway.txt
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/errors/Cardano.CLI.Commands.Governance.GovernanceCmdError/ShelleyGovernanceCmdGenesisDelegationNotSupportedInConway.txt
@@ -1,0 +1,1 @@
+Genesis delegation is not supported in Conway era onwards.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/errors/Cardano.CLI.Commands.Governance.GovernanceCmdError/ShelleyGovernanceCmdMIRCertNotSupportedInConway.txt
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/errors/Cardano.CLI.Commands.Governance.GovernanceCmdError/ShelleyGovernanceCmdMIRCertNotSupportedInConway.txt
@@ -1,0 +1,1 @@
+MIR certificates are not supported in Conway era onwards.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/errors/Cardano.CLI.Commands.Governance.GovernanceCmdError/StakeCredGovCmdError.txt
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/errors/Cardano.CLI.Commands.Governance.GovernanceCmdError/StakeCredGovCmdError.txt
@@ -1,0 +1,1 @@
+Stake credential error: path/file.txt: Invalid key.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/errors/Cardano.CLI.Commands.Governance.GovernanceCmdError/VotingCredentialDecodeGovCmdEror.txt
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/errors/Cardano.CLI.Commands.Governance.GovernanceCmdError/VotingCredentialDecodeGovCmdEror.txt
@@ -1,0 +1,1 @@
+Could not decode voting credential: Found unexpected empty list while decoding emptylist

--- a/cardano-cli/test/cardano-cli-golden/files/golden/errors/Cardano.CLI.Commands.Governance.GovernanceCmdError/WriteFileError.txt
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/errors/Cardano.CLI.Commands.Governance.GovernanceCmdError/WriteFileError.txt
@@ -1,0 +1,1 @@
+path/file.txt: 


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    User friendly error messages for Conway era
  # no-changes: the API has not changed
  # compatible: the API has changed but is non-breaking
  # breaking: the API has changed in a breaking way
  compatibility: no-api-changes
  # feature: the change implements a new feature in the API
  # bugfix: the change fixes a bug in the API
  # test: the change fixes modifies tests
  # maintenance: the change involves something other than the API
  # If more than one is applicable, it may be put into a list.
  type: feature
```

# Context

Requires: https://github.com/input-output-hk/cardano-api/pull/126/files

Closes: #87 

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
