### PR TITLE
Move legacy errors out of legacy command structure modules

### DIFF
--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -122,6 +122,7 @@ library
                         Cardano.CLI.Types.Errors.CmdError
                         Cardano.CLI.Types.Errors.GovernanceCmdError
                         Cardano.CLI.Types.Errors.ScriptDecodeError
+                        Cardano.CLI.Types.Errors.ShelleyAddressCmdError
                         Cardano.CLI.Types.Errors.ShelleyAddressInfoError
                         Cardano.CLI.Types.Errors.ShelleyStakeAddressCmdError
                         Cardano.CLI.Types.Errors.StakeAddressDelegationError

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -122,6 +122,7 @@ library
                         Cardano.CLI.Types.Errors.CmdError
                         Cardano.CLI.Types.Errors.GovernanceCmdError
                         Cardano.CLI.Types.Errors.ScriptDecodeError
+                        Cardano.CLI.Types.Errors.ShelleyAddressInfoError
                         Cardano.CLI.Types.Errors.ShelleyStakeAddressCmdError
                         Cardano.CLI.Types.Errors.StakeAddressDelegationError
                         Cardano.CLI.Types.Errors.StakeAddressRegistrationError

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -119,6 +119,7 @@ library
                         Cardano.CLI.Run.Ping
                         Cardano.CLI.TopHandler
                         Cardano.CLI.Types.Common
+                        Cardano.CLI.Types.Errors.CardanoAddressSigningKeyConversionError
                         Cardano.CLI.Types.Errors.CmdError
                         Cardano.CLI.Types.Errors.GovernanceCmdError
                         Cardano.CLI.Types.Errors.ItnKeyConversionError

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -122,6 +122,7 @@ library
                         Cardano.CLI.Types.Errors.CmdError
                         Cardano.CLI.Types.Errors.GovernanceCmdError
                         Cardano.CLI.Types.Errors.ItnKeyConversionError
+                        Cardano.CLI.Types.Errors.ProtocolParamsError
                         Cardano.CLI.Types.Errors.ScriptDecodeError
                         Cardano.CLI.Types.Errors.ShelleyAddressCmdError
                         Cardano.CLI.Types.Errors.ShelleyAddressInfoError

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -128,6 +128,7 @@ library
                         Cardano.CLI.Types.Errors.ShelleyAddressCmdError
                         Cardano.CLI.Types.Errors.ShelleyAddressInfoError
                         Cardano.CLI.Types.Errors.ShelleyGenesisCmdError
+                        Cardano.CLI.Types.Errors.ShelleyKeyCmdError
                         Cardano.CLI.Types.Errors.ShelleyStakeAddressCmdError
                         Cardano.CLI.Types.Errors.StakeAddressDelegationError
                         Cardano.CLI.Types.Errors.StakeAddressRegistrationError

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -130,6 +130,7 @@ library
                         Cardano.CLI.Types.Errors.ShelleyGenesisCmdError
                         Cardano.CLI.Types.Errors.ShelleyKeyCmdError
                         Cardano.CLI.Types.Errors.ShelleyNodeCmdError
+                        Cardano.CLI.Types.Errors.ShelleyPoolCmdError
                         Cardano.CLI.Types.Errors.ShelleyStakeAddressCmdError
                         Cardano.CLI.Types.Errors.StakeAddressDelegationError
                         Cardano.CLI.Types.Errors.StakeAddressRegistrationError

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -142,6 +142,7 @@ library
                         Cardano.CLI.Types.Key
                         Cardano.CLI.Types.Key.VerificationKey
                         Cardano.CLI.Types.Output
+                        Cardano.CLI.Types.TxFeature
 
   other-modules:        Paths_cardano_cli
   autogen-modules:      Paths_cardano_cli

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -136,6 +136,7 @@ library
                         Cardano.CLI.Types.Errors.ShelleyQueryCmdLocalStateQueryError
                         Cardano.CLI.Types.Errors.ShelleyStakeAddressCmdError
                         Cardano.CLI.Types.Errors.ShelleyTextViewFileError
+                        Cardano.CLI.Types.Errors.ShelleyTxCmdError
                         Cardano.CLI.Types.Errors.StakeAddressDelegationError
                         Cardano.CLI.Types.Errors.StakeAddressRegistrationError
                         Cardano.CLI.Types.Governance

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -131,6 +131,7 @@ library
                         Cardano.CLI.Types.Errors.ShelleyKeyCmdError
                         Cardano.CLI.Types.Errors.ShelleyNodeCmdError
                         Cardano.CLI.Types.Errors.ShelleyPoolCmdError
+                        Cardano.CLI.Types.Errors.ShelleyQueryCmdLocalStateQueryError
                         Cardano.CLI.Types.Errors.ShelleyStakeAddressCmdError
                         Cardano.CLI.Types.Errors.StakeAddressDelegationError
                         Cardano.CLI.Types.Errors.StakeAddressRegistrationError

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -129,6 +129,7 @@ library
                         Cardano.CLI.Types.Errors.ShelleyAddressInfoError
                         Cardano.CLI.Types.Errors.ShelleyGenesisCmdError
                         Cardano.CLI.Types.Errors.ShelleyKeyCmdError
+                        Cardano.CLI.Types.Errors.ShelleyNodeCmdError
                         Cardano.CLI.Types.Errors.ShelleyStakeAddressCmdError
                         Cardano.CLI.Types.Errors.StakeAddressDelegationError
                         Cardano.CLI.Types.Errors.StakeAddressRegistrationError

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -121,6 +121,7 @@ library
                         Cardano.CLI.Types.Common
                         Cardano.CLI.Types.Errors.CmdError
                         Cardano.CLI.Types.Errors.GovernanceCmdError
+                        Cardano.CLI.Types.Errors.ItnKeyConversionError
                         Cardano.CLI.Types.Errors.ScriptDecodeError
                         Cardano.CLI.Types.Errors.ShelleyAddressCmdError
                         Cardano.CLI.Types.Errors.ShelleyAddressInfoError

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -107,7 +107,6 @@ library
                         Cardano.CLI.Legacy.Run.StakeAddress
                         Cardano.CLI.Legacy.Run.TextView
                         Cardano.CLI.Legacy.Run.Transaction
-                        Cardano.CLI.Legacy.Run.Validate
                         Cardano.CLI.Options
                         Cardano.CLI.Orphans
                         Cardano.CLI.OS.Posix
@@ -139,6 +138,7 @@ library
                         Cardano.CLI.Types.Errors.ShelleyTxCmdError
                         Cardano.CLI.Types.Errors.StakeAddressDelegationError
                         Cardano.CLI.Types.Errors.StakeAddressRegistrationError
+                        Cardano.CLI.Types.Errors.TxValidationError
                         Cardano.CLI.Types.Governance
                         Cardano.CLI.Types.Key
                         Cardano.CLI.Types.Key.VerificationKey

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -127,6 +127,7 @@ library
                         Cardano.CLI.Types.Errors.ScriptDecodeError
                         Cardano.CLI.Types.Errors.ShelleyAddressCmdError
                         Cardano.CLI.Types.Errors.ShelleyAddressInfoError
+                        Cardano.CLI.Types.Errors.ShelleyBootstrapWitnessError
                         Cardano.CLI.Types.Errors.ShelleyGenesisCmdError
                         Cardano.CLI.Types.Errors.ShelleyKeyCmdError
                         Cardano.CLI.Types.Errors.ShelleyNodeCmdError

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -134,6 +134,7 @@ library
                         Cardano.CLI.Types.Errors.ShelleyQueryCmdError
                         Cardano.CLI.Types.Errors.ShelleyQueryCmdLocalStateQueryError
                         Cardano.CLI.Types.Errors.ShelleyStakeAddressCmdError
+                        Cardano.CLI.Types.Errors.ShelleyTextViewFileError
                         Cardano.CLI.Types.Errors.StakeAddressDelegationError
                         Cardano.CLI.Types.Errors.StakeAddressRegistrationError
                         Cardano.CLI.Types.Governance

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -131,6 +131,7 @@ library
                         Cardano.CLI.Types.Errors.ShelleyKeyCmdError
                         Cardano.CLI.Types.Errors.ShelleyNodeCmdError
                         Cardano.CLI.Types.Errors.ShelleyPoolCmdError
+                        Cardano.CLI.Types.Errors.ShelleyQueryCmdError
                         Cardano.CLI.Types.Errors.ShelleyQueryCmdLocalStateQueryError
                         Cardano.CLI.Types.Errors.ShelleyStakeAddressCmdError
                         Cardano.CLI.Types.Errors.StakeAddressDelegationError

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -124,6 +124,7 @@ library
                         Cardano.CLI.Types.Errors.ScriptDecodeError
                         Cardano.CLI.Types.Errors.ShelleyAddressCmdError
                         Cardano.CLI.Types.Errors.ShelleyAddressInfoError
+                        Cardano.CLI.Types.Errors.ShelleyGenesisCmdError
                         Cardano.CLI.Types.Errors.ShelleyStakeAddressCmdError
                         Cardano.CLI.Types.Errors.StakeAddressDelegationError
                         Cardano.CLI.Types.Errors.StakeAddressRegistrationError

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run.hs
@@ -26,6 +26,7 @@ import           Cardano.CLI.Types.Errors.ShelleyKeyCmdError
 import           Cardano.CLI.Types.Errors.ShelleyNodeCmdError
 import           Cardano.CLI.Types.Errors.ShelleyPoolCmdError
 import           Cardano.CLI.Types.Errors.ShelleyQueryCmdError
+import           Cardano.CLI.Types.Errors.ShelleyTextViewFileError
 
 import           Control.Monad.Trans.Except (ExceptT)
 import           Control.Monad.Trans.Except.Extra (firstExceptT)

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run.hs
@@ -25,6 +25,7 @@ import           Cardano.CLI.Types.Errors.ShelleyGenesisCmdError
 import           Cardano.CLI.Types.Errors.ShelleyKeyCmdError
 import           Cardano.CLI.Types.Errors.ShelleyNodeCmdError
 import           Cardano.CLI.Types.Errors.ShelleyPoolCmdError
+import           Cardano.CLI.Types.Errors.ShelleyQueryCmdError
 
 import           Control.Monad.Trans.Except (ExceptT)
 import           Control.Monad.Trans.Except.Extra (firstExceptT)

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run.hs
@@ -20,6 +20,7 @@ import           Cardano.CLI.Legacy.Run.StakeAddress
 import           Cardano.CLI.Legacy.Run.TextView
 import           Cardano.CLI.Legacy.Run.Transaction
 import           Cardano.CLI.Types.Errors.GovernanceCmdError
+import           Cardano.CLI.Types.Errors.ShelleyAddressCmdError
 
 import           Control.Monad.Trans.Except (ExceptT)
 import           Control.Monad.Trans.Except.Extra (firstExceptT)

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run.hs
@@ -27,6 +27,7 @@ import           Cardano.CLI.Types.Errors.ShelleyNodeCmdError
 import           Cardano.CLI.Types.Errors.ShelleyPoolCmdError
 import           Cardano.CLI.Types.Errors.ShelleyQueryCmdError
 import           Cardano.CLI.Types.Errors.ShelleyTextViewFileError
+import           Cardano.CLI.Types.Errors.ShelleyTxCmdError
 
 import           Control.Monad.Trans.Except (ExceptT)
 import           Control.Monad.Trans.Except.Extra (firstExceptT)

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run.hs
@@ -22,6 +22,7 @@ import           Cardano.CLI.Legacy.Run.Transaction
 import           Cardano.CLI.Types.Errors.GovernanceCmdError
 import           Cardano.CLI.Types.Errors.ShelleyAddressCmdError
 import           Cardano.CLI.Types.Errors.ShelleyGenesisCmdError
+import           Cardano.CLI.Types.Errors.ShelleyKeyCmdError
 
 import           Control.Monad.Trans.Except (ExceptT)
 import           Control.Monad.Trans.Except.Extra (firstExceptT)

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run.hs
@@ -23,6 +23,7 @@ import           Cardano.CLI.Types.Errors.GovernanceCmdError
 import           Cardano.CLI.Types.Errors.ShelleyAddressCmdError
 import           Cardano.CLI.Types.Errors.ShelleyGenesisCmdError
 import           Cardano.CLI.Types.Errors.ShelleyKeyCmdError
+import           Cardano.CLI.Types.Errors.ShelleyNodeCmdError
 
 import           Control.Monad.Trans.Except (ExceptT)
 import           Control.Monad.Trans.Except.Extra (firstExceptT)

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run.hs
@@ -21,6 +21,7 @@ import           Cardano.CLI.Legacy.Run.TextView
 import           Cardano.CLI.Legacy.Run.Transaction
 import           Cardano.CLI.Types.Errors.GovernanceCmdError
 import           Cardano.CLI.Types.Errors.ShelleyAddressCmdError
+import           Cardano.CLI.Types.Errors.ShelleyGenesisCmdError
 
 import           Control.Monad.Trans.Except (ExceptT)
 import           Control.Monad.Trans.Except.Extra (firstExceptT)

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run.hs
@@ -24,6 +24,7 @@ import           Cardano.CLI.Types.Errors.ShelleyAddressCmdError
 import           Cardano.CLI.Types.Errors.ShelleyGenesisCmdError
 import           Cardano.CLI.Types.Errors.ShelleyKeyCmdError
 import           Cardano.CLI.Types.Errors.ShelleyNodeCmdError
