### PR TITLE
Move `pool` run commands implementation into era based

### DIFF
--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -88,6 +88,7 @@ library
                         Cardano.CLI.EraBased.Run.Governance.DRep
                         Cardano.CLI.EraBased.Run.Governance.Query
                         Cardano.CLI.EraBased.Run.Governance.Vote
+                        Cardano.CLI.EraBased.Run.Pool
                         Cardano.CLI.EraBased.Run.StakeAddress
                         Cardano.CLI.EraBased.Run.Transaction
                         Cardano.CLI.Helpers
@@ -111,7 +112,6 @@ library
                         Cardano.CLI.Legacy.Run.Governance
                         Cardano.CLI.Legacy.Run.Key
                         Cardano.CLI.Legacy.Run.Node
-                        Cardano.CLI.Legacy.Run.Pool
                         Cardano.CLI.Legacy.Run.Query
                         Cardano.CLI.Legacy.Run.StakeAddress
                         Cardano.CLI.Legacy.Run.TextView

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -112,6 +112,7 @@ library
                         Cardano.CLI.Legacy.Run.Governance
                         Cardano.CLI.Legacy.Run.Key
                         Cardano.CLI.Legacy.Run.Node
+                        Cardano.CLI.Legacy.Run.Pool
                         Cardano.CLI.Legacy.Run.Query
                         Cardano.CLI.Legacy.Run.StakeAddress
                         Cardano.CLI.Legacy.Run.TextView

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Pool.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Pool.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RankNTypes #-}
 
-module Cardano.CLI.Legacy.Run.Pool
+module Cardano.CLI.EraBased.Run.Pool
   ( runLegacyPoolCmds
   ) where
 

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Pool.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Pool.hs
@@ -1,17 +1,18 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RankNTypes #-}
 
 module Cardano.CLI.EraBased.Run.Pool
