### PR TITLE
Share MIR certificates code between era-based and legacy CLI parsers

### DIFF
--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -75,6 +75,7 @@ library
                         Cardano.CLI.EraBased.Options.Governance
                         Cardano.CLI.EraBased.Governance
                         Cardano.CLI.EraBased.Legacy
+                        Cardano.CLI.EraBased.Run.Governance
                         Cardano.CLI.Orphans
                         Cardano.CLI.OS.Posix
                         Cardano.CLI.Pretty
@@ -97,6 +98,7 @@ library
                         Cardano.CLI.Run.Legacy.Validate
                         Cardano.CLI.Run.Ping
                         Cardano.CLI.TopHandler
+                        Cardano.CLI.Types.Common
                         Cardano.CLI.Types.Governance
                         Cardano.CLI.Types.Key
                         Cardano.CLI.Types.Legacy

--- a/cardano-cli/src/Cardano/CLI/Commands/EraBased.hs
+++ b/cardano-cli/src/Cardano/CLI/Commands/EraBased.hs
@@ -9,7 +9,7 @@ module Cardano.CLI.Commands.EraBased
   , pEraBasedCommand
   ) where
 
-import           Cardano.Api (CardanoEra (..))
+import           Cardano.Api (CardanoEra (..), ShelleyBasedEra (..))
 
 import           Cardano.CLI.Environment
 import           Cardano.CLI.EraBased.Options.Common
@@ -21,7 +21,7 @@ import           Options.Applicative (Parser)
 import qualified Options.Applicative as Opt
 
 data AnyEraCommand where
-  AnyEraCommandOf :: CardanoEra era -> EraBasedCommand era -> AnyEraCommand
+  AnyEraCommandOf :: ShelleyBasedEra era -> EraBasedCommand era -> AnyEraCommand
 
 newtype EraBasedCommand era
   = EraBasedGovernanceCmd (EraBasedGovernanceCmd era)
@@ -36,29 +36,29 @@ pAnyEraCommand envCli =
     [ -- Note, byron is ommitted because there is already a legacy command group for it.
 
       subParser "shelley"
-        $ Opt.info (AnyEraCommandOf ShelleyEra <$> pEraBasedCommand envCli ShelleyEra)
+        $ Opt.info (AnyEraCommandOf ShelleyBasedEraShelley <$> pEraBasedCommand envCli ShelleyEra)
         $ Opt.progDesc "Shelley era commands"
     , subParser "allegra"
-        $ Opt.info (AnyEraCommandOf AllegraEra <$> pEraBasedCommand envCli AllegraEra)
+        $ Opt.info (AnyEraCommandOf ShelleyBasedEraAllegra <$> pEraBasedCommand envCli AllegraEra)
         $ Opt.progDesc "Allegra era commands"
     , subParser "mary"
-        $ Opt.info (AnyEraCommandOf MaryEra <$> pEraBasedCommand envCli MaryEra)
+        $ Opt.info (AnyEraCommandOf ShelleyBasedEraMary <$> pEraBasedCommand envCli MaryEra)
         $ Opt.progDesc "Mary era commands"
     , subParser "alonzo"
-        $ Opt.info (AnyEraCommandOf AlonzoEra <$> pEraBasedCommand envCli AlonzoEra)
+        $ Opt.info (AnyEraCommandOf ShelleyBasedEraAlonzo <$> pEraBasedCommand envCli AlonzoEra)
         $ Opt.progDesc "Alonzo era commands"
     , subParser "babbage"
-        $ Opt.info (AnyEraCommandOf BabbageEra <$> pEraBasedCommand envCli BabbageEra)
+        $ Opt.info (AnyEraCommandOf ShelleyBasedEraBabbage <$> pEraBasedCommand envCli BabbageEra)
         $ Opt.progDesc "Babbage era commands"
     , subParser "conway"
-        $ Opt.info (AnyEraCommandOf ConwayEra <$> pEraBasedCommand envCli ConwayEra)
+        $ Opt.info (AnyEraCommandOf ShelleyBasedEraConway <$> pEraBasedCommand envCli ConwayEra)
         $ Opt.progDesc "Conway era commands"
 
     , subParser "latest"
-        $ Opt.info (AnyEraCommandOf BabbageEra <$> pEraBasedCommand envCli BabbageEra)
+        $ Opt.info (AnyEraCommandOf ShelleyBasedEraBabbage <$> pEraBasedCommand envCli BabbageEra)
         $ Opt.progDesc "Latest era commands (Babbage)"
     , subParser "experimental"
-        $ Opt.info (AnyEraCommandOf ConwayEra <$> pEraBasedCommand envCli ConwayEra)
+        $ Opt.info (AnyEraCommandOf ShelleyBasedEraConway <$> pEraBasedCommand envCli ConwayEra)
         $ Opt.progDesc "Experimental era commands (Conway)"
     ]
 

--- a/cardano-cli/src/Cardano/CLI/Environment.hs
+++ b/cardano-cli/src/Cardano/CLI/Environment.hs
@@ -5,13 +5,17 @@
 module Cardano.CLI.Environment
   ( EnvCli(..)
   , envCliAnyShelleyBasedEra
+  , envCliAnyShelleyToBabbageEra
   , getEnvCli
   , getEnvNetworkId
   , getEnvSocketPath
   ) where
 
 import           Cardano.Api (AnyCardanoEra (..), AnyShelleyBasedEra (..), CardanoEra (..),
-                   NetworkId (..), NetworkMagic (..), ShelleyBasedEra (..))
+                   NetworkId (..), NetworkMagic (..), ShelleyBasedEra (..),
+                   ShelleyToBabbageEra (..))
+
+import           Cardano.CLI.Types.Common
 
 import           Data.Word (Word32)
 import qualified System.Environment as IO
@@ -48,6 +52,19 @@ envCliAnyShelleyBasedEra envCli = do
     AlonzoEra -> Just $ AnyShelleyBasedEra ShelleyBasedEraAlonzo
     BabbageEra -> Just $ AnyShelleyBasedEra ShelleyBasedEraBabbage
     ConwayEra -> Just $ AnyShelleyBasedEra ShelleyBasedEraConway
+
+envCliAnyShelleyToBabbageEra :: EnvCli -> Maybe AnyShelleyToBabbageEra
+envCliAnyShelleyToBabbageEra envCli = do
+  AnyCardanoEra era <- envCliAnyCardanoEra envCli
+
+  case era of
+    ByronEra -> Nothing
+    ShelleyEra -> Just $ AnyShelleyToBabbageEra ShelleyToBabbageEraShelley
+    AllegraEra -> Just $ AnyShelleyToBabbageEra ShelleyToBabbageEraAllegra
+    MaryEra -> Just $ AnyShelleyToBabbageEra ShelleyToBabbageEraMary
+    AlonzoEra -> Just $ AnyShelleyToBabbageEra ShelleyToBabbageEraAlonzo
+    BabbageEra -> Just $ AnyShelleyToBabbageEra ShelleyToBabbageEraBabbage
+    ConwayEra -> Nothing
 
 -- | If the environment variable @CARDANO_NODE_NETWORK_ID@ is set, then return the network id therein.
 -- Otherwise, return 'Nothing'.

--- a/cardano-cli/src/Cardano/CLI/EraBased/Certificate.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Certificate.hs
@@ -1,11 +1,13 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeOperators #-}
 
 module Cardano.CLI.EraBased.Certificate
-  ( runGovernanceDelegrationCertificate
+  ( EraBasedDelegationError(..)
+  , runGovernanceDelegrationCertificate
   ) where
 
 import           Cardano.Api
@@ -24,6 +26,7 @@ data EraBasedDelegationError
   = EraBasedDelegReadError !(FileError InputDecodeError)
   | EraBasedCredentialError !ShelleyStakeAddressCmdError -- TODO: Refactor. We shouldn't be using legacy error types
   | EraBasedCertificateWriteFileError !(FileError ())
+  | EraBasedDelegationGenericError -- TODO Delete and replace with more specific errors
 
 runGovernanceDelegrationCertificate
   :: StakeIdentifier

--- a/cardano-cli/src/Cardano/CLI/EraBased/Certificate.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Certificate.hs
@@ -5,7 +5,7 @@
 {-# LANGUAGE TypeOperators #-}
 
 module Cardano.CLI.EraBased.Certificate
-  ( runAnyDelegationTarget
+  ( runGovernanceDelegrationCertificate
   ) where
 
 import           Cardano.Api
@@ -25,12 +25,12 @@ data EraBasedDelegationError
   | EraBasedCredentialError !ShelleyStakeAddressCmdError -- TODO: Refactor. We shouldn't be using legacy error types
   | EraBasedCertificateWriteFileError !(FileError ())
 
-runAnyDelegationTarget
+runGovernanceDelegrationCertificate
   :: StakeIdentifier
   -> AnyDelegationTarget
   -> File () Out
   -> ExceptT EraBasedDelegationError IO ()
-runAnyDelegationTarget stakeIdentifier delegationTarget outFp = do
+runGovernanceDelegrationCertificate stakeIdentifier delegationTarget outFp = do
   stakeCred <-
     getStakeCredentialFromIdentifier stakeIdentifier
       & firstExceptT EraBasedCredentialError

--- a/cardano-cli/src/Cardano/CLI/EraBased/Certificate.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Certificate.hs
@@ -26,16 +26,19 @@ data EraBasedDelegationError
   | EraBasedCertificateWriteFileError !(FileError ())
 
 runAnyDelegationTarget
-  :: AnyDelegationTarget
+  :: StakeIdentifier
+  -> AnyDelegationTarget
   -> File () Out
   -> ExceptT EraBasedDelegationError IO ()
-runAnyDelegationTarget delegationTarget outFp = do
+runAnyDelegationTarget stakeIdentifier delegationTarget outFp = do
+  stakeCred <-
+    getStakeCredentialFromIdentifier stakeIdentifier
+      & firstExceptT EraBasedCredentialError
+
   case delegationTarget of
-    ShelleyToBabbageDelegTarget sTob stakeIdentifier stakePool -> do
+    ShelleyToBabbageDelegTarget sTob stakePool -> do
       poolId <- lift (readVerificationKeyOrHashOrFile AsStakePoolKey stakePool)
                   & onLeft (left . EraBasedDelegReadError)
-      stakeCred <- firstExceptT EraBasedCredentialError
-                     $ getStakeCredentialFromIdentifier stakeIdentifier
       let req = StakeDelegationRequirementsPreConway sTob stakeCred poolId
           delegCert = makeStakeAddressDelegationCertificate req
           description = Just @TextEnvelopeDescr "Stake Address Delegation Certificate"
@@ -45,9 +48,7 @@ runAnyDelegationTarget delegationTarget outFp = do
         $ obtainIsShelleyBasedEraShelleyToBabbage sTob
         $ textEnvelopeToJSON description delegCert
 
-    ConwayOnwardDelegTarget cOnwards stakeIdentifier target -> do
-      stakeCred <- firstExceptT EraBasedCredentialError
-                     $ getStakeCredentialFromIdentifier stakeIdentifier
+    ConwayOnwardDelegTarget cOnwards target -> do
       delegatee <- toLedgerDelegatee target
       let req = StakeDelegationRequirementsConwayOnwards cOnwards stakeCred delegatee
           delegCert = makeStakeAddressDelegationCertificate req

--- a/cardano-cli/src/Cardano/CLI/EraBased/Governance.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Governance.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
 
 module Cardano.CLI.EraBased.Governance where
@@ -8,6 +9,7 @@ import           Cardano.Api.Shelley
 
 import           Cardano.CLI.Environment
 import           Cardano.CLI.EraBased.Options.Common
+import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Governance
 import           Cardano.CLI.Types.Key
 import           Cardano.CLI.Types.Legacy
@@ -17,18 +19,17 @@ import           Data.Text (Text)
 import           Options.Applicative hiding (help, str)
 import qualified Options.Applicative as Opt
 
-
 data GovernanceCmd
   = GovernanceVoteCmd VoteCmd
   | GovernanceActionCmd ActionCmd
   | GovernanceMIRPayStakeAddressesCertificate
-      AnyShelleyBasedEra
+      AnyShelleyToBabbageEra
       MIRPot
       [StakeAddress]
       [Lovelace]
       (File () Out)
   | GovernanceMIRTransfer
-      AnyShelleyBasedEra
+      AnyShelleyToBabbageEra
       Lovelace
       (File () Out)
       TransferDirection

--- a/cardano-cli/src/Cardano/CLI/EraBased/Legacy.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Legacy.hs
@@ -2075,15 +2075,6 @@ pMaybeOutputFile =
     , Opt.completer (Opt.bashCompleter "file")
     ]
 
-pOutputFile :: Parser (File content Out)
-pOutputFile =
-  fmap File $ Opt.strOption $ mconcat
-    [ Opt.long "out-file"
-    , Opt.metavar "FILE"
-    , Opt.help "The output file."
-    , Opt.completer (Opt.bashCompleter "file")
-    ]
-
 pColdVerificationKeyOrFile :: Parser ColdVerificationKeyOrFile
 pColdVerificationKeyOrFile =
   asum

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
@@ -445,3 +445,12 @@ pStakePoolVerificationKeyFile =
       , Opt.internal
       ]
     ]
