### PR TITLE
Read and write `VotingProcedures` files instead of `VotingEntry` files

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -14,7 +14,7 @@ repository cardano-haskell-packages
 -- you need to run if you change them
 index-state:
   , hackage.haskell.org 2023-08-08T19:56:09Z
-  , cardano-haskell-packages 2023-08-23T09:29:34Z
+  , cardano-haskell-packages 2023-08-24T08:58:33Z
 
 packages:
   cardano-cli

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -167,7 +167,7 @@ library
                       , binary
                       , bytestring
                       , canonical-json
-                      , cardano-api ^>= 8.16
+                      , cardano-api ^>= 8.16.1
                       , cardano-binary
                       , cardano-crypto
                       , cardano-crypto-class ^>= 2.1.2
@@ -258,7 +258,7 @@ test-suite cardano-cli-test
                       , base16-bytestring
                       , bech32 >= 1.1.0
                       , bytestring
-                      , cardano-api:{cardano-api, internal} ^>= 8.16
+                      , cardano-api:{cardano-api, internal} ^>= 8.16.1
                       , cardano-api-gen ^>= 8.1.1.0
                       , cardano-cli
                       , cardano-cli:cardano-cli-test-lib
@@ -302,7 +302,7 @@ test-suite cardano-cli-golden
   build-depends:        aeson >= 1.5.6.0
                       , base16-bytestring
                       , bytestring
-                      , cardano-api:{cardano-api, gen} ^>= 8.16
+                      , cardano-api:{cardano-api, gen} ^>= 8.16.1
                       , cardano-binary
                       , cardano-cli
                       , cardano-cli:cardano-cli-test-lib

--- a/cardano-cli/src/Cardano/CLI/Read.hs
+++ b/cardano-cli/src/Cardano/CLI/Read.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeOperators #-}
 
 {-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
 
@@ -77,9 +78,11 @@ module Cardano.CLI.Read
   , mergeVotingProcedures
   , readVotingProceduresFiles
   , readVotingProceduresFile
+  , votingProceduresToTxVotes
   ) where
 
 import           Cardano.Api as Api
+import qualified Cardano.Api.Ledger as Ledger
 import           Cardano.Api.Shelley as Api
 
 import qualified Cardano.Binary as CBOR
@@ -89,7 +92,7 @@ import           Cardano.CLI.Types.Errors.StakeCredentialError
 import           Cardano.CLI.Types.Governance
 import           Cardano.CLI.Types.Key
 import qualified Cardano.Ledger.Conway.Governance as Ledger
-import qualified Cardano.Ledger.Era as Ledger
+import           Ouroboros.Consensus.Shelley.Eras (StandardCrypto)
 
 import           Prelude
 
@@ -99,7 +102,7 @@ import           Control.Monad.Trans.Except (ExceptT (..), runExceptT)
 import           Control.Monad.Trans.Except.Extra (firstExceptT, handleIOExceptT, hoistEither,
                    hoistMaybe, left, newExceptT)
 import qualified Data.Aeson as Aeson
-import           Data.Bifunctor (first)
+import           Data.Bifunctor
 import qualified Data.ByteString.Builder as Builder
 import qualified Data.ByteString.Char8 as BS
 import qualified Data.ByteString.Lazy.Char8 as LBS

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1692802304,
-        "narHash": "sha256-t7RHKNanpG+4ciyvBf199zzuGFQZJeJvEUsAZpW7Qso=",
+        "lastModified": 1692973747,
+        "narHash": "sha256-mTlxhYzPUYJ/LggHQzsPomhqslCfTbjq8vqAhMaQN/o=",
         "owner": "input-output-hk",
         "repo": "cardano-haskell-packages",
-        "rev": "c4e89b49573d19f483b224717c3b395ee2aefdf8",
+        "rev": "1f0aed302bafbf897d3deefd9fc5de8229d04e1a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Read and write `VotingProcedures` files instead of `VotingEntry` files
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Using `VotingProcedures` as the serialisation types allows us to use ledger's serialisation rather than our own.

This PR converts the IO code to use `VotingProcedures`.  The conversion is not complete because `TxBodyContent` still has a `TxVotes` member.

A subsequent PR in `cardano-api` will switch that out.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
