### PR TITLE
Use record syntax for `TxBodyContent`

### DIFF
--- a/cardano-cli/src/Cardano/CLI/Byron/Tx.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Tx.hs
@@ -149,29 +149,32 @@ txSpendGenesisUTxOByronPBFT
 txSpendGenesisUTxOByronPBFT gc nId sk (ByronAddress bAddr) outs = do
     let txBodyCont =
           TxBodyContent
-            [ (fromByronTxIn txIn
-              , BuildTxWith (KeyWitness KeyWitnessForSpending))
-            ]
-            TxInsCollateralNone
-            TxInsReferenceNone
-            outs
-            TxTotalCollateralNone
-            TxReturnCollateralNone
-            (TxFeeImplicit TxFeesImplicitInByronEra)
-            ( TxValidityNoLowerBound
-            , TxValidityNoUpperBound ValidityNoUpperBoundInByronEra
-            )
-            TxMetadataNone
-            TxAuxScriptsNone
-            TxExtraKeyWitnessesNone
-            (BuildTxWith Nothing)
-            TxWithdrawalsNone
-            TxCertificatesNone
-            TxUpdateProposalNone
-            TxMintNone
-            TxScriptValidityNone
-            TxGovernanceActionsNone
-            Nothing
+            { txIns =
+                [ (fromByronTxIn txIn, BuildTxWith (KeyWitness KeyWitnessForSpending))
+                ]
+            , txInsCollateral = TxInsCollateralNone
+            , txInsReference = TxInsReferenceNone
+            , txOuts = outs
+            , txTotalCollateral = TxTotalCollateralNone
+            , txReturnCollateral = TxReturnCollateralNone
+            , txFee = TxFeeImplicit TxFeesImplicitInByronEra
+            , txValidityRange =
+                ( TxValidityNoLowerBound
+                , TxValidityNoUpperBound ValidityNoUpperBoundInByronEra
+                )
+            , txMetadata = TxMetadataNone
+            , txAuxScripts = TxAuxScriptsNone
+            , txExtraKeyWits = TxExtraKeyWitnessesNone
+            , txProtocolParams = BuildTxWith Nothing
+            , txWithdrawals = TxWithdrawalsNone
+            , txCertificates = TxCertificatesNone
+            , txUpdateProposal = TxUpdateProposalNone
+            , txMintValue = TxMintNone
+            , txScriptValidity = TxScriptValidityNone
+            , txGovernanceActions = TxGovernanceActionsNone
+            , txVotingProcedures = Nothing
+            }
+
     case createAndValidateTransactionBody txBodyCont of
       Left err -> error $ "Error occurred while creating a Byron genesis based UTxO transaction: " <> show err
       Right txBody -> let bWit = fromByronWitness sk nId txBody
@@ -191,31 +194,36 @@ txSpendUTxOByronPBFT
   -> [TxOut CtxTx ByronEra]
   -> Tx ByronEra
 txSpendUTxOByronPBFT nId sk txIns outs = do
-  let txBodyCont = TxBodyContent
-                     [ ( txIn
-                       , BuildTxWith (KeyWitness KeyWitnessForSpending)
-                       ) | txIn <- txIns
-                     ]
-                     TxInsCollateralNone
-                     TxInsReferenceNone
-                     outs
-                     TxTotalCollateralNone
-                     TxReturnCollateralNone
-                     (TxFeeImplicit TxFeesImplicitInByronEra)
-                     ( TxValidityNoLowerBound
-                     , TxValidityNoUpperBound ValidityNoUpperBoundInByronEra
-                     )
-                     TxMetadataNone
-                     TxAuxScriptsNone
-                     TxExtraKeyWitnessesNone
-                     (BuildTxWith Nothing)
-                     TxWithdrawalsNone
-                     TxCertificatesNone
-                     TxUpdateProposalNone
-                     TxMintNone
-                     TxScriptValidityNone
-                     TxGovernanceActionsNone
-                     Nothing
+  let txBodyCont =
+        TxBodyContent
+          { txIns =
+              [ ( txIn
+                , BuildTxWith (KeyWitness KeyWitnessForSpending)
+                ) | txIn <- txIns
+              ]
+          , txInsCollateral = TxInsCollateralNone
+          , txInsReference = TxInsReferenceNone
+          , txOuts = outs
+          , txTotalCollateral = TxTotalCollateralNone
+          , txReturnCollateral = TxReturnCollateralNone
+          , txFee = TxFeeImplicit TxFeesImplicitInByronEra
+          , txValidityRange =
+              ( TxValidityNoLowerBound
+              , TxValidityNoUpperBound ValidityNoUpperBoundInByronEra
+              )
+          , txMetadata = TxMetadataNone
+          , txAuxScripts = TxAuxScriptsNone
+          , txExtraKeyWits = TxExtraKeyWitnessesNone
+          , txProtocolParams = BuildTxWith Nothing
+          , txWithdrawals = TxWithdrawalsNone
+          , txCertificates = TxCertificatesNone
+          , txUpdateProposal = TxUpdateProposalNone
+          , txMintValue = TxMintNone
+          , txScriptValidity = TxScriptValidityNone
+          , txGovernanceActions = TxGovernanceActionsNone
+          , txVotingProcedures = Nothing
+          }
+
   case createAndValidateTransactionBody txBodyCont of
     Left err -> error $ "Error occurred while creating a Byron genesis based UTxO transaction: " <> show err
     Right txBody -> let bWit = fromByronWitness sk nId txBody

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Transaction.hs
@@ -413,26 +413,28 @@ runTxBuildRaw era
       <- first ShelleyTxCmdScriptValidityValidationError $ validateTxScriptValidity era mScriptValidity
     let validatedTxGovernanceActions = TxGovernanceActionsNone -- TODO: Conwary era
         validatedTxVotes = Nothing -- TODO: Conwary era
