### PR TITLE
Release 8.7.0.0

### DIFF
--- a/cardano-cli/CHANGELOG.md
+++ b/cardano-cli/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog for cardano-cli
 
+## 8.7.0.0
+
+- Change `--constitution-file` to `--proposal-file` in `transaction build`
+  (breaking, improvement)
+  [PR 219](https://github.com/input-output-hk/cardano-cli/pull/219)
+
+- Remove error placeholders in `Cardano.CLI.Json.Friendly`
+  (improvement)
+  [PR 212](https://github.com/input-output-hk/cardano-cli/pull/212)
+
+- Use record syntax for `TxBodyContent`
+  (improvement)
+  [PR 215](https://github.com/input-output-hk/cardano-cli/pull/215)
+
+- Upgrade to `cardano-api-8.17.0.0`
+  (improvement)
+  [PR 210](https://github.com/input-output-hk/cardano-cli/pull/210)
+
+- Remove `experimental` subcommand
+  (breaking, improvement)
+  [PR 211](https://github.com/input-output-hk/cardano-cli/pull/211)
+
+- Add governance query commands
+  (feature, compatible)
+  [PR 189](https://github.com/input-output-hk/cardano-cli/pull/189)
+
+- Read and write `VotingProcedures` files instead of `VotingEntry` files
+  (breaking)
+  [PR 203](https://github.com/input-output-hk/cardano-cli/pull/203)
+
+- Enable `--drep-script-hash` option
+  (feature, compatible)
+  [PR 204](https://github.com/input-output-hk/cardano-cli/pull/204)
+
 ## 8.6.0.0
 
 - conway related commands

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.4
 
 name:                   cardano-cli
-version:                8.6.0.0
+version:                8.7.0.0
 synopsis:               The Cardano command-line interface
 description:            The Cardano command-line interface.
 copyright:              2020-2023 Input Output Global Inc (IOG).


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Release 8.7.0.0
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
   - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Additional context for the PR goes here.

If the PR fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
