### PR TITLE
Update to `cardano-api-8.19`

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -14,7 +14,7 @@ repository cardano-haskell-packages
 -- you need to run if you change them
 index-state:
   , hackage.haskell.org 2023-08-08T19:56:09Z
-  , cardano-haskell-packages 2023-09-01T08:47:12Z
+  , cardano-haskell-packages 2023-09-06T08:30:00Z
 
 packages:
   cardano-cli

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -181,7 +181,7 @@ library
                       , binary
                       , bytestring
                       , canonical-json
-                      , cardano-api ^>= 8.17.1
+                      , cardano-api ^>= 8.19
                       , cardano-binary
                       , cardano-crypto
                       , cardano-crypto-class ^>= 2.1.2
@@ -271,7 +271,7 @@ test-suite cardano-cli-test
                       , base16-bytestring
                       , bech32 >= 1.1.0
                       , bytestring
-                      , cardano-api:{cardano-api, internal} ^>= 8.17.1
+                      , cardano-api:{cardano-api, internal} ^>= 8.19
                       , cardano-api-gen ^>= 8.2.0.0
                       , cardano-cli
                       , cardano-cli:cardano-cli-test-lib
@@ -315,7 +315,7 @@ test-suite cardano-cli-golden
   build-depends:        aeson >= 1.5.6.0
                       , base16-bytestring
                       , bytestring
-                      , cardano-api:{cardano-api, gen} ^>= 8.17.1
+                      , cardano-api:{cardano-api, gen} ^>= 8.19
                       , cardano-binary
                       , cardano-cli
                       , cardano-cli:cardano-cli-test-lib

--- a/cardano-cli/src/Cardano/CLI/Byron/Tx.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Tx.hs
@@ -171,7 +171,7 @@ txSpendGenesisUTxOByronPBFT gc nId sk (ByronAddress bAddr) outs = do
             , txUpdateProposal = TxUpdateProposalNone
             , txMintValue = TxMintNone
             , txScriptValidity = TxScriptValidityNone
-            , txGovernanceActions = TxGovernanceActionsNone
+            , txProposalProcedures = Nothing
             , txVotingProcedures = Nothing
             }
 
@@ -220,7 +220,7 @@ txSpendUTxOByronPBFT nId sk txIns outs = do
           , txUpdateProposal = TxUpdateProposalNone
           , txMintValue = TxMintNone
           , txScriptValidity = TxScriptValidityNone
-          , txGovernanceActions = TxGovernanceActionsNone
+          , txProposalProcedures = Nothing
           , txVotingProcedures = Nothing
           }
 

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/DRep.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/DRep.hs
@@ -9,7 +9,6 @@ module Cardano.CLI.EraBased.Options.Governance.DRep
   ) where
 
 import           Cardano.Api
-import qualified Cardano.Api.Ledger as Ledger
 
 import           Cardano.CLI.Environment
 import           Cardano.CLI.EraBased.Commands.Governance.DRep

--- a/cardano-cli/src/Cardano/CLI/Helpers.hs
+++ b/cardano-cli/src/Cardano/CLI/Helpers.hs
@@ -12,7 +12,6 @@ module Cardano.CLI.Helpers
   , readCBOR
   , renderHelpersError
   , validateCBOR
-  , hushM
   ) where
 
 import           Cardano.Chain.Block (decCBORABlockOrBoundary)
@@ -130,9 +129,3 @@ validateCBOR cborObject bs =
       void $ decodeCBOR bs (fromCBOR :: Decoder s Update.Vote)
       Right "Valid Byron vote."
 
--- | Convert an Either to a Maybe and execute the supplied handler
--- in the Left case.
-hushM :: forall e m a. Monad m => Either e a -> (e -> m ()) -> m (Maybe a)
-hushM r f = case r of
-  Right a -> return (Just a)
-  Left e -> f e >> return Nothing

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Query.hs
@@ -17,7 +17,7 @@ import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Errors.ShelleyQueryCmdError
 import           Cardano.CLI.Types.Key (VerificationKeyOrHashOrFile)
 
