### PR TITLE
Add `gh`, `jq` and `yq-go`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -75,8 +75,7 @@
               haskell-language-server = "2.0.0.0";
             };
           # and from nixpkgs or other inputs
-          shell.nativeBuildInputs = with nixpkgs; [
-          ];
+          shell.nativeBuildInputs = with nixpkgs; [ gh jq yq-go ];
           # disable Hoogle until someone request it
           shell.withHoogle = false;
           # Skip cross compilers for the shell


### PR DESCRIPTION
# Changelog

```yaml
- description: Add `gh`, `jq` and `yq-go` to developer shell
  compatibility: no-api-changes
  type: maintenance
```

# Context

@newhoggy asked for these tools to be added to the project developer shell (`nix develop`):

- https://github.com/cli/cli
- https://github.com/jqlang/jq
- https://github.com/mikefarah/yq

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] The change log section in the PR description has been filled in
- [x] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] The version bounds in `.cabal` files are updated
- [x] CI passes. See note on CI.  The following CI checks are required:
  - [x] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [x] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [x] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [x] The changelog section in the PR is updated to describe the change
- [x] Self-reviewed the diff