### PR TITLE
Add legacy prefix to legacy run commands

### DIFF
--- a/cardano-cli/src/Cardano/CLI/Legacy/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run.hs
@@ -22,13 +22,13 @@ import           Control.Monad.Trans.Except.Extra (firstExceptT)
 
 runLegacyCmds :: LegacyCmds -> ExceptT CmdError IO ()
 runLegacyCmds = \case
-  LegacyAddressCmds      cmd -> firstExceptT CmdAddressError $ runAddressCmds cmd
-  LegacyGenesisCmds      cmd -> firstExceptT CmdGenesisError $ runGenesisCmds cmd
+  LegacyAddressCmds      cmd -> firstExceptT CmdAddressError $ runLegacyAddressCmds cmd
+  LegacyGenesisCmds      cmd -> firstExceptT CmdGenesisError $ runLegacyGenesisCmds cmd
   LegacyGovernanceCmds   cmd -> firstExceptT CmdGovernanceCmdError $ runLegacyGovernanceCmds cmd
-  LegacyKeyCmds          cmd -> firstExceptT CmdKeyError $ runKeyCmds cmd
-  LegacyNodeCmds         cmd -> firstExceptT CmdNodeError $ runNodeCmds cmd
-  LegacyPoolCmds         cmd -> firstExceptT CmdPoolError $ runPoolCmds cmd
-  LegacyQueryCmds        cmd -> firstExceptT CmdQueryError $ runQueryCmds cmd
-  LegacyStakeAddressCmds cmd -> firstExceptT CmdStakeAddressError $ runStakeAddressCmds cmd
-  LegacyTextViewCmds     cmd -> firstExceptT CmdTextViewError $ runTextViewCmds cmd
-  LegacyTransactionCmds  cmd -> firstExceptT CmdTransactionError $ runTransactionCmds cmd
+  LegacyKeyCmds          cmd -> firstExceptT CmdKeyError $ runLegacyKeyCmds cmd
+  LegacyNodeCmds         cmd -> firstExceptT CmdNodeError $ runLegacyNodeCmds cmd
+  LegacyPoolCmds         cmd -> firstExceptT CmdPoolError $ runLegacyPoolCmds cmd
+  LegacyQueryCmds        cmd -> firstExceptT CmdQueryError $ runLegacyQueryCmds cmd
+  LegacyStakeAddressCmds cmd -> firstExceptT CmdStakeAddressError $ runLegacyStakeAddressCmds cmd
+  LegacyTextViewCmds     cmd -> firstExceptT CmdTextViewError $ runLegacyTextViewCmds cmd
+  LegacyTransactionCmds  cmd -> firstExceptT CmdTransactionError $ runLegacyTransactionCmds cmd

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Address/Info.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Address/Info.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE GADTs #-}
 
 module Cardano.CLI.Legacy.Run.Address.Info
-  ( runAddressInfo
+  ( runLegacyAddressInfoCmd
   ) where
 
 import           Cardano.Api
@@ -36,8 +36,8 @@ instance ToJSON AddressInfo where
       , "base16" .= aiBase16 addrInfo
       ]
 
-runAddressInfo :: Text -> Maybe (File () Out) -> ExceptT ShelleyAddressInfoError IO ()
-runAddressInfo addrTxt mOutputFp = do
+runLegacyAddressInfoCmd :: Text -> Maybe (File () Out) -> ExceptT ShelleyAddressInfoError IO ()
+runLegacyAddressInfoCmd addrTxt mOutputFp = do
     addrInfo <- case (Left  <$> deserialiseAddress AsAddressAny addrTxt)
                  <|> (Right <$> deserialiseAddress AsStakeAddress addrTxt) of
 

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Query.hs
@@ -18,7 +18,7 @@ module Cardano.CLI.Legacy.Run.Query
   , renderOpCertIntervalInformation
   , renderShelleyQueryCmdError
   , renderLocalStateQueryError
-  , runQueryCmds
+  , runLegacyQueryCmds
   , toEpochInfo
   , utcTimeToSlotNo
   , determineEra
@@ -97,47 +97,46 @@ import           Text.Printf (printf)
 {- HLINT ignore "Move brackets to avoid $" -}
 {- HLINT ignore "Redundant flip" -}
 
