### PR TITLE
Add rendering for `ConwayCertificate` in `Cardano.Cli.Json.Friendly`

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -19,6 +19,9 @@ index-state:
 packages:
   cardano-cli
 
+package cardano-cli
+  ghc-options: -Werror
+
 package cardano-api
   ghc-options: -Werror
 

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -124,10 +124,10 @@ library
                       , cardano-data >= 1.0
                       , cardano-git-rev
                       , cardano-ledger-alonzo >= 1.3.1.1
-                      , cardano-ledger-byron >= 1.0.0.2
                       , cardano-ledger-binary >= 1.0
-                      , cardano-ledger-core >= 1.2
+                      , cardano-ledger-byron >= 1.0.0.2
                       , cardano-ledger-conway >= 1.5
+                      , cardano-ledger-core >= 1.2
                       , cardano-ledger-shelley >=1.4.1.0
                       , cardano-ping ^>= 0.2.0.5
                       , cardano-prelude


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Add rendering for ConwayCertificate in Cardano.Cli.Json.Friendly
  # no-changes: the API has not changed
  # compatible: the API has changed but is non-breaking
  # breaking: the API has changed in a breaking way
  compatibility: no-api-changes
  # feature: the change implements a new feature in the API
  # bugfix: the change fixes a bug in the API
  # test: the change fixes modifies tests
  # maintenance: the change involves something other than the API
  # If more than one is applicable, it may be put into a list.
  type: bugfix
```

# Context

n/a

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [x] The changelog section in the PR is updated to describe the change
- [x] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
