### PR TITLE
Move command errors from era-based to `CmdError` module

### DIFF
--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -119,6 +119,7 @@ library
                         Cardano.CLI.Run.Ping
                         Cardano.CLI.TopHandler
                         Cardano.CLI.Types.Common
+                        Cardano.CLI.Types.Errors.CmdError
                         Cardano.CLI.Types.Errors.GovernanceCmdError
                         Cardano.CLI.Types.Errors.ScriptDecodeError
                         Cardano.CLI.Types.Errors.ShelleyStakeAddressCmdError

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Certificate.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Certificate.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RankNTypes #-}
@@ -24,35 +23,16 @@ import           Cardano.Api.Shelley
 
 import           Cardano.CLI.Read
 import           Cardano.CLI.Types.Common
+import           Cardano.CLI.Types.Errors.CmdError
 import           Cardano.CLI.Types.Errors.ShelleyStakeAddressCmdError
-import           Cardano.CLI.Types.Errors.StakeAddressRegistrationError
 import           Cardano.CLI.Types.Key
 
 import           Control.Monad.Trans.Class
 import           Control.Monad.Trans.Except (ExceptT)
 import           Control.Monad.Trans.Except.Extra
 import           Data.Function
-import           GHC.Generics (Generic)
 
 -- Delegation Certificate related
-
-data EraBasedDelegationError
-  = EraBasedDelegReadError !(FileError InputDecodeError)
-  | EraBasedCredentialError !ShelleyStakeAddressCmdError -- TODO: Refactor. We shouldn't be using legacy error types
-  | EraBasedCertificateWriteFileError !(FileError ())
-  | EraBasedDRepReadError !(FileError InputDecodeError)
-  deriving (Show, Generic)
-
-instance Error EraBasedDelegationError where
-  displayError = \case
-    EraBasedDelegReadError e ->
-      "Cannot read delegation target: " <> displayError e
-    EraBasedCredentialError e ->
-      "Cannot get stake credential: " <> displayError e
-    EraBasedCertificateWriteFileError e ->
-      "Cannot write certificate: " <> displayError e
-    EraBasedDRepReadError e ->
-      "Cannot read DRep key: " <> displayError e
 
 runGovernanceDelegationCertificate
   :: StakeIdentifier
@@ -131,21 +111,6 @@ toLedgerDelegatee t =
 --------------------------------------------------------------------------------
 
 -- Registration Certificate related
-
-
-data EraBasedRegistrationError
-  = EraBasedRegistReadError !(FileError InputDecodeError)
-  | EraBasedRegistWriteFileError !(FileError ())
-  | EraBasedRegistStakeCredReadError !ShelleyStakeAddressCmdError -- TODO: Conway era - don't use legacy error type
-  | EraBasedRegistStakeError !StakeAddressRegistrationError
-  deriving Show
-
-instance Error EraBasedRegistrationError where
-  displayError = \case
-    EraBasedRegistReadError e -> "Cannot read registration certificate: " <> displayError e
-    EraBasedRegistWriteFileError e -> "Cannot write registration certificate: " <> displayError e
-    EraBasedRegistStakeCredReadError e -> "Cannot read stake credential: " <> displayError e
-    EraBasedRegistStakeError e -> "Stake address registation error: " <> displayError e
 
 runGovernanceRegistrationCertificate
   :: AnyRegistrationTarget

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Actions.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Actions.hs
@@ -14,6 +14,7 @@ import           Cardano.Api.Shelley
 
 import           Cardano.CLI.EraBased.Commands.Governance.Actions
 import           Cardano.CLI.Types.Common
+import           Cardano.CLI.Types.Errors.CmdError
 import           Cardano.CLI.Types.Key
 
 import           Control.Monad.Except (ExceptT)
@@ -21,25 +22,6 @@ import           Control.Monad.IO.Class (liftIO)
 import           Control.Monad.Trans.Except.Extra
 import qualified Data.ByteString as BS
 import qualified Data.Text.Encoding as Text
