### PR TITLE
Plural for command groups

### DIFF
--- a/cardano-cli/src/Cardano/CLI/Byron/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Commands.hs
@@ -3,7 +3,7 @@
 
 module Cardano.CLI.Byron.Commands
   ( ByronCommand (..)
-  , NodeCmd (..)
+  , NodeCmds (..)
   , VerificationKeyFile
   , NewVerificationKeyFile (..)
   , CertificateFile (..)
@@ -26,8 +26,8 @@ import           Data.String (IsString)
 data ByronCommand =
 
   --- Node Related Commands ---
-    NodeCmd
-        NodeCmd
+    NodeCmds
+        NodeCmds
 
   --- Genesis Related Commands ---
   | Genesis
@@ -111,7 +111,7 @@ data ByronCommand =
   deriving Show
 
 
-data NodeCmd =
+data NodeCmds =
     CreateVote
       NetworkId
       (SigningKeyFile In)

--- a/cardano-cli/src/Cardano/CLI/Byron/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Parsers.hs
@@ -2,7 +2,7 @@
 
 module Cardano.CLI.Byron.Parsers
   ( ByronCommand(..)
-  , NodeCmd(..)
+  , NodeCmds(..)
   , backwardsCompatibilityCommands
   , parseByronCommands
   , parseHeavyDelThd
@@ -101,18 +101,18 @@ parseByronCommands envCli = asum
       $ Opt.progDesc "Byron node query commands.")
   , subParser' "genesis" (Opt.info (asum $ map Opt.subparser parseGenesisRelatedValues)
       $ Opt.progDesc "Byron genesis block commands")
-  , subParser' "governance" (Opt.info (NodeCmd <$> Opt.subparser (pNodeCmd envCli))
+  , subParser' "governance" (Opt.info (NodeCmds <$> Opt.subparser (pNodeCmds envCli))
       $ Opt.progDesc "Byron governance commands")
   , subParser' "miscellaneous" (Opt.info (asum $ map Opt.subparser parseMiscellaneous)
       $ Opt.progDesc "Byron miscellaneous commands")
-  , NodeCmd <$> pNodeCmdBackwardCompatible envCli
+  , NodeCmds <$> pNodeCmdBackwardCompatible envCli
   ]
  where
    subParser' :: String -> ParserInfo ByronCommand -> Parser ByronCommand
    subParser' name pInfo = Opt.subparser $ Opt.command name pInfo <> Opt.metavar name
 
-pNodeCmdBackwardCompatible :: EnvCli -> Parser NodeCmd
-pNodeCmdBackwardCompatible envCli = Opt.subparser $ pNodeCmd envCli <> Opt.internal
+pNodeCmdBackwardCompatible :: EnvCli -> Parser NodeCmds
+pNodeCmdBackwardCompatible envCli = Opt.subparser $ pNodeCmds envCli <> Opt.internal
 
 parseCBORObject :: Parser CBORObject
 parseCBORObject = asum
@@ -359,8 +359,8 @@ parseTxRelatedValues envCli =
             <$> parseTxFile "tx"
     ]
 
-pNodeCmd :: EnvCli -> Mod CommandFields NodeCmd
-pNodeCmd envCli =
+pNodeCmds :: EnvCli -> Mod CommandFields NodeCmds
+pNodeCmds envCli =
   mconcat
     [ Opt.command "create-update-proposal" $
         Opt.info (parseByronUpdateProposal envCli) $ Opt.progDesc  "Create an update proposal."
@@ -372,7 +372,7 @@ pNodeCmd envCli =
         Opt.info (parseByronVoteSubmission envCli) $ Opt.progDesc "Submit a proposal vote."
     ]
 
-parseByronUpdateProposal :: EnvCli -> Parser NodeCmd
+parseByronUpdateProposal :: EnvCli -> Parser NodeCmds
 parseByronUpdateProposal envCli = do
   UpdateProposal
     <$> pNetworkId envCli
@@ -384,7 +384,7 @@ parseByronUpdateProposal envCli = do
     <*> parseFilePath "filepath" "Byron proposal output filepath."
     <*> pByronProtocolParametersUpdate
 
-parseByronVoteSubmission :: EnvCli -> Parser NodeCmd
+parseByronVoteSubmission :: EnvCli -> Parser NodeCmds
 parseByronVoteSubmission envCli = do
   SubmitVote
     <$> pSocketPath envCli
@@ -410,14 +410,14 @@ pByronProtocolParametersUpdate =
     <*> optional parseTxFeePolicy
     <*> optional parseUnlockStakeEpoch
 
-parseByronUpdateProposalSubmission :: EnvCli -> Parser NodeCmd
+parseByronUpdateProposalSubmission :: EnvCli -> Parser NodeCmds
 parseByronUpdateProposalSubmission envCli =
   SubmitUpdateProposal
     <$> pSocketPath envCli
     <*> pNetworkId envCli
     <*> parseFilePath "filepath" "Filepath of Byron update proposal."
 
-parseByronVote :: EnvCli -> Parser NodeCmd
+parseByronVote :: EnvCli -> Parser NodeCmds
 parseByronVote envCli =
   CreateVote
     <$> pNetworkId envCli

--- a/cardano-cli/src/Cardano/CLI/Byron/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Run.hs
@@ -68,7 +68,7 @@ renderByronClientCmdError err =
 runByronClientCommand :: ByronCommand -> ExceptT ByronClientCmdError IO ()
 runByronClientCommand c =
   case c of
-    NodeCmd bc -> runNodeCmd bc
+    NodeCmds bc -> runNodeCmds bc
     Genesis outDir params -> runGenesisCommand outDir params
     GetLocalNodeTip mNodeSocketPath network -> liftIO $ runGetLocalNodeTip mNodeSocketPath network
     ValidateCBOR cborObject fp -> runValidateCBOR cborObject fp
@@ -88,18 +88,18 @@ runByronClientCommand c =
       runSpendUTxO nw era nftx ctKey ins outs
 
 
-runNodeCmd :: NodeCmd -> ExceptT ByronClientCmdError IO ()
-runNodeCmd (CreateVote nw sKey upPropFp voteBool outputFp) =
+runNodeCmds :: NodeCmds -> ExceptT ByronClientCmdError IO ()
+runNodeCmds (CreateVote nw sKey upPropFp voteBool outputFp) =
   firstExceptT ByronCmdVoteError $ runVoteCreation nw sKey upPropFp voteBool outputFp
 
-runNodeCmd (SubmitUpdateProposal nodeSocketPath network proposalFp) = do
+runNodeCmds (SubmitUpdateProposal nodeSocketPath network proposalFp) = do
   firstExceptT ByronCmdUpdateProposalError
     $ submitByronUpdateProposal nodeSocketPath network proposalFp
 
-runNodeCmd (SubmitVote nodeSocketPath network voteFp) = do
+runNodeCmds (SubmitVote nodeSocketPath network voteFp) = do
   firstExceptT ByronCmdVoteError $ submitByronVote nodeSocketPath network voteFp
 
-runNodeCmd (UpdateProposal nw sKey pVer sVer sysTag insHash outputFp params) =
+runNodeCmds (UpdateProposal nw sKey pVer sVer sysTag insHash outputFp params) =
   firstExceptT ByronCmdUpdateProposalError
     $ runProposalCreation nw sKey pVer sVer sysTag insHash outputFp params
 

--- a/cardano-cli/src/Cardano/CLI/Commands/Legacy.hs
+++ b/cardano-cli/src/Cardano/CLI/Commands/Legacy.hs
@@ -16,7 +16,7 @@ module Cardano.CLI.Commands.Legacy
   , PoolCmd (..)
   , QueryCmd (..)
   , GovernanceCmds (..)
-  , GenesisCmd (..)
+  , GenesisCmds (..)
   , TextViewCmd (..)
   , VoteCmd(..)
   , renderLegacyCommand
@@ -76,7 +76,7 @@ data LegacyCommand
   | PoolCmd         PoolCmd
   | QueryCmd        QueryCmd
   | GovernanceCmds    GovernanceCmds
-  | GenesisCmd      GenesisCmd
+  | GenesisCmds       GenesisCmds
   | TextViewCmd     TextViewCmd
 
 renderLegacyCommand :: LegacyCommand -> Text
@@ -90,7 +90,7 @@ renderLegacyCommand sc =
     PoolCmd cmd -> renderPoolCmd cmd
     QueryCmd cmd -> renderQueryCmd cmd
     GovernanceCmds cmd -> renderGovernanceCmds cmd
-    GenesisCmd cmd -> renderGenesisCmd cmd
+    GenesisCmds cmd -> renderGenesisCmds cmd
     TextViewCmd cmd -> renderTextViewCmd cmd
 
 data AddressCmd
@@ -422,7 +422,7 @@ data TextViewCmd
 renderTextViewCmd :: TextViewCmd -> Text
 renderTextViewCmd (TextViewInfo _ _) = "text-view decode-cbor"
 
-data GenesisCmd
+data GenesisCmds
   = GenesisCreate
       KeyOutputFormat
       GenesisDir
@@ -457,8 +457,8 @@ data GenesisCmd
   | GenesisHashFile GenesisFile
   deriving Show
 
-renderGenesisCmd :: GenesisCmd -> Text
-renderGenesisCmd cmd =
+renderGenesisCmds :: GenesisCmds -> Text
+renderGenesisCmds cmd =
   case cmd of
     GenesisCreate {} -> "genesis create"
     GenesisCreateCardano {} -> "genesis create-cardano"

--- a/cardano-cli/src/Cardano/CLI/Commands/Legacy.hs
+++ b/cardano-cli/src/Cardano/CLI/Commands/Legacy.hs
@@ -11,7 +11,7 @@ module Cardano.CLI.Commands.Legacy
   , AddressCmd (..)
   , StakeAddressCmd (..)
   , KeyCmd (..)
-  , TransactionCmd (..)
+  , TransactionCmds (..)
   , NodeCmds (..)
   , PoolCmds (..)
   , QueryCmds (..)
@@ -71,8 +71,8 @@ data LegacyCommand
   = AddressCmd      AddressCmd
   | StakeAddressCmd StakeAddressCmd
   | KeyCmd          KeyCmd
-  | TransactionCmd  TransactionCmd
-  | NodeCmds         NodeCmds
+  | TransactionCmds   TransactionCmds
+  | NodeCmds          NodeCmds
   | PoolCmds          PoolCmds
   | QueryCmds         QueryCmds
   | GovernanceCmds    GovernanceCmds
@@ -85,7 +85,7 @@ renderLegacyCommand sc =
     AddressCmd cmd -> renderAddressCmd cmd
     StakeAddressCmd cmd -> renderStakeAddressCmd cmd
     KeyCmd cmd -> renderKeyCmd cmd
-    TransactionCmd cmd -> renderTransactionCmd cmd
+    TransactionCmds cmd -> renderTransactionCmds cmd
     NodeCmds cmd -> renderNodeCmds cmd
     PoolCmds cmd -> renderPoolCmds cmd
     QueryCmds cmd -> renderQueryCmds cmd
@@ -167,7 +167,7 @@ renderKeyCmd cmd =
     KeyConvertITNBip32ToStakeKey {} -> "key convert-itn-bip32-key"
     KeyConvertCardanoAddressSigningKey {} -> "key convert-cardano-address-signing-key"
 
-data TransactionCmd
+data TransactionCmds
   = TxBuildRaw
       AnyCardanoEra
       (Maybe ScriptValidity) -- ^ Mark script as expected to pass or fail validation
@@ -271,8 +271,8 @@ data TransactionCmd
 data InputTxBodyOrTxFile = InputTxBodyFile (TxBodyFile In) | InputTxFile (TxFile In)
   deriving Show
 
-renderTransactionCmd :: TransactionCmd -> Text
-renderTransactionCmd cmd =
+renderTransactionCmds :: TransactionCmds -> Text
+renderTransactionCmds cmd =
   case cmd of
     TxBuild {} -> "transaction build"
     TxBuildRaw {} -> "transaction build-raw"

--- a/cardano-cli/src/Cardano/CLI/Commands/Legacy.hs
+++ b/cardano-cli/src/Cardano/CLI/Commands/Legacy.hs
@@ -10,7 +10,7 @@ module Cardano.CLI.Commands.Legacy
     LegacyCommand (..)
   , AddressCmd (..)
   , StakeAddressCmd (..)
-  , KeyCmd (..)
+  , KeyCmds (..)
   , TransactionCmds (..)
   , NodeCmds (..)
   , PoolCmds (..)
@@ -70,7 +70,7 @@ import           Data.Time.Clock
 data LegacyCommand
   = AddressCmd      AddressCmd
   | StakeAddressCmd StakeAddressCmd
-  | KeyCmd          KeyCmd
+  | KeyCmds           KeyCmds
   | TransactionCmds   TransactionCmds
   | NodeCmds          NodeCmds
   | PoolCmds          PoolCmds
@@ -84,7 +84,7 @@ renderLegacyCommand sc =
   case sc of
     AddressCmd cmd -> renderAddressCmd cmd
     StakeAddressCmd cmd -> renderStakeAddressCmd cmd
-    KeyCmd cmd -> renderKeyCmd cmd
+    KeyCmds cmd -> renderKeyCmds cmd
     TransactionCmds cmd -> renderTransactionCmds cmd
     NodeCmds cmd -> renderNodeCmds cmd
     PoolCmds cmd -> renderPoolCmds cmd
@@ -144,7 +144,7 @@ renderStakeAddressCmd cmd =
     StakeCredentialDelegationCert {} -> "stake-address delegation-certificate"
     StakeCredentialDeRegistrationCert {} -> "stake-address deregistration-certificate"
 
