### PR TITLE
Add test for conway governance action create-constitution

### DIFF
--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -210,12 +210,16 @@ library cardano-cli-test-lib
   visibility:           public
   hs-source-dirs:       test/cardano-cli-test-lib
   exposed-modules:      Test.Cardano.CLI.Util
-  build-depends:        cardano-api
+  build-depends:        aeson
+                      , aeson-pretty
+                      , bytestring
+                      , cardano-api
                       , cardano-cli
                       , exceptions
                       , hedgehog
                       , hedgehog-extras ^>= 0.4.7.0
                       , process
+                      , text
                       , transformers
 
 test-suite cardano-cli-test
@@ -302,6 +306,7 @@ test-suite cardano-cli-golden
                         Test.Golden.Byron.Vote
                         Test.Golden.Byron.Witness
                         Test.Golden.ErrorsSpec
+                        Test.Golden.Governance.Action
                         Test.Golden.Governance.Committee
                         Test.Golden.Governance.DRep
                         Test.Golden.Help

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Governance/Action.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Governance/Action.hs
@@ -1,0 +1,46 @@
+{- HLINT ignore "Use camelCase" -}
+
+module Test.Golden.Governance.Action where
+
+import           Control.Monad (void)
+
+import qualified Test.Cardano.CLI.Util as H
+import           Test.Cardano.CLI.Util
+
+import           Hedgehog (Property)
+import qualified Hedgehog.Extras.Test.Base as H
+import qualified Hedgehog.Extras.Test.File as H
+import qualified Hedgehog.Extras.Test.Golden as H
+
+hprop_golden_governanceActionCreateConstitution :: Property
+hprop_golden_governanceActionCreateConstitution =
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+    stakeAddressVKeyFile <- noteTempFile tempDir "stake-address.vkey"
+    stakeAddressSKeyFile <- noteTempFile tempDir "stake-address.skey"
+
+    void $ execCardanoCLI
+      [ "legacy", "stake-address", "key-gen"
+      , "--verification-key-file", stakeAddressVKeyFile
+      , "--signing-key-file", stakeAddressSKeyFile
+      ]
+
+    actionFile <- noteTempFile tempDir "create-constitution.action"
+    redactedActionFile <- noteTempFile tempDir "create-constitution.action.redacted"
+
+    void $ execCardanoCLI
+      [ "conway", "governance", "action", "create-constitution"
+      , "--governance-action-deposit", "10"
+      , "--stake-verification-key-file", stakeAddressVKeyFile
+      , "--out-file", actionFile
+      , "--constitution", "This is a test constitution."
+      ]
+
+    goldenActionFile <-  H.note "test/cardano-cli-golden/files/golden/governance/action/create-constitution-for-stake-address.action.golden"
+
+    H.redactJsonField "cborHex" "<cborHex>" actionFile redactedActionFile
+
+    H.diffFileVsGoldenFile redactedActionFile goldenActionFile
+
+    H.assertFileOccurences 1 "Governance proposal" actionFile
+
+    H.assertEndsWithSingleNewline actionFile

--- a/cardano-cli/test/cardano-cli-golden/files/golden/governance/action/create-constitution-for-stake-address.action.golden
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/governance/action/create-constitution-for-stake-address.action.golden
@@ -1,0 +1,5 @@
+{
+    "cborHex": "<cborHex>",
+    "description": "",
+    "type": "Governance proposal"
+}


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Add test for `conway governance action create-constitution`
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Adds a simple golden test for `conway governance action create-constitution` using a stake address verification key.

This is a true golden test.  True golden tests must use `diffFileVsGoldenFile` or `diffVsGoldenFile`.

Generally speaking generated files that involve keys cannot be golden files because a different file is generated every time.

`redactJsonField` is used to redact parts of the file that cannot be relied on the be reproducible.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
