### PR TITLE
Move transaction command code into era based

### DIFF
--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -113,6 +113,7 @@ library
                         Cardano.CLI.Legacy.Run.Query
                         Cardano.CLI.Legacy.Run.StakeAddress
                         Cardano.CLI.Legacy.Run.TextView
+                        Cardano.CLI.Legacy.Run.Transaction
                         Cardano.CLI.Options
                         Cardano.CLI.Orphans
                         Cardano.CLI.OS.Posix

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -86,6 +86,7 @@ library
                         Cardano.CLI.EraBased.Run.Governance.DRep
                         Cardano.CLI.EraBased.Run.Governance.Query
                         Cardano.CLI.EraBased.Run.Governance.Vote
+                        Cardano.CLI.EraBased.Run.Transaction
                         Cardano.CLI.Helpers
                         Cardano.CLI.IO.Lazy
                         Cardano.CLI.Json.Friendly
@@ -112,7 +113,6 @@ library
                         Cardano.CLI.Legacy.Run.Query
                         Cardano.CLI.Legacy.Run.StakeAddress
                         Cardano.CLI.Legacy.Run.TextView
-                        Cardano.CLI.Legacy.Run.Transaction
                         Cardano.CLI.Options
                         Cardano.CLI.Orphans
                         Cardano.CLI.OS.Posix

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Transaction.hs
@@ -13,19 +13,19 @@
 {- HLINT ignore "Use let" -}
 
 module Cardano.CLI.EraBased.Run.Transaction