-data KeyCmd
+data KeyCmds
   = KeyGetVerificationKey (SigningKeyFile In) (VerificationKeyFile Out)
   | KeyNonExtendedKey  (VerificationKeyFile In) (VerificationKeyFile Out)
   | KeyConvertByronKey (Maybe Text) ByronKeyType (SomeKeyFile In) (File () Out)
@@ -155,8 +155,8 @@ data KeyCmd
   | KeyConvertCardanoAddressSigningKey CardanoAddressKeyType (SigningKeyFile In) (File () Out)
   deriving Show
 
-renderKeyCmd :: KeyCmd -> Text
-renderKeyCmd cmd =
+renderKeyCmds :: KeyCmds -> Text
+renderKeyCmds cmd =
   case cmd of
     KeyGetVerificationKey {} -> "key verification-key"
     KeyNonExtendedKey {} -> "key non-extended-key"

--- a/cardano-cli/src/Cardano/CLI/Commands/Legacy.hs
+++ b/cardano-cli/src/Cardano/CLI/Commands/Legacy.hs
@@ -17,7 +17,7 @@ module Cardano.CLI.Commands.Legacy
   , QueryCmd (..)
   , GovernanceCmds (..)
   , GenesisCmds (..)
-  , TextViewCmd (..)
+  , TextViewCmds (..)
   , VoteCmd(..)
   , renderLegacyCommand
 
@@ -77,7 +77,7 @@ data LegacyCommand
   | QueryCmd        QueryCmd
   | GovernanceCmds    GovernanceCmds
   | GenesisCmds       GenesisCmds
-  | TextViewCmd     TextViewCmd
+  | TextViewCmds      TextViewCmds
 
 renderLegacyCommand :: LegacyCommand -> Text
 renderLegacyCommand sc =
@@ -91,7 +91,7 @@ renderLegacyCommand sc =
     QueryCmd cmd -> renderQueryCmd cmd
     GovernanceCmds cmd -> renderGovernanceCmds cmd
     GenesisCmds cmd -> renderGenesisCmds cmd
-    TextViewCmd cmd -> renderTextViewCmd cmd
+    TextViewCmds cmd -> renderTextViewCmds cmd
 
 data AddressCmd
   = AddressKeyGen KeyOutputFormat AddressKeyType (VerificationKeyFile Out) (SigningKeyFile Out)
@@ -414,13 +414,13 @@ renderQueryCmd cmd =
         TxMempoolQueryInfo -> "info"
 
 
-data TextViewCmd
+data TextViewCmds
   = TextViewInfo !FilePath (Maybe (File () Out))
   deriving Show
 
 
-renderTextViewCmd :: TextViewCmd -> Text
-renderTextViewCmd (TextViewInfo _ _) = "text-view decode-cbor"
+renderTextViewCmds :: TextViewCmds -> Text
+renderTextViewCmds (TextViewInfo _ _) = "text-view decode-cbor"
 
 data GenesisCmds
   = GenesisCreate

--- a/cardano-cli/src/Cardano/CLI/Commands/Legacy.hs
+++ b/cardano-cli/src/Cardano/CLI/Commands/Legacy.hs
@@ -12,7 +12,7 @@ module Cardano.CLI.Commands.Legacy
   , StakeAddressCmd (..)
   , KeyCmd (..)
   , TransactionCmd (..)
-  , NodeCmd (..)
+  , NodeCmds (..)
   , PoolCmds (..)
   , QueryCmds (..)
   , GovernanceCmds (..)
@@ -72,7 +72,7 @@ data LegacyCommand
   | StakeAddressCmd StakeAddressCmd
   | KeyCmd          KeyCmd
   | TransactionCmd  TransactionCmd
-  | NodeCmd         NodeCmd
+  | NodeCmds         NodeCmds
   | PoolCmds          PoolCmds
   | QueryCmds         QueryCmds
   | GovernanceCmds    GovernanceCmds
@@ -86,7 +86,7 @@ renderLegacyCommand sc =
     StakeAddressCmd cmd -> renderStakeAddressCmd cmd
     KeyCmd cmd -> renderKeyCmd cmd
     TransactionCmd cmd -> renderTransactionCmd cmd
-    NodeCmd cmd -> renderNodeCmd cmd
+    NodeCmds cmd -> renderNodeCmds cmd
     PoolCmds cmd -> renderPoolCmds cmd
     QueryCmds cmd -> renderQueryCmds cmd
     GovernanceCmds cmd -> renderGovernanceCmds cmd
@@ -287,7 +287,7 @@ renderTransactionCmd cmd =
     TxGetTxId {} -> "transaction txid"
     TxView {} -> "transaction view"
 
-data NodeCmd
+data NodeCmds
   = NodeKeyGenCold KeyOutputFormat (VerificationKeyFile Out) (SigningKeyFile Out) (OpCertCounterFile Out)
   | NodeKeyGenKES  KeyOutputFormat (VerificationKeyFile Out) (SigningKeyFile Out)
   | NodeKeyGenVRF  KeyOutputFormat (VerificationKeyFile Out) (SigningKeyFile Out)
@@ -297,8 +297,8 @@ data NodeCmd
                     KESPeriod (File () Out)
   deriving Show
 
-renderNodeCmd :: NodeCmd -> Text
-renderNodeCmd cmd = do
+renderNodeCmds :: NodeCmds -> Text
+renderNodeCmds cmd = do
   case cmd of
     NodeKeyGenCold {} -> "node key-gen"
     NodeKeyGenKES {} -> "node key-gen-KES"

