### PR TITLE
Add create-no-confidence command to era based cardano-cli

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/Actions.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/Actions.hs
@@ -8,6 +8,7 @@ module Cardano.CLI.EraBased.Commands.Governance.Actions
   , GovernanceActionCmds(..)
   , EraBasedNewCommittee(..)
   , EraBasedNewConstitution(..)
+  , EraBasedNoConfidence(..)
   , EraBasedTreasuryWithdrawal(..)
   , renderGovernanceActionCmds
   ) where
@@ -19,6 +20,7 @@ import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Key
 
 import           Data.Text (Text)
+import           Data.Word
 
 data GovernanceActionCmds era
   = GovernanceActionCreateConstitution
@@ -27,6 +29,9 @@ data GovernanceActionCmds era
   | GoveranceActionCreateNewCommittee
       (ConwayEraOnwards era)
       EraBasedNewCommittee
+  | GovernanceActionCreateNoConfidence
+      (ConwayEraOnwards era)
+      EraBasedNoConfidence
   | GovernanceActionProtocolParametersUpdate
       (ShelleyBasedEra era)
       EpochNo
@@ -57,6 +62,15 @@ data EraBasedNewConstitution
       , encFilePath :: File () Out
       } deriving Show
 
+data EraBasedNoConfidence
+  = EraBasedNoConfidence
+      { ncDeposit :: Lovelace
+      , ncStakeCredential :: AnyStakeIdentifier
+      , ncGovAct :: TxId
+      , ncGovActIndex :: Word32
+      , ncFilePath :: File () Out
+      } deriving Show
+
 data EraBasedTreasuryWithdrawal where
   EraBasedTreasuryWithdrawal
     :: Lovelace -- ^ Deposit
@@ -80,6 +94,9 @@ renderGovernanceActionCmds = \case
 
   GoveranceActionCreateNewCommittee {} ->
     "governance action create-new-committee"
+
+  GovernanceActionCreateNoConfidence {} ->
+    "governance action create-no-confidence"
 
 data AnyStakeIdentifier
   = AnyStakeKey (VerificationKeyOrHashOrFile StakeKey)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Actions.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Actions.hs
@@ -45,6 +45,23 @@ runGovernanceActionCmds = \case
   GoveranceActionCreateNewCommittee con newCommittee ->
     runGovernanceActionCreateNewCommittee con newCommittee
 
+  GovernanceActionCreateNoConfidence cOn noConfidence ->
+    runGovernanceActionCreateNoConfidence cOn noConfidence
+
+-- TODO: Conway era - update with new ledger types from cardano-ledger-conway-1.7.0.0
+runGovernanceActionCreateNoConfidence
+  :: ConwayEraOnwards era
+  -> EraBasedNoConfidence
+  -> ExceptT GovernanceActionsError IO ()
+runGovernanceActionCreateNoConfidence cOn (EraBasedNoConfidence deposit returnAddr _txid _ind outFp) = do
+  returnKeyHash <- readStakeKeyHash returnAddr
+  let sbe = conwayEraOnwardsToShelleyBasedEra cOn
+      proposal = createProposalProcedure sbe deposit returnKeyHash MotionOfNoConfidence
+
+  firstExceptT GovernanceActionsCmdWriteFileError . newExceptT
+    $ conwayEraOnwardsConstraints cOn
+    $ writeFileTextEnvelope outFp Nothing proposal
+
 runGovernanceActionCreateConstitution :: ()
   => ConwayEraOnwards era
   -> EraBasedNewConstitution

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -799,6 +799,7 @@ Usage: cardano-cli conway governance committee key-hash --verification-key-file 
 Usage: cardano-cli conway governance action 
                                               ( create-constitution
                                               | create-new-committee
+                                              | create-no-confidence
                                               | create-protocol-parameters-update
                                               | create-treasury-withdrawal
                                               )
@@ -849,6 +850,20 @@ Usage: cardano-cli conway governance action create-new-committee --governance-ac
                                                                    --out-file FILE
 
   Create a new committee proposal.
+
+Usage: cardano-cli conway governance action create-no-confidence --governance-action-deposit NATURAL
+                                                                   ( --stake-pool-verification-key STRING
+                                                                   | --cold-verification-key-file FILE
+                                                                   | --stake-pool-id STAKE_POOL_ID
+                                                                   | --stake-verification-key STRING
+                                                                   | --stake-verification-key-file FILE
+                                                                   | --stake-key-hash HASH
+                                                                   )
+                                                                   --governance-action-tx-id TXID
+                                                                   --goverenance-action-index WORD32
+                                                                   --out-file FILE
+
+  Create a no confidence proposal.
 
 Usage: cardano-cli conway governance action create-protocol-parameters-update --epoch NATURAL
                                                                                 [--min-fee-constant LOVELACE]
@@ -1166,6 +1181,7 @@ Usage: cardano-cli experimental governance committee key-hash --verification-key
 Usage: cardano-cli experimental governance action 
                                                     ( create-constitution
                                                     | create-new-committee
+                                                    | create-no-confidence
                                                     | create-protocol-parameters-update
                                                     | create-treasury-withdrawal
                                                     )
@@ -1216,6 +1232,20 @@ Usage: cardano-cli experimental governance action create-new-committee --governa
                                                                          --out-file FILE
 
   Create a new committee proposal.
