### PR TITLE
Move `address` run command implementation into era-based

### DIFF
--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -80,6 +80,8 @@ library
                         Cardano.CLI.EraBased.Options.Governance.Query
                         Cardano.CLI.EraBased.Options.Governance.Vote
                         Cardano.CLI.EraBased.Run
+                        Cardano.CLI.EraBased.Run.Address
+                        Cardano.CLI.EraBased.Run.Address.Info
                         Cardano.CLI.EraBased.Run.Governance
                         Cardano.CLI.EraBased.Run.Governance.Actions
                         Cardano.CLI.EraBased.Run.Governance.Committee
@@ -104,8 +106,6 @@ library
                         Cardano.CLI.Legacy.Commands.Transaction
                         Cardano.CLI.Legacy.Options
                         Cardano.CLI.Legacy.Run
-                        Cardano.CLI.Legacy.Run.Address
-                        Cardano.CLI.Legacy.Run.Address.Info
                         Cardano.CLI.Legacy.Run.Genesis
                         Cardano.CLI.Legacy.Run.Governance
                         Cardano.CLI.Legacy.Run.Key

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -106,6 +106,7 @@ library
                         Cardano.CLI.Legacy.Commands.Transaction
                         Cardano.CLI.Legacy.Options
                         Cardano.CLI.Legacy.Run
