### PR TITLE
Move `query` run commands implementation into era based

### DIFF
--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -117,6 +117,7 @@ library
                         Cardano.CLI.Legacy.Run.Key
                         Cardano.CLI.Legacy.Run.Node
                         Cardano.CLI.Legacy.Run.Pool
+                        Cardano.CLI.Legacy.Run.Query
                         Cardano.CLI.Legacy.Run.StakeAddress
                         Cardano.CLI.Legacy.Run.TextView
                         Cardano.CLI.Legacy.Run.Transaction

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -91,6 +91,7 @@ library
                         Cardano.CLI.EraBased.Run.Governance.Query
                         Cardano.CLI.EraBased.Run.Governance.Vote
                         Cardano.CLI.EraBased.Run.Pool
+                        Cardano.CLI.EraBased.Run.Query
                         Cardano.CLI.EraBased.Run.StakeAddress
                         Cardano.CLI.EraBased.Run.TextView
                         Cardano.CLI.EraBased.Run.Transaction
@@ -116,7 +117,6 @@ library
                         Cardano.CLI.Legacy.Run.Key
                         Cardano.CLI.Legacy.Run.Node
                         Cardano.CLI.Legacy.Run.Pool
-                        Cardano.CLI.Legacy.Run.Query
                         Cardano.CLI.Legacy.Run.StakeAddress
                         Cardano.CLI.Legacy.Run.TextView
                         Cardano.CLI.Legacy.Run.Transaction

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Query.hs
@@ -11,24 +11,23 @@
 {-# LANGUAGE TypeOperators #-}
 
 {-# OPTIONS_GHC -Wno-unticked-promoted-constructors #-}
-{-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Cardano.CLI.EraBased.Run.Query
-  ( runLegacyQueryConstitutionHashCmd
-  , runLegacyQueryKesPeriodInfoCmd
-  , runLegacyQueryLeadershipScheduleCmd
-  , runLegacyQueryLedgerStateCmd
-  , runLegacyQueryPoolStateCmd
-  , runLegacyQueryProtocolParametersCmd
-  , runLegacyQueryProtocolStateCmd
-  , runLegacyQuerySlotNumberCmd
-  , runLegacyQueryStakeAddressInfoCmd
-  , runLegacyQueryStakeDistributionCmd
-  , runLegacyQueryStakePoolsCmd
-  , runLegacyQueryStakeSnapshotCmd
-  , runLegacyQueryTipCmd
-  , runLegacyQueryTxMempoolCmd
-  , runLegacyQueryUTxOCmd
+  ( runQueryConstitutionHashCmd
+  , runQueryKesPeriodInfoCmd
+  , runQueryLeadershipScheduleCmd
+  , runQueryLedgerStateCmd
+  , runQueryPoolStateCmd
+  , runQueryProtocolParametersCmd
+  , runQueryProtocolStateCmd
+  , runQuerySlotNumberCmd
+  , runQueryStakeAddressInfoCmd
+  , runQueryStakeDistributionCmd
+  , runQueryStakePoolsCmd
+  , runQueryStakeSnapshotCmd
+  , runQueryTipCmd
+  , runQueryTxMempoolCmd
+  , runQueryUTxOCmd
 
   , DelegationsAndRewards(..)
   , renderShelleyQueryCmdError
@@ -106,13 +105,13 @@ import           Text.Printf (printf)
 {- HLINT ignore "Move brackets to avoid $" -}
 {- HLINT ignore "Redundant flip" -}
 
-runLegacyQueryConstitutionHashCmd
+runQueryConstitutionHashCmd
   :: SocketPath
   -> AnyConsensusModeParams
   -> NetworkId
   -> Maybe (File () Out)
   -> ExceptT ShelleyQueryCmdError IO ()
-runLegacyQueryConstitutionHashCmd socketPath (AnyConsensusModeParams cModeParams) network mOutFile = do
+runQueryConstitutionHashCmd socketPath (AnyConsensusModeParams cModeParams) network mOutFile = do
   let localNodeConnInfo = LocalNodeConnectInfo cModeParams network socketPath
 
   result <- liftIO $ executeLocalStateQueryExpr localNodeConnInfo Nothing $ runExceptT $ do
@@ -144,13 +143,13 @@ runLegacyQueryConstitutionHashCmd socketPath (AnyConsensusModeParams cModeParams
           handleIOExceptT (ShelleyQueryCmdWriteFileError . FileIOError fpath) $
             LBS.writeFile fpath (encodePretty cHash)
 
-runLegacyQueryProtocolParametersCmd
+runQueryProtocolParametersCmd
   :: SocketPath
   -> AnyConsensusModeParams
   -> NetworkId
   -> Maybe (File () Out)
   -> ExceptT ShelleyQueryCmdError IO ()
-runLegacyQueryProtocolParametersCmd socketPath (AnyConsensusModeParams cModeParams) network mOutFile = do
+runQueryProtocolParametersCmd socketPath (AnyConsensusModeParams cModeParams) network mOutFile = do
   let localNodeConnInfo = LocalNodeConnectInfo cModeParams network socketPath
 
   result <- liftIO $ executeLocalStateQueryExpr localNodeConnInfo Nothing $ runExceptT $ do
@@ -217,13 +216,13 @@ queryChainTipViaChainSync localNodeConnInfo = do
     "Warning: Local header state query unavailable. Falling back to chain sync query"
   liftIO $ getLocalChainTip localNodeConnInfo
 
-runLegacyQueryTipCmd
+runQueryTipCmd
   :: SocketPath
   -> AnyConsensusModeParams
   -> NetworkId
   -> Maybe (File () Out)
   -> ExceptT ShelleyQueryCmdError IO ()
-runLegacyQueryTipCmd socketPath (AnyConsensusModeParams cModeParams) network mOutFile = do
+runQueryTipCmd socketPath (AnyConsensusModeParams cModeParams) network mOutFile = do
   case consensusModeOnly cModeParams of
     CardanoMode -> do
       let localNodeConnInfo = LocalNodeConnectInfo cModeParams network socketPath
@@ -301,14 +300,14 @@ runLegacyQueryTipCmd socketPath (AnyConsensusModeParams cModeParams) network mOu
 
 -- | Query the UTxO, filtered by a given set of addresses, from a Shelley node
 -- via the local state query protocol.
-runLegacyQueryUTxOCmd
+runQueryUTxOCmd
   :: SocketPath
   -> AnyConsensusModeParams
   -> QueryUTxOFilter
   -> NetworkId
   -> Maybe (File () Out)
   -> ExceptT ShelleyQueryCmdError IO ()
-runLegacyQueryUTxOCmd socketPath (AnyConsensusModeParams cModeParams)
+runQueryUTxOCmd socketPath (AnyConsensusModeParams cModeParams)
              qfilter network mOutFile = do
   let localNodeConnInfo = LocalNodeConnectInfo cModeParams network socketPath
 
@@ -339,14 +338,14 @@ runLegacyQueryUTxOCmd socketPath (AnyConsensusModeParams cModeParams)
     & onLeft (left . ShelleyQueryCmdAcquireFailure)
     & onLeft left
 
-runLegacyQueryKesPeriodInfoCmd
+runQueryKesPeriodInfoCmd
   :: SocketPath
   -> AnyConsensusModeParams
   -> NetworkId
   -> File () In
   -> Maybe (File () Out)
   -> ExceptT ShelleyQueryCmdError IO ()
-runLegacyQueryKesPeriodInfoCmd socketPath (AnyConsensusModeParams cModeParams) network nodeOpCertFile mOutFile = do
+runQueryKesPeriodInfoCmd socketPath (AnyConsensusModeParams cModeParams) network nodeOpCertFile mOutFile = do
   opCert <- lift (readFileTextEnvelope AsOperationalCertificate nodeOpCertFile)
     & onLeft (left . ShelleyQueryCmdOpCertCounterReadError)
 
@@ -620,13 +619,13 @@ renderOpCertIntervalInformation opCertFile opCertInfo = case opCertInfo of
 -- | Query the current and future parameters for a stake pool, including the retirement date.
 -- Any of these may be empty (in which case a null will be displayed).
 --
-runLegacyQueryPoolStateCmd
+runQueryPoolStateCmd
   :: SocketPath
   -> AnyConsensusModeParams
   -> NetworkId
   -> [Hash StakePoolKey]
   -> ExceptT ShelleyQueryCmdError IO ()
-runLegacyQueryPoolStateCmd socketPath (AnyConsensusModeParams cModeParams) network poolIds = do
+runQueryPoolStateCmd socketPath (AnyConsensusModeParams cModeParams) network poolIds = do
   let localNodeConnInfo = LocalNodeConnectInfo cModeParams network socketPath
 
   join $ lift
@@ -657,14 +656,14 @@ runLegacyQueryPoolStateCmd socketPath (AnyConsensusModeParams cModeParams) netwo
     & onLeft left
 
 -- | Query the local mempool state
-runLegacyQueryTxMempoolCmd
+runQueryTxMempoolCmd
   :: SocketPath
   -> AnyConsensusModeParams
   -> NetworkId
   -> TxMempoolQuery
   -> Maybe (File () Out)
   -> ExceptT ShelleyQueryCmdError IO ()
-runLegacyQueryTxMempoolCmd socketPath (AnyConsensusModeParams cModeParams) network query mOutFile = do
+runQueryTxMempoolCmd socketPath (AnyConsensusModeParams cModeParams) network query mOutFile = do
   let localNodeConnInfo = LocalNodeConnectInfo cModeParams network socketPath
 
   localQuery <- case query of
@@ -686,27 +685,27 @@ runLegacyQueryTxMempoolCmd socketPath (AnyConsensusModeParams cModeParams) netwo
     Just (File oFp) -> handleIOExceptT (ShelleyQueryCmdWriteFileError . FileIOError oFp)
         $ LBS.writeFile oFp renderedResult
 
-runLegacyQuerySlotNumberCmd
+runQuerySlotNumberCmd
   :: SocketPath
   -> AnyConsensusModeParams
   -> NetworkId
   -> UTCTime
   -> ExceptT ShelleyQueryCmdError IO ()
-runLegacyQuerySlotNumberCmd sockPath aCmp network utcTime = do
+runQuerySlotNumberCmd sockPath aCmp network utcTime = do
   SlotNo slotNo <- utcTimeToSlotNo sockPath aCmp network utcTime
   liftIO . putStr $ show slotNo
 
 -- | Obtain stake snapshot information for a pool, plus information about the total active stake.
 -- This information can be used for leader slot calculation, for example, and has been requested by SPOs.
 -- Obtaining the information directly is significantly more time and memory efficient than using a full ledger state dump.
-runLegacyQueryStakeSnapshotCmd
+runQueryStakeSnapshotCmd
   :: SocketPath
   -> AnyConsensusModeParams
   -> NetworkId
   -> AllOrOnly [Hash StakePoolKey]
   -> Maybe (File () Out)
   -> ExceptT ShelleyQueryCmdError IO ()
-runLegacyQueryStakeSnapshotCmd socketPath (AnyConsensusModeParams cModeParams) network allOrOnlyPoolIds mOutFile = do
+runQueryStakeSnapshotCmd socketPath (AnyConsensusModeParams cModeParams) network allOrOnlyPoolIds mOutFile = do
   let localNodeConnInfo = LocalNodeConnectInfo cModeParams network socketPath
 
   join $ lift
@@ -740,13 +739,13 @@ runLegacyQueryStakeSnapshotCmd socketPath (AnyConsensusModeParams cModeParams) n
     & onLeft (left . ShelleyQueryCmdAcquireFailure)
     & onLeft left
 
-runLegacyQueryLedgerStateCmd
+runQueryLedgerStateCmd
   :: SocketPath
   -> AnyConsensusModeParams
   -> NetworkId
   -> Maybe (File () Out)
   -> ExceptT ShelleyQueryCmdError IO ()
-runLegacyQueryLedgerStateCmd socketPath (AnyConsensusModeParams cModeParams) network mOutFile = do
+runQueryLedgerStateCmd socketPath (AnyConsensusModeParams cModeParams) network mOutFile = do
   let localNodeConnInfo = LocalNodeConnectInfo cModeParams network socketPath
 
   join $ lift
@@ -776,13 +775,13 @@ runLegacyQueryLedgerStateCmd socketPath (AnyConsensusModeParams cModeParams) net
     & onLeft (left . ShelleyQueryCmdAcquireFailure)
     & onLeft left
 
-runLegacyQueryProtocolStateCmd
+runQueryProtocolStateCmd
   :: SocketPath
   -> AnyConsensusModeParams
   -> NetworkId
   -> Maybe (File () Out)
   -> ExceptT ShelleyQueryCmdError IO ()
-runLegacyQueryProtocolStateCmd socketPath (AnyConsensusModeParams cModeParams) network mOutFile = do
+runQueryProtocolStateCmd socketPath (AnyConsensusModeParams cModeParams) network mOutFile = do
   let localNodeConnInfo = LocalNodeConnectInfo cModeParams network socketPath
 
   join $ lift
@@ -817,14 +816,14 @@ runLegacyQueryProtocolStateCmd socketPath (AnyConsensusModeParams cModeParams) n
 -- | Query the current delegations and reward accounts, filtered by a given
 -- set of addresses, from a Shelley node via the local state query protocol.
 
-runLegacyQueryStakeAddressInfoCmd
+runQueryStakeAddressInfoCmd
   :: SocketPath
   -> AnyConsensusModeParams
   -> StakeAddress
   -> NetworkId
   -> Maybe (File () Out)
   -> ExceptT ShelleyQueryCmdError IO ()
-runLegacyQueryStakeAddressInfoCmd socketPath (AnyConsensusModeParams cModeParams) (StakeAddress _ addr) network mOutFile = do
+runQueryStakeAddressInfoCmd socketPath (AnyConsensusModeParams cModeParams) (StakeAddress _ addr) network mOutFile = do
   let localNodeConnInfo = LocalNodeConnectInfo cModeParams network socketPath
 
   join $ lift
@@ -1053,13 +1052,13 @@ printUtxo sbe txInOutTuple =
   printableValue (TxOutValue _ val) = renderValue val
   printableValue (TxOutAdaOnly _ (Lovelace i)) = Text.pack $ show i
 
-runLegacyQueryStakePoolsCmd
+runQueryStakePoolsCmd
   :: SocketPath
   -> AnyConsensusModeParams
   -> NetworkId
   -> Maybe (File () Out)
   -> ExceptT ShelleyQueryCmdError IO ()
-runLegacyQueryStakePoolsCmd socketPath (AnyConsensusModeParams cModeParams) network mOutFile = do
+runQueryStakePoolsCmd socketPath (AnyConsensusModeParams cModeParams) network mOutFile = do
   let localNodeConnInfo = LocalNodeConnectInfo cModeParams network socketPath
 
   join $ lift
@@ -1098,13 +1097,13 @@ writeStakePools Nothing stakePools =
   forM_ (Set.toList stakePools) $ \poolId ->
     liftIO . putStrLn $ Text.unpack (serialiseToBech32 poolId)
 
-runLegacyQueryStakeDistributionCmd
+runQueryStakeDistributionCmd
   :: SocketPath
   -> AnyConsensusModeParams
   -> NetworkId
   -> Maybe (File () Out)
   -> ExceptT ShelleyQueryCmdError IO ()
-runLegacyQueryStakeDistributionCmd socketPath (AnyConsensusModeParams cModeParams) network mOutFile = do
+runQueryStakeDistributionCmd socketPath (AnyConsensusModeParams cModeParams) network mOutFile = do
   let localNodeConnInfo = LocalNodeConnectInfo cModeParams network socketPath
 
   join $ lift
@@ -1225,7 +1224,7 @@ instance FromJSON DelegationsAndRewards where
         rewardAccountBalance <- o .:? "rewardAccountBalance"
         pure (address, rewardAccountBalance, delegation)
 
-runLegacyQueryLeadershipScheduleCmd
+runQueryLeadershipScheduleCmd
   :: SocketPath
   -> AnyConsensusModeParams
   -> NetworkId
@@ -1235,7 +1234,7 @@ runLegacyQueryLeadershipScheduleCmd
   -> EpochLeadershipSchedule
   -> Maybe (File () Out)
   -> ExceptT ShelleyQueryCmdError IO ()
-runLegacyQueryLeadershipScheduleCmd
+runQueryLeadershipScheduleCmd
     socketPath (AnyConsensusModeParams cModeParams) network
     (GenesisFile genFile) coldVerKeyFile vrfSkeyFp
     whichSchedule mJsonOutputFile = do

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Query.hs
@@ -13,7 +13,7 @@
 {-# OPTIONS_GHC -Wno-unticked-promoted-constructors #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
-module Cardano.CLI.Legacy.Run.Query
+module Cardano.CLI.EraBased.Run.Query
   ( DelegationsAndRewards(..)
   , renderOpCertIntervalInformation
   , renderShelleyQueryCmdError

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Query.hs
@@ -14,15 +14,25 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Cardano.CLI.EraBased.Run.Query
-  ( DelegationsAndRewards(..)
-  , renderOpCertIntervalInformation
+  ( runLegacyQueryConstitutionHashCmd
+  , runLegacyQueryKesPeriodInfoCmd
+  , runLegacyQueryLeadershipScheduleCmd
+  , runLegacyQueryLedgerStateCmd
+  , runLegacyQueryPoolStateCmd
+  , runLegacyQueryProtocolParametersCmd
+  , runLegacyQueryProtocolStateCmd
+  , runLegacyQuerySlotNumberCmd
+  , runLegacyQueryStakeAddressInfoCmd
+  , runLegacyQueryStakeDistributionCmd
+  , runLegacyQueryStakePoolsCmd
+  , runLegacyQueryStakeSnapshotCmd
+  , runLegacyQueryTipCmd
+  , runLegacyQueryTxMempoolCmd
+  , runLegacyQueryUTxOCmd
+
+  , DelegationsAndRewards(..)
   , renderShelleyQueryCmdError
   , renderLocalStateQueryError
-  , runLegacyQueryCmds
-  , toEpochInfo
-  , utcTimeToSlotNo
-  , determineEra
-  , mergeDelegsAndRewards
   , percentage
   ) where
 
@@ -32,7 +42,6 @@ import           Cardano.Api.Byron hiding (QueryInShelleyBasedEra (..))
 import           Cardano.Api.Shelley hiding (QueryInShelleyBasedEra (..))
 
 import           Cardano.CLI.Helpers (hushM, pPrintCBOR)
-import           Cardano.CLI.Legacy.Commands.Query
 import           Cardano.CLI.Legacy.Run.Genesis (readAndDecodeShelleyGenesis)
 import           Cardano.CLI.Pretty
 import           Cardano.CLI.Types.Common
@@ -96,39 +105,6 @@ import           Text.Printf (printf)
 
 {- HLINT ignore "Move brackets to avoid $" -}
 {- HLINT ignore "Redundant flip" -}
-
-runLegacyQueryCmds :: LegacyQueryCmds -> ExceptT ShelleyQueryCmdError IO ()
-runLegacyQueryCmds = \case
-  QueryLeadershipSchedule mNodeSocketPath consensusModeParams network shelleyGenFp poolid vrkSkeyFp whichSchedule outputAs ->
-    runLegacyQueryLeadershipScheduleCmd mNodeSocketPath consensusModeParams network shelleyGenFp poolid vrkSkeyFp whichSchedule outputAs
-  QueryProtocolParameters' mNodeSocketPath consensusModeParams network mOutFile ->
-    runLegacyQueryProtocolParametersCmd mNodeSocketPath consensusModeParams network mOutFile
-  QueryConstitutionHash mNodeSocketPath consensusModeParams network mOutFile ->
-    runLegacyQueryConstitutionHashCmd mNodeSocketPath consensusModeParams network mOutFile
-  QueryTip mNodeSocketPath consensusModeParams network mOutFile ->
-    runLegacyQueryTipCmd mNodeSocketPath consensusModeParams network mOutFile
-  QueryStakePools' mNodeSocketPath consensusModeParams network mOutFile ->
-    runLegacyQueryStakePoolsCmd mNodeSocketPath consensusModeParams network mOutFile
-  QueryStakeDistribution' mNodeSocketPath consensusModeParams network mOutFile ->
-    runLegacyQueryStakeDistributionCmd mNodeSocketPath consensusModeParams network mOutFile
-  QueryStakeAddressInfo mNodeSocketPath consensusModeParams addr network mOutFile ->
-    runLegacyQueryStakeAddressInfoCmd mNodeSocketPath consensusModeParams addr network mOutFile
-  QueryDebugLedgerState' mNodeSocketPath consensusModeParams network mOutFile ->
-    runLegacyQueryLedgerStateCmd mNodeSocketPath consensusModeParams network mOutFile
-  QueryStakeSnapshot' mNodeSocketPath consensusModeParams network allOrOnlyPoolIds mOutFile ->
-    runLegacyQueryStakeSnapshotCmd mNodeSocketPath consensusModeParams network allOrOnlyPoolIds mOutFile
-  QueryProtocolState' mNodeSocketPath consensusModeParams network mOutFile ->
-    runLegacyQueryProtocolStateCmd mNodeSocketPath consensusModeParams network mOutFile
-  QueryUTxO' mNodeSocketPath consensusModeParams qFilter networkId mOutFile ->
-    runLegacyQueryUTxOCmd mNodeSocketPath consensusModeParams qFilter networkId mOutFile
-  QueryKesPeriodInfo mNodeSocketPath consensusModeParams network nodeOpCert mOutFile ->
-    runLegacyQueryKesPeriodInfoCmd mNodeSocketPath consensusModeParams network nodeOpCert mOutFile
-  QueryPoolState' mNodeSocketPath consensusModeParams network poolid ->
-    runLegacyQueryPoolStateCmd mNodeSocketPath consensusModeParams network poolid
-  QueryTxMempool mNodeSocketPath consensusModeParams network op mOutFile ->
-    runLegacyQueryTxMempoolCmd mNodeSocketPath consensusModeParams network op mOutFile
-  QuerySlotNumber mNodeSocketPath consensusModeParams network utcTime ->
-    runLegacyQuerySlotNumberCmd mNodeSocketPath consensusModeParams network utcTime
 
 runLegacyQueryConstitutionHashCmd
   :: SocketPath

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run.hs
@@ -4,7 +4,6 @@ module Cardano.CLI.Legacy.Run
   ( runLegacyCmds
   ) where
 
-import           Cardano.CLI.EraBased.Run.Query
 import           Cardano.CLI.Legacy.Options
 import           Cardano.CLI.Legacy.Run.Address
 import           Cardano.CLI.Legacy.Run.Genesis
@@ -12,6 +11,7 @@ import           Cardano.CLI.Legacy.Run.Governance
 import           Cardano.CLI.Legacy.Run.Key
 import           Cardano.CLI.Legacy.Run.Node
 import           Cardano.CLI.Legacy.Run.Pool
+import           Cardano.CLI.Legacy.Run.Query
 import           Cardano.CLI.Legacy.Run.StakeAddress
 import           Cardano.CLI.Legacy.Run.TextView
 import           Cardano.CLI.Legacy.Run.Transaction

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run.hs
@@ -4,6 +4,7 @@ module Cardano.CLI.Legacy.Run
   ( runLegacyCmds
   ) where
 
+import           Cardano.CLI.EraBased.Run.Query
 import           Cardano.CLI.Legacy.Options
 import           Cardano.CLI.Legacy.Run.Address
 import           Cardano.CLI.Legacy.Run.Genesis
@@ -11,7 +12,6 @@ import           Cardano.CLI.Legacy.Run.Governance
 import           Cardano.CLI.Legacy.Run.Key
 import           Cardano.CLI.Legacy.Run.Node
 import           Cardano.CLI.Legacy.Run.Pool
-import           Cardano.CLI.Legacy.Run.Query
 import           Cardano.CLI.Legacy.Run.StakeAddress
 import           Cardano.CLI.Legacy.Run.TextView
 import           Cardano.CLI.Legacy.Run.Transaction

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Query.hs
@@ -59,7 +59,7 @@ runLegacyQueryConstitutionHashCmd :: ()
   -> NetworkId
   -> Maybe (File () Out)
   -> ExceptT ShelleyQueryCmdError IO ()
-runLegacyQueryConstitutionHashCmd = EraBased.runLegacyQueryConstitutionHashCmd
+runLegacyQueryConstitutionHashCmd = EraBased.runQueryConstitutionHashCmd
 
 runLegacyQueryProtocolParametersCmd :: ()
   => SocketPath
@@ -67,7 +67,7 @@ runLegacyQueryProtocolParametersCmd :: ()
   -> NetworkId
   -> Maybe (File () Out)
   -> ExceptT ShelleyQueryCmdError IO ()
-runLegacyQueryProtocolParametersCmd = EraBased.runLegacyQueryProtocolParametersCmd
+runLegacyQueryProtocolParametersCmd = EraBased.runQueryProtocolParametersCmd
 
 runLegacyQueryTipCmd :: ()
   => SocketPath
@@ -75,7 +75,7 @@ runLegacyQueryTipCmd :: ()
   -> NetworkId
   -> Maybe (File () Out)
   -> ExceptT ShelleyQueryCmdError IO ()
-runLegacyQueryTipCmd = EraBased.runLegacyQueryTipCmd
+runLegacyQueryTipCmd = EraBased.runQueryTipCmd
 
 -- | Query the UTxO, filtered by a given set of addresses, from a Shelley node
 -- via the local state query protocol.
@@ -86,7 +86,7 @@ runLegacyQueryUTxOCmd :: ()
   -> NetworkId
   -> Maybe (File () Out)
   -> ExceptT ShelleyQueryCmdError IO ()
-runLegacyQueryUTxOCmd = EraBased.runLegacyQueryUTxOCmd
+runLegacyQueryUTxOCmd = EraBased.runQueryUTxOCmd
 
 runLegacyQueryKesPeriodInfoCmd :: ()
   => SocketPath
@@ -95,7 +95,7 @@ runLegacyQueryKesPeriodInfoCmd :: ()
   -> File () In
   -> Maybe (File () Out)
   -> ExceptT ShelleyQueryCmdError IO ()
-runLegacyQueryKesPeriodInfoCmd = EraBased.runLegacyQueryKesPeriodInfoCmd
+runLegacyQueryKesPeriodInfoCmd = EraBased.runQueryKesPeriodInfoCmd
 
 -- | Query the current and future parameters for a stake pool, including the retirement date.
 -- Any of these may be empty (in which case a null will be displayed).
@@ -106,7 +106,7 @@ runLegacyQueryPoolStateCmd :: ()
   -> NetworkId
   -> [Hash StakePoolKey]
   -> ExceptT ShelleyQueryCmdError IO ()
-runLegacyQueryPoolStateCmd = EraBased.runLegacyQueryPoolStateCmd
+runLegacyQueryPoolStateCmd = EraBased.runQueryPoolStateCmd
 
 -- | Query the local mempool state
 runLegacyQueryTxMempoolCmd :: ()
@@ -116,7 +116,7 @@ runLegacyQueryTxMempoolCmd :: ()
   -> TxMempoolQuery
   -> Maybe (File () Out)
   -> ExceptT ShelleyQueryCmdError IO ()
-runLegacyQueryTxMempoolCmd = EraBased.runLegacyQueryTxMempoolCmd
+runLegacyQueryTxMempoolCmd = EraBased.runQueryTxMempoolCmd
 
 runLegacyQuerySlotNumberCmd :: ()
   => SocketPath
@@ -124,7 +124,7 @@ runLegacyQuerySlotNumberCmd :: ()
   -> NetworkId
   -> UTCTime
   -> ExceptT ShelleyQueryCmdError IO ()
-runLegacyQuerySlotNumberCmd = EraBased.runLegacyQuerySlotNumberCmd
+runLegacyQuerySlotNumberCmd = EraBased.runQuerySlotNumberCmd
 
 -- | Obtain stake snapshot information for a pool, plus information about the total active stake.
 -- This information can be used for leader slot calculation, for example, and has been requested by SPOs.
@@ -136,7 +136,7 @@ runLegacyQueryStakeSnapshotCmd :: ()
   -> AllOrOnly [Hash StakePoolKey]
   -> Maybe (File () Out)
   -> ExceptT ShelleyQueryCmdError IO ()
-runLegacyQueryStakeSnapshotCmd = EraBased.runLegacyQueryStakeSnapshotCmd
+runLegacyQueryStakeSnapshotCmd = EraBased.runQueryStakeSnapshotCmd
 
 runLegacyQueryLedgerStateCmd :: ()
   => SocketPath
@@ -144,7 +144,7 @@ runLegacyQueryLedgerStateCmd :: ()
   -> NetworkId
   -> Maybe (File () Out)
   -> ExceptT ShelleyQueryCmdError IO ()
-runLegacyQueryLedgerStateCmd = EraBased.runLegacyQueryLedgerStateCmd
+runLegacyQueryLedgerStateCmd = EraBased.runQueryLedgerStateCmd
 
 runLegacyQueryProtocolStateCmd :: ()
   => SocketPath
@@ -152,7 +152,7 @@ runLegacyQueryProtocolStateCmd :: ()
   -> NetworkId
   -> Maybe (File () Out)
   -> ExceptT ShelleyQueryCmdError IO ()
-runLegacyQueryProtocolStateCmd = EraBased.runLegacyQueryProtocolStateCmd
+runLegacyQueryProtocolStateCmd = EraBased.runQueryProtocolStateCmd
 
 -- | Query the current delegations and reward accounts, filtered by a given
 -- set of addresses, from a Shelley node via the local state query protocol.
@@ -164,7 +164,7 @@ runLegacyQueryStakeAddressInfoCmd :: ()
   -> NetworkId
   -> Maybe (File () Out)
   -> ExceptT ShelleyQueryCmdError IO ()
-runLegacyQueryStakeAddressInfoCmd = EraBased.runLegacyQueryStakeAddressInfoCmd
+runLegacyQueryStakeAddressInfoCmd = EraBased.runQueryStakeAddressInfoCmd
 
 runLegacyQueryStakePoolsCmd :: ()
   => SocketPath
@@ -172,7 +172,7 @@ runLegacyQueryStakePoolsCmd :: ()
   -> NetworkId
   -> Maybe (File () Out)
   -> ExceptT ShelleyQueryCmdError IO ()
-runLegacyQueryStakePoolsCmd = EraBased.runLegacyQueryStakePoolsCmd
+runLegacyQueryStakePoolsCmd = EraBased.runQueryStakePoolsCmd
 
 runLegacyQueryStakeDistributionCmd :: ()
   => SocketPath
@@ -180,7 +180,7 @@ runLegacyQueryStakeDistributionCmd :: ()
   -> NetworkId
   -> Maybe (File () Out)
   -> ExceptT ShelleyQueryCmdError IO ()
-runLegacyQueryStakeDistributionCmd = EraBased.runLegacyQueryStakeDistributionCmd
+runLegacyQueryStakeDistributionCmd = EraBased.runQueryStakeDistributionCmd
 
 runLegacyQueryLeadershipScheduleCmd :: ()
   => SocketPath
@@ -192,4 +192,4 @@ runLegacyQueryLeadershipScheduleCmd :: ()
   -> EpochLeadershipSchedule
   -> Maybe (File () Out)
   -> ExceptT ShelleyQueryCmdError IO ()
-runLegacyQueryLeadershipScheduleCmd = EraBased.runLegacyQueryLeadershipScheduleCmd
+runLegacyQueryLeadershipScheduleCmd = EraBased.runQueryLeadershipScheduleCmd

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Query.hs
@@ -1,0 +1,195 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+
+{-# OPTIONS_GHC -Wno-unticked-promoted-constructors #-}
+
+module Cardano.CLI.Legacy.Run.Query
+  ( runLegacyQueryCmds
+  ) where
+
+import           Cardano.Api hiding (QueryInShelleyBasedEra (..))
+import           Cardano.Api.Shelley hiding (QueryInShelleyBasedEra (..))
+
+import qualified Cardano.CLI.EraBased.Run.Query as EraBased
+import           Cardano.CLI.Legacy.Commands.Query
+import           Cardano.CLI.Types.Common
+import           Cardano.CLI.Types.Errors.ShelleyQueryCmdError
+import           Cardano.CLI.Types.Key (VerificationKeyOrHashOrFile)
+
+import           Control.Monad.Trans.Except (ExceptT)
+import           Data.Time.Clock
+
+runLegacyQueryCmds :: LegacyQueryCmds -> ExceptT ShelleyQueryCmdError IO ()
+runLegacyQueryCmds = \case
+  QueryLeadershipSchedule mNodeSocketPath consensusModeParams network shelleyGenFp poolid vrkSkeyFp whichSchedule outputAs ->
+    runLegacyQueryLeadershipScheduleCmd mNodeSocketPath consensusModeParams network shelleyGenFp poolid vrkSkeyFp whichSchedule outputAs
+  QueryProtocolParameters' mNodeSocketPath consensusModeParams network mOutFile ->
+    runLegacyQueryProtocolParametersCmd mNodeSocketPath consensusModeParams network mOutFile
+  QueryConstitutionHash mNodeSocketPath consensusModeParams network mOutFile ->
+    runLegacyQueryConstitutionHashCmd mNodeSocketPath consensusModeParams network mOutFile
+  QueryTip mNodeSocketPath consensusModeParams network mOutFile ->
+    runLegacyQueryTipCmd mNodeSocketPath consensusModeParams network mOutFile
+  QueryStakePools' mNodeSocketPath consensusModeParams network mOutFile ->
+    runLegacyQueryStakePoolsCmd mNodeSocketPath consensusModeParams network mOutFile
+  QueryStakeDistribution' mNodeSocketPath consensusModeParams network mOutFile ->
+    runLegacyQueryStakeDistributionCmd mNodeSocketPath consensusModeParams network mOutFile
+  QueryStakeAddressInfo mNodeSocketPath consensusModeParams addr network mOutFile ->
+    runLegacyQueryStakeAddressInfoCmd mNodeSocketPath consensusModeParams addr network mOutFile
+  QueryDebugLedgerState' mNodeSocketPath consensusModeParams network mOutFile ->
+    runLegacyQueryLedgerStateCmd mNodeSocketPath consensusModeParams network mOutFile
+  QueryStakeSnapshot' mNodeSocketPath consensusModeParams network allOrOnlyPoolIds mOutFile ->
+    runLegacyQueryStakeSnapshotCmd mNodeSocketPath consensusModeParams network allOrOnlyPoolIds mOutFile
+  QueryProtocolState' mNodeSocketPath consensusModeParams network mOutFile ->
+    runLegacyQueryProtocolStateCmd mNodeSocketPath consensusModeParams network mOutFile
+  QueryUTxO' mNodeSocketPath consensusModeParams qFilter networkId mOutFile ->
+    runLegacyQueryUTxOCmd mNodeSocketPath consensusModeParams qFilter networkId mOutFile
+  QueryKesPeriodInfo mNodeSocketPath consensusModeParams network nodeOpCert mOutFile ->
+    runLegacyQueryKesPeriodInfoCmd mNodeSocketPath consensusModeParams network nodeOpCert mOutFile
+  QueryPoolState' mNodeSocketPath consensusModeParams network poolid ->
+    runLegacyQueryPoolStateCmd mNodeSocketPath consensusModeParams network poolid
+  QueryTxMempool mNodeSocketPath consensusModeParams network op mOutFile ->
+    runLegacyQueryTxMempoolCmd mNodeSocketPath consensusModeParams network op mOutFile
+  QuerySlotNumber mNodeSocketPath consensusModeParams network utcTime ->
+    runLegacyQuerySlotNumberCmd mNodeSocketPath consensusModeParams network utcTime
+
+runLegacyQueryConstitutionHashCmd :: ()
+  => SocketPath
+  -> AnyConsensusModeParams
+  -> NetworkId
+  -> Maybe (File () Out)
+  -> ExceptT ShelleyQueryCmdError IO ()
+runLegacyQueryConstitutionHashCmd = EraBased.runLegacyQueryConstitutionHashCmd
+
+runLegacyQueryProtocolParametersCmd :: ()
+  => SocketPath
+  -> AnyConsensusModeParams
+  -> NetworkId
+  -> Maybe (File () Out)
+  -> ExceptT ShelleyQueryCmdError IO ()
+runLegacyQueryProtocolParametersCmd = EraBased.runLegacyQueryProtocolParametersCmd
+
+runLegacyQueryTipCmd :: ()
+  => SocketPath
+  -> AnyConsensusModeParams
+  -> NetworkId
+  -> Maybe (File () Out)
+  -> ExceptT ShelleyQueryCmdError IO ()
+runLegacyQueryTipCmd = EraBased.runLegacyQueryTipCmd
+
+-- | Query the UTxO, filtered by a given set of addresses, from a Shelley node
+-- via the local state query protocol.
+runLegacyQueryUTxOCmd :: ()
+  => SocketPath
+  -> AnyConsensusModeParams
+  -> QueryUTxOFilter
+  -> NetworkId
+  -> Maybe (File () Out)
+  -> ExceptT ShelleyQueryCmdError IO ()
+runLegacyQueryUTxOCmd = EraBased.runLegacyQueryUTxOCmd
+
+runLegacyQueryKesPeriodInfoCmd :: ()
+  => SocketPath
+  -> AnyConsensusModeParams
+  -> NetworkId
+  -> File () In
+  -> Maybe (File () Out)
+  -> ExceptT ShelleyQueryCmdError IO ()
+runLegacyQueryKesPeriodInfoCmd = EraBased.runLegacyQueryKesPeriodInfoCmd
+
+-- | Query the current and future parameters for a stake pool, including the retirement date.
+-- Any of these may be empty (in which case a null will be displayed).
+--
+runLegacyQueryPoolStateCmd :: ()
+  => SocketPath
+  -> AnyConsensusModeParams
+  -> NetworkId
+  -> [Hash StakePoolKey]
+  -> ExceptT ShelleyQueryCmdError IO ()
+runLegacyQueryPoolStateCmd = EraBased.runLegacyQueryPoolStateCmd
+
+-- | Query the local mempool state
+runLegacyQueryTxMempoolCmd :: ()
+  => SocketPath
+  -> AnyConsensusModeParams
+  -> NetworkId
+  -> TxMempoolQuery
+  -> Maybe (File () Out)
+  -> ExceptT ShelleyQueryCmdError IO ()
+runLegacyQueryTxMempoolCmd = EraBased.runLegacyQueryTxMempoolCmd
+
+runLegacyQuerySlotNumberCmd :: ()
+  => SocketPath
+  -> AnyConsensusModeParams
+  -> NetworkId
+  -> UTCTime
+  -> ExceptT ShelleyQueryCmdError IO ()
+runLegacyQuerySlotNumberCmd = EraBased.runLegacyQuerySlotNumberCmd
+
+-- | Obtain stake snapshot information for a pool, plus information about the total active stake.
+-- This information can be used for leader slot calculation, for example, and has been requested by SPOs.
+-- Obtaining the information directly is significantly more time and memory efficient than using a full ledger state dump.
+runLegacyQueryStakeSnapshotCmd :: ()
+  => SocketPath
+  -> AnyConsensusModeParams
+  -> NetworkId
+  -> AllOrOnly [Hash StakePoolKey]
+  -> Maybe (File () Out)
+  -> ExceptT ShelleyQueryCmdError IO ()
+runLegacyQueryStakeSnapshotCmd = EraBased.runLegacyQueryStakeSnapshotCmd
+
+runLegacyQueryLedgerStateCmd :: ()
+  => SocketPath
+  -> AnyConsensusModeParams
+  -> NetworkId
+  -> Maybe (File () Out)
+  -> ExceptT ShelleyQueryCmdError IO ()
+runLegacyQueryLedgerStateCmd = EraBased.runLegacyQueryLedgerStateCmd
+
+runLegacyQueryProtocolStateCmd :: ()
+  => SocketPath
+  -> AnyConsensusModeParams
+  -> NetworkId
+  -> Maybe (File () Out)
+  -> ExceptT ShelleyQueryCmdError IO ()
+runLegacyQueryProtocolStateCmd = EraBased.runLegacyQueryProtocolStateCmd
+
+-- | Query the current delegations and reward accounts, filtered by a given
+-- set of addresses, from a Shelley node via the local state query protocol.
+
+runLegacyQueryStakeAddressInfoCmd :: ()
+  => SocketPath
+  -> AnyConsensusModeParams
+  -> StakeAddress
+  -> NetworkId
+  -> Maybe (File () Out)
+  -> ExceptT ShelleyQueryCmdError IO ()
+runLegacyQueryStakeAddressInfoCmd = EraBased.runLegacyQueryStakeAddressInfoCmd
+
+runLegacyQueryStakePoolsCmd :: ()
+  => SocketPath
+  -> AnyConsensusModeParams
+  -> NetworkId
+  -> Maybe (File () Out)
+  -> ExceptT ShelleyQueryCmdError IO ()
+runLegacyQueryStakePoolsCmd = EraBased.runLegacyQueryStakePoolsCmd
+
+runLegacyQueryStakeDistributionCmd :: ()
+  => SocketPath
+  -> AnyConsensusModeParams
+  -> NetworkId
+  -> Maybe (File () Out)
+  -> ExceptT ShelleyQueryCmdError IO ()
+runLegacyQueryStakeDistributionCmd = EraBased.runLegacyQueryStakeDistributionCmd
+
+runLegacyQueryLeadershipScheduleCmd :: ()
+  => SocketPath
+  -> AnyConsensusModeParams
+  -> NetworkId
+  -> GenesisFile -- ^ Shelley genesis
+  -> VerificationKeyOrHashOrFile StakePoolKey
+  -> SigningKeyFile In -- ^ VRF signing key
+  -> EpochLeadershipSchedule
+  -> Maybe (File () Out)
+  -> ExceptT ShelleyQueryCmdError IO ()
+runLegacyQueryLeadershipScheduleCmd = EraBased.runLegacyQueryLeadershipScheduleCmd

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/JSON.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/JSON.hs
@@ -8,7 +8,7 @@ module Test.Cli.JSON
 
 import           Cardano.Api.Shelley
 
-import           Cardano.CLI.Legacy.Run.Query
+import           Cardano.CLI.EraBased.Run.Query
 import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Output (QueryKesPeriodInfoOutput (..), createOpCertIntervalInfo)
 

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/Shelley/Run/Query.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/Shelley/Run/Query.hs
@@ -2,7 +2,7 @@ module Test.Cli.Shelley.Run.Query
   ( hprop_percentage
   ) where
 
-import qualified Cardano.CLI.Legacy.Run.Query as Q
+import qualified Cardano.CLI.EraBased.Run.Query as Q
 import           Cardano.Slotting.Time (RelativeTime (..))
 
 import           Hedgehog (Property, (===))


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Move `query` run commands implementation into era based
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Only the implementation has been moved into era-based to minimise the size of the PR. The PR diff appears smaller if view by commits.

A future PR will make make the era-based run command era-sensitive and export them in the CLI.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