+
+pOutputFile :: Parser (File content Out)
+pOutputFile =
+  fmap File $ Opt.strOption $ mconcat
+    [ Opt.long "out-file"
+    , Opt.metavar "FILE"
+    , Opt.help "The output file."
+    , Opt.completer (Opt.bashCompleter "file")
+    ]

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
@@ -8,9 +8,12 @@ module Cardano.CLI.EraBased.Options.Common where
 import           Cardano.Api
 import           Cardano.Api.Shelley
 
-import           Cardano.CLI.Environment (EnvCli (..), envCliAnyShelleyBasedEra)
+import           Cardano.CLI.Environment (EnvCli (..), envCliAnyShelleyBasedEra,
+                   envCliAnyShelleyToBabbageEra)
+import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Key
 import           Cardano.CLI.Types.Legacy
+import qualified Cardano.Ledger.Shelley.TxBody as Shelley
 import           Cardano.Prelude (purer)
 
 import           Control.Monad (mfilter)
@@ -32,8 +35,11 @@ import qualified Text.Parsec.Language as Parsec
 import qualified Text.Parsec.String as Parsec
 import qualified Text.Parsec.Token as Parsec
 
-defaultCurrentEra :: AnyShelleyBasedEra
-defaultCurrentEra = AnyShelleyBasedEra ShelleyBasedEraBabbage
+defaultShelleyBasedEra :: AnyShelleyBasedEra
+defaultShelleyBasedEra = AnyShelleyBasedEra ShelleyBasedEraBabbage
+
+defaultShelleyToBabbageEra :: AnyShelleyToBabbageEra
+defaultShelleyToBabbageEra = AnyShelleyToBabbageEra ShelleyToBabbageEraBabbage
 
 pCardanoEra :: EnvCli -> Parser AnyCardanoEra
 pCardanoEra envCli =
@@ -75,7 +81,7 @@ pCardanoEra envCli =
     , purer defaultCardanoEra
   ]
     where
-      defaultCardanoEra = defaultCurrentEra & \(AnyShelleyBasedEra era) ->
+      defaultCardanoEra = defaultShelleyBasedEra & \(AnyShelleyBasedEra era) ->
         AnyCardanoEra (shelleyBasedToCardanoEra era)
 
 command' :: String -> String -> Parser a -> Mod CommandFields a
@@ -316,7 +322,25 @@ pAnyShelleyBasedEra envCli =
         $ mconcat [Opt.long "conway-era", Opt.help "Specify the Conway era"]
       ]
     , maybeToList $ pure <$> envCliAnyShelleyBasedEra envCli
-    , purer defaultCurrentEra
+    , purer defaultShelleyBasedEra
+  ]
+
+pAnyShelleyToBabbageEra :: EnvCli -> Parser AnyShelleyToBabbageEra
+pAnyShelleyToBabbageEra envCli =
+  asum $ mconcat
+    [ [ Opt.flag' (AnyShelleyToBabbageEra ShelleyToBabbageEraShelley)
+        $ mconcat [Opt.long "shelley-era", Opt.help "Specify the Shelley era"]
+      , Opt.flag' (AnyShelleyToBabbageEra ShelleyToBabbageEraAllegra)
+        $ mconcat [Opt.long "allegra-era", Opt.help "Specify the Allegra era"]
+      , Opt.flag' (AnyShelleyToBabbageEra ShelleyToBabbageEraMary)
+        $ mconcat [Opt.long "mary-era", Opt.help "Specify the Mary era"]
+      , Opt.flag' (AnyShelleyToBabbageEra ShelleyToBabbageEraAlonzo)
+        $ mconcat [Opt.long "alonzo-era", Opt.help "Specify the Alonzo era"]
+      , Opt.flag' (AnyShelleyToBabbageEra ShelleyToBabbageEraBabbage)
+        $ mconcat [Opt.long "babbage-era", Opt.help "Specify the Babbage era (default)"]
+      ]
+    , maybeToList $ pure <$> envCliAnyShelleyToBabbageEra envCli
+    , purer defaultShelleyToBabbageEra
   ]
 
 pShelleyBasedShelley :: EnvCli -> Parser AnyShelleyBasedEra
@@ -453,4 +477,33 @@ pOutputFile =
     , Opt.metavar "FILE"
     , Opt.help "The output file."
     , Opt.completer (Opt.bashCompleter "file")
+    ]
+
+pMIRPot :: Parser Shelley.MIRPot
+pMIRPot =
+  asum
+    [ Opt.flag' Shelley.ReservesMIR $ mconcat
+        [ Opt.long "reserves"
+        , Opt.help "Use the reserves pot."
+        ]
+    , Opt.flag' Shelley.TreasuryMIR $ mconcat
+        [ Opt.long "treasury"
+        , Opt.help "Use the treasury pot."
+        ]
+    ]
+
+pRewardAmt :: Parser Lovelace
+pRewardAmt =
+  Opt.option (readerFromParsecParser parseLovelace) $ mconcat
+    [ Opt.long "reward"
+    , Opt.metavar "LOVELACE"
+    , Opt.help "The reward for the relevant reward account."
+    ]
+
+pTransferAmt :: Parser Lovelace
+pTransferAmt =
+  Opt.option (readerFromParsecParser parseLovelace) $ mconcat
+    [ Opt.long "transfer"
+    , Opt.metavar "LOVELACE"
+    , Opt.help "The amount to transfer."
     ]

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance.hs
@@ -2,13 +2,18 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
 
-module Cardano.CLI.EraBased.Options.Governance where
+module Cardano.CLI.EraBased.Options.Governance
+  ( EraBasedGovernanceCmd(..)
+  , renderEraBasedGovernanceCmd
+  , pEraBasedGovernanceCmd
+  ) where
 
 import           Cardano.Api
 
 import           Cardano.CLI.Environment
 import           Cardano.CLI.EraBased.Legacy
 import           Cardano.CLI.EraBased.Options.Common
+import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Key
 
 import           Data.Foldable
@@ -20,6 +25,17 @@ import qualified Options.Applicative as Opt
 data EraBasedGovernanceCmd era
   = EraBasedGovernancePreConwayCmd (ShelleyToBabbageEra era)
   | EraBasedGovernancePostConwayCmd (ConwayEraOnwards era)
+  | EraBasedGovernanceMIRPayStakeAddressesCertificate
+      (ShelleyToBabbageEra era)
+      MIRPot
+      [StakeAddress]
+      [Lovelace]
+      (File () Out)
+  | EraBasedGovernanceMIRTransfer
+      (ShelleyToBabbageEra era)
+      Lovelace
+      (File () Out)
+      TransferDirection
   | EraBasedGovernanceDelegationCertificateCmd
       StakeIdentifier
       AnyDelegationTarget
@@ -29,13 +45,16 @@ renderEraBasedGovernanceCmd :: EraBasedGovernanceCmd era -> Text
 renderEraBasedGovernanceCmd = \case
   EraBasedGovernancePreConwayCmd {} -> "governance pre-conway"
   EraBasedGovernancePostConwayCmd {} -> "governance post-conway"
-
+  EraBasedGovernanceMIRPayStakeAddressesCertificate {} -> "TODO EraBasedGovernanceMIRPayStakeAddressesCertificate"
+  EraBasedGovernanceMIRTransfer {} -> "TODO EraBasedGovernanceMIRTransfer"
   EraBasedGovernanceDelegationCertificateCmd {} -> "governance delegation-certificate"
+
 -- TODO: Conway era - move to Cardano.CLI.Conway.Parsers
 pEraBasedGovernanceCmd :: EnvCli -> CardanoEra era -> Parser (EraBasedGovernanceCmd era)
 pEraBasedGovernanceCmd envCli era =
   asum $ catMaybes
     [ pEraBasedDelegationCertificateCmd envCli era
+    , pCreateMirCertificatesCmds era
     ]
 
 data AnyEraDecider era where
@@ -87,13 +106,57 @@ pStakeTarget cOnwards =
     -- , TargetVotingDrepAndStakePool cOnwards -- TODO: Conway era
     ]
 
