### PR TITLE
Refactor: Use `maybeFeatureInEra` instead of `featureInEra` where possible

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance.hs
@@ -44,12 +44,12 @@ pEraBasedGovernanceCmds envCli era =
 
 pEraBasedRegistrationCertificateCmd
   :: EnvCli -> CardanoEra era -> Maybe (Parser (EraBasedGovernanceCmds era))
-pEraBasedRegistrationCertificateCmd envCli =
-  featureInEra Nothing $ \w ->
-    Just
-      $ subParser "registration-certificate"
-      $ Opt.info (pEraCmd envCli w)
-      $ Opt.progDesc "Create a registration certificate."
+pEraBasedRegistrationCertificateCmd envCli era = do
+  w <- maybeFeatureInEra era
+  pure
+    $ subParser "registration-certificate"
+    $ Opt.info (pEraCmd envCli w)
+    $ Opt.progDesc "Create a registration certificate."
  where
   pEraCmd :: EnvCli -> AnyEraDecider era -> Parser (EraBasedGovernanceCmds era)
   pEraCmd envCli' = \case
@@ -94,12 +94,12 @@ instance FeatureInEra AnyEraDecider where
 -- Delegation Certificate related
 
 pEraBasedDelegationCertificateCmd :: EnvCli -> CardanoEra era -> Maybe (Parser (EraBasedGovernanceCmds era))
-pEraBasedDelegationCertificateCmd _envCli =
-  featureInEra Nothing $ \w ->
-    Just
-      $ subParser "delegation-certificate"
-      $ Opt.info (pCmd w)
-      $ Opt.progDesc "Delegation certificate creation."
+pEraBasedDelegationCertificateCmd _envCli era = do
+  w <- maybeFeatureInEra era
+  pure
+    $ subParser "delegation-certificate"
+    $ Opt.info (pCmd w)
+    $ Opt.progDesc "Delegation certificate creation."
  where
   pCmd :: AnyEraDecider era -> Parser (EraBasedGovernanceCmds era)
   pCmd w =
@@ -213,12 +213,12 @@ pDRepVerificationKeyFile =
 
 pEraBasedVoteCmd
   :: EnvCli -> CardanoEra era -> Maybe (Parser (EraBasedGovernanceCmds era))
