### PR TITLE
Wire up constitution creation in the new era based cli commands

### DIFF
--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -67,15 +67,18 @@ library
                         Cardano.CLI.Environment
                         Cardano.CLI.EraBased.Commands
                         Cardano.CLI.EraBased.Commands.Governance
+                        Cardano.CLI.EraBased.Commands.Governance.Actions
                         Cardano.CLI.EraBased.Commands.Governance.Committee
                         Cardano.CLI.EraBased.Governance
                         Cardano.CLI.EraBased.Legacy
                         Cardano.CLI.EraBased.Options.Common
                         Cardano.CLI.EraBased.Options.Governance
+                        Cardano.CLI.EraBased.Options.Governance.Actions
                         Cardano.CLI.EraBased.Options.Governance.Committee
                         Cardano.CLI.EraBased.Run
                         Cardano.CLI.EraBased.Run.Certificate
                         Cardano.CLI.EraBased.Run.Governance
+                        Cardano.CLI.EraBased.Run.Governance.Actions
                         Cardano.CLI.EraBased.Run.Governance.Committee
                         Cardano.CLI.EraBased.Vote
                         Cardano.CLI.Helpers

--- a/cardano-cli/src/Cardano/CLI/Commands/Governance.hs
+++ b/cardano-cli/src/Cardano/CLI/Commands/Governance.hs
@@ -10,6 +10,7 @@ import           Cardano.Api.Shelley
 import           Cardano.Binary (DecoderError)
 import           Cardano.CLI.Run.Legacy.Read (CddlError)
 import           Cardano.CLI.Run.Legacy.StakeAddress
+import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Governance
 import           Cardano.CLI.Types.Key
 import           Cardano.Prelude (intercalate, toS)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance.hs
@@ -9,6 +9,8 @@ module Cardano.CLI.EraBased.Commands.Governance
 
 import           Cardano.Api
 
+import           Cardano.CLI.EraBased.Commands.Governance.Actions (GovernanceActionCmds,
+                   renderGovernanceActionCmds)
 import           Cardano.CLI.EraBased.Commands.Governance.Committee
 import           Cardano.CLI.EraBased.Vote
 import           Cardano.CLI.Types.Common
@@ -42,6 +44,8 @@ data EraBasedGovernanceCmd era
       (File () Out)
   | EraBasedGovernanceCommitteeCmds
       (GovernanceCommitteeCmds era)
+  | EraBasedGovernanceActionCmds
+      (GovernanceActionCmds era)
 
 renderEraBasedGovernanceCmd :: EraBasedGovernanceCmd era -> Text
 renderEraBasedGovernanceCmd = \case
@@ -63,3 +67,5 @@ renderEraBasedGovernanceCmd = \case
     "goverance vote"
   EraBasedGovernanceCommitteeCmds cmds ->
     renderGovernanceCommitteeCmds cmds
+  EraBasedGovernanceActionCmds cmds ->
+    renderGovernanceActionCmds cmds

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/Actions.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/Actions.hs
@@ -1,0 +1,42 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE LambdaCase #-}
+
+module Cardano.CLI.EraBased.Commands.Governance.Actions
+  ( AnyStakeIdentifier(..)
+  , GovernanceActionCmds(..)
+  , EraBasedNewConstitution(..)
+  , renderGovernanceActionCmds
+  ) where
+
+import           Cardano.Api
+import           Cardano.Api.Shelley
+
+import           Cardano.CLI.Types.Common
+import           Cardano.CLI.Types.Key
+
+import           Data.Text (Text)
+
+data GovernanceActionCmds era
+  = GovernanceActionCreateConstitution
+      (ConwayEraOnwards era)
+      EraBasedNewConstitution
+    deriving Show
+
+data EraBasedNewConstitution
+  = EraBasedNewConstitution
+      { encDeposit :: Lovelace
+      , encStakeCredential :: AnyStakeIdentifier
+      , encConstitution :: Constitution
+      , encFilePath :: File () Out
+      } deriving Show
+
+renderGovernanceActionCmds :: GovernanceActionCmds era -> Text
+renderGovernanceActionCmds = \case
+  GovernanceActionCreateConstitution {} ->
+    "governance action create-constitution"
+
+
+data AnyStakeIdentifier
+  = AnyStakeKey (VerificationKeyOrHashOrFile StakeKey)
+  | AnyStakePoolKey (VerificationKeyOrHashOrFile StakePoolKey)
+  deriving Show