--- a/cardano-cli/src/Cardano/CLI/Commands/Legacy.hs
+++ b/cardano-cli/src/Cardano/CLI/Commands/Legacy.hs
@@ -8,7 +8,7 @@
 module Cardano.CLI.Commands.Legacy
   ( -- * CLI command types
     LegacyCommand (..)
-  , AddressCmd (..)
+  , AddressCmds (..)
   , StakeAddressCmds (..)
   , KeyCmds (..)
   , TransactionCmds (..)
@@ -68,7 +68,7 @@ import           Data.Time.Clock
 -- | All the CLI subcommands under \"shelley\".
 --
 data LegacyCommand
-  = AddressCmd      AddressCmd
+  = AddressCmds       AddressCmds
   | StakeAddressCmds  StakeAddressCmds
   | KeyCmds           KeyCmds
   | TransactionCmds   TransactionCmds
@@ -82,7 +82,7 @@ data LegacyCommand
 renderLegacyCommand :: LegacyCommand -> Text
 renderLegacyCommand sc =
   case sc of
-    AddressCmd cmd -> renderAddressCmd cmd
+    AddressCmds cmd -> renderAddressCmds cmd
     StakeAddressCmds cmd -> renderStakeAddressCmds cmd
     KeyCmds cmd -> renderKeyCmds cmd
     TransactionCmds cmd -> renderTransactionCmds cmd
@@ -93,7 +93,7 @@ renderLegacyCommand sc =
     GenesisCmds cmd -> renderGenesisCmds cmd
     TextViewCmds cmd -> renderTextViewCmds cmd
 
-data AddressCmd
+data AddressCmds
   = AddressKeyGen KeyOutputFormat AddressKeyType (VerificationKeyFile Out) (SigningKeyFile Out)
   | AddressKeyHash VerificationKeyTextOrFile (Maybe (File () Out))
   | AddressBuild
@@ -105,8 +105,8 @@ data AddressCmd
   deriving Show
 
 
-renderAddressCmd :: AddressCmd -> Text
-renderAddressCmd cmd =
+renderAddressCmds :: AddressCmds -> Text
+renderAddressCmds cmd =
   case cmd of
     AddressKeyGen {} -> "address key-gen"
     AddressKeyHash {} -> "address key-hash"

--- a/cardano-cli/src/Cardano/CLI/Commands/Legacy.hs
+++ b/cardano-cli/src/Cardano/CLI/Commands/Legacy.hs
@@ -15,7 +15,7 @@ module Cardano.CLI.Commands.Legacy
   , NodeCmd (..)
   , PoolCmd (..)
   , QueryCmd (..)
-  , GovernanceCmd (..)
+  , GovernanceCmds (..)
   , GenesisCmd (..)
   , TextViewCmd (..)
   , VoteCmd(..)
@@ -75,7 +75,7 @@ data LegacyCommand
   | NodeCmd         NodeCmd
   | PoolCmd         PoolCmd
   | QueryCmd        QueryCmd
-  | GovernanceCmd'   GovernanceCmd
+  | GovernanceCmds    GovernanceCmds
   | GenesisCmd      GenesisCmd
   | TextViewCmd     TextViewCmd
 
@@ -89,7 +89,7 @@ renderLegacyCommand sc =
     NodeCmd cmd -> renderNodeCmd cmd
     PoolCmd cmd -> renderPoolCmd cmd
     QueryCmd cmd -> renderQueryCmd cmd
-    GovernanceCmd' cmd -> renderGovernanceCmd cmd
+    GovernanceCmds cmd -> renderGovernanceCmds cmd
     GenesisCmd cmd -> renderGenesisCmd cmd
     TextViewCmd cmd -> renderTextViewCmd cmd
 

--- a/cardano-cli/src/Cardano/CLI/Commands/Legacy.hs
+++ b/cardano-cli/src/Cardano/CLI/Commands/Legacy.hs
@@ -14,7 +14,7 @@ module Cardano.CLI.Commands.Legacy
   , TransactionCmd (..)
   , NodeCmd (..)
   , PoolCmd (..)
-  , QueryCmd (..)
+  , QueryCmds (..)
   , GovernanceCmds (..)
   , GenesisCmds (..)
   , TextViewCmds (..)
@@ -74,7 +74,7 @@ data LegacyCommand
   | TransactionCmd  TransactionCmd
   | NodeCmd         NodeCmd
   | PoolCmd         PoolCmd
-  | QueryCmd        QueryCmd
+  | QueryCmds         QueryCmds
   | GovernanceCmds    GovernanceCmds
   | GenesisCmds       GenesisCmds
   | TextViewCmds      TextViewCmds
@@ -88,7 +88,7 @@ renderLegacyCommand sc =
     TransactionCmd cmd -> renderTransactionCmd cmd
     NodeCmd cmd -> renderNodeCmd cmd
     PoolCmd cmd -> renderPoolCmd cmd
-    QueryCmd cmd -> renderQueryCmd cmd
+    QueryCmds cmd -> renderQueryCmds cmd
     GovernanceCmds cmd -> renderGovernanceCmds cmd
     GenesisCmds cmd -> renderGenesisCmds cmd
     TextViewCmds cmd -> renderTextViewCmds cmd
@@ -351,7 +351,7 @@ renderPoolCmd cmd =
     PoolGetId {} -> "stake-pool id"
     PoolMetadataHash {} -> "stake-pool metadata-hash"
 
-data QueryCmd =
+data QueryCmds =
     QueryLeadershipSchedule
       SocketPath
       AnyConsensusModeParams
@@ -388,8 +388,8 @@ data QueryCmd =
   | QuerySlotNumber SocketPath AnyConsensusModeParams NetworkId UTCTime
   deriving Show
 
-renderQueryCmd :: QueryCmd -> Text
-renderQueryCmd cmd =
+renderQueryCmds :: QueryCmds -> Text
+renderQueryCmds cmd =
   case cmd of
     QueryLeadershipSchedule {} -> "query leadership-schedule"
     QueryProtocolParameters' {} -> "query protocol-parameters "

--- a/cardano-cli/src/Cardano/CLI/Commands/Legacy.hs
+++ b/cardano-cli/src/Cardano/CLI/Commands/Legacy.hs
@@ -13,7 +13,7 @@ module Cardano.CLI.Commands.Legacy
   , KeyCmd (..)
   , TransactionCmd (..)
   , NodeCmd (..)
-  , PoolCmd (..)
+  , PoolCmds (..)
   , QueryCmds (..)
   , GovernanceCmds (..)
   , GenesisCmds (..)
@@ -73,7 +73,7 @@ data LegacyCommand
   | KeyCmd          KeyCmd
   | TransactionCmd  TransactionCmd
   | NodeCmd         NodeCmd
-  | PoolCmd         PoolCmd
+  | PoolCmds          PoolCmds
   | QueryCmds         QueryCmds
   | GovernanceCmds    GovernanceCmds
   | GenesisCmds       GenesisCmds
@@ -87,7 +87,7 @@ renderLegacyCommand sc =
     KeyCmd cmd -> renderKeyCmd cmd
     TransactionCmd cmd -> renderTransactionCmd cmd
     NodeCmd cmd -> renderNodeCmd cmd
-    PoolCmd cmd -> renderPoolCmd cmd
+    PoolCmds cmd -> renderPoolCmds cmd
     QueryCmds cmd -> renderQueryCmds cmd
     GovernanceCmds cmd -> renderGovernanceCmds cmd
     GenesisCmds cmd -> renderGenesisCmds cmd
@@ -307,7 +307,7 @@ renderNodeCmd cmd = do
     NodeNewCounter {} -> "node new-counter"
     NodeIssueOpCert{} -> "node issue-op-cert"
 
-data PoolCmd
+data PoolCmds
   = PoolRegistrationCert
       AnyShelleyBasedEra
       -- ^ Era in which to register the stake pool.
@@ -343,8 +343,8 @@ data PoolCmd
   | PoolMetadataHash (StakePoolMetadataFile In) (Maybe (File () Out))
   deriving Show
 
-renderPoolCmd :: PoolCmd -> Text
-renderPoolCmd cmd =
+renderPoolCmds :: PoolCmds -> Text
+renderPoolCmds cmd =
   case cmd of
     PoolRegistrationCert {} -> "stake-pool registration-certificate"
     PoolRetirementCert {} -> "stake-pool deregistration-certificate"

--- a/cardano-cli/src/Cardano/CLI/Commands/Legacy.hs
+++ b/cardano-cli/src/Cardano/CLI/Commands/Legacy.hs
@@ -9,7 +9,7 @@ module Cardano.CLI.Commands.Legacy
   ( -- * CLI command types
     LegacyCommand (..)
   , AddressCmd (..)
-  , StakeAddressCmd (..)
+  , StakeAddressCmds (..)
   , KeyCmds (..)
   , TransactionCmds (..)
   , NodeCmds (..)
@@ -69,7 +69,7 @@ import           Data.Time.Clock
 --
 data LegacyCommand
   = AddressCmd      AddressCmd
-  | StakeAddressCmd StakeAddressCmd
+  | StakeAddressCmds  StakeAddressCmds
   | KeyCmds           KeyCmds
   | TransactionCmds   TransactionCmds
   | NodeCmds          NodeCmds
@@ -83,7 +83,7 @@ renderLegacyCommand :: LegacyCommand -> Text
 renderLegacyCommand sc =
   case sc of
     AddressCmd cmd -> renderAddressCmd cmd
-    StakeAddressCmd cmd -> renderStakeAddressCmd cmd
+    StakeAddressCmds cmd -> renderStakeAddressCmds cmd
     KeyCmds cmd -> renderKeyCmds cmd
     TransactionCmds cmd -> renderTransactionCmds cmd
     NodeCmds cmd -> renderNodeCmds cmd
@@ -113,7 +113,7 @@ renderAddressCmd cmd =
     AddressBuild {} -> "address build"
     AddressInfo {} -> "address info"
 
-data StakeAddressCmd
+data StakeAddressCmds
   = StakeAddressKeyGen KeyOutputFormat (VerificationKeyFile Out) (SigningKeyFile Out)
   | StakeAddressKeyHash (VerificationKeyOrFile StakeKey) (Maybe (File () Out))
   | StakeAddressBuild StakeVerifier NetworkId (Maybe (File () Out))
@@ -134,8 +134,8 @@ data StakeAddressCmd
       (File () Out)
   deriving Show
 
-renderStakeAddressCmd :: StakeAddressCmd -> Text
-renderStakeAddressCmd cmd =
+renderStakeAddressCmds :: StakeAddressCmds -> Text
+renderStakeAddressCmds cmd =
   case cmd of
     StakeAddressKeyGen {} -> "stake-address key-gen"
     StakeAddressKeyHash {} -> "stake-address key-hash"

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands.hs
@@ -24,11 +24,11 @@ data AnyEraCommand where
   AnyEraCommandOf :: ShelleyBasedEra era -> EraBasedCommand era -> AnyEraCommand
 
 newtype EraBasedCommand era
-  = EraBasedGovernanceCmd (EraBasedGovernanceCmd era)
+  = EraBasedGovernanceCmds (EraBasedGovernanceCmds era)
 
 renderEraBasedCommand :: EraBasedCommand era -> Text
 renderEraBasedCommand = \case
-  EraBasedGovernanceCmd cmd -> renderEraBasedGovernanceCmd cmd
+  EraBasedGovernanceCmds cmd -> renderEraBasedGovernanceCmds cmd
 
 pAnyEraCommand :: EnvCli -> Parser AnyEraCommand
 pAnyEraCommand envCli =
@@ -66,6 +66,6 @@ pEraBasedCommand :: EnvCli -> CardanoEra era -> Parser (EraBasedCommand era)
 pEraBasedCommand envCli era =
   asum
     [ subParser "governance"
-        $ Opt.info (EraBasedGovernanceCmd <$> pEraBasedGovernanceCmd envCli era)
+        $ Opt.info (EraBasedGovernanceCmds <$> pEraBasedGovernanceCmds envCli era)
         $ Opt.progDesc "Era-based governance commands"
     ]

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance.hs
@@ -3,8 +3,8 @@
 {-# LANGUAGE LambdaCase #-}
 
 module Cardano.CLI.EraBased.Commands.Governance
-  ( EraBasedGovernanceCmd(..)
-  , renderEraBasedGovernanceCmd
+  ( EraBasedGovernanceCmds(..)
+  , renderEraBasedGovernanceCmds
   ) where
 
 import           Cardano.Api
@@ -16,7 +16,7 @@ import           Cardano.CLI.Types.Key
 
 import           Data.Text (Text)
 
-data EraBasedGovernanceCmd era
+data EraBasedGovernanceCmds era
   = EraBasedGovernancePreConwayCmd (ShelleyToBabbageEra era)
   | EraBasedGovernancePostConwayCmd (ConwayEraOnwards era)
   | EraBasedGovernanceMIRPayStakeAddressesCertificate
@@ -43,8 +43,8 @@ data EraBasedGovernanceCmd era
   | EraBasedGovernanceCommitteeCmds
       (GovernanceCommitteeCmds era)
 
-renderEraBasedGovernanceCmd :: EraBasedGovernanceCmd era -> Text
-renderEraBasedGovernanceCmd = \case
+renderEraBasedGovernanceCmds :: EraBasedGovernanceCmds era -> Text
+renderEraBasedGovernanceCmds = \case
   EraBasedGovernancePreConwayCmd {} ->
     "governance pre-conway"
   EraBasedGovernancePostConwayCmd {} ->

--- a/cardano-cli/src/Cardano/CLI/EraBased/Governance.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Governance.hs
@@ -19,7 +19,7 @@ import           Data.Text (Text)
 import           Options.Applicative hiding (help, str)
 import qualified Options.Applicative as Opt
 
-data GovernanceCmd
+data GovernanceCmds
   = GovernanceVoteCmd VoteCmd
   | GovernanceActionCmd ActionCmd
   | GovernanceMIRPayStakeAddressesCertificate
@@ -59,8 +59,8 @@ data GovernanceCmd
       (Maybe (File () Out)) -- Tx file
   deriving Show
 
-renderGovernanceCmd :: GovernanceCmd -> Text
-renderGovernanceCmd = \case
+renderGovernanceCmds :: GovernanceCmds -> Text
+renderGovernanceCmds = \case
   GovernanceVoteCmd {} -> "governance vote"
   GovernanceActionCmd {} -> "governance action"
   GovernanceGenesisKeyDelegationCertificate {} -> "governance create-genesis-key-delegation-certificate"

--- a/cardano-cli/src/Cardano/CLI/EraBased/Legacy.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Legacy.hs
@@ -78,7 +78,7 @@ parseLegacyCommands envCli =
         $ Opt.info (AddressCmd <$> pAddressCmd envCli)
         $ Opt.progDesc "Payment address commands"
     , Opt.command "stake-address"
-        $ Opt.info (StakeAddressCmd <$> pStakeAddressCmd envCli)
+        $ Opt.info (StakeAddressCmds <$> pStakeAddressCmds envCli)
         $ Opt.progDesc "Stake address commands"
     , Opt.command "key"
         $ Opt.info (KeyCmds <$> pKeyCmds)
@@ -347,8 +347,8 @@ pScriptDataOrFile dataFlagPrefix helpTextForValue helpTextForFile =
             Left err -> fail (displayError err)
             Right sd -> return sd
 
-pStakeAddressCmd :: EnvCli -> Parser StakeAddressCmd
-pStakeAddressCmd envCli =
+pStakeAddressCmds :: EnvCli -> Parser StakeAddressCmds
+pStakeAddressCmds envCli =
     asum
       [ subParser "key-gen"
           $ Opt.info pStakeAddressKeyGen
@@ -370,24 +370,24 @@ pStakeAddressCmd envCli =
           $ Opt.progDesc "Create a stake address pool delegation certificate"
       ]
   where
-    pStakeAddressKeyGen :: Parser StakeAddressCmd
+    pStakeAddressKeyGen :: Parser StakeAddressCmds
     pStakeAddressKeyGen =
       StakeAddressKeyGen
         <$> pKeyOutputFormat
         <*> pVerificationKeyFileOut
         <*> pSigningKeyFileOut
 
-    pStakeAddressKeyHash :: Parser StakeAddressCmd
+    pStakeAddressKeyHash :: Parser StakeAddressCmds
     pStakeAddressKeyHash = StakeAddressKeyHash <$> pStakeVerificationKeyOrFile <*> pMaybeOutputFile
 
-    pStakeAddressBuild :: Parser StakeAddressCmd
+    pStakeAddressBuild :: Parser StakeAddressCmds
     pStakeAddressBuild =
       StakeAddressBuild
         <$> pStakeVerifier
         <*> pNetworkId envCli
         <*> pMaybeOutputFile
 
-    pStakeAddressRegistrationCert :: Parser StakeAddressCmd
+    pStakeAddressRegistrationCert :: Parser StakeAddressCmds
     pStakeAddressRegistrationCert =
       StakeRegistrationCert
         <$> pAnyShelleyBasedEra envCli
@@ -395,7 +395,7 @@ pStakeAddressCmd envCli =
         <*> optional pKeyRegistDeposit
         <*> pOutputFile
 
-    pStakeAddressDeregistrationCert :: Parser StakeAddressCmd
+    pStakeAddressDeregistrationCert :: Parser StakeAddressCmds
     pStakeAddressDeregistrationCert =
       StakeCredentialDeRegistrationCert
         <$> pAnyShelleyBasedEra envCli
@@ -403,7 +403,7 @@ pStakeAddressCmd envCli =
         <*> optional pKeyRegistDeposit
         <*> pOutputFile
 
-    pStakeAddressPoolDelegationCert :: Parser StakeAddressCmd
+    pStakeAddressPoolDelegationCert :: Parser StakeAddressCmds
     pStakeAddressPoolDelegationCert =
       StakeCredentialDelegationCert
         <$> pAnyShelleyBasedEra envCli

--- a/cardano-cli/src/Cardano/CLI/EraBased/Legacy.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Legacy.hs
@@ -81,7 +81,7 @@ parseLegacyCommands envCli =
         $ Opt.info (StakeAddressCmd <$> pStakeAddressCmd envCli)
         $ Opt.progDesc "Stake address commands"
     , Opt.command "key"
-        $ Opt.info (KeyCmd <$> pKeyCmd)
+        $ Opt.info (KeyCmds <$> pKeyCmds)
         $ Opt.progDesc "Key utility commands"
     , Opt.command "transaction"
         $ Opt.info (TransactionCmds <$> pTransaction envCli)
@@ -411,8 +411,8 @@ pStakeAddressCmd envCli =
         <*> pDelegationTarget
         <*> pOutputFile
 
-pKeyCmd :: Parser KeyCmd
-pKeyCmd =
+pKeyCmds :: Parser KeyCmds
+pKeyCmds =
   asum
     [ subParser "verification-key"
         $ Opt.info pKeyGetVerificationKey
@@ -478,19 +478,19 @@ pKeyCmd =
             ]
     ]
   where
-    pKeyGetVerificationKey :: Parser KeyCmd
+    pKeyGetVerificationKey :: Parser KeyCmds
     pKeyGetVerificationKey =
       KeyGetVerificationKey
         <$> pSigningKeyFileIn
         <*> pVerificationKeyFileOut
 
-    pKeyNonExtendedKey :: Parser KeyCmd
+    pKeyNonExtendedKey :: Parser KeyCmds
     pKeyNonExtendedKey =
       KeyNonExtendedKey
         <$> pExtendedVerificationKeyFileIn
         <*> pVerificationKeyFileOut
 
-    pKeyConvertByronKey :: Parser KeyCmd
+    pKeyConvertByronKey :: Parser KeyCmds
     pKeyConvertByronKey =
       KeyConvertByronKey
         <$> optional pPassword
@@ -560,7 +560,7 @@ pKeyCmd =
         , Opt.completer (Opt.bashCompleter "file")
         ]
 
-    pKeyConvertByronGenesisVKey :: Parser KeyCmd
+    pKeyConvertByronGenesisVKey :: Parser KeyCmds
     pKeyConvertByronGenesisVKey =
       KeyConvertByronGenesisVKey
         <$> pByronGenesisVKeyBase64
@@ -574,19 +574,19 @@ pKeyCmd =
         , Opt.help "Base64 string for the Byron genesis verification key."
         ]
 
-    pKeyConvertITNKey :: Parser KeyCmd
+    pKeyConvertITNKey :: Parser KeyCmds
     pKeyConvertITNKey =
       KeyConvertITNStakeKey
         <$> pITNKeyFIle
         <*> pOutputFile
 
-    pKeyConvertITNExtendedKey :: Parser KeyCmd
+    pKeyConvertITNExtendedKey :: Parser KeyCmds
     pKeyConvertITNExtendedKey =
       KeyConvertITNExtendedToStakeKey
         <$> pITNSigningKeyFile
         <*> pOutputFile
 
-    pKeyConvertITNBip32Key :: Parser KeyCmd
+    pKeyConvertITNBip32Key :: Parser KeyCmds
     pKeyConvertITNBip32Key =
       KeyConvertITNBip32ToStakeKey
         <$> pITNSigningKeyFile
@@ -617,7 +617,7 @@ pKeyCmd =
         , Opt.completer (Opt.bashCompleter "file")
         ]
 
-    pKeyConvertCardanoAddressSigningKey :: Parser KeyCmd
+    pKeyConvertCardanoAddressSigningKey :: Parser KeyCmds
     pKeyConvertCardanoAddressSigningKey =
       KeyConvertCardanoAddressSigningKey
         <$> pCardanoAddressKeyType

--- a/cardano-cli/src/Cardano/CLI/EraBased/Legacy.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Legacy.hs
@@ -93,7 +93,7 @@ parseLegacyCommands envCli =
         $ Opt.info (PoolCmd <$> pPoolCmd envCli)
         $ Opt.progDesc "Stake pool commands"
     , Opt.command "query"