-{-
-data DRep c
-  = DRepKeyHash !(KeyHash 'Voting c)
-  | DRepScriptHash !(ScriptHash c)
-  | DRepAlwaysAbstain
-  | DRepAlwaysNoConfidence
--}
+pCreateMirCertificatesCmds :: CardanoEra era -> Maybe (Parser (EraBasedGovernanceCmd era))
+pCreateMirCertificatesCmds =
+  featureInEra Nothing $ \w ->
+    Just
+      $ subParser "create-mir-certificate"
+      $ Opt.info (pMIRPayStakeAddresses w <|> mirCertParsers w)
+      $ Opt.progDesc "Create an MIR (Move Instantaneous Rewards) certificate"
+
+mirCertParsers :: ()
+  => ShelleyToBabbageEra era
+  -> Parser (EraBasedGovernanceCmd era)
+mirCertParsers w =
+  asum
+    [ subParser "stake-addresses"
+      $ Opt.info (pMIRPayStakeAddresses w)
+      $ Opt.progDesc "Create an MIR certificate to pay stake addresses"
+    , subParser "transfer-to-treasury"
+      $ Opt.info (pMIRTransferToTreasury w)
+      $ Opt.progDesc "Create an MIR certificate to transfer from the reserves pot to the treasury pot"
+    , subParser "transfer-to-rewards"
+      $ Opt.info (pMIRTransferToReserves w)
+      $ Opt.progDesc "Create an MIR certificate to transfer from the treasury pot to the reserves pot"
+    ]
+
+pMIRPayStakeAddresses :: ()
+  => ShelleyToBabbageEra era
+  -> Parser (EraBasedGovernanceCmd era)
+pMIRPayStakeAddresses w =
+  EraBasedGovernanceMIRPayStakeAddressesCertificate w
+    <$> pMIRPot
+    <*> some pStakeAddress
+    <*> some pRewardAmt
+    <*> pOutputFile
+
+pMIRTransferToTreasury :: ()
+  => ShelleyToBabbageEra era
+  -> Parser (EraBasedGovernanceCmd era)
+pMIRTransferToTreasury w =
+  EraBasedGovernanceMIRTransfer w
+    <$> pTransferAmt
+    <*> pOutputFile
+    <*> pure TransferToTreasury
+
+pMIRTransferToReserves :: ()
+  => ShelleyToBabbageEra era
+  -> Parser (EraBasedGovernanceCmd era)
+pMIRTransferToReserves w =
+  EraBasedGovernanceMIRTransfer w
+    <$> pTransferAmt
+    <*> pOutputFile
+    <*> pure TransferToReserves
 
 -- TODO: Conway era - parse the relevant voting
 -- credential (key hash, script hash, always abstain or no confidence)
@@ -102,19 +165,3 @@ pDrep = Opt.strOption $ mconcat
           [ Opt.long "dummy-drep-option"
           , Opt.help "Delegate voting stake to Drep"
           ]
-
-
-
-pPreConwayCmd :: EnvCli -> CardanoEra era -> Maybe (Parser (EraBasedGovernanceCmd era))
-pPreConwayCmd envCli =
-  featureInEra Nothing $ \feature ->
-    Just
-      $ subParser "pre-conway"
-      $ Opt.info (pPreConwayArgs envCli feature)
-      $ Opt.progDesc "Pre conway era governance command"
-
-pPreConwayArgs :: EnvCli -> ShelleyToBabbageEra era -> Parser (EraBasedGovernanceCmd era)
-pPreConwayArgs _envCli w = pure (EraBasedGovernancePreConwayCmd w)
-
-pPostConwayArgs :: EnvCli -> ConwayEraOnwards era -> Parser (EraBasedGovernanceCmd era)
-pPostConwayArgs _envCli w = pure (EraBasedGovernancePostConwayCmd w)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance.hs
@@ -67,7 +67,9 @@ pEraBasedDelegationCertificateCmd _envCli =
       <*> pAnyDelegationCertificateTarget w
       <*> pOutputFile
 
-  pAnyDelegationCertificateTarget :: AnyEraDecider era -> Parser AnyDelegationTarget
+  pAnyDelegationCertificateTarget :: ()
+    => AnyEraDecider era
+    -> Parser AnyDelegationTarget
   pAnyDelegationCertificateTarget e =
     case e of
       AnyEraDeciderShelleyToBabbage sbe ->

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance.hs
@@ -1,0 +1,73 @@
+{-# LANGUAGE DataKinds #-}
+
+module Cardano.CLI.EraBased.Run.Governance
+  ( runGovernanceMIRCertificatePayStakeAddrs
+  , runGovernanceMIRCertificateTransfer
+  ) where
+
+
+import           Cardano.Api
+import qualified Cardano.Api.Ledger as Ledger
+import           Cardano.Api.Shelley
+
+import           Cardano.CLI.Commands.Governance
+import           Cardano.CLI.Types.Legacy
+import qualified Cardano.Ledger.Shelley.TxBody as Shelley
+
+import           Control.Monad
+import           Control.Monad.Trans.Except (ExceptT)
+import           Control.Monad.Trans.Except.Extra
+import qualified Data.Map.Strict as Map
+
+runGovernanceMIRCertificatePayStakeAddrs
+  :: ShelleyToBabbageEra era
+  -> Shelley.MIRPot
+  -> [StakeAddress] -- ^ Stake addresses
+  -> [Lovelace]     -- ^ Corresponding reward amounts (same length)
+  -> File () Out
+  -> ExceptT GovernanceCmdError IO ()
+runGovernanceMIRCertificatePayStakeAddrs w mirPot sAddrs rwdAmts oFp = do
+  unless (length sAddrs == length rwdAmts) $
+    left $ GovernanceCmdMIRCertificateKeyRewardMistmach
+              (unFile oFp) (length sAddrs) (length rwdAmts)
+
+  let sCreds  = map stakeAddressCredential sAddrs
+      mirTarget = Ledger.StakeAddressesMIR
+                    $ Map.fromList [ (toShelleyStakeCredential scred, Ledger.toDeltaCoin (toShelleyLovelace rwdAmt))
+                                    | (scred, rwdAmt) <- zip sCreds rwdAmts
+                                    ]
+  let mirCert = makeMIRCertificate $ MirCertificateRequirements w mirPot $ shelleyToBabbageEraConstraints w mirTarget
+
+  firstExceptT GovernanceCmdTextEnvWriteError
+    . newExceptT
+    $ shelleyBasedEraConstraints (shelleyToBabbageEraToShelleyBasedEra w)
+    $ writeLazyByteStringFile oFp
+    $ textEnvelopeToJSON (Just mirCertDesc) mirCert
+  where
+    mirCertDesc :: TextEnvelopeDescr
+    mirCertDesc = "Move Instantaneous Rewards Certificate"
+
+runGovernanceMIRCertificateTransfer
+  :: ShelleyToBabbageEra era
+  -> Lovelace
+  -> File () Out
+  -> TransferDirection
+  -> ExceptT GovernanceCmdError IO ()
+runGovernanceMIRCertificateTransfer w ll oFp direction = do
+  let mirTarget = Ledger.SendToOppositePotMIR (toShelleyLovelace ll)
+
+  let mirCert =
+        makeMIRCertificate $
+          case direction of
+            TransferToReserves -> MirCertificateRequirements w Ledger.TreasuryMIR mirTarget
+            TransferToTreasury -> MirCertificateRequirements w Ledger.ReservesMIR mirTarget
+
+  firstExceptT GovernanceCmdTextEnvWriteError
+    . newExceptT
+    $ shelleyBasedEraConstraints (shelleyToBabbageEraToShelleyBasedEra w)
+    $ writeLazyByteStringFile oFp
+    $ textEnvelopeToJSON (Just $ mirCertDesc direction) mirCert
+ where
+  mirCertDesc :: TransferDirection -> TextEnvelopeDescr
+  mirCertDesc TransferToTreasury = "MIR Certificate Send To Treasury"
+  mirCertDesc TransferToReserves = "MIR Certificate Send To Reserves"

--- a/cardano-cli/src/Cardano/CLI/Options.hs
+++ b/cardano-cli/src/Cardano/CLI/Options.hs
@@ -8,7 +8,7 @@ module Cardano.CLI.Options
   , pref
   ) where
 
-import           Cardano.Api (CardanoEra (..))
+import           Cardano.Api (CardanoEra (..), ShelleyBasedEra (..))
 
 import           Cardano.CLI.Byron.Parsers (backwardsCompatibilityCommands, parseByronCommands)
 import           Cardano.CLI.Commands.EraBased
@@ -83,7 +83,7 @@ parseLegacy envCli =
 
 parseTopLevelLatest :: EnvCli -> Parser ClientCommand
 parseTopLevelLatest envCli =
-  AnyEraCommand . AnyEraCommandOf BabbageEra <$> pEraBasedCommand envCli BabbageEra
+  AnyEraCommand . AnyEraCommandOf ShelleyBasedEraBabbage <$> pEraBasedCommand envCli BabbageEra
 
 -- | Parse Legacy commands at the top level of the CLI.
 parseTopLevelLegacy :: EnvCli -> Parser ClientCommand

--- a/cardano-cli/src/Cardano/CLI/Run/EraBased.hs
+++ b/cardano-cli/src/Cardano/CLI/Run/EraBased.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
 
 module Cardano.CLI.Run.EraBased
@@ -10,10 +11,12 @@ module Cardano.CLI.Run.EraBased
   ) where
 
 import           Cardano.Api
+import           Cardano.Api.Shelley
 
 import           Cardano.CLI.Commands.EraBased
 import           Cardano.CLI.EraBased.Certificate
 import           Cardano.CLI.EraBased.Options.Governance
+import           Cardano.CLI.EraBased.Run.Governance
 
 import           Control.Monad.Trans.Except
 import           Control.Monad.Trans.Except.Extra (firstExceptT)
@@ -26,23 +29,35 @@ renderAnyEraCmdError :: AnyEraCmdError -> Text
 renderAnyEraCmdError = \case
   AnyEraCmdGenericError () -> "Generic any era command error"
 
-runAnyEraCommand :: AnyEraCommand -> ExceptT AnyEraCmdError IO ()
+runAnyEraCommand :: ()
+  => AnyEraCommand
+  -> ExceptT AnyEraCmdError IO ()
 runAnyEraCommand = \case
-  AnyEraCommandOf _ cmd -> firstExceptT AnyEraCmdGenericError $ runEraBasedCommand cmd
+  AnyEraCommandOf sbe cmd ->
+    firstExceptT AnyEraCmdGenericError $ obtainEraCryptoConstraints sbe $ runEraBasedCommand cmd
 
-runEraBasedCommand :: EraBasedCommand era -> ExceptT () IO ()
+runEraBasedCommand :: ()
+  => EraBasedCommand era -> ExceptT () IO ()
 runEraBasedCommand = \case
   EraBasedGovernanceCmd cmd -> runEraBasedGovernanceCmd cmd
 
-runEraBasedGovernanceCmd :: EraBasedGovernanceCmd era -> ExceptT () IO ()
+runEraBasedGovernanceCmd :: ()
+  => EraBasedGovernanceCmd era
+  -> ExceptT () IO ()
 runEraBasedGovernanceCmd = \case
   EraBasedGovernancePreConwayCmd w ->
     runEraBasedGovernancePreConwayCmd w
   EraBasedGovernancePostConwayCmd w ->
     runEraBasedGovernancePostConwayCmd w
+  EraBasedGovernanceMIRPayStakeAddressesCertificate w mirpot vKeys rewards out ->
+    firstExceptT (const ()) -- TODO fix error handling
+      $ runGovernanceMIRCertificatePayStakeAddrs w mirpot vKeys rewards out
+  EraBasedGovernanceMIRTransfer w ll oFp direction ->
+    firstExceptT (const ()) -- TODO fix error handling
+      $ runGovernanceMIRCertificateTransfer w ll oFp direction
 
   EraBasedGovernanceDelegationCertificateCmd stakeIdentifier delegationTarget outFp ->