--- a/cardano-cli/src/Cardano/CLI/EraBased/Governance.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Governance.hs
@@ -160,23 +160,3 @@ pCreateConstitution envCli =
       <*> pVotingCredential
       <*> pConstitution
       <*> pFileOutDirection "out-file" "Output filepath of the governance action."
-
-pConstitution :: Parser Constitution
-pConstitution =
-  asum
-    [ fmap ConstitutionFromText $ Opt.strOption $ mconcat
-        [ Opt.long "constitution"
-        , Opt.metavar "TEXT"
-        , Opt.help "Input constitution as UTF-8 encoded text."
-        ]
-    , ConstitutionFromFile
-        <$> pFileInDirection "constitution-file" "Input constitution as a text file."
-    ]
-
-pGovActionDeposit :: Parser Lovelace
-pGovActionDeposit =
-  Opt.option (readerFromParsecParser parseLovelace) $ mconcat
-    [ Opt.long "governance-action-deposit"
-    , Opt.metavar "NATURAL"
-    , Opt.help "Deposit required to submit a governance action."
-    ]

--- a/cardano-cli/src/Cardano/CLI/EraBased/Legacy.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Legacy.hs
@@ -2639,29 +2639,9 @@ pAddress =
     , Opt.help "A Cardano address"
     ]
 
-
-pStakePoolVerificationKeyHash :: Parser (Hash StakePoolKey)
-pStakePoolVerificationKeyHash =
-    Opt.option (pBech32KeyHash AsStakePoolKey <|> pHexHash AsStakePoolKey) $ mconcat
-      [ Opt.long "stake-pool-id"
-      , Opt.metavar "STAKE_POOL_ID"
-      , Opt.help $ mconcat
-          [ "Stake pool ID/verification key hash (either Bech32-encoded or hex-encoded).  "
-          , "Zero or more occurences of this option is allowed."
-          ]
-      ]
-
 pDelegationTarget
   :: Parser DelegationTarget
 pDelegationTarget = StakePoolDelegationTarget <$> pStakePoolVerificationKeyOrHashOrFile
-
-pStakePoolVerificationKeyOrHashOrFile
-  :: Parser (VerificationKeyOrHashOrFile StakePoolKey)
-pStakePoolVerificationKeyOrHashOrFile =
-  asum
-    [ VerificationKeyOrFile <$> pStakePoolVerificationKeyOrFile
-    , VerificationKeyHash <$> pStakePoolVerificationKeyHash
-    ]
 
 pVrfVerificationKeyFile :: Parser (VerificationKeyFile In)
 pVrfVerificationKeyFile =

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
@@ -685,3 +685,62 @@ catCommands :: [Parser a] -> Maybe (Parser a)
 catCommands = \case
   [] -> Nothing
   ps -> Just $ asum ps