-runQueryCmds :: LegacyQueryCmds -> ExceptT ShelleyQueryCmdError IO ()
-runQueryCmds cmd =
-  case cmd of
-    QueryLeadershipSchedule mNodeSocketPath consensusModeParams network shelleyGenFp poolid vrkSkeyFp whichSchedule outputAs ->
-      runQueryLeadershipSchedule mNodeSocketPath consensusModeParams network shelleyGenFp poolid vrkSkeyFp whichSchedule outputAs
-    QueryProtocolParameters' mNodeSocketPath consensusModeParams network mOutFile ->
-      runQueryProtocolParameters mNodeSocketPath consensusModeParams network mOutFile
-    QueryConstitutionHash mNodeSocketPath consensusModeParams network mOutFile ->
-      runQueryConstitutionHash mNodeSocketPath consensusModeParams network mOutFile
-    QueryTip mNodeSocketPath consensusModeParams network mOutFile ->
-      runQueryTip mNodeSocketPath consensusModeParams network mOutFile
-    QueryStakePools' mNodeSocketPath consensusModeParams network mOutFile ->
-      runQueryStakePools mNodeSocketPath consensusModeParams network mOutFile
-    QueryStakeDistribution' mNodeSocketPath consensusModeParams network mOutFile ->
-      runQueryStakeDistribution mNodeSocketPath consensusModeParams network mOutFile
-    QueryStakeAddressInfo mNodeSocketPath consensusModeParams addr network mOutFile ->
-      runQueryStakeAddressInfo mNodeSocketPath consensusModeParams addr network mOutFile
-    QueryDebugLedgerState' mNodeSocketPath consensusModeParams network mOutFile ->
-      runQueryLedgerState mNodeSocketPath consensusModeParams network mOutFile
-    QueryStakeSnapshot' mNodeSocketPath consensusModeParams network allOrOnlyPoolIds mOutFile ->
-      runQueryStakeSnapshot mNodeSocketPath consensusModeParams network allOrOnlyPoolIds mOutFile
-    QueryProtocolState' mNodeSocketPath consensusModeParams network mOutFile ->
-      runQueryProtocolState mNodeSocketPath consensusModeParams network mOutFile
-    QueryUTxO' mNodeSocketPath consensusModeParams qFilter networkId mOutFile ->
-      runQueryUTxO mNodeSocketPath consensusModeParams qFilter networkId mOutFile
-    QueryKesPeriodInfo mNodeSocketPath consensusModeParams network nodeOpCert mOutFile ->
-      runQueryKesPeriodInfo mNodeSocketPath consensusModeParams network nodeOpCert mOutFile
-    QueryPoolState' mNodeSocketPath consensusModeParams network poolid ->
-      runQueryPoolState mNodeSocketPath consensusModeParams network poolid
-    QueryTxMempool mNodeSocketPath consensusModeParams network op mOutFile ->
-      runQueryTxMempool mNodeSocketPath consensusModeParams network op mOutFile
-    QuerySlotNumber mNodeSocketPath consensusModeParams network utcTime ->
-      runQuerySlotNumber mNodeSocketPath consensusModeParams network utcTime
+runLegacyQueryCmds :: LegacyQueryCmds -> ExceptT ShelleyQueryCmdError IO ()
+runLegacyQueryCmds = \case
+  QueryLeadershipSchedule mNodeSocketPath consensusModeParams network shelleyGenFp poolid vrkSkeyFp whichSchedule outputAs ->
+    runLegacyQueryLeadershipScheduleCmd mNodeSocketPath consensusModeParams network shelleyGenFp poolid vrkSkeyFp whichSchedule outputAs
+  QueryProtocolParameters' mNodeSocketPath consensusModeParams network mOutFile ->
+    runLegacyQueryProtocolParametersCmd mNodeSocketPath consensusModeParams network mOutFile
+  QueryConstitutionHash mNodeSocketPath consensusModeParams network mOutFile ->
+    runLegacyQueryConstitutionHashCmd mNodeSocketPath consensusModeParams network mOutFile
+  QueryTip mNodeSocketPath consensusModeParams network mOutFile ->
+    runLegacyQueryTipCmd mNodeSocketPath consensusModeParams network mOutFile
+  QueryStakePools' mNodeSocketPath consensusModeParams network mOutFile ->
+    runLegacyQueryStakePoolsCmd mNodeSocketPath consensusModeParams network mOutFile
+  QueryStakeDistribution' mNodeSocketPath consensusModeParams network mOutFile ->
+    runLegacyQueryStakeDistributionCmd mNodeSocketPath consensusModeParams network mOutFile
+  QueryStakeAddressInfo mNodeSocketPath consensusModeParams addr network mOutFile ->
+    runLegacyQueryStakeAddressInfoCmd mNodeSocketPath consensusModeParams addr network mOutFile
+  QueryDebugLedgerState' mNodeSocketPath consensusModeParams network mOutFile ->
+    runLegacyQueryLedgerStateCmd mNodeSocketPath consensusModeParams network mOutFile
+  QueryStakeSnapshot' mNodeSocketPath consensusModeParams network allOrOnlyPoolIds mOutFile ->
+    runLegacyQueryStakeSnapshotCmd mNodeSocketPath consensusModeParams network allOrOnlyPoolIds mOutFile
+  QueryProtocolState' mNodeSocketPath consensusModeParams network mOutFile ->
+    runLegacyQueryProtocolStateCmd mNodeSocketPath consensusModeParams network mOutFile
+  QueryUTxO' mNodeSocketPath consensusModeParams qFilter networkId mOutFile ->
+    runLegacyQueryUTxOCmd mNodeSocketPath consensusModeParams qFilter networkId mOutFile
+  QueryKesPeriodInfo mNodeSocketPath consensusModeParams network nodeOpCert mOutFile ->
+    runLegacyQueryKesPeriodInfoCmd mNodeSocketPath consensusModeParams network nodeOpCert mOutFile
+  QueryPoolState' mNodeSocketPath consensusModeParams network poolid ->
+    runLegacyQueryPoolStateCmd mNodeSocketPath consensusModeParams network poolid
+  QueryTxMempool mNodeSocketPath consensusModeParams network op mOutFile ->
+    runLegacyQueryTxMempoolCmd mNodeSocketPath consensusModeParams network op mOutFile
+  QuerySlotNumber mNodeSocketPath consensusModeParams network utcTime ->
+    runLegacyQuerySlotNumberCmd mNodeSocketPath consensusModeParams network utcTime
 
