### PR TITLE
Version 8.3.2.0

### DIFF
--- a/cardano-cli/CHANGELOG.md
+++ b/cardano-cli/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog for cardano-cli
 
+# 8.3.2.0
+
+- Make it build with ghc-9.6
+  (maintenance; compatible)
+  [PR 89](https://github.com/input-output-hk/cardano-cli/pull/89)
+
 # 8.3.1.0
 
 - Make it build with ghc-9.6

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.4
 
 name:                   cardano-cli
-version:                8.3.1.0
+version:                8.3.2.0
 synopsis:               The Cardano command-line interface
 description:            The Cardano command-line interface.
 copyright:              2020-2023 Input Output Global Inc (IOG).


### PR DESCRIPTION
# Changelog

```yaml
- description: Make it build with ghc-9.6
  compatibility: no-api-changes
  type: maintenance
```
