### PR TITLE
Fix incorrect cardano era environment variable name

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ["8.10.7", "9.2.7"]
+        ghc: ["8.10.7", "9.2.7", "9.6.2"]
         cabal: ["3.10.1.0"]
         os: [ubuntu-latest, macos-latest, windows-latest]
 
@@ -48,14 +48,14 @@ jobs:
       with:
         ghc-version: ${{ matrix.ghc }}
         cabal-version: ${{ matrix.cabal }}
-  
+
     - name: Install system dependencies
       uses: input-output-hk/actions/base@latest
       with:
         use-sodium-vrf: true # default is true
 
     - uses: actions/checkout@v3
-  
+
     - name: Cabal update
       run: cabal update
 

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -115,7 +115,6 @@ library
                       , bytestring
                       , canonical-json
                       , cardano-api ^>= 8.8.1
-                      , cardano-api:internal ^>= 8.8.1
                       , cardano-binary
                       , cardano-crypto
                       , cardano-crypto-class >= 2.1.1

--- a/cardano-cli/src/Cardano/CLI/Environment.hs
+++ b/cardano-cli/src/Cardano/CLI/Environment.hs
@@ -79,7 +79,7 @@ getEnvSocketPath = IO.lookupEnv "CARDANO_NODE_SOCKET_PATH"
 -- Otherwise, return 'Nothing'.
 getCardanoEra :: IO (Maybe AnyCardanoEra)
 getCardanoEra = do
-  mEraString <- IO.lookupEnv "CARDANO_NODE_SOCKET_PATH"
+  mEraString <- IO.lookupEnv "CARDANO_ERA"
 
   case mEraString of
     Just eraString ->

--- a/cardano-cli/src/Cardano/CLI/Shelley/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Key.hs
@@ -207,8 +207,8 @@ readVerificationKeyOrHashOrTextEnvFile asType verKeyOrHashOrFile =
     VerificationKeyHash vkHash -> pure (Right vkHash)
 
 generateKeyPair ::
-#if __GLASGOW_HASKELL__ >= 902
--- GHC 8.10 considers the HasTypeProxy constraint redundant but ghc-9.2 and above complains if its
+#if __GLASGOW_HASKELL__ >= 940
+-- GHC 8.10 considers the HasTypeProxy constraint redundant but ghc-9.4 and above complains if its
 -- not present.
     (Key keyrole, HasTypeProxy keyrole) =>
 #else

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Address.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Address.hs
@@ -79,8 +79,8 @@ runAddressKeyGenToFile fmt kt vkf skf = case kt of
 
 generateAndWriteByronKeyFiles
   :: Key keyrole
-#if __GLASGOW_HASKELL__ >= 902
--- GHC 8.10 considers the HasTypeProxy constraint redundant but ghc-9.2 and above complains if its
+#if __GLASGOW_HASKELL__ >= 940
+-- GHC 8.10 considers the HasTypeProxy constraint redundant but ghc-9.4 and above complains if its
 -- not present.
   => HasTypeProxy keyrole
 #endif
@@ -93,8 +93,8 @@ generateAndWriteByronKeyFiles asType vkf skf = do
 
 generateAndWriteKeyFiles
   :: Key keyrole
-#if __GLASGOW_HASKELL__ >= 902
--- GHC 8.10 considers the HasTypeProxy constraint redundant but ghc-9.2 and above complains if its
+#if __GLASGOW_HASKELL__ >= 940
+-- GHC 8.10 considers the HasTypeProxy constraint redundant but ghc-9.4 and above complains if its
 -- not present.
   => HasTypeProxy keyrole
 #endif

--- a/cardano-cli/src/Cardano/CLI/Shelley/Run/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/Shelley/Run/Genesis.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE ConstraintKinds #-}
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
@@ -458,7 +459,15 @@ runGenesisCreate
 toSKeyJSON :: Key a => SigningKey a -> ByteString
 toSKeyJSON = LBS.toStrict . textEnvelopeToJSON Nothing
 