-    firstExceptT (const ())
+    firstExceptT (const ()) -- TODO fix error handling
       $ runGovernanceDelegrationCertificate stakeIdentifier delegationTarget outFp
 
 runEraBasedGovernancePreConwayCmd
@@ -54,5 +69,3 @@ runEraBasedGovernancePostConwayCmd
   :: ConwayEraOnwards era
   -> ExceptT () IO ()
 runEraBasedGovernancePostConwayCmd _w = pure ()
-
-

--- a/cardano-cli/src/Cardano/CLI/Run/EraBased.hs
+++ b/cardano-cli/src/Cardano/CLI/Run/EraBased.hs
@@ -41,10 +41,9 @@ runEraBasedGovernanceCmd = \case
   EraBasedGovernancePostConwayCmd w ->
     runEraBasedGovernancePostConwayCmd w
 
-  EraBasedGovernanceDelegationCertificateCmd w ->
+  EraBasedGovernanceDelegationCertificateCmd stakeIdentifier delegationTarget outFp ->
     firstExceptT (const ())
-      $ runAnyDelegationTarget w
-        (error "TODO: Propagate output filepath via AnyDelegateTarget")
+      $ runAnyDelegationTarget stakeIdentifier delegationTarget outFp
 
 
 runEraBasedGovernancePreConwayCmd

--- a/cardano-cli/src/Cardano/CLI/Run/EraBased.hs
+++ b/cardano-cli/src/Cardano/CLI/Run/EraBased.hs
@@ -43,8 +43,7 @@ runEraBasedGovernanceCmd = \case
 
   EraBasedGovernanceDelegationCertificateCmd stakeIdentifier delegationTarget outFp ->
     firstExceptT (const ())
-      $ runAnyDelegationTarget stakeIdentifier delegationTarget outFp
-
+      $ runGovernanceDelegrationCertificate stakeIdentifier delegationTarget outFp
 
 runEraBasedGovernancePreConwayCmd
   :: ShelleyToBabbageEra era

--- a/cardano-cli/src/Cardano/CLI/Types/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Common.hs
@@ -1,0 +1,21 @@
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE StandaloneDeriving #-}
+
+module Cardano.CLI.Types.Common
+  ( AnyShelleyToBabbageEra(..)
+  , TransferDirection(..)
+  ) where
+
+import           Cardano.Api
+
+-- | Determines the direction in which the MIR certificate will transfer ADA.
+data TransferDirection =
+    TransferToReserves
+  | TransferToTreasury
+  deriving Show
+
+-- TODO Use the one from cardano-api
+data AnyShelleyToBabbageEra where
+  AnyShelleyToBabbageEra :: ShelleyToBabbageEra era -> AnyShelleyToBabbageEra
+
+deriving instance Show AnyShelleyToBabbageEra

--- a/cardano-cli/src/Cardano/CLI/Types/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Key.hs
@@ -128,13 +128,11 @@ data StakeIdentifier
 data AnyDelegationTarget where
   ShelleyToBabbageDelegTarget
     :: ShelleyToBabbageEra era
-    -> StakeIdentifier
     -> VerificationKeyOrHashOrFile StakePoolKey -- ^ Stake pool target
     -> AnyDelegationTarget
 
   ConwayOnwardDelegTarget
     :: ConwayEraOnwards era
-    -> StakeIdentifier
     -> StakeTarget era
     -> AnyDelegationTarget
 

--- a/cardano-cli/src/Cardano/CLI/Types/Legacy.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Legacy.hs
@@ -51,6 +51,7 @@ import           Cardano.Api (AddressAny, AnyScriptLanguage, EpochNo, ExecutionU
                    WitCtxStake, WitCtxTxIn)
 
 import qualified Cardano.Chain.Slotting as Byron
+import           Cardano.CLI.Types.Common
 import qualified Cardano.Ledger.Crypto as Crypto
 import           Cardano.Ledger.Shelley.TxBody (PoolParams (..))
 
@@ -297,10 +298,6 @@ instance ToJSON SlotsTillKesKeyExpiry where
 
 instance FromJSON SlotsTillKesKeyExpiry where
   parseJSON v = SlotsTillKesKeyExpiry <$> parseJSON v
-
--- | Determines the direction in which the MIR certificate will transfer ADA.
-data TransferDirection = TransferToReserves | TransferToTreasury
-                         deriving Show
 
 -- | A TxOut value that is the superset of possibilities for any era: any
 -- address type and allowing multi-asset values. This is used as the type for

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Certificates/MIR.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Certificates/MIR.hs
@@ -43,8 +43,7 @@ golden_shelleyMIRCertificate = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir
   let testAddr = "stake1u9j6axhcpd0exvrthn5dqzqt54g85akqvkn4uqmccm70qsc5hpv9w"
   -- Create MIR certificate
   void $ execCardanoCLI
-    [ "legacy", "governance", "create-mir-certificate"
-    , "--babbage-era"
+    [ "babbage", "governance", "create-mir-certificate"
     , "--reserves" --TODO: Should also do "--reserves"
     , "--stake-address", testAddr
     , "--reward", "1000"

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -19,7 +19,10 @@ Usage: cardano-cli shelley governance
 
   Shelley era commands
 
-Usage: cardano-cli shelley governance delegation-certificate
+Usage: cardano-cli shelley governance 
+                                        ( delegation-certificate
+                                        | create-mir-certificate
+                                        )
 
   Era-based governance commands
 
@@ -33,14 +36,54 @@ Usage: cardano-cli shelley governance delegation-certificate
                                                                | --cold-verification-key-file FILE
                                                                | --stake-pool-id STAKE_POOL_ID
                                                                )
+                                                               --out-file FILE
 
   Post conway era governance command
+
+Usage: cardano-cli shelley governance create-mir-certificate 
+                                                               ( ( --reserves
+                                                                 | --treasury
+                                                                 )
+                                                                 (--stake-address ADDRESS)
+                                                                 (--reward LOVELACE)
+                                                                 --out-file FILE
+                                                               | stake-addresses
+                                                               | transfer-to-treasury
+                                                               | transfer-to-rewards
+                                                               )
+
+  Create an MIR (Move Instantaneous Rewards) certificate
+
+Usage: cardano-cli shelley governance create-mir-certificate stake-addresses 
+                                                                               ( --reserves
+                                                                               | --treasury
+                                                                               )
+                                                                               (--stake-address ADDRESS)
+                                                                               (--reward LOVELACE)
+                                                                               --out-file FILE
+
+  Create an MIR certificate to pay stake addresses
+
+Usage: cardano-cli shelley governance create-mir-certificate transfer-to-treasury --transfer LOVELACE
+                                                                                    --out-file FILE
+
+  Create an MIR certificate to transfer from the reserves pot to the treasury
+  pot
+
+Usage: cardano-cli shelley governance create-mir-certificate transfer-to-rewards --transfer LOVELACE
+                                                                                   --out-file FILE
+
+  Create an MIR certificate to transfer from the treasury pot to the reserves
+  pot
 
 Usage: cardano-cli allegra governance
 
   Allegra era commands
 
-Usage: cardano-cli allegra governance delegation-certificate
+Usage: cardano-cli allegra governance 
+                                        ( delegation-certificate
+                                        | create-mir-certificate
+                                        )
 
   Era-based governance commands
 
@@ -54,14 +97,54 @@ Usage: cardano-cli allegra governance delegation-certificate
                                                                | --cold-verification-key-file FILE
                                                                | --stake-pool-id STAKE_POOL_ID
                                                                )
+                                                               --out-file FILE
 
   Post conway era governance command
+
+Usage: cardano-cli allegra governance create-mir-certificate 
+                                                               ( ( --reserves
+                                                                 | --treasury
+                                                                 )
+                                                                 (--stake-address ADDRESS)
+                                                                 (--reward LOVELACE)
+                                                                 --out-file FILE
+                                                               | stake-addresses
+                                                               | transfer-to-treasury
+                                                               | transfer-to-rewards
+                                                               )
+
+  Create an MIR (Move Instantaneous Rewards) certificate
+
+Usage: cardano-cli allegra governance create-mir-certificate stake-addresses 
+                                                                               ( --reserves
+                                                                               | --treasury
+                                                                               )
+                                                                               (--stake-address ADDRESS)
+                                                                               (--reward LOVELACE)
+                                                                               --out-file FILE
+
+  Create an MIR certificate to pay stake addresses
+
+Usage: cardano-cli allegra governance create-mir-certificate transfer-to-treasury --transfer LOVELACE
+                                                                                    --out-file FILE
+
+  Create an MIR certificate to transfer from the reserves pot to the treasury
+  pot
+
+Usage: cardano-cli allegra governance create-mir-certificate transfer-to-rewards --transfer LOVELACE
+                                                                                   --out-file FILE
+
+  Create an MIR certificate to transfer from the treasury pot to the reserves
+  pot
 
 Usage: cardano-cli mary governance
 
   Mary era commands
 
-Usage: cardano-cli mary governance delegation-certificate
+Usage: cardano-cli mary governance 
+                                     ( delegation-certificate
+                                     | create-mir-certificate
+                                     )
 
   Era-based governance commands
 
@@ -75,14 +158,54 @@ Usage: cardano-cli mary governance delegation-certificate
                                                             | --cold-verification-key-file FILE
                                                             | --stake-pool-id STAKE_POOL_ID
                                                             )
+                                                            --out-file FILE
 
   Post conway era governance command
+
+Usage: cardano-cli mary governance create-mir-certificate 
+                                                            ( ( --reserves
+                                                              | --treasury
+                                                              )
+                                                              (--stake-address ADDRESS)
+                                                              (--reward LOVELACE)
+                                                              --out-file FILE
+                                                            | stake-addresses
+                                                            | transfer-to-treasury
+                                                            | transfer-to-rewards
+                                                            )
+
+  Create an MIR (Move Instantaneous Rewards) certificate
+
+Usage: cardano-cli mary governance create-mir-certificate stake-addresses 
+                                                                            ( --reserves
+                                                                            | --treasury
+                                                                            )
+                                                                            (--stake-address ADDRESS)
+                                                                            (--reward LOVELACE)
+                                                                            --out-file FILE
+
+  Create an MIR certificate to pay stake addresses
+
+Usage: cardano-cli mary governance create-mir-certificate transfer-to-treasury --transfer LOVELACE
+                                                                                 --out-file FILE
+
+  Create an MIR certificate to transfer from the reserves pot to the treasury
+  pot
+
+Usage: cardano-cli mary governance create-mir-certificate transfer-to-rewards --transfer LOVELACE
+                                                                                --out-file FILE
+
+  Create an MIR certificate to transfer from the treasury pot to the reserves
+  pot
 
 Usage: cardano-cli alonzo governance
 
   Alonzo era commands
 
-Usage: cardano-cli alonzo governance delegation-certificate
+Usage: cardano-cli alonzo governance 
+                                       ( delegation-certificate
+                                       | create-mir-certificate
+                                       )
 
   Era-based governance commands
 
@@ -96,14 +219,54 @@ Usage: cardano-cli alonzo governance delegation-certificate
                                                               | --cold-verification-key-file FILE
                                                               | --stake-pool-id STAKE_POOL_ID
                                                               )