+import           Cardano.CLI.Types.Errors.ShelleyPoolCmdError
 
 import           Control.Monad.Trans.Except (ExceptT)
 import           Control.Monad.Trans.Except.Extra (firstExceptT)

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Address.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Address.hs
@@ -5,8 +5,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Cardano.CLI.Legacy.Run.Address
-  ( ShelleyAddressCmdError(..)
-  , SomeAddressVerificationKey(..)
+  ( SomeAddressVerificationKey(..)
   , buildShelleyAddress
   , renderShelleyAddressCmdError
   , runAddressCmds
@@ -20,44 +19,17 @@ import           Cardano.Api.Shelley
 import           Cardano.CLI.Legacy.Commands.Address
 import           Cardano.CLI.Legacy.Run.Address.Info (runAddressInfo)
 import           Cardano.CLI.Read
-import           Cardano.CLI.Types.Errors.ShelleyAddressInfoError
 import           Cardano.CLI.Types.Key (PaymentVerifier (..), StakeIdentifier (..),
-                   StakeVerifier (..), VerificationKeyTextOrFile,
-                   VerificationKeyTextOrFileError (..), generateKeyPair, readVerificationKeyOrFile,
-                   readVerificationKeyTextOrFileAnyOf, renderVerificationKeyTextOrFileError)
+                   StakeVerifier (..), VerificationKeyTextOrFile, generateKeyPair, readVerificationKeyOrFile,
+                   readVerificationKeyTextOrFileAnyOf)
 import           Cardano.CLI.Types.Common
+import           Cardano.CLI.Types.Errors.ShelleyAddressCmdError
 
 import           Control.Monad.IO.Class (MonadIO (..))
 import           Control.Monad.Trans.Except (ExceptT)
 import           Control.Monad.Trans.Except.Extra (firstExceptT, left, newExceptT)
 import qualified Data.ByteString.Char8 as BS
-import           Data.Text (Text)
-import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
-
-data ShelleyAddressCmdError
-  = ShelleyAddressCmdAddressInfoError !ShelleyAddressInfoError
-  | ShelleyAddressCmdReadKeyFileError !(FileError InputDecodeError)
-  | ShelleyAddressCmdReadScriptFileError !(FileError ScriptDecodeError)
-  | ShelleyAddressCmdVerificationKeyTextOrFileError !VerificationKeyTextOrFileError
-  | ShelleyAddressCmdWriteFileError !(FileError ())
-  | ShelleyAddressCmdExpectedPaymentVerificationKey SomeAddressVerificationKey
-  deriving Show
-
-renderShelleyAddressCmdError :: ShelleyAddressCmdError -> Text
-renderShelleyAddressCmdError err =
-  case err of
-    ShelleyAddressCmdAddressInfoError addrInfoErr ->
-      Text.pack (displayError addrInfoErr)
-    ShelleyAddressCmdReadKeyFileError fileErr ->
-      Text.pack (displayError fileErr)
-    ShelleyAddressCmdVerificationKeyTextOrFileError vkTextOrFileErr ->
-      renderVerificationKeyTextOrFileError vkTextOrFileErr
-    ShelleyAddressCmdReadScriptFileError fileErr ->
-      Text.pack (displayError fileErr)
-    ShelleyAddressCmdWriteFileError fileErr -> Text.pack (displayError fileErr)
-    ShelleyAddressCmdExpectedPaymentVerificationKey someAddress ->
-      "Expected payment verification key but got: " <> renderSomeAddressVerificationKey someAddress
 
 runAddressCmds :: LegacyAddressCmds -> ExceptT ShelleyAddressCmdError IO ()
 runAddressCmds cmd =

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Address.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Address.hs
@@ -18,8 +18,9 @@ import           Cardano.Api
 import           Cardano.Api.Shelley
 
 import           Cardano.CLI.Legacy.Commands.Address
-import           Cardano.CLI.Legacy.Run.Address.Info (ShelleyAddressInfoError, runAddressInfo)
+import           Cardano.CLI.Legacy.Run.Address.Info (runAddressInfo)
 import           Cardano.CLI.Read
+import           Cardano.CLI.Types.Errors.ShelleyAddressInfoError
 import           Cardano.CLI.Types.Key (PaymentVerifier (..), StakeIdentifier (..),
                    StakeVerifier (..), VerificationKeyTextOrFile,
                    VerificationKeyTextOrFileError (..), generateKeyPair, readVerificationKeyOrFile,

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Address/Info.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Address/Info.hs
@@ -3,10 +3,11 @@
 
 module Cardano.CLI.Legacy.Run.Address.Info
   ( runAddressInfo
-  , ShelleyAddressInfoError(..)
   ) where
 
 import           Cardano.Api
+
+import           Cardano.CLI.Types.Errors.ShelleyAddressInfoError
 
 import           Control.Monad.IO.Class (MonadIO (..))
 import           Control.Monad.Trans.Except (ExceptT)
@@ -16,13 +17,6 @@ import           Data.Aeson.Encode.Pretty (encodePretty)
 import qualified Data.ByteString.Lazy.Char8 as LBS
 import           Data.Text (Text)
 import           Options.Applicative (Alternative (..))
-
-newtype ShelleyAddressInfoError = ShelleyAddressInvalid Text
-  deriving Show
-
-instance Error ShelleyAddressInfoError where
-  displayError (ShelleyAddressInvalid addrTxt) =
-    "Invalid address: " <> show addrTxt
 
 data AddressInfo = AddressInfo
   { aiType :: !Text

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Genesis.hs
@@ -49,12 +49,12 @@ import qualified Cardano.CLI.IO.Lazy as Lazy
 import           Cardano.CLI.Legacy.Commands.Genesis
 import           Cardano.CLI.Legacy.Run.Node (
                    runNodeIssueOpCert, runNodeKeyGenCold, runNodeKeyGenKES, runNodeKeyGenVRF)
-import           Cardano.CLI.Legacy.Run.Pool (ShelleyPoolCmdError (..))
 import           Cardano.CLI.Legacy.Run.StakeAddress (runStakeAddressKeyGenToFile)
 import           Cardano.CLI.Orphans ()
 import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Errors.ProtocolParamsError
 import           Cardano.CLI.Types.Errors.ShelleyGenesisCmdError
+import           Cardano.CLI.Types.Errors.ShelleyPoolCmdError
 import           Cardano.CLI.Types.Errors.ShelleyNodeCmdError
 import           Cardano.CLI.Types.Key
 import qualified Cardano.Crypto as CC

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Genesis.hs
@@ -47,7 +47,7 @@ import           Cardano.CLI.Byron.Genesis as Byron
 import qualified Cardano.CLI.Byron.Key as Byron
 import qualified Cardano.CLI.IO.Lazy as Lazy
 import           Cardano.CLI.Legacy.Commands.Genesis
-import           Cardano.CLI.Legacy.Run.Node (ShelleyNodeCmdError (..),
+import           Cardano.CLI.Legacy.Run.Node (
                    runNodeIssueOpCert, runNodeKeyGenCold, runNodeKeyGenKES, runNodeKeyGenVRF)
 import           Cardano.CLI.Legacy.Run.Pool (ShelleyPoolCmdError (..))
 import           Cardano.CLI.Legacy.Run.StakeAddress (runStakeAddressKeyGenToFile)
@@ -55,6 +55,7 @@ import           Cardano.CLI.Orphans ()
 import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Errors.ProtocolParamsError
 import           Cardano.CLI.Types.Errors.ShelleyGenesisCmdError
+import           Cardano.CLI.Types.Errors.ShelleyNodeCmdError
 import           Cardano.CLI.Types.Key
 import qualified Cardano.Crypto as CC
 import           Cardano.Crypto.Hash (HashAlgorithm)

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Genesis.hs
@@ -58,6 +58,7 @@ import           Cardano.CLI.Legacy.Run.StakeAddress (ShelleyStakeAddressCmdErro
 import           Cardano.CLI.Orphans ()
 import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Key
+import           Cardano.CLI.Types.Errors.ShelleyAddressCmdError
 import qualified Cardano.Crypto as CC
 import           Cardano.Crypto.Hash (HashAlgorithm)
 import qualified Cardano.Crypto.Hash as Crypto

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Genesis.hs
@@ -53,6 +53,7 @@ import           Cardano.CLI.Legacy.Run.Pool (ShelleyPoolCmdError (..))
 import           Cardano.CLI.Legacy.Run.StakeAddress (runStakeAddressKeyGenToFile)
 import           Cardano.CLI.Orphans ()
 import           Cardano.CLI.Types.Common
+import           Cardano.CLI.Types.Errors.ProtocolParamsError
 import           Cardano.CLI.Types.Errors.ShelleyGenesisCmdError
 import           Cardano.CLI.Types.Key
 import qualified Cardano.Crypto as CC
@@ -1308,16 +1309,6 @@ readConwayGenesis fpath = do
     . hoistEither $ Aeson.eitherDecode' lbs
 
 -- Protocol Parameters
-
-data ProtocolParamsError
-  = ProtocolParamsErrorFile (FileError ())
-  | ProtocolParamsErrorJSON !FilePath !Text
-
-renderProtocolParamsError :: ProtocolParamsError -> Text
-renderProtocolParamsError (ProtocolParamsErrorFile fileErr) =
-  Text.pack $ displayError fileErr
-renderProtocolParamsError (ProtocolParamsErrorJSON fp jsonErr) =
-  "Error while decoding the protocol parameters at: " <> Text.pack fp <> " Error: " <> jsonErr
 
 --TODO: eliminate this and get only the necessary params, and get them in a more
 -- helpful way rather than requiring them as a local file.

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Key.hs
@@ -22,6 +22,7 @@ import           Cardano.Api.Shelley
 import qualified Cardano.CLI.Byron.Key as Byron
 import           Cardano.CLI.Legacy.Commands.Key
 import           Cardano.CLI.Types.Common
+import           Cardano.CLI.Types.Errors.CardanoAddressSigningKeyConversionError
 import           Cardano.CLI.Types.Errors.ItnKeyConversionError
 import           Cardano.CLI.Types.Key
 import qualified Cardano.Crypto.DSIGN as DSIGN
@@ -43,7 +44,6 @@ import           Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import           System.Exit (exitFailure)
-
 
 data ShelleyKeyCmdError
   = ShelleyKeyCmdReadFileError !(FileError TextEnvelopeError)
@@ -515,32 +515,6 @@ data SomeCardanoAddressSigningKey
   = ACardanoAddrShelleyPaymentSigningKey !(SigningKey PaymentExtendedKey)
   | ACardanoAddrShelleyStakeSigningKey !(SigningKey StakeExtendedKey)
   | ACardanoAddrByronSigningKey !(SigningKey ByronKey)
-
--- | An error that can occur while converting a @cardano-address@ extended
--- signing key.
-data CardanoAddressSigningKeyConversionError
-  = CardanoAddressSigningKeyBech32DecodeError !Bech32DecodeError
-  -- ^ There was an error in decoding the string as Bech32.
-  | CardanoAddressSigningKeyDeserialisationError !ByteString
-  -- ^ There was an error in converting the @cardano-address@ extended signing
-  -- key.
-  deriving (Show, Eq)
-
-instance Error CardanoAddressSigningKeyConversionError where
-  displayError = Text.unpack . renderCardanoAddressSigningKeyConversionError
-
--- | Render an error message for a 'CardanoAddressSigningKeyConversionError'.
-renderCardanoAddressSigningKeyConversionError
-  :: CardanoAddressSigningKeyConversionError
-  -> Text
-renderCardanoAddressSigningKeyConversionError err =
-  case err of
-    CardanoAddressSigningKeyBech32DecodeError decErr ->
-      Text.pack (displayError decErr)
-    CardanoAddressSigningKeyDeserialisationError _bs ->
-      -- Sensitive data, such as the signing key, is purposely not included in
-      -- the error message.
-      "Error deserialising cardano-address signing key."
 
 -- | Decode a Bech32-encoded string.
 decodeBech32

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Key.hs
@@ -4,9 +4,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Cardano.CLI.Legacy.Run.Key
-  ( ShelleyKeyCmdError
-  , SomeSigningKey(..)
-  , renderShelleyKeyCmdError
+  ( SomeSigningKey(..)
   , runKeyCmds
   , readSigningKeyFile
 
@@ -24,6 +22,7 @@ import           Cardano.CLI.Legacy.Commands.Key
 import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Errors.CardanoAddressSigningKeyConversionError
 import           Cardano.CLI.Types.Errors.ItnKeyConversionError
+import           Cardano.CLI.Types.Errors.ShelleyKeyCmdError
 import           Cardano.CLI.Types.Key
 import qualified Cardano.Crypto.DSIGN as DSIGN
 import qualified Cardano.Crypto.Signing as Byron
@@ -44,43 +43,6 @@ import           Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import           System.Exit (exitFailure)
-
-data ShelleyKeyCmdError
-  = ShelleyKeyCmdReadFileError !(FileError TextEnvelopeError)
-  | ShelleyKeyCmdReadKeyFileError !(FileError InputDecodeError)
-  | ShelleyKeyCmdWriteFileError !(FileError ())
-  | ShelleyKeyCmdByronKeyFailure !Byron.ByronKeyFailure
-  | ShelleyKeyCmdByronKeyParseError
-      !Text
-      -- ^ Text representation of the parse error. Unfortunately, the actual
-      -- error type isn't exported.
-  | ShelleyKeyCmdItnKeyConvError !ItnKeyConversionError
-  | ShelleyKeyCmdWrongKeyTypeError
-  | ShelleyKeyCmdCardanoAddressSigningKeyFileError
-      !(FileError CardanoAddressSigningKeyConversionError)
-  | ShelleyKeyCmdNonLegacyKey !FilePath
-  | ShelleyKeyCmdExpectedExtendedVerificationKey SomeAddressVerificationKey
-  | ShelleyKeyCmdVerificationKeyReadError VerificationKeyTextOrFileError
-  deriving Show
-
-renderShelleyKeyCmdError :: ShelleyKeyCmdError -> Text
-renderShelleyKeyCmdError err =
-  case err of
-    ShelleyKeyCmdReadFileError fileErr -> Text.pack (displayError fileErr)
-    ShelleyKeyCmdReadKeyFileError fileErr -> Text.pack (displayError fileErr)
-    ShelleyKeyCmdWriteFileError fileErr -> Text.pack (displayError fileErr)
-    ShelleyKeyCmdByronKeyFailure e -> Byron.renderByronKeyFailure e
-    ShelleyKeyCmdByronKeyParseError errTxt -> errTxt
-    ShelleyKeyCmdItnKeyConvError convErr -> renderConversionError convErr
-    ShelleyKeyCmdWrongKeyTypeError ->
-      Text.pack "Please use a signing key file when converting ITN BIP32 or Extended keys"
-    ShelleyKeyCmdCardanoAddressSigningKeyFileError fileErr ->
-      Text.pack (displayError fileErr)
-    ShelleyKeyCmdNonLegacyKey fp ->
-      "Signing key at: " <> Text.pack fp <> " is not a legacy Byron signing key and should not need to be converted."
-    ShelleyKeyCmdVerificationKeyReadError e -> renderVerificationKeyTextOrFileError e
-    ShelleyKeyCmdExpectedExtendedVerificationKey someVerKey ->
-      "Expected an extended verification key but got: " <> renderSomeAddressVerificationKey someVerKey
 
 runKeyCmds :: LegacyKeyCmds -> ExceptT ShelleyKeyCmdError IO ()
 runKeyCmds cmd =

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Node.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Node.hs
@@ -1,9 +1,7 @@
 {-# LANGUAGE DataKinds #-}
 
 module Cardano.CLI.Legacy.Run.Node
-  ( ShelleyNodeCmdError(ShelleyNodeCmdReadFileError)
-  , renderShelleyNodeCmdError
-  , runNodeCmds
+  ( runNodeCmds
   , runNodeIssueOpCert
   , runNodeKeyGenCold
   , runNodeKeyGenKES
@@ -16,6 +14,7 @@ import           Cardano.Api.Shelley
 
 import           Cardano.CLI.Legacy.Commands.Node
 import           Cardano.CLI.Types.Common
+import           Cardano.CLI.Types.Errors.ShelleyNodeCmdError
 import           Cardano.CLI.Types.Key
 
 import           Control.Monad.IO.Class (MonadIO (..))
@@ -23,40 +22,9 @@ import           Control.Monad.Trans.Except (ExceptT)
 import           Control.Monad.Trans.Except.Extra (firstExceptT, hoistEither, newExceptT)
 import qualified Data.ByteString.Char8 as BS
 import           Data.String (fromString)
-import           Data.Text (Text)
-import qualified Data.Text as Text
 import           Data.Word (Word64)
 
 {- HLINT ignore "Reduce duplication" -}
-
-data ShelleyNodeCmdError
-  = ShelleyNodeCmdReadFileError !(FileError TextEnvelopeError)
-  | ShelleyNodeCmdReadKeyFileError !(FileError InputDecodeError)
-  | ShelleyNodeCmdWriteFileError !(FileError ())
-  | ShelleyNodeCmdOperationalCertificateIssueError !OperationalCertIssueError
-  | ShelleyNodeCmdVrfSigningKeyCreationError
-      FilePath
-      -- ^ Target path
-      FilePath
-      -- ^ Temp path
-  deriving Show
-
-renderShelleyNodeCmdError :: ShelleyNodeCmdError -> Text
-renderShelleyNodeCmdError err =
-  case err of
-    ShelleyNodeCmdVrfSigningKeyCreationError targetPath tempPath ->
-      Text.pack $ "Error creating VRF signing key file. Target path: " <> targetPath
-      <> " Temporary path: " <> tempPath
-
-    ShelleyNodeCmdReadFileError fileErr -> Text.pack (displayError fileErr)
-
-    ShelleyNodeCmdReadKeyFileError fileErr -> Text.pack (displayError fileErr)
-
-    ShelleyNodeCmdWriteFileError fileErr -> Text.pack (displayError fileErr)
-
-    ShelleyNodeCmdOperationalCertificateIssueError issueErr ->
-      Text.pack (displayError issueErr)
-
 
 runNodeCmds :: LegacyNodeCmds -> ExceptT ShelleyNodeCmdError IO ()
 runNodeCmds (NodeKeyGenCold fmt vk sk ctr) = runNodeKeyGenCold fmt vk sk ctr

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Pool.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Pool.hs
@@ -4,9 +4,7 @@
 {-# LANGUAGE RankNTypes #-}
 
 module Cardano.CLI.Legacy.Run.Pool
-  ( ShelleyPoolCmdError(ShelleyPoolCmdReadFileError)
-  , renderShelleyPoolCmdError
-  , runPoolCmds
+  ( runPoolCmds
   ) where
 
 import           Cardano.Api
@@ -15,6 +13,7 @@ import           Cardano.Api.Shelley
 
 import           Cardano.CLI.Legacy.Commands.Pool
 import           Cardano.CLI.Types.Common
+import           Cardano.CLI.Types.Errors.ShelleyPoolCmdError
 import           Cardano.CLI.Types.Key (VerificationKeyOrFile, readVerificationKeyOrFile)
 import qualified Cardano.Ledger.Slot as Shelley
 
@@ -25,26 +24,6 @@ import           Control.Monad.Trans.Except.Extra (firstExceptT, handleIOExceptT
                    newExceptT, onLeft)
 import qualified Data.ByteString.Char8 as BS
 import           Data.Function ((&))
-import           Data.Text (Text)
-import qualified Data.Text as Text
-
-data ShelleyPoolCmdError
-  = ShelleyPoolCmdReadFileError !(FileError TextEnvelopeError)
-  | ShelleyPoolCmdReadKeyFileError !(FileError InputDecodeError)
-  | ShelleyPoolCmdWriteFileError !(FileError ())
-  | ShelleyPoolCmdMetadataValidationError !StakePoolMetadataValidationError
-  deriving Show
-
-renderShelleyPoolCmdError :: ShelleyPoolCmdError -> Text
-renderShelleyPoolCmdError err =
-  case err of
-    ShelleyPoolCmdReadFileError fileErr -> Text.pack (displayError fileErr)
-    ShelleyPoolCmdReadKeyFileError fileErr -> Text.pack (displayError fileErr)
-    ShelleyPoolCmdWriteFileError fileErr -> Text.pack (displayError fileErr)
-    ShelleyPoolCmdMetadataValidationError validationErr ->
-      "Error validating stake pool metadata: " <> Text.pack (displayError validationErr)
-
-
 
 runPoolCmds :: LegacyPoolCmds -> ExceptT ShelleyPoolCmdError IO ()
 runPoolCmds = \case

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Query.hs
@@ -15,7 +15,6 @@
 
 module Cardano.CLI.Legacy.Run.Query
   ( DelegationsAndRewards(..)
-  , ShelleyQueryCmdError
   , renderOpCertIntervalInformation
   , renderShelleyQueryCmdError
   , renderLocalStateQueryError
@@ -32,13 +31,12 @@ import qualified Cardano.Api as Api
 import           Cardano.Api.Byron hiding (QueryInShelleyBasedEra (..))
 import           Cardano.Api.Shelley hiding (QueryInShelleyBasedEra (..))
 
-import           Cardano.Binary (DecoderError)
-import           Cardano.CLI.Helpers (HelpersError (..), hushM, pPrintCBOR, renderHelpersError)
+import           Cardano.CLI.Helpers (hushM, pPrintCBOR)
 import           Cardano.CLI.Legacy.Commands.Query
 import           Cardano.CLI.Legacy.Run.Genesis (readAndDecodeShelleyGenesis)
 import           Cardano.CLI.Pretty
 import           Cardano.CLI.Types.Common
-import           Cardano.CLI.Types.Errors.ShelleyGenesisCmdError
+import           Cardano.CLI.Types.Errors.ShelleyQueryCmdError
 import           Cardano.CLI.Types.Errors.ShelleyQueryCmdLocalStateQueryError
 import           Cardano.CLI.Types.Key (VerificationKeyOrHashOrFile,
                    readVerificationKeyOrHashOrFile)
@@ -55,9 +53,7 @@ import qualified Cardano.Ledger.Shelley.LedgerState as SL
 import           Cardano.Slotting.EpochInfo (EpochInfo (..), epochInfoSlotToUTCTime, hoistEpochInfo)
 import           Ouroboros.Consensus.BlockchainTime.WallClock.Types (RelativeTime (..),
                    toRelativeTime)
-import           Ouroboros.Consensus.Cardano.Block as Consensus (EraMismatch (..))
 import qualified Ouroboros.Consensus.HardFork.History as Consensus
-import qualified Ouroboros.Consensus.HardFork.History.Qry as Qry
 import qualified Ouroboros.Consensus.Protocol.Abstract as Consensus
 import qualified Ouroboros.Consensus.Protocol.Praos.Common as Consensus
 import           Ouroboros.Consensus.Protocol.TPraos (StandardCrypto)
@@ -91,11 +87,8 @@ import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import qualified Data.Text.IO as T
 import qualified Data.Text.IO as Text
-import           Data.Text.Lazy (toStrict)
-import           Data.Text.Lazy.Builder (toLazyText)
 import           Data.Time.Clock
 import qualified Data.Vector as Vector
-import           Formatting.Buildable (build)
 import           Numeric (showEFloat)
 import           Prettyprinter
 import qualified System.IO as IO
@@ -103,64 +96,6 @@ import           Text.Printf (printf)
 
 {- HLINT ignore "Move brackets to avoid $" -}
 {- HLINT ignore "Redundant flip" -}
-
-data ShelleyQueryCmdError
-  = ShelleyQueryCmdLocalStateQueryError !ShelleyQueryCmdLocalStateQueryError
-  | ShelleyQueryCmdWriteFileError !(FileError ())
-  | ShelleyQueryCmdHelpersError !HelpersError
-  | ShelleyQueryCmdAcquireFailure !AcquiringFailure
-  | ShelleyQueryCmdEraConsensusModeMismatch !AnyConsensusMode !AnyCardanoEra
-  | ShelleyQueryCmdByronEra
-  | ShelleyQueryCmdEraMismatch !EraMismatch
-  | ShelleyQueryCmdUnsupportedMode !AnyConsensusMode
-  | ShelleyQueryCmdPastHorizon !Qry.PastHorizonException
-  | ShelleyQueryCmdSystemStartUnavailable
-  | ShelleyQueryCmdGenesisReadError !ShelleyGenesisCmdError
-  | ShelleyQueryCmdLeaderShipError !LeadershipError
-  | ShelleyQueryCmdTextEnvelopeReadError !(FileError TextEnvelopeError)
-  | ShelleyQueryCmdTextReadError !(FileError InputDecodeError)
-  | ShelleyQueryCmdOpCertCounterReadError !(FileError TextEnvelopeError)
-  | ShelleyQueryCmdProtocolStateDecodeFailure !(LBS.ByteString, DecoderError)
-  | ShelleyQueryCmdPoolStateDecodeError DecoderError
-  | ShelleyQueryCmdStakeSnapshotDecodeError DecoderError
-  | ShelleyQueryCmdUnsupportedNtcVersion !UnsupportedNtcVersionError
-  | ShelleyQueryCmdProtocolParameterConversionError !ProtocolParametersConversionError
-  deriving Show
-
-renderShelleyQueryCmdError :: ShelleyQueryCmdError -> Text
-renderShelleyQueryCmdError err =
-  case err of
-    ShelleyQueryCmdLocalStateQueryError lsqErr -> renderLocalStateQueryError lsqErr
-    ShelleyQueryCmdWriteFileError fileErr -> Text.pack (displayError fileErr)
-    ShelleyQueryCmdHelpersError helpersErr -> renderHelpersError helpersErr
-    ShelleyQueryCmdAcquireFailure acquireFail -> Text.pack $ show acquireFail
-    ShelleyQueryCmdByronEra -> "This query cannot be used for the Byron era"
-    ShelleyQueryCmdEraConsensusModeMismatch (AnyConsensusMode cMode) (AnyCardanoEra era) ->
-      "Consensus mode and era mismatch. Consensus mode: " <> textShow cMode <>
-      " Era: " <> textShow era
-    ShelleyQueryCmdEraMismatch (EraMismatch ledgerEra queryEra) ->
-      "\nAn error mismatch occurred." <> "\nSpecified query era: " <> queryEra <>
-      "\nCurrent ledger era: " <> ledgerEra
-    ShelleyQueryCmdUnsupportedMode mode -> "Unsupported mode: " <> renderMode mode
-    ShelleyQueryCmdPastHorizon e -> "Past horizon: " <> textShow e
-    ShelleyQueryCmdSystemStartUnavailable -> "System start unavailable"
-    ShelleyQueryCmdGenesisReadError err' -> Text.pack $ displayError err'
-    ShelleyQueryCmdLeaderShipError e -> Text.pack $ displayError e
-    ShelleyQueryCmdTextEnvelopeReadError e -> Text.pack $ displayError e
-    ShelleyQueryCmdTextReadError e -> Text.pack $ displayError e
-    ShelleyQueryCmdOpCertCounterReadError e -> Text.pack $ displayError e
-    ShelleyQueryCmdProtocolStateDecodeFailure (_, decErr) ->
-      "Failed to decode the protocol state: " <> toStrict (toLazyText $ build decErr)
-    ShelleyQueryCmdPoolStateDecodeError decoderError ->
-      "Failed to decode PoolState.  Error: " <> Text.pack (show decoderError)
-    ShelleyQueryCmdStakeSnapshotDecodeError decoderError ->
-      "Failed to decode StakeSnapshot.  Error: " <> Text.pack (show decoderError)
-    ShelleyQueryCmdUnsupportedNtcVersion (UnsupportedNtcVersionError minNtcVersion ntcVersion) ->
-      "Unsupported feature for the node-to-client protocol version.\n" <>
-      "This query requires at least " <> textShow minNtcVersion <> " but the node negotiated " <> textShow ntcVersion <> ".\n" <>
-      "Later node versions support later protocol versions (but development protocol versions are not enabled in the node by default)."
-    ShelleyQueryCmdProtocolParameterConversionError ppce ->
-      Text.pack $ "Failed to convert protocol parameter: " <> displayError ppce
 
 runQueryCmds :: LegacyQueryCmds -> ExceptT ShelleyQueryCmdError IO ()
 runQueryCmds cmd =

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Query.hs
@@ -36,10 +36,10 @@ import           Cardano.Api.Shelley hiding (QueryInShelleyBasedEra (..))
 import           Cardano.Binary (DecoderError)
 import           Cardano.CLI.Helpers (HelpersError (..), hushM, pPrintCBOR, renderHelpersError)
 import           Cardano.CLI.Legacy.Commands.Query
-import           Cardano.CLI.Legacy.Run.Genesis (ShelleyGenesisCmdError,
-                   readAndDecodeShelleyGenesis)
+import           Cardano.CLI.Legacy.Run.Genesis (readAndDecodeShelleyGenesis)
 import           Cardano.CLI.Pretty
 import           Cardano.CLI.Types.Common
+import           Cardano.CLI.Types.Errors.ShelleyGenesisCmdError
 import           Cardano.CLI.Types.Key (VerificationKeyOrHashOrFile,
                    readVerificationKeyOrHashOrFile)
 import qualified Cardano.CLI.Types.Output as O

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Query.hs
@@ -16,7 +16,6 @@
 module Cardano.CLI.Legacy.Run.Query
   ( DelegationsAndRewards(..)
   , ShelleyQueryCmdError
-  , ShelleyQueryCmdLocalStateQueryError (..)
   , renderOpCertIntervalInformation
   , renderShelleyQueryCmdError
   , renderLocalStateQueryError
@@ -40,6 +39,7 @@ import           Cardano.CLI.Legacy.Run.Genesis (readAndDecodeShelleyGenesis)
 import           Cardano.CLI.Pretty
 import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Errors.ShelleyGenesisCmdError
+import           Cardano.CLI.Types.Errors.ShelleyQueryCmdLocalStateQueryError
 import           Cardano.CLI.Types.Key (VerificationKeyOrHashOrFile,
                    readVerificationKeyOrHashOrFile)
 import qualified Cardano.CLI.Types.Output as O
@@ -950,19 +950,6 @@ runQueryStakeAddressInfo socketPath (AnyConsensusModeParams cModeParams) (StakeA
     & onLeft left
 
 -- -------------------------------------------------------------------------------------------------
-
--- | An error that can occur while querying a node's local state.
-newtype ShelleyQueryCmdLocalStateQueryError
-  = EraMismatchError EraMismatch
-  -- ^ A query from a certain era was applied to a ledger from a different
-  -- era.
-  deriving (Eq, Show)
-
-renderLocalStateQueryError :: ShelleyQueryCmdLocalStateQueryError -> Text
-renderLocalStateQueryError lsqErr =
-  case lsqErr of
-    EraMismatchError err ->
-      "A query from a certain era was applied to a ledger from a different era: " <> textShow err
 
 writeStakeAddressInfo
   :: Maybe (File () Out)

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/TextView.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/TextView.hs
@@ -1,35 +1,19 @@
 {-# LANGUAGE DataKinds #-}
 
 module Cardano.CLI.Legacy.Run.TextView
-  ( ShelleyTextViewFileError(..)
-  , renderShelleyTextViewFileError
-  , runTextViewCmds
+  ( runTextViewCmds
   ) where
 
 import           Cardano.Api
 
-import           Cardano.CLI.Helpers (HelpersError, pPrintCBOR, renderHelpersError)
+import           Cardano.CLI.Helpers (pPrintCBOR)
 import           Cardano.CLI.Legacy.Commands.TextView
+import           Cardano.CLI.Types.Errors.ShelleyTextViewFileError
 
 import           Control.Monad.IO.Class (MonadIO (..))
 import           Control.Monad.Trans.Except (ExceptT)
 import           Control.Monad.Trans.Except.Extra (firstExceptT, newExceptT)
 import qualified Data.ByteString.Lazy.Char8 as LBS
-import           Data.Text (Text)
-import qualified Data.Text as Text
-
-data ShelleyTextViewFileError
-  = TextViewReadFileError (FileError TextEnvelopeError)
-  | TextViewCBORPrettyPrintError !HelpersError
-  deriving Show
-
-renderShelleyTextViewFileError :: ShelleyTextViewFileError -> Text
-renderShelleyTextViewFileError err =
-  case err of
-    TextViewReadFileError fileErr -> Text.pack (displayError fileErr)
-    TextViewCBORPrettyPrintError hlprsErr ->
-      "Error pretty printing CBOR: " <> renderHelpersError hlprsErr
-
 
 runTextViewCmds :: LegacyTextViewCmds -> ExceptT ShelleyTextViewFileError IO ()
 runTextViewCmds cmd =

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Transaction.hs
@@ -9,10 +9,11 @@
 
 {-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
 
+{- HLINT ignore "Unused LANGUAGE pragma" -}
+{- HLINT ignore "Use let" -}
+
 module Cardano.CLI.Legacy.Run.Transaction
-  ( ShelleyTxCmdError(..)
-  , renderShelleyTxCmdError
-  , runTransactionCmds
+  ( runTransactionCmds
   , readFileTx
   , toTxOutInAnyEra
   ) where
@@ -28,10 +29,10 @@ import           Cardano.CLI.Legacy.Run.Validate
 import           Cardano.CLI.Read
 import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Errors.ShelleyBootstrapWitnessError
+import           Cardano.CLI.Types.Errors.ShelleyTxCmdError
 import           Cardano.CLI.Types.Governance
 import           Cardano.CLI.Types.Output
 import           Cardano.CLI.Types.TxFeature
-import           Ouroboros.Consensus.Cardano.Block (EraMismatch (..))
 import qualified Ouroboros.Network.Protocol.LocalTxSubmission.Client as Net.Tx
 
 import           Control.Monad (forM)
@@ -59,191 +60,6 @@ import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
 import           Data.Type.Equality (TestEquality (..))
 import qualified System.IO as IO
-
-{- HLINT ignore "Use let" -}
-
-data ShelleyTxCmdError
-  = ShelleyTxCmdMetadataError MetadataError
-  | ShelleyTxCmdVoteError VoteError
-  | ShelleyTxCmdConstitutionError ConstitutionError
-  | ShelleyTxCmdScriptWitnessError ScriptWitnessError
-  | ShelleyTxCmdProtocolParamsError ProtocolParamsError
-  | ShelleyTxCmdScriptFileError (FileError ScriptDecodeError)
-  | ShelleyTxCmdReadTextViewFileError !(FileError TextEnvelopeError)
-  | ShelleyTxCmdReadWitnessSigningDataError !ReadWitnessSigningDataError
-  | ShelleyTxCmdWriteFileError !(FileError ())
-  | ShelleyTxCmdEraConsensusModeMismatch
-      !(Maybe FilePath)
-      !AnyConsensusMode
-      !AnyCardanoEra
-      -- ^ Era
-  | ShelleyTxCmdBootstrapWitnessError !ShelleyBootstrapWitnessError
-  | ShelleyTxCmdTxSubmitError !Text
-  | ShelleyTxCmdTxSubmitErrorEraMismatch !EraMismatch
-  | ShelleyTxCmdTxFeatureMismatch !AnyCardanoEra !TxFeature
-  | ShelleyTxCmdTxBodyError !TxBodyError
-  | ShelleyTxCmdNotImplemented !Text
-  | ShelleyTxCmdWitnessEraMismatch !AnyCardanoEra !AnyCardanoEra !WitnessFile
-  | ShelleyTxCmdPolicyIdsMissing ![PolicyId]
-  | ShelleyTxCmdPolicyIdsExcess  ![PolicyId]
-  | ShelleyTxCmdUnsupportedMode !AnyConsensusMode
-  | ShelleyTxCmdByronEra
-  | ShelleyTxCmdEraConsensusModeMismatchTxBalance
-      !TxBuildOutputOptions
-      !AnyConsensusMode
-      !AnyCardanoEra
-  | ShelleyTxCmdBalanceTxBody !TxBodyErrorAutoBalance
-  | ShelleyTxCmdTxInsDoNotExist !TxInsExistError
-  | ShelleyTxCmdPParamsErr !ProtocolParametersError
-  | ShelleyTxCmdTextEnvCddlError
-      !(FileError TextEnvelopeError)
-      !(FileError TextEnvelopeCddlError)
-  | ShelleyTxCmdTxExecUnitsErr !TransactionValidityError
-  | ShelleyTxCmdPlutusScriptCostErr !PlutusScriptCostError
-  | ShelleyTxCmdPParamExecutionUnitsNotAvailable
-  | ShelleyTxCmdPlutusScriptsRequireCardanoMode
-  | ShelleyTxCmdProtocolParametersNotPresentInTxBody
-  | ShelleyTxCmdTxEraCastErr EraCastError
-  | ShelleyTxCmdQueryConvenienceError !QueryConvenienceError
-  | ShelleyTxCmdQueryNotScriptLocked !ScriptLockedTxInsError
-  | ShelleyTxCmdScriptDataError !ScriptDataError
-  | ShelleyTxCmdCddlError CddlError
-  | ShelleyTxCmdCddlWitnessError CddlWitnessError
-  | ShelleyTxCmdRequiredSignerError RequiredSignerError
-  -- Validation errors
-  | ShelleyTxCmdAuxScriptsValidationError TxAuxScriptsValidationError
-  | ShelleyTxCmdTotalCollateralValidationError TxTotalCollateralValidationError
-  | ShelleyTxCmdReturnCollateralValidationError TxReturnCollateralValidationError
-  | ShelleyTxCmdTxFeeValidationError TxFeeValidationError
-  | ShelleyTxCmdTxValidityLowerBoundValidationError TxValidityLowerBoundValidationError
-  | ShelleyTxCmdTxValidityUpperBoundValidationError TxValidityUpperBoundValidationError
-  | ShelleyTxCmdRequiredSignersValidationError TxRequiredSignersValidationError
-  | ShelleyTxCmdProtocolParametersValidationError TxProtocolParametersValidationError
-  | ShelleyTxCmdTxWithdrawalsValidationError TxWithdrawalsValidationError
-  | ShelleyTxCmdTxCertificatesValidationError TxCertificatesValidationError
-  | ShelleyTxCmdTxUpdateProposalValidationError TxUpdateProposalValidationError
-  | ShelleyTxCmdScriptValidityValidationError TxScriptValidityValidationError
-  | ShelleyTxCmdProtocolParamsConverstionError ProtocolParametersConversionError
-
-renderShelleyTxCmdError :: ShelleyTxCmdError -> Text
-renderShelleyTxCmdError err =
-  case err of
-    ShelleyTxCmdProtocolParamsConverstionError err' ->
-      "Error while converting protocol parameters: " <> Text.pack (displayError err')
-    ShelleyTxCmdVoteError voteErr -> Text.pack $ show voteErr
-    ShelleyTxCmdConstitutionError constErr -> Text.pack $ show constErr
-    ShelleyTxCmdReadTextViewFileError fileErr -> Text.pack (displayError fileErr)
-    ShelleyTxCmdScriptFileError fileErr -> Text.pack (displayError fileErr)
-    ShelleyTxCmdReadWitnessSigningDataError witSignDataErr ->
-      renderReadWitnessSigningDataError witSignDataErr
-    ShelleyTxCmdWriteFileError fileErr -> Text.pack (displayError fileErr)
-    ShelleyTxCmdTxSubmitError res -> "Error while submitting tx: " <> res
-    ShelleyTxCmdTxSubmitErrorEraMismatch EraMismatch{ledgerEraName, otherEraName} ->
-      "The era of the node and the tx do not match. " <>
-      "The node is running in the " <> ledgerEraName <>
-      " era, but the transaction is for the " <> otherEraName <> " era."
-    ShelleyTxCmdBootstrapWitnessError sbwErr ->
-      renderShelleyBootstrapWitnessError sbwErr
-    ShelleyTxCmdTxFeatureMismatch era TxFeatureImplicitFees ->
-      "An explicit transaction fee must be specified for " <>
-      renderEra era <> " era transactions."
-
-    ShelleyTxCmdTxFeatureMismatch (AnyCardanoEra ShelleyEra)
-                                  TxFeatureValidityNoUpperBound ->
-      "A TTL must be specified for Shelley era transactions."
-
-    ShelleyTxCmdTxFeatureMismatch era feature ->
-      renderFeature feature <> " cannot be used for " <> renderEra era <>
-      " era transactions."
-
-    ShelleyTxCmdTxBodyError err' ->
-      "Transaction validaton error: " <> Text.pack (displayError err')
-
-    ShelleyTxCmdNotImplemented msg ->
-      "Feature not yet implemented: " <> msg
-
-    ShelleyTxCmdWitnessEraMismatch era era' (WitnessFile file) ->
-      "The era of a witness does not match the era of the transaction. " <>
-      "The transaction is for the " <> renderEra era <> " era, but the " <>
-      "witness in " <> textShow file <> " is for the " <> renderEra era' <> " era."
-
-    ShelleyTxCmdEraConsensusModeMismatch fp mode era ->
-       "Submitting " <> renderEra era <> " era transaction (" <> textShow fp <>
-       ") is not supported in the " <> renderMode mode <> " consensus mode."
-    ShelleyTxCmdPolicyIdsMissing policyids -> mconcat
-      [ "The \"--mint\" flag specifies an asset with a policy Id, but no "
-      , "corresponding monetary policy script has been provided as a witness "
-      , "(via the \"--mint-script-file\" flag). The policy Id in question is: "
-      , Text.intercalate ", " (map serialiseToRawBytesHexText policyids)
-      ]
-
-    ShelleyTxCmdPolicyIdsExcess policyids -> mconcat
-      [ "A script provided to witness minting does not correspond to the policy "
-      , "id of any asset specified in the \"--mint\" field. The script hash is: "
-      , Text.intercalate ", " (map serialiseToRawBytesHexText policyids)
-      ]
-    ShelleyTxCmdUnsupportedMode mode -> "Unsupported mode: " <> renderMode mode
-    ShelleyTxCmdByronEra -> "This query cannot be used for the Byron era"
-    ShelleyTxCmdEraConsensusModeMismatchTxBalance fp mode era ->
-       "Cannot balance " <> renderEra era <> " era transaction body (" <> textShow fp <>
-       ") because is not supported in the " <> renderMode mode <> " consensus mode."
-    ShelleyTxCmdBalanceTxBody err' -> Text.pack $ displayError err'
-    ShelleyTxCmdTxInsDoNotExist e ->
-      renderTxInsExistError e
-    ShelleyTxCmdPParamsErr err' -> Text.pack $ displayError err'
-    ShelleyTxCmdTextEnvCddlError textEnvErr cddlErr -> mconcat
-      [ "Failed to decode neither the cli's serialisation format nor the ledger's "
-      , "CDDL serialisation format. TextEnvelope error: " <> Text.pack (displayError textEnvErr) <> "\n"
-      , "TextEnvelopeCddl error: " <> Text.pack (displayError cddlErr)
-      ]
-    ShelleyTxCmdTxExecUnitsErr err' ->  Text.pack $ displayError err'
-    ShelleyTxCmdPlutusScriptCostErr err'-> Text.pack $ displayError err'
-    ShelleyTxCmdPParamExecutionUnitsNotAvailable -> mconcat
-      [ "Execution units not available in the protocol parameters. This is "
-      , "likely due to not being in the Alonzo era"
-      ]
-    ShelleyTxCmdTxEraCastErr (EraCastError value fromEra toEra) ->
-      "Unable to cast era from " <> textShow fromEra <> " to " <> textShow toEra <> " the value " <> textShow value
-    ShelleyTxCmdQueryConvenienceError e ->
-      renderQueryConvenienceError e
-    ShelleyTxCmdQueryNotScriptLocked e ->
-      renderNotScriptLockedTxInsError e
-    ShelleyTxCmdPlutusScriptsRequireCardanoMode ->
-      "Plutus scripts are only available in CardanoMode"
-    ShelleyTxCmdProtocolParametersNotPresentInTxBody ->
-      "Protocol parameters were not found in transaction body"
-    ShelleyTxCmdMetadataError e -> renderMetadataError e
-    ShelleyTxCmdScriptWitnessError e -> renderScriptWitnessError e
-    ShelleyTxCmdScriptDataError e -> renderScriptDataError e
-    ShelleyTxCmdProtocolParamsError e -> renderProtocolParamsError e
-    ShelleyTxCmdCddlError e -> Text.pack $ displayError e
-    ShelleyTxCmdCddlWitnessError e -> Text.pack $ displayError e
-    ShelleyTxCmdRequiredSignerError e -> Text.pack $ displayError e
-    -- Validation errors
-    ShelleyTxCmdAuxScriptsValidationError e ->
-      Text.pack $ displayError e
-    ShelleyTxCmdTotalCollateralValidationError e ->
-      Text.pack $ displayError e
-    ShelleyTxCmdReturnCollateralValidationError e ->
-      Text.pack $ displayError e
-    ShelleyTxCmdTxFeeValidationError e ->
-      Text.pack $ displayError e
-    ShelleyTxCmdTxValidityLowerBoundValidationError e ->
-      Text.pack $ displayError e
-    ShelleyTxCmdTxValidityUpperBoundValidationError e ->
-      Text.pack $ displayError e
-    ShelleyTxCmdRequiredSignersValidationError e ->
-      Text.pack $ displayError e
-    ShelleyTxCmdProtocolParametersValidationError e ->
-      Text.pack $ displayError e
-    ShelleyTxCmdTxWithdrawalsValidationError e ->
-      Text.pack $ displayError e
-    ShelleyTxCmdTxCertificatesValidationError e ->
-      Text.pack $ displayError e
-    ShelleyTxCmdTxUpdateProposalValidationError e ->
-      Text.pack $ displayError e
-    ShelleyTxCmdScriptValidityValidationError e ->
-      Text.pack $ displayError e
 
 runTransactionCmds :: LegacyTransactionCmds -> ExceptT ShelleyTxCmdError IO ()
 runTransactionCmds cmd =

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Transaction.hs
@@ -27,6 +27,7 @@ import           Cardano.CLI.Legacy.Run.Genesis
 import           Cardano.CLI.Legacy.Run.Validate
 import           Cardano.CLI.Read
 import           Cardano.CLI.Types.Common
+import           Cardano.CLI.Types.Errors.ShelleyBootstrapWitnessError
 import           Cardano.CLI.Types.Governance
 import           Cardano.CLI.Types.Output
 import           Ouroboros.Consensus.Cardano.Block (EraMismatch (..))
@@ -1293,23 +1294,6 @@ partitionSomeWitnesses = reversePartitionedWits . foldl' go mempty
           (byronWit:byronAcc, shelleyKeyAcc)
         AShelleyKeyWitness shelleyKeyWit ->
           (byronAcc, shelleyKeyWit:shelleyKeyAcc)
-
-
--- | Error constructing a Shelley bootstrap witness (i.e. a Byron key witness
--- in the Shelley era).
-data ShelleyBootstrapWitnessError
-  = MissingNetworkIdOrByronAddressError
-  -- ^ Neither a network ID nor a Byron address were provided to construct the
-  -- Shelley bootstrap witness. One or the other is required.
-  deriving Show
-
--- | Render an error message for a 'ShelleyBootstrapWitnessError'.
-renderShelleyBootstrapWitnessError :: ShelleyBootstrapWitnessError -> Text
-renderShelleyBootstrapWitnessError MissingNetworkIdOrByronAddressError =
-  "Transactions witnessed by a Byron signing key must be accompanied by a "
-    <> "network ID. Either provide a network ID or provide a Byron "
-    <> "address with each Byron signing key (network IDs can be derived "
-    <> "from Byron addresses)."
 
 -- | Construct a Shelley bootstrap witness (i.e. a Byron key witness in the
 -- Shelley era).

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Transaction.hs
@@ -30,6 +30,7 @@ import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Errors.ShelleyBootstrapWitnessError
 import           Cardano.CLI.Types.Governance
 import           Cardano.CLI.Types.Output
+import           Cardano.CLI.Types.TxFeature
 import           Ouroboros.Consensus.Cardano.Block (EraMismatch (..))
 import qualified Ouroboros.Network.Protocol.LocalTxSubmission.Client as Net.Tx
 
@@ -243,31 +244,6 @@ renderShelleyTxCmdError err =
       Text.pack $ displayError e
     ShelleyTxCmdScriptValidityValidationError e ->
       Text.pack $ displayError e
-
-renderFeature :: TxFeature -> Text
-renderFeature TxFeatureShelleyAddresses     = "Shelley addresses"
-renderFeature TxFeatureExplicitFees         = "Explicit fees"
-renderFeature TxFeatureImplicitFees         = "Implicit fees"
-renderFeature TxFeatureValidityLowerBound   = "A validity lower bound"
-renderFeature TxFeatureValidityUpperBound   = "A validity upper bound"
-renderFeature TxFeatureValidityNoUpperBound = "An absent validity upper bound"
-renderFeature TxFeatureTxMetadata           = "Transaction metadata"
-renderFeature TxFeatureAuxScripts           = "Auxiliary scripts"
-renderFeature TxFeatureWithdrawals          = "Reward account withdrawals"
-renderFeature TxFeatureCertificates         = "Certificates"
-renderFeature TxFeatureMintValue            = "Asset minting"
-renderFeature TxFeatureMultiAssetOutputs    = "Multi-Asset outputs"
-renderFeature TxFeatureScriptWitnesses      = "Script witnesses"
-renderFeature TxFeatureShelleyKeys          = "Shelley keys"
-renderFeature TxFeatureCollateral           = "Collateral inputs"
-renderFeature TxFeatureProtocolParameters   = "Protocol parameters"
-renderFeature TxFeatureTxOutDatum           = "Transaction output datums"
-renderFeature TxFeatureScriptValidity       = "Script validity"
-renderFeature TxFeatureExtraKeyWits         = "Required signers"
-renderFeature TxFeatureInlineDatums         = "Inline datums"
-renderFeature TxFeatureTotalCollateral      = "Total collateral"
-renderFeature TxFeatureReferenceInputs      = "Reference inputs"
-renderFeature TxFeatureReturnCollateral     = "Return collateral"
 
 runTransactionCmds :: LegacyTransactionCmds -> ExceptT ShelleyTxCmdError IO ()
 runTransactionCmds cmd =
@@ -807,34 +783,6 @@ runTxBuild
 -- ----------------------------------------------------------------------------
 -- Transaction body validation and conversion
 --
-
--- | An enumeration of era-dependent features where we have to check that it
--- is permissible to use this feature in this era.
---
-data TxFeature = TxFeatureShelleyAddresses
-               | TxFeatureExplicitFees
-               | TxFeatureImplicitFees
-               | TxFeatureValidityLowerBound
-               | TxFeatureValidityUpperBound
-               | TxFeatureValidityNoUpperBound
-               | TxFeatureTxMetadata
-               | TxFeatureAuxScripts
-               | TxFeatureWithdrawals
-               | TxFeatureCertificates
-               | TxFeatureMintValue
-               | TxFeatureMultiAssetOutputs
-               | TxFeatureScriptWitnesses
-               | TxFeatureShelleyKeys
-               | TxFeatureCollateral
-               | TxFeatureProtocolParameters
-               | TxFeatureTxOutDatum
-               | TxFeatureScriptValidity
-               | TxFeatureExtraKeyWits
-               | TxFeatureInlineDatums
-               | TxFeatureTotalCollateral
-               | TxFeatureReferenceInputs
-               | TxFeatureReturnCollateral
-  deriving Show
 
 txFeatureMismatch :: ()
   => Monad m

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Transaction.hs
@@ -25,11 +25,11 @@ import           Cardano.Api.Shelley
 import           Cardano.CLI.Json.Friendly (friendlyTxBS, friendlyTxBodyBS)
 import           Cardano.CLI.Legacy.Commands.Transaction
 import           Cardano.CLI.Legacy.Run.Genesis
-import           Cardano.CLI.Legacy.Run.Validate
 import           Cardano.CLI.Read
 import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Errors.ShelleyBootstrapWitnessError
 import           Cardano.CLI.Types.Errors.ShelleyTxCmdError
+import           Cardano.CLI.Types.Errors.TxValidationError
 import           Cardano.CLI.Types.Governance
 import           Cardano.CLI.Types.Output
 import           Cardano.CLI.Types.TxFeature

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/CardanoAddressSigningKeyConversionError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/CardanoAddressSigningKeyConversionError.hs
@@ -1,0 +1,36 @@
+module Cardano.CLI.Types.Errors.CardanoAddressSigningKeyConversionError
+  ( CardanoAddressSigningKeyConversionError(..)
+  , renderCardanoAddressSigningKeyConversionError
+  ) where
+
+import           Cardano.Api
+
+import           Data.ByteString (ByteString)
+import           Data.Text (Text)
+import qualified Data.Text as Text
+
+-- | An error that can occur while converting a @cardano-address@ extended
+-- signing key.
+data CardanoAddressSigningKeyConversionError
+  = CardanoAddressSigningKeyBech32DecodeError !Bech32DecodeError
+  -- ^ There was an error in decoding the string as Bech32.
+  | CardanoAddressSigningKeyDeserialisationError !ByteString
+  -- ^ There was an error in converting the @cardano-address@ extended signing
+  -- key.
+  deriving (Show, Eq)
+
+instance Error CardanoAddressSigningKeyConversionError where
+  displayError = Text.unpack . renderCardanoAddressSigningKeyConversionError
+
+-- | Render an error message for a 'CardanoAddressSigningKeyConversionError'.
+renderCardanoAddressSigningKeyConversionError
+  :: CardanoAddressSigningKeyConversionError
+  -> Text
+renderCardanoAddressSigningKeyConversionError err =
+  case err of
+    CardanoAddressSigningKeyBech32DecodeError decErr ->
+      Text.pack (displayError decErr)
+    CardanoAddressSigningKeyDeserialisationError _bs ->
+      -- Sensitive data, such as the signing key, is purposely not included in
+      -- the error message.
+      "Error deserialising cardano-address signing key."

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/ItnKeyConversionError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/ItnKeyConversionError.hs
@@ -1,0 +1,42 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Cardano.CLI.Types.Errors.ItnKeyConversionError
+  ( ItnKeyConversionError(..)
+  , renderConversionError
+  ) where
+
+import           Cardano.Api
+
+import           Control.Exception (Exception (..), IOException)
+import           Data.ByteString (ByteString)
+import qualified Data.ByteString.Char8 as BSC
+import           Data.Text (Text)
+import qualified Data.Text as Text
+
+-- | An error that can occur while converting an Incentivized Testnet (ITN)
+-- key.
+data ItnKeyConversionError
+  = ItnKeyBech32DecodeError !Bech32DecodeError
+  | ItnReadBech32FileError !FilePath !IOException
+  | ItnSigningKeyDeserialisationError !ByteString
+  | ItnVerificationKeyDeserialisationError !ByteString
+  deriving Show
+
+-- | Render an error message for an 'ItnKeyConversionError'.
+renderConversionError :: ItnKeyConversionError -> Text
+renderConversionError err =
+  case err of
+    ItnKeyBech32DecodeError decErr ->
+      "Error decoding Bech32 key: " <> Text.pack (displayError decErr)
+    ItnReadBech32FileError fp readErr ->
+      "Error reading Bech32 key at: " <> textShow fp
+                        <> " Error: " <> Text.pack (displayException readErr)
+    ItnSigningKeyDeserialisationError _sKey ->
+      -- Sensitive data, such as the signing key, is purposely not included in
+      -- the error message.
+      "Error deserialising signing key."
+    ItnVerificationKeyDeserialisationError vKey ->
+      "Error deserialising verification key: " <> textShow (BSC.unpack vKey)

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/ProtocolParamsError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/ProtocolParamsError.hs
@@ -1,0 +1,24 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Cardano.CLI.Types.Errors.ProtocolParamsError
+  ( ProtocolParamsError(..)
+  , renderProtocolParamsError
+  ) where
+
+import           Cardano.Api
+
+import           Data.Text (Text)
+import qualified Data.Text as Text
+
+data ProtocolParamsError
+  = ProtocolParamsErrorFile (FileError ())
+  | ProtocolParamsErrorJSON !FilePath !Text
+
+renderProtocolParamsError :: ProtocolParamsError -> Text
+renderProtocolParamsError (ProtocolParamsErrorFile fileErr) =
+  Text.pack $ displayError fileErr
+renderProtocolParamsError (ProtocolParamsErrorJSON fp jsonErr) =
+  "Error while decoding the protocol parameters at: " <> Text.pack fp <> " Error: " <> jsonErr

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/ShelleyAddressCmdError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/ShelleyAddressCmdError.hs
@@ -1,0 +1,44 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Cardano.CLI.Types.Errors.ShelleyAddressCmdError
+  ( ShelleyAddressCmdError(..)
+  , renderShelleyAddressCmdError
+  ) where
+
+import           Cardano.Api
+
+import           Cardano.CLI.Read
+import           Cardano.CLI.Types.Errors.ShelleyAddressInfoError
+import           Cardano.CLI.Types.Key (VerificationKeyTextOrFileError (..),
+                   renderVerificationKeyTextOrFileError)
+
+import           Data.Text (Text)
+import qualified Data.Text as Text
+
+data ShelleyAddressCmdError
+  = ShelleyAddressCmdAddressInfoError !ShelleyAddressInfoError
+  | ShelleyAddressCmdReadKeyFileError !(FileError InputDecodeError)
+  | ShelleyAddressCmdReadScriptFileError !(FileError ScriptDecodeError)
+  | ShelleyAddressCmdVerificationKeyTextOrFileError !VerificationKeyTextOrFileError
+  | ShelleyAddressCmdWriteFileError !(FileError ())
+  | ShelleyAddressCmdExpectedPaymentVerificationKey SomeAddressVerificationKey
+  deriving Show
+
+renderShelleyAddressCmdError :: ShelleyAddressCmdError -> Text
+renderShelleyAddressCmdError err =
+  case err of
+    ShelleyAddressCmdAddressInfoError addrInfoErr ->
+      Text.pack (displayError addrInfoErr)
+    ShelleyAddressCmdReadKeyFileError fileErr ->
+      Text.pack (displayError fileErr)
+    ShelleyAddressCmdVerificationKeyTextOrFileError vkTextOrFileErr ->
+      renderVerificationKeyTextOrFileError vkTextOrFileErr
+    ShelleyAddressCmdReadScriptFileError fileErr ->
+      Text.pack (displayError fileErr)
+    ShelleyAddressCmdWriteFileError fileErr -> Text.pack (displayError fileErr)
+    ShelleyAddressCmdExpectedPaymentVerificationKey someAddress ->
+      "Expected payment verification key but got: " <> renderSomeAddressVerificationKey someAddress

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/ShelleyAddressInfoError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/ShelleyAddressInfoError.hs
@@ -1,0 +1,14 @@
+module Cardano.CLI.Types.Errors.ShelleyAddressInfoError
+  ( ShelleyAddressInfoError(..)
+  ) where
+
+import           Cardano.Api
+
+import           Data.Text (Text)
+
+newtype ShelleyAddressInfoError = ShelleyAddressInvalid Text
+  deriving Show
+
+instance Error ShelleyAddressInfoError where
+  displayError (ShelleyAddressInvalid addrTxt) =
+    "Invalid address: " <> show addrTxt

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/ShelleyBootstrapWitnessError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/ShelleyBootstrapWitnessError.hs
@@ -1,0 +1,22 @@
+module Cardano.CLI.Types.Errors.ShelleyBootstrapWitnessError
+  ( ShelleyBootstrapWitnessError(..)
+  , renderShelleyBootstrapWitnessError
+  ) where
+
+import           Data.Text (Text)
+
+-- | Error constructing a Shelley bootstrap witness (i.e. a Byron key witness
+-- in the Shelley era).
+data ShelleyBootstrapWitnessError
+  = MissingNetworkIdOrByronAddressError
+  -- ^ Neither a network ID nor a Byron address were provided to construct the
+  -- Shelley bootstrap witness. One or the other is required.
+  deriving Show
+
+-- | Render an error message for a 'ShelleyBootstrapWitnessError'.
+renderShelleyBootstrapWitnessError :: ShelleyBootstrapWitnessError -> Text
+renderShelleyBootstrapWitnessError MissingNetworkIdOrByronAddressError =
+  "Transactions witnessed by a Byron signing key must be accompanied by a "
+    <> "network ID. Either provide a network ID or provide a Byron "
+    <> "address with each Byron signing key (network IDs can be derived "
+    <> "from Byron addresses)."

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/ShelleyGenesisCmdError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/ShelleyGenesisCmdError.hs
@@ -9,12 +9,12 @@ import           Cardano.Api
 
 import           Cardano.CLI.Byron.Genesis as Byron
 import           Cardano.CLI.Legacy.Run.Address
-import           Cardano.CLI.Legacy.Run.Pool (ShelleyPoolCmdError (..), renderShelleyPoolCmdError)
 import           Cardano.CLI.Legacy.Run.StakeAddress (ShelleyStakeAddressCmdError (..))
 import           Cardano.CLI.Orphans ()
 import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Errors.ShelleyAddressCmdError
 import           Cardano.CLI.Types.Errors.ShelleyNodeCmdError
+import           Cardano.CLI.Types.Errors.ShelleyPoolCmdError
 
 import           Control.Exception (IOException)
 import           Data.Text (Text)

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/ShelleyGenesisCmdError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/ShelleyGenesisCmdError.hs
@@ -8,13 +8,12 @@ module Cardano.CLI.Types.Errors.ShelleyGenesisCmdError
 import           Cardano.Api
 
 import           Cardano.CLI.Byron.Genesis as Byron
-import           Cardano.CLI.Legacy.Run.Address
-import           Cardano.CLI.Legacy.Run.StakeAddress (ShelleyStakeAddressCmdError (..))
 import           Cardano.CLI.Orphans ()
 import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Errors.ShelleyAddressCmdError
 import           Cardano.CLI.Types.Errors.ShelleyNodeCmdError
 import           Cardano.CLI.Types.Errors.ShelleyPoolCmdError
+import           Cardano.CLI.Types.Errors.ShelleyStakeAddressCmdError
 
 import           Control.Exception (IOException)
 import           Data.Text (Text)

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/ShelleyGenesisCmdError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/ShelleyGenesisCmdError.hs
@@ -9,12 +9,12 @@ import           Cardano.Api
 
 import           Cardano.CLI.Byron.Genesis as Byron
 import           Cardano.CLI.Legacy.Run.Address
-import           Cardano.CLI.Legacy.Run.Node (ShelleyNodeCmdError (..), renderShelleyNodeCmdError)
 import           Cardano.CLI.Legacy.Run.Pool (ShelleyPoolCmdError (..), renderShelleyPoolCmdError)
 import           Cardano.CLI.Legacy.Run.StakeAddress (ShelleyStakeAddressCmdError (..))
 import           Cardano.CLI.Orphans ()
 import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Errors.ShelleyAddressCmdError
+import           Cardano.CLI.Types.Errors.ShelleyNodeCmdError
 
 import           Control.Exception (IOException)
 import           Data.Text (Text)

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/ShelleyGenesisCmdError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/ShelleyGenesisCmdError.hs
@@ -1,0 +1,88 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE LambdaCase #-}
+
+module Cardano.CLI.Types.Errors.ShelleyGenesisCmdError
+  ( ShelleyGenesisCmdError(..)
+  ) where
+
+import           Cardano.Api
+
+import           Cardano.CLI.Byron.Genesis as Byron
+import           Cardano.CLI.Legacy.Run.Address
+import           Cardano.CLI.Legacy.Run.Node (ShelleyNodeCmdError (..), renderShelleyNodeCmdError)
+import           Cardano.CLI.Legacy.Run.Pool (ShelleyPoolCmdError (..), renderShelleyPoolCmdError)
+import           Cardano.CLI.Legacy.Run.StakeAddress (ShelleyStakeAddressCmdError (..))
+import           Cardano.CLI.Orphans ()
+import           Cardano.CLI.Types.Common
+import           Cardano.CLI.Types.Errors.ShelleyAddressCmdError
+
+import           Control.Exception (IOException)
+import           Data.Text (Text)
+import qualified Data.Text as Text
+
+data ShelleyGenesisCmdError
+  = ShelleyGenesisCmdAesonDecodeError !FilePath !Text
+  | ShelleyGenesisCmdGenesisFileReadError !(FileError IOException)
+  | ShelleyGenesisCmdGenesisFileDecodeError !FilePath !Text
+  | ShelleyGenesisCmdGenesisFileError !(FileError ())
+  | ShelleyGenesisCmdFileError !(FileError ())
+  | ShelleyGenesisCmdMismatchedGenesisKeyFiles [Int] [Int] [Int]
+  | ShelleyGenesisCmdFilesNoIndex [FilePath]
+  | ShelleyGenesisCmdFilesDupIndex [FilePath]
+  | ShelleyGenesisCmdTextEnvReadFileError !(FileError TextEnvelopeError)
+  | ShelleyGenesisCmdUnexpectedAddressVerificationKey !(VerificationKeyFile In) !Text !SomeAddressVerificationKey
+  | ShelleyGenesisCmdTooFewPoolsForBulkCreds !Word !Word !Word
+  | ShelleyGenesisCmdAddressCmdError !ShelleyAddressCmdError
+  | ShelleyGenesisCmdNodeCmdError !ShelleyNodeCmdError
+  | ShelleyGenesisCmdPoolCmdError !ShelleyPoolCmdError
+  | ShelleyGenesisCmdStakeAddressCmdError !ShelleyStakeAddressCmdError
+  | ShelleyGenesisCmdCostModelsError !FilePath
+  | ShelleyGenesisCmdByronError !ByronGenesisError
+  | ShelleyGenesisStakePoolRelayFileError !FilePath !IOException
+  | ShelleyGenesisStakePoolRelayJsonDecodeError !FilePath !String
+  deriving Show
+
+instance Error ShelleyGenesisCmdError where
+  displayError =
+    \case
+      ShelleyGenesisCmdAesonDecodeError fp decErr ->
+        "Error while decoding Shelley genesis at: " <> fp <> " Error: " <> Text.unpack decErr
+      ShelleyGenesisCmdGenesisFileError fe -> displayError fe
+      ShelleyGenesisCmdFileError fe -> displayError fe
+      ShelleyGenesisCmdMismatchedGenesisKeyFiles gfiles dfiles vfiles ->
+        "Mismatch between the files found:\n"
+          <> "Genesis key file indexes:      " <> show gfiles <> "\n"
+          <> "Delegate key file indexes:     " <> show dfiles <> "\n"
+          <> "Delegate VRF key file indexes: " <> show vfiles
+      ShelleyGenesisCmdFilesNoIndex files ->
+        "The genesis keys files are expected to have a numeric index but these do not:\n"
+          <> unlines files
+      ShelleyGenesisCmdFilesDupIndex files ->
+        "The genesis keys files are expected to have a unique numeric index but these do not:\n"
+          <> unlines files
+      ShelleyGenesisCmdTextEnvReadFileError fileErr -> displayError fileErr
+      ShelleyGenesisCmdUnexpectedAddressVerificationKey (File file) expect got -> mconcat
+        [ "Unexpected address verification key type in file ", file
+        , ", expected: ", Text.unpack expect, ", got: ", Text.unpack (renderSomeAddressVerificationKey got)
+        ]
+      ShelleyGenesisCmdTooFewPoolsForBulkCreds pools files perPool -> mconcat
+        [ "Number of pools requested for generation (", show pools
+        , ") is insufficient to fill ", show files
+        , " bulk files, with ", show perPool, " pools per file."
+        ]
+      ShelleyGenesisCmdAddressCmdError e -> Text.unpack $ renderShelleyAddressCmdError e
+      ShelleyGenesisCmdNodeCmdError e -> Text.unpack $ renderShelleyNodeCmdError e
+      ShelleyGenesisCmdPoolCmdError e -> Text.unpack $ renderShelleyPoolCmdError e
+      ShelleyGenesisCmdStakeAddressCmdError e -> displayError e
+      ShelleyGenesisCmdCostModelsError fp -> "Cost model is invalid: " <> fp
+      ShelleyGenesisCmdGenesisFileDecodeError fp e ->
+       "Error while decoding Shelley genesis at: " <> fp <>
+       " Error: " <>  Text.unpack e
+      ShelleyGenesisCmdGenesisFileReadError e -> displayError e
+      ShelleyGenesisCmdByronError e -> show e
+      ShelleyGenesisStakePoolRelayFileError fp e ->
+        "Error occurred while reading the stake pool relay specification file: " <> fp <>
+        " Error: " <> show e
+      ShelleyGenesisStakePoolRelayJsonDecodeError fp e ->
+        "Error occurred while decoding the stake pool relay specification file: " <> fp <>
+        " Error: " <>  e

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/ShelleyKeyCmdError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/ShelleyKeyCmdError.hs
@@ -1,0 +1,56 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Cardano.CLI.Types.Errors.ShelleyKeyCmdError
+  ( ShelleyKeyCmdError(..)
+  , renderShelleyKeyCmdError
+  ) where
+
+import           Cardano.Api
+
+import qualified Cardano.CLI.Byron.Key as Byron
+import           Cardano.CLI.Types.Errors.CardanoAddressSigningKeyConversionError
+import           Cardano.CLI.Types.Errors.ItnKeyConversionError
+import           Cardano.CLI.Types.Key
+
+import           Data.Text (Text)
+import qualified Data.Text as Text
+
+data ShelleyKeyCmdError
+  = ShelleyKeyCmdReadFileError !(FileError TextEnvelopeError)
+  | ShelleyKeyCmdReadKeyFileError !(FileError InputDecodeError)
+  | ShelleyKeyCmdWriteFileError !(FileError ())
+  | ShelleyKeyCmdByronKeyFailure !Byron.ByronKeyFailure
+  | ShelleyKeyCmdByronKeyParseError
+      !Text
+      -- ^ Text representation of the parse error. Unfortunately, the actual
+      -- error type isn't exported.
+  | ShelleyKeyCmdItnKeyConvError !ItnKeyConversionError
+  | ShelleyKeyCmdWrongKeyTypeError
+  | ShelleyKeyCmdCardanoAddressSigningKeyFileError
+      !(FileError CardanoAddressSigningKeyConversionError)
+  | ShelleyKeyCmdNonLegacyKey !FilePath
+  | ShelleyKeyCmdExpectedExtendedVerificationKey SomeAddressVerificationKey
+  | ShelleyKeyCmdVerificationKeyReadError VerificationKeyTextOrFileError
+  deriving Show
+
+renderShelleyKeyCmdError :: ShelleyKeyCmdError -> Text
+renderShelleyKeyCmdError err =
+  case err of
+    ShelleyKeyCmdReadFileError fileErr -> Text.pack (displayError fileErr)
+    ShelleyKeyCmdReadKeyFileError fileErr -> Text.pack (displayError fileErr)
+    ShelleyKeyCmdWriteFileError fileErr -> Text.pack (displayError fileErr)
+    ShelleyKeyCmdByronKeyFailure e -> Byron.renderByronKeyFailure e
+    ShelleyKeyCmdByronKeyParseError errTxt -> errTxt
+    ShelleyKeyCmdItnKeyConvError convErr -> renderConversionError convErr
+    ShelleyKeyCmdWrongKeyTypeError ->
+      Text.pack "Please use a signing key file when converting ITN BIP32 or Extended keys"
+    ShelleyKeyCmdCardanoAddressSigningKeyFileError fileErr ->
+      Text.pack (displayError fileErr)
+    ShelleyKeyCmdNonLegacyKey fp ->
+      "Signing key at: " <> Text.pack fp <> " is not a legacy Byron signing key and should not need to be converted."
+    ShelleyKeyCmdVerificationKeyReadError e -> renderVerificationKeyTextOrFileError e
+    ShelleyKeyCmdExpectedExtendedVerificationKey someVerKey ->
+      "Expected an extended verification key but got: " <> renderSomeAddressVerificationKey someVerKey

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/ShelleyNodeCmdError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/ShelleyNodeCmdError.hs
@@ -1,0 +1,41 @@
+{-# LANGUAGE DataKinds #-}
+
+module Cardano.CLI.Types.Errors.ShelleyNodeCmdError
+  ( ShelleyNodeCmdError(..)
+  , renderShelleyNodeCmdError
+  ) where
+
+import           Cardano.Api
+
+import           Data.Text (Text)
+import qualified Data.Text as Text
+
+{- HLINT ignore "Reduce duplication" -}
+
+data ShelleyNodeCmdError
+  = ShelleyNodeCmdReadFileError !(FileError TextEnvelopeError)
+  | ShelleyNodeCmdReadKeyFileError !(FileError InputDecodeError)
+  | ShelleyNodeCmdWriteFileError !(FileError ())
+  | ShelleyNodeCmdOperationalCertificateIssueError !OperationalCertIssueError
+  | ShelleyNodeCmdVrfSigningKeyCreationError
+      FilePath
+      -- ^ Target path
+      FilePath
+      -- ^ Temp path
+  deriving Show
+
+renderShelleyNodeCmdError :: ShelleyNodeCmdError -> Text
+renderShelleyNodeCmdError err =
+  case err of
+    ShelleyNodeCmdVrfSigningKeyCreationError targetPath tempPath ->
+      Text.pack $ "Error creating VRF signing key file. Target path: " <> targetPath
+      <> " Temporary path: " <> tempPath
+
+    ShelleyNodeCmdReadFileError fileErr -> Text.pack (displayError fileErr)
+
+    ShelleyNodeCmdReadKeyFileError fileErr -> Text.pack (displayError fileErr)
+
+    ShelleyNodeCmdWriteFileError fileErr -> Text.pack (displayError fileErr)
+
+    ShelleyNodeCmdOperationalCertificateIssueError issueErr ->
+      Text.pack (displayError issueErr)

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/ShelleyPoolCmdError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/ShelleyPoolCmdError.hs
@@ -1,0 +1,29 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE RankNTypes #-}
+
+module Cardano.CLI.Types.Errors.ShelleyPoolCmdError
+  ( ShelleyPoolCmdError(..)
+  , renderShelleyPoolCmdError
+  ) where
+
+import           Cardano.Api
+
+import           Data.Text (Text)
+import qualified Data.Text as Text
+
+data ShelleyPoolCmdError
+  = ShelleyPoolCmdReadFileError !(FileError TextEnvelopeError)
+  | ShelleyPoolCmdReadKeyFileError !(FileError InputDecodeError)
+  | ShelleyPoolCmdWriteFileError !(FileError ())
+  | ShelleyPoolCmdMetadataValidationError !StakePoolMetadataValidationError
+  deriving Show
+
+renderShelleyPoolCmdError :: ShelleyPoolCmdError -> Text
+renderShelleyPoolCmdError err =
+  case err of
+    ShelleyPoolCmdReadFileError fileErr -> Text.pack (displayError fileErr)
+    ShelleyPoolCmdReadKeyFileError fileErr -> Text.pack (displayError fileErr)
+    ShelleyPoolCmdWriteFileError fileErr -> Text.pack (displayError fileErr)
+    ShelleyPoolCmdMetadataValidationError validationErr ->
+      "Error validating stake pool metadata: " <> Text.pack (displayError validationErr)

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/ShelleyQueryCmdError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/ShelleyQueryCmdError.hs
@@ -1,0 +1,91 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Cardano.CLI.Types.Errors.ShelleyQueryCmdError
+  ( ShelleyQueryCmdError(..)
+  , renderShelleyQueryCmdError
+  ) where
+
+import           Cardano.Api hiding (QueryInShelleyBasedEra (..))
+import           Cardano.Api.Shelley hiding (QueryInShelleyBasedEra (..))
+
+import           Cardano.Binary (DecoderError)
+import           Cardano.CLI.Helpers (HelpersError (..), renderHelpersError)
+import           Cardano.CLI.Types.Errors.ShelleyGenesisCmdError
+import           Cardano.CLI.Types.Errors.ShelleyQueryCmdLocalStateQueryError
+import           Ouroboros.Consensus.Cardano.Block as Consensus (EraMismatch (..))
+import qualified Ouroboros.Consensus.HardFork.History.Qry as Qry
+
+import qualified Data.ByteString.Lazy.Char8 as LBS
+import           Data.Text (Text)
+import qualified Data.Text as Text
+import           Data.Text.Lazy (toStrict)
+import           Data.Text.Lazy.Builder (toLazyText)
+import           Formatting.Buildable (build)
+
+{- HLINT ignore "Move brackets to avoid $" -}
+{- HLINT ignore "Redundant flip" -}
+
+data ShelleyQueryCmdError
+  = ShelleyQueryCmdLocalStateQueryError !ShelleyQueryCmdLocalStateQueryError
+  | ShelleyQueryCmdWriteFileError !(FileError ())
+  | ShelleyQueryCmdHelpersError !HelpersError
+  | ShelleyQueryCmdAcquireFailure !AcquiringFailure
+  | ShelleyQueryCmdEraConsensusModeMismatch !AnyConsensusMode !AnyCardanoEra
+  | ShelleyQueryCmdByronEra
+  | ShelleyQueryCmdEraMismatch !EraMismatch
+  | ShelleyQueryCmdUnsupportedMode !AnyConsensusMode
+  | ShelleyQueryCmdPastHorizon !Qry.PastHorizonException
+  | ShelleyQueryCmdSystemStartUnavailable
+  | ShelleyQueryCmdGenesisReadError !ShelleyGenesisCmdError
+  | ShelleyQueryCmdLeaderShipError !LeadershipError
+  | ShelleyQueryCmdTextEnvelopeReadError !(FileError TextEnvelopeError)
+  | ShelleyQueryCmdTextReadError !(FileError InputDecodeError)
+  | ShelleyQueryCmdOpCertCounterReadError !(FileError TextEnvelopeError)
+  | ShelleyQueryCmdProtocolStateDecodeFailure !(LBS.ByteString, DecoderError)
+  | ShelleyQueryCmdPoolStateDecodeError DecoderError
+  | ShelleyQueryCmdStakeSnapshotDecodeError DecoderError
+  | ShelleyQueryCmdUnsupportedNtcVersion !UnsupportedNtcVersionError
+  | ShelleyQueryCmdProtocolParameterConversionError !ProtocolParametersConversionError
+  deriving Show
+
+renderShelleyQueryCmdError :: ShelleyQueryCmdError -> Text
+renderShelleyQueryCmdError err =
+  case err of
+    ShelleyQueryCmdLocalStateQueryError lsqErr -> renderLocalStateQueryError lsqErr
+    ShelleyQueryCmdWriteFileError fileErr -> Text.pack (displayError fileErr)
+    ShelleyQueryCmdHelpersError helpersErr -> renderHelpersError helpersErr
+    ShelleyQueryCmdAcquireFailure acquireFail -> Text.pack $ show acquireFail
+    ShelleyQueryCmdByronEra -> "This query cannot be used for the Byron era"
+    ShelleyQueryCmdEraConsensusModeMismatch (AnyConsensusMode cMode) (AnyCardanoEra era) ->
+      "Consensus mode and era mismatch. Consensus mode: " <> textShow cMode <>
+      " Era: " <> textShow era
+    ShelleyQueryCmdEraMismatch (EraMismatch ledgerEra queryEra) ->
+      "\nAn error mismatch occurred." <> "\nSpecified query era: " <> queryEra <>
+      "\nCurrent ledger era: " <> ledgerEra
+    ShelleyQueryCmdUnsupportedMode mode -> "Unsupported mode: " <> renderMode mode
+    ShelleyQueryCmdPastHorizon e -> "Past horizon: " <> textShow e
+    ShelleyQueryCmdSystemStartUnavailable -> "System start unavailable"
+    ShelleyQueryCmdGenesisReadError err' -> Text.pack $ displayError err'
+    ShelleyQueryCmdLeaderShipError e -> Text.pack $ displayError e
+    ShelleyQueryCmdTextEnvelopeReadError e -> Text.pack $ displayError e
+    ShelleyQueryCmdTextReadError e -> Text.pack $ displayError e
+    ShelleyQueryCmdOpCertCounterReadError e -> Text.pack $ displayError e
+    ShelleyQueryCmdProtocolStateDecodeFailure (_, decErr) ->
+      "Failed to decode the protocol state: " <> toStrict (toLazyText $ build decErr)
+    ShelleyQueryCmdPoolStateDecodeError decoderError ->
+      "Failed to decode PoolState.  Error: " <> Text.pack (show decoderError)
+    ShelleyQueryCmdStakeSnapshotDecodeError decoderError ->
+      "Failed to decode StakeSnapshot.  Error: " <> Text.pack (show decoderError)
+    ShelleyQueryCmdUnsupportedNtcVersion (UnsupportedNtcVersionError minNtcVersion ntcVersion) ->
+      "Unsupported feature for the node-to-client protocol version.\n" <>
+      "This query requires at least " <> textShow minNtcVersion <> " but the node negotiated " <> textShow ntcVersion <> ".\n" <>
+      "Later node versions support later protocol versions (but development protocol versions are not enabled in the node by default)."
+    ShelleyQueryCmdProtocolParameterConversionError ppce ->
+      Text.pack $ "Failed to convert protocol parameter: " <> displayError ppce

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/ShelleyQueryCmdLocalStateQueryError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/ShelleyQueryCmdLocalStateQueryError.hs
@@ -1,0 +1,23 @@
+module Cardano.CLI.Types.Errors.ShelleyQueryCmdLocalStateQueryError
+  ( ShelleyQueryCmdLocalStateQueryError(..)
+  , renderLocalStateQueryError
+  ) where
+
+import           Cardano.Api
+
+import           Ouroboros.Consensus.Cardano.Block (EraMismatch (..))
+
+import           Data.Text (Text)
+
+-- | An error that can occur while querying a node's local state.
+newtype ShelleyQueryCmdLocalStateQueryError
+  = EraMismatchError EraMismatch
+  -- ^ A query from a certain era was applied to a ledger from a different
+  -- era.
+  deriving (Eq, Show)
+
+renderLocalStateQueryError :: ShelleyQueryCmdLocalStateQueryError -> Text
+renderLocalStateQueryError lsqErr =
+  case lsqErr of
+    EraMismatchError err ->
+      "A query from a certain era was applied to a ledger from a different era: " <> textShow err

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/ShelleyTextViewFileError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/ShelleyTextViewFileError.hs
@@ -1,0 +1,25 @@
+{-# LANGUAGE DataKinds #-}
+
+module Cardano.CLI.Types.Errors.ShelleyTextViewFileError
+  ( ShelleyTextViewFileError(..)
+  , renderShelleyTextViewFileError
+  ) where
+
+import           Cardano.Api
+
+import           Cardano.CLI.Helpers (HelpersError, renderHelpersError)
+
+import           Data.Text (Text)
+import qualified Data.Text as Text
+
+data ShelleyTextViewFileError
+  = TextViewReadFileError (FileError TextEnvelopeError)
+  | TextViewCBORPrettyPrintError !HelpersError
+  deriving Show
+
+renderShelleyTextViewFileError :: ShelleyTextViewFileError -> Text
+renderShelleyTextViewFileError err =
+  case err of
+    TextViewReadFileError fileErr -> Text.pack (displayError fileErr)
+    TextViewCBORPrettyPrintError hlprsErr ->
+      "Error pretty printing CBOR: " <> renderHelpersError hlprsErr

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/ShelleyTxCmdError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/ShelleyTxCmdError.hs
@@ -1,0 +1,211 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Cardano.CLI.Types.Errors.ShelleyTxCmdError
+  ( ShelleyTxCmdError(..)
+  , renderShelleyTxCmdError
+  ) where
+
+import           Cardano.Api
+import           Cardano.Api.Shelley
+
+import           Cardano.CLI.Legacy.Run.Genesis
+import           Cardano.CLI.Legacy.Run.Validate
+import           Cardano.CLI.Read
+import           Cardano.CLI.Types.Common
+import           Cardano.CLI.Types.Errors.ShelleyBootstrapWitnessError
+import           Cardano.CLI.Types.Output
+import           Cardano.CLI.Types.TxFeature
+import           Ouroboros.Consensus.Cardano.Block (EraMismatch (..))
+
+import           Data.Text (Text)
+import qualified Data.Text as Text
+
+{- HLINT ignore "Use let" -}
+
+data ShelleyTxCmdError
+  = ShelleyTxCmdMetadataError MetadataError
+  | ShelleyTxCmdVoteError VoteError
+  | ShelleyTxCmdConstitutionError ConstitutionError
+  | ShelleyTxCmdScriptWitnessError ScriptWitnessError
+  | ShelleyTxCmdProtocolParamsError ProtocolParamsError
+  | ShelleyTxCmdScriptFileError (FileError ScriptDecodeError)
+  | ShelleyTxCmdReadTextViewFileError !(FileError TextEnvelopeError)
+  | ShelleyTxCmdReadWitnessSigningDataError !ReadWitnessSigningDataError
+  | ShelleyTxCmdWriteFileError !(FileError ())
+  | ShelleyTxCmdEraConsensusModeMismatch
+      !(Maybe FilePath)
+      !AnyConsensusMode
+      !AnyCardanoEra
+      -- ^ Era
+  | ShelleyTxCmdBootstrapWitnessError !ShelleyBootstrapWitnessError
+  | ShelleyTxCmdTxSubmitError !Text
+  | ShelleyTxCmdTxSubmitErrorEraMismatch !EraMismatch
+  | ShelleyTxCmdTxFeatureMismatch !AnyCardanoEra !TxFeature
+  | ShelleyTxCmdTxBodyError !TxBodyError
+  | ShelleyTxCmdNotImplemented !Text
+  | ShelleyTxCmdWitnessEraMismatch !AnyCardanoEra !AnyCardanoEra !WitnessFile
+  | ShelleyTxCmdPolicyIdsMissing ![PolicyId]
+  | ShelleyTxCmdPolicyIdsExcess  ![PolicyId]
+  | ShelleyTxCmdUnsupportedMode !AnyConsensusMode
+  | ShelleyTxCmdByronEra
+  | ShelleyTxCmdEraConsensusModeMismatchTxBalance
+      !TxBuildOutputOptions
+      !AnyConsensusMode
+      !AnyCardanoEra
+  | ShelleyTxCmdBalanceTxBody !TxBodyErrorAutoBalance
+  | ShelleyTxCmdTxInsDoNotExist !TxInsExistError
+  | ShelleyTxCmdPParamsErr !ProtocolParametersError
+  | ShelleyTxCmdTextEnvCddlError
+      !(FileError TextEnvelopeError)
+      !(FileError TextEnvelopeCddlError)
+  | ShelleyTxCmdTxExecUnitsErr !TransactionValidityError
+  | ShelleyTxCmdPlutusScriptCostErr !PlutusScriptCostError
+  | ShelleyTxCmdPParamExecutionUnitsNotAvailable
+  | ShelleyTxCmdPlutusScriptsRequireCardanoMode
+  | ShelleyTxCmdProtocolParametersNotPresentInTxBody
+  | ShelleyTxCmdTxEraCastErr EraCastError
+  | ShelleyTxCmdQueryConvenienceError !QueryConvenienceError
+  | ShelleyTxCmdQueryNotScriptLocked !ScriptLockedTxInsError
+  | ShelleyTxCmdScriptDataError !ScriptDataError
+  | ShelleyTxCmdCddlError CddlError
+  | ShelleyTxCmdCddlWitnessError CddlWitnessError
+  | ShelleyTxCmdRequiredSignerError RequiredSignerError
+  -- Validation errors
+  | ShelleyTxCmdAuxScriptsValidationError TxAuxScriptsValidationError
+  | ShelleyTxCmdTotalCollateralValidationError TxTotalCollateralValidationError
+  | ShelleyTxCmdReturnCollateralValidationError TxReturnCollateralValidationError
+  | ShelleyTxCmdTxFeeValidationError TxFeeValidationError
+  | ShelleyTxCmdTxValidityLowerBoundValidationError TxValidityLowerBoundValidationError
+  | ShelleyTxCmdTxValidityUpperBoundValidationError TxValidityUpperBoundValidationError
+  | ShelleyTxCmdRequiredSignersValidationError TxRequiredSignersValidationError
+  | ShelleyTxCmdProtocolParametersValidationError TxProtocolParametersValidationError
+  | ShelleyTxCmdTxWithdrawalsValidationError TxWithdrawalsValidationError
+  | ShelleyTxCmdTxCertificatesValidationError TxCertificatesValidationError
+  | ShelleyTxCmdTxUpdateProposalValidationError TxUpdateProposalValidationError
+  | ShelleyTxCmdScriptValidityValidationError TxScriptValidityValidationError
+  | ShelleyTxCmdProtocolParamsConverstionError ProtocolParametersConversionError
+
+renderShelleyTxCmdError :: ShelleyTxCmdError -> Text
+renderShelleyTxCmdError err =
+  case err of
+    ShelleyTxCmdProtocolParamsConverstionError err' ->
+      "Error while converting protocol parameters: " <> Text.pack (displayError err')
+    ShelleyTxCmdVoteError voteErr -> Text.pack $ show voteErr
+    ShelleyTxCmdConstitutionError constErr -> Text.pack $ show constErr
+    ShelleyTxCmdReadTextViewFileError fileErr -> Text.pack (displayError fileErr)
+    ShelleyTxCmdScriptFileError fileErr -> Text.pack (displayError fileErr)
+    ShelleyTxCmdReadWitnessSigningDataError witSignDataErr ->
+      renderReadWitnessSigningDataError witSignDataErr
+    ShelleyTxCmdWriteFileError fileErr -> Text.pack (displayError fileErr)
+    ShelleyTxCmdTxSubmitError res -> "Error while submitting tx: " <> res
+    ShelleyTxCmdTxSubmitErrorEraMismatch EraMismatch{ledgerEraName, otherEraName} ->
+      "The era of the node and the tx do not match. " <>
+      "The node is running in the " <> ledgerEraName <>
+      " era, but the transaction is for the " <> otherEraName <> " era."
+    ShelleyTxCmdBootstrapWitnessError sbwErr ->
+      renderShelleyBootstrapWitnessError sbwErr
+    ShelleyTxCmdTxFeatureMismatch era TxFeatureImplicitFees ->
+      "An explicit transaction fee must be specified for " <>
+      renderEra era <> " era transactions."
+
+    ShelleyTxCmdTxFeatureMismatch (AnyCardanoEra ShelleyEra)
+                                  TxFeatureValidityNoUpperBound ->
+      "A TTL must be specified for Shelley era transactions."
+
+    ShelleyTxCmdTxFeatureMismatch era feature ->
+      renderFeature feature <> " cannot be used for " <> renderEra era <>
+      " era transactions."
+
+    ShelleyTxCmdTxBodyError err' ->
+      "Transaction validaton error: " <> Text.pack (displayError err')
+
+    ShelleyTxCmdNotImplemented msg ->
+      "Feature not yet implemented: " <> msg
+
+    ShelleyTxCmdWitnessEraMismatch era era' (WitnessFile file) ->
+      "The era of a witness does not match the era of the transaction. " <>
+      "The transaction is for the " <> renderEra era <> " era, but the " <>
+      "witness in " <> textShow file <> " is for the " <> renderEra era' <> " era."
+
+    ShelleyTxCmdEraConsensusModeMismatch fp mode era ->
+       "Submitting " <> renderEra era <> " era transaction (" <> textShow fp <>
+       ") is not supported in the " <> renderMode mode <> " consensus mode."
+    ShelleyTxCmdPolicyIdsMissing policyids -> mconcat
+      [ "The \"--mint\" flag specifies an asset with a policy Id, but no "
+      , "corresponding monetary policy script has been provided as a witness "
+      , "(via the \"--mint-script-file\" flag). The policy Id in question is: "
+      , Text.intercalate ", " (map serialiseToRawBytesHexText policyids)
+      ]
+
+    ShelleyTxCmdPolicyIdsExcess policyids -> mconcat
+      [ "A script provided to witness minting does not correspond to the policy "
+      , "id of any asset specified in the \"--mint\" field. The script hash is: "
+      , Text.intercalate ", " (map serialiseToRawBytesHexText policyids)
+      ]
+    ShelleyTxCmdUnsupportedMode mode -> "Unsupported mode: " <> renderMode mode
+    ShelleyTxCmdByronEra -> "This query cannot be used for the Byron era"
+    ShelleyTxCmdEraConsensusModeMismatchTxBalance fp mode era ->
+       "Cannot balance " <> renderEra era <> " era transaction body (" <> textShow fp <>
+       ") because is not supported in the " <> renderMode mode <> " consensus mode."
+    ShelleyTxCmdBalanceTxBody err' -> Text.pack $ displayError err'
+    ShelleyTxCmdTxInsDoNotExist e ->
+      renderTxInsExistError e
+    ShelleyTxCmdPParamsErr err' -> Text.pack $ displayError err'
+    ShelleyTxCmdTextEnvCddlError textEnvErr cddlErr -> mconcat
+      [ "Failed to decode neither the cli's serialisation format nor the ledger's "
+      , "CDDL serialisation format. TextEnvelope error: " <> Text.pack (displayError textEnvErr) <> "\n"
+      , "TextEnvelopeCddl error: " <> Text.pack (displayError cddlErr)
+      ]
+    ShelleyTxCmdTxExecUnitsErr err' ->  Text.pack $ displayError err'
+    ShelleyTxCmdPlutusScriptCostErr err'-> Text.pack $ displayError err'
+    ShelleyTxCmdPParamExecutionUnitsNotAvailable -> mconcat
+      [ "Execution units not available in the protocol parameters. This is "
+      , "likely due to not being in the Alonzo era"
+      ]
+    ShelleyTxCmdTxEraCastErr (EraCastError value fromEra toEra) ->
+      "Unable to cast era from " <> textShow fromEra <> " to " <> textShow toEra <> " the value " <> textShow value
+    ShelleyTxCmdQueryConvenienceError e ->
+      renderQueryConvenienceError e
+    ShelleyTxCmdQueryNotScriptLocked e ->
+      renderNotScriptLockedTxInsError e
+    ShelleyTxCmdPlutusScriptsRequireCardanoMode ->
+      "Plutus scripts are only available in CardanoMode"
+    ShelleyTxCmdProtocolParametersNotPresentInTxBody ->
+      "Protocol parameters were not found in transaction body"
+    ShelleyTxCmdMetadataError e -> renderMetadataError e
+    ShelleyTxCmdScriptWitnessError e -> renderScriptWitnessError e
+    ShelleyTxCmdScriptDataError e -> renderScriptDataError e
+    ShelleyTxCmdProtocolParamsError e -> renderProtocolParamsError e
+    ShelleyTxCmdCddlError e -> Text.pack $ displayError e
+    ShelleyTxCmdCddlWitnessError e -> Text.pack $ displayError e
+    ShelleyTxCmdRequiredSignerError e -> Text.pack $ displayError e
+    -- Validation errors
+    ShelleyTxCmdAuxScriptsValidationError e ->
+      Text.pack $ displayError e
+    ShelleyTxCmdTotalCollateralValidationError e ->
+      Text.pack $ displayError e
+    ShelleyTxCmdReturnCollateralValidationError e ->
+      Text.pack $ displayError e
+    ShelleyTxCmdTxFeeValidationError e ->
+      Text.pack $ displayError e
+    ShelleyTxCmdTxValidityLowerBoundValidationError e ->
+      Text.pack $ displayError e
+    ShelleyTxCmdTxValidityUpperBoundValidationError e ->
+      Text.pack $ displayError e
+    ShelleyTxCmdRequiredSignersValidationError e ->
+      Text.pack $ displayError e
+    ShelleyTxCmdProtocolParametersValidationError e ->
+      Text.pack $ displayError e
+    ShelleyTxCmdTxWithdrawalsValidationError e ->
+      Text.pack $ displayError e
+    ShelleyTxCmdTxCertificatesValidationError e ->
+      Text.pack $ displayError e
+    ShelleyTxCmdTxUpdateProposalValidationError e ->
+      Text.pack $ displayError e
+    ShelleyTxCmdScriptValidityValidationError e ->
+      Text.pack $ displayError e

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/ShelleyTxCmdError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/ShelleyTxCmdError.hs
@@ -13,9 +13,9 @@ module Cardano.CLI.Types.Errors.ShelleyTxCmdError
 import           Cardano.Api
 import           Cardano.Api.Shelley
 
-import           Cardano.CLI.Legacy.Run.Genesis
 import           Cardano.CLI.Read
 import           Cardano.CLI.Types.Common
+import           Cardano.CLI.Types.Errors.ProtocolParamsError
 import           Cardano.CLI.Types.Errors.ShelleyBootstrapWitnessError
 import           Cardano.CLI.Types.Errors.TxValidationError
 import           Cardano.CLI.Types.Output

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/ShelleyTxCmdError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/ShelleyTxCmdError.hs
@@ -14,10 +14,10 @@ import           Cardano.Api
 import           Cardano.Api.Shelley
 
 import           Cardano.CLI.Legacy.Run.Genesis
-import           Cardano.CLI.Legacy.Run.Validate
 import           Cardano.CLI.Read
 import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Errors.ShelleyBootstrapWitnessError
+import           Cardano.CLI.Types.Errors.TxValidationError
 import           Cardano.CLI.Types.Output
 import           Cardano.CLI.Types.TxFeature
 import           Ouroboros.Consensus.Cardano.Block (EraMismatch (..))

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/TxValidationError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/TxValidationError.hs
@@ -6,7 +6,7 @@
 
 {-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
 
-module Cardano.CLI.Legacy.Run.Validate
+module Cardano.CLI.Types.Errors.TxValidationError
   ( TxAuxScriptsValidationError(..)
   , TxCertificatesValidationError(..)
   , TxFeeValidationError(..)

--- a/cardano-cli/src/Cardano/CLI/Types/TxFeature.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/TxFeature.hs
@@ -1,0 +1,63 @@
+{-# LANGUAGE LambdaCase #-}
+
+module Cardano.CLI.Types.TxFeature
+  ( TxFeature(..)
+  , renderFeature
+  ) where
+
+import           Data.Text (Text)
+
+-- | An enumeration of era-dependent features where we have to check that it
+-- is permissible to use this feature in this era.
+--
+data TxFeature
+  = TxFeatureShelleyAddresses
+  | TxFeatureExplicitFees
+  | TxFeatureImplicitFees
+  | TxFeatureValidityLowerBound
+  | TxFeatureValidityUpperBound
+  | TxFeatureValidityNoUpperBound
+  | TxFeatureTxMetadata
+  | TxFeatureAuxScripts
+  | TxFeatureWithdrawals
+  | TxFeatureCertificates
+  | TxFeatureMintValue
+  | TxFeatureMultiAssetOutputs
+  | TxFeatureScriptWitnesses
+  | TxFeatureShelleyKeys
+  | TxFeatureCollateral
+  | TxFeatureProtocolParameters
+  | TxFeatureTxOutDatum
+  | TxFeatureScriptValidity
+  | TxFeatureExtraKeyWits
+  | TxFeatureInlineDatums
+  | TxFeatureTotalCollateral
+  | TxFeatureReferenceInputs
+  | TxFeatureReturnCollateral
+  deriving Show
+
+renderFeature :: TxFeature -> Text
+renderFeature = \case
+  TxFeatureShelleyAddresses     -> "Shelley addresses"
+  TxFeatureExplicitFees         -> "Explicit fees"
+  TxFeatureImplicitFees         -> "Implicit fees"
+  TxFeatureValidityLowerBound   -> "A validity lower bound"
+  TxFeatureValidityUpperBound   -> "A validity upper bound"
+  TxFeatureValidityNoUpperBound -> "An absent validity upper bound"
+  TxFeatureTxMetadata           -> "Transaction metadata"
+  TxFeatureAuxScripts           -> "Auxiliary scripts"
+  TxFeatureWithdrawals          -> "Reward account withdrawals"
+  TxFeatureCertificates         -> "Certificates"
+  TxFeatureMintValue            -> "Asset minting"
+  TxFeatureMultiAssetOutputs    -> "Multi-Asset outputs"
+  TxFeatureScriptWitnesses      -> "Script witnesses"
+  TxFeatureShelleyKeys          -> "Shelley keys"
+  TxFeatureCollateral           -> "Collateral inputs"
+  TxFeatureProtocolParameters   -> "Protocol parameters"
+  TxFeatureTxOutDatum           -> "Transaction output datums"
+  TxFeatureScriptValidity       -> "Script validity"
+  TxFeatureExtraKeyWits         -> "Required signers"
+  TxFeatureInlineDatums         -> "Inline datums"
+  TxFeatureTotalCollateral      -> "Total collateral"
+  TxFeatureReferenceInputs      -> "Reference inputs"
+  TxFeatureReturnCollateral     -> "Return collateral"


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Move legacy errors out of legacy command structure modules
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Having error types defined in command structure modules makes it difficult to move command structure code and prevents re-use.  See earlier merged PR for explanation.

https://github.com/input-output-hk/cardano-cli/pull/188

Having the error types defined outside of the command structure is a pre-requisite to sharing code between era-based and legacy command structure code.

For example one of the things I want do to do is move `runTxBuildCmd` into era-based and then create a `runLegacyTxBuildCmd` function that delegates to it, but to do that both functions should return the same error type so the error types have to be in a location that is sharable and does not obstruct this kind of refactoring.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