+
+
+
+pConstitution :: Parser Constitution
+pConstitution =
+  asum
+    [ fmap ConstitutionFromText $ Opt.strOption $ mconcat
+        [ Opt.long "constitution"
+        , Opt.metavar "TEXT"
+        , Opt.help "Input constitution as UTF-8 encoded text."
+        ]
+    , ConstitutionFromFile
+        <$> pFileInDirection "constitution-file" "Input constitution as a text file."
+    ]
+
+pGovActionDeposit :: Parser Lovelace
+pGovActionDeposit =
+  Opt.option (readerFromParsecParser parseLovelace) $ mconcat
+    [ Opt.long "governance-action-deposit"
+    , Opt.metavar "NATURAL"
+    , Opt.help "Deposit required to submit a governance action."
+    ]
+
+
+pStakeVerificationKeyOrHashOrFile :: Parser (VerificationKeyOrHashOrFile StakeKey)
+pStakeVerificationKeyOrHashOrFile = asum
+  [ VerificationKeyOrFile <$> pStakeVerificationKeyOrFile
+  , VerificationKeyHash <$> pStakeVerificationKeyHash
+  ]
+
+pStakeVerificationKeyHash :: Parser (Hash StakeKey)
+pStakeVerificationKeyHash =
+   Opt.option (pHexHash AsStakeKey) $ mconcat
+      [ Opt.long "stake-key-hash"
+      , Opt.metavar "HASH"
+      , Opt.help $ mconcat
+          [ "Stake verification key hash (hex-encoded)."
+          ]
+      ]
+
+
+pStakePoolVerificationKeyOrHashOrFile
+  :: Parser (VerificationKeyOrHashOrFile StakePoolKey)
+pStakePoolVerificationKeyOrHashOrFile =
+  asum
+    [ VerificationKeyOrFile <$> pStakePoolVerificationKeyOrFile
+    , VerificationKeyHash <$> pStakePoolVerificationKeyHash
+    ]
+
+pStakePoolVerificationKeyHash :: Parser (Hash StakePoolKey)
+pStakePoolVerificationKeyHash =
+    Opt.option (pBech32KeyHash AsStakePoolKey <|> pHexHash AsStakePoolKey) $ mconcat
+      [ Opt.long "stake-pool-id"
+      , Opt.metavar "STAKE_POOL_ID"
+      , Opt.help $ mconcat
+          [ "Stake pool ID/verification key hash (either Bech32-encoded or hex-encoded).  "
+          , "Zero or more occurences of this option is allowed."
+          ]
+      ]

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance.hs
@@ -15,6 +15,7 @@ import           Cardano.CLI.EraBased.Commands.Governance
 import           Cardano.CLI.EraBased.Governance
 import           Cardano.CLI.EraBased.Legacy
 import           Cardano.CLI.EraBased.Options.Common
+import           Cardano.CLI.EraBased.Options.Governance.Actions
 import           Cardano.CLI.EraBased.Options.Governance.Committee
 import           Cardano.CLI.EraBased.Vote
 import           Cardano.CLI.Types.Common
@@ -37,7 +38,9 @@ pEraBasedGovernanceCmd envCli era =
     , pEraBasedVoteCmd envCli era
     , pCreateMirCertificatesCmds era
     , pGovernanceCommitteeCmds era <&> fmap EraBasedGovernanceCommitteeCmds
+    , fmap EraBasedGovernanceActionCmds <$> pGovernanceActionCmds era
     ]
+
 
 -- Registration Certificate related
 

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Actions.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Actions.hs
@@ -1,0 +1,50 @@
+module Cardano.CLI.EraBased.Options.Governance.Actions
+  ( pGovernanceActionCmds
+  ) where
+
+import           Cardano.Api
+
+import           Cardano.CLI.EraBased.Commands.Governance.Actions
+import           Cardano.CLI.EraBased.Options.Common
+
+import           Data.Foldable
+import           Options.Applicative
+import qualified Options.Applicative as Opt
+
+pGovernanceActionCmds :: ()
+  => CardanoEra era
+  -> Maybe (Parser (GovernanceActionCmds era))
+pGovernanceActionCmds era =
+  subInfoParser "action"
+    ( Opt.progDesc
+        $ mconcat
+          [ "Governance action commands."
+          ]
+    )
+    [ pGovernanceActionNewConstitution era
+    ]
+
+
+pGovernanceActionNewConstitution
+  :: CardanoEra era  -> Maybe (Parser (GovernanceActionCmds era))
+pGovernanceActionNewConstitution =
+  featureInEra Nothing (\cOn -> Just $
+     subParser "create-constitution"
+        $ Opt.info (pCmd cOn)
+        $ Opt.progDesc "Create a constitution.")
+ where
+  pCmd :: ConwayEraOnwards era -> Parser (GovernanceActionCmds era)
+  pCmd cOn =
+    fmap (GovernanceActionCreateConstitution cOn)  $
+      EraBasedNewConstitution
+        <$> pGovActionDeposit
+        <*> pAnyStakeIdentifier
+        <*> pConstitution
+        <*> pFileOutDirection "out-file" "Output filepath of the constitution."
+
+pAnyStakeIdentifier :: Parser AnyStakeIdentifier
+pAnyStakeIdentifier =
+  asum [ AnyStakePoolKey <$> pStakePoolVerificationKeyOrHashOrFile
+       , AnyStakeKey <$> pStakeVerificationKeyOrHashOrFile
+       ]
+

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run.hs
@@ -16,6 +16,7 @@ import           Cardano.CLI.EraBased.Commands
 import           Cardano.CLI.EraBased.Options.Governance
 import           Cardano.CLI.EraBased.Run.Certificate
 import           Cardano.CLI.EraBased.Run.Governance
