### PR TITLE
Remove example era-based parsers we don't need anymore

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance.hs
@@ -19,9 +19,7 @@ import           Cardano.CLI.Types.Key
 import           Data.Text (Text)
 
 data EraBasedGovernanceCmds era
-  = EraBasedGovernancePreConwayCmd (ShelleyToBabbageEra era)
-  | EraBasedGovernancePostConwayCmd (ConwayEraOnwards era)
-  | EraBasedGovernanceMIRPayStakeAddressesCertificate
+  = EraBasedGovernanceMIRPayStakeAddressesCertificate
       (ShelleyToBabbageEra era)
       MIRPot
       [StakeAddress]
@@ -53,10 +51,6 @@ data EraBasedGovernanceCmds era
 
 renderEraBasedGovernanceCmds :: EraBasedGovernanceCmds era -> Text
 renderEraBasedGovernanceCmds = \case
-  EraBasedGovernancePreConwayCmd {} ->
-    "governance pre-conway"
-  EraBasedGovernancePostConwayCmd {} ->
-    "governance post-conway"
   EraBasedGovernanceMIRPayStakeAddressesCertificate {} ->
     "governance create-mir-certificate stake-addresses"
   EraBasedGovernanceMIRTransfer _ _ _ TransferToTreasury ->

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run.hs
@@ -57,10 +57,6 @@ runEraBasedGovernanceCmds :: ()
   => EraBasedGovernanceCmds era
   -> ExceptT AnyEraCmdError IO ()
 runEraBasedGovernanceCmds = \case
-  EraBasedGovernancePreConwayCmd w ->
-    runEraBasedGovernancePreConwayCmd w
-  EraBasedGovernancePostConwayCmd w ->
-    runEraBasedGovernancePostConwayCmd w
   EraBasedGovernanceMIRPayStakeAddressesCertificate w mirpot vKeys rewards out ->
     runGovernanceMIRCertificatePayStakeAddrs w mirpot vKeys rewards out
       & firstExceptT AnyEraCmdGovernanceCmdError
@@ -92,14 +88,3 @@ runEraBasedGovernanceCmds = \case
   EraBasedGovernanceDRepGenerateKey w vrf sgn ->
     runGovernanceDRepKeyGen w vrf sgn
       & firstExceptT AnyEraCmdGovernanceCmdError
-
-
-runEraBasedGovernancePreConwayCmd
-  :: ShelleyToBabbageEra era
-  -> ExceptT e IO ()
-runEraBasedGovernancePreConwayCmd _w = pure ()
-
-runEraBasedGovernancePostConwayCmd
-  :: ConwayEraOnwards era
-  -> ExceptT e IO ()
-runEraBasedGovernancePostConwayCmd _w = pure ()

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Actions.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Actions.hs
@@ -37,10 +37,10 @@ instance Error GovernanceActionsError where
       "Cannot write file: " <> displayError e
     GovernanceActionsCmdReadFileError e ->
       "Cannot read file: " <> displayError e
+    GovernanceActionsCmdReadTextEnvelopeFileError e ->
+      "Cannot read text envelope from file: " <> displayError e
     GovernanceActionsCmdNonUtf8EncodedConstitution e ->
       "Cannot read constitution: " <> show e
-    GovernanceActionsCmdReadTextEnvelopeFileError e ->
-      "Cannot read text envelope file: " <> displayError e
 
 runGovernanceActionCmds :: ()
   => GovernanceActionCmds era


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Remove example era-based parsers we don't need anymore
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

These commands were example era-sensitive commands only and are no longer needed

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