-        $ Opt.info (QueryCmd <$> pQueryCmd envCli) . Opt.progDesc
+        $ Opt.info (QueryCmds <$> pQueryCmds envCli) . Opt.progDesc
         $ mconcat
             [ "Node query commands. Will query the local node whose Unix domain socket "
             , "is obtained from the CARDANO_NODE_SOCKET_PATH environment variable."
@@ -967,8 +967,8 @@ pPoolCmd  envCli =
     pPoolMetadataHashSubCmd :: Parser PoolCmd
     pPoolMetadataHashSubCmd = PoolMetadataHash <$> pPoolMetadataFile <*> pMaybeOutputFile
 
-pQueryCmd :: EnvCli -> Parser QueryCmd
-pQueryCmd envCli =
+pQueryCmds :: EnvCli -> Parser QueryCmds
+pQueryCmds envCli =
   asum
     [ subParser "protocol-parameters"
         $ Opt.info pQueryProtocolParameters
@@ -1033,7 +1033,7 @@ pQueryCmd envCli =
         $ Opt.progDesc "Query slot number for UTC timestamp"
     ]
   where
-    pQueryProtocolParameters :: Parser QueryCmd
+    pQueryProtocolParameters :: Parser QueryCmds
     pQueryProtocolParameters =
       QueryProtocolParameters'
         <$> pSocketPath envCli
@@ -1041,7 +1041,7 @@ pQueryCmd envCli =
         <*> pNetworkId envCli
         <*> pMaybeOutputFile
 
-    pQueryConstitutionHash :: Parser QueryCmd
+    pQueryConstitutionHash :: Parser QueryCmds
     pQueryConstitutionHash =
       QueryConstitutionHash
         <$> pSocketPath envCli
@@ -1049,7 +1049,7 @@ pQueryCmd envCli =
         <*> pNetworkId envCli
         <*> pMaybeOutputFile
 
-    pQueryTip :: Parser QueryCmd
+    pQueryTip :: Parser QueryCmds
     pQueryTip =
       QueryTip
         <$> pSocketPath envCli
@@ -1057,7 +1057,7 @@ pQueryCmd envCli =
         <*> pNetworkId envCli
         <*> pMaybeOutputFile
 
-    pQueryUTxO :: Parser QueryCmd
+    pQueryUTxO :: Parser QueryCmds
     pQueryUTxO =
       QueryUTxO'
         <$> pSocketPath envCli
@@ -1066,7 +1066,7 @@ pQueryCmd envCli =
         <*> pNetworkId envCli
         <*> pMaybeOutputFile
 
-    pQueryStakePools :: Parser QueryCmd
+    pQueryStakePools :: Parser QueryCmds
     pQueryStakePools =
       QueryStakePools'
         <$> pSocketPath envCli
@@ -1074,7 +1074,7 @@ pQueryCmd envCli =
         <*> pNetworkId envCli
         <*> pMaybeOutputFile
 
-    pQueryStakeDistribution :: Parser QueryCmd
+    pQueryStakeDistribution :: Parser QueryCmds
     pQueryStakeDistribution =
       QueryStakeDistribution'
         <$> pSocketPath envCli
@@ -1082,7 +1082,7 @@ pQueryCmd envCli =
         <*> pNetworkId envCli
         <*> pMaybeOutputFile
 
-    pQueryStakeAddressInfo :: Parser QueryCmd
+    pQueryStakeAddressInfo :: Parser QueryCmds
     pQueryStakeAddressInfo =
       QueryStakeAddressInfo
         <$> pSocketPath envCli
@@ -1091,7 +1091,7 @@ pQueryCmd envCli =
         <*> pNetworkId envCli
         <*> pMaybeOutputFile
 
-    pQueryLedgerState :: Parser QueryCmd
+    pQueryLedgerState :: Parser QueryCmds
     pQueryLedgerState =
       QueryDebugLedgerState'
         <$> pSocketPath envCli
@@ -1099,7 +1099,7 @@ pQueryCmd envCli =
         <*> pNetworkId envCli
         <*> pMaybeOutputFile
 
-    pQueryProtocolState :: Parser QueryCmd
+    pQueryProtocolState :: Parser QueryCmds
     pQueryProtocolState =
       QueryProtocolState'
         <$> pSocketPath envCli
@@ -1117,7 +1117,7 @@ pQueryCmd envCli =
             pOnly :: Parser (AllOrOnly [Hash StakePoolKey])
             pOnly = Only <$> many pStakePoolVerificationKeyHash
 
-    pQueryStakeSnapshot :: Parser QueryCmd
+    pQueryStakeSnapshot :: Parser QueryCmds
     pQueryStakeSnapshot =
       QueryStakeSnapshot'
         <$> pSocketPath envCli
@@ -1126,7 +1126,7 @@ pQueryCmd envCli =
         <*> pAllStakePoolsOrOnly
         <*> pMaybeOutputFile
 
-    pQueryPoolState :: Parser QueryCmd
+    pQueryPoolState :: Parser QueryCmds
     pQueryPoolState =
       QueryPoolState'
         <$> pSocketPath envCli
@@ -1134,7 +1134,7 @@ pQueryCmd envCli =
         <*> pNetworkId envCli
         <*> many pStakePoolVerificationKeyHash
 
-    pQueryTxMempool :: Parser QueryCmd
+    pQueryTxMempool :: Parser QueryCmds
     pQueryTxMempool =
       QueryTxMempool
         <$> pSocketPath envCli
@@ -1155,7 +1155,7 @@ pQueryCmd envCli =
               $ Opt.info (TxMempoolQueryTxExists <$> argument Opt.str (metavar "TX_ID"))
               $ Opt.progDesc "Query if a particular transaction exists in the mempool"
           ]
-    pLeadershipSchedule :: Parser QueryCmd
+    pLeadershipSchedule :: Parser QueryCmds
     pLeadershipSchedule =
       QueryLeadershipSchedule
         <$> pSocketPath envCli
@@ -1167,7 +1167,7 @@ pQueryCmd envCli =
         <*> pWhichLeadershipSchedule
         <*> pMaybeOutputFile
 
-    pKesPeriodInfo :: Parser QueryCmd
+    pKesPeriodInfo :: Parser QueryCmds
     pKesPeriodInfo =
       QueryKesPeriodInfo
         <$> pSocketPath envCli
@@ -1176,7 +1176,7 @@ pQueryCmd envCli =
         <*> pOperationalCertificateFile
         <*> pMaybeOutputFile
 
-    pQuerySlotNumber :: Parser QueryCmd
+    pQuerySlotNumber :: Parser QueryCmds
     pQuerySlotNumber =
       QuerySlotNumber
         <$> pSocketPath envCli

--- a/cardano-cli/src/Cardano/CLI/EraBased/Legacy.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Legacy.hs
@@ -99,7 +99,7 @@ parseLegacyCommands envCli =
             , "is obtained from the CARDANO_NODE_SOCKET_PATH environment variable."
             ]
     , Opt.command "genesis"
-        $ Opt.info (GenesisCmd <$> pGenesisCmd envCli)
+        $ Opt.info (GenesisCmds <$> pGenesisCmds envCli)
         $ Opt.progDesc "Genesis block commands"
     , Opt.command "governance"
         $ Opt.info (GovernanceCmds <$> pGovernanceCmds envCli)
@@ -1349,8 +1349,8 @@ pPollNonce =
     , Opt.help "An (optional) nonce for non-replayability."
     ]
 
-pGenesisCmd :: EnvCli -> Parser GenesisCmd
-pGenesisCmd envCli =
+pGenesisCmds :: EnvCli -> Parser GenesisCmds
+pGenesisCmds envCli =
   asum
     [ subParser "key-gen-genesis"
         $ Opt.info pGenesisKeyGen
@@ -1399,51 +1399,51 @@ pGenesisCmd envCli =
         $ Opt.progDesc "Compute the hash of a genesis file"
     ]
   where
-    pGenesisKeyGen :: Parser GenesisCmd
+    pGenesisKeyGen :: Parser GenesisCmds
     pGenesisKeyGen =
       GenesisKeyGenGenesis
         <$> pVerificationKeyFileOut
         <*> pSigningKeyFileOut
 
-    pGenesisDelegateKeyGen :: Parser GenesisCmd
+    pGenesisDelegateKeyGen :: Parser GenesisCmds
     pGenesisDelegateKeyGen =
       GenesisKeyGenDelegate
         <$> pVerificationKeyFileOut
         <*> pSigningKeyFileOut
         <*> pOperatorCertIssueCounterFile
 
-    pGenesisUTxOKeyGen :: Parser GenesisCmd
+    pGenesisUTxOKeyGen :: Parser GenesisCmds
     pGenesisUTxOKeyGen =
       GenesisKeyGenUTxO
         <$> pVerificationKeyFileOut
         <*> pSigningKeyFileOut
 
-    pGenesisKeyHash :: Parser GenesisCmd
+    pGenesisKeyHash :: Parser GenesisCmds
     pGenesisKeyHash =
       GenesisCmdKeyHash
         <$> pVerificationKeyFileIn
 
-    pGenesisVerKey :: Parser GenesisCmd
+    pGenesisVerKey :: Parser GenesisCmds
     pGenesisVerKey =
       GenesisVerKey
         <$> pVerificationKeyFileOut
         <*> pSigningKeyFileIn
 
-    pGenesisAddr :: Parser GenesisCmd
+    pGenesisAddr :: Parser GenesisCmds
     pGenesisAddr =
       GenesisAddr
         <$> pVerificationKeyFileIn
         <*> pNetworkId envCli
         <*> pMaybeOutputFile
 
-    pGenesisTxIn :: Parser GenesisCmd
+    pGenesisTxIn :: Parser GenesisCmds
     pGenesisTxIn =
       GenesisTxIn
         <$> pVerificationKeyFileIn
         <*> pNetworkId envCli
         <*> pMaybeOutputFile
 
-    pGenesisCreateCardano :: Parser GenesisCmd
+    pGenesisCreateCardano :: Parser GenesisCmds
     pGenesisCreateCardano =
       GenesisCreateCardano
         <$> pGenesisDir
@@ -1469,7 +1469,7 @@ pGenesisCmd envCli =
               "JSON file with genesis defaults for conway."
         <*> pNodeConfigTemplate
 
-    pGenesisCreate :: Parser GenesisCmd
+    pGenesisCreate :: Parser GenesisCmds
     pGenesisCreate =
       GenesisCreate
         <$> pKeyOutputFormat
@@ -1480,7 +1480,7 @@ pGenesisCmd envCli =
         <*> pInitialSupplyNonDelegated
         <*> pNetworkId envCli
 
-    pGenesisCreateStaked :: Parser GenesisCmd
+    pGenesisCreateStaked :: Parser GenesisCmds
     pGenesisCreateStaked =
       GenesisCreateStaked
         <$> pKeyOutputFormat
@@ -1498,7 +1498,7 @@ pGenesisCmd envCli =
         <*> pStuffedUtxoCount
         <*> Opt.optional pRelayJsonFp
 
-    pGenesisHash :: Parser GenesisCmd
+    pGenesisHash :: Parser GenesisCmds
     pGenesisHash =
       GenesisHashFile <$> pGenesisFile "The genesis file."
 

--- a/cardano-cli/src/Cardano/CLI/EraBased/Legacy.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Legacy.hs
@@ -87,7 +87,7 @@ parseLegacyCommands envCli =
         $ Opt.info (TransactionCmd <$> pTransaction envCli)
         $ Opt.progDesc "Transaction commands"
     , Opt.command "node"
-        $ Opt.info (NodeCmd <$> pNodeCmd)
+        $ Opt.info (NodeCmds <$> pNodeCmds)
         $ Opt.progDesc "Node operation commands"
     , Opt.command "stake-pool"
         $ Opt.info (PoolCmds <$> pPoolCmds envCli)
@@ -868,8 +868,8 @@ pTransaction envCli =
   pTransactionView :: Parser TransactionCmd
   pTransactionView = TxView <$> pInputTxOrTxBodyFile
 
-pNodeCmd :: Parser NodeCmd
-pNodeCmd =
+pNodeCmds :: Parser NodeCmds
+pNodeCmds =
   asum
     [ subParser "key-gen" . Opt.info pKeyGenOperator . Opt.progDesc $ mconcat
       [ "Create a key pair for a node operator's offline "
@@ -892,7 +892,7 @@ pNodeCmd =
       ]
     ]
   where
-    pKeyGenOperator :: Parser NodeCmd
+    pKeyGenOperator :: Parser NodeCmds
     pKeyGenOperator =
       NodeKeyGenCold
         <$> pKeyOutputFormat
@@ -900,27 +900,27 @@ pNodeCmd =
         <*> pColdSigningKeyFile
         <*> pOperatorCertIssueCounterFile
 
-    pKeyGenKES :: Parser NodeCmd
+    pKeyGenKES :: Parser NodeCmds
     pKeyGenKES =
       NodeKeyGenKES
         <$> pKeyOutputFormat
         <*> pVerificationKeyFileOut
         <*> pSigningKeyFileOut
 
-    pKeyGenVRF :: Parser NodeCmd
+    pKeyGenVRF :: Parser NodeCmds
     pKeyGenVRF =
       NodeKeyGenVRF
         <$> pKeyOutputFormat
         <*> pVerificationKeyFileOut
         <*> pSigningKeyFileOut
 
-    pKeyHashVRF :: Parser NodeCmd
+    pKeyHashVRF :: Parser NodeCmds
     pKeyHashVRF =
       NodeKeyHashVRF
         <$> pVerificationKeyOrFile AsVrfKey
         <*> pMaybeOutputFile
 