+import           Cardano.CLI.EraBased.Run.Governance.Actions
 import           Cardano.CLI.EraBased.Run.Governance.Committee
 import           Cardano.CLI.EraBased.Vote
 
@@ -73,6 +74,9 @@ runEraBasedGovernanceCmd = \case
     firstExceptT (const ()) -- TODO: Conway era - fix error handling
       $ runGovernanceCommitteeCmds cmds
 
+  EraBasedGovernanceActionCmds cmds ->
+    firstExceptT (const ()) -- TODO: Conway era - fix error handling
+      $ runGovernanceActionCmds cmds
 runEraBasedGovernancePreConwayCmd
   :: ShelleyToBabbageEra era
   -> ExceptT () IO ()

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Actions.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Actions.hs
@@ -1,0 +1,76 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE LambdaCase #-}
+
+module Cardano.CLI.EraBased.Run.Governance.Actions
+  ( runGovernanceActionCmds
+  ) where
+
+import           Cardano.Api
+import           Cardano.Api.Ledger (HasKeyRole (coerceKeyRole))
+import           Cardano.Api.Shelley
+
+import           Cardano.CLI.EraBased.Commands.Governance.Actions
+import           Cardano.CLI.Types.Common
+import           Cardano.CLI.Types.Key
+
+import           Control.Monad.Except (ExceptT)
+import           Control.Monad.IO.Class (liftIO)
+import           Control.Monad.Trans.Except.Extra
+import qualified Data.ByteString as BS
+import qualified Data.Text.Encoding as Text
+import           Data.Text.Encoding.Error
+
+
+data GovernanceActionsError
+  = GovernanceActionsCmdWriteFileError (FileError ())
+  | GovernanceActionsCmdReadFileError (FileError InputDecodeError)
+  | GovernanceActionsCmdNonUtf8EncodedConstitution UnicodeException
+
+
+runGovernanceActionCmds :: ()
+  => GovernanceActionCmds era
+  -> ExceptT GovernanceActionsError IO ()
+runGovernanceActionCmds = \case
+  GovernanceActionCreateConstitution cOn newConstitution ->
+    runGovernanceActionCreateConstitution cOn newConstitution
+
+runGovernanceActionCreateConstitution :: ()
+  => ConwayEraOnwards era
+  -> EraBasedNewConstitution
+  -> ExceptT GovernanceActionsError IO ()
+runGovernanceActionCreateConstitution cOn (EraBasedNewConstitution deposit anyStake constit outFp) = do
+
+  stakeKeyHash
+    <- case anyStake of
+         AnyStakeKey stake ->
+           firstExceptT GovernanceActionsCmdReadFileError
+             . newExceptT $ readVerificationKeyOrHashOrFile AsStakeKey stake
+
+         AnyStakePoolKey stake -> do
+           StakePoolKeyHash t <- firstExceptT GovernanceActionsCmdReadFileError
+                                   . newExceptT $ readVerificationKeyOrHashOrFile AsStakePoolKey stake
+           return $ StakeKeyHash $ coerceKeyRole t
+
+  case constit of
+    ConstitutionFromFile fp  -> do
+      cBs <- liftIO $ BS.readFile $ unFile fp
+      _utf8EncodedText <- firstExceptT GovernanceActionsCmdNonUtf8EncodedConstitution . hoistEither $ Text.decodeUtf8' cBs
+      let govAct = ProposeNewConstitution cBs
+          sbe = conwayEraOnwardsToShelleyBasedEra cOn
+          proposal = createProposalProcedure sbe deposit stakeKeyHash govAct
+
+      firstExceptT GovernanceActionsCmdWriteFileError . newExceptT
+        $ conwayEraOnwardsConstraints cOn
+        $ writeFileTextEnvelope outFp Nothing proposal
+
+    ConstitutionFromText c -> do
+      let constitBs = Text.encodeUtf8 c
+          sbe = conwayEraOnwardsToShelleyBasedEra cOn
+          govAct = ProposeNewConstitution constitBs
+          proposal = createProposalProcedure sbe deposit stakeKeyHash govAct
+
+      firstExceptT GovernanceActionsCmdWriteFileError . newExceptT
+        $ conwayEraOnwardsConstraints cOn
+        $ writeFileTextEnvelope outFp Nothing proposal
+
+

