### PR TITLE
Use `cardano-prelude` less

### DIFF
--- a/cardano-cli/src/Cardano/CLI/Byron/Legacy.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Legacy.hs
@@ -13,7 +13,6 @@ import           Cardano.Api (textShow)
 
 import           Cardano.Crypto.Signing (SigningKey (..))
 import qualified Cardano.Crypto.Wallet as Wallet
-import           Cardano.Prelude (cborError)
 
 import qualified Codec.CBOR.Decoding as D
 import qualified Codec.CBOR.Encoding as E
@@ -48,7 +47,7 @@ enforceSize lbl requestedSize = D.decodeListLenCanonical >>= matchSize requested
 matchSize :: Int -> Text -> Int -> D.Decoder s ()
 matchSize requestedSize lbl actualSize =
   when (actualSize /= requestedSize) $
-    cborError (lbl <> " failed the size check. Expected " <> textShow requestedSize <> ", found " <> textShow actualSize)
+    fail $ formatToString build (lbl <> " failed the size check. Expected " <> textShow requestedSize <> ", found " <> textShow actualSize)
 
 -- | Encoder for a Byron/Classic signing key.
 --   Lifted from cardano-sl legacy codebase.

--- a/cardano-cli/src/Cardano/CLI/Byron/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Parsers.hs
@@ -50,7 +50,6 @@ import           Cardano.Crypto.Hashing (hashRaw)
 import           Cardano.Crypto.ProtocolMagic (AProtocolMagic (..), ProtocolMagic,
                    ProtocolMagicId (..))
 import           Cardano.Ledger.Binary (Annotated (..))
-import           Cardano.Prelude (ConvertText (..))
 
 import           Control.Monad (when)
 import qualified Data.Attoparsec.ByteString.Char8 as Atto
@@ -60,6 +59,7 @@ import qualified Data.ByteString.Lazy.Char8 as C8
 import qualified Data.Char as Char
 import           Data.Foldable
 import           Data.Text (Text)
+import qualified Data.Text as Text
 import           Data.Time (UTCTime)
 import           Data.Time.Clock.POSIX (posixSecondsToUTCTime)
 import           Data.Word (Word16, Word64)
@@ -68,7 +68,6 @@ import           GHC.Natural (Natural)
 import           GHC.Word (Word8)
 import           Options.Applicative
 import qualified Options.Applicative as Opt
-
 
 backwardsCompatibilityCommands :: EnvCli -> Parser ClientCommand
 backwardsCompatibilityCommands envCli =
@@ -454,9 +453,9 @@ parseSystemTag = Opt.option (eitherReader checkSysTag)
  where
   checkSysTag :: String -> Either String SystemTag
   checkSysTag name =
-    let tag = SystemTag $ toS name
+    let tag = SystemTag $ Text.pack name
     in case checkSystemTag tag of
-         Left err -> Left . toS $ sformat build err
+         Left err -> Left . Text.unpack $ sformat build err
          Right () -> Right tag
 
 parseInstallerHash :: Parser InstallerHash
@@ -555,9 +554,9 @@ parseApplicationName = Opt.option (eitherReader checkAppNameLength)
  where
   checkAppNameLength :: String -> Either String ApplicationName
   checkAppNameLength name =
-    let appName = ApplicationName $ toS name
+    let appName = ApplicationName $ Text.pack name
     in case checkApplicationName appName of
-         Left err -> Left . toS $ sformat build err
+         Left err -> Left . Text.unpack $ sformat build err
          Right () -> Right appName
 
 parseNumSoftwareVersion :: Parser NumSoftwareVersion

--- a/cardano-cli/src/Cardano/CLI/Byron/UpdateProposal.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/UpdateProposal.hs
@@ -20,7 +20,6 @@ import           Cardano.CLI.Byron.Key (ByronKeyFailure, readByronSigningKey)
 import           Cardano.CLI.Byron.Tx (ByronTxError, nodeSubmitTx)
 import           Cardano.CLI.Helpers (HelpersError, ensureNewFileLBS, renderHelpersError)
 import           Cardano.CLI.Types.Common
-import           Cardano.Prelude (ConvertText (..))
 import           Ouroboros.Consensus.Ledger.SupportsMempool (txId)
 import           Ouroboros.Consensus.Util.Condense (condense)
 
@@ -31,6 +30,7 @@ import           Control.Tracer (stdoutTracer, traceWith)
 import           Data.Bifunctor (Bifunctor (..))
 import qualified Data.ByteString as BS
 import           Data.Text (Text)
+import qualified Data.Text as Text
 
 data ByronUpdateProposalError
   = ByronReadUpdateProposalFileFailure !FilePath !Text