+                                                              --out-file FILE
 
   Post conway era governance command
+
+Usage: cardano-cli alonzo governance create-mir-certificate 
+                                                              ( ( --reserves
+                                                                | --treasury
+                                                                )
+                                                                (--stake-address ADDRESS)
+                                                                (--reward LOVELACE)
+                                                                --out-file FILE
+                                                              | stake-addresses
+                                                              | transfer-to-treasury
+                                                              | transfer-to-rewards
+                                                              )
+
+  Create an MIR (Move Instantaneous Rewards) certificate
+
+Usage: cardano-cli alonzo governance create-mir-certificate stake-addresses 
+                                                                              ( --reserves
+                                                                              | --treasury
+                                                                              )
+                                                                              (--stake-address ADDRESS)
+                                                                              (--reward LOVELACE)
+                                                                              --out-file FILE
+
+  Create an MIR certificate to pay stake addresses
+
+Usage: cardano-cli alonzo governance create-mir-certificate transfer-to-treasury --transfer LOVELACE
+                                                                                   --out-file FILE
+
+  Create an MIR certificate to transfer from the reserves pot to the treasury
+  pot
+
+Usage: cardano-cli alonzo governance create-mir-certificate transfer-to-rewards --transfer LOVELACE
+                                                                                  --out-file FILE
+
+  Create an MIR certificate to transfer from the treasury pot to the reserves
+  pot
 
 Usage: cardano-cli babbage governance
 
   Babbage era commands
 
-Usage: cardano-cli babbage governance delegation-certificate
+Usage: cardano-cli babbage governance 
+                                        ( delegation-certificate
+                                        | create-mir-certificate
+                                        )
 
   Era-based governance commands
 
@@ -117,8 +280,45 @@ Usage: cardano-cli babbage governance delegation-certificate
                                                                | --cold-verification-key-file FILE
                                                                | --stake-pool-id STAKE_POOL_ID
                                                                )
+                                                               --out-file FILE
 
   Post conway era governance command
+
+Usage: cardano-cli babbage governance create-mir-certificate 
+                                                               ( ( --reserves
+                                                                 | --treasury
+                                                                 )
+                                                                 (--stake-address ADDRESS)
+                                                                 (--reward LOVELACE)
+                                                                 --out-file FILE
+                                                               | stake-addresses
+                                                               | transfer-to-treasury
+                                                               | transfer-to-rewards
+                                                               )
+
+  Create an MIR (Move Instantaneous Rewards) certificate
+
+Usage: cardano-cli babbage governance create-mir-certificate stake-addresses 
+                                                                               ( --reserves
+                                                                               | --treasury
+                                                                               )
+                                                                               (--stake-address ADDRESS)
+                                                                               (--reward LOVELACE)
+                                                                               --out-file FILE
+
+  Create an MIR certificate to pay stake addresses
+
+Usage: cardano-cli babbage governance create-mir-certificate transfer-to-treasury --transfer LOVELACE
+                                                                                    --out-file FILE
+
+  Create an MIR certificate to transfer from the reserves pot to the treasury
+  pot
+
+Usage: cardano-cli babbage governance create-mir-certificate transfer-to-rewards --transfer LOVELACE
+                                                                                   --out-file FILE
+
+  Create an MIR certificate to transfer from the treasury pot to the reserves
+  pot
 
 Usage: cardano-cli conway governance
 
@@ -139,6 +339,7 @@ Usage: cardano-cli conway governance delegation-certificate
                                                               | --stake-pool-id STAKE_POOL_ID
                                                               | --dummy-drep-option ARG
                                                               )
+                                                              --out-file FILE
 
   Post conway era governance command
 
@@ -146,7 +347,10 @@ Usage: cardano-cli latest governance
 
   Latest era commands (Babbage)
 
-Usage: cardano-cli latest governance delegation-certificate
+Usage: cardano-cli latest governance 
+                                       ( delegation-certificate
+                                       | create-mir-certificate
+                                       )
 
   Era-based governance commands
 
@@ -160,8 +364,45 @@ Usage: cardano-cli latest governance delegation-certificate
                                                               | --cold-verification-key-file FILE
                                                               | --stake-pool-id STAKE_POOL_ID
                                                               )
+                                                              --out-file FILE
 
   Post conway era governance command
+
+Usage: cardano-cli latest governance create-mir-certificate 
+                                                              ( ( --reserves
+                                                                | --treasury
+                                                                )
+                                                                (--stake-address ADDRESS)
+                                                                (--reward LOVELACE)
+                                                                --out-file FILE
+                                                              | stake-addresses
+                                                              | transfer-to-treasury
+                                                              | transfer-to-rewards
+                                                              )
+
+  Create an MIR (Move Instantaneous Rewards) certificate
+
+Usage: cardano-cli latest governance create-mir-certificate stake-addresses 
+                                                                              ( --reserves
+                                                                              | --treasury
+                                                                              )
+                                                                              (--stake-address ADDRESS)
+                                                                              (--reward LOVELACE)
+                                                                              --out-file FILE
+
+  Create an MIR certificate to pay stake addresses
+
+Usage: cardano-cli latest governance create-mir-certificate transfer-to-treasury --transfer LOVELACE
+                                                                                   --out-file FILE
+
+  Create an MIR certificate to transfer from the reserves pot to the treasury
+  pot
+
+Usage: cardano-cli latest governance create-mir-certificate transfer-to-rewards --transfer LOVELACE
+                                                                                  --out-file FILE
+
+  Create an MIR certificate to transfer from the treasury pot to the reserves
+  pot
 
 Usage: cardano-cli experimental governance
 
@@ -182,6 +423,7 @@ Usage: cardano-cli experimental governance delegation-certificate
                                                                     | --stake-pool-id STAKE_POOL_ID
                                                                     | --dummy-drep-option ARG
                                                                     )
+                                                                    --out-file FILE
 
   Post conway era governance command
 
@@ -217,7 +459,6 @@ Usage: cardano-cli legacy governance create-mir-certificate
                                                                 | --mary-era
                                                                 | --alonzo-era
                                                                 | --babbage-era
-                                                                | --conway-era
                                                                 ]
                                                                 ( --reserves
                                                                 | --treasury
@@ -238,7 +479,6 @@ Usage: cardano-cli legacy governance create-mir-certificate stake-addresses
                                                                               | --mary-era
                                                                               | --alonzo-era
                                                                               | --babbage-era
-                                                                              | --conway-era
                                                                               ]
                                                                               ( --reserves
                                                                               | --treasury
@@ -255,7 +495,6 @@ Usage: cardano-cli legacy governance create-mir-certificate transfer-to-treasury
                                                                                    | --mary-era
                                                                                    | --alonzo-era
                                                                                    | --babbage-era
-                                                                                   | --conway-era
                                                                                    ]
                                                                                    --transfer LOVELACE
                                                                                    --out-file FILE
@@ -269,7 +508,6 @@ Usage: cardano-cli legacy governance create-mir-certificate transfer-to-rewards
                                                                                   | --mary-era
                                                                                   | --alonzo-era
                                                                                   | --babbage-era
-                                                                                  | --conway-era
                                                                                   ]
                                                                                   --transfer LOVELACE
                                                                                   --out-file FILE
@@ -1550,7 +1788,7 @@ Usage: cardano-cli legacy address info --address ADDRESS [--out-file FILE]
 
   Print information about an address.
 
-Usage: cardano-cli governance delegation-certificate
+Usage: cardano-cli governance (delegation-certificate | create-mir-certificate)
 
   Era-based governance commands
 
@@ -1564,8 +1802,45 @@ Usage: cardano-cli governance delegation-certificate
                                                        | --cold-verification-key-file FILE
                                                        | --stake-pool-id STAKE_POOL_ID
                                                        )
+                                                       --out-file FILE
 
   Post conway era governance command
+
+Usage: cardano-cli governance create-mir-certificate 
+                                                       ( ( --reserves
+                                                         | --treasury
+                                                         )
+                                                         (--stake-address ADDRESS)
+                                                         (--reward LOVELACE)
+                                                         --out-file FILE
+                                                       | stake-addresses
+                                                       | transfer-to-treasury
+                                                       | transfer-to-rewards
+                                                       )
+
+  Create an MIR (Move Instantaneous Rewards) certificate
+
+Usage: cardano-cli governance create-mir-certificate stake-addresses 
+                                                                       ( --reserves
+                                                                       | --treasury
+                                                                       )
+                                                                       (--stake-address ADDRESS)
+                                                                       (--reward LOVELACE)
+                                                                       --out-file FILE
+
+  Create an MIR certificate to pay stake addresses
+
+Usage: cardano-cli governance create-mir-certificate transfer-to-treasury --transfer LOVELACE
+                                                                            --out-file FILE
+
+  Create an MIR certificate to transfer from the reserves pot to the treasury
+  pot
+
+Usage: cardano-cli governance create-mir-certificate transfer-to-rewards --transfer LOVELACE
+                                                                           --out-file FILE
+
+  Create an MIR certificate to transfer from the treasury pot to the reserves
+  pot
 
 Usage: cardano-cli text-view decode-cbor
 
@@ -1595,7 +1870,6 @@ Usage: cardano-cli governance create-mir-certificate
                                                          | --mary-era
                                                          | --alonzo-era
                                                          | --babbage-era
-                                                         | --conway-era
                                                          ]
                                                          ( --reserves
                                                          | --treasury
@@ -1616,7 +1890,6 @@ Usage: cardano-cli governance create-mir-certificate stake-addresses
                                                                        | --mary-era
                                                                        | --alonzo-era
                                                                        | --babbage-era
-                                                                       | --conway-era
                                                                        ]
                                                                        ( --reserves
                                                                        | --treasury
@@ -1633,7 +1906,6 @@ Usage: cardano-cli governance create-mir-certificate transfer-to-treasury
                                                                             | --mary-era
                                                                             | --alonzo-era
                                                                             | --babbage-era
-                                                                            | --conway-era
                                                                             ]
                                                                             --transfer LOVELACE
                                                                             --out-file FILE
@@ -1647,7 +1919,6 @@ Usage: cardano-cli governance create-mir-certificate transfer-to-rewards
                                                                            | --mary-era
                                                                            | --alonzo-era
                                                                            | --babbage-era
-                                                                           | --conway-era
                                                                            ]
                                                                            --transfer LOVELACE
                                                                            --out-file FILE

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_governance.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_governance.cli
@@ -1,4 +1,7 @@
-Usage: cardano-cli allegra governance delegation-certificate
+Usage: cardano-cli allegra governance 
+                                        ( delegation-certificate
+                                        | create-mir-certificate
+                                        )
 
   Era-based governance commands
 
@@ -7,3 +10,5 @@ Available options:
 
 Available commands:
   delegation-certificate   Post conway era governance command
