### PR TITLE
Wire up remaining DReps

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Certificate.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Certificate.hs
@@ -100,6 +100,14 @@ toLedgerDelegatee t =
                 (conwayEraOnwardsConstraints cOnwards kHash)
                 (conwayEraOnwardsConstraints cOnwards drepCred)
 
+    TargetAlwaysAbstain{}-> right $ Ledger.DelegVote Ledger.DRepAlwaysAbstain
+
+    TargetAlwaysNoConfidence{} -> right $ Ledger.DelegVote Ledger.DRepAlwaysNoConfidence
+
+    TargetVotingDRepScriptHash _cOn (ScriptHash _scriptHash) ->
+      error "TODO: Conway era - DRepScriptHash not exposed by ledger yet"
+      -- right $ Ledger.DelegVote $ Ledger.DRepScriptHash scriptHash
+
 --------------------------------------------------------------------------------
 
 -- Registration Certificate related

--- a/cardano-cli/src/Cardano/CLI/EraBased/Legacy.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Legacy.hs
@@ -2684,7 +2684,7 @@ pAddress =
 
 pStakePoolVerificationKeyHash :: Parser (Hash StakePoolKey)
 pStakePoolVerificationKeyHash =
-    Opt.option (pBech32KeyHash AsStakePoolKey <|> pHexKeyHash AsStakePoolKey) $ mconcat
+    Opt.option (pBech32KeyHash AsStakePoolKey <|> pHexHash AsStakePoolKey) $ mconcat
       [ Opt.long "stake-pool-id"
       , Opt.metavar "STAKE_POOL_ID"
       , Opt.help $ mconcat

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
@@ -515,9 +515,9 @@ pTransferAmt =
     , Opt.help "The amount to transfer."
     ]
 
-pHexKeyHash
+pHexHash
   :: SerialiseAsRawBytes (Hash a) => AsType a -> ReadM (Hash a)
-pHexKeyHash a =
+pHexHash a =
   Opt.eitherReader $
     first displayError
       . deserialiseFromRawBytesHex (AsHash a)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance.hs
@@ -145,7 +145,7 @@ pAlwaysAbstain =
 pAlwaysNoConfidence :: Parser ()
 pAlwaysNoConfidence =
   flag' () $ mconcat [ long "always-no-confidence"
-                     , help "Always vote no confidence."
+                     , help "Always vote no confidence"
                      ]
 
 pDRepScriptHash :: Parser ScriptHash

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance.hs
@@ -24,6 +24,7 @@ import           Cardano.CLI.Types.Legacy
 import           Data.Foldable
 import           Data.Functor
 import           Data.Maybe
+import           Data.String
 import           Options.Applicative
 import qualified Options.Applicative as Opt
 
@@ -127,7 +128,39 @@ pStakeTarget cOnwards =
     , TargetVotingDrepAndStakePool cOnwards
          <$> pDRepVerificationKeyOrHashOrFile
          <*> pStakePoolVerificationKeyOrHashOrFile
+    , TargetAlwaysAbstain cOnwards <$ pAlwaysAbstain
+    , TargetAlwaysNoConfidence cOnwards <$ pAlwaysNoConfidence
+   -- TODO: Conway era - necessary constructor not exposed by ledger yet
+   -- so this option is hidden
+    , TargetVotingDRepScriptHash cOnwards <$> pDRepScriptHash
     ]
+
+pAlwaysAbstain :: Parser ()
+pAlwaysAbstain =
+  flag' () $ mconcat [ long "always-abstain"
+                     , help "Abstain from voting on all proposals."
+                     ]
+
+
+pAlwaysNoConfidence :: Parser ()
+pAlwaysNoConfidence =
+  flag' () $ mconcat [ long "always-no-confidence"
+                     , help "Always vote no confidence."
+                     ]
+
+pDRepScriptHash :: Parser ScriptHash
+pDRepScriptHash =
+  Opt.option scriptHashReader $ mconcat
+    [ Opt.long "drep-script-hash"
+    , Opt.metavar "HASH"
+    , Opt.help $ mconcat
+        [ "DRep script hash (hex-encoded).  "
+        ]
+    , Opt.hidden
+    ]
+
+scriptHashReader :: ReadM ScriptHash
+scriptHashReader = eitherReader $ Right . fromString
 
 pDRepVerificationKeyOrHashOrFile
   :: Parser (VerificationKeyOrHashOrFile DRepKey)
