### PR TITLE
Remove `Legacy` prefix from legacy command type name.

### DIFF
--- a/cardano-cli/src/Cardano/CLI/Commands/Legacy.hs
+++ b/cardano-cli/src/Cardano/CLI/Commands/Legacy.hs
@@ -7,7 +7,7 @@
 -- | Shelley CLI command types
 module Cardano.CLI.Commands.Legacy
   ( -- * CLI command types
-    LegacyCommand (..)
+    Command (..)
   , AddressCmds (..)
   , StakeAddressCmds (..)
   , KeyCmds (..)
@@ -67,7 +67,7 @@ import           Data.Time.Clock
 
 -- | All the CLI subcommands under \"shelley\".
 --
-data LegacyCommand
+data Command
   = AddressCmds       AddressCmds
   | StakeAddressCmds  StakeAddressCmds
   | KeyCmds           KeyCmds
@@ -79,7 +79,7 @@ data LegacyCommand
   | GenesisCmds       GenesisCmds
   | TextViewCmds      TextViewCmds
 
-renderLegacyCommand :: LegacyCommand -> Text
+renderLegacyCommand :: Command -> Text
 renderLegacyCommand sc =
   case sc of
     AddressCmds cmd -> renderAddressCmds cmd

--- a/cardano-cli/src/Cardano/CLI/EraBased/Legacy.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Legacy.hs
@@ -69,7 +69,7 @@ import           Text.Read (readEither, readMaybe)
 -- Shelley CLI command parsers
 --
 
-parseLegacyCommands :: EnvCli -> Parser LegacyCommand
+parseLegacyCommands :: EnvCli -> Parser Command
 parseLegacyCommands envCli =
   Opt.hsubparser $ mconcat
     [ Opt.metavar "Legacy commands"

--- a/cardano-cli/src/Cardano/CLI/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Run.hs
@@ -12,7 +12,7 @@ module Cardano.CLI.Run
 import           Cardano.CLI.Byron.Commands (ByronCommand)
 import           Cardano.CLI.Byron.Run (ByronClientCmdError, renderByronClientCmdError,
                    runByronClientCommand)
-import           Cardano.CLI.Commands.Legacy (LegacyCommand)
+import qualified Cardano.CLI.Commands.Legacy as Legacy
 import           Cardano.CLI.EraBased.Commands
 import           Cardano.CLI.EraBased.Run
 import           Cardano.CLI.Render (customRenderHelp)
@@ -47,7 +47,7 @@ data ClientCommand =
   | ByronCommand ByronCommand
 
     -- | Legacy shelley-based Commands
-  | LegacyCommand LegacyCommand
+  | LegacyCommand Legacy.Command
 
   | CliPingCommand PingCmd
 
@@ -57,7 +57,7 @@ data ClientCommand =
 data ClientCommandErrors
   = AnyEraCmdError AnyEraCmdError
   | ByronClientError ByronClientCmdError
-  | LegacyClientError LegacyCommand LegacyClientCmdError
+  | LegacyClientError Legacy.Command LegacyClientCmdError
   | PingClientError PingClientCmdError
 
 runClientCommand :: ClientCommand -> ExceptT ClientCommandErrors IO ()

--- a/cardano-cli/src/Cardano/CLI/Run/Legacy.hs
+++ b/cardano-cli/src/Cardano/CLI/Run/Legacy.hs
@@ -38,7 +38,7 @@ data LegacyClientCmdError
   | LegacyCmdQueryError !ShelleyQueryCmdError
   | LegacyCmdKeyError !ShelleyKeyCmdError
 
-renderLegacyClientCmdError :: LegacyCommand -> LegacyClientCmdError -> Text
+renderLegacyClientCmdError :: Command -> LegacyClientCmdError -> Text
 renderLegacyClientCmdError cmd err =
   case err of
     LegacyCmdAddressError addrCmdErr ->
@@ -62,7 +62,7 @@ renderLegacyClientCmdError cmd err =
     LegacyCmdKeyError keyErr ->
        renderError cmd renderShelleyKeyCmdError keyErr
   where
-    renderError :: LegacyCommand -> (a -> Text) -> a -> Text
+    renderError :: Command -> (a -> Text) -> a -> Text
     renderError shelleyCmd renderer shelCliCmdErr =
       mconcat
         [ "Command failed: "
@@ -76,7 +76,7 @@ renderLegacyClientCmdError cmd err =
 -- CLI shelley command dispatch
 --
 
-runLegacyClientCommand :: LegacyCommand -> ExceptT LegacyClientCmdError IO ()
+runLegacyClientCommand :: Command -> ExceptT LegacyClientCmdError IO ()
 runLegacyClientCommand = \case
   AddressCmds      cmd -> firstExceptT LegacyCmdAddressError $ runAddressCmds cmd
   StakeAddressCmds cmd -> firstExceptT LegacyCmdStakeAddressError $ runStakeAddressCmds cmd


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Remove `Legacy` prefix from legacy command type name.
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Seems like removing the prefix is not as bad as I thought.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