+  create-mir-certificate   Create an MIR (Move Instantaneous Rewards)
+                           certificate

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_governance_create-mir-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_governance_create-mir-certificate.cli
@@ -1,0 +1,28 @@
+Usage: cardano-cli allegra governance create-mir-certificate 
+                                                               ( ( --reserves
+                                                                 | --treasury
+                                                                 )
+                                                                 (--stake-address ADDRESS)
+                                                                 (--reward LOVELACE)
+                                                                 --out-file FILE
+                                                               | stake-addresses
+                                                               | transfer-to-treasury
+                                                               | transfer-to-rewards
+                                                               )
+
+  Create an MIR (Move Instantaneous Rewards) certificate
+
+Available options:
+  --reserves               Use the reserves pot.
+  --treasury               Use the treasury pot.
+  --stake-address ADDRESS  Target stake address (bech32 format).
+  --reward LOVELACE        The reward for the relevant reward account.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text
+
+Available commands:
+  stake-addresses          Create an MIR certificate to pay stake addresses
+  transfer-to-treasury     Create an MIR certificate to transfer from the
+                           reserves pot to the treasury pot
+  transfer-to-rewards      Create an MIR certificate to transfer from the
+                           treasury pot to the reserves pot

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_governance_create-mir-certificate_stake-addresses.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_governance_create-mir-certificate_stake-addresses.cli
@@ -1,0 +1,17 @@
+Usage: cardano-cli allegra governance create-mir-certificate stake-addresses 
+                                                                               ( --reserves
+                                                                               | --treasury
+                                                                               )
+                                                                               (--stake-address ADDRESS)
+                                                                               (--reward LOVELACE)
+                                                                               --out-file FILE
+
+  Create an MIR certificate to pay stake addresses
+
+Available options:
+  --reserves               Use the reserves pot.
+  --treasury               Use the treasury pot.
+  --stake-address ADDRESS  Target stake address (bech32 format).
+  --reward LOVELACE        The reward for the relevant reward account.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_governance_create-mir-certificate_transfer-to-rewards.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_governance_create-mir-certificate_transfer-to-rewards.cli
@@ -1,0 +1,10 @@
+Usage: cardano-cli allegra governance create-mir-certificate transfer-to-rewards --transfer LOVELACE
+                                                                                   --out-file FILE
+
+  Create an MIR certificate to transfer from the treasury pot to the reserves
+  pot
+
+Available options:
+  --transfer LOVELACE      The amount to transfer.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_governance_create-mir-certificate_transfer-to-treasury.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_governance_create-mir-certificate_transfer-to-treasury.cli
@@ -1,0 +1,10 @@
+Usage: cardano-cli allegra governance create-mir-certificate transfer-to-treasury --transfer LOVELACE
+                                                                                    --out-file FILE
+
+  Create an MIR certificate to transfer from the reserves pot to the treasury
+  pot
+
+Available options:
+  --transfer LOVELACE      The amount to transfer.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_governance_delegation-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_governance_delegation-certificate.cli
@@ -8,6 +8,7 @@ Usage: cardano-cli allegra governance delegation-certificate
                                                                | --cold-verification-key-file FILE
                                                                | --stake-pool-id STAKE_POOL_ID
                                                                )
+                                                               --out-file FILE
 
   Post conway era governance command
 
@@ -26,4 +27,5 @@ Available options:
                            Stake pool ID/verification key hash (either
                            Bech32-encoded or hex-encoded). Zero or more
                            occurences of this option is allowed.
+  --out-file FILE          The output file.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_governance.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_governance.cli
@@ -1,4 +1,7 @@
-Usage: cardano-cli alonzo governance delegation-certificate
+Usage: cardano-cli alonzo governance 
+                                       ( delegation-certificate
+                                       | create-mir-certificate
+                                       )
 
   Era-based governance commands
 
@@ -7,3 +10,5 @@ Available options:
 
 Available commands:
   delegation-certificate   Post conway era governance command
+  create-mir-certificate   Create an MIR (Move Instantaneous Rewards)
+                           certificate

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_governance_create-mir-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_governance_create-mir-certificate.cli
@@ -1,0 +1,28 @@
+Usage: cardano-cli alonzo governance create-mir-certificate 
+                                                              ( ( --reserves
+                                                                | --treasury
+                                                                )
+                                                                (--stake-address ADDRESS)
+                                                                (--reward LOVELACE)
+                                                                --out-file FILE
+                                                              | stake-addresses
+                                                              | transfer-to-treasury
+                                                              | transfer-to-rewards
+                                                              )
+
+  Create an MIR (Move Instantaneous Rewards) certificate
+
+Available options:
+  --reserves               Use the reserves pot.
+  --treasury               Use the treasury pot.
+  --stake-address ADDRESS  Target stake address (bech32 format).
+  --reward LOVELACE        The reward for the relevant reward account.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text
+
+Available commands:
+  stake-addresses          Create an MIR certificate to pay stake addresses
+  transfer-to-treasury     Create an MIR certificate to transfer from the
+                           reserves pot to the treasury pot
+  transfer-to-rewards      Create an MIR certificate to transfer from the
+                           treasury pot to the reserves pot

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_governance_create-mir-certificate_stake-addresses.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_governance_create-mir-certificate_stake-addresses.cli
@@ -1,0 +1,17 @@
+Usage: cardano-cli alonzo governance create-mir-certificate stake-addresses 
+                                                                              ( --reserves
+                                                                              | --treasury
+                                                                              )
+                                                                              (--stake-address ADDRESS)
+                                                                              (--reward LOVELACE)
+                                                                              --out-file FILE
+
+  Create an MIR certificate to pay stake addresses
+
+Available options:
+  --reserves               Use the reserves pot.
+  --treasury               Use the treasury pot.
+  --stake-address ADDRESS  Target stake address (bech32 format).
+  --reward LOVELACE        The reward for the relevant reward account.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_governance_create-mir-certificate_transfer-to-rewards.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_governance_create-mir-certificate_transfer-to-rewards.cli
@@ -1,0 +1,10 @@
+Usage: cardano-cli alonzo governance create-mir-certificate transfer-to-rewards --transfer LOVELACE
+                                                                                  --out-file FILE
+
+  Create an MIR certificate to transfer from the treasury pot to the reserves
+  pot
+
+Available options:
+  --transfer LOVELACE      The amount to transfer.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_governance_create-mir-certificate_transfer-to-treasury.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_governance_create-mir-certificate_transfer-to-treasury.cli
@@ -1,0 +1,10 @@
+Usage: cardano-cli alonzo governance create-mir-certificate transfer-to-treasury --transfer LOVELACE
+                                                                                   --out-file FILE
+
+  Create an MIR certificate to transfer from the reserves pot to the treasury
+  pot
+
+Available options:
+  --transfer LOVELACE      The amount to transfer.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_governance_delegation-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_governance_delegation-certificate.cli
@@ -8,6 +8,7 @@ Usage: cardano-cli alonzo governance delegation-certificate
                                                               | --cold-verification-key-file FILE
                                                               | --stake-pool-id STAKE_POOL_ID
                                                               )
+                                                              --out-file FILE
 
   Post conway era governance command
 
@@ -26,4 +27,5 @@ Available options:
                            Stake pool ID/verification key hash (either
                            Bech32-encoded or hex-encoded). Zero or more
                            occurences of this option is allowed.
+  --out-file FILE          The output file.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_governance.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_governance.cli
@@ -1,4 +1,7 @@
-Usage: cardano-cli babbage governance delegation-certificate
+Usage: cardano-cli babbage governance 
+                                        ( delegation-certificate
+                                        | create-mir-certificate
+                                        )
 
   Era-based governance commands
 
@@ -7,3 +10,5 @@ Available options:
 
 Available commands:
   delegation-certificate   Post conway era governance command
+  create-mir-certificate   Create an MIR (Move Instantaneous Rewards)
+                           certificate

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_governance_create-mir-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_governance_create-mir-certificate.cli
@@ -1,0 +1,28 @@
+Usage: cardano-cli babbage governance create-mir-certificate 
+                                                               ( ( --reserves
+                                                                 | --treasury
+                                                                 )
+                                                                 (--stake-address ADDRESS)
+                                                                 (--reward LOVELACE)
+                                                                 --out-file FILE
+                                                               | stake-addresses
+                                                               | transfer-to-treasury
+                                                               | transfer-to-rewards
+                                                               )
+
+  Create an MIR (Move Instantaneous Rewards) certificate
+
+Available options:
+  --reserves               Use the reserves pot.
+  --treasury               Use the treasury pot.
+  --stake-address ADDRESS  Target stake address (bech32 format).
+  --reward LOVELACE        The reward for the relevant reward account.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text
+
+Available commands:
+  stake-addresses          Create an MIR certificate to pay stake addresses
+  transfer-to-treasury     Create an MIR certificate to transfer from the
+                           reserves pot to the treasury pot
+  transfer-to-rewards      Create an MIR certificate to transfer from the
+                           treasury pot to the reserves pot

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_governance_create-mir-certificate_stake-addresses.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_governance_create-mir-certificate_stake-addresses.cli
@@ -1,0 +1,17 @@
+Usage: cardano-cli babbage governance create-mir-certificate stake-addresses 
+                                                                               ( --reserves
+                                                                               | --treasury
+                                                                               )
+                                                                               (--stake-address ADDRESS)
+                                                                               (--reward LOVELACE)
+                                                                               --out-file FILE
+
+  Create an MIR certificate to pay stake addresses
+
+Available options:
+  --reserves               Use the reserves pot.
+  --treasury               Use the treasury pot.
+  --stake-address ADDRESS  Target stake address (bech32 format).
+  --reward LOVELACE        The reward for the relevant reward account.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_governance_create-mir-certificate_transfer-to-rewards.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_governance_create-mir-certificate_transfer-to-rewards.cli
@@ -1,0 +1,10 @@
+Usage: cardano-cli babbage governance create-mir-certificate transfer-to-rewards --transfer LOVELACE
+                                                                                   --out-file FILE
+
+  Create an MIR certificate to transfer from the treasury pot to the reserves
+  pot
+
+Available options:
+  --transfer LOVELACE      The amount to transfer.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_governance_create-mir-certificate_transfer-to-treasury.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_governance_create-mir-certificate_transfer-to-treasury.cli
@@ -1,0 +1,10 @@
+Usage: cardano-cli babbage governance create-mir-certificate transfer-to-treasury --transfer LOVELACE
+                                                                                    --out-file FILE
+
+  Create an MIR certificate to transfer from the reserves pot to the treasury
+  pot
+
+Available options:
+  --transfer LOVELACE      The amount to transfer.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_governance_delegation-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_governance_delegation-certificate.cli
@@ -8,6 +8,7 @@ Usage: cardano-cli babbage governance delegation-certificate
                                                                | --cold-verification-key-file FILE
                                                                | --stake-pool-id STAKE_POOL_ID
                                                                )
+                                                               --out-file FILE
 
   Post conway era governance command
 
@@ -26,4 +27,5 @@ Available options:
                            Stake pool ID/verification key hash (either
                            Bech32-encoded or hex-encoded). Zero or more
                            occurences of this option is allowed.
+  --out-file FILE          The output file.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_delegation-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_delegation-certificate.cli
@@ -9,6 +9,7 @@ Usage: cardano-cli conway governance delegation-certificate
                                                               | --stake-pool-id STAKE_POOL_ID
                                                               | --dummy-drep-option ARG
                                                               )
+                                                              --out-file FILE
 
   Post conway era governance command
 