@@ -139,7 +172,7 @@ pDRepVerificationKeyOrHashOrFile =
 
 pDRepVerificationKeyHash :: Parser (Hash DRepKey)
 pDRepVerificationKeyHash =
-    Opt.option (pBech32KeyHash AsDRepKey <|> pHexKeyHash AsDRepKey) $ mconcat
+    Opt.option (pBech32KeyHash AsDRepKey <|> pHexHash AsDRepKey) $ mconcat
       [ Opt.long "drep-key-hash"
       , Opt.metavar "HASH"
       , Opt.help $ mconcat

--- a/cardano-cli/src/Cardano/CLI/Types/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Key.hs
@@ -222,11 +222,18 @@ data StakeTarget era where
     -> VerificationKeyOrHashOrFile StakePoolKey
     -> StakeTarget era
 
-  {-
-  -- TODO: Conway era - DRepScriptHash !(ScriptHash c)
-  -- TODO: Conway era - DRepAlwaysAbstain
-  -- TODO: Conway era - DRepAlwaysNoConfidence
-  -}
+  TargetAlwaysAbstain
+    :: ConwayEraOnwards era
+    -> StakeTarget era
+
+  TargetAlwaysNoConfidence
+    :: ConwayEraOnwards era
+    -> StakeTarget era
+
+  TargetVotingDRepScriptHash
+    :: ConwayEraOnwards era
+    -> ScriptHash
+    -> StakeTarget era
 
 deriving instance Show (StakeTarget era)
 newtype DelegationTarget

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -586,6 +586,8 @@ Usage: cardano-cli conway governance delegation-certificate
                                                                 | --cold-verification-key-file FILE
                                                                 | --stake-pool-id STAKE_POOL_ID
                                                                 )
+                                                              | --always-abstain
+                                                              | --always-no-confidence
                                                               )
                                                               --out-file FILE
 
@@ -790,6 +792,8 @@ Usage: cardano-cli experimental governance delegation-certificate
                                                                       | --cold-verification-key-file FILE
                                                                       | --stake-pool-id STAKE_POOL_ID
                                                                       )
+                                                                    | --always-abstain
+                                                                    | --always-no-confidence
                                                                     )
                                                                     --out-file FILE
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_delegation-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_delegation-certificate.cli
@@ -18,6 +18,8 @@ Usage: cardano-cli conway governance delegation-certificate
                                                                 | --cold-verification-key-file FILE
                                                                 | --stake-pool-id STAKE_POOL_ID
                                                                 )
+                                                              | --always-abstain
+                                                              | --always-no-confidence
                                                               )
                                                               --out-file FILE
 
@@ -60,5 +62,8 @@ Available options:
                            Stake pool ID/verification key hash (either
                            Bech32-encoded or hex-encoded). Zero or more
                            occurences of this option is allowed.
+  --always-abstain         Abstain from voting on all proposals.
+  --always-no-confidence   Always vote no confidence
+  --drep-script-hash HASH  DRep script hash (hex-encoded).
   --out-file FILE          The output file.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/experimental_governance_delegation-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/experimental_governance_delegation-certificate.cli
@@ -18,6 +18,8 @@ Usage: cardano-cli experimental governance delegation-certificate
                                                                       | --cold-verification-key-file FILE
                                                                       | --stake-pool-id STAKE_POOL_ID
                                                                       )
+                                                                    | --always-abstain
+                                                                    | --always-no-confidence
                                                                     )
                                                                     --out-file FILE
 
@@ -60,5 +62,8 @@ Available options:
                            Stake pool ID/verification key hash (either
                            Bech32-encoded or hex-encoded). Zero or more
                            occurences of this option is allowed.
+  --always-abstain         Abstain from voting on all proposals.
+  --always-no-confidence   Always vote no confidence
+  --drep-script-hash HASH  DRep script hash (hex-encoded).
   --out-file FILE          The output file.
   -h,--help                Show this help text


### PR DESCRIPTION


# Changelog

```yaml
- description: |
    Add always abstain, always no confidence and drep script hash options. NB: The drep script hash option is hidden until ledger exposed the necessary constructor.
  # no-changes: the API has not changed
  # compatible: the API has changed but is non-breaking
  # breaking: the API has changed in a breaking way
  compatibility: compatible
  # feature: the change implements a new feature in the API
  # bugfix: the change fixes a bug in the API
  # test: the change fixes modifies tests
  # maintenance: the change involves something other than the API
  # If more than one is applicable, it may be put into a list.
  type: feature
```

# Context

Addititional context for the PR goes here.

If the PR fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
