### PR TITLE
Cleanup flake.nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1691771469,
-        "narHash": "sha256-uCEuNvy77nTQ5A1PGj+lvnTx1S7faQ/dXS1RDsBagLY=",
+        "lastModified": 1692114433,
+        "narHash": "sha256-l6UoBkt1SUUBga/u0qpQeuNTN2YgtdZMBJSw29Wb0xU=",
         "owner": "input-output-hk",
         "repo": "cardano-haskell-packages",
-        "rev": "5726d16ea0f440f705594bef95adbc6bdbf7778b",
+        "rev": "73093fde5e26b9f7594a2219d339175005256475",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -41,7 +41,7 @@
         inherit (nixpkgs) lib;
 
         # see flake `variants` below for alternative compilers
-        defaultCompiler = "ghc927";
+        defaultCompiler = "ghc928";
         # We use cabalProject' to ensure we don't build the plan for
         # all systems.
         cabalProject = nixpkgs.haskell-nix.cabalProject' ({config, ...}: {
@@ -168,13 +168,7 @@
               profiling = (p.appendModule {modules = [{enableLibraryProfiling = true;}];}).shell;
             };
           in
-            profillingShell cabalProject
-            # Additional shells for every GHC version supported by haskell.nix, eg. `nix develop .#ghc927`
-            // lib.mapAttrs (compiler-nix-name: _: let
-              p = cabalProject.appendModule {inherit compiler-nix-name;};
-            in
-              p.shell // (profillingShell p))
-            nixpkgs.haskell-nix.compiler;
+            profillingShell cabalProject;
           # formatter used by nix fmt
           formatter = nixpkgs.alejandra;
         }


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Cleanup flake.nix
# uncomment types applicable to the change:
  type:
  - maintenance    # not directly related to the code
```

# Context

Cleanup the `flake.nix`:
-  update CHaP (index-state in project was newer than CHaP reference)
- ghc927 -> ghc928
- drop excessive generation of dev shells; if we need more than the ones we use to build this, let's be explicit about that.