-import           Data.Text.Encoding.Error
-
-data GovernanceActionsError
-  = GovernanceActionsCmdNonUtf8EncodedConstitution UnicodeException
-  | GovernanceActionsCmdReadFileError (FileError InputDecodeError)
-  | GovernanceActionsCmdReadTextEnvelopeFileError (FileError TextEnvelopeError)
-  | GovernanceActionsCmdWriteFileError (FileError ())
-  deriving Show
-
-instance Error GovernanceActionsError where
-  displayError = \case
-    GovernanceActionsCmdNonUtf8EncodedConstitution e ->
-      "Cannot read constitution: " <> show e
-    GovernanceActionsCmdReadFileError e ->
-      "Cannot read file: " <> displayError e
-    GovernanceActionsCmdReadTextEnvelopeFileError e ->
-      "Cannot read text envelope file: " <> displayError e
-    GovernanceActionsCmdWriteFileError e ->
-      "Cannot write file: " <> displayError e
 
 runGovernanceActionCmds :: ()
   => GovernanceActionCmds era

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Committee.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Committee.hs
@@ -10,6 +10,7 @@ import           Cardano.Api
 import           Cardano.Api.Shelley
 
 import           Cardano.CLI.EraBased.Commands.Governance.Committee
+import           Cardano.CLI.Types.Errors.CmdError
 import           Cardano.CLI.Types.Key
 import           Cardano.CLI.Types.Key.VerificationKey
 
@@ -20,27 +21,6 @@ import           Control.Monad.Trans.Except.Extra
 import           Data.ByteString (ByteString)
 import qualified Data.ByteString.Char8 as BS
 import           Data.Function
-
-data GovernanceCommitteeError
-  = GovernanceCommitteeCmdKeyDecodeError InputDecodeError
-  | GovernanceCommitteeCmdKeyReadError (FileError InputDecodeError)
-  | GovernanceCommitteeCmdTextEnvReadFileError (FileError TextEnvelopeError)
-  | GovernanceCommitteeCmdTextEnvWriteError (FileError ())
-  | GovernanceCommitteeCmdWriteFileError (FileError ())
-  deriving Show
-
-instance Error GovernanceCommitteeError where
-  displayError = \case
-    GovernanceCommitteeCmdKeyDecodeError e ->
-      "Cannot decode key: " <> displayError e
-    GovernanceCommitteeCmdKeyReadError e ->
-      "Cannot read key: " <> displayError e
-    GovernanceCommitteeCmdWriteFileError e ->
-      "Cannot write file: " <> displayError e
-    GovernanceCommitteeCmdTextEnvReadFileError e ->
-      "Cannot read text envelope file: " <> displayError e
-    GovernanceCommitteeCmdTextEnvWriteError e ->
-      "Cannot write text envelope file: " <> displayError e
 
 runGovernanceCommitteeCmds :: ()
   => GovernanceCommitteeCmds era