+
+Usage: cardano-cli experimental governance action create-no-confidence --governance-action-deposit NATURAL
+                                                                         ( --stake-pool-verification-key STRING
+                                                                         | --cold-verification-key-file FILE
+                                                                         | --stake-pool-id STAKE_POOL_ID
+                                                                         | --stake-verification-key STRING
+                                                                         | --stake-verification-key-file FILE
+                                                                         | --stake-key-hash HASH
+                                                                         )
+                                                                         --governance-action-tx-id TXID
+                                                                         --goverenance-action-index WORD32
+                                                                         --out-file FILE
+
+  Create a no confidence proposal.
 
 Usage: cardano-cli experimental governance action create-protocol-parameters-update --epoch NATURAL
                                                                                       [--min-fee-constant LOVELACE]

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action.cli
@@ -1,6 +1,7 @@
 Usage: cardano-cli conway governance action 
                                               ( create-constitution
                                               | create-new-committee
+                                              | create-no-confidence
                                               | create-protocol-parameters-update
                                               | create-treasury-withdrawal
                                               )
@@ -13,6 +14,7 @@ Available options:
 Available commands:
   create-constitution      Create a constitution.
   create-new-committee     Create a new committee proposal.
+  create-no-confidence     Create a no confidence proposal.
   create-protocol-parameters-update
                            Create a protocol parameters update.
   create-treasury-withdrawal

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_create-no-confidence.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_create-no-confidence.cli
@@ -1,0 +1,38 @@
+Usage: cardano-cli conway governance action create-no-confidence --governance-action-deposit NATURAL
+                                                                   ( --stake-pool-verification-key STRING
+                                                                   | --cold-verification-key-file FILE
+                                                                   | --stake-pool-id STAKE_POOL_ID
+                                                                   | --stake-verification-key STRING
+                                                                   | --stake-verification-key-file FILE
+                                                                   | --stake-key-hash HASH
+                                                                   )
+                                                                   --governance-action-tx-id TXID
+                                                                   --goverenance-action-index WORD32
+                                                                   --out-file FILE
+
+  Create a no confidence proposal.
+
+Available options:
+  --governance-action-deposit NATURAL
+                           Deposit required to submit a governance action.
+  --stake-pool-verification-key STRING
+                           Stake pool verification key (Bech32 or hex-encoded).
+  --cold-verification-key-file FILE
+                           Filepath of the stake pool verification key.
+  --stake-pool-id STAKE_POOL_ID
+                           Stake pool ID/verification key hash (either
+                           Bech32-encoded or hex-encoded). Zero or more
+                           occurences of this option is allowed.
+  --stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --stake-verification-key-file FILE
+                           Filepath of the staking verification key.
+  --stake-key-hash HASH    Stake verification key hash (hex-encoded).
+  --governance-action-tx-id TXID
+                           Previous txid of `NoConfidence` or `NewCommittee`
+                           governance action.
+  --goverenance-action-index WORD32
+                           Previous tx's governance action index of
+                           `NoConfidence` or `NewCommittee` governance action.
+  --out-file FILE          Output filepath of the no confidence proposal.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/experimental_governance_action.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/experimental_governance_action.cli
@@ -1,6 +1,7 @@
 Usage: cardano-cli experimental governance action 
                                                     ( create-constitution
                                                     | create-new-committee
+                                                    | create-no-confidence
                                                     | create-protocol-parameters-update
                                                     | create-treasury-withdrawal
                                                     )
@@ -13,6 +14,7 @@ Available options:
 Available commands:
   create-constitution      Create a constitution.
   create-new-committee     Create a new committee proposal.
+  create-no-confidence     Create a no confidence proposal.
   create-protocol-parameters-update
                            Create a protocol parameters update.
   create-treasury-withdrawal

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/experimental_governance_action_create-no-confidence.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/experimental_governance_action_create-no-confidence.cli
@@ -1,0 +1,38 @@
+Usage: cardano-cli experimental governance action create-no-confidence --governance-action-deposit NATURAL
+                                                                         ( --stake-pool-verification-key STRING
+                                                                         | --cold-verification-key-file FILE
+                                                                         | --stake-pool-id STAKE_POOL_ID
+                                                                         | --stake-verification-key STRING
+                                                                         | --stake-verification-key-file FILE
+                                                                         | --stake-key-hash HASH
+                                                                         )
+                                                                         --governance-action-tx-id TXID
+                                                                         --goverenance-action-index WORD32
+                                                                         --out-file FILE
+
+  Create a no confidence proposal.
+
+Available options:
+  --governance-action-deposit NATURAL
+                           Deposit required to submit a governance action.
+  --stake-pool-verification-key STRING
+                           Stake pool verification key (Bech32 or hex-encoded).
+  --cold-verification-key-file FILE
+                           Filepath of the stake pool verification key.
+  --stake-pool-id STAKE_POOL_ID
+                           Stake pool ID/verification key hash (either
+                           Bech32-encoded or hex-encoded). Zero or more
+                           occurences of this option is allowed.
+  --stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --stake-verification-key-file FILE
+                           Filepath of the staking verification key.
+  --stake-key-hash HASH    Stake verification key hash (hex-encoded).
+  --governance-action-tx-id TXID
+                           Previous txid of `NoConfidence` or `NewCommittee`
+                           governance action.
+  --goverenance-action-index WORD32
+                           Previous tx's governance action index of
+                           `NoConfidence` or `NewCommittee` governance action.
+  --out-file FILE          Output filepath of the no confidence proposal.
+  -h,--help                Show this help text


### PR DESCRIPTION
# Changelog
Resolves #177 
```yaml
- description: |
   Add create-no-confidence command to era based cardano-cli
# uncomment types applicable to the change:
  type:
  - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Additional context for the PR goes here.

If the PR fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