-runQueryConstitutionHash
+runLegacyQueryConstitutionHashCmd
   :: SocketPath
   -> AnyConsensusModeParams
   -> NetworkId
   -> Maybe (File () Out)
   -> ExceptT ShelleyQueryCmdError IO ()
-runQueryConstitutionHash socketPath (AnyConsensusModeParams cModeParams) network mOutFile = do
+runLegacyQueryConstitutionHashCmd socketPath (AnyConsensusModeParams cModeParams) network mOutFile = do
   let localNodeConnInfo = LocalNodeConnectInfo cModeParams network socketPath
 
   result <- liftIO $ executeLocalStateQueryExpr localNodeConnInfo Nothing $ runExceptT $ do
@@ -169,13 +168,13 @@ runQueryConstitutionHash socketPath (AnyConsensusModeParams cModeParams) network
           handleIOExceptT (ShelleyQueryCmdWriteFileError . FileIOError fpath) $
             LBS.writeFile fpath (encodePretty cHash)
 
-runQueryProtocolParameters
+runLegacyQueryProtocolParametersCmd
   :: SocketPath
   -> AnyConsensusModeParams
   -> NetworkId
   -> Maybe (File () Out)
   -> ExceptT ShelleyQueryCmdError IO ()
-runQueryProtocolParameters socketPath (AnyConsensusModeParams cModeParams) network mOutFile = do
+runLegacyQueryProtocolParametersCmd socketPath (AnyConsensusModeParams cModeParams) network mOutFile = do
   let localNodeConnInfo = LocalNodeConnectInfo cModeParams network socketPath
 
   result <- liftIO $ executeLocalStateQueryExpr localNodeConnInfo Nothing $ runExceptT $ do
@@ -242,13 +241,13 @@ queryChainTipViaChainSync localNodeConnInfo = do
     "Warning: Local header state query unavailable. Falling back to chain sync query"
   liftIO $ getLocalChainTip localNodeConnInfo
 
-runQueryTip
+runLegacyQueryTipCmd
   :: SocketPath
   -> AnyConsensusModeParams
   -> NetworkId
   -> Maybe (File () Out)
   -> ExceptT ShelleyQueryCmdError IO ()