-toVkeyJSON :: (Key a, HasTypeProxy a) => SigningKey a -> ByteString
+toVkeyJSON ::
+#if __GLASGOW_HASKELL__ >= 940
+-- GHC 8.10 considers the HasTypeProxy constraint redundant but ghc-9.4 and above complains if its
+-- not present.
+              (Key a, HasTypeProxy a) =>
+#else
+              (Key a) =>
+#endif
+              SigningKey a -> ByteString
 toVkeyJSON = LBS.toStrict . textEnvelopeToJSON Nothing . getVerificationKey
 
 toVkeyJSON' :: Key a => VerificationKey a -> ByteString

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -23,13 +23,13 @@ Usage: cardano-cli governance
   Governance commands
 
 Usage: cardano-cli governance create-mir-certificate 
-                                                       ( ( --shelley-era
+                                                       ( [ --shelley-era
                                                          | --allegra-era
                                                          | --mary-era
                                                          | --alonzo-era
                                                          | --babbage-era
                                                          | --conway-era
-                                                         )
+                                                         ]
                                                          ( --reserves
                                                          | --treasury
                                                          )
@@ -44,13 +44,13 @@ Usage: cardano-cli governance create-mir-certificate
   Create an MIR (Move Instantaneous Rewards) certificate
 
 Usage: cardano-cli governance create-mir-certificate stake-addresses 
-                                                                       ( --shelley-era
+                                                                       [ --shelley-era
                                                                        | --allegra-era
                                                                        | --mary-era
                                                                        | --alonzo-era
                                                                        | --babbage-era
                                                                        | --conway-era
-                                                                       )
+                                                                       ]
                                                                        ( --reserves
                                                                        | --treasury
                                                                        )
@@ -61,13 +61,13 @@ Usage: cardano-cli governance create-mir-certificate stake-addresses
   Create an MIR certificate to pay stake addresses
 
 Usage: cardano-cli governance create-mir-certificate transfer-to-treasury 
-                                                                            ( --shelley-era
+                                                                            [ --shelley-era
                                                                             | --allegra-era
                                                                             | --mary-era
                                                                             | --alonzo-era
                                                                             | --babbage-era
                                                                             | --conway-era
-                                                                            )
+                                                                            ]
                                                                             --transfer LOVELACE
                                                                             --out-file FILE
 
@@ -75,13 +75,13 @@ Usage: cardano-cli governance create-mir-certificate transfer-to-treasury
   pot
 
 Usage: cardano-cli governance create-mir-certificate transfer-to-rewards 
-                                                                           ( --shelley-era
+                                                                           [ --shelley-era
                                                                            | --allegra-era
                                                                            | --mary-era
                                                                            | --alonzo-era
                                                                            | --babbage-era
                                                                            | --conway-era
-                                                                           )
+                                                                           ]
                                                                            --transfer LOVELACE
                                                                            --out-file FILE
 
@@ -89,13 +89,13 @@ Usage: cardano-cli governance create-mir-certificate transfer-to-rewards
   pot
 
 Usage: cardano-cli governance create-genesis-key-delegation-certificate 
-                                                                          ( --shelley-era
+                                                                          [ --shelley-era
                                                                           | --allegra-era
                                                                           | --mary-era
                                                                           | --alonzo-era
                                                                           | --babbage-era
                                                                           | --conway-era
-                                                                          )
+                                                                          ]
                                                                           ( --genesis-verification-key STRING
                                                                           | --genesis-verification-key-file FILE
                                                                           | --genesis-verification-key-hash STRING
@@ -559,13 +559,13 @@ Usage: cardano-cli stake-pool
   Stake pool commands
 
 Usage: cardano-cli stake-pool registration-certificate 
-                                                         ( --shelley-era
+                                                         [ --shelley-era
                                                          | --allegra-era
                                                          | --mary-era
                                                          | --alonzo-era
                                                          | --babbage-era
                                                          | --conway-era
-                                                         )
+                                                         ]
                                                          ( --stake-pool-verification-key STRING
                                                          | --cold-verification-key-file FILE
                                                          )
@@ -598,13 +598,13 @@ Usage: cardano-cli stake-pool registration-certificate
   Create a stake pool registration certificate
 
 Usage: cardano-cli stake-pool deregistration-certificate 
-                                                           ( --shelley-era
+                                                           [ --shelley-era
                                                            | --allegra-era
                                                            | --mary-era
                                                            | --alonzo-era
                                                            | --babbage-era
                                                            | --conway-era
-                                                           )
+                                                           ]
                                                            ( --stake-pool-verification-key STRING
                                                            | --cold-verification-key-file FILE
                                                            )
@@ -1193,13 +1193,13 @@ Usage: cardano-cli stake-address key-hash
   Print the hash of a stake address key.
 
 Usage: cardano-cli stake-address registration-certificate 
-                                                            ( --shelley-era
+                                                            [ --shelley-era
                                                             | --allegra-era
                                                             | --mary-era
                                                             | --alonzo-era
                                                             | --babbage-era
                                                             | --conway-era
-                                                            )
+                                                            ]
                                                             ( --stake-verification-key STRING
                                                             | --stake-verification-key-file FILE
                                                             | --stake-script-file FILE
@@ -1210,13 +1210,13 @@ Usage: cardano-cli stake-address registration-certificate
   Create a stake address registration certificate
 
 Usage: cardano-cli stake-address deregistration-certificate 
-                                                              ( --shelley-era
+                                                              [ --shelley-era
                                                               | --allegra-era
                                                               | --mary-era
                                                               | --alonzo-era
                                                               | --babbage-era
                                                               | --conway-era
-                                                              )
+                                                              ]
                                                               ( --stake-verification-key STRING
                                                               | --stake-verification-key-file FILE
                                                               | --stake-script-file FILE
@@ -1227,13 +1227,13 @@ Usage: cardano-cli stake-address deregistration-certificate
   Create a stake address deregistration certificate
 
 Usage: cardano-cli stake-address delegation-certificate 
-                                                          ( --shelley-era
+                                                          [ --shelley-era
                                                           | --allegra-era
                                                           | --mary-era
                                                           | --alonzo-era
                                                           | --babbage-era
                                                           | --conway-era
-                                                          )
+                                                          ]
                                                           ( --stake-verification-key STRING
                                                           | --stake-verification-key-file FILE
                                                           | --stake-script-file FILE

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_create-genesis-key-delegation-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_create-genesis-key-delegation-certificate.cli
@@ -1,11 +1,11 @@
 Usage: cardano-cli governance create-genesis-key-delegation-certificate 
-                                                                          ( --shelley-era
+                                                                          [ --shelley-era
                                                                           | --allegra-era
                                                                           | --mary-era
                                                                           | --alonzo-era
                                                                           | --babbage-era
                                                                           | --conway-era
-                                                                          )
+                                                                          ]
                                                                           ( --genesis-verification-key STRING
                                                                           | --genesis-verification-key-file FILE
                                                                           | --genesis-verification-key-hash STRING
@@ -27,7 +27,7 @@ Available options:
   --allegra-era            Specify the Allegra era
   --mary-era               Specify the Mary era
   --alonzo-era             Specify the Alonzo era
-  --babbage-era            Specify the Babbage era
+  --babbage-era            Specify the Babbage era (default)
   --conway-era             Specify the Conway era
   --genesis-verification-key STRING
                            Genesis verification key (hex-encoded).

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_create-mir-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_create-mir-certificate.cli
@@ -1,11 +1,11 @@
 Usage: cardano-cli governance create-mir-certificate 
-                                                       ( ( --shelley-era
+                                                       ( [ --shelley-era
                                                          | --allegra-era
                                                          | --mary-era
                                                          | --alonzo-era
                                                          | --babbage-era
                                                          | --conway-era
-                                                         )
+                                                         ]
                                                          ( --reserves
                                                          | --treasury
                                                          )
@@ -24,7 +24,7 @@ Available options:
   --allegra-era            Specify the Allegra era
   --mary-era               Specify the Mary era
   --alonzo-era             Specify the Alonzo era
-  --babbage-era            Specify the Babbage era
+  --babbage-era            Specify the Babbage era (default)
   --conway-era             Specify the Conway era
   --reserves               Use the reserves pot.
   --treasury               Use the treasury pot.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_create-mir-certificate_stake-addresses.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_create-mir-certificate_stake-addresses.cli
@@ -1,11 +1,11 @@
 Usage: cardano-cli governance create-mir-certificate stake-addresses 
-                                                                       ( --shelley-era
+                                                                       [ --shelley-era
                                                                        | --allegra-era
                                                                        | --mary-era
                                                                        | --alonzo-era
                                                                        | --babbage-era
                                                                        | --conway-era
-                                                                       )
+                                                                       ]
                                                                        ( --reserves
                                                                        | --treasury
                                                                        )
@@ -20,7 +20,7 @@ Available options:
   --allegra-era            Specify the Allegra era
   --mary-era               Specify the Mary era
   --alonzo-era             Specify the Alonzo era
-  --babbage-era            Specify the Babbage era
+  --babbage-era            Specify the Babbage era (default)
   --conway-era             Specify the Conway era
   --reserves               Use the reserves pot.
   --treasury               Use the treasury pot.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_create-mir-certificate_transfer-to-rewards.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_create-mir-certificate_transfer-to-rewards.cli
@@ -1,11 +1,11 @@
 Usage: cardano-cli governance create-mir-certificate transfer-to-rewards 
-                                                                           ( --shelley-era
+                                                                           [ --shelley-era
                                                                            | --allegra-era
                                                                            | --mary-era
                                                                            | --alonzo-era
                                                                            | --babbage-era
                                                                            | --conway-era
-                                                                           )
+                                                                           ]
                                                                            --transfer LOVELACE
                                                                            --out-file FILE
 
@@ -17,7 +17,7 @@ Available options:
   --allegra-era            Specify the Allegra era
   --mary-era               Specify the Mary era
   --alonzo-era             Specify the Alonzo era
-  --babbage-era            Specify the Babbage era
+  --babbage-era            Specify the Babbage era (default)
   --conway-era             Specify the Conway era
   --transfer LOVELACE      The amount to transfer.
   --out-file FILE          The output file.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_create-mir-certificate_transfer-to-treasury.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_create-mir-certificate_transfer-to-treasury.cli
@@ -1,11 +1,11 @@
 Usage: cardano-cli governance create-mir-certificate transfer-to-treasury 
-                                                                            ( --shelley-era
+                                                                            [ --shelley-era
                                                                             | --allegra-era
                                                                             | --mary-era
                                                                             | --alonzo-era
                                                                             | --babbage-era
                                                                             | --conway-era
-                                                                            )
+                                                                            ]
                                                                             --transfer LOVELACE
                                                                             --out-file FILE
 
@@ -17,7 +17,7 @@ Available options:
   --allegra-era            Specify the Allegra era
   --mary-era               Specify the Mary era
   --alonzo-era             Specify the Alonzo era
-  --babbage-era            Specify the Babbage era
+  --babbage-era            Specify the Babbage era (default)
   --conway-era             Specify the Conway era
   --transfer LOVELACE      The amount to transfer.
   --out-file FILE          The output file.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/stake-address_delegation-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/stake-address_delegation-certificate.cli
@@ -1,11 +1,11 @@
 Usage: cardano-cli stake-address delegation-certificate 
-                                                          ( --shelley-era
+                                                          [ --shelley-era
                                                           | --allegra-era
                                                           | --mary-era
                                                           | --alonzo-era
                                                           | --babbage-era
                                                           | --conway-era
-                                                          )
+                                                          ]
                                                           ( --stake-verification-key STRING
                                                           | --stake-verification-key-file FILE
                                                           | --stake-script-file FILE
@@ -24,7 +24,7 @@ Available options:
   --allegra-era            Specify the Allegra era
   --mary-era               Specify the Mary era
   --alonzo-era             Specify the Alonzo era
-  --babbage-era            Specify the Babbage era
+  --babbage-era            Specify the Babbage era (default)
   --conway-era             Specify the Conway era
   --stake-verification-key STRING
                            Stake verification key (Bech32 or hex-encoded).

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/stake-address_deregistration-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/stake-address_deregistration-certificate.cli
@@ -1,11 +1,11 @@
 Usage: cardano-cli stake-address deregistration-certificate 
-                                                              ( --shelley-era
+                                                              [ --shelley-era
                                                               | --allegra-era
                                                               | --mary-era
                                                               | --alonzo-era
                                                               | --babbage-era
                                                               | --conway-era
-                                                              )
+                                                              ]
                                                               ( --stake-verification-key STRING
                                                               | --stake-verification-key-file FILE
                                                               | --stake-script-file FILE
@@ -20,7 +20,7 @@ Available options:
   --allegra-era            Specify the Allegra era
   --mary-era               Specify the Mary era
   --alonzo-era             Specify the Alonzo era
-  --babbage-era            Specify the Babbage era
+  --babbage-era            Specify the Babbage era (default)
   --conway-era             Specify the Conway era
   --stake-verification-key STRING
                            Stake verification key (Bech32 or hex-encoded).

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/stake-address_registration-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/stake-address_registration-certificate.cli
@@ -1,11 +1,11 @@
 Usage: cardano-cli stake-address registration-certificate 
-                                                            ( --shelley-era
+                                                            [ --shelley-era
                                                             | --allegra-era
                                                             | --mary-era
                                                             | --alonzo-era
                                                             | --babbage-era
                                                             | --conway-era
-                                                            )
+                                                            ]
                                                             ( --stake-verification-key STRING
                                                             | --stake-verification-key-file FILE
                                                             | --stake-script-file FILE
@@ -20,7 +20,7 @@ Available options:
   --allegra-era            Specify the Allegra era
   --mary-era               Specify the Mary era
   --alonzo-era             Specify the Alonzo era
-  --babbage-era            Specify the Babbage era
+  --babbage-era            Specify the Babbage era (default)
   --conway-era             Specify the Conway era
   --stake-verification-key STRING
                            Stake verification key (Bech32 or hex-encoded).

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/stake-pool_deregistration-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/stake-pool_deregistration-certificate.cli
@@ -1,11 +1,11 @@
 Usage: cardano-cli stake-pool deregistration-certificate 
-                                                           ( --shelley-era
+                                                           [ --shelley-era
                                                            | --allegra-era
                                                            | --mary-era
                                                            | --alonzo-era
                                                            | --babbage-era
                                                            | --conway-era
-                                                           )
+                                                           ]
                                                            ( --stake-pool-verification-key STRING
                                                            | --cold-verification-key-file FILE
                                                            )
@@ -19,7 +19,7 @@ Available options:
   --allegra-era            Specify the Allegra era
   --mary-era               Specify the Mary era
   --alonzo-era             Specify the Alonzo era
-  --babbage-era            Specify the Babbage era
+  --babbage-era            Specify the Babbage era (default)
   --conway-era             Specify the Conway era
   --stake-pool-verification-key STRING
                            Stake pool verification key (Bech32 or hex-encoded).

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/stake-pool_registration-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/stake-pool_registration-certificate.cli
@@ -1,11 +1,11 @@
 Usage: cardano-cli stake-pool registration-certificate 
-                                                         ( --shelley-era
+                                                         [ --shelley-era
                                                          | --allegra-era
                                                          | --mary-era
                                                          | --alonzo-era
                                                          | --babbage-era
                                                          | --conway-era
-                                                         )
+                                                         ]
                                                          ( --stake-pool-verification-key STRING
                                                          | --cold-verification-key-file FILE
                                                          )
@@ -42,7 +42,7 @@ Available options:
   --allegra-era            Specify the Allegra era
   --mary-era               Specify the Mary era
   --alonzo-era             Specify the Alonzo era
-  --babbage-era            Specify the Babbage era
+  --babbage-era            Specify the Babbage era (default)
   --conway-era             Specify the Conway era
   --stake-pool-verification-key STRING
                            Stake pool verification key (Bech32 or hex-encoded).


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Fix incorrect cardano era environment variable name
  # no-changes: the API has not changed
  # compatible: the API has changed but is non-breaking
  # breaking: the API has changed in a breaking way
  compatibility: no-api-changes
  # feature: the change implements a new feature in the API
  # bugfix: the change fixes a bug in the API
  # test: the change fixes modifies tests
  # maintenance: the change involves something other than the API
  # If more than one is applicable, it may be put into a list.
  type: bugfix
```

# Context

n/a

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
