### PR TITLE
Avoid `mkForce` in nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -345,11 +345,11 @@
         "sodium": "sodium"
       },
       "locked": {
-        "lastModified": 1687951625,
-        "narHash": "sha256-jwUD9tyGAvcuIl4TZYc+qGFTCEwIMriim+whXO+fiE4=",
+        "lastModified": 1691469905,
+        "narHash": "sha256-TV0p1dFGYAMl1dLJEfe/tNFjxvV2H7VgHU1I43q+b84=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "7bb42e5de0c1318e57017eedbe206751d58b78b3",
+        "rev": "2f3760f135616ebc477d3ed74eba9b63c22f83a0",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -87,9 +87,9 @@
             ({pkgs, ...}: {
               packages.cardano-cli.configureFlags = ["--ghc-option=-Werror"];
               packages.cardano-cli.components.tests.cardano-cli-test.build-tools =
-                lib.mkForce (with pkgs.buildPackages; [jq coreutils shellcheck]);
+                lib.mkForce (with pkgs.buildPackages; [jq coreutils shellcheck buildPackages.haskell-nix.haskellPackages.tasty-discover]);
               packages.cardano-cli.components.tests.cardano-cli-golden.build-tools =
-                lib.mkForce (with pkgs.buildPackages; [jq coreutils shellcheck]);
+                lib.mkForce (with pkgs.buildPackages; [jq coreutils shellcheck buildPackages.haskell-nix.haskellPackages.tasty-discover]);
             })
             ({
               pkgs,


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Avoid `mkForce` in nix
  compatibility: no-api-changes
  type: maintenance
```

# Context

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - roundtrip tests
  - integration tests
  See [Runnings tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

# Note on CI
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges.  Please contact IOG node developers to do this
for you.