-runQueryTip socketPath (AnyConsensusModeParams cModeParams) network mOutFile = do
+runLegacyQueryTipCmd socketPath (AnyConsensusModeParams cModeParams) network mOutFile = do
   case consensusModeOnly cModeParams of
     CardanoMode -> do
       let localNodeConnInfo = LocalNodeConnectInfo cModeParams network socketPath
@@ -326,14 +325,14 @@ runQueryTip socketPath (AnyConsensusModeParams cModeParams) network mOutFile = d
 
 -- | Query the UTxO, filtered by a given set of addresses, from a Shelley node
 -- via the local state query protocol.
-runQueryUTxO
+runLegacyQueryUTxOCmd
   :: SocketPath
   -> AnyConsensusModeParams
   -> QueryUTxOFilter
   -> NetworkId
   -> Maybe (File () Out)
   -> ExceptT ShelleyQueryCmdError IO ()
-runQueryUTxO socketPath (AnyConsensusModeParams cModeParams)
+runLegacyQueryUTxOCmd socketPath (AnyConsensusModeParams cModeParams)
              qfilter network mOutFile = do
   let localNodeConnInfo = LocalNodeConnectInfo cModeParams network socketPath
 
@@ -364,14 +363,14 @@ runQueryUTxO socketPath (AnyConsensusModeParams cModeParams)
     & onLeft (left . ShelleyQueryCmdAcquireFailure)
     & onLeft left
 
-runQueryKesPeriodInfo
+runLegacyQueryKesPeriodInfoCmd
   :: SocketPath
   -> AnyConsensusModeParams
   -> NetworkId
   -> File () In
   -> Maybe (File () Out)
   -> ExceptT ShelleyQueryCmdError IO ()
-runQueryKesPeriodInfo socketPath (AnyConsensusModeParams cModeParams) network nodeOpCertFile mOutFile = do
+runLegacyQueryKesPeriodInfoCmd socketPath (AnyConsensusModeParams cModeParams) network nodeOpCertFile mOutFile = do
   opCert <- lift (readFileTextEnvelope AsOperationalCertificate nodeOpCertFile)
     & onLeft (left . ShelleyQueryCmdOpCertCounterReadError)
 
@@ -648,13 +647,13 @@ renderOpCertIntervalInformation opCertFile opCertInfo = case opCertInfo of
 -- | Query the current and future parameters for a stake pool, including the retirement date.
 -- Any of these may be empty (in which case a null will be displayed).
 --
-runQueryPoolState
+runLegacyQueryPoolStateCmd
   :: SocketPath
   -> AnyConsensusModeParams
   -> NetworkId
   -> [Hash StakePoolKey]
   -> ExceptT ShelleyQueryCmdError IO ()
-runQueryPoolState socketPath (AnyConsensusModeParams cModeParams) network poolIds = do
+runLegacyQueryPoolStateCmd socketPath (AnyConsensusModeParams cModeParams) network poolIds = do
   let localNodeConnInfo = LocalNodeConnectInfo cModeParams network socketPath
 
   join $ lift
@@ -685,14 +684,14 @@ runQueryPoolState socketPath (AnyConsensusModeParams cModeParams) network poolId
     & onLeft left
 
 -- | Query the local mempool state
-runQueryTxMempool
+runLegacyQueryTxMempoolCmd
   :: SocketPath
   -> AnyConsensusModeParams
   -> NetworkId
   -> TxMempoolQuery
   -> Maybe (File () Out)
   -> ExceptT ShelleyQueryCmdError IO ()
-runQueryTxMempool socketPath (AnyConsensusModeParams cModeParams) network query mOutFile = do
+runLegacyQueryTxMempoolCmd socketPath (AnyConsensusModeParams cModeParams) network query mOutFile = do
   let localNodeConnInfo = LocalNodeConnectInfo cModeParams network socketPath
 
   localQuery <- case query of
@@ -714,27 +713,27 @@ runQueryTxMempool socketPath (AnyConsensusModeParams cModeParams) network query 
     Just (File oFp) -> handleIOExceptT (ShelleyQueryCmdWriteFileError . FileIOError oFp)
         $ LBS.writeFile oFp renderedResult
 
-runQuerySlotNumber
+runLegacyQuerySlotNumberCmd
   :: SocketPath
   -> AnyConsensusModeParams
   -> NetworkId
   -> UTCTime
   -> ExceptT ShelleyQueryCmdError IO ()