-  ( runLegacyTransactionCmds
-  , runLegacyTxBuildCmd
-  , runLegacyTxBuildRawCmd
-  , runLegacyTxSignCmd
-  , runLegacyTxSubmitCmd
-  , runLegacyTxCalculateMinFeeCmd
-  , runLegacyTxCalculateMinRequiredUTxOCmd
-  , runLegacyTxCreatePolicyIdCmd
-  , runLegacyTxHashScriptDataCmd
-  , runLegacyTxGetTxIdCmd
-  , runLegacyTxViewCmd
-  , runLegacyTxCreateWitnessCmd
-  , runLegacyTxSignWitnessCmd
+  ( runTransactionCmds
+  , runTxBuildCmd
+  , runTxBuildRawCmd
+  , runTxSignCmd
+  , runTxSubmitCmd
+  , runTxCalculateMinFeeCmd
+  , runTxCalculateMinRequiredUTxOCmd
+  , runTxCreatePolicyIdCmd
+  , runTxHashScriptDataCmd
+  , runTxGetTxIdCmd
+  , runTxViewCmd
+  , runTxCreateWitnessCmd
+  , runTxSignWitnessCmd
   ) where
 
 import           Cardano.Api
@@ -71,49 +71,49 @@ import qualified Data.Text.IO as Text
 import           Data.Type.Equality (TestEquality (..))
 import qualified System.IO as IO
 
-runLegacyTransactionCmds :: LegacyTransactionCmds -> ExceptT ShelleyTxCmdError IO ()
-runLegacyTransactionCmds cmd =
+runTransactionCmds :: LegacyTransactionCmds -> ExceptT ShelleyTxCmdError IO ()
+runTransactionCmds cmd =
   case cmd of
     TxBuild mNodeSocketPath era consensusModeParams nid mScriptValidity mOverrideWits txins readOnlyRefIns
             reqSigners txinsc mReturnColl mTotCollateral txouts changeAddr mValue mLowBound
             mUpperBound certs wdrls metadataSchema scriptFiles metadataFiles mUpProp mconwayVote
             mNewConstitution outputOptions -> do
-      runLegacyTxBuildCmd mNodeSocketPath era consensusModeParams nid mScriptValidity mOverrideWits txins readOnlyRefIns
+      runTxBuildCmd mNodeSocketPath era consensusModeParams nid mScriptValidity mOverrideWits txins readOnlyRefIns
             reqSigners txinsc mReturnColl mTotCollateral txouts changeAddr mValue mLowBound
             mUpperBound certs wdrls metadataSchema scriptFiles metadataFiles mUpProp mconwayVote
             mNewConstitution outputOptions
     TxBuildRaw era mScriptValidity txins readOnlyRefIns txinsc mReturnColl
                mTotColl reqSigners txouts mValue mLowBound mUpperBound fee certs wdrls
                metadataSchema scriptFiles metadataFiles mProtocolParamsFile mUpProp out -> do
-      runLegacyTxBuildRawCmd era mScriptValidity txins readOnlyRefIns txinsc mReturnColl
+      runTxBuildRawCmd era mScriptValidity txins readOnlyRefIns txinsc mReturnColl
                mTotColl reqSigners txouts mValue mLowBound mUpperBound fee certs wdrls
                metadataSchema scriptFiles metadataFiles mProtocolParamsFile mUpProp out
     TxSign txinfile skfiles network txoutfile ->
-      runLegacyTxSignCmd txinfile skfiles network txoutfile
+      runTxSignCmd txinfile skfiles network txoutfile
     TxSubmit mNodeSocketPath anyConsensusModeParams network txFp ->
-      runLegacyTxSubmitCmd mNodeSocketPath anyConsensusModeParams network txFp
+      runTxSubmitCmd mNodeSocketPath anyConsensusModeParams network txFp
     TxCalculateMinFee txbody nw pParamsFile nInputs nOutputs nShelleyKeyWitnesses nByronKeyWitnesses ->
-      runLegacyTxCalculateMinFeeCmd txbody nw pParamsFile nInputs nOutputs nShelleyKeyWitnesses nByronKeyWitnesses
+      runTxCalculateMinFeeCmd txbody nw pParamsFile nInputs nOutputs nShelleyKeyWitnesses nByronKeyWitnesses
     TxCalculateMinRequiredUTxO era pParamsFile txOuts ->
-      runLegacyTxCalculateMinRequiredUTxOCmd era pParamsFile txOuts
+      runTxCalculateMinRequiredUTxOCmd era pParamsFile txOuts
     TxHashScriptData scriptDataOrFile ->
-      runLegacyTxHashScriptDataCmd scriptDataOrFile
+      runTxHashScriptDataCmd scriptDataOrFile
     TxGetTxId txinfile ->
-      runLegacyTxGetTxIdCmd txinfile
+      runTxGetTxIdCmd txinfile
     TxView txinfile ->
-      runLegacyTxViewCmd txinfile
+      runTxViewCmd txinfile
     TxMintedPolicyId sFile ->
-      runLegacyTxCreatePolicyIdCmd sFile
+      runTxCreatePolicyIdCmd sFile
     TxCreateWitness txBodyfile witSignData mbNw outFile ->
-      runLegacyTxCreateWitnessCmd txBodyfile witSignData mbNw outFile
+      runTxCreateWitnessCmd txBodyfile witSignData mbNw outFile
     TxAssembleTxBodyWitness txBodyFile witnessFile outFile ->
-      runLegacyTxSignWitnessCmd txBodyFile witnessFile outFile
+      runTxSignWitnessCmd txBodyFile witnessFile outFile
 
 -- ----------------------------------------------------------------------------
 -- Building transactions
 --
 
-runLegacyTxBuildCmd
+runTxBuildCmd
   :: SocketPath
   -> AnyCardanoEra
   -> AnyConsensusModeParams
@@ -141,7 +141,7 @@ runLegacyTxBuildCmd
   -> [ProposalFile In]
   -> TxBuildOutputOptions
   -> ExceptT ShelleyTxCmdError IO ()
-runLegacyTxBuildCmd
+runTxBuildCmd
     socketPath (AnyCardanoEra cEra) consensusModeParams@(AnyConsensusModeParams cModeParams) nid
     mScriptValidity mOverrideWits txins readOnlyRefIns reqSigners txinsc mReturnColl mTotCollateral txouts
     changeAddr mValue mLowBound mUpperBound certs wdrls metadataSchema scriptFiles metadataFiles mUpProp
@@ -277,7 +277,7 @@ runLegacyTxBuildCmd
             & onLeft (left . ShelleyTxCmdWriteFileError)
 
 
-runLegacyTxBuildRawCmd
+runTxBuildRawCmd
   :: AnyCardanoEra
   -> Maybe ScriptValidity
   -> [(TxIn, Maybe (ScriptWitnessFiles WitCtxTxIn))]
@@ -300,7 +300,7 @@ runLegacyTxBuildRawCmd
   -> Maybe UpdateProposalFile
   -> TxBodyFile Out
   -> ExceptT ShelleyTxCmdError IO ()
-runLegacyTxBuildRawCmd
+runTxBuildRawCmd
   (AnyCardanoEra cEra) mScriptValidity txins readOnlyRefIns txinsc mReturnColl
   mTotColl reqSigners txouts mValue mLowBound mUpperBound fee certs wdrls
   metadataSchema scriptFiles metadataFiles mpParamsFile mUpProp out = do
@@ -872,12 +872,12 @@ readValueScriptWitnesses era (v, sWitFiles) = do
 -- Transaction signing
 --
 
-runLegacyTxSignCmd :: InputTxBodyOrTxFile
+runTxSignCmd :: InputTxBodyOrTxFile
           -> [WitnessSigningData]
           -> Maybe NetworkId
           -> TxFile Out
           -> ExceptT ShelleyTxCmdError IO ()
-runLegacyTxSignCmd txOrTxBody witSigningData mnw outTxFile = do
+runTxSignCmd txOrTxBody witSigningData mnw outTxFile = do
   sks <-  mapM (firstExceptT ShelleyTxCmdReadWitnessSigningDataError . newExceptT . readWitnessSigningData) witSigningData
 
   let (sksByron, sksShelley) = partitionSomeWitnesses $ map categoriseSomeWitness sks
@@ -948,13 +948,13 @@ runLegacyTxSignCmd txOrTxBody witSigningData mnw outTxFile = do
 --
 
 
-runLegacyTxSubmitCmd
+runTxSubmitCmd
   :: SocketPath
   -> AnyConsensusModeParams
   -> NetworkId
   -> FilePath
   -> ExceptT ShelleyTxCmdError IO ()
-runLegacyTxSubmitCmd socketPath (AnyConsensusModeParams cModeParams) network txFilePath = do
+runTxSubmitCmd socketPath (AnyConsensusModeParams cModeParams) network txFilePath = do
     txFile <- liftIO $ fileOrPipe txFilePath
     InAnyCardanoEra era tx <- lift (readFileTx txFile) & onLeft (left . ShelleyTxCmdCddlError)
     let cMode = AnyConsensusMode $ consensusModeOnly cModeParams
@@ -980,7 +980,7 @@ runLegacyTxSubmitCmd socketPath (AnyConsensusModeParams cModeParams) network txF
 -- Transaction fee calculation
 --
 
-runLegacyTxCalculateMinFeeCmd
+runTxCalculateMinFeeCmd
   :: TxBodyFile In
   -> NetworkId
   -> ProtocolParamsFile
@@ -989,7 +989,7 @@ runLegacyTxCalculateMinFeeCmd
   -> TxShelleyWitnessCount
   -> TxByronWitnessCount
   -> ExceptT ShelleyTxCmdError IO ()
-runLegacyTxCalculateMinFeeCmd (File txbodyFilePath) nw pParamsFile
+runTxCalculateMinFeeCmd (File txbodyFilePath) nw pParamsFile
                      (TxInCount nInputs) (TxOutCount nOutputs)
                      (TxShelleyWitnessCount nShelleyKeyWitnesses)
                      (TxByronWitnessCount nByronKeyWitnesses) = do
@@ -1034,16 +1034,16 @@ runLegacyTxCalculateMinFeeCmd (File txbodyFilePath) nw pParamsFile
 -- Transaction fee calculation
 --
 
-runLegacyTxCalculateMinRequiredUTxOCmd
+runTxCalculateMinRequiredUTxOCmd
   :: AnyCardanoEra
   -> ProtocolParamsFile
   -> TxOutAnyEra
   -> ExceptT ShelleyTxCmdError IO ()
-runLegacyTxCalculateMinRequiredUTxOCmd (AnyCardanoEra era) pParamsFile txOut = do
+runTxCalculateMinRequiredUTxOCmd (AnyCardanoEra era) pParamsFile txOut = do
   pp <- firstExceptT ShelleyTxCmdProtocolParamsError (readProtocolParameters pParamsFile)
   out <- toTxOutInAnyEra era txOut
   case cardanoEraStyle era of
-    LegacyByronEra -> error "runLegacyTxCalculateMinRequiredUTxOCmd: Byron era not implemented yet"
+    LegacyByronEra -> error "runTxCalculateMinRequiredUTxOCmd: Byron era not implemented yet"
     ShelleyBasedEra sbe -> do
       firstExceptT ShelleyTxCmdPParamsErr . hoistEither
         $ checkProtocolParameters sbe pp
@@ -1051,8 +1051,8 @@ runLegacyTxCalculateMinRequiredUTxOCmd (AnyCardanoEra era) pParamsFile txOut = d
       let minValue = calculateMinimumUTxO sbe out pp'
       liftIO . IO.print $ minValue
 
-runLegacyTxCreatePolicyIdCmd :: ScriptFile -> ExceptT ShelleyTxCmdError IO ()
-runLegacyTxCreatePolicyIdCmd (ScriptFile sFile) = do
+runTxCreatePolicyIdCmd :: ScriptFile -> ExceptT ShelleyTxCmdError IO ()
+runTxCreatePolicyIdCmd (ScriptFile sFile) = do
   ScriptInAnyLang _ script <- firstExceptT ShelleyTxCmdScriptFileError $
                                 readFileScriptInAnyLang sFile
   liftIO . Text.putStrLn . serialiseToRawBytesHexText $ hashScript script
@@ -1109,13 +1109,13 @@ mkShelleyBootstrapWitnesses mnw txBody =
 -- Other misc small commands
 --
 
-runLegacyTxHashScriptDataCmd :: ScriptDataOrFile -> ExceptT ShelleyTxCmdError IO ()
-runLegacyTxHashScriptDataCmd scriptDataOrFile = do
+runTxHashScriptDataCmd :: ScriptDataOrFile -> ExceptT ShelleyTxCmdError IO ()
+runTxHashScriptDataCmd scriptDataOrFile = do
     d <- firstExceptT ShelleyTxCmdScriptDataError $ readScriptDataOrFile scriptDataOrFile
     liftIO $ BS.putStrLn $ serialiseToRawBytesHex (hashScriptDataBytes d)
 
-runLegacyTxGetTxIdCmd :: InputTxBodyOrTxFile -> ExceptT ShelleyTxCmdError IO ()
-runLegacyTxGetTxIdCmd txfile = do
+runTxGetTxIdCmd :: InputTxBodyOrTxFile -> ExceptT ShelleyTxCmdError IO ()
+runTxGetTxIdCmd txfile = do
     InAnyCardanoEra _era txbody <-
       case txfile of
         InputTxBodyFile (File txbodyFilePath) -> do
@@ -1134,8 +1134,8 @@ runLegacyTxGetTxIdCmd txfile = do
 
     liftIO $ BS.putStrLn $ serialiseToRawBytesHex (getTxId txbody)
 
-runLegacyTxViewCmd :: InputTxBodyOrTxFile -> ExceptT ShelleyTxCmdError IO ()
-runLegacyTxViewCmd = \case
+runTxViewCmd :: InputTxBodyOrTxFile -> ExceptT ShelleyTxCmdError IO ()
+runTxViewCmd = \case
   InputTxBodyFile (File txbodyFilePath) -> do
     txbodyFile <- liftIO $ fileOrPipe txbodyFilePath
     unwitnessed <- firstExceptT ShelleyTxCmdCddlError . newExceptT
@@ -1159,13 +1159,13 @@ runLegacyTxViewCmd = \case
 -- Witness commands
 --
 
-runLegacyTxCreateWitnessCmd
+runTxCreateWitnessCmd
   :: TxBodyFile In
   -> WitnessSigningData
   -> Maybe NetworkId
   -> File () Out
   -> ExceptT ShelleyTxCmdError IO ()
-runLegacyTxCreateWitnessCmd (File txbodyFilePath) witSignData mbNw oFile = do
+runTxCreateWitnessCmd (File txbodyFilePath) witSignData mbNw oFile = do
   txbodyFile <- liftIO $ fileOrPipe txbodyFilePath
   unwitnessed <- firstExceptT ShelleyTxCmdCddlError . newExceptT
                    $ readFileTxBody txbodyFile
@@ -1213,12 +1213,12 @@ runLegacyTxCreateWitnessCmd (File txbodyFilePath) witSignData mbNw oFile = do
         $ writeLazyByteStringFile oFile
         $ textEnvelopeToJSON Nothing witness
 
-runLegacyTxSignWitnessCmd
+runTxSignWitnessCmd
   :: TxBodyFile In
   -> [WitnessFile]
   -> File () Out
   -> ExceptT ShelleyTxCmdError IO ()
-runLegacyTxSignWitnessCmd (File txbodyFilePath) witnessFiles oFp = do
+runTxSignWitnessCmd (File txbodyFilePath) witnessFiles oFp = do
     txbodyFile <- liftIO $ fileOrPipe txbodyFilePath
     unwitnessed <- firstExceptT ShelleyTxCmdCddlError . newExceptT
                      $ readFileTxBody txbodyFile

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Transaction.hs
@@ -14,8 +14,18 @@
 
 module Cardano.CLI.EraBased.Run.Transaction
   ( runLegacyTransactionCmds
-  , readFileTx
-  , toTxOutInAnyEra
+  , runLegacyTxBuildCmd
+  , runLegacyTxBuildRawCmd
+  , runLegacyTxSignCmd
+  , runLegacyTxSubmitCmd
+  , runLegacyTxCalculateMinFeeCmd
+  , runLegacyTxCalculateMinRequiredUTxOCmd
+  , runLegacyTxCreatePolicyIdCmd
+  , runLegacyTxHashScriptDataCmd
+  , runLegacyTxGetTxIdCmd
+  , runLegacyTxViewCmd
+  , runLegacyTxCreateWitnessCmd
+  , runLegacyTxSignWitnessCmd
   ) where
 
 import           Cardano.Api

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Transaction.hs
@@ -12,7 +12,7 @@
 {- HLINT ignore "Unused LANGUAGE pragma" -}
 {- HLINT ignore "Use let" -}
 
-module Cardano.CLI.Legacy.Run.Transaction
+module Cardano.CLI.EraBased.Run.Transaction
   ( runLegacyTransactionCmds
   , readFileTx
   , toTxOutInAnyEra
@@ -1263,5 +1263,3 @@ onlyInShelleyBasedEras notImplMsg (InAnyCardanoEra era x) =
     case cardanoEraStyle era of
       LegacyByronEra      -> left (ShelleyTxCmdNotImplemented notImplMsg)
       ShelleyBasedEra sbe -> return (InAnyShelleyBasedEra sbe x)
-
-

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run.hs
@@ -4,6 +4,7 @@ module Cardano.CLI.Legacy.Run
   ( runLegacyCmds
   ) where
 
+import           Cardano.CLI.EraBased.Run.Transaction
 import           Cardano.CLI.Legacy.Options
 import           Cardano.CLI.Legacy.Run.Address
 import           Cardano.CLI.Legacy.Run.Genesis
@@ -14,7 +15,6 @@ import           Cardano.CLI.Legacy.Run.Pool
 import           Cardano.CLI.Legacy.Run.Query
 import           Cardano.CLI.Legacy.Run.StakeAddress
 import           Cardano.CLI.Legacy.Run.TextView
-import           Cardano.CLI.Legacy.Run.Transaction
 import           Cardano.CLI.Types.Errors.CmdError
 
 import           Control.Monad.Trans.Except (ExceptT)

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run.hs
@@ -4,7 +4,6 @@ module Cardano.CLI.Legacy.Run
   ( runLegacyCmds
   ) where
 
-import           Cardano.CLI.EraBased.Run.Transaction
 import           Cardano.CLI.Legacy.Options
 import           Cardano.CLI.Legacy.Run.Address
 import           Cardano.CLI.Legacy.Run.Genesis
@@ -15,6 +14,7 @@ import           Cardano.CLI.Legacy.Run.Pool
 import           Cardano.CLI.Legacy.Run.Query
 import           Cardano.CLI.Legacy.Run.StakeAddress
 import           Cardano.CLI.Legacy.Run.TextView
+import           Cardano.CLI.Legacy.Run.Transaction
 import           Cardano.CLI.Types.Errors.CmdError
 
 import           Control.Monad.Trans.Except (ExceptT)

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Transaction.hs
@@ -1,0 +1,185 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TupleSections #-}
+
+{-# OPTIONS_GHC -Wno-incomplete-uni-patterns #-}
+
+{- HLINT ignore "Unused LANGUAGE pragma" -}
+{- HLINT ignore "Use let" -}
+
+module Cardano.CLI.Legacy.Run.Transaction
+  ( runLegacyTransactionCmds
+  ) where
+
+import           Cardano.Api
+
+import qualified Cardano.CLI.EraBased.Run.Transaction as EraBased
+import           Cardano.CLI.Legacy.Commands.Transaction
+import           Cardano.CLI.Types.Common
+import           Cardano.CLI.Types.Errors.ShelleyTxCmdError
+import           Cardano.CLI.Types.Governance
+
+import           Control.Monad.Trans.Except
+
+runLegacyTransactionCmds :: LegacyTransactionCmds -> ExceptT ShelleyTxCmdError IO ()
+runLegacyTransactionCmds cmd =
+  case cmd of
+    TxBuild mNodeSocketPath era consensusModeParams nid mScriptValidity mOverrideWits txins readOnlyRefIns
+            reqSigners txinsc mReturnColl mTotCollateral txouts changeAddr mValue mLowBound
+            mUpperBound certs wdrls metadataSchema scriptFiles metadataFiles mUpProp mconwayVote
+            mNewConstitution outputOptions -> do
+      runLegacyTxBuildCmd mNodeSocketPath era consensusModeParams nid mScriptValidity mOverrideWits txins readOnlyRefIns
+            reqSigners txinsc mReturnColl mTotCollateral txouts changeAddr mValue mLowBound
+            mUpperBound certs wdrls metadataSchema scriptFiles metadataFiles mUpProp mconwayVote
+            mNewConstitution outputOptions
+    TxBuildRaw era mScriptValidity txins readOnlyRefIns txinsc mReturnColl
+               mTotColl reqSigners txouts mValue mLowBound mUpperBound fee certs wdrls
+               metadataSchema scriptFiles metadataFiles mProtocolParamsFile mUpProp out -> do
+      runLegacyTxBuildRawCmd era mScriptValidity txins readOnlyRefIns txinsc mReturnColl
+               mTotColl reqSigners txouts mValue mLowBound mUpperBound fee certs wdrls
+               metadataSchema scriptFiles metadataFiles mProtocolParamsFile mUpProp out
+    TxSign txinfile skfiles network txoutfile ->
+      runLegacyTxSignCmd txinfile skfiles network txoutfile
+    TxSubmit mNodeSocketPath anyConsensusModeParams network txFp ->
+      runLegacyTxSubmitCmd mNodeSocketPath anyConsensusModeParams network txFp
+    TxCalculateMinFee txbody nw pParamsFile nInputs nOutputs nShelleyKeyWitnesses nByronKeyWitnesses ->
+      runLegacyTxCalculateMinFeeCmd txbody nw pParamsFile nInputs nOutputs nShelleyKeyWitnesses nByronKeyWitnesses
+    TxCalculateMinRequiredUTxO era pParamsFile txOuts ->
+      runLegacyTxCalculateMinRequiredUTxOCmd era pParamsFile txOuts
+    TxHashScriptData scriptDataOrFile ->
+      runLegacyTxHashScriptDataCmd scriptDataOrFile
+    TxGetTxId txinfile ->
+      runLegacyTxGetTxIdCmd txinfile
+    TxView txinfile ->
+      runLegacyTxViewCmd txinfile
+    TxMintedPolicyId sFile ->
+      runLegacyTxCreatePolicyIdCmd sFile
+    TxCreateWitness txBodyfile witSignData mbNw outFile ->
+      runLegacyTxCreateWitnessCmd txBodyfile witSignData mbNw outFile
+    TxAssembleTxBodyWitness txBodyFile witnessFile outFile ->
+      runLegacyTxSignWitnessCmd txBodyFile witnessFile outFile
+
+-- ----------------------------------------------------------------------------
+-- Building transactions
+--
+
+runLegacyTxBuildCmd
+  :: SocketPath
+  -> AnyCardanoEra
+  -> AnyConsensusModeParams
+  -> NetworkId
+  -> Maybe ScriptValidity
+  -> Maybe Word -- ^ Override the required number of tx witnesses
+  -> [(TxIn, Maybe (ScriptWitnessFiles WitCtxTxIn))] -- ^ Transaction inputs with optional spending scripts
+  -> [TxIn] -- ^ Read only reference inputs
+  -> [RequiredSigner] -- ^ Required signers
+  -> [TxIn] -- ^ Transaction inputs for collateral, only key witnesses, no scripts.
+  -> Maybe TxOutAnyEra -- ^ Return collateral
+  -> Maybe Lovelace -- ^ Total collateral
+  -> [TxOutAnyEra]
+  -> TxOutChangeAddress
+  -> Maybe (Value, [ScriptWitnessFiles WitCtxMint])
+  -> Maybe SlotNo -- ^ Validity lower bound
+  -> Maybe SlotNo -- ^ Validity upper bound
+  -> [(CertificateFile, Maybe (ScriptWitnessFiles WitCtxStake))]
+  -> [(StakeAddress, Lovelace, Maybe (ScriptWitnessFiles WitCtxStake))] -- ^ Withdrawals with potential script witness
+  -> TxMetadataJsonSchema
+  -> [ScriptFile]
+  -> [MetadataFile]
+  -> Maybe UpdateProposalFile
+  -> [VoteFile In]
+  -> [ProposalFile In]
+  -> TxBuildOutputOptions
+  -> ExceptT ShelleyTxCmdError IO ()
+runLegacyTxBuildCmd = EraBased.runLegacyTxBuildCmd
+
+
+runLegacyTxBuildRawCmd
+  :: AnyCardanoEra
+  -> Maybe ScriptValidity
+  -> [(TxIn, Maybe (ScriptWitnessFiles WitCtxTxIn))]
+  -> [TxIn] -- ^ Read only reference inputs
+  -> [TxIn] -- ^ Transaction inputs for collateral, only key witnesses, no scripts.
+  -> Maybe TxOutAnyEra
+  -> Maybe Lovelace -- ^ Total collateral
+  -> [RequiredSigner]
+  -> [TxOutAnyEra]
+  -> Maybe (Value, [ScriptWitnessFiles WitCtxMint]) -- ^ Multi-Asset value with script witness
+  -> Maybe SlotNo -- ^ Validity lower bound
+  -> Maybe SlotNo -- ^ Validity upper bound
+  -> Maybe Lovelace -- ^ Tx fee
+  -> [(CertificateFile, Maybe (ScriptWitnessFiles WitCtxStake))]
+  -> [(StakeAddress, Lovelace, Maybe (ScriptWitnessFiles WitCtxStake))]
+  -> TxMetadataJsonSchema
+  -> [ScriptFile]
+  -> [MetadataFile]
+  -> Maybe ProtocolParamsFile
+  -> Maybe UpdateProposalFile
+  -> TxBodyFile Out
+  -> ExceptT ShelleyTxCmdError IO ()
+runLegacyTxBuildRawCmd = EraBased.runLegacyTxBuildRawCmd
+
+runLegacyTxSignCmd :: InputTxBodyOrTxFile
+          -> [WitnessSigningData]
+          -> Maybe NetworkId
+          -> TxFile Out
+          -> ExceptT ShelleyTxCmdError IO ()
+runLegacyTxSignCmd = EraBased.runLegacyTxSignCmd
+
+runLegacyTxSubmitCmd
+  :: SocketPath
+  -> AnyConsensusModeParams
+  -> NetworkId
+  -> FilePath
+  -> ExceptT ShelleyTxCmdError IO ()
+runLegacyTxSubmitCmd = EraBased.runLegacyTxSubmitCmd
+
+runLegacyTxCalculateMinFeeCmd
+  :: TxBodyFile In
+  -> NetworkId
+  -> ProtocolParamsFile
+  -> TxInCount
+  -> TxOutCount
+  -> TxShelleyWitnessCount
+  -> TxByronWitnessCount
+  -> ExceptT ShelleyTxCmdError IO ()
+runLegacyTxCalculateMinFeeCmd = EraBased.runLegacyTxCalculateMinFeeCmd
+
+runLegacyTxCalculateMinRequiredUTxOCmd
+  :: AnyCardanoEra
+  -> ProtocolParamsFile
+  -> TxOutAnyEra
+  -> ExceptT ShelleyTxCmdError IO ()
+runLegacyTxCalculateMinRequiredUTxOCmd = EraBased.runLegacyTxCalculateMinRequiredUTxOCmd
+
+runLegacyTxCreatePolicyIdCmd :: ScriptFile -> ExceptT ShelleyTxCmdError IO ()
+runLegacyTxCreatePolicyIdCmd = EraBased.runLegacyTxCreatePolicyIdCmd
+
+runLegacyTxHashScriptDataCmd :: ScriptDataOrFile -> ExceptT ShelleyTxCmdError IO ()
+runLegacyTxHashScriptDataCmd = EraBased.runLegacyTxHashScriptDataCmd
+
+runLegacyTxGetTxIdCmd :: InputTxBodyOrTxFile -> ExceptT ShelleyTxCmdError IO ()
+runLegacyTxGetTxIdCmd = EraBased.runLegacyTxGetTxIdCmd
+
+runLegacyTxViewCmd :: InputTxBodyOrTxFile -> ExceptT ShelleyTxCmdError IO ()
+runLegacyTxViewCmd = EraBased.runLegacyTxViewCmd
+
+runLegacyTxCreateWitnessCmd
+  :: TxBodyFile In
+  -> WitnessSigningData
+  -> Maybe NetworkId
+  -> File () Out
+  -> ExceptT ShelleyTxCmdError IO ()
+runLegacyTxCreateWitnessCmd = EraBased.runLegacyTxCreateWitnessCmd
+
+runLegacyTxSignWitnessCmd
+  :: TxBodyFile In
+  -> [WitnessFile]
+  -> File () Out
+  -> ExceptT ShelleyTxCmdError IO ()
+runLegacyTxSignWitnessCmd = EraBased.runLegacyTxSignWitnessCmd

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Transaction.hs
@@ -18,7 +18,7 @@ module Cardano.CLI.Legacy.Run.Transaction
 
 import           Cardano.Api
 
-import qualified Cardano.CLI.EraBased.Run.Transaction as EraBased
+import           Cardano.CLI.EraBased.Run.Transaction
 import           Cardano.CLI.Legacy.Commands.Transaction
 import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Errors.ShelleyTxCmdError
@@ -68,8 +68,8 @@ runLegacyTransactionCmds cmd =
 -- Building transactions
 --
 
-runLegacyTxBuildCmd
-  :: SocketPath
+runLegacyTxBuildCmd :: ()
+  => SocketPath
   -> AnyCardanoEra
   -> AnyConsensusModeParams
   -> NetworkId
@@ -96,11 +96,10 @@ runLegacyTxBuildCmd
   -> [ProposalFile In]
   -> TxBuildOutputOptions
   -> ExceptT ShelleyTxCmdError IO ()
-runLegacyTxBuildCmd = EraBased.runLegacyTxBuildCmd
+runLegacyTxBuildCmd = runTxBuildCmd
 
-
-runLegacyTxBuildRawCmd
-  :: AnyCardanoEra
+runLegacyTxBuildRawCmd :: ()
+  => AnyCardanoEra
   -> Maybe ScriptValidity
   -> [(TxIn, Maybe (ScriptWitnessFiles WitCtxTxIn))]
   -> [TxIn] -- ^ Read only reference inputs
@@ -122,25 +121,25 @@ runLegacyTxBuildRawCmd
   -> Maybe UpdateProposalFile
   -> TxBodyFile Out
   -> ExceptT ShelleyTxCmdError IO ()
-runLegacyTxBuildRawCmd = EraBased.runLegacyTxBuildRawCmd
+runLegacyTxBuildRawCmd = runTxBuildRawCmd
 
 runLegacyTxSignCmd :: InputTxBodyOrTxFile
           -> [WitnessSigningData]
           -> Maybe NetworkId
           -> TxFile Out
           -> ExceptT ShelleyTxCmdError IO ()
-runLegacyTxSignCmd = EraBased.runLegacyTxSignCmd
+runLegacyTxSignCmd = runTxSignCmd
 
-runLegacyTxSubmitCmd
-  :: SocketPath
+runLegacyTxSubmitCmd :: ()
+  => SocketPath
   -> AnyConsensusModeParams
   -> NetworkId
   -> FilePath
   -> ExceptT ShelleyTxCmdError IO ()
-runLegacyTxSubmitCmd = EraBased.runLegacyTxSubmitCmd
+runLegacyTxSubmitCmd = runTxSubmitCmd
 
-runLegacyTxCalculateMinFeeCmd
-  :: TxBodyFile In
+runLegacyTxCalculateMinFeeCmd :: ()
+  => TxBodyFile In
   -> NetworkId
   -> ProtocolParamsFile
   -> TxInCount
@@ -148,38 +147,38 @@ runLegacyTxCalculateMinFeeCmd
   -> TxShelleyWitnessCount
   -> TxByronWitnessCount
   -> ExceptT ShelleyTxCmdError IO ()
-runLegacyTxCalculateMinFeeCmd = EraBased.runLegacyTxCalculateMinFeeCmd
+runLegacyTxCalculateMinFeeCmd = runTxCalculateMinFeeCmd
 
-runLegacyTxCalculateMinRequiredUTxOCmd
-  :: AnyCardanoEra
+runLegacyTxCalculateMinRequiredUTxOCmd :: ()
+  => AnyCardanoEra
   -> ProtocolParamsFile
   -> TxOutAnyEra
   -> ExceptT ShelleyTxCmdError IO ()
-runLegacyTxCalculateMinRequiredUTxOCmd = EraBased.runLegacyTxCalculateMinRequiredUTxOCmd
+runLegacyTxCalculateMinRequiredUTxOCmd = runTxCalculateMinRequiredUTxOCmd
 
 runLegacyTxCreatePolicyIdCmd :: ScriptFile -> ExceptT ShelleyTxCmdError IO ()
-runLegacyTxCreatePolicyIdCmd = EraBased.runLegacyTxCreatePolicyIdCmd
+runLegacyTxCreatePolicyIdCmd = runTxCreatePolicyIdCmd
 
 runLegacyTxHashScriptDataCmd :: ScriptDataOrFile -> ExceptT ShelleyTxCmdError IO ()
-runLegacyTxHashScriptDataCmd = EraBased.runLegacyTxHashScriptDataCmd
+runLegacyTxHashScriptDataCmd = runTxHashScriptDataCmd
 
 runLegacyTxGetTxIdCmd :: InputTxBodyOrTxFile -> ExceptT ShelleyTxCmdError IO ()
-runLegacyTxGetTxIdCmd = EraBased.runLegacyTxGetTxIdCmd
+runLegacyTxGetTxIdCmd = runTxGetTxIdCmd
 
 runLegacyTxViewCmd :: InputTxBodyOrTxFile -> ExceptT ShelleyTxCmdError IO ()
-runLegacyTxViewCmd = EraBased.runLegacyTxViewCmd
+runLegacyTxViewCmd = runTxViewCmd
 
-runLegacyTxCreateWitnessCmd
-  :: TxBodyFile In
+runLegacyTxCreateWitnessCmd :: ()
+  => TxBodyFile In
   -> WitnessSigningData
   -> Maybe NetworkId
   -> File () Out
   -> ExceptT ShelleyTxCmdError IO ()
-runLegacyTxCreateWitnessCmd = EraBased.runLegacyTxCreateWitnessCmd
+runLegacyTxCreateWitnessCmd = runTxCreateWitnessCmd
 
-runLegacyTxSignWitnessCmd
-  :: TxBodyFile In
+runLegacyTxSignWitnessCmd :: ()
+  => TxBodyFile In
   -> [WitnessFile]
   -> File () Out
   -> ExceptT ShelleyTxCmdError IO ()
-runLegacyTxSignWitnessCmd = EraBased.runLegacyTxSignWitnessCmd
+runLegacyTxSignWitnessCmd = runTxSignWitnessCmd


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Move transaction command code into era based
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

The purpose of this change is to move the transaction command run functions into the era-based command structure so that work can start on making it era-sensitive.

There have been numerous attempts to do this before, but they all failed because of rebase conflicts.

This PR does the minimum thing which is to move the functions without change into `Cardano.CLI.EraBased.Run.Transaction` in a way that `git` can recognise it as a move.

After this the `Cardano.CLI.Legacy.Run.Transaction` module is recreated to delegate there and the legacy prefix removed from functions in `Cardano.CLI.EraBased.Run.Transaction`.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
