### PR TITLE
Move `genesis` run commands implementation into era based

### DIFF
--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -122,6 +122,7 @@ library
                         Cardano.CLI.Legacy.Options
                         Cardano.CLI.Legacy.Run
                         Cardano.CLI.Legacy.Run.Address
+                        Cardano.CLI.Legacy.Run.Genesis
                         Cardano.CLI.Legacy.Run.Governance
                         Cardano.CLI.Legacy.Run.Key
                         Cardano.CLI.Legacy.Run.Node

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -91,6 +91,7 @@ library
                         Cardano.CLI.EraBased.Run
                         Cardano.CLI.EraBased.Run.Address
                         Cardano.CLI.EraBased.Run.Address.Info
+                        Cardano.CLI.EraBased.Run.Genesis
                         Cardano.CLI.EraBased.Run.Governance
                         Cardano.CLI.EraBased.Run.Governance.Actions
                         Cardano.CLI.EraBased.Run.Governance.Committee
@@ -121,7 +122,6 @@ library
                         Cardano.CLI.Legacy.Options
                         Cardano.CLI.Legacy.Run
                         Cardano.CLI.Legacy.Run.Address
-                        Cardano.CLI.Legacy.Run.Genesis
                         Cardano.CLI.Legacy.Run.Governance
                         Cardano.CLI.Legacy.Run.Key
                         Cardano.CLI.Legacy.Run.Node

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Genesis.hs
@@ -17,17 +17,17 @@
 {- HLINT ignore "Use let" -}
 
 module Cardano.CLI.EraBased.Run.Genesis