-runQuerySlotNumber sockPath aCmp network utcTime = do
+runLegacyQuerySlotNumberCmd sockPath aCmp network utcTime = do
   SlotNo slotNo <- utcTimeToSlotNo sockPath aCmp network utcTime
   liftIO . putStr $ show slotNo
 
 -- | Obtain stake snapshot information for a pool, plus information about the total active stake.
 -- This information can be used for leader slot calculation, for example, and has been requested by SPOs.
 -- Obtaining the information directly is significantly more time and memory efficient than using a full ledger state dump.
-runQueryStakeSnapshot
+runLegacyQueryStakeSnapshotCmd
   :: SocketPath
   -> AnyConsensusModeParams
   -> NetworkId
   -> AllOrOnly [Hash StakePoolKey]
   -> Maybe (File () Out)
   -> ExceptT ShelleyQueryCmdError IO ()
-runQueryStakeSnapshot socketPath (AnyConsensusModeParams cModeParams) network allOrOnlyPoolIds mOutFile = do
+runLegacyQueryStakeSnapshotCmd socketPath (AnyConsensusModeParams cModeParams) network allOrOnlyPoolIds mOutFile = do
   let localNodeConnInfo = LocalNodeConnectInfo cModeParams network socketPath
 
   join $ lift
@@ -768,13 +767,13 @@ runQueryStakeSnapshot socketPath (AnyConsensusModeParams cModeParams) network al
     & onLeft (left . ShelleyQueryCmdAcquireFailure)
     & onLeft left
 
-runQueryLedgerState
+runLegacyQueryLedgerStateCmd
   :: SocketPath
   -> AnyConsensusModeParams
   -> NetworkId
   -> Maybe (File () Out)
   -> ExceptT ShelleyQueryCmdError IO ()
-runQueryLedgerState socketPath (AnyConsensusModeParams cModeParams) network mOutFile = do
+runLegacyQueryLedgerStateCmd socketPath (AnyConsensusModeParams cModeParams) network mOutFile = do
   let localNodeConnInfo = LocalNodeConnectInfo cModeParams network socketPath
 
   join $ lift
@@ -804,13 +803,13 @@ runQueryLedgerState socketPath (AnyConsensusModeParams cModeParams) network mOut
     & onLeft (left . ShelleyQueryCmdAcquireFailure)
     & onLeft left
 
-runQueryProtocolState
+runLegacyQueryProtocolStateCmd
   :: SocketPath
   -> AnyConsensusModeParams
   -> NetworkId
   -> Maybe (File () Out)
   -> ExceptT ShelleyQueryCmdError IO ()
-runQueryProtocolState socketPath (AnyConsensusModeParams cModeParams) network mOutFile = do
+runLegacyQueryProtocolStateCmd socketPath (AnyConsensusModeParams cModeParams) network mOutFile = do
   let localNodeConnInfo = LocalNodeConnectInfo cModeParams network socketPath
 
   join $ lift
@@ -845,14 +844,14 @@ runQueryProtocolState socketPath (AnyConsensusModeParams cModeParams) network mO
 -- | Query the current delegations and reward accounts, filtered by a given
 -- set of addresses, from a Shelley node via the local state query protocol.
 
-runQueryStakeAddressInfo
+runLegacyQueryStakeAddressInfoCmd
   :: SocketPath
   -> AnyConsensusModeParams
   -> StakeAddress
   -> NetworkId
   -> Maybe (File () Out)
   -> ExceptT ShelleyQueryCmdError IO ()
-runQueryStakeAddressInfo socketPath (AnyConsensusModeParams cModeParams) (StakeAddress _ addr) network mOutFile = do
+runLegacyQueryStakeAddressInfoCmd socketPath (AnyConsensusModeParams cModeParams) (StakeAddress _ addr) network mOutFile = do
   let localNodeConnInfo = LocalNodeConnectInfo cModeParams network socketPath
 
   join $ lift
@@ -1081,13 +1080,13 @@ printUtxo sbe txInOutTuple =
   printableValue (TxOutValue _ val) = renderValue val
   printableValue (TxOutAdaOnly _ (Lovelace i)) = Text.pack $ show i
 
-runQueryStakePools
+runLegacyQueryStakePoolsCmd
   :: SocketPath
   -> AnyConsensusModeParams
   -> NetworkId
   -> Maybe (File () Out)
   -> ExceptT ShelleyQueryCmdError IO ()
