### PR TITLE
cardano-cli 8.5.0.0

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -14,7 +14,7 @@ repository cardano-haskell-packages
 -- you need to run if you change them
 index-state:
   , hackage.haskell.org 2023-07-27T22:41:49Z
-  , cardano-haskell-packages 2023-08-02T14:04:47Z
+  , cardano-haskell-packages 2023-08-05T00:00:00Z
 
 packages:
   cardano-cli

--- a/cardano-cli/CHANGELOG.md
+++ b/cardano-cli/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog for cardano-cli
 
+## 8.5.0.0
+
+- Add always abstain, always no confidence and drep script hash options. NB: The drep script hash option is hidden until ledger exposed the necessary constructor.
+  (feature; compatible)
+  [PR 137](https://github.com/input-output-hk/cardano-cli/pull/137)
+
+- Stub `governance committee key-gen-cold` command
+  (feature; compatible)
+  [PR 126](https://github.com/input-output-hk/cardano-cli/pull/126)
+
+- Add vote creation command to new era based cli structure
+  (feature; compatible)
+  [PR 114](https://github.com/input-output-hk/cardano-cli/pull/114)
+
+- Remove `--protocol-params-file`  from `transaction build`  command.
+  (feature; breaking)
+  [PR 34](https://github.com/input-output-hk/cardano-cli/pull/34)
+
 ## 8.4.1.0
 
 - Add registration certificate creation command to the new era based cli

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.4
 
 name:                   cardano-cli
-version:                8.4.1.0
+version:                8.5.0.0
 synopsis:               The Cardano command-line interface
 description:            The Cardano command-line interface.
 copyright:              2020-2023 Input Output Global Inc (IOG).
@@ -121,7 +121,7 @@ library
                       , binary
                       , bytestring
                       , canonical-json
-                      , cardano-api ^>= 8.11.1
+                      , cardano-api ^>= 8.12
                       , cardano-binary
                       , cardano-crypto
                       , cardano-crypto-class >= 2.1.1
@@ -208,7 +208,7 @@ test-suite cardano-cli-test
                       , base16-bytestring
                       , bech32 >= 1.1.0
                       , bytestring
-                      , cardano-api:{cardano-api, internal, gen} ^>= 8.11.1
+                      , cardano-api:{cardano-api, internal, gen} ^>= 8.12
                       , cardano-api-gen ^>= 8.1.1.0
                       , cardano-cli
                       , cardano-cli:cardano-cli-test-lib
@@ -251,7 +251,7 @@ test-suite cardano-cli-golden
   build-depends:        aeson >= 1.5.6.0
                       , base16-bytestring
                       , bytestring
-                      , cardano-api:{cardano-api, gen} ^>= 8.11.1
+                      , cardano-api:{cardano-api, gen} ^>= 8.12
                       , cardano-binary
                       , cardano-cli
                       , cardano-cli:cardano-cli-test-lib


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    cardano-cli 8.5.0.0
  # no-changes: the API has not changed
  # compatible: the API has changed but is non-breaking
  # breaking: the API has changed in a breaking way
  compatibility: compatible
  # feature: the change implements a new feature in the API
  # bugfix: the change fixes a bug in the API
  # test: the change fixes modifies tests
  # maintenance: the change involves something other than the API
  # If more than one is applicable, it may be put into a list.
  type: maintenance
```

# Context

Addititional context for the PR goes here.

If the PR fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