--- a/cardano-cli/src/Cardano/CLI/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Run.hs
@@ -22,6 +22,7 @@ import           Cardano.CLI.Legacy.Run (LegacyClientCmdError, renderLegacyClien
 import           Cardano.CLI.Render (customRenderHelp)
 import           Cardano.CLI.Run.Ping (PingClientCmdError (..), PingCmd (..),
                    renderPingClientCmdError, runPingCmd)
+import           Cardano.CLI.Types.Errors.CmdError
 import           Cardano.Git.Rev (gitRev)
 
 import           Control.Monad (forM_)
@@ -57,7 +58,7 @@ data ClientCommand =
   | DisplayVersion
 
 data ClientCommandErrors
-  = AnyEraCmdError AnyEraCmdError
+  = CmdError CmdError
   | ByronClientError ByronClientCmdError
   | LegacyClientError LegacyCmds LegacyClientCmdError
   | PingClientError PingClientCmdError
@@ -65,7 +66,7 @@ data ClientCommandErrors
 runClientCommand :: ClientCommand -> ExceptT ClientCommandErrors IO ()
 runClientCommand = \case
   AnyEraCommand cmd ->
-    firstExceptT AnyEraCmdError $ runAnyEraCommand cmd
+    firstExceptT CmdError $ runAnyEraCommand cmd
   ByronCommand c ->
     firstExceptT ByronClientError $ runByronClientCommand c
   LegacyCmds c ->
@@ -79,7 +80,7 @@ runClientCommand = \case
 
 renderClientCommandError :: ClientCommandErrors -> Text
 renderClientCommandError = \case
-  AnyEraCmdError err ->
+  CmdError err ->
     Text.pack $ displayError err
   ByronClientError err ->
     renderByronClientCmdError err

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/CmdError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/CmdError.hs
@@ -1,0 +1,110 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+
+module Cardano.CLI.Types.Errors.CmdError
+  ( CmdError(..)
+  , EraBasedDelegationError(..)
+  , EraBasedRegistrationError(..)
+  , GovernanceActionsError(..)
+  , GovernanceCommitteeError(..)
+  ) where
+
+import           Cardano.Api
+
+import           Cardano.CLI.EraBased.Vote
+import           Cardano.CLI.Types.Errors.GovernanceCmdError
+import           Cardano.CLI.Types.Errors.ShelleyStakeAddressCmdError
+import           Cardano.CLI.Types.Errors.StakeAddressRegistrationError
+
+import           Data.Text.Encoding.Error
+import           GHC.Generics (Generic)
+
+data CmdError
+  = CmdGovernanceCmdError        !GovernanceCmdError
+  | CmdEraDelegationError        !EraBasedDelegationError
+  | CmdEraBasedRegistrationError !EraBasedRegistrationError
+  | CmdEraBasedVoteError         !EraBasedVoteError
+  | CmdGovernanceCommitteeError  !GovernanceCommitteeError
+  | CmdGovernanceActionError     !GovernanceActionsError
+  deriving Show
+
+instance Error CmdError where
+  displayError = \case
+    CmdGovernanceCmdError e -> displayError e
+    CmdEraDelegationError e -> displayError e
+    CmdEraBasedRegistrationError e -> displayError e
+    CmdEraBasedVoteError e -> displayError e
+    CmdGovernanceCommitteeError e -> displayError e
+    CmdGovernanceActionError e -> displayError e
+
+data GovernanceActionsError
+  = GovernanceActionsCmdNonUtf8EncodedConstitution UnicodeException
+  | GovernanceActionsCmdReadFileError (FileError InputDecodeError)
+  | GovernanceActionsCmdReadTextEnvelopeFileError (FileError TextEnvelopeError)
+  | GovernanceActionsCmdWriteFileError (FileError ())
+  deriving Show
+
+instance Error GovernanceActionsError where
+  displayError = \case
+    GovernanceActionsCmdNonUtf8EncodedConstitution e ->
+      "Cannot read constitution: " <> show e
+    GovernanceActionsCmdReadFileError e ->
+      "Cannot read file: " <> displayError e
+    GovernanceActionsCmdReadTextEnvelopeFileError e ->
+      "Cannot read text envelope file: " <> displayError e
+    GovernanceActionsCmdWriteFileError e ->
+      "Cannot write file: " <> displayError e
+
+data EraBasedDelegationError
+  = EraBasedDelegReadError !(FileError InputDecodeError)
+  | EraBasedCredentialError !ShelleyStakeAddressCmdError -- TODO: Refactor. We shouldn't be using legacy error types
+  | EraBasedCertificateWriteFileError !(FileError ())
+  | EraBasedDRepReadError !(FileError InputDecodeError)
+  deriving (Show, Generic)
+
+instance Error EraBasedDelegationError where
+  displayError = \case
+    EraBasedDelegReadError e ->
+      "Cannot read delegation target: " <> displayError e
+    EraBasedCredentialError e ->
+      "Cannot get stake credential: " <> displayError e
+    EraBasedCertificateWriteFileError e ->
+      "Cannot write certificate: " <> displayError e
+    EraBasedDRepReadError e ->
+      "Cannot read DRep key: " <> displayError e
+
+data EraBasedRegistrationError
+  = EraBasedRegistReadError !(FileError InputDecodeError)
+  | EraBasedRegistWriteFileError !(FileError ())
+  | EraBasedRegistStakeCredReadError !ShelleyStakeAddressCmdError -- TODO: Conway era - don't use legacy error type
+  | EraBasedRegistStakeError !StakeAddressRegistrationError
+  deriving Show
+
+instance Error EraBasedRegistrationError where
+  displayError = \case
+    EraBasedRegistReadError e -> "Cannot read registration certificate: " <> displayError e
+    EraBasedRegistWriteFileError e -> "Cannot write registration certificate: " <> displayError e
+    EraBasedRegistStakeCredReadError e -> "Cannot read stake credential: " <> displayError e
+    EraBasedRegistStakeError e -> "Stake address registation error: " <> displayError e
+
+data GovernanceCommitteeError
+  = GovernanceCommitteeCmdKeyDecodeError InputDecodeError
+  | GovernanceCommitteeCmdKeyReadError (FileError InputDecodeError)
+  | GovernanceCommitteeCmdTextEnvReadFileError (FileError TextEnvelopeError)
+  | GovernanceCommitteeCmdTextEnvWriteError (FileError ())
+  | GovernanceCommitteeCmdWriteFileError (FileError ())
+  deriving Show
+
+instance Error GovernanceCommitteeError where
+  displayError = \case
+    GovernanceCommitteeCmdKeyDecodeError e ->
+      "Cannot decode key: " <> displayError e
+    GovernanceCommitteeCmdKeyReadError e ->
+      "Cannot read key: " <> displayError e
+    GovernanceCommitteeCmdWriteFileError e ->
+      "Cannot write file: " <> displayError e
+    GovernanceCommitteeCmdTextEnvReadFileError e ->
+      "Cannot read text envelope file: " <> displayError e
+    GovernanceCommitteeCmdTextEnvWriteError e ->
+      "Cannot write text envelope file: " <> displayError e

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/GovernanceCmdError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/GovernanceCmdError.hs
@@ -8,8 +8,8 @@ import           Cardano.Api
 import           Cardano.Api.Shelley
 
 import           Cardano.Binary (DecoderError)
-import           Cardano.CLI.Legacy.Run.StakeAddress
 import           Cardano.CLI.Read (CddlError)
+import           Cardano.CLI.Types.Errors.ShelleyStakeAddressCmdError
 
 import qualified Data.List as List
 import           Data.Text (Text)


### PR DESCRIPTION
# Changelog

```yaml
- description: |
   Move command errors from era-based to `CmdError` module
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

It is often better for errors to live in a module separate from other code.

For command errors in particular this is especially true.

This is because sometimes moving a function that has a error type in its signature, if that function were defined in the same module as the error type and that function needed to move, it is very often the case that the error type has to move with it.

This is especially true with commands that have a strict hierarchical structure and you wanted to push down a command into a subgroup.

If `runX` throws `Error` and they both live in `Parent` and you want to move `runX` to `Child` that requires you to move the `Error` type to `Child` as well.

If you have `runX` throws `Error` and `runY` throws `Error` and you wanted to move `runX` to `ChildX` and `runY` to `ChildY`, `Error` can't move with both of them and you're stuck with having to do a more drastic change.

In this case you're forced to move `Error` to a shared module or split the `Error` type.

Perhaps that is one of these is the proper approach, but it doesn't change the fact that a simple move can become a more complicated change and PRs become bigger than we want them to be.

If the `Error` types were in a separate module to start with the problem doesn't arise. 

Over the course of Conway work, there will be a lot of restructuring of commands.  Having command error types live with command functions will be very disruptive to this process and it is better to just move them out of the way to cause less pain going forward.

This PR moves these error types into `CmdError`, this does not mean this is the most ideal home for them.  Just that they are not co-inhabiting with command functions and so not be in a position of triggering the bad situation.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
