### PR TITLE
Bump CHaP index in preparation for  8.3.0 pre

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -20,7 +20,7 @@ jobs:
 
     env:
       # Modify this value to "invalidate" the cabal cache.
-      CABAL_CACHE_VERSION: "2023-08-14"
+      CABAL_CACHE_VERSION: "2023-08-23"
 
     concurrency:
       group: >

--- a/cabal.project
+++ b/cabal.project
@@ -14,7 +14,7 @@ repository cardano-haskell-packages
 -- you need to run if you change them
 index-state:
   , hackage.haskell.org 2023-08-08T19:56:09Z
-  , cardano-haskell-packages 2023-08-15T15:38:21Z
+  , cardano-haskell-packages 2023-08-23T09:29:34Z
 
 packages:
   cardano-cli
@@ -43,3 +43,4 @@ write-ghc-environment-files: always
 -- IMPORTANT
 -- Do NOT add more source-repository-package stanzas here unless they are strictly
 -- temporary! Please read the section in CONTRIBUTING about updating dependencies.
+

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -167,10 +167,10 @@ library
                       , binary
                       , bytestring
                       , canonical-json
-                      , cardano-api ^>= 8.14
+                      , cardano-api ^>= 8.16
                       , cardano-binary
                       , cardano-crypto
-                      , cardano-crypto-class >= 2.1.1
+                      , cardano-crypto-class ^>= 2.1.2
                       , cardano-crypto-wrapper ^>= 1.5
                       , cardano-data >= 1.0
                       , cardano-git-rev
@@ -200,7 +200,7 @@ library
                       , network
                       , optparse-applicative-fork
                       , ouroboros-consensus >= 0.9
-                      , ouroboros-consensus-cardano >= 0.7
+                      , ouroboros-consensus-cardano >= 0.8
                       , ouroboros-consensus-protocol >= 0.5.0.4
                       , ouroboros-network-api
                       , ouroboros-network-protocols
@@ -226,7 +226,7 @@ executable cardano-cli
   ghc-options:          -threaded -rtsopts "-with-rtsopts=-T"
 
   build-depends:        cardano-cli
-                      , cardano-crypto-class ^>= 2.1
+                      , cardano-crypto-class ^>= 2.1.2
                       , optparse-applicative-fork
                       , transformers-except
 
@@ -258,7 +258,7 @@ test-suite cardano-cli-test
                       , base16-bytestring
                       , bech32 >= 1.1.0
                       , bytestring
-                      , cardano-api:{cardano-api, internal} ^>= 8.14
+                      , cardano-api:{cardano-api, internal} ^>= 8.16
                       , cardano-api-gen ^>= 8.1.1.0
                       , cardano-cli
                       , cardano-cli:cardano-cli-test-lib
@@ -302,7 +302,7 @@ test-suite cardano-cli-golden
   build-depends:        aeson >= 1.5.6.0
                       , base16-bytestring
                       , bytestring
-                      , cardano-api:{cardano-api, gen} ^>= 8.14
+                      , cardano-api:{cardano-api, gen} ^>= 8.16
                       , cardano-binary
                       , cardano-cli
                       , cardano-cli:cardano-cli-test-lib

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/Actions.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/Actions.hs
@@ -14,9 +14,10 @@ module Cardano.CLI.EraBased.Commands.Governance.Actions
   ) where
 
 import           Cardano.Api
+import qualified Cardano.Api.Ledger as Ledger
 import           Cardano.Api.Shelley
 
-import           Cardano.CLI.Types.Common
+import           Cardano.CLI.Types.Common (Constitution, VerificationKeyFile)
 import           Cardano.CLI.Types.Key
 
 import           Data.Text (Text)
@@ -49,27 +50,34 @@ data GovernanceActionCmds era
 
 data EraBasedNewCommittee
   = EraBasedNewCommittee