-pEraBasedVoteCmd envCli =
-  featureInEra Nothing $ \w ->
-    Just
-      $ subParser "vote"
-      $ Opt.info (pEraCmd' envCli w)
-      $ Opt.progDesc "Vote creation."
+pEraBasedVoteCmd envCli era = do
+  w <- maybeFeatureInEra era
+  pure
+    $ subParser "vote"
+    $ Opt.info (pEraCmd' envCli w)
+    $ Opt.progDesc "Vote creation."
  where
   pEraCmd'
     :: EnvCli -> ConwayEraOnwards era -> Parser (EraBasedGovernanceCmds era)
@@ -246,12 +246,12 @@ pAnyVotingStakeVerificationKeyOrHashOrFile =
 
 
 pCreateMirCertificatesCmds :: CardanoEra era -> Maybe (Parser (EraBasedGovernanceCmds era))
-pCreateMirCertificatesCmds =
-  featureInEra Nothing $ \w ->
-    Just
-      $ subParser "create-mir-certificate"
-      $ Opt.info (pMIRPayStakeAddresses w <|> mirCertParsers w)
-      $ Opt.progDesc "Create an MIR (Move Instantaneous Rewards) certificate"
+pCreateMirCertificatesCmds era = do
+  w <- maybeFeatureInEra era
+  pure
+    $ subParser "create-mir-certificate"
+    $ Opt.info (pMIRPayStakeAddresses w <|> mirCertParsers w)
+    $ Opt.progDesc "Create an MIR (Move Instantaneous Rewards) certificate"
 
 mirCertParsers :: ()
   => ShelleyToBabbageEra era

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Actions.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Actions.hs
@@ -41,12 +41,14 @@ pGovernanceActionCmds era =
 
 
 pGovernanceActionNewConstitution
-  :: CardanoEra era  -> Maybe (Parser (GovernanceActionCmds era))
-pGovernanceActionNewConstitution =
-  featureInEra Nothing (\cOn -> Just $
-     subParser "create-constitution"
-        $ Opt.info (pCmd cOn)
-        $ Opt.progDesc "Create a constitution.")
+  :: CardanoEra era
+  -> Maybe (Parser (GovernanceActionCmds era))
+pGovernanceActionNewConstitution era = do
+  cOn <- maybeFeatureInEra era
+  pure
+    $ subParser "create-constitution"
+    $ Opt.info (pCmd cOn)
+    $ Opt.progDesc "Create a constitution."
  where
   pCmd :: ConwayEraOnwards era -> Parser (GovernanceActionCmds era)
   pCmd cOn =
@@ -58,12 +60,14 @@ pGovernanceActionNewConstitution =
         <*> pFileOutDirection "out-file" "Output filepath of the constitution."
 
 pGovernanceActionNewCommittee
-  :: CardanoEra era  -> Maybe (Parser (GovernanceActionCmds era))
-pGovernanceActionNewCommittee =
-  featureInEra Nothing (\cOn -> Just $
-     subParser "create-new-committee"
-        $ Opt.info (pCmd cOn)
-        $ Opt.progDesc "Create a new committee proposal.")
+  :: CardanoEra era
+  -> Maybe (Parser (GovernanceActionCmds era))
+pGovernanceActionNewCommittee era = do
+  cOn <- maybeFeatureInEra era
+  pure
+    $ subParser "create-new-committee"
+    $ Opt.info (pCmd cOn)
+    $ Opt.progDesc "Create a new committee proposal."
  where
   pCmd :: ConwayEraOnwards era -> Parser (GovernanceActionCmds era)
   pCmd cOn = GoveranceActionCreateNewCommittee cOn
@@ -82,12 +86,14 @@ pEraBasedNewCommittee =
 
 
 pGovernanceActionNoConfidence
-  :: CardanoEra era  -> Maybe (Parser (GovernanceActionCmds era))
-pGovernanceActionNoConfidence =
-  featureInEra Nothing (\cOn -> Just $
-     subParser "create-no-confidence"
-        $ Opt.info (pCmd cOn)
-        $ Opt.progDesc "Create a no confidence proposal.")
+  :: CardanoEra era
+  -> Maybe (Parser (GovernanceActionCmds era))
+pGovernanceActionNoConfidence era = do
+  cOn <- maybeFeatureInEra era
+  pure
+    $ subParser "create-no-confidence"
+    $ Opt.info (pCmd cOn)
+    $ Opt.progDesc "Create a no confidence proposal."
  where
   pCmd :: ConwayEraOnwards era -> Parser (GovernanceActionCmds era)
   pCmd cOn =
@@ -300,11 +306,12 @@ dpGovActionProtocolParametersUpdate = \case
       <*> pIntroducedInBabbagePParams
 
 pGovernanceActionTreasuryWithdrawal :: CardanoEra era -> Maybe (Parser (GovernanceActionCmds era))
-pGovernanceActionTreasuryWithdrawal =
-  featureInEra Nothing (\cOn -> Just $
-     subParser "create-treasury-withdrawal"
-        $ Opt.info (pCmd cOn)
-        $ Opt.progDesc "Create a treasury withdrawal.")
+pGovernanceActionTreasuryWithdrawal era = do
+  cOn <- maybeFeatureInEra era
+  pure
+    $ subParser "create-treasury-withdrawal"
+    $ Opt.info (pCmd cOn)
+    $ Opt.progDesc "Create a treasury withdrawal."
  where
   pCmd :: ConwayEraOnwards era -> Parser (GovernanceActionCmds era)
   pCmd cOn =

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Committee.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Committee.hs
@@ -30,18 +30,15 @@ pGovernanceCommitteeCmds era =
 pGovernanceCommitteeKeyGenCold :: ()
   => CardanoEra era
   -> Maybe (Parser (GovernanceCommitteeCmds era))
-pGovernanceCommitteeKeyGenCold =
-  featureInEra
-    Nothing
-    ( \w ->
-        Just
-          $ subParser "key-gen-cold"
-          $ Opt.info (pCmd w)
-          $ Opt.progDesc
-          $ mconcat
-              [ "Create a cold key pair for a Constitutional Committee Member"
-              ]
-    )
+pGovernanceCommitteeKeyGenCold era = do
+  w <- maybeFeatureInEra era
+  pure
+    $ subParser "key-gen-cold"
+    $ Opt.info (pCmd w)
+    $ Opt.progDesc
+    $ mconcat
+        [ "Create a cold key pair for a Constitutional Committee Member"
+        ]
   where
     pCmd :: ()
       => ConwayEraOnwards era
@@ -54,18 +51,15 @@ pGovernanceCommitteeKeyGenCold =
 pGovernanceCommitteeKeyGenHot :: ()
   => CardanoEra era
   -> Maybe (Parser (GovernanceCommitteeCmds era))
-pGovernanceCommitteeKeyGenHot =
-  featureInEra
-    Nothing
-    ( \w ->
-        Just
-          $ subParser "key-gen-hot"
-          $ Opt.info (pCmd w)
-          $ Opt.progDesc
-          $ mconcat
-              [ "Create a cold key pair for a Constitutional Committee Member"
-              ]
-    )
+pGovernanceCommitteeKeyGenHot era = do
+  w <- maybeFeatureInEra era
+  pure
+    $ subParser "key-gen-hot"
+    $ Opt.info (pCmd w)
+    $ Opt.progDesc
+    $ mconcat
+        [ "Create a cold key pair for a Constitutional Committee Member"
+        ]
   where
     pCmd :: ()
       => ConwayEraOnwards era
@@ -78,18 +72,15 @@ pGovernanceCommitteeKeyGenHot =
 pGovernanceCommitteeKeyHash :: ()
   => CardanoEra era
   -> Maybe (Parser (GovernanceCommitteeCmds era))
-pGovernanceCommitteeKeyHash =
-  featureInEra
-    Nothing
-    ( \w ->
-        Just
-          $ subParser "key-hash"
-          $ Opt.info (pCmd w)
-          $ Opt.progDesc
-          $ mconcat
-              [ "Print the identifier (hash) of a public key"
-              ]
-    )
+pGovernanceCommitteeKeyHash era = do
+  w <- maybeFeatureInEra era
+  pure
+    $ subParser "key-hash"
+    $ Opt.info (pCmd w)
+    $ Opt.progDesc
+    $ mconcat
+        [ "Print the identifier (hash) of a public key"
+        ]
   where
     pCmd :: ()
       => ConwayEraOnwards era


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Refactor: Use `maybeFeatureInEra` instead of `featureInEra` where possible
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
   - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context
n/a

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