@@ -28,4 +29,5 @@ Available options:
                            Bech32-encoded or hex-encoded). Zero or more
                            occurences of this option is allowed.
   --dummy-drep-option ARG  Delegate voting stake to Drep
+  --out-file FILE          The output file.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/experimental_governance_delegation-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/experimental_governance_delegation-certificate.cli
@@ -9,6 +9,7 @@ Usage: cardano-cli experimental governance delegation-certificate
                                                                     | --stake-pool-id STAKE_POOL_ID
                                                                     | --dummy-drep-option ARG
                                                                     )
+                                                                    --out-file FILE
 
   Post conway era governance command
 
@@ -28,4 +29,5 @@ Available options:
                            Bech32-encoded or hex-encoded). Zero or more
                            occurences of this option is allowed.
   --dummy-drep-option ARG  Delegate voting stake to Drep
+  --out-file FILE          The output file.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/governance.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/governance.cli
@@ -1,4 +1,4 @@
-Usage: cardano-cli governance delegation-certificate
+Usage: cardano-cli governance (delegation-certificate | create-mir-certificate)
 
   Era-based governance commands
 
@@ -7,3 +7,5 @@ Available options:
 
 Available commands:
   delegation-certificate   Post conway era governance command
+  create-mir-certificate   Create an MIR (Move Instantaneous Rewards)
+                           certificate

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_action_create-action.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_action_create-action.cli
@@ -1,5 +1,5 @@
 Invalid argument `action'
 
-Usage: cardano-cli governance delegation-certificate
+Usage: cardano-cli governance (delegation-certificate | create-mir-certificate)
 
   Era-based governance commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_action_create-action_create-constitution.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_action_create-action_create-constitution.cli
@@ -1,5 +1,5 @@
 Invalid argument `action'
 
-Usage: cardano-cli governance delegation-certificate
+Usage: cardano-cli governance (delegation-certificate | create-mir-certificate)
 
   Era-based governance commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_answer-poll.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_answer-poll.cli
@@ -1,5 +1,5 @@
 Invalid argument `answer-poll'
 
-Usage: cardano-cli governance delegation-certificate
+Usage: cardano-cli governance (delegation-certificate | create-mir-certificate)
 
   Era-based governance commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_create-genesis-key-delegation-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_create-genesis-key-delegation-certificate.cli
@@ -1,5 +1,5 @@
 Invalid argument `create-genesis-key-delegation-certificate'
 
-Usage: cardano-cli governance delegation-certificate
+Usage: cardano-cli governance (delegation-certificate | create-mir-certificate)
 
   Era-based governance commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_create-mir-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_create-mir-certificate.cli
@@ -1,5 +1,28 @@
-Invalid argument `create-mir-certificate'
+Usage: cardano-cli governance create-mir-certificate 
+                                                       ( ( --reserves
+                                                         | --treasury
+                                                         )
+                                                         (--stake-address ADDRESS)
+                                                         (--reward LOVELACE)
+                                                         --out-file FILE
+                                                       | stake-addresses
+                                                       | transfer-to-treasury
+                                                       | transfer-to-rewards
+                                                       )
 
-Usage: cardano-cli governance delegation-certificate
+  Create an MIR (Move Instantaneous Rewards) certificate
 
-  Era-based governance commands
+Available options:
+  --reserves               Use the reserves pot.
+  --treasury               Use the treasury pot.
+  --stake-address ADDRESS  Target stake address (bech32 format).
+  --reward LOVELACE        The reward for the relevant reward account.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text
+
+Available commands:
+  stake-addresses          Create an MIR certificate to pay stake addresses
+  transfer-to-treasury     Create an MIR certificate to transfer from the
+                           reserves pot to the treasury pot
+  transfer-to-rewards      Create an MIR certificate to transfer from the
+                           treasury pot to the reserves pot

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_create-mir-certificate_stake-addresses.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_create-mir-certificate_stake-addresses.cli
@@ -1,5 +1,17 @@
-Invalid argument `create-mir-certificate'
+Usage: cardano-cli governance create-mir-certificate stake-addresses 
+                                                                       ( --reserves
+                                                                       | --treasury
+                                                                       )
+                                                                       (--stake-address ADDRESS)
+                                                                       (--reward LOVELACE)
+                                                                       --out-file FILE
 
-Usage: cardano-cli governance delegation-certificate
+  Create an MIR certificate to pay stake addresses
 
-  Era-based governance commands
+Available options:
+  --reserves               Use the reserves pot.
+  --treasury               Use the treasury pot.
+  --stake-address ADDRESS  Target stake address (bech32 format).
+  --reward LOVELACE        The reward for the relevant reward account.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_create-mir-certificate_transfer-to-rewards.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_create-mir-certificate_transfer-to-rewards.cli
@@ -1,5 +1,10 @@
-Invalid argument `create-mir-certificate'
+Usage: cardano-cli governance create-mir-certificate transfer-to-rewards --transfer LOVELACE
+                                                                           --out-file FILE
 
-Usage: cardano-cli governance delegation-certificate
+  Create an MIR certificate to transfer from the treasury pot to the reserves
+  pot
 
-  Era-based governance commands
+Available options:
+  --transfer LOVELACE      The amount to transfer.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_create-mir-certificate_transfer-to-treasury.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_create-mir-certificate_transfer-to-treasury.cli
@@ -1,5 +1,10 @@
-Invalid argument `create-mir-certificate'
+Usage: cardano-cli governance create-mir-certificate transfer-to-treasury --transfer LOVELACE
+                                                                            --out-file FILE
 
-Usage: cardano-cli governance delegation-certificate
+  Create an MIR certificate to transfer from the reserves pot to the treasury
+  pot
 
-  Era-based governance commands
+Available options:
+  --transfer LOVELACE      The amount to transfer.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_create-poll.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_create-poll.cli
@@ -1,5 +1,5 @@
 Invalid argument `create-poll'
 
-Usage: cardano-cli governance delegation-certificate
+Usage: cardano-cli governance (delegation-certificate | create-mir-certificate)
 
   Era-based governance commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_create-update-proposal.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_create-update-proposal.cli
@@ -1,5 +1,5 @@
 Invalid argument `create-update-proposal'
 
-Usage: cardano-cli governance delegation-certificate
+Usage: cardano-cli governance (delegation-certificate | create-mir-certificate)
 
   Era-based governance commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_delegation-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_delegation-certificate.cli
@@ -8,6 +8,7 @@ Usage: cardano-cli governance delegation-certificate
                                                        | --cold-verification-key-file FILE
                                                        | --stake-pool-id STAKE_POOL_ID
                                                        )
+                                                       --out-file FILE
 
   Post conway era governance command
 
@@ -26,4 +27,5 @@ Available options:
                            Stake pool ID/verification key hash (either
                            Bech32-encoded or hex-encoded). Zero or more
                            occurences of this option is allowed.
+  --out-file FILE          The output file.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_verify-poll.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_verify-poll.cli
@@ -1,5 +1,5 @@
 Invalid argument `verify-poll'
 
-Usage: cardano-cli governance delegation-certificate
+Usage: cardano-cli governance (delegation-certificate | create-mir-certificate)
 
   Era-based governance commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_vote_create-vote.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_vote_create-vote.cli
@@ -1,5 +1,5 @@
 Invalid argument `vote'
 
-Usage: cardano-cli governance delegation-certificate
+Usage: cardano-cli governance (delegation-certificate | create-mir-certificate)
 
   Era-based governance commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_governance.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_governance.cli
@@ -1,4 +1,7 @@
-Usage: cardano-cli latest governance delegation-certificate
+Usage: cardano-cli latest governance 
+                                       ( delegation-certificate
+                                       | create-mir-certificate
+                                       )
 
   Era-based governance commands
 
@@ -7,3 +10,5 @@ Available options:
 
 Available commands:
   delegation-certificate   Post conway era governance command
+  create-mir-certificate   Create an MIR (Move Instantaneous Rewards)
+                           certificate

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_governance_create-mir-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_governance_create-mir-certificate.cli
@@ -1,0 +1,28 @@
+Usage: cardano-cli latest governance create-mir-certificate 
+                                                              ( ( --reserves
+                                                                | --treasury
+                                                                )
+                                                                (--stake-address ADDRESS)
+                                                                (--reward LOVELACE)
+                                                                --out-file FILE
+                                                              | stake-addresses
+                                                              | transfer-to-treasury
+                                                              | transfer-to-rewards
+                                                              )
+
+  Create an MIR (Move Instantaneous Rewards) certificate
+
+Available options:
+  --reserves               Use the reserves pot.
+  --treasury               Use the treasury pot.
+  --stake-address ADDRESS  Target stake address (bech32 format).
+  --reward LOVELACE        The reward for the relevant reward account.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text
+
+Available commands:
+  stake-addresses          Create an MIR certificate to pay stake addresses
+  transfer-to-treasury     Create an MIR certificate to transfer from the
+                           reserves pot to the treasury pot
+  transfer-to-rewards      Create an MIR certificate to transfer from the
+                           treasury pot to the reserves pot

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_governance_create-mir-certificate_stake-addresses.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_governance_create-mir-certificate_stake-addresses.cli
@@ -1,0 +1,17 @@
+Usage: cardano-cli latest governance create-mir-certificate stake-addresses 
+                                                                              ( --reserves
+                                                                              | --treasury
+                                                                              )
+                                                                              (--stake-address ADDRESS)
+                                                                              (--reward LOVELACE)
+                                                                              --out-file FILE
+
+  Create an MIR certificate to pay stake addresses
+
+Available options:
+  --reserves               Use the reserves pot.
+  --treasury               Use the treasury pot.
+  --stake-address ADDRESS  Target stake address (bech32 format).
+  --reward LOVELACE        The reward for the relevant reward account.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_governance_create-mir-certificate_transfer-to-rewards.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_governance_create-mir-certificate_transfer-to-rewards.cli
@@ -1,0 +1,10 @@
+Usage: cardano-cli latest governance create-mir-certificate transfer-to-rewards --transfer LOVELACE
+                                                                                  --out-file FILE
+
+  Create an MIR certificate to transfer from the treasury pot to the reserves
+  pot
+
+Available options:
+  --transfer LOVELACE      The amount to transfer.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_governance_create-mir-certificate_transfer-to-treasury.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_governance_create-mir-certificate_transfer-to-treasury.cli
@@ -1,0 +1,10 @@
+Usage: cardano-cli latest governance create-mir-certificate transfer-to-treasury --transfer LOVELACE
+                                                                                   --out-file FILE
+
+  Create an MIR certificate to transfer from the reserves pot to the treasury
+  pot
+
+Available options:
+  --transfer LOVELACE      The amount to transfer.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_governance_delegation-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_governance_delegation-certificate.cli
@@ -8,6 +8,7 @@ Usage: cardano-cli latest governance delegation-certificate
                                                               | --cold-verification-key-file FILE
                                                               | --stake-pool-id STAKE_POOL_ID
                                                               )
+                                                              --out-file FILE
 
   Post conway era governance command
 
@@ -26,4 +27,5 @@ Available options:
                            Stake pool ID/verification key hash (either
                            Bech32-encoded or hex-encoded). Zero or more
                            occurences of this option is allowed.