@@ -76,7 +76,7 @@ runProposalCreation nw sKey@(File sKeyfp) pVer sVer
 
 readByronUpdateProposal :: FilePath -> ExceptT ByronUpdateProposalError IO ByronUpdateProposal
 readByronUpdateProposal fp = do
-  proposalBs <- handleIOExceptT (ByronReadUpdateProposalFileFailure fp . toS . displayException)
+  proposalBs <- handleIOExceptT (ByronReadUpdateProposalFileFailure fp . Text.pack . displayException)
                   $ BS.readFile fp
   let proposalResult = deserialiseFromRawBytes AsByronUpdateProposal proposalBs
   hoistEither $ first (const (UpdateProposalDecodingError fp)) proposalResult

--- a/cardano-cli/src/Cardano/CLI/Commands/Governance.hs
+++ b/cardano-cli/src/Cardano/CLI/Commands/Governance.hs
@@ -13,16 +13,18 @@ import           Cardano.CLI.Read (CddlError)
 import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Governance
 import           Cardano.CLI.Types.Key
-import           Cardano.Prelude (intercalate, toS)
 
 import           Control.Monad.IO.Class
 import           Control.Monad.Trans.Except (ExceptT)
 import           Control.Monad.Trans.Except.Extra (firstExceptT, hoistEither, newExceptT)
 import           Data.Bifunctor
 import qualified Data.ByteString as BS
+import qualified Data.List as List
 import           Data.Text (Text)
+import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import           Data.Text.Encoding.Error
+import qualified Data.Text.Lazy as TL
 import qualified Data.Text.Lazy.Builder as TL
 import qualified Formatting.Buildable as B
 
@@ -94,12 +96,12 @@ instance Error GovernanceCmdError where
       <> " and the number of reward amounts: " <> show nRewards
       <> " are not equivalent."
     GovernanceCmdCostModelsJsonDecodeErr fp msg ->
-      "Error decoding cost model: " <> toS msg <> " at: " <> fp
+      "Error decoding cost model: " <> Text.unpack msg <> " at: " <> fp
     GovernanceCmdEmptyCostModel fp ->
       "The decoded cost model was empty at: " <> fp
     GovernanceCmdUnexpectedKeyType expectedTypes ->
       "Unexpected poll key type; expected one of: "
-      <> intercalate ", " (show <$> expectedTypes)
+      <> List.intercalate ", " (show <$> expectedTypes)
     GovernanceCmdPollOutOfBoundAnswer maxIdx ->
       "Poll answer out of bounds. Choices are between 0 and " <> show maxIdx
     GovernanceCmdPollInvalidChoice ->
@@ -107,7 +109,7 @@ instance Error GovernanceCmdError where
     GovernanceCmdDecoderError decoderError ->
       "Unable to decode metadata: " <> renderDecoderError decoderError
     GovernanceCmdVerifyPollError pollError ->
-      toS (renderGovernancePollError pollError)
+      Text.unpack (renderGovernancePollError pollError)
     GovernanceCmdWriteFileError fileError ->
       "Cannot write file: " <> displayError fileError
     GovernanceCmdMIRCertNotSupportedInConway ->
@@ -115,7 +117,7 @@ instance Error GovernanceCmdError where
     GovernanceCmdGenesisDelegationNotSupportedInConway ->
       "Genesis delegation is not supported in Conway era onwards."
     where
-      renderDecoderError = toS . TL.toLazyText . B.build
+      renderDecoderError = TL.unpack . TL.toLazyText . B.build
 
 runGovernanceCreateVoteCmd
   :: AnyShelleyBasedEra

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
@@ -21,7 +21,6 @@ import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Governance
 import           Cardano.CLI.Types.Key
 import qualified Cardano.Ledger.Shelley.TxBody as Shelley
-import           Cardano.Prelude (purer)
 
 import           Control.Monad (mfilter)
 import qualified Data.Aeson as Aeson
@@ -97,7 +96,7 @@ pCardanoEra envCli =
       ]
     , maybeToList $ pure <$> envCliAnyCardanoEra envCli
     -- TODO is this default needed anymore?
-    , purer defaultCardanoEra
+    , pure $ pure defaultCardanoEra
   ]
     where
       defaultCardanoEra = defaultShelleyBasedEra & \(AnyShelleyBasedEra era) ->
@@ -346,7 +345,7 @@ pAnyShelleyBasedEra envCli =
         $ mconcat [Opt.long "conway-era", Opt.help "Specify the Conway era"]
       ]
     , maybeToList $ pure <$> envCliAnyShelleyBasedEra envCli
-    , purer defaultShelleyBasedEra
+    , pure $ pure defaultShelleyBasedEra
   ]
 
 pAnyShelleyToBabbageEra :: EnvCli -> Parser AnyShelleyToBabbageEra
