### PR TITLE
Remove ghc-9.2.x in CI for Mac

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -14,6 +14,9 @@ jobs:
         ghc: ["8.10.7", "9.2.7", "9.6.2"]
         cabal: ["3.10.1.0"]
         os: [ubuntu-latest, macos-latest, windows-latest]
+        exclude:
+          - ghc: "9.2.7"
+            os: macos-latest
 
     env:
       # Modify this value to "invalidate" the cabal cache.


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Remove `ghc-9.2.x` in CI for Mac
  compatibility: no-api-changes
  type: maintenance
```

# Context

We don't have a lot of Mac runners.  If to many builds get queued up for the Mac, it can cause jobs on the merge queue to timeout and fail, which cause merges to cancel.

This PR aims to reduce the number of jobs by removing a build configuration we care less about.


# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