-  ( runLegacyPoolCmds
+  ( runLegacyPoolIdCmd
+  , runLegacyPoolMetadataHashCmd
+  , runLegacyStakePoolRegistrationCertCmd
+  , runLegacyStakePoolRetirementCertCmd
   ) where
 
 import           Cardano.Api
 import qualified Cardano.Api.Ledger as Ledger
 import           Cardano.Api.Shelley
 
-import           Cardano.CLI.Legacy.Commands.Pool
 import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Errors.ShelleyPoolCmdError
 import           Cardano.CLI.Types.Key (VerificationKeyOrFile, readVerificationKeyOrFile)
@@ -24,17 +25,6 @@ import           Control.Monad.Trans.Except.Extra (firstExceptT, handleIOExceptT
                    newExceptT, onLeft)
 import qualified Data.ByteString.Char8 as BS
 import           Data.Function ((&))
-
-runLegacyPoolCmds :: LegacyPoolCmds -> ExceptT ShelleyPoolCmdError IO ()
-runLegacyPoolCmds = \case
-  PoolRegistrationCert anyEra sPvkey vrfVkey pldg pCost pMrgn rwdVerFp ownerVerFps relays mbMetadata network outfp ->
-    runLegacyStakePoolRegistrationCertCmd anyEra sPvkey vrfVkey pldg pCost pMrgn rwdVerFp ownerVerFps relays mbMetadata network outfp
-  PoolRetirementCert anyEra sPvkeyFp retireEpoch outfp ->
-    runLegacyStakePoolRetirementCertCmd anyEra sPvkeyFp retireEpoch outfp
-  PoolGetId sPvkey outputFormat mOutFile ->
-    runLegacyPoolIdCmd sPvkey outputFormat mOutFile
-  PoolMetadataHash poolMdFile mOutFile ->
-    runLegacyPoolMetadataHashCmd poolMdFile mOutFile
 
 --
 -- Stake pool command implementations

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Pool.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Pool.hs
@@ -3,10 +3,10 @@
 {-# LANGUAGE RankNTypes #-}
 
 module Cardano.CLI.EraBased.Run.Pool
-  ( runLegacyPoolIdCmd
-  , runLegacyPoolMetadataHashCmd
-  , runLegacyStakePoolRegistrationCertCmd
-  , runLegacyStakePoolRetirementCertCmd
+  ( runPoolIdCmd
+  , runPoolMetadataHashCmd
+  , runStakePoolRegistrationCertCmd
+  , runStakePoolRetirementCertCmd
   ) where
 
 import           Cardano.Api
@@ -33,7 +33,7 @@ import           Data.Function ((&))
 -- | Create a stake pool registration cert.
 -- TODO: Metadata and more stake pool relay support to be
 -- added in the future.
-runLegacyStakePoolRegistrationCertCmd
+runStakePoolRegistrationCertCmd
   :: AnyShelleyBasedEra
   -> VerificationKeyOrFile StakePoolKey
   -- ^ Stake pool verification key.
@@ -56,7 +56,7 @@ runLegacyStakePoolRegistrationCertCmd
   -> NetworkId
   -> File () Out
   -> ExceptT ShelleyPoolCmdError IO ()
-runLegacyStakePoolRegistrationCertCmd
+runStakePoolRegistrationCertCmd
   anyEra
   stakePoolVerKeyOrFile
   vrfVerKeyOrFile
@@ -146,13 +146,13 @@ createStakePoolRegistrationRequirements sbe pparams =
      StakePoolRegistrationRequirementsConwayOnwards ConwayEraOnwardsConway pparams
 
 
-runLegacyStakePoolRetirementCertCmd
+runStakePoolRetirementCertCmd
   :: AnyShelleyBasedEra
   -> VerificationKeyOrFile StakePoolKey
   -> Shelley.EpochNo
   -> File () Out
   -> ExceptT ShelleyPoolCmdError IO ()
-runLegacyStakePoolRetirementCertCmd anyEra stakePoolVerKeyOrFile retireEpoch outfp = do
+runStakePoolRetirementCertCmd anyEra stakePoolVerKeyOrFile retireEpoch outfp = do
     AnyShelleyBasedEra sbe <- pure anyEra
 
     -- Pool verification key
@@ -193,12 +193,12 @@ createStakePoolRetirementRequirements sbe pid epoch =
       StakePoolRetirementRequirementsConwayOnwards ConwayEraOnwardsConway pid epoch
 
 
-runLegacyPoolIdCmd
+runPoolIdCmd
   :: VerificationKeyOrFile StakePoolKey
   -> IdOutputFormat
   -> Maybe (File () Out)
   -> ExceptT ShelleyPoolCmdError IO ()
-runLegacyPoolIdCmd verKeyOrFile outputFormat mOutFile = do
+runPoolIdCmd verKeyOrFile outputFormat mOutFile = do
   stakePoolVerKey <- firstExceptT ShelleyPoolCmdReadKeyFileError
     . newExceptT
     $ readVerificationKeyOrFile AsStakePoolKey verKeyOrFile
@@ -215,8 +215,8 @@ runLegacyPoolIdCmd verKeyOrFile outputFormat mOutFile = do
         $ writeTextOutput mOutFile
         $ serialiseToBech32 (verificationKeyHash stakePoolVerKey)
 
-runLegacyPoolMetadataHashCmd :: StakePoolMetadataFile In -> Maybe (File () Out) -> ExceptT ShelleyPoolCmdError IO ()
-runLegacyPoolMetadataHashCmd poolMDPath mOutFile = do
+runPoolMetadataHashCmd :: StakePoolMetadataFile In -> Maybe (File () Out) -> ExceptT ShelleyPoolCmdError IO ()
+runPoolMetadataHashCmd poolMDPath mOutFile = do
   metadataBytes <- lift (readByteStringFile poolMDPath)
     & onLeft (left . ShelleyPoolCmdReadFileError)
 

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run.hs
@@ -4,13 +4,13 @@ module Cardano.CLI.Legacy.Run
   ( runLegacyCmds
   ) where
 
+import           Cardano.CLI.EraBased.Run.Pool
 import           Cardano.CLI.Legacy.Options
 import           Cardano.CLI.Legacy.Run.Address
 import           Cardano.CLI.Legacy.Run.Genesis
 import           Cardano.CLI.Legacy.Run.Governance
 import           Cardano.CLI.Legacy.Run.Key
 import           Cardano.CLI.Legacy.Run.Node
-import           Cardano.CLI.Legacy.Run.Pool
 import           Cardano.CLI.Legacy.Run.Query
 import           Cardano.CLI.Legacy.Run.StakeAddress
 import           Cardano.CLI.Legacy.Run.TextView

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run.hs
@@ -4,13 +4,13 @@ module Cardano.CLI.Legacy.Run
   ( runLegacyCmds
   ) where
 
-import           Cardano.CLI.EraBased.Run.Pool
 import           Cardano.CLI.Legacy.Options
 import           Cardano.CLI.Legacy.Run.Address
 import           Cardano.CLI.Legacy.Run.Genesis
 import           Cardano.CLI.Legacy.Run.Governance
 import           Cardano.CLI.Legacy.Run.Key
 import           Cardano.CLI.Legacy.Run.Node
+import           Cardano.CLI.Legacy.Run.Pool
 import           Cardano.CLI.Legacy.Run.Query
 import           Cardano.CLI.Legacy.Run.StakeAddress
 import           Cardano.CLI.Legacy.Run.TextView

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Pool.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Pool.hs
@@ -9,7 +9,7 @@ module Cardano.CLI.Legacy.Run.Pool
 import           Cardano.Api
 import           Cardano.Api.Shelley
 
-import qualified Cardano.CLI.EraBased.Run.Pool as EraBased
+import           Cardano.CLI.EraBased.Run.Pool
 import           Cardano.CLI.Legacy.Commands.Pool
 import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Errors.ShelleyPoolCmdError
@@ -57,7 +57,7 @@ runLegacyStakePoolRegistrationCertCmd :: ()
   -> NetworkId
   -> File () Out
   -> ExceptT ShelleyPoolCmdError IO ()
-runLegacyStakePoolRegistrationCertCmd = EraBased.runLegacyStakePoolRegistrationCertCmd
+runLegacyStakePoolRegistrationCertCmd = runStakePoolRegistrationCertCmd
 
 runLegacyStakePoolRetirementCertCmd :: ()
   => AnyShelleyBasedEra
@@ -65,17 +65,17 @@ runLegacyStakePoolRetirementCertCmd :: ()
   -> Shelley.EpochNo
   -> File () Out
   -> ExceptT ShelleyPoolCmdError IO ()
-runLegacyStakePoolRetirementCertCmd = EraBased.runLegacyStakePoolRetirementCertCmd
+runLegacyStakePoolRetirementCertCmd = runStakePoolRetirementCertCmd
 
 runLegacyPoolIdCmd :: ()
   => VerificationKeyOrFile StakePoolKey
   -> IdOutputFormat
   -> Maybe (File () Out)
   -> ExceptT ShelleyPoolCmdError IO ()
-runLegacyPoolIdCmd = EraBased.runLegacyPoolIdCmd
+runLegacyPoolIdCmd = runPoolIdCmd
 
 runLegacyPoolMetadataHashCmd :: ()
   => StakePoolMetadataFile In
   -> Maybe (File () Out)
   -> ExceptT ShelleyPoolCmdError IO ()
-runLegacyPoolMetadataHashCmd = EraBased.runLegacyPoolMetadataHashCmd
+runLegacyPoolMetadataHashCmd = runPoolMetadataHashCmd

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Pool.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Pool.hs
@@ -1,0 +1,81 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+
+module Cardano.CLI.Legacy.Run.Pool
+  ( runLegacyPoolCmds
+  ) where
+
+import           Cardano.Api
+import           Cardano.Api.Shelley
+
+import qualified Cardano.CLI.EraBased.Run.Pool as EraBased
+import           Cardano.CLI.Legacy.Commands.Pool
+import           Cardano.CLI.Types.Common
+import           Cardano.CLI.Types.Errors.ShelleyPoolCmdError
+import           Cardano.CLI.Types.Key (VerificationKeyOrFile)
+import qualified Cardano.Ledger.Slot as Shelley
+
+import           Control.Monad.Trans.Except (ExceptT)
+
+runLegacyPoolCmds :: ()
+  => LegacyPoolCmds
+  -> ExceptT ShelleyPoolCmdError IO ()
+runLegacyPoolCmds = \case
+  PoolRegistrationCert anyEra sPvkey vrfVkey pldg pCost pMrgn rwdVerFp ownerVerFps relays mbMetadata network outfp ->
+    runLegacyStakePoolRegistrationCertCmd anyEra sPvkey vrfVkey pldg pCost pMrgn rwdVerFp ownerVerFps relays mbMetadata network outfp
+  PoolRetirementCert anyEra sPvkeyFp retireEpoch outfp ->
+    runLegacyStakePoolRetirementCertCmd anyEra sPvkeyFp retireEpoch outfp
+  PoolGetId sPvkey outputFormat mOutFile ->
+    runLegacyPoolIdCmd sPvkey outputFormat mOutFile
+  PoolMetadataHash poolMdFile mOutFile ->
+    runLegacyPoolMetadataHashCmd poolMdFile mOutFile
+
+-- | Create a stake pool registration cert.
+-- TODO: Metadata and more stake pool relay support to be
+-- added in the future.
+runLegacyStakePoolRegistrationCertCmd :: ()
+  => AnyShelleyBasedEra
+  -> VerificationKeyOrFile StakePoolKey
+  -- ^ Stake pool verification key.
+  -> VerificationKeyOrFile VrfKey
+  -- ^ VRF Verification key.
+  -> Lovelace
+  -- ^ Pool pledge.
+  -> Lovelace
+  -- ^ Pool cost.
+  -> Rational
+  -- ^ Pool margin.
+  -> VerificationKeyOrFile StakeKey
+  -- ^ Stake verification key for reward account.
+  -> [VerificationKeyOrFile StakeKey]
+  -- ^ Pool owner stake verification key(s).
+  -> [StakePoolRelay]
+  -- ^ Stake pool relays.
+  -> Maybe StakePoolMetadataReference
+  -- ^ Stake pool metadata.
+  -> NetworkId
+  -> File () Out
+  -> ExceptT ShelleyPoolCmdError IO ()
+runLegacyStakePoolRegistrationCertCmd = EraBased.runLegacyStakePoolRegistrationCertCmd
+
+runLegacyStakePoolRetirementCertCmd :: ()
+  => AnyShelleyBasedEra
+  -> VerificationKeyOrFile StakePoolKey
+  -> Shelley.EpochNo
+  -> File () Out
+  -> ExceptT ShelleyPoolCmdError IO ()
+runLegacyStakePoolRetirementCertCmd = EraBased.runLegacyStakePoolRetirementCertCmd
+
+runLegacyPoolIdCmd :: ()
+  => VerificationKeyOrFile StakePoolKey
+  -> IdOutputFormat
+  -> Maybe (File () Out)
+  -> ExceptT ShelleyPoolCmdError IO ()
+runLegacyPoolIdCmd = EraBased.runLegacyPoolIdCmd
+
+runLegacyPoolMetadataHashCmd :: ()
+  => StakePoolMetadataFile In
+  -> Maybe (File () Out)
+  -> ExceptT ShelleyPoolCmdError IO ()
+runLegacyPoolMetadataHashCmd = EraBased.runLegacyPoolMetadataHashCmd


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Move `pool` run commands implementation into era based
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Only the implementation has been moved into era-based to minimise the size of the PR. The PR diff appears smaller if view by commits.

A future PR will make make the era-based run command era-sensitive and export them in the CLI.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