@@ -364,7 +363,7 @@ pAnyShelleyToBabbageEra envCli =
         $ mconcat [Opt.long "babbage-era", Opt.help "Specify the Babbage era (default)"]
       ]
     , maybeToList $ pure <$> envCliAnyShelleyToBabbageEra envCli
-    , purer defaultShelleyToBabbageEra
+    , pure $ pure defaultShelleyToBabbageEra
   ]
 
 pShelleyBasedShelley :: EnvCli -> Parser AnyShelleyBasedEra

--- a/cardano-cli/src/Cardano/CLI/Helpers.hs
+++ b/cardano-cli/src/Cardano/CLI/Helpers.hs
@@ -22,7 +22,6 @@ import qualified Cardano.Chain.UTxO as UTxO
 import           Cardano.CLI.Types.Common
 import           Cardano.Ledger.Binary (byronProtVer, toPlainDecoder)
 import           Cardano.Ledger.Binary.Plain (Decoder, fromCBOR)
-import           Cardano.Prelude (ConvertText (..))
 
 import           Codec.CBOR.Pretty (prettyHexEnc)
 import           Codec.CBOR.Read (DeserialiseFailure, deserialiseFromBytes)
@@ -98,14 +97,14 @@ pPrintCBOR bs = do
   case deserialiseFromBytes decodeTerm bs of
     Left err -> left $ CBORPrettyPrintError err
     Right (remaining, decodedVal) -> do
-      liftIO . Text.putStrLn . toS . prettyHexEnc $ encodeTerm decodedVal
+      liftIO . Text.putStrLn . Text.pack . prettyHexEnc $ encodeTerm decodedVal
       unless (LB.null remaining) $
         pPrintCBOR remaining
 
 readCBOR :: FilePath -> ExceptT HelpersError IO LB.ByteString
 readCBOR fp =
   handleIOExceptT
-    (ReadCBORFileFailure fp . toS . displayException)
+    (ReadCBORFileFailure fp . Text.pack . displayException)
     (LB.readFile fp)
 
 validateCBOR :: CBORObject -> LB.ByteString -> Either HelpersError Text