-    pNewCounter :: Parser NodeCmd
+    pNewCounter :: Parser NodeCmds
     pNewCounter =
       NodeNewCounter
         <$> pColdVerificationKeyOrFile
@@ -935,7 +935,7 @@ pNodeCmd =
         , Opt.help "The next certificate issue counter value to use."
         ]
 
-    pIssueOpCert :: Parser NodeCmd
+    pIssueOpCert :: Parser NodeCmds
     pIssueOpCert =
       NodeIssueOpCert
         <$> pKesVerificationKeyOrFile

--- a/cardano-cli/src/Cardano/CLI/EraBased/Legacy.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Legacy.hs
@@ -102,7 +102,7 @@ parseLegacyCommands envCli =
         $ Opt.info (GenesisCmd <$> pGenesisCmd envCli)
         $ Opt.progDesc "Genesis block commands"
     , Opt.command "governance"
-        $ Opt.info (GovernanceCmd' <$> pGovernanceCmd envCli)
+        $ Opt.info (GovernanceCmds <$> pGovernanceCmds envCli)
         $ Opt.progDesc "Governance commands"
     , Opt.command "text-view"
         $ Opt.info (TextViewCmd <$> pTextViewCmd) . Opt.progDesc
@@ -1192,8 +1192,8 @@ pQueryCmd envCli =
 
 
 -- TODO: Conway era - move to Cardano.CLI.Conway.Parsers
-pGovernanceCmd :: EnvCli -> Parser GovernanceCmd
-pGovernanceCmd envCli =
+pGovernanceCmds :: EnvCli -> Parser GovernanceCmds
+pGovernanceCmds envCli =
   asum
     [ subParser "create-mir-certificate"
         $ Opt.info (pLegacyMIRPayStakeAddresses <|> mirCertParsers)
@@ -1221,7 +1221,7 @@ pGovernanceCmd envCli =
         $ Opt.progDesc "Governance action related commands."
     ]
   where
-    mirCertParsers :: Parser GovernanceCmd
+    mirCertParsers :: Parser GovernanceCmds
     mirCertParsers = asum
       [ subParser "stake-addresses"
         $ Opt.info pLegacyMIRPayStakeAddresses
@@ -1234,7 +1234,7 @@ pGovernanceCmd envCli =
         $ Opt.progDesc "Create an MIR certificate to transfer from the treasury pot to the reserves pot"
       ]
 
-    pLegacyMIRPayStakeAddresses :: Parser GovernanceCmd
+    pLegacyMIRPayStakeAddresses :: Parser GovernanceCmds
     pLegacyMIRPayStakeAddresses =
       GovernanceMIRPayStakeAddressesCertificate
         <$> pAnyShelleyToBabbageEra envCli
@@ -1243,7 +1243,7 @@ pGovernanceCmd envCli =
         <*> some pRewardAmt
         <*> pOutputFile
 
-    pLegacyMIRTransferToTreasury :: Parser GovernanceCmd
+    pLegacyMIRTransferToTreasury :: Parser GovernanceCmds
     pLegacyMIRTransferToTreasury =
       GovernanceMIRTransfer
         <$> pAnyShelleyToBabbageEra envCli
@@ -1251,7 +1251,7 @@ pGovernanceCmd envCli =
         <*> pOutputFile
         <*> pure TransferToTreasury
 
-    pLegacyMIRTransferToReserves :: Parser GovernanceCmd
+    pLegacyMIRTransferToReserves :: Parser GovernanceCmds
     pLegacyMIRTransferToReserves =
       GovernanceMIRTransfer
         <$> pAnyShelleyToBabbageEra envCli
@@ -1259,7 +1259,7 @@ pGovernanceCmd envCli =
         <*> pOutputFile
         <*> pure TransferToReserves
 
-    pGovernanceGenesisKeyDelegationCertificate :: Parser GovernanceCmd
+    pGovernanceGenesisKeyDelegationCertificate :: Parser GovernanceCmds
     pGovernanceGenesisKeyDelegationCertificate =
       GovernanceGenesisKeyDelegationCertificate
         <$> pAnyShelleyBasedEra envCli
@@ -1268,7 +1268,7 @@ pGovernanceCmd envCli =
         <*> pVrfVerificationKeyOrHashOrFile
         <*> pOutputFile
 
-    pUpdateProposal :: Parser GovernanceCmd
+    pUpdateProposal :: Parser GovernanceCmds
     pUpdateProposal =
       GovernanceUpdateProposal
         <$> pOutputFile
@@ -1277,7 +1277,7 @@ pGovernanceCmd envCli =
         <*> pProtocolParametersUpdate
         <*> optional pCostModels
 
-    pGovernanceCreatePoll :: Parser GovernanceCmd
+    pGovernanceCreatePoll :: Parser GovernanceCmds
     pGovernanceCreatePoll =
       GovernanceCreatePoll
         <$> pPollQuestion
@@ -1285,14 +1285,14 @@ pGovernanceCmd envCli =
         <*> optional pPollNonce
         <*> pOutputFile
 
-    pGovernanceAnswerPoll :: Parser GovernanceCmd
+    pGovernanceAnswerPoll :: Parser GovernanceCmds
     pGovernanceAnswerPoll =
       GovernanceAnswerPoll
         <$> pPollFile
         <*> optional pPollAnswerIndex
         <*> optional pOutputFile
 
-    pGovernanceVerifyPoll :: Parser GovernanceCmd
+    pGovernanceVerifyPoll :: Parser GovernanceCmds
     pGovernanceVerifyPoll =
       GovernanceVerifyPoll
         <$> pPollFile

--- a/cardano-cli/src/Cardano/CLI/EraBased/Legacy.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Legacy.hs
@@ -105,15 +105,15 @@ parseLegacyCommands envCli =
         $ Opt.info (GovernanceCmds <$> pGovernanceCmds envCli)
         $ Opt.progDesc "Governance commands"
     , Opt.command "text-view"
-        $ Opt.info (TextViewCmd <$> pTextViewCmd) . Opt.progDesc
+        $ Opt.info (TextViewCmds <$> pTextViewCmds) . Opt.progDesc
         $ mconcat
             [ "Commands for dealing with Shelley TextView files. "
             , "Transactions, addresses etc are stored on disk as TextView files."
             ]
     ]
 
-pTextViewCmd :: Parser TextViewCmd
-pTextViewCmd =
+pTextViewCmds :: Parser TextViewCmds
+pTextViewCmds =
   asum
     [ subParser "decode-cbor"
         (Opt.info (TextViewInfo <$> pCBORInFile <*> pMaybeOutputFile)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Legacy.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Legacy.hs
@@ -75,7 +75,7 @@ parseLegacyCommands envCli =
     [ Opt.metavar "Legacy commands"
     , Opt.commandGroup "Legacy commands"
     , Opt.command "address"
-        $ Opt.info (AddressCmd <$> pAddressCmd envCli)
+        $ Opt.info (AddressCmds <$> pAddressCmds envCli)
         $ Opt.progDesc "Payment address commands"
     , Opt.command "stake-address"
         $ Opt.info (StakeAddressCmds <$> pStakeAddressCmds envCli)
@@ -137,8 +137,8 @@ pCBORInFile =
     ]
 
 
-pAddressCmd :: EnvCli -> Parser AddressCmd
-pAddressCmd envCli =
+pAddressCmds :: EnvCli -> Parser AddressCmds
+pAddressCmds envCli =
    asum
      [ subParser "key-gen"
          (Opt.info pAddressKeyGen $ Opt.progDesc "Create an address key pair.")
@@ -150,7 +150,7 @@ pAddressCmd envCli =
          (Opt.info pAddressInfo $ Opt.progDesc "Print information about an address.")
      ]
   where
-    pAddressKeyGen :: Parser AddressCmd
+    pAddressKeyGen :: Parser AddressCmds
     pAddressKeyGen =
       AddressKeyGen
         <$> pKeyOutputFormat
@@ -158,20 +158,20 @@ pAddressCmd envCli =
         <*> pVerificationKeyFileOut
         <*> pSigningKeyFileOut
 
-    pAddressKeyHash :: Parser AddressCmd
+    pAddressKeyHash :: Parser AddressCmds
     pAddressKeyHash =
       AddressKeyHash
         <$> pPaymentVerificationKeyTextOrFile
         <*> pMaybeOutputFile
 
-    pAddressBuild :: Parser AddressCmd
+    pAddressBuild :: Parser AddressCmds
     pAddressBuild = AddressBuild
       <$> pPaymentVerifier
       <*> Opt.optional pStakeIdentifier
       <*> pNetworkId envCli
       <*> pMaybeOutputFile
 
-    pAddressInfo :: Parser AddressCmd
+    pAddressInfo :: Parser AddressCmds
     pAddressInfo = AddressInfo <$> pAddress <*> pMaybeOutputFile
 
 pPaymentVerifier :: Parser PaymentVerifier

--- a/cardano-cli/src/Cardano/CLI/EraBased/Legacy.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Legacy.hs
@@ -90,7 +90,7 @@ parseLegacyCommands envCli =
         $ Opt.info (NodeCmd <$> pNodeCmd)
         $ Opt.progDesc "Node operation commands"
     , Opt.command "stake-pool"
-        $ Opt.info (PoolCmd <$> pPoolCmd envCli)
+        $ Opt.info (PoolCmds <$> pPoolCmds envCli)
         $ Opt.progDesc "Stake pool commands"
     , Opt.command "query"
         $ Opt.info (QueryCmds <$> pQueryCmds envCli) . Opt.progDesc
@@ -944,8 +944,8 @@ pNodeCmd =
         <*> pKesPeriod
         <*> pOutputFile
 
-pPoolCmd :: EnvCli -> Parser PoolCmd
-pPoolCmd  envCli =
+pPoolCmds :: EnvCli -> Parser PoolCmds
+pPoolCmds  envCli =
   asum
     [ subParser "registration-certificate"
         $ Opt.info (pStakePoolRegistrationCert envCli)
@@ -961,10 +961,10 @@ pPoolCmd  envCli =
         $ Opt.progDesc "Print the hash of pool metadata."
     ]
   where
-    pId :: Parser PoolCmd
+    pId :: Parser PoolCmds
     pId = PoolGetId <$> pStakePoolVerificationKeyOrFile <*> pPoolIdOutputFormat <*> pMaybeOutputFile
 
-    pPoolMetadataHashSubCmd :: Parser PoolCmd
+    pPoolMetadataHashSubCmd :: Parser PoolCmds
     pPoolMetadataHashSubCmd = PoolMetadataHash <$> pPoolMetadataFile <*> pMaybeOutputFile
 
 pQueryCmds :: EnvCli -> Parser QueryCmds
@@ -2907,7 +2907,7 @@ pStakePoolMetadataHash =
         . deserialiseFromRawBytesHex (AsHash AsStakePoolMetadata)
         . BSC.pack
 
-pStakePoolRegistrationCert :: EnvCli -> Parser PoolCmd
+pStakePoolRegistrationCert :: EnvCli -> Parser PoolCmds
 pStakePoolRegistrationCert envCli =
   PoolRegistrationCert
     <$> pAnyShelleyBasedEra envCli
@@ -2940,7 +2940,7 @@ pStakePoolRegistrationParserRequirements envCli =
     <*> pNetworkId envCli
 
 
-pStakePoolRetirementCert :: EnvCli -> Parser PoolCmd
+pStakePoolRetirementCert :: EnvCli -> Parser PoolCmds
 pStakePoolRetirementCert envCli =
   PoolRetirementCert
     <$> pAnyShelleyBasedEra envCli

--- a/cardano-cli/src/Cardano/CLI/EraBased/Legacy.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Legacy.hs
@@ -84,7 +84,7 @@ parseLegacyCommands envCli =
         $ Opt.info (KeyCmd <$> pKeyCmd)
         $ Opt.progDesc "Key utility commands"
     , Opt.command "transaction"
-        $ Opt.info (TransactionCmd <$> pTransaction envCli)
+        $ Opt.info (TransactionCmds <$> pTransaction envCli)
         $ Opt.progDesc "Transaction commands"
     , Opt.command "node"
         $ Opt.info (NodeCmds <$> pNodeCmds)
@@ -645,7 +645,7 @@ pKeyCmd =
             ]
         ]
 
-pTransaction :: EnvCli -> Parser TransactionCmd
+pTransaction :: EnvCli -> Parser TransactionCmds
 pTransaction envCli =
   asum
     [ subParser "build-raw"
@@ -701,22 +701,22 @@ pTransaction envCli =
     ]
  where
   -- Backwards compatible parsers
-  calcMinValueInfo :: ParserInfo TransactionCmd
+  calcMinValueInfo :: ParserInfo TransactionCmds
   calcMinValueInfo =
     Opt.info pTransactionCalculateMinReqUTxO
       $ Opt.progDesc "DEPRECATED: Use 'calculate-min-required-utxo' instead."
 
-  pCalculateMinRequiredUtxoBackwardCompatible :: Parser TransactionCmd
+  pCalculateMinRequiredUtxoBackwardCompatible :: Parser TransactionCmds
   pCalculateMinRequiredUtxoBackwardCompatible =
     Opt.subparser
       $ Opt.command "calculate-min-value" calcMinValueInfo <> Opt.internal
 
-  assembleInfo :: ParserInfo TransactionCmd
+  assembleInfo :: ParserInfo TransactionCmds
   assembleInfo =
     Opt.info pTransactionAssembleTxBodyWit
       $ Opt.progDesc "Assemble a tx body and witness(es) to form a transaction"
 
-  pSignWitnessBackwardCompatible :: Parser TransactionCmd
+  pSignWitnessBackwardCompatible :: Parser TransactionCmds
   pSignWitnessBackwardCompatible =
     Opt.subparser
       $ Opt.command "sign-witness" assembleInfo <> Opt.internal