-    { ebDeposit :: Lovelace
+    { ebNetwork :: Ledger.Network
+    , ebDeposit :: Lovelace
     , ebReturnAddress :: AnyStakeIdentifier
+    , ebPropAnchor :: (Ledger.Url, Text)
     , ebOldCommittee :: [AnyStakeIdentifier]
     , ebNewCommittee :: [(AnyStakeIdentifier, EpochNo)]
     , ebRequiredQuorum :: Rational
-    , ebPreviousGovActionId :: TxIn
+    , ebPreviousGovActionId :: Maybe (TxId, Word32)
     , ebFilePath :: File () Out
     } deriving Show
 
 data EraBasedNewConstitution
   = EraBasedNewConstitution
-      { encDeposit :: Lovelace
+      { encNetwork :: Ledger.Network
+      , encDeposit :: Lovelace
       , encStakeCredential :: AnyStakeIdentifier
+      , encPrevGovActId :: Maybe (TxId, Word32)
+      , encPropAnchor :: (Ledger.Url, Text)
       , encConstitution :: Constitution
       , encFilePath :: File () Out
       } deriving Show
 
 data EraBasedNoConfidence
   = EraBasedNoConfidence
-      { ncDeposit :: Lovelace
+      { ncNetwork :: Ledger.Network
+      , ncDeposit :: Lovelace
       , ncStakeCredential :: AnyStakeIdentifier
+      , ncProposalAnchor :: (Ledger.Url, Text)
       , ncGovAct :: TxId
       , ncGovActIndex :: Word32
       , ncFilePath :: File () Out
@@ -77,8 +85,10 @@ data EraBasedNoConfidence
 
 data EraBasedTreasuryWithdrawal where
   EraBasedTreasuryWithdrawal
-    :: Lovelace -- ^ Deposit
+    :: Ledger.Network
+    -> Lovelace -- ^ Deposit
     -> AnyStakeIdentifier -- ^ Return address
+    -> (Ledger.Url, Text) -- ^ Proposal anchor
     -> [(AnyStakeIdentifier, Lovelace)]
     -> File () Out
     -> EraBasedTreasuryWithdrawal

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/Vote.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/Vote.hs
@@ -6,16 +6,14 @@ module Cardano.CLI.EraBased.Commands.Governance.Vote
   , renderGovernanceVoteCmds
   ) where
 
-import           Cardano.Api
 
 import           Cardano.CLI.Types.Governance
 
 import           Data.Text (Text)
 
-data GovernanceVoteCmds era
+newtype GovernanceVoteCmds era
   = GovernanceVoteCreateCmd
       AnyVote
-      (File () Out)
 
 renderGovernanceVoteCmds :: ()
   => GovernanceVoteCmds era

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
@@ -782,22 +782,22 @@ pConstitution :: Parser Constitution
 pConstitution =
   asum
     [ ConstitutionFromText
-         <$> pUrl "Constitution URL."
+         <$> pUrl "constitution-url" "Constitution URL."
          <*> Opt.strOption (mconcat
                [ Opt.long "constitution"
                , Opt.metavar "TEXT"
                , Opt.help "Input constitution as UTF-8 encoded text."
                ])
     , ConstitutionFromFile
-        <$> pUrl "Constitution URL."
+        <$> pUrl "constitution-url" "Constitution URL."
         <*> pFileInDirection "constitution-file" "Input constitution as a text file."
     ]
 
-pUrl :: String -> Parser Ledger.Url
-pUrl h = fromMaybe (error "Url longer than 64 bytes")
+pUrl :: String -> String -> Parser Ledger.Url
+pUrl l h = fromMaybe (error "Url longer than 64 bytes")
          . Ledger.textToUrl <$>
              Opt.strOption (mconcat
-                            [ Opt.long "url"
+                            [ Opt.long l
                             , Opt.metavar "TEXT"
                             , Opt.help h
                             ])
@@ -2717,7 +2717,16 @@ pDRepVerificationKeyFile =
     , Opt.completer (Opt.bashCompleter "file")
     ]
 pProposalAnchor :: Parser (Ledger.Url, Text)
-pProposalAnchor = undefined
+pProposalAnchor = (,) <$> pUrl "proposal-url" "Proposal anchor URL"
+                      <*> pAnchorHash
+
+pAnchorHash :: Parser Text
+pAnchorHash =
+  Opt.strOption $ mconcat
+    [ Opt.long "anchor-data-hash"
+    , Opt.metavar "TEXT"
+    , Opt.help "Hash of anchor data."
+    ]
 
 pPreviousGovernanceAction :: Parser (Maybe (TxId, Word32))
 pPreviousGovernanceAction = optional $

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
@@ -12,6 +12,7 @@
 module Cardano.CLI.EraBased.Options.Common where
 
 import           Cardano.Api
+import qualified Cardano.Api.Ledger as Ledger
 import           Cardano.Api.Shelley
 
 import           Cardano.CLI.Environment (EnvCli (..), envCliAnyShelleyBasedEra,
@@ -41,7 +42,7 @@ import           Data.Text (Text)
 import qualified Data.Text as Text
 import           Data.Time.Clock (UTCTime)
 import           Data.Time.Format (defaultTimeLocale, parseTimeOrError)
-import           Data.Word (Word64)
+import           Data.Word
 import           GHC.Natural (Natural)
 import           Network.Socket (PortNumber)
 import           Options.Applicative hiding (help, str)
@@ -780,14 +781,26 @@ catCommands = \case
 pConstitution :: Parser Constitution
 pConstitution =
   asum
-    [ fmap ConstitutionFromText $ Opt.strOption $ mconcat
-        [ Opt.long "constitution"
-        , Opt.metavar "TEXT"
-        , Opt.help "Input constitution as UTF-8 encoded text."
-        ]
+    [ ConstitutionFromText
+         <$> pUrl "Constitution URL."
+         <*> Opt.strOption (mconcat
+               [ Opt.long "constitution"
+               , Opt.metavar "TEXT"
+               , Opt.help "Input constitution as UTF-8 encoded text."
+               ])
     , ConstitutionFromFile
-        <$> pFileInDirection "constitution-file" "Input constitution as a text file."
+        <$> pUrl "Constitution URL."
+        <*> pFileInDirection "constitution-file" "Input constitution as a text file."
     ]
+
+pUrl :: String -> Parser Ledger.Url
+pUrl h = fromMaybe (error "Url longer than 64 bytes")
+         . Ledger.textToUrl <$>
+             Opt.strOption (mconcat
+                            [ Opt.long "url"
+                            , Opt.metavar "TEXT"
+                            , Opt.help h
+                            ])
 
 pGovActionDeposit :: Parser Lovelace
 pGovActionDeposit =
@@ -2657,14 +2670,6 @@ pVoterType =
    ,  flag' VSP $ mconcat [long "spo", Opt.help "Stake pool operator"]
    ]
 
-pGoveranceActionIdentifier :: String -> Parser TxIn
-pGoveranceActionIdentifier h =
-  Opt.option (readerFromParsecParser parseTxIn) $ mconcat
-    [ Opt.long "tx-in"
-    , Opt.metavar "TX-IN"
-    , Opt.help h
-    ]
-
 -- TODO: Conway era include "normal" stake keys
 pVotingCredential :: Parser (VerificationKeyOrFile StakePoolKey)
 pVotingCredential = pStakePoolVerificationKeyOrFile
@@ -2711,6 +2716,35 @@ pDRepVerificationKeyFile =
     , Opt.help "Filepath of the DRep verification key."
     , Opt.completer (Opt.bashCompleter "file")
     ]
+pProposalAnchor :: Parser (Ledger.Url, Text)
+pProposalAnchor = undefined
+
+pPreviousGovernanceAction :: Parser (Maybe (TxId, Word32))
+pPreviousGovernanceAction = optional $
+  (,) <$> pTxId "governance-action-tx-id" "Previous txid of the governance action."
+      <*> pWord32 "governance-action-index" "Previous tx's governance action index."
+
+pGovernanceActionId :: Parser (TxId, Word32)
+pGovernanceActionId =
+  (,) <$> pTxId "governance-action-tx-id" "Txid of the governance action."
+      <*> pWord32 "governance-action-index" "Tx's governance action index."
+
+pWord32 :: String -> String -> Parser Word32
+pWord32 l h =
+  Opt.option auto $ mconcat
+    [ Opt.long l
+    , Opt.metavar "WORD32"
+    , Opt.help h
+    ]
+
+pTxId :: String -> String -> Parser TxId
+pTxId l h =
+  Opt.option (readerFromParsecParser parseTxId) $ mconcat
+    [ Opt.long l
+    , Opt.metavar "TXID"
+    , Opt.help h
+    ]
+
 
 --------------------------------------------------------------------------------
 -- Helpers

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Vote.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Vote.hs
@@ -38,16 +38,16 @@ pGovernanceVoteCreateCmd era = do
     $ Opt.info
         ( GovernanceVoteCreateCmd
             <$> pAnyVote w
-            <*> pOutputFile
         )
     $ Opt.progDesc "Vote creation."
 
 pAnyVote :: ConwayEraOnwards era -> Parser AnyVote
 pAnyVote cOnwards =
   ConwayOnwardsVote cOnwards
-    <$> pVoteChoice
-    <*> pGoveranceActionIdentifier "TxIn of governance action (already on chain)."
-    <*> pAnyVotingStakeVerificationKeyOrHashOrFile
+      <$> pVoteChoice
+      <*> pGovernanceActionId
+      <*> pAnyVotingStakeVerificationKeyOrHashOrFile
+      <*> pFileOutDirection "out-file" "Output filepath of the vote."
 
 pAnyVotingStakeVerificationKeyOrHashOrFile :: Parser AnyVotingStakeVerificationKeyOrHashOrFile
 pAnyVotingStakeVerificationKeyOrHashOrFile =

--- a/cardano-cli/src/Cardano/CLI/Legacy/Commands/Governance.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Commands/Governance.hs
@@ -142,7 +142,7 @@ pNetwork  = asum $ mconcat
       , Opt.help "Use the mainnet magic id."
       ]
     , Opt.flag' Ledger.Testnet $ mconcat
-      [ Opt.long "testnet-magic"
+      [ Opt.long "testnet"
       , Opt.help "Use the testnet magic id."
       ]
     ]

--- a/cardano-cli/src/Cardano/CLI/Legacy/Commands/Governance.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Commands/Governance.hs
@@ -5,6 +5,7 @@
 module Cardano.CLI.Legacy.Commands.Governance where
 
 import           Cardano.Api
+import qualified Cardano.Api.Ledger as Ledger
 import           Cardano.Api.Shelley
 
 import           Cardano.CLI.Environment
@@ -93,7 +94,7 @@ pCreateVote envCli =
     ConwayVote
       <$> pVoteChoice
       <*> pVoterType
-      <*> pGoveranceActionIdentifier "TxIn of governance action (already on chain)."
+      <*> pGovernanceActionId
       <*> pVotingCredential
       <*> (pShelleyBasedConway envCli <|> pure (AnyShelleyBasedEra ShelleyBasedEraConway))
       <*> pFileOutDirection "out-file" "Output filepath of the vote."
@@ -125,9 +126,24 @@ pCreateConstitution :: EnvCli -> Parser ActionCmd
 pCreateConstitution envCli =
   fmap CreateConstitution $
     NewConstitution
-      <$> (pShelleyBasedConway envCli <|> pure (AnyShelleyBasedEra ShelleyBasedEraConway))
+      <$> pNetwork
+      <*> (pShelleyBasedConway envCli <|> pure (AnyShelleyBasedEra ShelleyBasedEraConway))
       <*> pGovActionDeposit
       <*> pVotingCredential
+      <*> pPreviousGovernanceAction
+      <*> pProposalAnchor
       <*> pConstitution
       <*> pFileOutDirection "out-file" "Output filepath of the governance action."
 
+pNetwork :: Parser Ledger.Network
+pNetwork  = asum $ mconcat
+  [ [ Opt.flag' Ledger.Mainnet $ mconcat
+      [ Opt.long "mainnet"
+      , Opt.help "Use the mainnet magic id."
+      ]
+    , Opt.flag' Ledger.Testnet $ mconcat
+      [ Opt.long "testnet-magic"
+      , Opt.help "Use the testnet magic id."
+      ]
+    ]
+  ]

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Governance.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Governance.hs
@@ -45,8 +45,8 @@ runGovernanceCmds :: LegacyGovernanceCmds -> ExceptT GovernanceCmdError IO ()
 runGovernanceCmds = \case
   GovernanceVoteCmd (CreateVoteCmd (ConwayVote voteChoice voteType govActTcIn voteStakeCred sbe fp)) ->
     runGovernanceCreateVoteCmd sbe voteChoice voteType govActTcIn voteStakeCred fp
-  GovernanceActionCmd (CreateConstitution (Cli.NewConstitution sbe deposit voteStakeCred newconstitution fp)) ->
-    runGovernanceNewConstitutionCmd sbe deposit voteStakeCred newconstitution fp
+  GovernanceActionCmd (CreateConstitution (Cli.NewConstitution network sbe deposit voteStakeCred mPrevGovActId propAnchor newconstitution fp)) ->
+    runGovernanceNewConstitutionCmd network sbe deposit voteStakeCred mPrevGovActId propAnchor newconstitution fp
   GovernanceMIRPayStakeAddressesCertificate (AnyShelleyToBabbageEra w) mirpot vKeys rewards out ->
     runGovernanceMIRCertificatePayStakeAddrs w mirpot vKeys rewards out
   GovernanceMIRTransfer (AnyShelleyToBabbageEra w) amt out direction -> do

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Query.hs
@@ -43,6 +43,7 @@ import           Cardano.CLI.Types.Key (VerificationKeyOrHashOrFile,
 import qualified Cardano.CLI.Types.Output as O
 import           Cardano.Crypto.Hash (hashToBytesAsHex)
 import qualified Cardano.Crypto.Hash.Blake2b as Blake2b
+import qualified Cardano.Ledger.BaseTypes as L
 import qualified Cardano.Ledger.Core as Core
 import qualified Cardano.Ledger.Crypto as Crypto
 import           Cardano.Ledger.Keys (KeyHash (..), KeyRole (..))
@@ -70,7 +71,6 @@ import           Data.Aeson as Aeson
 import           Data.Aeson.Encode.Pretty (encodePretty)
 import           Data.Aeson.Types as Aeson
 import           Data.Bifunctor (Bifunctor (..))
-import           Data.ByteString (ByteString)
 import qualified Data.ByteString.Lazy.Char8 as LBS
 import           Data.Coerce (coerce)
 import           Data.Function ((&))
@@ -160,7 +160,7 @@ runQueryConstitutionHash socketPath (AnyConsensusModeParams cModeParams) network
   where
     writeConstitutionHash
       :: Maybe (File () Out)
-      -> Maybe (SafeHash StandardCrypto ByteString)
+      -> Maybe (SafeHash StandardCrypto L.AnchorData)
       -> ExceptT ShelleyQueryCmdError IO ()
     writeConstitutionHash mOutFile' cHash =
       case mOutFile' of

--- a/cardano-cli/src/Cardano/CLI/Read.hs
+++ b/cardano-cli/src/Cardano/CLI/Read.hs
@@ -585,6 +585,7 @@ data SomeWitness
   | AGenesisDelegateExtendedSigningKey
                                (SigningKey GenesisDelegateExtendedKey)
   | AGenesisUTxOSigningKey     (SigningKey GenesisUTxOKey)
+  | ADRepSigningKey            (SigningKey DRepKey)
 
 
 -- | Data required for constructing a Shelley bootstrap witness.
@@ -618,6 +619,11 @@ categoriseSomeWitness swsk =
     AGenesisDelegateExtendedSigningKey sk
                                        -> AShelleyKeyWitness (WitnessGenesisDelegateExtendedKey sk)
     AGenesisUTxOSigningKey     sk      -> AShelleyKeyWitness (WitnessGenesisUTxOKey     sk)
+    ADRepSigningKey            sk      -> AShelleyKeyWitness (WitnessPaymentKey $ castDrep sk)
+
+-- TODO: Conway era - Add constrctor for SigningKey DrepKey to ShelleyWitnessSigningKey
+castDrep :: SigningKey DRepKey -> SigningKey PaymentKey
+castDrep (DRepSigningKey sk) = PaymentSigningKey sk
 
 data ReadWitnessSigningDataError
   = ReadWitnessSigningDataSigningKeyDecodeError !(FileError InputDecodeError)
@@ -676,6 +682,7 @@ readWitnessSigningData (KeyWitnessSigningData skFile mbByronAddr) = do
                           AGenesisDelegateExtendedSigningKey
       , FromSomeType (AsSigningKey AsGenesisUTxOKey)
                           AGenesisUTxOSigningKey
+      , FromSomeType (AsSigningKey AsDRepKey) ADRepSigningKey
       ]
 
     bech32FileTypes =

--- a/cardano-cli/src/Cardano/CLI/Types/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Common.hs
@@ -70,6 +70,7 @@ module Cardano.CLI.Types.Common
   ) where
 
 import           Cardano.Api
+import qualified Cardano.Api.Ledger as Ledger
 
 import qualified Cardano.Chain.Slotting as Byron
 import qualified Cardano.Ledger.Crypto as Crypto
@@ -91,8 +92,11 @@ data TransferDirection =
 data OpCertCounter
 
 data Constitution
-  = ConstitutionFromFile (File () In)
-  | ConstitutionFromText Text deriving Show
+  = ConstitutionFromFile Ledger.Url (File () In)
+  | ConstitutionFromText
+      Ledger.Url
+      Text -- ^ Constitution text
+  deriving Show
 
 -- | Specify whether to render the script cost as JSON
 -- in the cli's build command.

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/GovernanceVoteCmdError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/GovernanceVoteCmdError.hs
@@ -15,7 +15,7 @@ import qualified Formatting.Buildable as B
 data GovernanceVoteCmdError
   = GovernanceVoteCmdReadError !(FileError InputDecodeError)
   | GovernanceVoteCmdCredentialDecodeError !DecoderError
-  | GovernanceVoteCmeWriteError !(FileError ())
+  | GovernanceVoteCmdWriteError !(FileError ())
   deriving Show
 
 instance Error GovernanceVoteCmdError where
@@ -24,7 +24,7 @@ instance Error GovernanceVoteCmdError where
       "Cannot read verification key: " <> displayError e
     GovernanceVoteCmdCredentialDecodeError e ->
       "Cannot decode voting credential: " <> renderDecoderError e
-    GovernanceVoteCmeWriteError e ->
+    GovernanceVoteCmdWriteError e ->
       "Cannot write vote: " <> displayError e
     where
       renderDecoderError = TL.unpack . TL.toLazyText . B.build

--- a/cardano-cli/src/Cardano/CLI/Types/Governance.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Governance.hs
@@ -4,10 +4,14 @@
 module Cardano.CLI.Types.Governance where
 
 import           Cardano.Api
+import qualified Cardano.Api.Ledger as Ledger
 import           Cardano.Api.Shelley
 
 import           Cardano.CLI.Types.Common
-import           Cardano.CLI.Types.Key
+import           Cardano.CLI.Types.Key (VerificationKeyOrFile, VerificationKeyOrHashOrFile)
+
+import           Data.Text (Text)
+import           Data.Word
 
 type VoteFile = File ConwayVote
 
@@ -15,7 +19,7 @@ data ConwayVote
   = ConwayVote
     { cvVoteChoice :: Vote
     , cvVoterType :: VType
-    , cvGovActionTxIn :: TxIn
+    , cvGovActionId :: (TxId, Word32)
     , cvVotingStakeCredential :: VerificationKeyOrFile StakePoolKey
     , cvEra :: AnyShelleyBasedEra
     , cvFilepath :: VoteFile Out
@@ -25,9 +29,12 @@ type NewConstitutionFile = File NewConstitution
 
 data NewConstitution
   = NewConstitution
-      { ncEra :: AnyShelleyBasedEra
+      { ncNetwork :: Ledger.Network
+      , ncEra :: AnyShelleyBasedEra
       , ncDeposit :: Lovelace
       , ncVotingStakeCredential :: VerificationKeyOrFile StakePoolKey
+      , ncPrevGovActId :: Maybe (TxId, Word32)
+      , ncPropAnchor :: (Ledger.Url, Text)
       , ncConstitution :: Constitution
       , ncFilePath :: NewConstitutionFile Out
       } deriving Show
@@ -42,8 +49,9 @@ data AnyVote where
   ConwayOnwardsVote
     :: ConwayEraOnwards era
     -> Vote
-    -> TxIn
+    -> (TxId, Word32)
     -> AnyVotingStakeVerificationKeyOrHashOrFile
+    -> VoteFile Out
     -> AnyVote
 
 data AnyVotingStakeVerificationKeyOrHashOrFile where

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/ErrorsSpec.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/ErrorsSpec.hs
@@ -145,8 +145,8 @@ test_EraBasedVoteReadError =
         $ DecoderErrorCustom "<todecode>" "<decodeeerror>")
     , ("GovernanceVoteCmdReadError"
       , GovernanceVoteCmdReadError $ FileError "path/file.txt" InputInvalidError)
-    , ("GovernanceVoteCmeWriteError"
-      , GovernanceVoteCmeWriteError $ FileError "path/file.txt" ())
+    , ("GovernanceVoteCmdWriteError"
+      , GovernanceVoteCmdWriteError $ FileError "path/file.txt" ())
     ]
 
 test_GovernanceComitteeError :: TestTree

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Governance/Action.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Governance/Action.hs
@@ -29,9 +29,13 @@ hprop_golden_governanceActionCreateConstitution =
 
     void $ execCardanoCLI
       [ "conway", "governance", "action", "create-constitution"
+      , "--mainnet"
+      , "--anchor-data-hash" , "eda258650888d4a7f8ac1127cfa136962f527f341c99db49929c79ae"
+      , "--proposal-url" , "proposal-dummy-url"
       , "--governance-action-deposit", "10"
       , "--stake-verification-key-file", stakeAddressVKeyFile
       , "--out-file", actionFile
+      , "--constitution-url", "constitution-dummy-url"
       , "--constitution", "This is a test constitution."
       ]
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/conway/genesis.conway.spec.json
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/conway/genesis.conway.spec.json
@@ -1,3 +1,26 @@
 {
-  "genDelegs": {}
+  "committeeTermLimit": 0,
+  "dRepActivity": 0,
+  "dRepDeposit": 0,
+  "dRepVotingThresholds": {
+    "dvtCommitteeNoConfidence": 0,
+    "dvtCommitteeNormal": 0,
+    "dvtHardForkInitiation": 0,
+    "dvtMotionNoConfidence": 0,
+    "dvtPPEconomicGroup": 0,
+    "dvtPPGovGroup": 0,
+    "dvtPPNetworkGroup": 0,
+    "dvtPPTechnicalGroup": 0,
+    "dvtTreasuryWithdrawal": 0,
+    "dvtUpdateToConstitution": 0
+  },
+  "govActionDeposit": 0,
+  "govActionExpiration": 0,
+  "minCommitteeSize": 0,
+  "poolVotingThresholds": {
+    "pvtCommitteeNoConfidence": 0,
+    "pvtCommitteeNormal": 0,
+    "pvtHardForkInitiation": 0,
+    "pvtMotionNoConfidence": 0
+  }
 }

--- a/cardano-cli/test/cardano-cli-golden/files/golden/errors/Cardano.CLI.Types.Errors.GovernanceVoteCmdError.GovernanceVoteCmdError/GovernanceVoteCmdWriteError.txt
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/errors/Cardano.CLI.Types.Errors.GovernanceVoteCmdError.GovernanceVoteCmdError/GovernanceVoteCmdWriteError.txt
@@ -1,0 +1,1 @@
+Cannot write vote: path/file.txt: 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -702,7 +702,11 @@ Usage: cardano-cli conway governance action
 
   Governance action commands.
 
-Usage: cardano-cli conway governance action create-constitution --governance-action-deposit NATURAL
+Usage: cardano-cli conway governance action create-constitution 
+                                                                  ( --mainnet
+                                                                  | --testnet
+                                                                  )
+                                                                  --governance-action-deposit NATURAL
                                                                   ( --stake-pool-verification-key STRING
                                                                   | --cold-verification-key-file FILE
                                                                   | --stake-pool-id STAKE_POOL_ID
@@ -710,14 +714,24 @@ Usage: cardano-cli conway governance action create-constitution --governance-act
                                                                   | --stake-verification-key-file FILE
                                                                   | --stake-key-hash HASH
                                                                   )
-                                                                  ( --constitution TEXT
-                                                                  | --constitution-file FILE
+                                                                  [--governance-action-tx-id TXID
+                                                                    --governance-action-index WORD32]
+                                                                  --proposal-url TEXT
+                                                                  --anchor-data-hash TEXT
+                                                                  ( --constitution-url TEXT
+                                                                    --constitution TEXT
+                                                                  | --constitution-url TEXT
+                                                                    --constitution-file FILE
                                                                   )
                                                                   --out-file FILE
 
   Create a constitution.
 
-Usage: cardano-cli conway governance action create-new-committee --governance-action-deposit NATURAL
+Usage: cardano-cli conway governance action create-new-committee 
+                                                                   ( --mainnet
+                                                                   | --testnet
+                                                                   )
+                                                                   --governance-action-deposit NATURAL
                                                                    ( --stake-pool-verification-key STRING
                                                                    | --cold-verification-key-file FILE
                                                                    | --stake-pool-id STAKE_POOL_ID
@@ -725,6 +739,8 @@ Usage: cardano-cli conway governance action create-new-committee --governance-ac
                                                                    | --stake-verification-key-file FILE
                                                                    | --stake-key-hash HASH
                                                                    )
+                                                                   --proposal-url TEXT
+                                                                   --anchor-data-hash TEXT
                                                                    [ --stake-pool-verification-key STRING
                                                                    | --cold-verification-key-file FILE
                                                                    | --stake-pool-id STAKE_POOL_ID
@@ -742,12 +758,17 @@ Usage: cardano-cli conway governance action create-new-committee --governance-ac
                                                                      )
                                                                      --epoch NATURAL]
                                                                    --quorum RATIONAL
-                                                                   --tx-in TX-IN
+                                                                   [--governance-action-tx-id TXID
+                                                                     --governance-action-index WORD32]
                                                                    --out-file FILE
 
   Create a new committee proposal.
 
-Usage: cardano-cli conway governance action create-no-confidence --governance-action-deposit NATURAL
+Usage: cardano-cli conway governance action create-no-confidence 
+                                                                   ( --mainnet
+                                                                   | --testnet
+                                                                   )
+                                                                   --governance-action-deposit NATURAL
                                                                    ( --stake-pool-verification-key STRING
                                                                    | --cold-verification-key-file FILE
                                                                    | --stake-pool-id STAKE_POOL_ID
@@ -755,8 +776,10 @@ Usage: cardano-cli conway governance action create-no-confidence --governance-ac
                                                                    | --stake-verification-key-file FILE
                                                                    | --stake-key-hash HASH
                                                                    )
+                                                                   --proposal-url TEXT
+                                                                   --anchor-data-hash TEXT
                                                                    --governance-action-tx-id TXID
-                                                                   --goverenance-action-index WORD32
+                                                                   --governance-action-index WORD32
                                                                    --out-file FILE
 
   Create a no confidence proposal.
@@ -789,7 +812,11 @@ Usage: cardano-cli conway governance action create-protocol-parameters-update --
 
   Create a protocol parameters update.
 
-Usage: cardano-cli conway governance action create-treasury-withdrawal --governance-action-deposit NATURAL
+Usage: cardano-cli conway governance action create-treasury-withdrawal 
+                                                                         ( --mainnet
+                                                                         | --testnet
+                                                                         )
+                                                                         --governance-action-deposit NATURAL
                                                                          ( --stake-pool-verification-key STRING
                                                                          | --cold-verification-key-file FILE
                                                                          | --stake-pool-id STAKE_POOL_ID
@@ -797,6 +824,8 @@ Usage: cardano-cli conway governance action create-treasury-withdrawal --governa
                                                                          | --stake-verification-key-file FILE
                                                                          | --stake-key-hash HASH
                                                                          )
+                                                                         --proposal-url TEXT
+                                                                         --anchor-data-hash TEXT
                                                                          [
                                                                            ( --stake-pool-verification-key STRING
                                                                            | --cold-verification-key-file FILE
@@ -959,7 +988,8 @@ Usage: cardano-cli conway governance vote create
   Vote commands.
 
 Usage: cardano-cli conway governance vote create (--yes | --no | --abstain)
-                                                   --tx-in TX-IN
+                                                   --governance-action-tx-id TXID
+                                                   --governance-action-index WORD32
                                                    ( --drep-verification-key STRING
                                                    | --drep-verification-key-file FILE
                                                    | --drep-key-hash HASH
@@ -1124,7 +1154,11 @@ Usage: cardano-cli experimental governance action
 
   Governance action commands.
 
-Usage: cardano-cli experimental governance action create-constitution --governance-action-deposit NATURAL
+Usage: cardano-cli experimental governance action create-constitution 
+                                                                        ( --mainnet
+                                                                        | --testnet
+                                                                        )
+                                                                        --governance-action-deposit NATURAL
                                                                         ( --stake-pool-verification-key STRING
                                                                         | --cold-verification-key-file FILE
                                                                         | --stake-pool-id STAKE_POOL_ID
@@ -1132,14 +1166,24 @@ Usage: cardano-cli experimental governance action create-constitution --governan
                                                                         | --stake-verification-key-file FILE
                                                                         | --stake-key-hash HASH
                                                                         )
-                                                                        ( --constitution TEXT
-                                                                        | --constitution-file FILE
+                                                                        [--governance-action-tx-id TXID
+                                                                          --governance-action-index WORD32]
+                                                                        --proposal-url TEXT
+                                                                        --anchor-data-hash TEXT
+                                                                        ( --constitution-url TEXT
+                                                                          --constitution TEXT
+                                                                        | --constitution-url TEXT
+                                                                          --constitution-file FILE
                                                                         )
                                                                         --out-file FILE
 
   Create a constitution.
 
-Usage: cardano-cli experimental governance action create-new-committee --governance-action-deposit NATURAL
+Usage: cardano-cli experimental governance action create-new-committee 
+                                                                         ( --mainnet
+                                                                         | --testnet
+                                                                         )
+                                                                         --governance-action-deposit NATURAL
                                                                          ( --stake-pool-verification-key STRING
                                                                          | --cold-verification-key-file FILE
                                                                          | --stake-pool-id STAKE_POOL_ID
@@ -1147,6 +1191,8 @@ Usage: cardano-cli experimental governance action create-new-committee --governa
                                                                          | --stake-verification-key-file FILE
                                                                          | --stake-key-hash HASH
                                                                          )
+                                                                         --proposal-url TEXT
+                                                                         --anchor-data-hash TEXT
                                                                          [ --stake-pool-verification-key STRING
                                                                          | --cold-verification-key-file FILE
                                                                          | --stake-pool-id STAKE_POOL_ID
@@ -1164,12 +1210,17 @@ Usage: cardano-cli experimental governance action create-new-committee --governa
                                                                            )
                                                                            --epoch NATURAL]
                                                                          --quorum RATIONAL
-                                                                         --tx-in TX-IN
+                                                                         [--governance-action-tx-id TXID
+                                                                           --governance-action-index WORD32]
                                                                          --out-file FILE
 
   Create a new committee proposal.
 
-Usage: cardano-cli experimental governance action create-no-confidence --governance-action-deposit NATURAL
+Usage: cardano-cli experimental governance action create-no-confidence 
+                                                                         ( --mainnet
+                                                                         | --testnet
+                                                                         )
+                                                                         --governance-action-deposit NATURAL
                                                                          ( --stake-pool-verification-key STRING
                                                                          | --cold-verification-key-file FILE
                                                                          | --stake-pool-id STAKE_POOL_ID
@@ -1177,8 +1228,10 @@ Usage: cardano-cli experimental governance action create-no-confidence --governa
                                                                          | --stake-verification-key-file FILE
                                                                          | --stake-key-hash HASH
                                                                          )
+                                                                         --proposal-url TEXT
+                                                                         --anchor-data-hash TEXT
                                                                          --governance-action-tx-id TXID
-                                                                         --goverenance-action-index WORD32
+                                                                         --governance-action-index WORD32
                                                                          --out-file FILE
 
   Create a no confidence proposal.
@@ -1211,7 +1264,11 @@ Usage: cardano-cli experimental governance action create-protocol-parameters-upd
 
   Create a protocol parameters update.
 
-Usage: cardano-cli experimental governance action create-treasury-withdrawal --governance-action-deposit NATURAL
+Usage: cardano-cli experimental governance action create-treasury-withdrawal 
+                                                                               ( --mainnet
+                                                                               | --testnet
+                                                                               )
+                                                                               --governance-action-deposit NATURAL
                                                                                ( --stake-pool-verification-key STRING
                                                                                | --cold-verification-key-file FILE
                                                                                | --stake-pool-id STAKE_POOL_ID
@@ -1219,6 +1276,8 @@ Usage: cardano-cli experimental governance action create-treasury-withdrawal --g
                                                                                | --stake-verification-key-file FILE
                                                                                | --stake-key-hash HASH
                                                                                )
+                                                                               --proposal-url TEXT
+                                                                               --anchor-data-hash TEXT
                                                                                [
                                                                                  ( --stake-pool-verification-key STRING
                                                                                  | --cold-verification-key-file FILE
@@ -1385,7 +1444,8 @@ Usage: cardano-cli experimental governance vote create
                                                          | --no
                                                          | --abstain
                                                          )
-                                                         --tx-in TX-IN
+                                                         --governance-action-tx-id TXID
+                                                         --governance-action-index WORD32
                                                          ( --drep-verification-key STRING
                                                          | --drep-verification-key-file FILE
                                                          | --drep-key-hash HASH
@@ -1573,7 +1633,8 @@ Usage: cardano-cli legacy governance vote create-vote (--yes | --no | --abstain)
                                                         | --drep
                                                         | --spo
                                                         )
-                                                        --tx-in TX-IN
+                                                        --governance-action-tx-id TXID
+                                                        --governance-action-index WORD32
                                                         ( --stake-pool-verification-key STRING
                                                         | --cold-verification-key-file FILE
                                                         )
@@ -1591,13 +1652,22 @@ Usage: cardano-cli legacy governance action create-action create-constitution
   Create a governance action.
 
 Usage: cardano-cli legacy governance action create-action create-constitution 
+                                                                                ( --mainnet
+                                                                                | --testnet
+                                                                                )
                                                                                 [--conway-era]
                                                                                 --governance-action-deposit NATURAL
                                                                                 ( --stake-pool-verification-key STRING
                                                                                 | --cold-verification-key-file FILE
                                                                                 )
-                                                                                ( --constitution TEXT
-                                                                                | --constitution-file FILE
+                                                                                [--governance-action-tx-id TXID
+                                                                                  --governance-action-index WORD32]
+                                                                                --proposal-url TEXT
+                                                                                --anchor-data-hash TEXT
+                                                                                ( --constitution-url TEXT
+                                                                                  --constitution TEXT
+                                                                                | --constitution-url TEXT
+                                                                                  --constitution-file FILE
                                                                                 )
                                                                                 --out-file FILE
 
@@ -2929,7 +2999,8 @@ Usage: cardano-cli governance vote create-vote (--yes | --no | --abstain)
                                                  | --drep
                                                  | --spo
                                                  )
-                                                 --tx-in TX-IN
+                                                 --governance-action-tx-id TXID
+                                                 --governance-action-index WORD32
                                                  ( --stake-pool-verification-key STRING
                                                  | --cold-verification-key-file FILE
                                                  )
@@ -2947,13 +3018,22 @@ Usage: cardano-cli governance action create-action create-constitution
   Create a governance action.
 
 Usage: cardano-cli governance action create-action create-constitution 
+                                                                         ( --mainnet
+                                                                         | --testnet
+                                                                         )
                                                                          [--conway-era]
                                                                          --governance-action-deposit NATURAL
                                                                          ( --stake-pool-verification-key STRING
                                                                          | --cold-verification-key-file FILE
                                                                          )
-                                                                         ( --constitution TEXT
-                                                                         | --constitution-file FILE
+                                                                         [--governance-action-tx-id TXID
+                                                                           --governance-action-index WORD32]
+                                                                         --proposal-url TEXT
+                                                                         --anchor-data-hash TEXT
+                                                                         ( --constitution-url TEXT
+                                                                           --constitution TEXT
+                                                                         | --constitution-url TEXT
+                                                                           --constitution-file FILE
                                                                          )
                                                                          --out-file FILE
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_create-constitution.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_create-constitution.cli
@@ -1,4 +1,8 @@
-Usage: cardano-cli conway governance action create-constitution --governance-action-deposit NATURAL
+Usage: cardano-cli conway governance action create-constitution 
+                                                                  ( --mainnet
+                                                                  | --testnet
+                                                                  )
+                                                                  --governance-action-deposit NATURAL
                                                                   ( --stake-pool-verification-key STRING
                                                                   | --cold-verification-key-file FILE
                                                                   | --stake-pool-id STAKE_POOL_ID
@@ -6,14 +10,22 @@ Usage: cardano-cli conway governance action create-constitution --governance-act
                                                                   | --stake-verification-key-file FILE
                                                                   | --stake-key-hash HASH
                                                                   )
-                                                                  ( --constitution TEXT
-                                                                  | --constitution-file FILE
+                                                                  [--governance-action-tx-id TXID
+                                                                    --governance-action-index WORD32]
+                                                                  --proposal-url TEXT
+                                                                  --anchor-data-hash TEXT
+                                                                  ( --constitution-url TEXT
+                                                                    --constitution TEXT
+                                                                  | --constitution-url TEXT
+                                                                    --constitution-file FILE
                                                                   )
                                                                   --out-file FILE
 
   Create a constitution.
 
 Available options:
+  --mainnet                Use the mainnet magic id.
+  --testnet                Use the testnet magic id.
   --governance-action-deposit NATURAL
                            Deposit required to submit a governance action.
   --stake-pool-verification-key STRING
@@ -29,7 +41,15 @@ Available options:
   --stake-verification-key-file FILE
                            Filepath of the staking verification key.
   --stake-key-hash HASH    Stake verification key hash (hex-encoded).
+  --governance-action-tx-id TXID
+                           Previous txid of the governance action.
+  --governance-action-index WORD32
+                           Previous tx's governance action index.
+  --proposal-url TEXT      Proposal anchor URL
+  --anchor-data-hash TEXT  Hash of anchor data.
+  --constitution-url TEXT  Constitution URL.
   --constitution TEXT      Input constitution as UTF-8 encoded text.
+  --constitution-url TEXT  Constitution URL.
   --constitution-file FILE Input constitution as a text file.
   --out-file FILE          Output filepath of the constitution.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_create-new-committee.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_create-new-committee.cli
@@ -1,4 +1,8 @@
-Usage: cardano-cli conway governance action create-new-committee --governance-action-deposit NATURAL
+Usage: cardano-cli conway governance action create-new-committee 
+                                                                   ( --mainnet
+                                                                   | --testnet
+                                                                   )
+                                                                   --governance-action-deposit NATURAL
                                                                    ( --stake-pool-verification-key STRING
                                                                    | --cold-verification-key-file FILE
                                                                    | --stake-pool-id STAKE_POOL_ID
@@ -6,6 +10,8 @@ Usage: cardano-cli conway governance action create-new-committee --governance-ac
                                                                    | --stake-verification-key-file FILE
                                                                    | --stake-key-hash HASH
                                                                    )
+                                                                   --proposal-url TEXT
+                                                                   --anchor-data-hash TEXT
                                                                    [ --stake-pool-verification-key STRING
                                                                    | --cold-verification-key-file FILE
                                                                    | --stake-pool-id STAKE_POOL_ID
@@ -23,12 +29,15 @@ Usage: cardano-cli conway governance action create-new-committee --governance-ac
                                                                      )
                                                                      --epoch NATURAL]
                                                                    --quorum RATIONAL
-                                                                   --tx-in TX-IN
+                                                                   [--governance-action-tx-id TXID
+                                                                     --governance-action-index WORD32]
                                                                    --out-file FILE
 
   Create a new committee proposal.
 
 Available options:
+  --mainnet                Use the mainnet magic id.
+  --testnet                Use the testnet magic id.
   --governance-action-deposit NATURAL
                            Deposit required to submit a governance action.
   --stake-pool-verification-key STRING
@@ -44,6 +53,8 @@ Available options:
   --stake-verification-key-file FILE
                            Filepath of the staking verification key.
   --stake-key-hash HASH    Stake verification key hash (hex-encoded).
+  --proposal-url TEXT      Proposal anchor URL
+  --anchor-data-hash TEXT  Hash of anchor data.
   --stake-pool-verification-key STRING
                            Stake pool verification key (Bech32 or hex-encoded).
   --cold-verification-key-file FILE
@@ -73,7 +84,9 @@ Available options:
   --epoch NATURAL          Committee member expiry epoch
   --quorum RATIONAL        Quorum of the committee that is necessary for a
                            successful vote.
-  --tx-in TX-IN            Previous governance action id of `NewCommittee` or
-                           `NoConfidence` type
+  --governance-action-tx-id TXID
+                           Previous txid of the governance action.
+  --governance-action-index WORD32
+                           Previous tx's governance action index.
   --out-file FILE          The output file.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_create-no-confidence.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_create-no-confidence.cli
@@ -1,4 +1,8 @@
-Usage: cardano-cli conway governance action create-no-confidence --governance-action-deposit NATURAL
+Usage: cardano-cli conway governance action create-no-confidence 
+                                                                   ( --mainnet
+                                                                   | --testnet
+                                                                   )
+                                                                   --governance-action-deposit NATURAL
                                                                    ( --stake-pool-verification-key STRING
                                                                    | --cold-verification-key-file FILE
                                                                    | --stake-pool-id STAKE_POOL_ID
@@ -6,13 +10,17 @@ Usage: cardano-cli conway governance action create-no-confidence --governance-ac
                                                                    | --stake-verification-key-file FILE
                                                                    | --stake-key-hash HASH
                                                                    )
+                                                                   --proposal-url TEXT
+                                                                   --anchor-data-hash TEXT
                                                                    --governance-action-tx-id TXID
-                                                                   --goverenance-action-index WORD32
+                                                                   --governance-action-index WORD32
                                                                    --out-file FILE
 
   Create a no confidence proposal.
 
 Available options:
+  --mainnet                Use the mainnet magic id.
+  --testnet                Use the testnet magic id.
   --governance-action-deposit NATURAL
                            Deposit required to submit a governance action.
   --stake-pool-verification-key STRING
@@ -28,10 +36,12 @@ Available options:
   --stake-verification-key-file FILE
                            Filepath of the staking verification key.
   --stake-key-hash HASH    Stake verification key hash (hex-encoded).
+  --proposal-url TEXT      Proposal anchor URL
+  --anchor-data-hash TEXT  Hash of anchor data.
   --governance-action-tx-id TXID
                            Previous txid of `NoConfidence` or `NewCommittee`
                            governance action.
-  --goverenance-action-index WORD32
+  --governance-action-index WORD32
                            Previous tx's governance action index of
                            `NoConfidence` or `NewCommittee` governance action.
   --out-file FILE          Output filepath of the no confidence proposal.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_create-treasury-withdrawal.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_create-treasury-withdrawal.cli
@@ -1,4 +1,8 @@
-Usage: cardano-cli conway governance action create-treasury-withdrawal --governance-action-deposit NATURAL
+Usage: cardano-cli conway governance action create-treasury-withdrawal 
+                                                                         ( --mainnet
+                                                                         | --testnet
+                                                                         )
+                                                                         --governance-action-deposit NATURAL
                                                                          ( --stake-pool-verification-key STRING
                                                                          | --cold-verification-key-file FILE
                                                                          | --stake-pool-id STAKE_POOL_ID
@@ -6,6 +10,8 @@ Usage: cardano-cli conway governance action create-treasury-withdrawal --governa
                                                                          | --stake-verification-key-file FILE
                                                                          | --stake-key-hash HASH
                                                                          )
+                                                                         --proposal-url TEXT
+                                                                         --anchor-data-hash TEXT
                                                                          [
                                                                            ( --stake-pool-verification-key STRING
                                                                            | --cold-verification-key-file FILE
@@ -20,6 +26,8 @@ Usage: cardano-cli conway governance action create-treasury-withdrawal --governa
   Create a treasury withdrawal.
 
 Available options:
+  --mainnet                Use the mainnet magic id.
+  --testnet                Use the testnet magic id.
   --governance-action-deposit NATURAL
                            Deposit required to submit a governance action.
   --stake-pool-verification-key STRING
@@ -35,6 +43,8 @@ Available options:
   --stake-verification-key-file FILE
                            Filepath of the staking verification key.
   --stake-key-hash HASH    Stake verification key hash (hex-encoded).
+  --proposal-url TEXT      Proposal anchor URL
+  --anchor-data-hash TEXT  Hash of anchor data.
   --stake-pool-verification-key STRING
                            Stake pool verification key (Bech32 or hex-encoded).
   --cold-verification-key-file FILE

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_vote_create.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_vote_create.cli
@@ -1,5 +1,6 @@
 Usage: cardano-cli conway governance vote create (--yes | --no | --abstain)
-                                                   --tx-in TX-IN
+                                                   --governance-action-tx-id TXID
+                                                   --governance-action-index WORD32
                                                    ( --drep-verification-key STRING
                                                    | --drep-verification-key-file FILE
                                                    | --drep-key-hash HASH
@@ -12,7 +13,10 @@ Usage: cardano-cli conway governance vote create (--yes | --no | --abstain)
   Vote creation.
 
 Available options:
-  --tx-in TX-IN            TxIn of governance action (already on chain).
+  --governance-action-tx-id TXID
+                           Txid of the governance action.
+  --governance-action-index WORD32
+                           Tx's governance action index.
   --drep-verification-key STRING
                            DRep verification key (Bech32 or hex-encoded).
   --drep-verification-key-file FILE
@@ -28,5 +32,5 @@ Available options:
                            Stake pool ID/verification key hash (either
                            Bech32-encoded or hex-encoded). Zero or more
                            occurences of this option is allowed.
-  --out-file FILE          The output file.
+  --out-file FILE          Output filepath of the vote.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/experimental_governance_action_create-constitution.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/experimental_governance_action_create-constitution.cli
@@ -1,4 +1,8 @@
-Usage: cardano-cli experimental governance action create-constitution --governance-action-deposit NATURAL
+Usage: cardano-cli experimental governance action create-constitution 
+                                                                        ( --mainnet
+                                                                        | --testnet
+                                                                        )
+                                                                        --governance-action-deposit NATURAL
                                                                         ( --stake-pool-verification-key STRING
                                                                         | --cold-verification-key-file FILE
                                                                         | --stake-pool-id STAKE_POOL_ID
@@ -6,14 +10,22 @@ Usage: cardano-cli experimental governance action create-constitution --governan
                                                                         | --stake-verification-key-file FILE
                                                                         | --stake-key-hash HASH
                                                                         )
-                                                                        ( --constitution TEXT
-                                                                        | --constitution-file FILE
+                                                                        [--governance-action-tx-id TXID
+                                                                          --governance-action-index WORD32]
+                                                                        --proposal-url TEXT
+                                                                        --anchor-data-hash TEXT
+                                                                        ( --constitution-url TEXT
+                                                                          --constitution TEXT
+                                                                        | --constitution-url TEXT
+                                                                          --constitution-file FILE
                                                                         )
                                                                         --out-file FILE
 
   Create a constitution.
 
 Available options:
+  --mainnet                Use the mainnet magic id.
+  --testnet                Use the testnet magic id.
   --governance-action-deposit NATURAL
                            Deposit required to submit a governance action.
   --stake-pool-verification-key STRING
@@ -29,7 +41,15 @@ Available options:
   --stake-verification-key-file FILE
                            Filepath of the staking verification key.
   --stake-key-hash HASH    Stake verification key hash (hex-encoded).
+  --governance-action-tx-id TXID
+                           Previous txid of the governance action.
+  --governance-action-index WORD32
+                           Previous tx's governance action index.
+  --proposal-url TEXT      Proposal anchor URL
+  --anchor-data-hash TEXT  Hash of anchor data.
+  --constitution-url TEXT  Constitution URL.
   --constitution TEXT      Input constitution as UTF-8 encoded text.
+  --constitution-url TEXT  Constitution URL.
   --constitution-file FILE Input constitution as a text file.
   --out-file FILE          Output filepath of the constitution.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/experimental_governance_action_create-new-committee.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/experimental_governance_action_create-new-committee.cli
@@ -1,4 +1,8 @@
-Usage: cardano-cli experimental governance action create-new-committee --governance-action-deposit NATURAL
+Usage: cardano-cli experimental governance action create-new-committee 
+                                                                         ( --mainnet
+                                                                         | --testnet
+                                                                         )
+                                                                         --governance-action-deposit NATURAL
                                                                          ( --stake-pool-verification-key STRING
                                                                          | --cold-verification-key-file FILE
                                                                          | --stake-pool-id STAKE_POOL_ID
@@ -6,6 +10,8 @@ Usage: cardano-cli experimental governance action create-new-committee --governa
                                                                          | --stake-verification-key-file FILE
                                                                          | --stake-key-hash HASH
                                                                          )
+                                                                         --proposal-url TEXT
+                                                                         --anchor-data-hash TEXT
                                                                          [ --stake-pool-verification-key STRING
                                                                          | --cold-verification-key-file FILE
                                                                          | --stake-pool-id STAKE_POOL_ID
@@ -23,12 +29,15 @@ Usage: cardano-cli experimental governance action create-new-committee --governa
                                                                            )
                                                                            --epoch NATURAL]
                                                                          --quorum RATIONAL
-                                                                         --tx-in TX-IN
+                                                                         [--governance-action-tx-id TXID
+                                                                           --governance-action-index WORD32]
                                                                          --out-file FILE
 
   Create a new committee proposal.
 
 Available options:
+  --mainnet                Use the mainnet magic id.
+  --testnet                Use the testnet magic id.
   --governance-action-deposit NATURAL
                            Deposit required to submit a governance action.
   --stake-pool-verification-key STRING
@@ -44,6 +53,8 @@ Available options:
   --stake-verification-key-file FILE
                            Filepath of the staking verification key.
   --stake-key-hash HASH    Stake verification key hash (hex-encoded).
+  --proposal-url TEXT      Proposal anchor URL
+  --anchor-data-hash TEXT  Hash of anchor data.
   --stake-pool-verification-key STRING
                            Stake pool verification key (Bech32 or hex-encoded).
   --cold-verification-key-file FILE
@@ -73,7 +84,9 @@ Available options:
   --epoch NATURAL          Committee member expiry epoch
   --quorum RATIONAL        Quorum of the committee that is necessary for a
                            successful vote.
-  --tx-in TX-IN            Previous governance action id of `NewCommittee` or
-                           `NoConfidence` type
+  --governance-action-tx-id TXID
+                           Previous txid of the governance action.
+  --governance-action-index WORD32
+                           Previous tx's governance action index.
   --out-file FILE          The output file.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/experimental_governance_action_create-no-confidence.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/experimental_governance_action_create-no-confidence.cli
@@ -1,4 +1,8 @@
-Usage: cardano-cli experimental governance action create-no-confidence --governance-action-deposit NATURAL
+Usage: cardano-cli experimental governance action create-no-confidence 
+                                                                         ( --mainnet
+                                                                         | --testnet
+                                                                         )
+                                                                         --governance-action-deposit NATURAL
                                                                          ( --stake-pool-verification-key STRING
                                                                          | --cold-verification-key-file FILE
                                                                          | --stake-pool-id STAKE_POOL_ID
@@ -6,13 +10,17 @@ Usage: cardano-cli experimental governance action create-no-confidence --governa
                                                                          | --stake-verification-key-file FILE
                                                                          | --stake-key-hash HASH
                                                                          )
+                                                                         --proposal-url TEXT
+                                                                         --anchor-data-hash TEXT
                                                                          --governance-action-tx-id TXID
-                                                                         --goverenance-action-index WORD32
+                                                                         --governance-action-index WORD32
                                                                          --out-file FILE
 
   Create a no confidence proposal.
 
 Available options:
+  --mainnet                Use the mainnet magic id.
+  --testnet                Use the testnet magic id.
   --governance-action-deposit NATURAL
                            Deposit required to submit a governance action.
   --stake-pool-verification-key STRING
@@ -28,10 +36,12 @@ Available options:
   --stake-verification-key-file FILE
                            Filepath of the staking verification key.
   --stake-key-hash HASH    Stake verification key hash (hex-encoded).
+  --proposal-url TEXT      Proposal anchor URL
+  --anchor-data-hash TEXT  Hash of anchor data.
   --governance-action-tx-id TXID
                            Previous txid of `NoConfidence` or `NewCommittee`
                            governance action.
-  --goverenance-action-index WORD32
+  --governance-action-index WORD32
                            Previous tx's governance action index of
                            `NoConfidence` or `NewCommittee` governance action.
   --out-file FILE          Output filepath of the no confidence proposal.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/experimental_governance_action_create-treasury-withdrawal.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/experimental_governance_action_create-treasury-withdrawal.cli
@@ -1,4 +1,8 @@
-Usage: cardano-cli experimental governance action create-treasury-withdrawal --governance-action-deposit NATURAL
+Usage: cardano-cli experimental governance action create-treasury-withdrawal 
+                                                                               ( --mainnet
+                                                                               | --testnet
+                                                                               )
+                                                                               --governance-action-deposit NATURAL
                                                                                ( --stake-pool-verification-key STRING
                                                                                | --cold-verification-key-file FILE
                                                                                | --stake-pool-id STAKE_POOL_ID
@@ -6,6 +10,8 @@ Usage: cardano-cli experimental governance action create-treasury-withdrawal --g
                                                                                | --stake-verification-key-file FILE
                                                                                | --stake-key-hash HASH
                                                                                )
+                                                                               --proposal-url TEXT
+                                                                               --anchor-data-hash TEXT
                                                                                [
                                                                                  ( --stake-pool-verification-key STRING
                                                                                  | --cold-verification-key-file FILE
@@ -20,6 +26,8 @@ Usage: cardano-cli experimental governance action create-treasury-withdrawal --g
   Create a treasury withdrawal.
 
 Available options:
+  --mainnet                Use the mainnet magic id.
+  --testnet                Use the testnet magic id.
   --governance-action-deposit NATURAL
                            Deposit required to submit a governance action.
   --stake-pool-verification-key STRING
@@ -35,6 +43,8 @@ Available options:
   --stake-verification-key-file FILE
                            Filepath of the staking verification key.
   --stake-key-hash HASH    Stake verification key hash (hex-encoded).
+  --proposal-url TEXT      Proposal anchor URL
+  --anchor-data-hash TEXT  Hash of anchor data.
   --stake-pool-verification-key STRING
                            Stake pool verification key (Bech32 or hex-encoded).
   --cold-verification-key-file FILE

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/experimental_governance_vote_create.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/experimental_governance_vote_create.cli
@@ -3,7 +3,8 @@ Usage: cardano-cli experimental governance vote create
                                                          | --no
                                                          | --abstain
                                                          )
-                                                         --tx-in TX-IN
+                                                         --governance-action-tx-id TXID
+                                                         --governance-action-index WORD32
                                                          ( --drep-verification-key STRING
                                                          | --drep-verification-key-file FILE
                                                          | --drep-key-hash HASH
@@ -16,7 +17,10 @@ Usage: cardano-cli experimental governance vote create
   Vote creation.
 
 Available options:
-  --tx-in TX-IN            TxIn of governance action (already on chain).
+  --governance-action-tx-id TXID
+                           Txid of the governance action.
+  --governance-action-index WORD32
+                           Tx's governance action index.
   --drep-verification-key STRING
                            DRep verification key (Bech32 or hex-encoded).
   --drep-verification-key-file FILE
@@ -32,5 +36,5 @@ Available options:
                            Stake pool ID/verification key hash (either
                            Bech32-encoded or hex-encoded). Zero or more
                            occurences of this option is allowed.
-  --out-file FILE          The output file.
+  --out-file FILE          Output filepath of the vote.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_action_create-action_create-constitution.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_action_create-action_create-constitution.cli
@@ -1,17 +1,28 @@
 Usage: cardano-cli governance action create-action create-constitution 
+                                                                         ( --mainnet
+                                                                         | --testnet
+                                                                         )
                                                                          [--conway-era]
                                                                          --governance-action-deposit NATURAL
                                                                          ( --stake-pool-verification-key STRING
                                                                          | --cold-verification-key-file FILE
                                                                          )
-                                                                         ( --constitution TEXT
-                                                                         | --constitution-file FILE
+                                                                         [--governance-action-tx-id TXID
+                                                                           --governance-action-index WORD32]
+                                                                         --proposal-url TEXT
+                                                                         --anchor-data-hash TEXT
+                                                                         ( --constitution-url TEXT
+                                                                           --constitution TEXT
+                                                                         | --constitution-url TEXT
+                                                                           --constitution-file FILE
                                                                          )
                                                                          --out-file FILE
 
   Create a constitution.
 
 Available options:
+  --mainnet                Use the mainnet magic id.
+  --testnet                Use the testnet magic id.
   --conway-era             Specify the Conway era
   --governance-action-deposit NATURAL
                            Deposit required to submit a governance action.
@@ -19,7 +30,15 @@ Available options:
                            Stake pool verification key (Bech32 or hex-encoded).
   --cold-verification-key-file FILE
                            Filepath of the stake pool verification key.
+  --governance-action-tx-id TXID
+                           Previous txid of the governance action.
+  --governance-action-index WORD32
+                           Previous tx's governance action index.
+  --proposal-url TEXT      Proposal anchor URL
+  --anchor-data-hash TEXT  Hash of anchor data.
+  --constitution-url TEXT  Constitution URL.
   --constitution TEXT      Input constitution as UTF-8 encoded text.
+  --constitution-url TEXT  Constitution URL.
   --constitution-file FILE Input constitution as a text file.
   --out-file FILE          Output filepath of the governance action.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_vote_create-vote.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_vote_create-vote.cli
@@ -3,7 +3,8 @@ Usage: cardano-cli governance vote create-vote (--yes | --no | --abstain)
                                                  | --drep
                                                  | --spo
                                                  )
-                                                 --tx-in TX-IN
+                                                 --governance-action-tx-id TXID
+                                                 --governance-action-index WORD32
                                                  ( --stake-pool-verification-key STRING
                                                  | --cold-verification-key-file FILE
                                                  )
@@ -17,7 +18,10 @@ Available options:
                            Member of the constiutional committee
   --drep                   Delegate representative
   --spo                    Stake pool operator
-  --tx-in TX-IN            TxIn of governance action (already on chain).
+  --governance-action-tx-id TXID
+                           Txid of the governance action.
+  --governance-action-index WORD32
+                           Tx's governance action index.
   --stake-pool-verification-key STRING
                            Stake pool verification key (Bech32 or hex-encoded).
   --cold-verification-key-file FILE

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_governance_action_create-action_create-constitution.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_governance_action_create-action_create-constitution.cli
@@ -1,17 +1,28 @@
 Usage: cardano-cli legacy governance action create-action create-constitution 
+                                                                                ( --mainnet
+                                                                                | --testnet
+                                                                                )
                                                                                 [--conway-era]
                                                                                 --governance-action-deposit NATURAL
                                                                                 ( --stake-pool-verification-key STRING
                                                                                 | --cold-verification-key-file FILE
                                                                                 )
-                                                                                ( --constitution TEXT
-                                                                                | --constitution-file FILE
+                                                                                [--governance-action-tx-id TXID
+                                                                                  --governance-action-index WORD32]
+                                                                                --proposal-url TEXT
+                                                                                --anchor-data-hash TEXT
+                                                                                ( --constitution-url TEXT
+                                                                                  --constitution TEXT
+                                                                                | --constitution-url TEXT
+                                                                                  --constitution-file FILE
                                                                                 )
                                                                                 --out-file FILE
 
   Create a constitution.
 
 Available options:
+  --mainnet                Use the mainnet magic id.
+  --testnet                Use the testnet magic id.
   --conway-era             Specify the Conway era
   --governance-action-deposit NATURAL
                            Deposit required to submit a governance action.
@@ -19,7 +30,15 @@ Available options:
                            Stake pool verification key (Bech32 or hex-encoded).
   --cold-verification-key-file FILE
                            Filepath of the stake pool verification key.
+  --governance-action-tx-id TXID
+                           Previous txid of the governance action.
+  --governance-action-index WORD32
+                           Previous tx's governance action index.
+  --proposal-url TEXT      Proposal anchor URL
+  --anchor-data-hash TEXT  Hash of anchor data.
+  --constitution-url TEXT  Constitution URL.
   --constitution TEXT      Input constitution as UTF-8 encoded text.
+  --constitution-url TEXT  Constitution URL.
   --constitution-file FILE Input constitution as a text file.
   --out-file FILE          Output filepath of the governance action.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_governance_vote_create-vote.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_governance_vote_create-vote.cli
@@ -3,7 +3,8 @@ Usage: cardano-cli legacy governance vote create-vote (--yes | --no | --abstain)
                                                         | --drep
                                                         | --spo
                                                         )
-                                                        --tx-in TX-IN
+                                                        --governance-action-tx-id TXID
+                                                        --governance-action-index WORD32
                                                         ( --stake-pool-verification-key STRING
                                                         | --cold-verification-key-file FILE
                                                         )
@@ -17,7 +18,10 @@ Available options:
                            Member of the constiutional committee
   --drep                   Delegate representative
   --spo                    Stake pool operator
-  --tx-in TX-IN            TxIn of governance action (already on chain).
+  --governance-action-tx-id TXID
+                           Txid of the governance action.
+  --governance-action-index WORD32
+                           Tx's governance action index.
   --stake-pool-verification-key STRING
                            Stake pool verification key (Bech32 or hex-encoded).
   --cold-verification-key-file FILE

--- a/flake.lock
+++ b/flake.lock
@@ -189,11 +189,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1692231735,
-        "narHash": "sha256-75jxGw+Mzt/2OzTz9gRb5LPwysq76JyNMBjDzMTAdXE=",
+        "lastModified": 1692750150,
+        "narHash": "sha256-PQUa3d/xx/ow5+aWAJcbo5ReSfXUUaREmv11iv/gw0I=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "7624c4239624ba595c41b81e05aa147c86cd8235",
+        "rev": "5bdde609b165186227df40511bc0aa43c3fee3ac",
         "type": "github"
       },
       "original": {
@@ -233,11 +233,11 @@
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1692254824,
-        "narHash": "sha256-U18N6WYvVidlKBZjt61QsIK/PLccmM2Gv6BSJgr3uqE=",
+        "lastModified": 1692759275,
+        "narHash": "sha256-OuaF9FgFtXEsoqSqp7yl8fuShpgR+DmYY+jlvh7anTg=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "0ad4dcb7286ec71fbf3b90626758bf67772a408c",
+        "rev": "fc87a1ca9211b05267c9603752f008442db87c8b",
         "type": "github"
       },
       "original": {
@@ -654,11 +654,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1692230916,
-        "narHash": "sha256-Mm1nPNVgZl8Rdcs/A1cliBQTlzqx1Wv1tMjr9zEwlCE=",
+        "lastModified": 1692749313,
+        "narHash": "sha256-gBe4uaEOoem6GwL2iN2v4oy4kts6GbQFbg2J9fkcgqs=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "cfbafab66ac72fd00d69122d95491fdb78c57b78",
+        "rev": "347b8f075d0bfc69b4a88fe0bd2f0f0a1b2b1789",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1692114433,
-        "narHash": "sha256-l6UoBkt1SUUBga/u0qpQeuNTN2YgtdZMBJSw29Wb0xU=",
+        "lastModified": 1692802304,
+        "narHash": "sha256-t7RHKNanpG+4ciyvBf199zzuGFQZJeJvEUsAZpW7Qso=",
         "owner": "input-output-hk",
         "repo": "cardano-haskell-packages",
-        "rev": "73093fde5e26b9f7594a2219d339175005256475",
+        "rev": "c4e89b49573d19f483b224717c3b395ee2aefdf8",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    conway related commands
    `create-constitution` now requires: 
       - mainnet or testnet
       - Optionally the previous governance action id 
       - A proposal url and an anchor data hash of the proposal 
       - A constitution url
    `create-new-committee` now requires:
       - mainnet or testnet
       - A proposal url and an anchor data hash of the proposal
       - Optionally the previous governance action id 
    `create-no-confidence` now requires:
       - mainnet or testnet
       - A proposal url and an anchor data hash of the proposal
    `create-treasury-withdrawal` now requires:
       - mainnet or testnet
       - A proposal url and an anchor data hash of the proposal
    `governance vote create` now requires:
       - The governance action identifier
       
# uncomment types applicable to the change:
  type:
  - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Additional context for the PR goes here.

If the PR fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
