### PR TITLE
Bump index states

### DIFF
--- a/.github/workflows/check-stylish-haskell.yml
+++ b/.github/workflows/check-stylish-haskell.yml
@@ -27,7 +27,7 @@ jobs:
 
     env:
       # Modify this value to "invalidate" the cabal cache.
-      CABAL_CACHE_VERSION: "2022-12-30"
+      CABAL_CACHE_VERSION: "2023-07-28"
 
       STYLISH_HASKELL_VERSION: "0.14.4.0"
 

--- a/.github/workflows/github-page.yml
+++ b/.github/workflows/github-page.yml
@@ -22,7 +22,7 @@ jobs:
 
     env:
       # Modify this value to "invalidate" the cabal cache.
-      CABAL_CACHE_VERSION: "2023-07-11"
+      CABAL_CACHE_VERSION: "2023-07-28"
 
       # Modify this value to "invalidate" the secp cache.
       SECP_CACHE_VERSION: "2022-12-30"

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -20,7 +20,7 @@ jobs:
 
     env:
       # Modify this value to "invalidate" the cabal cache.
-      CABAL_CACHE_VERSION: "2023-07-26"
+      CABAL_CACHE_VERSION: "2023-07-28"
 
     concurrency:
       group: >

--- a/cabal.project
+++ b/cabal.project
@@ -13,8 +13,8 @@ repository cardano-haskell-packages
 -- See CONTRIBUTING for information about these, including some Nix commands
 -- you need to run if you change them
 index-state:
-  , hackage.haskell.org 2023-07-27T22:41:49Z
-  , cardano-haskell-packages 2023-08-05T00:00:00Z
+  , hackage.haskell.org 2023-08-08T19:56:09Z
+  , cardano-haskell-packages 2023-08-08T21:04:17Z
 
 packages:
   cardano-cli
@@ -39,14 +39,6 @@ test-show-details: direct
 
 -- Always write GHC env files, because they are needed for ghci.
 write-ghc-environment-files: always
-
-if impl(ghc >= 9.6)
-  allow-newer:
-    -- Only really needed because `cardano-ledger-byron-test` has not yet been released to CHaP
-    -- and its not possible to specify `cardano-ledger-byron-test:base` because the dependencies
-    -- of `cardano-ledger-byron-test` also do not permit the version of `base` that `ghc-9.6`
-    -- provides.
-    , *:base
 
 -- IMPORTANT
 -- Do NOT add more source-repository-package stanzas here unless they are strictly

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/Pipes.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/Pipes.hs
@@ -7,6 +7,10 @@ module Test.Cli.Pipes
 
 #if !defined(mingw32_HOST_OS)
 #define UNIX
+#else
+-- Need this to avoid an unused-package error on Windows when compiling with
+-- cabal-3.10 and ghc-9.6.
+import           System.FilePath ()
 #endif
 
 import qualified Hedgehog as H

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1691164943,
-        "narHash": "sha256-+/WNJZkwQcXsEvu7XB35eoU8dx0e74YT/pHZxZA73Zg=",
+        "lastModified": 1691529171,
+        "narHash": "sha256-Z8sSJPKTrknxUnVaq6XRo4MYHTOJ5Ump4S5YxB2S73E=",
         "owner": "input-output-hk",
         "repo": "cardano-haskell-packages",
-        "rev": "839be197a32f413d2ce46ceb9a60249a0dc03f59",
+        "rev": "c03fdfe126241783ddacd073202a8c24de195231",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
This allows the removal of the ghc-9.6 specific allow-newer stanza.

# Changelog

```yaml
- description: |
    Bump index states
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Additional context for the PR goes here.

If the PR fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