--- a/cardano-cli/src/Cardano/CLI/Types/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Common.hs
@@ -1,9 +1,15 @@
+{-# LANGUAGE DataKinds #-}
 {-# LANGUAGE GADTs #-}
 
 module Cardano.CLI.Types.Common
-  ( OpCertCounter
+  ( Constitution(..)
+  , OpCertCounter
   , TransferDirection(..)
   ) where
+
+import           Cardano.Api
+
+import           Data.Text (Text)
 
 -- | Determines the direction in which the MIR certificate will transfer ADA.
 data TransferDirection =
@@ -12,3 +18,7 @@ data TransferDirection =
   deriving Show
 
 data OpCertCounter
+
+data Constitution
+  = ConstitutionFromFile (File () In)
+  | ConstitutionFromText Text deriving Show

--- a/cardano-cli/src/Cardano/CLI/Types/Governance.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Governance.hs
@@ -6,9 +6,8 @@ module Cardano.CLI.Types.Governance where
 import           Cardano.Api
 import           Cardano.Api.Shelley
 
+import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Key
-
-import           Data.Text (Text)
 
 
 type VoteFile = File ConwayVote
@@ -33,10 +32,6 @@ data NewConstitution
       , ncConstitution :: Constitution
       , ncFilePath :: NewConstitutionFile Out
       } deriving Show
-
-data Constitution
-  = ConstitutionFromFile (File () In)
-  | ConstitutionFromText Text deriving Show
 
 -- Vote type -- TODO: Conway era - remove me
 data VType = VCC -- committee

--- a/cardano-cli/src/Cardano/CLI/Types/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Key.hs
@@ -236,6 +236,7 @@ data StakeTarget era where
     -> StakeTarget era
 
 deriving instance Show (StakeTarget era)
+
 newtype DelegationTarget
   = StakePoolDelegationTarget (VerificationKeyOrHashOrFile StakePoolKey)
   deriving Show

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -518,6 +518,7 @@ Usage: cardano-cli conway governance
                                        | delegation-certificate
                                        | vote
                                        | committee
+                                       | action
                                        )
 
   Era-based governance commands
@@ -629,6 +630,25 @@ Usage: cardano-cli conway governance committee key-hash --verification-key-file 
 
   Print the identifier (hash) of a public key
 
+Usage: cardano-cli conway governance action create-constitution
+
+  Governance action commands.
+
+Usage: cardano-cli conway governance action create-constitution --governance-action-deposit NATURAL
+                                                                  ( --stake-pool-verification-key STRING
+                                                                  | --cold-verification-key-file FILE
+                                                                  | --stake-pool-id STAKE_POOL_ID
+                                                                  | --stake-verification-key STRING
+                                                                  | --stake-verification-key-file FILE
+                                                                  | --stake-key-hash HASH
+                                                                  )
+                                                                  ( --constitution TEXT
+                                                                  | --constitution-file FILE
+                                                                  )
+                                                                  --out-file FILE
+
+  Create a constitution.
+
 Usage: cardano-cli latest governance
 
   Latest era commands (Babbage)
@@ -737,6 +757,7 @@ Usage: cardano-cli experimental governance
                                              | delegation-certificate
                                              | vote
                                              | committee
+                                             | action
                                              )
 
   Era-based governance commands
@@ -847,6 +868,25 @@ Usage: cardano-cli experimental governance committee key-gen-hot --verification-
 Usage: cardano-cli experimental governance committee key-hash --verification-key-file FILE
 
   Print the identifier (hash) of a public key
+
+Usage: cardano-cli experimental governance action create-constitution
+
+  Governance action commands.
+
+Usage: cardano-cli experimental governance action create-constitution --governance-action-deposit NATURAL
+                                                                        ( --stake-pool-verification-key STRING
+                                                                        | --cold-verification-key-file FILE
+                                                                        | --stake-pool-id STAKE_POOL_ID
+                                                                        | --stake-verification-key STRING
+                                                                        | --stake-verification-key-file FILE
+                                                                        | --stake-key-hash HASH
+                                                                        )
+                                                                        ( --constitution TEXT
+                                                                        | --constitution-file FILE
+                                                                        )
+                                                                        --out-file FILE
+
+  Create a constitution.
 
 Usage: cardano-cli legacy Legacy commands
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance.cli
@@ -3,6 +3,7 @@ Usage: cardano-cli conway governance
                                        | delegation-certificate
                                        | vote
                                        | committee
