### PR TITLE
Add goverance info action creation to era based cli

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/Actions.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/Actions.hs
@@ -41,6 +41,10 @@ data GovernanceActionCmds era
   | GovernanceActionTreasuryWithdrawal
       (ConwayEraOnwards era)
       EraBasedTreasuryWithdrawal
+  | GoveranceActionInfo -- TODO: Conway era - ledger currently provides a placeholder constructor
+      (ConwayEraOnwards era)
+      (File () In)
+      (File () Out)
   deriving Show
 
 data EraBasedNewCommittee
@@ -97,6 +101,9 @@ renderGovernanceActionCmds = \case
 
   GovernanceActionCreateNoConfidence {} ->
     "governance action create-no-confidence"
+
+  GoveranceActionInfo {} ->
+    "governance action create-info"
 
 data AnyStakeIdentifier
   = AnyStakeKey (VerificationKeyOrHashOrFile StakeKey)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Actions.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Actions.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE TupleSections #-}
+{-# LANGUAGE TypeApplications #-}
 
 module Cardano.CLI.EraBased.Run.Governance.Actions
   ( runGovernanceActionCmds
@@ -38,6 +39,8 @@ instance Error GovernanceActionsError where
       "Cannot read file: " <> displayError e
     GovernanceActionsCmdNonUtf8EncodedConstitution e ->
       "Cannot read constitution: " <> show e
+    GovernanceActionsCmdReadTextEnvelopeFileError e ->
+      "Cannot read text envelope file: " <> displayError e
 
 runGovernanceActionCmds :: ()
   => GovernanceActionCmds era
@@ -57,6 +60,17 @@ runGovernanceActionCmds = \case
 
   GovernanceActionCreateNoConfidence cOn noConfidence ->
     runGovernanceActionCreateNoConfidence cOn noConfidence
+
+  GoveranceActionInfo cOn iFp oFp ->
+    runGovernanceActionInfo cOn iFp oFp
+
+runGovernanceActionInfo
+  :: ConwayEraOnwards era
+  -> File () In
+  -> File () Out
+  -> ExceptT GovernanceActionsError IO ()
+runGovernanceActionInfo _cOn _iFp _oFp =
+  liftIO $ print @String "TODO: Conway era - implement runGovernanceActionInfo - ledger currently provides a placeholder constructor"
 
 -- TODO: Conway era - update with new ledger types from cardano-ledger-conway-1.7.0.0
 runGovernanceActionCreateNoConfidence


### PR DESCRIPTION
# Changelog

```yaml
- description: |
     Add goverance info action creation to era based cli. Note this currently does nothing as cardano-ledger provides a placeholder constructor for this governance action.
# uncomment types applicable to the change:
  type:
  - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Additional context for the PR goes here.

If the PR fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