--- a/cardano-cli/src/Cardano/CLI/Json/Canonical.hs
+++ b/cardano-cli/src/Cardano/CLI/Json/Canonical.hs
@@ -1,0 +1,145 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE NumDecimals #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+-- | Instances used in the canonical JSON encoding of `GenesisData`
+
+module Cardano.CLI.Json.Canonical
+  ( SchemaError(..)
+  , canonicalDecodePretty
+  , canonicalEncodePretty
+  )
+where
+
+-- import           Cardano.Prelude.Base
+-- import qualified Cardano.Prelude.Compat as I
+-- import           Cardano.Prelude.Json.Parse (parseJSString)
+
+import           Cardano.Prelude (toS)
+
+import           Data.Bifunctor
+import qualified Data.ByteString.Lazy as LB
+import           Data.Functor.Identity
+import           Data.Text (Text)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text
+import qualified Text.JSON.Canonical as CanonicalJSON
+
+-- import           Control.Monad.Error
+-- import           Data.Fixed (E12, resolution)
+-- import           Data.Int
+-- import qualified Data.Text.Lazy.Builder as Builder
+-- import           Data.Time (NominalDiffTime, UTCTime)
+-- import           Data.Time.Clock.POSIX (posixSecondsToUTCTime, utcTimeToPOSIXSeconds)
+-- import           Data.Word
+-- import           Formatting (bprint, builder)
+-- import           Formatting.Buildable (Buildable (build))
+-- import           GHC.Natural (Natural)
+-- import           Text.JSON.Canonical (FromJSON (fromJSON), Int54, JSValue (JSNum, JSString),
+--                    ReportSchemaErrors (expected), ToJSON (toJSON))
+
+data SchemaError = SchemaError
+  { seExpected :: !Text
+  , seActual   :: !(Maybe Text)
+  } deriving (Show, Eq)
+
+-- instance Buildable SchemaError where
+--   build se = mconcat
+--     [ bprint ("expected " . builder) $ Builder.fromText (seExpected se)
+--     , case seActual se of
+--       Nothing     -> mempty
+--       Just actual -> bprint (" but got " . builder) $ Builder.fromText actual
+--     ]
+
+-- instance
+--     (Applicative m, Monad m, MonadError SchemaError m)
+--     => ReportSchemaErrors m
+--   where
+--   expected expec actual = throwError SchemaError
+--     { seExpected = toS expec
+--     , seActual   = fmap toS actual
+--     }
+
+-- instance Monad m => ToJSON m Int32 where
+--   toJSON = pure . JSNum . fromIntegral
+
+-- instance Monad m => ToJSON m Word16 where
+--   toJSON = pure . JSNum . fromIntegral
+
+-- instance Monad m => ToJSON m Word32 where
+--   toJSON = pure . JSNum . fromIntegral
+
+-- instance Monad m => ToJSON m Word64 where
+--   toJSON = pure . JSString . CanonicalJSON.toJSString . show
+
+-- instance Monad m => ToJSON m Integer where
+--   toJSON = pure . JSString . CanonicalJSON.toJSString . show
+
+-- instance Monad m => ToJSON m Natural where
+--   toJSON = pure . JSString . CanonicalJSON.toJSString . show
+
+-- -- | For backwards compatibility we convert this to seconds
+-- instance Monad m => ToJSON m UTCTime where
+--   toJSON = pure . JSNum . round . utcTimeToPOSIXSeconds
+
+-- -- | For backwards compatibility we convert this to microseconds
+-- instance Monad m => ToJSON m NominalDiffTime where
+--   toJSON = toJSON . (`div` 1e6) . toPicoseconds
+--    where
+--     toPicoseconds :: NominalDiffTime -> Integer
+--     toPicoseconds t =
+--       numerator (toRational t * toRational (resolution $ Proxy @E12))
+
+-- instance ReportSchemaErrors m => FromJSON m Int32 where
+--   fromJSON (JSNum i) = pure . fromIntegral $ i
+--   fromJSON val       = CanonicalJSON.expectedButGotValue "Int32" val
+
+-- instance ReportSchemaErrors m => FromJSON m Word16 where
+--   fromJSON (JSNum i) = pure . fromIntegral $ i
+--   fromJSON val       = CanonicalJSON.expectedButGotValue "Word16" val
+
+-- instance ReportSchemaErrors m => FromJSON m Word32 where
+--   fromJSON (JSNum i) = pure . fromIntegral $ i
+--   fromJSON val       = CanonicalJSON.expectedButGotValue "Word32" val
+
+-- instance ReportSchemaErrors m => FromJSON m Word64 where
+--   fromJSON = parseJSString (I.readEither @Word64 @Text . toS)
+
+-- instance ReportSchemaErrors m => FromJSON m Integer where
+--   fromJSON = parseJSString (I.readEither @Integer @Text . toS)
+
+-- instance MonadError SchemaError m => FromJSON m Natural where
+--   fromJSON = parseJSString (I.readEither @Natural @Text . toS)
+
+-- instance MonadError SchemaError m => FromJSON m UTCTime where
+--   fromJSON = fmap (posixSecondsToUTCTime . fromIntegral) . fromJSON @_ @Int54
+
+-- instance MonadError SchemaError m => FromJSON m NominalDiffTime where
+--   fromJSON = fmap (fromRational . (% 1e6)) . fromJSON
+
+canonicalDecodePretty
+  :: forall a
+   . CanonicalJSON.FromJSON (Either SchemaError) a
+  => LB.ByteString
+  -> Either Text a
+canonicalDecodePretty y = do
+  eVal <- first toS (CanonicalJSON.parseCanonicalJSON y)
+  first (Text.pack . show) (CanonicalJSON.fromJSON eVal :: Either SchemaError a)
+
+canonicalEncodePretty
+  :: forall a . CanonicalJSON.ToJSON Identity a => a -> LB.ByteString
+canonicalEncodePretty x =
+  LB.fromStrict
+    . Text.encodeUtf8
+    . toS
+    $ CanonicalJSON.prettyCanonicalJSON
+    $ runIdentity
+    $ CanonicalJSON.toJSON x

--- a/cardano-cli/src/Cardano/CLI/Parser.hs
+++ b/cardano-cli/src/Cardano/CLI/Parser.hs
@@ -14,7 +14,6 @@ module Cardano.CLI.Parser
 
 import           Cardano.CLI.Types.Common
 import qualified Cardano.Ledger.BaseTypes as Shelley
-import           Cardano.Prelude (ConvertText (..))
 
 import qualified Data.Attoparsec.ByteString.Char8 as Atto
 import           Data.ByteString (ByteString)
@@ -94,6 +93,6 @@ readerFromAttoParser p =
 eDNSName :: String -> Either String ByteString
 eDNSName str =
   -- We're using 'Shelley.textToDns' to validate the string.
-  case Shelley.textToDns (toS str) of
+  case Shelley.textToDns (Text.pack str) of
     Nothing -> Left $ "DNS name is more than 64 bytes: " <> str
     Just dnsName -> Right . Text.encodeUtf8 . Shelley.dnsToText $ dnsName


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Use `cardano-prelude` less
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Remove uses to `toS`, `intercalate`, `cborError`, `purer` from `Cardano.Prelude` because `Cardano.Prelude` is deprecated and we want to avoid accidentally duplicated deprecated code.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