-runQueryStakePools socketPath (AnyConsensusModeParams cModeParams) network mOutFile = do
+runLegacyQueryStakePoolsCmd socketPath (AnyConsensusModeParams cModeParams) network mOutFile = do
   let localNodeConnInfo = LocalNodeConnectInfo cModeParams network socketPath
 
   join $ lift
@@ -1126,13 +1125,13 @@ writeStakePools Nothing stakePools =
   forM_ (Set.toList stakePools) $ \poolId ->
     liftIO . putStrLn $ Text.unpack (serialiseToBech32 poolId)
 
-runQueryStakeDistribution
+runLegacyQueryStakeDistributionCmd
   :: SocketPath
   -> AnyConsensusModeParams
   -> NetworkId
   -> Maybe (File () Out)
   -> ExceptT ShelleyQueryCmdError IO ()
-runQueryStakeDistribution socketPath (AnyConsensusModeParams cModeParams) network mOutFile = do
+runLegacyQueryStakeDistributionCmd socketPath (AnyConsensusModeParams cModeParams) network mOutFile = do
   let localNodeConnInfo = LocalNodeConnectInfo cModeParams network socketPath
 
   join $ lift
@@ -1253,7 +1252,7 @@ instance FromJSON DelegationsAndRewards where
         rewardAccountBalance <- o .:? "rewardAccountBalance"
         pure (address, rewardAccountBalance, delegation)
 
-runQueryLeadershipSchedule
+runLegacyQueryLeadershipScheduleCmd
   :: SocketPath
   -> AnyConsensusModeParams
   -> NetworkId
@@ -1263,7 +1262,7 @@ runQueryLeadershipSchedule
   -> EpochLeadershipSchedule
   -> Maybe (File () Out)
   -> ExceptT ShelleyQueryCmdError IO ()
-runQueryLeadershipSchedule
+runLegacyQueryLeadershipScheduleCmd
     socketPath (AnyConsensusModeParams cModeParams) network
     (GenesisFile genFile) coldVerKeyFile vrfSkeyFp
     whichSchedule mJsonOutputFile = do

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/TextView.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/TextView.hs
@@ -1,7 +1,8 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE LambdaCase #-}
 
 module Cardano.CLI.Legacy.Run.TextView
-  ( runTextViewCmds
+  ( runLegacyTextViewCmds
   ) where
 
 import           Cardano.Api
@@ -15,13 +16,12 @@ import           Control.Monad.Trans.Except (ExceptT)
 import           Control.Monad.Trans.Except.Extra (firstExceptT, newExceptT)
 import qualified Data.ByteString.Lazy.Char8 as LBS
 
-runTextViewCmds :: LegacyTextViewCmds -> ExceptT ShelleyTextViewFileError IO ()
-runTextViewCmds cmd =
-  case cmd of
-    TextViewInfo fpath mOutfile -> runTextViewInfo fpath mOutfile
+runLegacyTextViewCmds :: LegacyTextViewCmds -> ExceptT ShelleyTextViewFileError IO ()
+runLegacyTextViewCmds = \case
+  TextViewInfo fpath mOutfile -> runLegacyTextViewInfoCmd fpath mOutfile
 
-runTextViewInfo :: FilePath -> Maybe (File () Out) -> ExceptT ShelleyTextViewFileError IO ()
-runTextViewInfo fpath mOutFile = do
+runLegacyTextViewInfoCmd :: FilePath -> Maybe (File () Out) -> ExceptT ShelleyTextViewFileError IO ()
+runLegacyTextViewInfoCmd fpath mOutFile = do
   tv <- firstExceptT TextViewReadFileError $ newExceptT (readTextEnvelopeFromFile fpath)
   let lbCBOR = LBS.fromStrict (textEnvelopeRawCBOR tv)
   case mOutFile of

--- a/cardano-cli/src/Cardano/CLI/Read.hs
+++ b/cardano-cli/src/Cardano/CLI/Read.hs
@@ -4,7 +4,6 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeOperators #-}
 
 module Cardano.CLI.Read
   ( -- * Metadata


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Add legacy prefix to legacy run commands
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

This will ensure that the era-based run commands and legacy commands are named differently so the legacy commands can delegate them without confusion.

Governance legacy commands were not modified in this PR (this will be done separately) because there is a legacy governance PR that already does this.

The PR also ensures all legacy run commands have a `Cmd` suffix.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