-    let txBodyContent = TxBodyContent
-                          (validateTxIns inputsAndMaybeScriptWits)
-                          validatedCollateralTxIns
-                          validatedRefInputs
-                          txouts
-                          validatedTotCollateral
-                          validatedRetCol
-                          validatedFee
-                          validatedBounds
-                          txMetadata
-                          txAuxScripts
-                          validatedReqSigners
-                          validatedPParams
-                          validatedTxWtdrwls
-                          validatedTxCerts
-                          validatedTxUpProp
-                          validatedMintValue
-                          validatedTxScriptValidity
-                          validatedTxGovernanceActions
-                          validatedTxVotes
+    let txBodyContent =
+          TxBodyContent
+            { txIns = validateTxIns inputsAndMaybeScriptWits
+            , txInsCollateral = validatedCollateralTxIns
+            , txInsReference = validatedRefInputs
+            , txOuts = txouts
+            , txTotalCollateral = validatedTotCollateral
+            , txReturnCollateral = validatedRetCol
+            , txFee = validatedFee
+            , txValidityRange = validatedBounds
+            , txMetadata = txMetadata
+            , txAuxScripts = txAuxScripts
+            , txExtraKeyWits = validatedReqSigners
+            , txProtocolParams = validatedPParams
+            , txWithdrawals = validatedTxWtdrwls
+            , txCertificates = validatedTxCerts
+            , txUpdateProposal = validatedTxUpProp
+            , txMintValue = validatedMintValue
+            , txScriptValidity = validatedTxScriptValidity
+            , txGovernanceActions = validatedTxGovernanceActions
+            , txVotingProcedures = validatedTxVotes
+            }
 
     first ShelleyTxCmdTxBodyError $
       getIsCardanoEraConstraint era $ createAndValidateTransactionBody txBodyContent
@@ -548,26 +550,28 @@ runTxBuild
 
       let validatedTxGovernanceActions = proposals
           validatedTxVotes =  votes
-          txBodyContent = TxBodyContent
-                          (validateTxIns inputsAndMaybeScriptWits)
-                          validatedCollateralTxIns
-                          validatedRefInputs
-                          txouts
-                          validatedTotCollateral
-                          validatedRetCol
-                          dFee
-                          validatedBounds
-                          txMetadata
-                          txAuxScripts
-                          validatedReqSigners
-                          validatedPParams
-                          validatedTxWtdrwls
-                          validatedTxCerts
-                          validatedTxUpProp
-                          validatedMintValue
-                          validatedTxScriptValidity
-                          validatedTxGovernanceActions
-                          (inEraFeature era Nothing (\w -> Just (Featured w validatedTxVotes)))
+          txBodyContent =
+            TxBodyContent
+              { txIns = validateTxIns inputsAndMaybeScriptWits
+              , txInsCollateral = validatedCollateralTxIns
+              , txInsReference = validatedRefInputs
+              , txOuts = txouts
+              , txTotalCollateral = validatedTotCollateral
+              , txReturnCollateral = validatedRetCol
+              , txFee = dFee
+              , txValidityRange = validatedBounds
+              , txMetadata = txMetadata
+              , txAuxScripts = txAuxScripts
+              , txExtraKeyWits = validatedReqSigners
+              , txProtocolParams = validatedPParams
+              , txWithdrawals = validatedTxWtdrwls
+              , txCertificates = validatedTxCerts
+              , txUpdateProposal = validatedTxUpProp
+              , txMintValue = validatedMintValue
+              , txScriptValidity = validatedTxScriptValidity
+              , txGovernanceActions = validatedTxGovernanceActions
+              , txVotingProcedures = inEraFeature era Nothing (\w -> Just (Featured w validatedTxVotes))
+              }
 
       firstExceptT ShelleyTxCmdTxInsDoNotExist
         . hoistEither $ txInsExistInUTxO allTxInputs nodeEraUTxO


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Use record syntax for `TxBodyContent`
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context


# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