@@ -737,7 +737,7 @@ pTransaction envCli =
       ]
     ]
 
-  pTransactionBuild :: Parser TransactionCmd
+  pTransactionBuild :: Parser TransactionCmds
   pTransactionBuild =
     TxBuild
       <$> pSocketPath envCli
@@ -778,7 +778,7 @@ pTransaction envCli =
       , Opt.help "Address where ADA in excess of the tx fee will go to."
       ]
 
-  pTransactionBuildRaw :: Parser TransactionCmd
+  pTransactionBuildRaw :: Parser TransactionCmds
   pTransactionBuildRaw =
     TxBuildRaw
       <$> pCardanoEra envCli
@@ -803,7 +803,7 @@ pTransaction envCli =
       <*> optional pUpdateProposalFile
       <*> pTxBodyFileOut
 
-  pTransactionSign  :: Parser TransactionCmd
+  pTransactionSign  :: Parser TransactionCmds
   pTransactionSign =
     TxSign
       <$> pInputTxOrTxBodyFile
@@ -811,7 +811,7 @@ pTransaction envCli =
       <*> optional (pNetworkId envCli)
       <*> pTxFileOut
 
-  pTransactionCreateWitness :: Parser TransactionCmd
+  pTransactionCreateWitness :: Parser TransactionCmds
   pTransactionCreateWitness =
     TxCreateWitness
       <$> pTxBodyFileIn
@@ -819,14 +819,14 @@ pTransaction envCli =
       <*> optional (pNetworkId envCli)
       <*> pOutputFile
 
-  pTransactionAssembleTxBodyWit :: Parser TransactionCmd
+  pTransactionAssembleTxBodyWit :: Parser TransactionCmds
   pTransactionAssembleTxBodyWit =
     TxAssembleTxBodyWitness
       <$> pTxBodyFileIn
       <*> many pWitnessFile
       <*> pOutputFile
 
-  pTransactionSubmit :: Parser TransactionCmd
+  pTransactionSubmit :: Parser TransactionCmds
   pTransactionSubmit =
     TxSubmit
       <$> pSocketPath envCli
@@ -834,10 +834,10 @@ pTransaction envCli =
       <*> pNetworkId envCli
       <*> pTxSubmitFile
 
-  pTransactionPolicyId :: Parser TransactionCmd
+  pTransactionPolicyId :: Parser TransactionCmds
   pTransactionPolicyId = TxMintedPolicyId <$> pScript
 
-  pTransactionCalculateMinFee :: Parser TransactionCmd
+  pTransactionCalculateMinFee :: Parser TransactionCmds
   pTransactionCalculateMinFee =
     TxCalculateMinFee
       <$> pTxBodyFileIn
@@ -848,13 +848,13 @@ pTransaction envCli =
       <*> pTxShelleyWitnessCount
       <*> pTxByronWitnessCount
 
-  pTransactionCalculateMinReqUTxO :: Parser TransactionCmd
+  pTransactionCalculateMinReqUTxO :: Parser TransactionCmds
   pTransactionCalculateMinReqUTxO = TxCalculateMinRequiredUTxO
     <$> pCardanoEra envCli
     <*> pProtocolParamsFile
     <*> pTxOut
 
-  pTxHashScriptData :: Parser TransactionCmd
+  pTxHashScriptData :: Parser TransactionCmds
   pTxHashScriptData =
     fmap TxHashScriptData
       $ pScriptDataOrFile
@@ -862,10 +862,10 @@ pTransaction envCli =
           "The script data, in JSON syntax."
           "The script data, in the given JSON file."
 
-  pTransactionId  :: Parser TransactionCmd
+  pTransactionId  :: Parser TransactionCmds
   pTransactionId = TxGetTxId <$> pInputTxOrTxBodyFile
 