+  --out-file FILE          The output file.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_governance_create-mir-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_governance_create-mir-certificate.cli
@@ -4,7 +4,6 @@ Usage: cardano-cli legacy governance create-mir-certificate
                                                                 | --mary-era
                                                                 | --alonzo-era
                                                                 | --babbage-era
-                                                                | --conway-era
                                                                 ]
                                                                 ( --reserves
                                                                 | --treasury
@@ -25,7 +24,6 @@ Available options:
   --mary-era               Specify the Mary era
   --alonzo-era             Specify the Alonzo era
   --babbage-era            Specify the Babbage era (default)
-  --conway-era             Specify the Conway era
   --reserves               Use the reserves pot.
   --treasury               Use the treasury pot.
   --stake-address ADDRESS  Target stake address (bech32 format).

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_governance_create-mir-certificate_stake-addresses.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_governance_create-mir-certificate_stake-addresses.cli
@@ -4,7 +4,6 @@ Usage: cardano-cli legacy governance create-mir-certificate stake-addresses
                                                                               | --mary-era
                                                                               | --alonzo-era
                                                                               | --babbage-era
-                                                                              | --conway-era
                                                                               ]
                                                                               ( --reserves
                                                                               | --treasury
@@ -21,7 +20,6 @@ Available options:
   --mary-era               Specify the Mary era
   --alonzo-era             Specify the Alonzo era
   --babbage-era            Specify the Babbage era (default)
-  --conway-era             Specify the Conway era
   --reserves               Use the reserves pot.
   --treasury               Use the treasury pot.
   --stake-address ADDRESS  Target stake address (bech32 format).

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_governance_create-mir-certificate_transfer-to-rewards.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_governance_create-mir-certificate_transfer-to-rewards.cli
@@ -4,7 +4,6 @@ Usage: cardano-cli legacy governance create-mir-certificate transfer-to-rewards
                                                                                   | --mary-era
                                                                                   | --alonzo-era
                                                                                   | --babbage-era
-                                                                                  | --conway-era
                                                                                   ]
                                                                                   --transfer LOVELACE
                                                                                   --out-file FILE
@@ -18,7 +17,6 @@ Available options:
   --mary-era               Specify the Mary era
   --alonzo-era             Specify the Alonzo era
   --babbage-era            Specify the Babbage era (default)
-  --conway-era             Specify the Conway era
   --transfer LOVELACE      The amount to transfer.
   --out-file FILE          The output file.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_governance_create-mir-certificate_transfer-to-treasury.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_governance_create-mir-certificate_transfer-to-treasury.cli
@@ -4,7 +4,6 @@ Usage: cardano-cli legacy governance create-mir-certificate transfer-to-treasury
                                                                                    | --mary-era
                                                                                    | --alonzo-era
                                                                                    | --babbage-era
-                                                                                   | --conway-era
                                                                                    ]
                                                                                    --transfer LOVELACE
                                                                                    --out-file FILE
@@ -18,7 +17,6 @@ Available options:
   --mary-era               Specify the Mary era
   --alonzo-era             Specify the Alonzo era
   --babbage-era            Specify the Babbage era (default)
-  --conway-era             Specify the Conway era
   --transfer LOVELACE      The amount to transfer.
   --out-file FILE          The output file.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_governance.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_governance.cli
@@ -1,4 +1,7 @@
-Usage: cardano-cli mary governance delegation-certificate
+Usage: cardano-cli mary governance 
+                                     ( delegation-certificate
+                                     | create-mir-certificate
+                                     )
 
   Era-based governance commands
 
@@ -7,3 +10,5 @@ Available options:
 
 Available commands:
   delegation-certificate   Post conway era governance command
+  create-mir-certificate   Create an MIR (Move Instantaneous Rewards)
+                           certificate

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_governance_create-mir-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_governance_create-mir-certificate.cli
@@ -1,0 +1,28 @@
+Usage: cardano-cli mary governance create-mir-certificate 
+                                                            ( ( --reserves
+                                                              | --treasury
+                                                              )
+                                                              (--stake-address ADDRESS)
+                                                              (--reward LOVELACE)
+                                                              --out-file FILE
+                                                            | stake-addresses
+                                                            | transfer-to-treasury
+                                                            | transfer-to-rewards
+                                                            )
+
+  Create an MIR (Move Instantaneous Rewards) certificate
+
+Available options:
+  --reserves               Use the reserves pot.
+  --treasury               Use the treasury pot.
+  --stake-address ADDRESS  Target stake address (bech32 format).
+  --reward LOVELACE        The reward for the relevant reward account.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text
+
+Available commands:
+  stake-addresses          Create an MIR certificate to pay stake addresses
+  transfer-to-treasury     Create an MIR certificate to transfer from the
+                           reserves pot to the treasury pot
+  transfer-to-rewards      Create an MIR certificate to transfer from the
+                           treasury pot to the reserves pot

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_governance_create-mir-certificate_stake-addresses.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_governance_create-mir-certificate_stake-addresses.cli
@@ -1,0 +1,17 @@
+Usage: cardano-cli mary governance create-mir-certificate stake-addresses 
+                                                                            ( --reserves
+                                                                            | --treasury
+                                                                            )
+                                                                            (--stake-address ADDRESS)
+                                                                            (--reward LOVELACE)
+                                                                            --out-file FILE
+
+  Create an MIR certificate to pay stake addresses
+
+Available options:
+  --reserves               Use the reserves pot.
+  --treasury               Use the treasury pot.
+  --stake-address ADDRESS  Target stake address (bech32 format).
+  --reward LOVELACE        The reward for the relevant reward account.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_governance_create-mir-certificate_transfer-to-rewards.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_governance_create-mir-certificate_transfer-to-rewards.cli
@@ -1,0 +1,10 @@
+Usage: cardano-cli mary governance create-mir-certificate transfer-to-rewards --transfer LOVELACE
+                                                                                --out-file FILE
+
+  Create an MIR certificate to transfer from the treasury pot to the reserves
+  pot
+
+Available options:
+  --transfer LOVELACE      The amount to transfer.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_governance_create-mir-certificate_transfer-to-treasury.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_governance_create-mir-certificate_transfer-to-treasury.cli
@@ -1,0 +1,10 @@
+Usage: cardano-cli mary governance create-mir-certificate transfer-to-treasury --transfer LOVELACE
+                                                                                 --out-file FILE
+
+  Create an MIR certificate to transfer from the reserves pot to the treasury
+  pot
+
+Available options:
+  --transfer LOVELACE      The amount to transfer.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_governance_delegation-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_governance_delegation-certificate.cli
@@ -8,6 +8,7 @@ Usage: cardano-cli mary governance delegation-certificate
                                                             | --cold-verification-key-file FILE
                                                             | --stake-pool-id STAKE_POOL_ID
                                                             )
+                                                            --out-file FILE
 
   Post conway era governance command
 
@@ -26,4 +27,5 @@ Available options:
                            Stake pool ID/verification key hash (either
                            Bech32-encoded or hex-encoded). Zero or more
                            occurences of this option is allowed.
+  --out-file FILE          The output file.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_governance.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_governance.cli
@@ -1,4 +1,7 @@
-Usage: cardano-cli shelley governance delegation-certificate
+Usage: cardano-cli shelley governance 
+                                        ( delegation-certificate
+                                        | create-mir-certificate
+                                        )
 
   Era-based governance commands
 
@@ -7,3 +10,5 @@ Available options:
 
 Available commands:
   delegation-certificate   Post conway era governance command
+  create-mir-certificate   Create an MIR (Move Instantaneous Rewards)
+                           certificate

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_governance_create-mir-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_governance_create-mir-certificate.cli
@@ -1,0 +1,28 @@
+Usage: cardano-cli shelley governance create-mir-certificate 
+                                                               ( ( --reserves
+                                                                 | --treasury
+                                                                 )
+                                                                 (--stake-address ADDRESS)
+                                                                 (--reward LOVELACE)
+                                                                 --out-file FILE
+                                                               | stake-addresses
+                                                               | transfer-to-treasury
+                                                               | transfer-to-rewards
+                                                               )
+
+  Create an MIR (Move Instantaneous Rewards) certificate
+
+Available options:
+  --reserves               Use the reserves pot.
+  --treasury               Use the treasury pot.
+  --stake-address ADDRESS  Target stake address (bech32 format).
+  --reward LOVELACE        The reward for the relevant reward account.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text
+
+Available commands:
+  stake-addresses          Create an MIR certificate to pay stake addresses
+  transfer-to-treasury     Create an MIR certificate to transfer from the
+                           reserves pot to the treasury pot
+  transfer-to-rewards      Create an MIR certificate to transfer from the
+                           treasury pot to the reserves pot

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_governance_create-mir-certificate_stake-addresses.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_governance_create-mir-certificate_stake-addresses.cli
@@ -1,0 +1,17 @@
+Usage: cardano-cli shelley governance create-mir-certificate stake-addresses 
+                                                                               ( --reserves
+                                                                               | --treasury
+                                                                               )
+                                                                               (--stake-address ADDRESS)
+                                                                               (--reward LOVELACE)
+                                                                               --out-file FILE
+
+  Create an MIR certificate to pay stake addresses
+
+Available options:
+  --reserves               Use the reserves pot.
+  --treasury               Use the treasury pot.
+  --stake-address ADDRESS  Target stake address (bech32 format).
+  --reward LOVELACE        The reward for the relevant reward account.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_governance_create-mir-certificate_transfer-to-rewards.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_governance_create-mir-certificate_transfer-to-rewards.cli
@@ -1,0 +1,10 @@
+Usage: cardano-cli shelley governance create-mir-certificate transfer-to-rewards --transfer LOVELACE
+                                                                                   --out-file FILE
+
+  Create an MIR certificate to transfer from the treasury pot to the reserves
+  pot
+
+Available options:
+  --transfer LOVELACE      The amount to transfer.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_governance_create-mir-certificate_transfer-to-treasury.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_governance_create-mir-certificate_transfer-to-treasury.cli
@@ -1,0 +1,10 @@
+Usage: cardano-cli shelley governance create-mir-certificate transfer-to-treasury --transfer LOVELACE
+                                                                                    --out-file FILE
+
+  Create an MIR certificate to transfer from the reserves pot to the treasury
+  pot
+
+Available options:
+  --transfer LOVELACE      The amount to transfer.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_governance_delegation-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_governance_delegation-certificate.cli
@@ -8,6 +8,7 @@ Usage: cardano-cli shelley governance delegation-certificate
                                                                | --cold-verification-key-file FILE
                                                                | --stake-pool-id STAKE_POOL_ID
                                                                )
+                                                               --out-file FILE
 
   Post conway era governance command
 
@@ -26,4 +27,5 @@ Available options:
                            Stake pool ID/verification key hash (either
                            Bech32-encoded or hex-encoded). Zero or more
                            occurences of this option is allowed.
+  --out-file FILE          The output file.
   -h,--help                Show this help text


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Share MIR certificates code between era-based and legacy CLI parsers
  compatibility: breaking
  type: feature
```

# Context


# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