+                        Cardano.CLI.Legacy.Run.Address
                         Cardano.CLI.Legacy.Run.Genesis
                         Cardano.CLI.Legacy.Run.Governance
                         Cardano.CLI.Legacy.Run.Key

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Address.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Address.hs
@@ -1,14 +1,11 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Cardano.CLI.EraBased.Run.Address
-  ( runLegacyAddressCmds
-
-  , runLegacyAddressBuildCmd
+  ( runLegacyAddressBuildCmd
   , runLegacyAddressKeyGenCmd
   , runLegacyAddressKeyHashCmd
 
@@ -20,8 +17,6 @@ module Cardano.CLI.EraBased.Run.Address
 import           Cardano.Api
 import           Cardano.Api.Shelley
 
-import           Cardano.CLI.Legacy.Commands.Address
-import           Cardano.CLI.EraBased.Run.Address.Info (runLegacyAddressInfoCmd)
 import           Cardano.CLI.Read
 import           Cardano.CLI.Types.Key (PaymentVerifier (..), StakeIdentifier (..),
                    StakeVerifier (..), VerificationKeyTextOrFile, generateKeyPair, readVerificationKeyOrFile,
@@ -34,17 +29,6 @@ import           Control.Monad.Trans.Except (ExceptT)
 import           Control.Monad.Trans.Except.Extra (firstExceptT, left, newExceptT)
 import qualified Data.ByteString.Char8 as BS
 import qualified Data.Text.IO as Text
-
-runLegacyAddressCmds :: LegacyAddressCmds -> ExceptT ShelleyAddressCmdError IO ()
-runLegacyAddressCmds = \case
-  AddressKeyGen fmt kt vkf skf ->
-    runLegacyAddressKeyGenCmd fmt kt vkf skf
-  AddressKeyHash vkf mOFp ->
-    runLegacyAddressKeyHashCmd vkf mOFp
-  AddressBuild paymentVerifier mbStakeVerifier nw mOutFp ->
-    runLegacyAddressBuildCmd paymentVerifier mbStakeVerifier nw mOutFp
-  AddressInfo txt mOFp ->
-    firstExceptT ShelleyAddressCmdAddressInfoError $ runLegacyAddressInfoCmd txt mOFp
 
 runLegacyAddressKeyGenCmd
   :: KeyOutputFormat

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Address.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Address.hs
@@ -6,10 +6,14 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Cardano.CLI.EraBased.Run.Address
-  ( SomeAddressVerificationKey(..)
+  ( runLegacyAddressCmds
+
+  , runLegacyAddressBuildCmd
+  , runLegacyAddressKeyGenCmd
+  , runLegacyAddressKeyHashCmd
+
   , buildShelleyAddress
   , renderShelleyAddressCmdError
-  , runLegacyAddressCmds
   , makeStakeAddressRef
   ) where
 

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Address.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Address.hs
@@ -5,7 +5,7 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-module Cardano.CLI.Legacy.Run.Address
+module Cardano.CLI.EraBased.Run.Address
   ( SomeAddressVerificationKey(..)
   , buildShelleyAddress
   , renderShelleyAddressCmdError
@@ -17,7 +17,7 @@ import           Cardano.Api
 import           Cardano.Api.Shelley
 
 import           Cardano.CLI.Legacy.Commands.Address
-import           Cardano.CLI.Legacy.Run.Address.Info (runLegacyAddressInfoCmd)
+import           Cardano.CLI.EraBased.Run.Address.Info (runLegacyAddressInfoCmd)
 import           Cardano.CLI.Read
 import           Cardano.CLI.Types.Key (PaymentVerifier (..), StakeIdentifier (..),
                    StakeVerifier (..), VerificationKeyTextOrFile, generateKeyPair, readVerificationKeyOrFile,

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Address.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Address.hs
@@ -8,10 +8,6 @@ module Cardano.CLI.EraBased.Run.Address
   ( runLegacyAddressBuildCmd
   , runLegacyAddressKeyGenCmd
   , runLegacyAddressKeyHashCmd
-
-  , buildShelleyAddress
-  , renderShelleyAddressCmdError
-  , makeStakeAddressRef
   ) where
 
 import           Cardano.Api

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Address.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Address.hs
@@ -5,9 +5,9 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Cardano.CLI.EraBased.Run.Address
-  ( runLegacyAddressBuildCmd
-  , runLegacyAddressKeyGenCmd
-  , runLegacyAddressKeyHashCmd
+  ( runAddressBuildCmd
+  , runAddressKeyGenCmd
+  , runAddressKeyHashCmd
   ) where
 
 import           Cardano.Api
@@ -26,13 +26,13 @@ import           Control.Monad.Trans.Except.Extra (firstExceptT, left, newExcept
 import qualified Data.ByteString.Char8 as BS
 import qualified Data.Text.IO as Text
 
-runLegacyAddressKeyGenCmd
+runAddressKeyGenCmd
   :: KeyOutputFormat
   -> AddressKeyType
   -> VerificationKeyFile Out
   -> SigningKeyFile Out
   -> ExceptT ShelleyAddressCmdError IO ()
-runLegacyAddressKeyGenCmd fmt kt vkf skf = case kt of
+runAddressKeyGenCmd fmt kt vkf skf = case kt of
   AddressKeyShelley         -> generateAndWriteKeyFiles fmt  AsPaymentKey          vkf skf
   AddressKeyShelleyExtended -> generateAndWriteKeyFiles fmt  AsPaymentExtendedKey  vkf skf
   AddressKeyByron           -> generateAndWriteByronKeyFiles AsByronKey            vkf skf
@@ -122,10 +122,10 @@ writeByronPaymentKeyFiles vkeyPath skeyPath vkey skey = do
     skeyDesc = "Payment Signing Key"
     vkeyDesc = "Payment Verification Key"
 
-runLegacyAddressKeyHashCmd :: VerificationKeyTextOrFile
+runAddressKeyHashCmd :: VerificationKeyTextOrFile
                   -> Maybe (File () Out)
                   -> ExceptT ShelleyAddressCmdError IO ()
-runLegacyAddressKeyHashCmd vkeyTextOrFile mOutputFp = do
+runAddressKeyHashCmd vkeyTextOrFile mOutputFp = do
   vkey <- firstExceptT ShelleyAddressCmdVerificationKeyTextOrFileError $
              newExceptT $ readVerificationKeyTextOrFileAnyOf vkeyTextOrFile
 
@@ -137,12 +137,12 @@ runLegacyAddressKeyHashCmd vkeyTextOrFile mOutputFp = do
     Nothing -> liftIO $ BS.putStrLn hexKeyHash
 
 
-runLegacyAddressBuildCmd :: PaymentVerifier
+runAddressBuildCmd :: PaymentVerifier
                 -> Maybe StakeIdentifier
                 -> NetworkId
                 -> Maybe (File () Out)
                 -> ExceptT ShelleyAddressCmdError IO ()
-runLegacyAddressBuildCmd paymentVerifier mbStakeVerifier nw mOutFp = do
+runAddressBuildCmd paymentVerifier mbStakeVerifier nw mOutFp = do
   outText <- case paymentVerifier of
     PaymentVerifierKey payVkeyTextOrFile -> do
       payVKey <- firstExceptT ShelleyAddressCmdVerificationKeyTextOrFileError $

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Address/Info.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Address/Info.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE GADTs #-}
 
 module Cardano.CLI.EraBased.Run.Address.Info
-  ( runLegacyAddressInfoCmd
+  ( runAddressInfoCmd
   ) where
 
 import           Cardano.Api
@@ -36,8 +36,8 @@ instance ToJSON AddressInfo where
       , "base16" .= aiBase16 addrInfo
       ]
 
-runLegacyAddressInfoCmd :: Text -> Maybe (File () Out) -> ExceptT ShelleyAddressInfoError IO ()
-runLegacyAddressInfoCmd addrTxt mOutputFp = do
+runAddressInfoCmd :: Text -> Maybe (File () Out) -> ExceptT ShelleyAddressInfoError IO ()
+runAddressInfoCmd addrTxt mOutputFp = do
     addrInfo <- case (Left  <$> deserialiseAddress AsAddressAny addrTxt)
                  <|> (Right <$> deserialiseAddress AsStakeAddress addrTxt) of
 

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Address/Info.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Address/Info.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE GADTs #-}
 
-module Cardano.CLI.Legacy.Run.Address.Info
+module Cardano.CLI.EraBased.Run.Address.Info
   ( runLegacyAddressInfoCmd
   ) where
 

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run.hs
@@ -4,8 +4,8 @@ module Cardano.CLI.Legacy.Run
   ( runLegacyCmds
   ) where
 
-import           Cardano.CLI.EraBased.Run.Address
 import           Cardano.CLI.Legacy.Options
+import           Cardano.CLI.Legacy.Run.Address
 import           Cardano.CLI.Legacy.Run.Genesis
 import           Cardano.CLI.Legacy.Run.Governance
 import           Cardano.CLI.Legacy.Run.Key

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run.hs
@@ -4,8 +4,8 @@ module Cardano.CLI.Legacy.Run
   ( runLegacyCmds
   ) where
 
+import           Cardano.CLI.EraBased.Run.Address
 import           Cardano.CLI.Legacy.Options
-import           Cardano.CLI.Legacy.Run.Address
 import           Cardano.CLI.Legacy.Run.Genesis
 import           Cardano.CLI.Legacy.Run.Governance
 import           Cardano.CLI.Legacy.Run.Key

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Address.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Address.hs
@@ -11,8 +11,8 @@ module Cardano.CLI.Legacy.Run.Address
 
 import           Cardano.Api
 
-import qualified Cardano.CLI.EraBased.Run.Address as EraBased
-import qualified Cardano.CLI.EraBased.Run.Address.Info as EraBased
+import           Cardano.CLI.EraBased.Run.Address
+import           Cardano.CLI.EraBased.Run.Address.Info
 import           Cardano.CLI.Legacy.Commands.Address
 import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Errors.ShelleyAddressCmdError
@@ -42,13 +42,13 @@ runLegacyAddressKeyGenCmd :: ()
   -> VerificationKeyFile Out
   -> SigningKeyFile Out
   -> ExceptT ShelleyAddressCmdError IO ()
-runLegacyAddressKeyGenCmd = EraBased.runLegacyAddressKeyGenCmd
+runLegacyAddressKeyGenCmd = runAddressKeyGenCmd
 
 runLegacyAddressKeyHashCmd :: ()
   => VerificationKeyTextOrFile
   -> Maybe (File () Out)
   -> ExceptT ShelleyAddressCmdError IO ()
-runLegacyAddressKeyHashCmd = EraBased.runLegacyAddressKeyHashCmd
+runLegacyAddressKeyHashCmd = runAddressKeyHashCmd
 
 runLegacyAddressBuildCmd :: ()
   => PaymentVerifier
@@ -56,10 +56,10 @@ runLegacyAddressBuildCmd :: ()
   -> NetworkId
   -> Maybe (File () Out)
   -> ExceptT ShelleyAddressCmdError IO ()
-runLegacyAddressBuildCmd = EraBased.runLegacyAddressBuildCmd
+runLegacyAddressBuildCmd = runAddressBuildCmd
 
 runLegacyAddressInfoCmd :: ()
   => Text
   -> Maybe (File () Out)
   -> ExceptT ShelleyAddressInfoError IO ()
-runLegacyAddressInfoCmd = EraBased.runLegacyAddressInfoCmd
+runLegacyAddressInfoCmd = runAddressInfoCmd

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Address.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Address.hs
@@ -1,0 +1,65 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Cardano.CLI.Legacy.Run.Address
+  ( runLegacyAddressCmds
+  ) where
+
+import           Cardano.Api
+
+import qualified Cardano.CLI.EraBased.Run.Address as EraBased
+import qualified Cardano.CLI.EraBased.Run.Address.Info as EraBased
+import           Cardano.CLI.Legacy.Commands.Address
+import           Cardano.CLI.Types.Common
+import           Cardano.CLI.Types.Errors.ShelleyAddressCmdError
+import           Cardano.CLI.Types.Errors.ShelleyAddressInfoError
+import           Cardano.CLI.Types.Key (PaymentVerifier (..), StakeIdentifier (..),
+                   VerificationKeyTextOrFile)
+
+import           Control.Monad.Trans.Except (ExceptT)
+import           Control.Monad.Trans.Except.Extra (firstExceptT)
+import           Data.Function
+import           Data.Text (Text)
+
+runLegacyAddressCmds :: LegacyAddressCmds -> ExceptT ShelleyAddressCmdError IO ()
+runLegacyAddressCmds = \case
+  AddressKeyGen fmt kt vkf skf ->
+    runLegacyAddressKeyGenCmd fmt kt vkf skf
+  AddressKeyHash vkf mOFp ->
+    runLegacyAddressKeyHashCmd vkf mOFp
+  AddressBuild paymentVerifier mbStakeVerifier nw mOutFp ->
+    runLegacyAddressBuildCmd paymentVerifier mbStakeVerifier nw mOutFp
+  AddressInfo txt mOFp ->
+    runLegacyAddressInfoCmd txt mOFp & firstExceptT ShelleyAddressCmdAddressInfoError
+
+runLegacyAddressKeyGenCmd :: ()
+  => KeyOutputFormat
+  -> AddressKeyType
+  -> VerificationKeyFile Out
+  -> SigningKeyFile Out
+  -> ExceptT ShelleyAddressCmdError IO ()
+runLegacyAddressKeyGenCmd = EraBased.runLegacyAddressKeyGenCmd
+
+runLegacyAddressKeyHashCmd :: ()
+  => VerificationKeyTextOrFile
+  -> Maybe (File () Out)
+  -> ExceptT ShelleyAddressCmdError IO ()
+runLegacyAddressKeyHashCmd = EraBased.runLegacyAddressKeyHashCmd
+
+runLegacyAddressBuildCmd :: ()
+  => PaymentVerifier
+  -> Maybe StakeIdentifier
+  -> NetworkId
+  -> Maybe (File () Out)
+  -> ExceptT ShelleyAddressCmdError IO ()
+runLegacyAddressBuildCmd = EraBased.runLegacyAddressBuildCmd
+
+runLegacyAddressInfoCmd :: ()
+  => Text
+  -> Maybe (File () Out)
+  -> ExceptT ShelleyAddressInfoError IO ()
+runLegacyAddressInfoCmd = EraBased.runLegacyAddressInfoCmd


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Move `address` run command implementation into era-based
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Only the implementation has been moved into era-based to minimise the size of the PR.  The PR diff appears smaller if view by commits.

A future PR will make make the era-based run command era-sensitive and export them in the CLI.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