-  ( runLegacyGenesisAddrCmd
-  , runLegacyGenesisCreateCardanoCmd
-  , runLegacyGenesisCreateCmd
-  , runLegacyGenesisCreateStakedCmd
-  , runLegacyGenesisHashFileCmd
-  , runLegacyGenesisKeyGenDelegateCmd
-  , runLegacyGenesisKeyGenGenesisCmd
-  , runLegacyGenesisKeyGenUTxOCmd
-  , runLegacyGenesisKeyHashCmd
-  , runLegacyGenesisTxInCmd
-  , runLegacyGenesisVerKeyCmd
+  ( runGenesisAddrCmd
+  , runGenesisCreateCardanoCmd
+  , runGenesisCreateCmd
+  , runGenesisCreateStakedCmd
+  , runGenesisHashFileCmd
+  , runGenesisKeyGenDelegateCmd
+  , runGenesisKeyGenGenesisCmd
+  , runGenesisKeyGenUTxOCmd
+  , runGenesisKeyHashCmd
+  , runGenesisTxInCmd
+  , runGenesisVerKeyCmd
 
   , readAndDecodeShelleyGenesis
 
@@ -136,15 +136,11 @@ import           Text.Read (readMaybe)
 
 import           Crypto.Random as Crypto
 
---
--- Genesis command implementations
---
-
-runLegacyGenesisKeyGenGenesisCmd ::
+runGenesisKeyGenGenesisCmd ::
      VerificationKeyFile Out
   -> SigningKeyFile Out
   -> ExceptT ShelleyGenesisCmdError IO ()
-runLegacyGenesisKeyGenGenesisCmd vkeyPath skeyPath = do
+runGenesisKeyGenGenesisCmd vkeyPath skeyPath = do
     skey <- liftIO $ generateSigningKey AsGenesisKey
     let vkey = getVerificationKey skey
     firstExceptT ShelleyGenesisCmdGenesisFileError
@@ -161,12 +157,12 @@ runLegacyGenesisKeyGenGenesisCmd vkeyPath skeyPath = do
     vkeyDesc = "Genesis Verification Key"
 
 
-runLegacyGenesisKeyGenDelegateCmd ::
+runGenesisKeyGenDelegateCmd ::
      VerificationKeyFile Out
   -> SigningKeyFile Out
   -> OpCertCounterFile Out
   -> ExceptT ShelleyGenesisCmdError IO ()
-runLegacyGenesisKeyGenDelegateCmd vkeyPath skeyPath ocertCtrPath = do
+runGenesisKeyGenDelegateCmd vkeyPath skeyPath ocertCtrPath = do
     skey <- liftIO $ generateSigningKey AsGenesisDelegateKey
     let vkey = getVerificationKey skey
     firstExceptT ShelleyGenesisCmdGenesisFileError
@@ -216,11 +212,11 @@ runGenesisKeyGenDelegateVRF vkeyPath skeyPath = do
     vkeyDesc = "VRF Verification Key"
 
 
-runLegacyGenesisKeyGenUTxOCmd ::
+runGenesisKeyGenUTxOCmd ::
      VerificationKeyFile Out
   -> SigningKeyFile Out
   -> ExceptT ShelleyGenesisCmdError IO ()
-runLegacyGenesisKeyGenUTxOCmd vkeyPath skeyPath = do
+runGenesisKeyGenUTxOCmd vkeyPath skeyPath = do
     skey <- liftIO $ generateSigningKey AsGenesisUTxOKey
     let vkey = getVerificationKey skey
     firstExceptT ShelleyGenesisCmdGenesisFileError
@@ -237,8 +233,8 @@ runLegacyGenesisKeyGenUTxOCmd vkeyPath skeyPath = do
     vkeyDesc = "Genesis Initial UTxO Verification Key"
 
 
-runLegacyGenesisKeyHashCmd :: VerificationKeyFile In -> ExceptT ShelleyGenesisCmdError IO ()
-runLegacyGenesisKeyHashCmd vkeyPath = do
+runGenesisKeyHashCmd :: VerificationKeyFile In -> ExceptT ShelleyGenesisCmdError IO ()
+runGenesisKeyHashCmd vkeyPath = do
     vkey <- firstExceptT ShelleyGenesisCmdTextEnvReadFileError . newExceptT $
             readFileTextEnvelopeAnyOf
               [ FromSomeType (AsVerificationKey AsGenesisKey)
@@ -261,11 +257,11 @@ runLegacyGenesisKeyHashCmd vkeyPath = do
                               . verificationKeyHash
 
 
-runLegacyGenesisVerKeyCmd ::
+runGenesisVerKeyCmd ::
      VerificationKeyFile Out
   -> SigningKeyFile In
   -> ExceptT ShelleyGenesisCmdError IO ()
-runLegacyGenesisVerKeyCmd vkeyPath skeyPath = do
+runGenesisVerKeyCmd vkeyPath skeyPath = do
     skey <- firstExceptT ShelleyGenesisCmdTextEnvReadFileError . newExceptT $
             readFileTextEnvelopeAnyOf
               [ FromSomeType (AsSigningKey AsGenesisKey)
@@ -295,24 +291,24 @@ data SomeGenesisKey f
      | AGenesisUTxOKey     (f GenesisUTxOKey)
 
 
-runLegacyGenesisTxInCmd ::
+runGenesisTxInCmd ::
      VerificationKeyFile In
   -> NetworkId
   -> Maybe (File () Out)
   -> ExceptT ShelleyGenesisCmdError IO ()
-runLegacyGenesisTxInCmd vkeyPath network mOutFile = do
+runGenesisTxInCmd vkeyPath network mOutFile = do
     vkey <- firstExceptT ShelleyGenesisCmdTextEnvReadFileError . newExceptT $
             readFileTextEnvelope (AsVerificationKey AsGenesisUTxOKey) vkeyPath
     let txin = genesisUTxOPseudoTxIn network (verificationKeyHash vkey)
     liftIO $ writeOutput mOutFile (renderTxIn txin)
 
 
-runLegacyGenesisAddrCmd ::
+runGenesisAddrCmd ::
      VerificationKeyFile In
   -> NetworkId
   -> Maybe (File () Out)
   -> ExceptT ShelleyGenesisCmdError IO ()
-runLegacyGenesisAddrCmd vkeyPath network mOutFile = do
+runGenesisAddrCmd vkeyPath network mOutFile = do
     vkey <- firstExceptT ShelleyGenesisCmdTextEnvReadFileError . newExceptT $
             readFileTextEnvelope (AsVerificationKey AsGenesisUTxOKey) vkeyPath
     let vkh  = verificationKeyHash (castVerificationKey vkey)
@@ -329,7 +325,7 @@ writeOutput Nothing                   = Text.putStrLn
 -- Create Genesis command implementation
 --
 
-runLegacyGenesisCreateCmd
+runGenesisCreateCmd
   :: KeyOutputFormat
   -> GenesisDir
   -> Word  -- ^ num genesis & delegate keys to make
@@ -338,7 +334,7 @@ runLegacyGenesisCreateCmd
   -> Maybe Lovelace
   -> NetworkId
   -> ExceptT ShelleyGenesisCmdError IO ()
-runLegacyGenesisCreateCmd
+runGenesisCreateCmd
     fmt (GenesisDir rootdir)
     genNumGenesisKeys genNumUTxOKeys
     mStart mAmount network = do
@@ -447,7 +443,7 @@ generateShelleyNodeSecrets shelleyDelegateKeys shelleyGenesisvkeys = do
 -- Create Genesis Cardano command implementation
 --
 
-runLegacyGenesisCreateCardanoCmd :: GenesisDir
+runGenesisCreateCardanoCmd :: GenesisDir
                  -> Word  -- ^ num genesis & delegate keys to make
                  -> Word  -- ^ num utxo keys to make
                  -> Maybe SystemStart
@@ -462,7 +458,7 @@ runLegacyGenesisCreateCardanoCmd :: GenesisDir
                  -> FilePath -- ^ Conway Genesis
                  -> Maybe FilePath
                  -> ExceptT ShelleyGenesisCmdError IO ()
-runLegacyGenesisCreateCardanoCmd (GenesisDir rootdir)
+runGenesisCreateCardanoCmd (GenesisDir rootdir)
                  genNumGenesisKeys genNumUTxOKeys
                  mStart mAmount mSecurity slotLength mSlotCoeff
                  network byronGenesisT shelleyGenesisT alonzoGenesisT conwayGenesisT mNodeCfg = do
@@ -609,7 +605,7 @@ runLegacyGenesisCreateCardanoCmd (GenesisDir rootdir)
     dlgCertMap :: Genesis.GenesisData -> Map Byron.KeyHash Dlg.Certificate
     dlgCertMap byronGenesis = Genesis.unGenesisDelegation $ Genesis.gdHeavyDelegation byronGenesis
 
-runLegacyGenesisCreateStakedCmd
+runGenesisCreateStakedCmd
   :: KeyOutputFormat    -- ^ key output format
   -> GenesisDir
   -> Word               -- ^ num genesis & delegate keys to make
@@ -625,7 +621,7 @@ runLegacyGenesisCreateStakedCmd
   -> Word               -- ^ num stuffed UTxO entries
   -> Maybe FilePath     -- ^ Specified stake pool relays
   -> ExceptT ShelleyGenesisCmdError IO ()
-runLegacyGenesisCreateStakedCmd
+runGenesisCreateStakedCmd
     fmt (GenesisDir rootdir)
     genNumGenesisKeys genNumUTxOKeys genNumPools genNumStDelegs
     mStart mNonDlgAmount stDlgAmount network
@@ -759,7 +755,7 @@ runLegacyGenesisCreateStakedCmd
 createDelegateKeys :: KeyOutputFormat -> FilePath -> Word -> ExceptT ShelleyGenesisCmdError IO ()
 createDelegateKeys fmt dir index = do
   liftIO $ createDirectoryIfMissing False dir
-  runLegacyGenesisKeyGenDelegateCmd
+  runGenesisKeyGenDelegateCmd
         (File @(VerificationKey ()) $ dir </> "delegate" ++ strIndex ++ ".vkey")
         (onlyOut coldSK)
         (onlyOut opCertCtr)
@@ -787,7 +783,7 @@ createGenesisKeys :: FilePath -> Word -> ExceptT ShelleyGenesisCmdError IO ()
 createGenesisKeys dir index = do
   liftIO $ createDirectoryIfMissing False dir
   let strIndex = show index
-  runLegacyGenesisKeyGenGenesisCmd
+  runGenesisKeyGenGenesisCmd
         (File @(VerificationKey ()) $ dir </> "genesis" ++ strIndex ++ ".vkey")
         (File @(SigningKey ()) $ dir </> "genesis" ++ strIndex ++ ".skey")
 
@@ -796,7 +792,7 @@ createUtxoKeys :: FilePath -> Word -> ExceptT ShelleyGenesisCmdError IO ()
 createUtxoKeys dir index = do
   liftIO $ createDirectoryIfMissing False dir
   let strIndex = show index
-  runLegacyGenesisKeyGenUTxOCmd
+  runGenesisKeyGenUTxOCmd
         (File @(VerificationKey ()) $ dir </> "utxo" ++ strIndex ++ ".vkey")
         (File @(SigningKey ()) $ dir </> "utxo" ++ strIndex ++ ".skey")
 
@@ -1272,8 +1268,8 @@ readInitialFundAddresses utxodir nw = do
 
 
 -- | Hash a genesis file
-runLegacyGenesisHashFileCmd :: GenesisFile -> ExceptT ShelleyGenesisCmdError IO ()
-runLegacyGenesisHashFileCmd (GenesisFile fpath) = do
+runGenesisHashFileCmd :: GenesisFile -> ExceptT ShelleyGenesisCmdError IO ()
+runGenesisHashFileCmd (GenesisFile fpath) = do
    content <- handleIOExceptT (ShelleyGenesisCmdGenesisFileError . FileIOError fpath) $
               BS.readFile fpath
    let gh :: Crypto.Hash Crypto.Blake2b_256 ByteString

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Genesis.hs
@@ -5,7 +5,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeApplications #-}
@@ -18,10 +17,19 @@
 {- HLINT ignore "Use let" -}
 
 module Cardano.CLI.EraBased.Run.Genesis
-  ( readShelleyGenesisWithDefault
+  ( runLegacyGenesisAddrCmd
+  , runLegacyGenesisCreateCardanoCmd
+  , runLegacyGenesisCreateCmd
+  , runLegacyGenesisCreateStakedCmd
+  , runLegacyGenesisHashFileCmd
+  , runLegacyGenesisKeyGenDelegateCmd
+  , runLegacyGenesisKeyGenGenesisCmd
+  , runLegacyGenesisKeyGenUTxOCmd
+  , runLegacyGenesisKeyHashCmd
+  , runLegacyGenesisTxInCmd
+  , runLegacyGenesisVerKeyCmd
+
   , readAndDecodeShelleyGenesis
-  , readAlonzoGenesis
-  , runLegacyGenesisCmds
 
   -- * Protocol Parameters
   , readProtocolParameters
@@ -47,7 +55,6 @@ import           Cardano.CLI.EraBased.Run.Node (runNodeIssueOpCertCmd, runNodeKe
                    runNodeKeyGenKesCmd, runNodeKeyGenVrfCmd)
 import           Cardano.CLI.EraBased.Run.StakeAddress (runStakeAddressKeyGenCmd)
 import qualified Cardano.CLI.IO.Lazy as Lazy
-import           Cardano.CLI.Legacy.Commands.Genesis
 import           Cardano.CLI.Orphans ()
 import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Errors.ProtocolParamsError
@@ -128,31 +135,6 @@ import           Text.JSON.Canonical (parseCanonicalJSON, renderCanonicalJSON)
 import           Text.Read (readMaybe)
 
 import           Crypto.Random as Crypto
-
-runLegacyGenesisCmds :: LegacyGenesisCmds -> ExceptT ShelleyGenesisCmdError IO ()
-runLegacyGenesisCmds = \case
-  GenesisKeyGenGenesis vk sk ->
-    runLegacyGenesisKeyGenGenesisCmd vk sk
-  GenesisKeyGenDelegate vk sk ctr ->
-    runLegacyGenesisKeyGenDelegateCmd vk sk ctr
-  GenesisKeyGenUTxO vk sk ->
-    runLegacyGenesisKeyGenUTxOCmd vk sk
-  GenesisCmdKeyHash vk ->
-    runLegacyGenesisKeyHashCmd vk
-  GenesisVerKey vk sk ->
-    runLegacyGenesisVerKeyCmd vk sk
-  GenesisTxIn vk nw mOutFile ->
-    runLegacyGenesisTxInCmd vk nw mOutFile
-  GenesisAddr vk nw mOutFile ->
-    runLegacyGenesisAddrCmd vk nw mOutFile
-  GenesisCreate fmt gd gn un ms am nw ->
-    runLegacyGenesisCreateCmd fmt gd gn un ms am nw
-  GenesisCreateCardano gd gn un ms am k slotLength sc nw bg sg ag cg mNodeCfg ->
-    runLegacyGenesisCreateCardanoCmd gd gn un ms am k slotLength sc nw bg sg ag cg mNodeCfg
-  GenesisCreateStaked fmt gd gn gp gl un ms am ds nw bf bp su relayJsonFp ->
-    runLegacyGenesisCreateStakedCmd fmt gd gn gp gl un ms am ds nw bf bp su relayJsonFp
-  GenesisHashFile gf ->
-    runLegacyGenesisHashFileCmd gf
 
 --
 -- Genesis command implementations

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Genesis.hs
@@ -17,15 +17,13 @@
 {- HLINT ignore "Redundant <$>" -}
 {- HLINT ignore "Use let" -}
 
-module Cardano.CLI.Legacy.Run.Genesis
+module Cardano.CLI.EraBased.Run.Genesis
   ( readShelleyGenesisWithDefault
   , readAndDecodeShelleyGenesis
   , readAlonzoGenesis
   , runLegacyGenesisCmds
 
   -- * Protocol Parameters
-  , ProtocolParamsError(..)
-  , renderProtocolParamsError
   , readProtocolParameters
   ) where
 

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Query.hs
@@ -39,8 +39,8 @@ import           Cardano.Api.Byron hiding (QueryInShelleyBasedEra (..))
 import qualified Cardano.Api.Ledger as Ledger
 import           Cardano.Api.Shelley hiding (QueryInShelleyBasedEra (..))
 
+import           Cardano.CLI.EraBased.Run.Genesis (readAndDecodeShelleyGenesis)
 import           Cardano.CLI.Helpers (pPrintCBOR)
-import           Cardano.CLI.Legacy.Run.Genesis (readAndDecodeShelleyGenesis)
 import           Cardano.CLI.Pretty
 import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Errors.ShelleyQueryCmdError

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Transaction.hs
@@ -32,8 +32,8 @@ import qualified Cardano.Api.Ledger as Ledger
 import           Cardano.Api.Shelley
 
 import           Cardano.CLI.EraBased.Commands.Transaction
+import           Cardano.CLI.EraBased.Run.Genesis
 import           Cardano.CLI.Json.Friendly (friendlyTxBS, friendlyTxBodyBS)
-import           Cardano.CLI.Legacy.Run.Genesis
 import           Cardano.CLI.Read
 import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Errors.ShelleyBootstrapWitnessError

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run.hs
@@ -4,9 +4,9 @@ module Cardano.CLI.Legacy.Run
   ( runLegacyCmds
   ) where
 
-import           Cardano.CLI.EraBased.Run.Genesis
 import           Cardano.CLI.Legacy.Options
 import           Cardano.CLI.Legacy.Run.Address
+import           Cardano.CLI.Legacy.Run.Genesis
 import           Cardano.CLI.Legacy.Run.Governance
 import           Cardano.CLI.Legacy.Run.Key
 import           Cardano.CLI.Legacy.Run.Node

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run.hs
@@ -4,9 +4,9 @@ module Cardano.CLI.Legacy.Run
   ( runLegacyCmds
   ) where
 
+import           Cardano.CLI.EraBased.Run.Genesis
 import           Cardano.CLI.Legacy.Options
 import           Cardano.CLI.Legacy.Run.Address
-import           Cardano.CLI.Legacy.Run.Genesis
 import           Cardano.CLI.Legacy.Run.Governance
 import           Cardano.CLI.Legacy.Run.Key
 import           Cardano.CLI.Legacy.Run.Node

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Genesis.hs
@@ -11,7 +11,7 @@ module Cardano.CLI.Legacy.Run.Genesis
 import           Cardano.Api
 
 import           Cardano.Chain.Common (BlockCount)
-import qualified Cardano.CLI.EraBased.Run.Genesis as EraBased
+import           Cardano.CLI.EraBased.Run.Genesis
 import           Cardano.CLI.Legacy.Commands.Genesis
 import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Errors.ShelleyGenesisCmdError
@@ -47,43 +47,43 @@ runLegacyGenesisKeyGenGenesisCmd :: ()
   => VerificationKeyFile Out
   -> SigningKeyFile Out
   -> ExceptT ShelleyGenesisCmdError IO ()
-runLegacyGenesisKeyGenGenesisCmd = EraBased.runLegacyGenesisKeyGenGenesisCmd
+runLegacyGenesisKeyGenGenesisCmd = runGenesisKeyGenGenesisCmd
 
 runLegacyGenesisKeyGenDelegateCmd :: ()
   => VerificationKeyFile Out
   -> SigningKeyFile Out
   -> OpCertCounterFile Out
   -> ExceptT ShelleyGenesisCmdError IO ()
-runLegacyGenesisKeyGenDelegateCmd = EraBased.runLegacyGenesisKeyGenDelegateCmd
+runLegacyGenesisKeyGenDelegateCmd = runGenesisKeyGenDelegateCmd
 
 runLegacyGenesisKeyGenUTxOCmd :: ()
   => VerificationKeyFile Out
   -> SigningKeyFile Out
   -> ExceptT ShelleyGenesisCmdError IO ()
-runLegacyGenesisKeyGenUTxOCmd = EraBased.runLegacyGenesisKeyGenUTxOCmd
+runLegacyGenesisKeyGenUTxOCmd = runGenesisKeyGenUTxOCmd
 
 runLegacyGenesisKeyHashCmd :: VerificationKeyFile In -> ExceptT ShelleyGenesisCmdError IO ()
-runLegacyGenesisKeyHashCmd = EraBased.runLegacyGenesisKeyHashCmd
+runLegacyGenesisKeyHashCmd = runGenesisKeyHashCmd
 
 runLegacyGenesisVerKeyCmd ::
      VerificationKeyFile Out
   -> SigningKeyFile In
   -> ExceptT ShelleyGenesisCmdError IO ()
-runLegacyGenesisVerKeyCmd = EraBased.runLegacyGenesisVerKeyCmd
+runLegacyGenesisVerKeyCmd = runGenesisVerKeyCmd
 
 runLegacyGenesisTxInCmd :: ()
   => VerificationKeyFile In
   -> NetworkId
   -> Maybe (File () Out)
   -> ExceptT ShelleyGenesisCmdError IO ()
-runLegacyGenesisTxInCmd = EraBased.runLegacyGenesisTxInCmd
+runLegacyGenesisTxInCmd = runGenesisTxInCmd
 
 runLegacyGenesisAddrCmd :: ()
   => VerificationKeyFile In
   -> NetworkId
   -> Maybe (File () Out)
   -> ExceptT ShelleyGenesisCmdError IO ()
-runLegacyGenesisAddrCmd = EraBased.runLegacyGenesisAddrCmd
+runLegacyGenesisAddrCmd = runGenesisAddrCmd
 
 runLegacyGenesisCreateCmd :: ()
   => KeyOutputFormat
@@ -94,7 +94,7 @@ runLegacyGenesisCreateCmd :: ()
   -> Maybe Lovelace
   -> NetworkId
   -> ExceptT ShelleyGenesisCmdError IO ()
-runLegacyGenesisCreateCmd = EraBased.runLegacyGenesisCreateCmd
+runLegacyGenesisCreateCmd = runGenesisCreateCmd
 
 runLegacyGenesisCreateCardanoCmd :: ()
   => GenesisDir
@@ -112,7 +112,7 @@ runLegacyGenesisCreateCardanoCmd :: ()
   -> FilePath -- ^ Conway Genesis
   -> Maybe FilePath
   -> ExceptT ShelleyGenesisCmdError IO ()
-runLegacyGenesisCreateCardanoCmd = EraBased.runLegacyGenesisCreateCardanoCmd
+runLegacyGenesisCreateCardanoCmd = runGenesisCreateCardanoCmd
 
 runLegacyGenesisCreateStakedCmd :: ()
   => KeyOutputFormat    -- ^ key output format
@@ -130,10 +130,10 @@ runLegacyGenesisCreateStakedCmd :: ()
   -> Word               -- ^ num stuffed UTxO entries
   -> Maybe FilePath     -- ^ Specified stake pool relays
   -> ExceptT ShelleyGenesisCmdError IO ()
-runLegacyGenesisCreateStakedCmd = EraBased.runLegacyGenesisCreateStakedCmd
+runLegacyGenesisCreateStakedCmd = runGenesisCreateStakedCmd
 
 -- | Hash a genesis file
 runLegacyGenesisHashFileCmd :: ()
   => GenesisFile
   -> ExceptT ShelleyGenesisCmdError IO ()
-runLegacyGenesisHashFileCmd = EraBased.runLegacyGenesisHashFileCmd
+runLegacyGenesisHashFileCmd = runGenesisHashFileCmd

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Genesis.hs
@@ -1,0 +1,139 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+
+{-# OPTIONS_GHC -Wno-unticked-promoted-constructors #-}
+
+module Cardano.CLI.Legacy.Run.Genesis
+  ( runLegacyGenesisCmds
+  ) where
+
+import           Cardano.Api
+
+import           Cardano.Chain.Common (BlockCount)
+import qualified Cardano.CLI.EraBased.Run.Genesis as EraBased
+import           Cardano.CLI.Legacy.Commands.Genesis
+import           Cardano.CLI.Types.Common
+import           Cardano.CLI.Types.Errors.ShelleyGenesisCmdError
+
+import           Control.Monad.Trans.Except (ExceptT)
+
+runLegacyGenesisCmds :: LegacyGenesisCmds -> ExceptT ShelleyGenesisCmdError IO ()
+runLegacyGenesisCmds = \case
+  GenesisKeyGenGenesis vk sk ->
+    runLegacyGenesisKeyGenGenesisCmd vk sk
+  GenesisKeyGenDelegate vk sk ctr ->
+    runLegacyGenesisKeyGenDelegateCmd vk sk ctr
+  GenesisKeyGenUTxO vk sk ->
+    runLegacyGenesisKeyGenUTxOCmd vk sk
+  GenesisCmdKeyHash vk ->
+    runLegacyGenesisKeyHashCmd vk
+  GenesisVerKey vk sk ->
+    runLegacyGenesisVerKeyCmd vk sk
+  GenesisTxIn vk nw mOutFile ->
+    runLegacyGenesisTxInCmd vk nw mOutFile
+  GenesisAddr vk nw mOutFile ->
+    runLegacyGenesisAddrCmd vk nw mOutFile
+  GenesisCreate fmt gd gn un ms am nw ->
+    runLegacyGenesisCreateCmd fmt gd gn un ms am nw
+  GenesisCreateCardano gd gn un ms am k slotLength sc nw bg sg ag cg mNodeCfg ->
+    runLegacyGenesisCreateCardanoCmd gd gn un ms am k slotLength sc nw bg sg ag cg mNodeCfg
+  GenesisCreateStaked fmt gd gn gp gl un ms am ds nw bf bp su relayJsonFp ->
+    runLegacyGenesisCreateStakedCmd fmt gd gn gp gl un ms am ds nw bf bp su relayJsonFp
+  GenesisHashFile gf ->
+    runLegacyGenesisHashFileCmd gf
+
+runLegacyGenesisKeyGenGenesisCmd :: ()
+  => VerificationKeyFile Out
+  -> SigningKeyFile Out
+  -> ExceptT ShelleyGenesisCmdError IO ()
+runLegacyGenesisKeyGenGenesisCmd = EraBased.runLegacyGenesisKeyGenGenesisCmd
+
+runLegacyGenesisKeyGenDelegateCmd :: ()
+  => VerificationKeyFile Out
+  -> SigningKeyFile Out
+  -> OpCertCounterFile Out
+  -> ExceptT ShelleyGenesisCmdError IO ()
+runLegacyGenesisKeyGenDelegateCmd = EraBased.runLegacyGenesisKeyGenDelegateCmd
+
+runLegacyGenesisKeyGenUTxOCmd :: ()
+  => VerificationKeyFile Out
+  -> SigningKeyFile Out
+  -> ExceptT ShelleyGenesisCmdError IO ()
+runLegacyGenesisKeyGenUTxOCmd = EraBased.runLegacyGenesisKeyGenUTxOCmd
+
+runLegacyGenesisKeyHashCmd :: VerificationKeyFile In -> ExceptT ShelleyGenesisCmdError IO ()
+runLegacyGenesisKeyHashCmd = EraBased.runLegacyGenesisKeyHashCmd
+
+runLegacyGenesisVerKeyCmd ::
+     VerificationKeyFile Out
+  -> SigningKeyFile In
+  -> ExceptT ShelleyGenesisCmdError IO ()
+runLegacyGenesisVerKeyCmd = EraBased.runLegacyGenesisVerKeyCmd
+
+runLegacyGenesisTxInCmd :: ()
+  => VerificationKeyFile In
+  -> NetworkId
+  -> Maybe (File () Out)
+  -> ExceptT ShelleyGenesisCmdError IO ()
+runLegacyGenesisTxInCmd = EraBased.runLegacyGenesisTxInCmd
+
+runLegacyGenesisAddrCmd :: ()
+  => VerificationKeyFile In
+  -> NetworkId
+  -> Maybe (File () Out)
+  -> ExceptT ShelleyGenesisCmdError IO ()
+runLegacyGenesisAddrCmd = EraBased.runLegacyGenesisAddrCmd
+
+runLegacyGenesisCreateCmd :: ()
+  => KeyOutputFormat
+  -> GenesisDir
+  -> Word  -- ^ num genesis & delegate keys to make
+  -> Word  -- ^ num utxo keys to make
+  -> Maybe SystemStart
+  -> Maybe Lovelace
+  -> NetworkId
+  -> ExceptT ShelleyGenesisCmdError IO ()
+runLegacyGenesisCreateCmd = EraBased.runLegacyGenesisCreateCmd
+
+runLegacyGenesisCreateCardanoCmd :: ()
+  => GenesisDir
+  -> Word  -- ^ num genesis & delegate keys to make
+  -> Word  -- ^ num utxo keys to make
+  -> Maybe SystemStart
+  -> Maybe Lovelace
+  -> BlockCount
+  -> Word     -- ^ slot length in ms
+  -> Rational
+  -> NetworkId
+  -> FilePath -- ^ Byron Genesis
+  -> FilePath -- ^ Shelley Genesis
+  -> FilePath -- ^ Alonzo Genesis
+  -> FilePath -- ^ Conway Genesis
+  -> Maybe FilePath
+  -> ExceptT ShelleyGenesisCmdError IO ()
+runLegacyGenesisCreateCardanoCmd = EraBased.runLegacyGenesisCreateCardanoCmd
+
+runLegacyGenesisCreateStakedCmd :: ()
+  => KeyOutputFormat    -- ^ key output format
+  -> GenesisDir
+  -> Word               -- ^ num genesis & delegate keys to make
+  -> Word               -- ^ num utxo keys to make
+  -> Word               -- ^ num pools to make
+  -> Word               -- ^ num delegators to make
+  -> Maybe SystemStart
+  -> Maybe Lovelace     -- ^ supply going to non-delegators
+  -> Lovelace           -- ^ supply going to delegators
+  -> NetworkId
+  -> Word               -- ^ bulk credential files to write
+  -> Word               -- ^ pool credentials per bulk file
+  -> Word               -- ^ num stuffed UTxO entries
+  -> Maybe FilePath     -- ^ Specified stake pool relays
+  -> ExceptT ShelleyGenesisCmdError IO ()
+runLegacyGenesisCreateStakedCmd = EraBased.runLegacyGenesisCreateStakedCmd
+
+-- | Hash a genesis file
+runLegacyGenesisHashFileCmd :: ()
+  => GenesisFile
+  -> ExceptT ShelleyGenesisCmdError IO ()
+runLegacyGenesisHashFileCmd = EraBased.runLegacyGenesisHashFileCmd


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Move `genesis` run commands implementation into era based
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