+                                       | action
                                        )
 
   Era-based governance commands
@@ -15,3 +16,4 @@ Available commands:
   delegation-certificate   Delegation certificate creation.
   vote                     Vote creation.
   committee                Committee member commands.
+  action                   Governance action commands.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_create-constitution.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_create-constitution.cli
@@ -1,0 +1,35 @@
+Usage: cardano-cli conway governance action create-constitution --governance-action-deposit NATURAL
+                                                                  ( --stake-pool-verification-key STRING
+                                                                  | --cold-verification-key-file FILE
+                                                                  | --stake-pool-id STAKE_POOL_ID
+                                                                  | --stake-verification-key STRING
+                                                                  | --stake-verification-key-file FILE
+                                                                  | --stake-key-hash HASH
+                                                                  )
+                                                                  ( --constitution TEXT
+                                                                  | --constitution-file FILE
+                                                                  )
+                                                                  --out-file FILE
+
+  Create a constitution.
+
+Available options:
+  --governance-action-deposit NATURAL
+                           Deposit required to submit a governance action.
+  --stake-pool-verification-key STRING
+                           Stake pool verification key (Bech32 or hex-encoded).
+  --cold-verification-key-file FILE
+                           Filepath of the stake pool verification key.
+  --stake-pool-id STAKE_POOL_ID
+                           Stake pool ID/verification key hash (either
+                           Bech32-encoded or hex-encoded). Zero or more
+                           occurences of this option is allowed.
+  --stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --stake-verification-key-file FILE
+                           Filepath of the staking verification key.
+  --stake-key-hash HASH    Stake verification key hash (hex-encoded).
+  --constitution TEXT      Input constitution as UTF-8 encoded text.
+  --constitution-file FILE Input constitution as a text file.
+  --out-file FILE          Output filepath of the constitution.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/experimental_governance.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/experimental_governance.cli
@@ -3,6 +3,7 @@ Usage: cardano-cli experimental governance
                                              | delegation-certificate
                                              | vote
                                              | committee
+                                             | action
                                              )
 
   Era-based governance commands
@@ -15,3 +16,4 @@ Available commands:
   delegation-certificate   Delegation certificate creation.
   vote                     Vote creation.
   committee                Committee member commands.
+  action                   Governance action commands.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/experimental_governance_action_create-constitution.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/experimental_governance_action_create-constitution.cli
@@ -1,0 +1,35 @@
+Usage: cardano-cli experimental governance action create-constitution --governance-action-deposit NATURAL
+                                                                        ( --stake-pool-verification-key STRING
+                                                                        | --cold-verification-key-file FILE
+                                                                        | --stake-pool-id STAKE_POOL_ID
+                                                                        | --stake-verification-key STRING
+                                                                        | --stake-verification-key-file FILE
+                                                                        | --stake-key-hash HASH
+                                                                        )
+                                                                        ( --constitution TEXT
+                                                                        | --constitution-file FILE
+                                                                        )
+                                                                        --out-file FILE
+
+  Create a constitution.
+
+Available options:
+  --governance-action-deposit NATURAL
+                           Deposit required to submit a governance action.
+  --stake-pool-verification-key STRING
+                           Stake pool verification key (Bech32 or hex-encoded).
+  --cold-verification-key-file FILE
+                           Filepath of the stake pool verification key.
+  --stake-pool-id STAKE_POOL_ID
+                           Stake pool ID/verification key hash (either
+                           Bech32-encoded or hex-encoded). Zero or more
+                           occurences of this option is allowed.
+  --stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --stake-verification-key-file FILE
+                           Filepath of the staking verification key.
+  --stake-key-hash HASH    Stake verification key hash (hex-encoded).
+  --constitution TEXT      Input constitution as UTF-8 encoded text.
+  --constitution-file FILE Input constitution as a text file.
+  --out-file FILE          Output filepath of the constitution.
+  -h,--help                Show this help text


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Wire up constitution creation in the new era based cli commands
# uncomment types applicable to the change:
  type:
  # - breaking       # the API has changed in a breaking way
  - feature
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - documentation  # change in code docs, haddocks...
```

# Context

Addititional context for the PR goes here.

If the PR fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
