### PR TITLE
Use AnyShelleyToBabbageEra from cardano-api instead

### DIFF
--- a/cardano-cli/src/Cardano/CLI/Run/Legacy/StakeAddress.hs
+++ b/cardano-cli/src/Cardano/CLI/Run/Legacy/StakeAddress.hs
@@ -24,7 +24,6 @@ import           Cardano.Api.Shelley
 
 import           Cardano.CLI.EraBased.Legacy
 import           Cardano.CLI.Run.Legacy.Read
-import           Cardano.CLI.Types.Governance
 import           Cardano.CLI.Types.Key (DelegationTarget (..), StakeIdentifier (..),
                    StakeVerifier (..), VerificationKeyOrFile, readVerificationKeyOrFile,
                    readVerificationKeyOrHashOrFile)
@@ -237,8 +236,7 @@ createDelegationCertRequirements sbe stakeCred delegatee =
       return $ StakeDelegationRequirementsConwayOnwards ConwayEraOnwardsConway stakeCred delegatee
 
 onlySpoDelegatee
-  :: IsShelleyBasedEra era
-  => ShelleyToBabbageEra era
+  :: ShelleyToBabbageEra era
   -> Ledger.Delegatee (Ledger.EraCrypto (ShelleyLedgerEra era))
   -> Either StakeAddressDelegationError PoolId
 onlySpoDelegatee w ledgerDelegatee =
@@ -246,11 +244,11 @@ onlySpoDelegatee w ledgerDelegatee =
     Ledger.DelegStake stakePoolKeyHash ->
       Right $ StakePoolKeyHash $ shelleyToBabbageEraConstraints w stakePoolKeyHash
     Ledger.DelegVote{} ->
-      Left . VoteDelegationNotSupported $ AnyAtMostBabbageEra w
+      Left . VoteDelegationNotSupported $ AnyShelleyToBabbageEra w
     Ledger.DelegStakeVote{} ->
-      Left . VoteDelegationNotSupported $ AnyAtMostBabbageEra w
+      Left . VoteDelegationNotSupported $ AnyShelleyToBabbageEra w
 
-newtype StakeAddressDelegationError = VoteDelegationNotSupported AnyAtMostBabbageEra deriving Show
+newtype StakeAddressDelegationError = VoteDelegationNotSupported AnyShelleyToBabbageEra deriving Show
 
 runStakeCredentialDeRegistrationCert
   :: AnyShelleyBasedEra

--- a/cardano-cli/src/Cardano/CLI/Types/Governance.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Governance.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE StandaloneDeriving #-}
 
 module Cardano.CLI.Types.Governance where
 
@@ -44,9 +43,3 @@ data VType = VCC -- committee
            | VDR -- drep
            | VSP -- spo
            deriving Show
-
-
-data AnyAtMostBabbageEra where
-  AnyAtMostBabbageEra :: IsShelleyBasedEra era => ShelleyToBabbageEra era -> AnyAtMostBabbageEra
-
-deriving instance Show AnyAtMostBabbageEra


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Use `AnyShelleyToBabbageEra` from `cardano-api` instead
  compatibility: compatible
  type: maintenance
```

# Context

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