-  pTransactionView :: Parser TransactionCmd
+  pTransactionView :: Parser TransactionCmds
   pTransactionView = TxView <$> pInputTxOrTxBodyFile
 
 pNodeCmds :: Parser NodeCmds

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance.hs
@@ -3,9 +3,9 @@
 {-# LANGUAGE LambdaCase #-}
 
 module Cardano.CLI.EraBased.Options.Governance
-  ( EraBasedGovernanceCmd(..)
-  , renderEraBasedGovernanceCmd
-  , pEraBasedGovernanceCmd
+  ( EraBasedGovernanceCmds(..)
+  , renderEraBasedGovernanceCmds
+  , pEraBasedGovernanceCmds
   ) where
 
 import           Cardano.Api
@@ -29,8 +29,8 @@ import           Options.Applicative
 import qualified Options.Applicative as Opt
 
 -- TODO: Conway era - move to Cardano.CLI.Conway.Parsers
-pEraBasedGovernanceCmd :: EnvCli -> CardanoEra era -> Parser (EraBasedGovernanceCmd era)
-pEraBasedGovernanceCmd envCli era =
+pEraBasedGovernanceCmds :: EnvCli -> CardanoEra era -> Parser (EraBasedGovernanceCmds era)
+pEraBasedGovernanceCmds envCli era =
   asum $ catMaybes
     [ pEraBasedRegistrationCertificateCmd envCli era
     , pEraBasedDelegationCertificateCmd envCli era
@@ -42,7 +42,7 @@ pEraBasedGovernanceCmd envCli era =
 -- Registration Certificate related
 
 pEraBasedRegistrationCertificateCmd
-  :: EnvCli -> CardanoEra era -> Maybe (Parser (EraBasedGovernanceCmd era))
+  :: EnvCli -> CardanoEra era -> Maybe (Parser (EraBasedGovernanceCmds era))
 pEraBasedRegistrationCertificateCmd envCli =
   featureInEra Nothing $ \w ->
     Just
@@ -50,7 +50,7 @@ pEraBasedRegistrationCertificateCmd envCli =
       $ Opt.info (pEraCmd envCli w)
       $ Opt.progDesc "Create a registration certificate."
  where
-  pEraCmd :: EnvCli -> AnyEraDecider era -> Parser (EraBasedGovernanceCmd era)
+  pEraCmd :: EnvCli -> AnyEraDecider era -> Parser (EraBasedGovernanceCmds era)
   pEraCmd envCli' = \case
     AnyEraDeciderShelleyToBabbage sToB ->
       EraBasedGovernanceRegistrationCertificateCmd
@@ -92,7 +92,7 @@ instance FeatureInEra AnyEraDecider where
 
 -- Delegation Certificate related
 
-pEraBasedDelegationCertificateCmd :: EnvCli -> CardanoEra era -> Maybe (Parser (EraBasedGovernanceCmd era))
+pEraBasedDelegationCertificateCmd :: EnvCli -> CardanoEra era -> Maybe (Parser (EraBasedGovernanceCmds era))
 pEraBasedDelegationCertificateCmd _envCli =
   featureInEra Nothing $ \w ->
     Just
@@ -100,7 +100,7 @@ pEraBasedDelegationCertificateCmd _envCli =
       $ Opt.info (pCmd w)
       $ Opt.progDesc "Delegation certificate creation."
  where
-  pCmd :: AnyEraDecider era -> Parser (EraBasedGovernanceCmd era)
+  pCmd :: AnyEraDecider era -> Parser (EraBasedGovernanceCmds era)
   pCmd w =
     EraBasedGovernanceDelegationCertificateCmd
       <$> pStakeIdentifier
@@ -211,7 +211,7 @@ pDRepVerificationKeyFile =
 -- Vote related
 
 pEraBasedVoteCmd
-  :: EnvCli -> CardanoEra era -> Maybe (Parser (EraBasedGovernanceCmd era))
+  :: EnvCli -> CardanoEra era -> Maybe (Parser (EraBasedGovernanceCmds era))
 pEraBasedVoteCmd envCli =
   featureInEra Nothing $ \w ->
     Just
@@ -220,7 +220,7 @@ pEraBasedVoteCmd envCli =
       $ Opt.progDesc "Vote creation."
  where
   pEraCmd'
-    :: EnvCli -> ConwayEraOnwards era -> Parser (EraBasedGovernanceCmd era)
+    :: EnvCli -> ConwayEraOnwards era -> Parser (EraBasedGovernanceCmds era)
   pEraCmd' _envCli cOn =
       EraBasedGovernanceVoteCmd
         <$> pAnyVote cOn
@@ -244,7 +244,7 @@ pAnyVotingStakeVerificationKeyOrHashOrFile =
 --------------------------------------------------------------------------------
 
 
-pCreateMirCertificatesCmds :: CardanoEra era -> Maybe (Parser (EraBasedGovernanceCmd era))
+pCreateMirCertificatesCmds :: CardanoEra era -> Maybe (Parser (EraBasedGovernanceCmds era))
 pCreateMirCertificatesCmds =
   featureInEra Nothing $ \w ->
     Just
@@ -254,7 +254,7 @@ pCreateMirCertificatesCmds =
 
 mirCertParsers :: ()
   => ShelleyToBabbageEra era
-  -> Parser (EraBasedGovernanceCmd era)
+  -> Parser (EraBasedGovernanceCmds era)
 mirCertParsers w =
   asum
     [ subParser "stake-addresses"
@@ -270,7 +270,7 @@ mirCertParsers w =
 
 pMIRPayStakeAddresses :: ()
   => ShelleyToBabbageEra era
-  -> Parser (EraBasedGovernanceCmd era)
+  -> Parser (EraBasedGovernanceCmds era)
 pMIRPayStakeAddresses w =
   EraBasedGovernanceMIRPayStakeAddressesCertificate w
     <$> pMIRPot
@@ -280,7 +280,7 @@ pMIRPayStakeAddresses w =
 
 pMIRTransferToTreasury :: ()
   => ShelleyToBabbageEra era
-  -> Parser (EraBasedGovernanceCmd era)
+  -> Parser (EraBasedGovernanceCmds era)
 pMIRTransferToTreasury w =
   EraBasedGovernanceMIRTransfer w
     <$> pTransferAmt
@@ -289,7 +289,7 @@ pMIRTransferToTreasury w =
 
 pMIRTransferToReserves :: ()
   => ShelleyToBabbageEra era
-  -> Parser (EraBasedGovernanceCmd era)
+  -> Parser (EraBasedGovernanceCmds era)
 pMIRTransferToReserves w =
   EraBasedGovernanceMIRTransfer w
     <$> pTransferAmt

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run.hs
@@ -5,7 +5,7 @@ module Cardano.CLI.EraBased.Run
   ( AnyEraCmdError(..)
   , runAnyEraCommand
   , runEraBasedCommand
-  , runEraBasedGovernanceCmd
+  , runEraBasedGovernanceCmds
 
   , renderAnyEraCmdError
   ) where
@@ -40,12 +40,12 @@ runAnyEraCommand = \case
 runEraBasedCommand :: ()
   => EraBasedCommand era -> ExceptT () IO ()
 runEraBasedCommand = \case
-  EraBasedGovernanceCmd cmd -> runEraBasedGovernanceCmd cmd
+  EraBasedGovernanceCmds cmd -> runEraBasedGovernanceCmds cmd
 
-runEraBasedGovernanceCmd :: ()
-  => EraBasedGovernanceCmd era
+runEraBasedGovernanceCmds :: ()
+  => EraBasedGovernanceCmds era
   -> ExceptT () IO ()
-runEraBasedGovernanceCmd = \case
+runEraBasedGovernanceCmds = \case
   EraBasedGovernancePreConwayCmd w ->
     runEraBasedGovernancePreConwayCmd w
   EraBasedGovernancePostConwayCmd w ->

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance.hs
@@ -5,7 +5,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Cardano.CLI.EraBased.Run.Governance
-  ( runGovernanceCmd
+  ( runGovernanceCmds
   , runGovernanceMIRCertificatePayStakeAddrs
   , runGovernanceMIRCertificateTransfer
   ) where
@@ -100,8 +100,8 @@ runGovernanceMIRCertificateTransfer w ll oFp direction = do
   mirCertDesc TransferToTreasury = "MIR Certificate Send To Treasury"
   mirCertDesc TransferToReserves = "MIR Certificate Send To Reserves"
 
-runGovernanceCmd :: GovernanceCmd -> ExceptT GovernanceCmdError IO ()
-runGovernanceCmd = \case
+runGovernanceCmds :: GovernanceCmds -> ExceptT GovernanceCmdError IO ()
+runGovernanceCmds = \case
   GovernanceVoteCmd (CreateVoteCmd (ConwayVote voteChoice voteType govActTcIn voteStakeCred sbe fp)) ->
     runGovernanceCreateVoteCmd sbe voteChoice voteType govActTcIn voteStakeCred fp
   GovernanceActionCmd (CreateConstitution (Cli.NewConstitution sbe deposit voteStakeCred newconstitution fp)) ->

--- a/cardano-cli/src/Cardano/CLI/Run/Legacy.hs
+++ b/cardano-cli/src/Cardano/CLI/Run/Legacy.hs
@@ -79,7 +79,7 @@ renderLegacyClientCmdError cmd err =
 runLegacyClientCommand :: LegacyCommand -> ExceptT LegacyClientCmdError IO ()
 runLegacyClientCommand = \case
   AddressCmd      cmd -> firstExceptT LegacyCmdAddressError $ runAddressCmd cmd
-  StakeAddressCmd cmd -> firstExceptT LegacyCmdStakeAddressError $ runStakeAddressCmd cmd
+  StakeAddressCmds cmd -> firstExceptT LegacyCmdStakeAddressError $ runStakeAddressCmds cmd
   KeyCmds          cmd -> firstExceptT LegacyCmdKeyError $ runKeyCmds cmd
   TransactionCmds  cmd -> firstExceptT LegacyCmdTransactionError $ runTransactionCmds cmd
   NodeCmds         cmd -> firstExceptT LegacyCmdNodeError $ runNodeCmds cmd

--- a/cardano-cli/src/Cardano/CLI/Run/Legacy.hs
+++ b/cardano-cli/src/Cardano/CLI/Run/Legacy.hs
@@ -83,7 +83,7 @@ runLegacyClientCommand = \case
   KeyCmd          cmd -> firstExceptT LegacyCmdKeyError $ runKeyCmd cmd
   TransactionCmd  cmd -> firstExceptT LegacyCmdTransactionError $ runTransactionCmd  cmd
   NodeCmd         cmd -> firstExceptT LegacyCmdNodeError $ runNodeCmd cmd
-  PoolCmd         cmd -> firstExceptT LegacyCmdPoolError $ runPoolCmd cmd
+  PoolCmds         cmd -> firstExceptT LegacyCmdPoolError $ runPoolCmds cmd
   QueryCmds        cmd -> firstExceptT LegacyCmdQueryError $ runQueryCmds cmd
   GovernanceCmds  cmd -> firstExceptT LegacyCmdGovernanceError $ runGovernanceCmds cmd
   GenesisCmds      cmd -> firstExceptT LegacyCmdGenesisError $ runGenesisCmds cmd

--- a/cardano-cli/src/Cardano/CLI/Run/Legacy.hs
+++ b/cardano-cli/src/Cardano/CLI/Run/Legacy.hs
@@ -80,7 +80,7 @@ runLegacyClientCommand :: LegacyCommand -> ExceptT LegacyClientCmdError IO ()
 runLegacyClientCommand = \case
   AddressCmd      cmd -> firstExceptT LegacyCmdAddressError $ runAddressCmd cmd
   StakeAddressCmd cmd -> firstExceptT LegacyCmdStakeAddressError $ runStakeAddressCmd cmd
-  KeyCmd          cmd -> firstExceptT LegacyCmdKeyError $ runKeyCmd cmd
+  KeyCmds          cmd -> firstExceptT LegacyCmdKeyError $ runKeyCmds cmd
   TransactionCmds  cmd -> firstExceptT LegacyCmdTransactionError $ runTransactionCmds cmd
   NodeCmds         cmd -> firstExceptT LegacyCmdNodeError $ runNodeCmds cmd
   PoolCmds         cmd -> firstExceptT LegacyCmdPoolError $ runPoolCmds cmd

--- a/cardano-cli/src/Cardano/CLI/Run/Legacy.hs
+++ b/cardano-cli/src/Cardano/CLI/Run/Legacy.hs
@@ -81,7 +81,7 @@ runLegacyClientCommand = \case
   AddressCmd      cmd -> firstExceptT LegacyCmdAddressError $ runAddressCmd cmd
   StakeAddressCmd cmd -> firstExceptT LegacyCmdStakeAddressError $ runStakeAddressCmd cmd
   KeyCmd          cmd -> firstExceptT LegacyCmdKeyError $ runKeyCmd cmd
-  TransactionCmd  cmd -> firstExceptT LegacyCmdTransactionError $ runTransactionCmd  cmd
+  TransactionCmds  cmd -> firstExceptT LegacyCmdTransactionError $ runTransactionCmds cmd
   NodeCmds         cmd -> firstExceptT LegacyCmdNodeError $ runNodeCmds cmd
   PoolCmds         cmd -> firstExceptT LegacyCmdPoolError $ runPoolCmds cmd
   QueryCmds        cmd -> firstExceptT LegacyCmdQueryError $ runQueryCmds cmd

--- a/cardano-cli/src/Cardano/CLI/Run/Legacy.hs
+++ b/cardano-cli/src/Cardano/CLI/Run/Legacy.hs
@@ -86,5 +86,5 @@ runLegacyClientCommand = \case
   PoolCmd         cmd -> firstExceptT LegacyCmdPoolError $ runPoolCmd cmd
   QueryCmd        cmd -> firstExceptT LegacyCmdQueryError $ runQueryCmd cmd
   GovernanceCmds  cmd -> firstExceptT LegacyCmdGovernanceError $ runGovernanceCmds cmd
-  GenesisCmd      cmd -> firstExceptT LegacyCmdGenesisError $ runGenesisCmd cmd
+  GenesisCmds      cmd -> firstExceptT LegacyCmdGenesisError $ runGenesisCmds cmd
   TextViewCmd     cmd -> firstExceptT LegacyCmdTextViewError $ runTextViewCmd cmd

--- a/cardano-cli/src/Cardano/CLI/Run/Legacy.hs
+++ b/cardano-cli/src/Cardano/CLI/Run/Legacy.hs
@@ -87,4 +87,4 @@ runLegacyClientCommand = \case
   QueryCmd        cmd -> firstExceptT LegacyCmdQueryError $ runQueryCmd cmd
   GovernanceCmds  cmd -> firstExceptT LegacyCmdGovernanceError $ runGovernanceCmds cmd
   GenesisCmds      cmd -> firstExceptT LegacyCmdGenesisError $ runGenesisCmds cmd
-  TextViewCmd     cmd -> firstExceptT LegacyCmdTextViewError $ runTextViewCmd cmd
+  TextViewCmds     cmd -> firstExceptT LegacyCmdTextViewError $ runTextViewCmds cmd

--- a/cardano-cli/src/Cardano/CLI/Run/Legacy.hs
+++ b/cardano-cli/src/Cardano/CLI/Run/Legacy.hs
@@ -82,7 +82,7 @@ runLegacyClientCommand = \case
   StakeAddressCmd cmd -> firstExceptT LegacyCmdStakeAddressError $ runStakeAddressCmd cmd
   KeyCmd          cmd -> firstExceptT LegacyCmdKeyError $ runKeyCmd cmd
   TransactionCmd  cmd -> firstExceptT LegacyCmdTransactionError $ runTransactionCmd  cmd
-  NodeCmd         cmd -> firstExceptT LegacyCmdNodeError $ runNodeCmd cmd
+  NodeCmds         cmd -> firstExceptT LegacyCmdNodeError $ runNodeCmds cmd
   PoolCmds         cmd -> firstExceptT LegacyCmdPoolError $ runPoolCmds cmd
   QueryCmds        cmd -> firstExceptT LegacyCmdQueryError $ runQueryCmds cmd
   GovernanceCmds  cmd -> firstExceptT LegacyCmdGovernanceError $ runGovernanceCmds cmd

--- a/cardano-cli/src/Cardano/CLI/Run/Legacy.hs
+++ b/cardano-cli/src/Cardano/CLI/Run/Legacy.hs
@@ -84,7 +84,7 @@ runLegacyClientCommand = \case
   TransactionCmd  cmd -> firstExceptT LegacyCmdTransactionError $ runTransactionCmd  cmd
   NodeCmd         cmd -> firstExceptT LegacyCmdNodeError $ runNodeCmd cmd
   PoolCmd         cmd -> firstExceptT LegacyCmdPoolError $ runPoolCmd cmd
-  QueryCmd        cmd -> firstExceptT LegacyCmdQueryError $ runQueryCmd cmd
+  QueryCmds        cmd -> firstExceptT LegacyCmdQueryError $ runQueryCmds cmd
   GovernanceCmds  cmd -> firstExceptT LegacyCmdGovernanceError $ runGovernanceCmds cmd
   GenesisCmds      cmd -> firstExceptT LegacyCmdGenesisError $ runGenesisCmds cmd
   TextViewCmds     cmd -> firstExceptT LegacyCmdTextViewError $ runTextViewCmds cmd

--- a/cardano-cli/src/Cardano/CLI/Run/Legacy.hs
+++ b/cardano-cli/src/Cardano/CLI/Run/Legacy.hs
@@ -85,6 +85,6 @@ runLegacyClientCommand = \case
   NodeCmd         cmd -> firstExceptT LegacyCmdNodeError $ runNodeCmd cmd
   PoolCmd         cmd -> firstExceptT LegacyCmdPoolError $ runPoolCmd cmd
   QueryCmd        cmd -> firstExceptT LegacyCmdQueryError $ runQueryCmd cmd
-  GovernanceCmd'  cmd -> firstExceptT LegacyCmdGovernanceError $ runGovernanceCmd cmd
+  GovernanceCmds  cmd -> firstExceptT LegacyCmdGovernanceError $ runGovernanceCmds cmd
   GenesisCmd      cmd -> firstExceptT LegacyCmdGenesisError $ runGenesisCmd cmd
   TextViewCmd     cmd -> firstExceptT LegacyCmdTextViewError $ runTextViewCmd cmd

--- a/cardano-cli/src/Cardano/CLI/Run/Legacy.hs
+++ b/cardano-cli/src/Cardano/CLI/Run/Legacy.hs
@@ -78,7 +78,7 @@ renderLegacyClientCmdError cmd err =
 
 runLegacyClientCommand :: LegacyCommand -> ExceptT LegacyClientCmdError IO ()
 runLegacyClientCommand = \case
-  AddressCmd      cmd -> firstExceptT LegacyCmdAddressError $ runAddressCmd cmd
+  AddressCmds      cmd -> firstExceptT LegacyCmdAddressError $ runAddressCmds cmd
   StakeAddressCmds cmd -> firstExceptT LegacyCmdStakeAddressError $ runStakeAddressCmds cmd
   KeyCmds          cmd -> firstExceptT LegacyCmdKeyError $ runKeyCmds cmd
   TransactionCmds  cmd -> firstExceptT LegacyCmdTransactionError $ runTransactionCmds cmd

--- a/cardano-cli/src/Cardano/CLI/Run/Legacy/Address.hs
+++ b/cardano-cli/src/Cardano/CLI/Run/Legacy/Address.hs
@@ -9,7 +9,7 @@ module Cardano.CLI.Run.Legacy.Address
   , SomeAddressVerificationKey(..)
   , buildShelleyAddress
   , renderShelleyAddressCmdError
-  , runAddressCmd
+  , runAddressCmds
   , runAddressKeyGenToFile
   , makeStakeAddressRef
   ) where
@@ -17,7 +17,7 @@ module Cardano.CLI.Run.Legacy.Address
 import           Cardano.Api
 import           Cardano.Api.Shelley
 
-import           Cardano.CLI.EraBased.Legacy (AddressCmd (..), AddressKeyType (..))
+import           Cardano.CLI.EraBased.Legacy (AddressCmds (..), AddressKeyType (..))
 import           Cardano.CLI.Run.Legacy.Address.Info (ShelleyAddressInfoError, runAddressInfo)
 import           Cardano.CLI.Run.Legacy.Read
 import           Cardano.CLI.Types.Key (PaymentVerifier (..), StakeIdentifier (..),
@@ -58,8 +58,8 @@ renderShelleyAddressCmdError err =
     ShelleyAddressCmdExpectedPaymentVerificationKey someAddress ->
       "Expected payment verification key but got: " <> renderSomeAddressVerificationKey someAddress
 
-runAddressCmd :: AddressCmd -> ExceptT ShelleyAddressCmdError IO ()
-runAddressCmd cmd =
+runAddressCmds :: AddressCmds -> ExceptT ShelleyAddressCmdError IO ()
+runAddressCmds cmd =
   case cmd of
     AddressKeyGen fmt kt vkf skf -> runAddressKeyGenToFile fmt kt vkf skf
     AddressKeyHash vkf mOFp -> runAddressKeyHash vkf mOFp

--- a/cardano-cli/src/Cardano/CLI/Run/Legacy/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/Run/Legacy/Genesis.hs
@@ -22,7 +22,7 @@ module Cardano.CLI.Run.Legacy.Genesis
   , readShelleyGenesisWithDefault
   , readAndDecodeShelleyGenesis
   , readAlonzoGenesis
-  , runGenesisCmd
+  , runGenesisCmds
 
   -- * Protocol Parameters
   , ProtocolParamsError(..)
@@ -199,19 +199,19 @@ instance Error ShelleyGenesisCmdError where
         "Error occurred while decoding the stake pool relay specification file: " <> fp <>
         " Error: " <>  e
 
-runGenesisCmd :: GenesisCmd -> ExceptT ShelleyGenesisCmdError IO ()
-runGenesisCmd (GenesisKeyGenGenesis vk sk) = runGenesisKeyGenGenesis vk sk
-runGenesisCmd (GenesisKeyGenDelegate vk sk ctr) = runGenesisKeyGenDelegate vk sk ctr
-runGenesisCmd (GenesisKeyGenUTxO vk sk) = runGenesisKeyGenUTxO vk sk
-runGenesisCmd (GenesisCmdKeyHash vk) = runGenesisKeyHash vk
-runGenesisCmd (GenesisVerKey vk sk) = runGenesisVerKey vk sk
-runGenesisCmd (GenesisTxIn vk nw mOutFile) = runGenesisTxIn vk nw mOutFile
-runGenesisCmd (GenesisAddr vk nw mOutFile) = runGenesisAddr vk nw mOutFile
-runGenesisCmd (GenesisCreate fmt gd gn un ms am nw) = runGenesisCreate fmt gd gn un ms am nw
-runGenesisCmd (GenesisCreateCardano gd gn un ms am k slotLength sc nw bg sg ag cg mNodeCfg) = runGenesisCreateCardano gd gn un ms am k slotLength sc nw bg sg ag cg mNodeCfg
-runGenesisCmd (GenesisCreateStaked fmt gd gn gp gl un ms am ds nw bf bp su relayJsonFp) =
+runGenesisCmds :: GenesisCmds -> ExceptT ShelleyGenesisCmdError IO ()
+runGenesisCmds (GenesisKeyGenGenesis vk sk) = runGenesisKeyGenGenesis vk sk
+runGenesisCmds (GenesisKeyGenDelegate vk sk ctr) = runGenesisKeyGenDelegate vk sk ctr
+runGenesisCmds (GenesisKeyGenUTxO vk sk) = runGenesisKeyGenUTxO vk sk
+runGenesisCmds (GenesisCmdKeyHash vk) = runGenesisKeyHash vk
+runGenesisCmds (GenesisVerKey vk sk) = runGenesisVerKey vk sk
+runGenesisCmds (GenesisTxIn vk nw mOutFile) = runGenesisTxIn vk nw mOutFile
+runGenesisCmds (GenesisAddr vk nw mOutFile) = runGenesisAddr vk nw mOutFile
+runGenesisCmds (GenesisCreate fmt gd gn un ms am nw) = runGenesisCreate fmt gd gn un ms am nw
+runGenesisCmds (GenesisCreateCardano gd gn un ms am k slotLength sc nw bg sg ag cg mNodeCfg) = runGenesisCreateCardano gd gn un ms am k slotLength sc nw bg sg ag cg mNodeCfg
+runGenesisCmds (GenesisCreateStaked fmt gd gn gp gl un ms am ds nw bf bp su relayJsonFp) =
   runGenesisCreateStaked fmt gd gn gp gl un ms am ds nw bf bp su relayJsonFp
-runGenesisCmd (GenesisHashFile gf) = runGenesisHashFile gf
+runGenesisCmds (GenesisHashFile gf) = runGenesisHashFile gf
 
 --
 -- Genesis command implementations

--- a/cardano-cli/src/Cardano/CLI/Run/Legacy/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/Run/Legacy/Key.hs
@@ -7,7 +7,7 @@ module Cardano.CLI.Run.Legacy.Key
   ( ShelleyKeyCmdError
   , SomeSigningKey(..)
   , renderShelleyKeyCmdError
-  , runKeyCmd
+  , runKeyCmds
   , readSigningKeyFile
 
     -- * Exports for testing
@@ -85,8 +85,8 @@ renderShelleyKeyCmdError err =
     ShelleyKeyCmdExpectedExtendedVerificationKey someVerKey ->
       "Expected an extended verification key but got: " <> renderSomeAddressVerificationKey someVerKey
 
-runKeyCmd :: KeyCmd -> ExceptT ShelleyKeyCmdError IO ()
-runKeyCmd cmd =
+runKeyCmds :: KeyCmds -> ExceptT ShelleyKeyCmdError IO ()
+runKeyCmds cmd =
   case cmd of
     KeyGetVerificationKey skf vkf ->
       runGetVerificationKey skf vkf

--- a/cardano-cli/src/Cardano/CLI/Run/Legacy/Node.hs
+++ b/cardano-cli/src/Cardano/CLI/Run/Legacy/Node.hs
@@ -3,7 +3,7 @@
 module Cardano.CLI.Run.Legacy.Node
   ( ShelleyNodeCmdError(ShelleyNodeCmdReadFileError)
   , renderShelleyNodeCmdError
-  , runNodeCmd
+  , runNodeCmds
   , runNodeIssueOpCert
   , runNodeKeyGenCold
   , runNodeKeyGenKES
@@ -16,7 +16,8 @@ import           Cardano.Api.Shelley
 
 import           Cardano.CLI.Commands.Legacy
 import           Cardano.CLI.Types.Key (VerificationKeyOrFile, readVerificationKeyOrFile)
-import           Cardano.CLI.Types.Legacy (KeyOutputFormat (..), SigningKeyFile, VerificationKeyFile)
+import           Cardano.CLI.Types.Legacy (KeyOutputFormat (..), SigningKeyFile,
+                   VerificationKeyFile)
 
 import           Control.Monad.IO.Class (MonadIO (..))
 import           Control.Monad.Trans.Except (ExceptT)
@@ -58,13 +59,13 @@ renderShelleyNodeCmdError err =
       Text.pack (displayError issueErr)
 
 
-runNodeCmd :: NodeCmd -> ExceptT ShelleyNodeCmdError IO ()
-runNodeCmd (NodeKeyGenCold fmt vk sk ctr) = runNodeKeyGenCold fmt vk sk ctr
-runNodeCmd (NodeKeyGenKES  fmt vk sk)     = runNodeKeyGenKES fmt vk sk
-runNodeCmd (NodeKeyGenVRF  fmt vk sk)     = runNodeKeyGenVRF fmt vk sk
-runNodeCmd (NodeKeyHashVRF vk mOutFp) = runNodeKeyHashVRF vk mOutFp
-runNodeCmd (NodeNewCounter vk ctr out) = runNodeNewCounter vk ctr out
-runNodeCmd (NodeIssueOpCert vk sk ctr p out) =
+runNodeCmds :: NodeCmds -> ExceptT ShelleyNodeCmdError IO ()
+runNodeCmds (NodeKeyGenCold fmt vk sk ctr) = runNodeKeyGenCold fmt vk sk ctr
+runNodeCmds (NodeKeyGenKES  fmt vk sk)     = runNodeKeyGenKES fmt vk sk
+runNodeCmds (NodeKeyGenVRF  fmt vk sk)     = runNodeKeyGenVRF fmt vk sk
+runNodeCmds (NodeKeyHashVRF vk mOutFp) = runNodeKeyHashVRF vk mOutFp
+runNodeCmds (NodeNewCounter vk ctr out) = runNodeNewCounter vk ctr out
+runNodeCmds (NodeIssueOpCert vk sk ctr p out) =
   runNodeIssueOpCert vk sk ctr p out
 
 

--- a/cardano-cli/src/Cardano/CLI/Run/Legacy/Pool.hs
+++ b/cardano-cli/src/Cardano/CLI/Run/Legacy/Pool.hs
@@ -6,7 +6,7 @@
 module Cardano.CLI.Run.Legacy.Pool
   ( ShelleyPoolCmdError(ShelleyPoolCmdReadFileError)
   , renderShelleyPoolCmdError
-  , runPoolCmd
+  , runPoolCmds
   ) where
 
 import           Cardano.Api
@@ -46,8 +46,8 @@ renderShelleyPoolCmdError err =
 
 
 
-runPoolCmd :: PoolCmd -> ExceptT ShelleyPoolCmdError IO ()
-runPoolCmd = \case
+runPoolCmds :: PoolCmds -> ExceptT ShelleyPoolCmdError IO ()
+runPoolCmds = \case
   PoolRegistrationCert anyEra sPvkey vrfVkey pldg pCost pMrgn rwdVerFp ownerVerFps relays mbMetadata network outfp ->
     runStakePoolRegistrationCert anyEra sPvkey vrfVkey pldg pCost pMrgn rwdVerFp ownerVerFps relays mbMetadata network outfp
   PoolRetirementCert anyEra sPvkeyFp retireEpoch outfp ->

--- a/cardano-cli/src/Cardano/CLI/Run/Legacy/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Run/Legacy/Query.hs
@@ -20,7 +20,7 @@ module Cardano.CLI.Run.Legacy.Query
   , renderOpCertIntervalInformation
   , renderShelleyQueryCmdError
   , renderLocalStateQueryError
-  , runQueryCmd
+  , runQueryCmds
   , toEpochInfo
   , utcTimeToSlotNo
   , determineEra
@@ -162,8 +162,8 @@ renderShelleyQueryCmdError err =
     ShelleyQueryCmdProtocolParameterConversionError ppce ->
       Text.pack $ "Failed to convert protocol parameter: " <> displayError ppce
 
-runQueryCmd :: QueryCmd -> ExceptT ShelleyQueryCmdError IO ()
-runQueryCmd cmd =
+runQueryCmds :: QueryCmds -> ExceptT ShelleyQueryCmdError IO ()
+runQueryCmds cmd =
   case cmd of
     QueryLeadershipSchedule mNodeSocketPath consensusModeParams network shelleyGenFp poolid vrkSkeyFp whichSchedule outputAs ->
       runQueryLeadershipSchedule mNodeSocketPath consensusModeParams network shelleyGenFp poolid vrkSkeyFp whichSchedule outputAs

--- a/cardano-cli/src/Cardano/CLI/Run/Legacy/StakeAddress.hs
+++ b/cardano-cli/src/Cardano/CLI/Run/Legacy/StakeAddress.hs
@@ -11,7 +11,7 @@ module Cardano.CLI.Run.Legacy.StakeAddress
   ( ShelleyStakeAddressCmdError(ShelleyStakeAddressCmdReadKeyFileError)
   , getStakeCredentialFromIdentifier
   , renderShelleyStakeAddressCmdError
-  , runStakeAddressCmd
+  , runStakeAddressCmds
   , runStakeAddressKeyGenToFile
 
   , StakeAddressDelegationError(..)
@@ -60,16 +60,16 @@ renderShelleyStakeAddressCmdError err =
     StakeRegistrationError regErr -> Text.pack $ show regErr
     StakeDelegationError delegErr -> Text.pack $ show delegErr
 
-runStakeAddressCmd :: StakeAddressCmd -> ExceptT ShelleyStakeAddressCmdError IO ()
-runStakeAddressCmd (StakeAddressKeyGen fmt vk sk) = runStakeAddressKeyGenToFile fmt vk sk
-runStakeAddressCmd (StakeAddressKeyHash vk mOutputFp) = runStakeAddressKeyHash vk mOutputFp
-runStakeAddressCmd (StakeAddressBuild stakeVerifier nw mOutputFp) =
+runStakeAddressCmds :: StakeAddressCmds -> ExceptT ShelleyStakeAddressCmdError IO ()
+runStakeAddressCmds (StakeAddressKeyGen fmt vk sk) = runStakeAddressKeyGenToFile fmt vk sk
+runStakeAddressCmds (StakeAddressKeyHash vk mOutputFp) = runStakeAddressKeyHash vk mOutputFp
+runStakeAddressCmds (StakeAddressBuild stakeVerifier nw mOutputFp) =
   runStakeAddressBuild stakeVerifier nw mOutputFp
-runStakeAddressCmd (StakeRegistrationCert anyEra stakeIdentifier mDeposit outputFp) =
+runStakeAddressCmds (StakeRegistrationCert anyEra stakeIdentifier mDeposit outputFp) =
   runStakeCredentialRegistrationCert anyEra stakeIdentifier mDeposit outputFp
-runStakeAddressCmd (StakeCredentialDelegationCert anyEra stakeIdentifier stkPoolVerKeyHashOrFp outputFp) =
+runStakeAddressCmds (StakeCredentialDelegationCert anyEra stakeIdentifier stkPoolVerKeyHashOrFp outputFp) =
   runStakeCredentialDelegationCert anyEra stakeIdentifier stkPoolVerKeyHashOrFp outputFp
-runStakeAddressCmd (StakeCredentialDeRegistrationCert anyEra stakeIdentifier mDeposit outputFp) =
+runStakeAddressCmds (StakeCredentialDeRegistrationCert anyEra stakeIdentifier mDeposit outputFp) =
   runStakeCredentialDeRegistrationCert anyEra stakeIdentifier mDeposit outputFp
 
 

--- a/cardano-cli/src/Cardano/CLI/Run/Legacy/TextView.hs
+++ b/cardano-cli/src/Cardano/CLI/Run/Legacy/TextView.hs
@@ -3,7 +3,7 @@
 module Cardano.CLI.Run.Legacy.TextView
   ( ShelleyTextViewFileError(..)
   , renderShelleyTextViewFileError
-  , runTextViewCmd
+  , runTextViewCmds
   ) where
 
 import           Cardano.Api
@@ -31,8 +31,8 @@ renderShelleyTextViewFileError err =
       "Error pretty printing CBOR: " <> renderHelpersError hlprsErr
 
 
-runTextViewCmd :: TextViewCmd -> ExceptT ShelleyTextViewFileError IO ()
-runTextViewCmd cmd =
+runTextViewCmds :: TextViewCmds -> ExceptT ShelleyTextViewFileError IO ()
+runTextViewCmds cmd =
   case cmd of
     TextViewInfo fpath mOutfile -> runTextViewInfo fpath mOutfile
 

--- a/cardano-cli/src/Cardano/CLI/Run/Legacy/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/Run/Legacy/Transaction.hs
@@ -12,7 +12,7 @@
 module Cardano.CLI.Run.Legacy.Transaction
   ( ShelleyTxCmdError(..)
   , renderShelleyTxCmdError
-  , runTransactionCmd
+  , runTransactionCmds
   , readFileTx
   , toTxOutInAnyEra
   ) where
@@ -265,8 +265,8 @@ renderFeature TxFeatureTotalCollateral      = "Total collateral"
 renderFeature TxFeatureReferenceInputs      = "Reference inputs"
 renderFeature TxFeatureReturnCollateral     = "Return collateral"
 
-runTransactionCmd :: TransactionCmd -> ExceptT ShelleyTxCmdError IO ()
-runTransactionCmd cmd =
+runTransactionCmds :: TransactionCmds -> ExceptT ShelleyTxCmdError IO ()
+runTransactionCmds cmd =
   case cmd of
     TxBuild mNodeSocketPath era consensusModeParams nid mScriptValidity mOverrideWits txins readOnlyRefIns
             reqSigners txinsc mReturnColl mTotCollateral txouts changeAddr mValue mLowBound


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Plural for command groups
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

This renames command groups to have the `Cmds` suffix.  This is to distinguish them from commands which will have the singular `Cmd` suffix representing one command.

The change also renames `GovernanceCmd'` constructor to `GovernanceCmds` doing away with the apostrophe.

The aim is to introduce consistency in the code to make it easier to maintain with growing complexity in requirements.

No golden files were changed indicating the CLI  interface is unchanged.

This is one of the changes picked from https://github.com/input-output-hk/cardano-cli/pull/148, but applied across all command groups rather than just the transaction command group.

The change is mechanical and grouped into one PR to make it easy to follow.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