-import           Control.Monad.Trans.Except (ExceptT)
+import           Control.Monad.Trans.Except
 import           Data.Time.Clock
 
 runLegacyQueryCmds :: LegacyQueryCmds -> ExceptT ShelleyQueryCmdError IO ()

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Transaction.hs
@@ -1,16 +1,8 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TupleSections #-}
-
-{-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
-
-{- HLINT ignore "Unused LANGUAGE pragma" -}
-{- HLINT ignore "Use let" -}
 
 module Cardano.CLI.Legacy.Run.Transaction
   ( runLegacyTransactionCmds
@@ -25,6 +17,7 @@ import           Cardano.CLI.Types.Errors.ShelleyTxCmdError
 import           Cardano.CLI.Types.Governance
 
 import           Control.Monad.Trans.Except
+
 
 runLegacyTransactionCmds :: LegacyTransactionCmds -> ExceptT ShelleyTxCmdError IO ()
 runLegacyTransactionCmds cmd =
@@ -49,8 +42,8 @@ runLegacyTransactionCmds cmd =
       runLegacyTxSubmitCmd mNodeSocketPath anyConsensusModeParams network txFp
     TxCalculateMinFee txbody nw pParamsFile nInputs nOutputs nShelleyKeyWitnesses nByronKeyWitnesses ->
       runLegacyTxCalculateMinFeeCmd txbody nw pParamsFile nInputs nOutputs nShelleyKeyWitnesses nByronKeyWitnesses
-    TxCalculateMinRequiredUTxO era pParamsFile txOuts ->
-      runLegacyTxCalculateMinRequiredUTxOCmd era pParamsFile txOuts
+    TxCalculateMinRequiredUTxO era pParamsFile txOuts' ->
+      runLegacyTxCalculateMinRequiredUTxOCmd era pParamsFile txOuts'
     TxHashScriptData scriptDataOrFile ->
       runLegacyTxHashScriptDataCmd scriptDataOrFile
     TxGetTxId txinfile ->

--- a/cardano-cli/src/Cardano/CLI/Orphans.hs
+++ b/cardano-cli/src/Cardano/CLI/Orphans.hs
@@ -1,23 +1,6 @@
-{-# LANGUAGE DataKinds #-}
-{-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE UndecidableInstances #-}
-
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Cardano.CLI.Orphans () where
 
-import           Cardano.Api (CardanoEra (..), FeatureInEra (..), ShelleyBasedEra (..))
+import           Cardano.Api ()
 
-instance FeatureInEra ShelleyBasedEra where
-  featureInEra no yes = \case
-    ByronEra    -> no
-    ShelleyEra  -> yes ShelleyBasedEraShelley
-    AllegraEra  -> yes ShelleyBasedEraAllegra
-    MaryEra     -> yes ShelleyBasedEraMary
-    AlonzoEra   -> yes ShelleyBasedEraAlonzo
-    BabbageEra  -> yes ShelleyBasedEraBabbage
-    ConwayEra   -> yes ShelleyBasedEraConway

--- a/cardano-cli/src/Cardano/CLI/Read.hs
+++ b/cardano-cli/src/Cardano/CLI/Read.hs
@@ -803,13 +803,12 @@ data ProposalError
 readTxGovernanceActions
   :: CardanoEra era
   -> [ProposalFile In]
-  -> IO (Either ConstitutionError (TxGovernanceActions era))
-readTxGovernanceActions _ [] = return $ Right TxGovernanceActionsNone
+  -> IO (Either ConstitutionError [Proposal era])
+readTxGovernanceActions _ [] = return $ Right []
 readTxGovernanceActions era files = runExceptT $ do
   w <- maybeFeatureInEra era
         & hoistMaybe (ConstitutionNotSupportedInEra $ cardanoEraConstraints era $ AnyCardanoEra era)
-  proposals <- newExceptT $ sequence <$> mapM (readProposal w) files
-  pure $ TxGovernanceActions w proposals
+  newExceptT $ sequence <$> mapM (readProposal w) files
 
 readProposal
   :: ConwayEraOnwards era

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/ShelleyQueryCmdError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/ShelleyQueryCmdError.hs
@@ -34,6 +34,7 @@ import           Formatting.Buildable (build)
 
 data ShelleyQueryCmdError
   = ShelleyQueryCmdLocalStateQueryError !ShelleyQueryCmdLocalStateQueryError
+  | ShelleyQueryCmdConvenienceError !QueryConvenienceError
   | ShelleyQueryCmdWriteFileError !(FileError ())
   | ShelleyQueryCmdHelpersError !HelpersError
   | ShelleyQueryCmdAcquireFailure !AcquiringFailure
@@ -89,3 +90,4 @@ renderShelleyQueryCmdError err =
       "Later node versions support later protocol versions (but development protocol versions are not enabled in the node by default)."
     ShelleyQueryCmdProtocolParameterConversionError ppce ->
       Text.pack $ "Failed to convert protocol parameter: " <> displayError ppce
+    ShelleyQueryCmdConvenienceError qce -> renderQueryConvenienceError qce

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/TxValidationError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/TxValidationError.hs
@@ -309,15 +309,15 @@ instance Error TxProtocolParametersValidationError where
 
 validateProtocolParameters
   :: CardanoEra era
-  -> Maybe ProtocolParameters
-  -> Either TxProtocolParametersValidationError (BuildTxWith BuildTx (Maybe ProtocolParameters))
+  -> Maybe (LedgerProtocolParameters era)
+  -> Either TxProtocolParametersValidationError (BuildTxWith BuildTx (Maybe (LedgerProtocolParameters era)))
 validateProtocolParameters _ Nothing = return (BuildTxWith Nothing)
 validateProtocolParameters era (Just pparams) =
-    case scriptDataSupportedInEra era of
-      Nothing -> Left $ ProtocolParametersNotSupported
+    case cardanoEraStyle era of
+      LegacyByronEra -> Left $ ProtocolParametersNotSupported
                       $ getIsCardanoEraConstraint era
                       $ AnyCardanoEra era
-      Just _  -> return . BuildTxWith $ Just pparams
+      ShelleyBasedEra _  -> return . BuildTxWith $ Just pparams
 
 newtype TxUpdateProposalValidationError
   = TxUpdateProposalNotSupported AnyCardanoEra

--- a/cardano-cli/src/Cardano/CLI/Types/Output.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Output.hs
@@ -12,6 +12,7 @@ module Cardano.CLI.Types.Output
   ) where
 
 import           Cardano.Api
+import qualified Cardano.Api.Ledger as Ledger
 import           Cardano.Api.Shelley
 
 import           Cardano.CLI.Orphans ()
@@ -260,7 +261,7 @@ instance ToJSON ScriptCostOutput where
 data PlutusScriptCostError
   = PlutusScriptCostErrPlutusScriptNotFound ScriptWitnessIndex
   | PlutusScriptCostErrExecError ScriptWitnessIndex (Maybe ScriptHash) ScriptExecutionError
-  | PlutusScriptCostErrRationalExceedsBound ExecutionUnitPrices  ExecutionUnits
+  | PlutusScriptCostErrRationalExceedsBound Ledger.Prices  ExecutionUnits
   | PlutusScriptCostErrRefInputNoScript TxIn
   | PlutusScriptCostErrRefInputNotInUTxO TxIn
   deriving Show
@@ -282,7 +283,7 @@ instance Error PlutusScriptCostError where
 
 renderScriptCosts
   :: UTxO era
-  -> ExecutionUnitPrices
+  -> Ledger.Prices
   -> [(ScriptWitnessIndex, AnyScriptWitness era)]
   -- ^ Initial mapping of script witness index to actual script.
   -- We need this in order to know which script corresponds to the

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1693560763,
-        "narHash": "sha256-Ta2CkAzPn70QiGn62vYQDfxwYCrqiOFfrONrUuza1u8=",
+        "lastModified": 1693988844,
+        "narHash": "sha256-0fvQy6GxgSkpufa0QeEtYNEY4G5nSQ7L4VIkGdfTt+w=",
         "owner": "input-output-hk",
         "repo": "cardano-haskell-packages",
-        "rev": "f941b803944a7c70e27a8fb02fc6456807053684",
+        "rev": "27f047c00b5d079e6322a3eab53549cad9e77680",
         "type": "github"
       },
       "original": {
@@ -153,24 +153,6 @@
         "type": "github"
       }
     },
-    "flake-utils_2": {
-      "inputs": {
-        "systems": "systems_2"
-      },
-      "locked": {
-        "lastModified": 1692799911,
-        "narHash": "sha256-3eihraek4qL744EvQXsK1Ha6C3CR7nnT8X2qWap4RNk=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "f9e7cf818399d17d347f847525c5a5a8032e4e44",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "ghc-8.6.5-iohk": {
       "flake": false,
       "locked": {
@@ -191,11 +173,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1693182531,
-        "narHash": "sha256-OejogS2E745biMj8NuUYatN7uoMRsg7giVnRQwfiays=",
+        "lastModified": 1693959895,
+        "narHash": "sha256-qLmbEucG4NTA507cQzhsqnE3nJqUSVAALQX6MgzDwGo=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "34cd9fe31d210f2ff041f490eaa4029f6b2812c4",
+        "rev": "d0d990c3a8daba50aee6ee31794cb87226f4e18f",
         "type": "github"
       },
       "original": {
@@ -212,11 +194,11 @@
         "cabal-36": "cabal-36",
         "cardano-shell": "cardano-shell",
         "flake-compat": "flake-compat",
-        "flake-utils": "flake-utils_2",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk",
         "hackage": "hackage",
         "hls-1.10": "hls-1.10",
         "hls-2.0": "hls-2.0",
+        "hls-2.2": "hls-2.2",
         "hpc-coveralls": "hpc-coveralls",
         "hydra": "hydra",
         "iserv-proxy": "iserv-proxy",
@@ -235,11 +217,11 @@
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1693196365,
-        "narHash": "sha256-3fC4Ynlzxbpwwqnwlw+UesIB2808z6bTh3MitM1EVd4=",
+        "lastModified": 1693961398,
+        "narHash": "sha256-+ju59T0KJL0rIDhUXsS+OKrx7TOlE+R4GjbtVEjo9mA=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "5ed5f276df29a441ee4991667e7947528fa3cbb9",
+        "rev": "37d562be0e4c0090c230347968eb3d0d813cac02",
         "type": "github"
       },
       "original": {
@@ -278,6 +260,23 @@
       "original": {
         "owner": "haskell",
         "ref": "2.0.0.1",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1693064058,
+        "narHash": "sha256-8DGIyz5GjuCFmohY6Fa79hHA/p1iIqubfJUTGQElbNk=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "b30f4b6cf5822f3112c35d14a0cba51f3fe23b85",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.2.0.0",
         "repo": "haskell-language-server",
         "type": "github"
       }
@@ -347,11 +346,11 @@
         "sodium": "sodium"
       },
       "locked": {
-        "lastModified": 1692743532,
-        "narHash": "sha256-OcnZRZBh3pOx5uChTuO+4o9OHiG1ip36C35DaFrwjbM=",
+        "lastModified": 1693968598,
+        "narHash": "sha256-2wFadXHMgNYrF7N6jndfp3Ywm2G0r+QTPifrlzugkjo=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "e5b4889e4d191cf2cb1495dd16b13ea016b5569a",
+        "rev": "7d738e59d276336d1e02447e27b0373164d3bc88",
         "type": "github"
       },
       "original": {
@@ -656,11 +655,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1693181390,
-        "narHash": "sha256-SWcgiVwyYfbd/ypwhkEmjJ92tCCsqQ179vwKH1m2lZE=",
+        "lastModified": 1693786159,
+        "narHash": "sha256-IzpBwbwD90CIdhOKfdzS98+o3AtoADNsSz5QBr281Gg=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "6479adae3f7559a300d3ee94af92ed9da5030794",
+        "rev": "69d620fde80c1dfbe78b081db1b5725e9c0ce9e2",
         "type": "github"
       },
       "original": {
@@ -670,21 +669,6 @@
       }
     },
     "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Update to `cardano-api-8.19`
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Requires:
- https://github.com/input-output-hk/cardano-haskell-packages/pull/469

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
