### PR TITLE
Move `key` run commands implementation into era based

### DIFF
--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -90,6 +90,7 @@ library
                         Cardano.CLI.EraBased.Run.Governance.DRep
                         Cardano.CLI.EraBased.Run.Governance.Query
                         Cardano.CLI.EraBased.Run.Governance.Vote
+                        Cardano.CLI.EraBased.Run.Key
                         Cardano.CLI.EraBased.Run.Pool
                         Cardano.CLI.EraBased.Run.StakeAddress
                         Cardano.CLI.EraBased.Run.TextView
@@ -113,7 +114,6 @@ library
                         Cardano.CLI.Legacy.Run.Address
                         Cardano.CLI.Legacy.Run.Genesis
                         Cardano.CLI.Legacy.Run.Governance
-                        Cardano.CLI.Legacy.Run.Key
                         Cardano.CLI.Legacy.Run.Node
                         Cardano.CLI.Legacy.Run.Pool
                         Cardano.CLI.Legacy.Run.Query

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -114,6 +114,7 @@ library
                         Cardano.CLI.Legacy.Run.Address
                         Cardano.CLI.Legacy.Run.Genesis
                         Cardano.CLI.Legacy.Run.Governance
+                        Cardano.CLI.Legacy.Run.Key
                         Cardano.CLI.Legacy.Run.Node
                         Cardano.CLI.Legacy.Run.Pool
                         Cardano.CLI.Legacy.Run.Query

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Key.hs
@@ -1,13 +1,17 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Cardano.CLI.EraBased.Run.Key
-  ( SomeSigningKey(..)
-  , runLegacyKeyCmds
-  , readSigningKeyFile
+  ( runLegacyConvertByronGenesisVerificationKeyCmd
+  , runLegacyConvertByronKeyCmd
+  , runLegacyConvertCardanoAddressSigningKeyCmd
+  , runLegacyConvertITNBip32ToStakeKeyCmd
+  , runLegacyConvertITNExtendedToStakeKeyCmd
+  , runLegacyConvertITNStakeKeyCmd
+  , runLegacyConvertToNonExtendedKeyCmd
+  , runLegacyGetVerificationKeyCmd
 
     -- * Exports for testing
   , decodeBech32
@@ -19,7 +23,6 @@ import           Cardano.Api.Crypto.Ed25519Bip32 (xPrvFromBytes)
 import           Cardano.Api.Shelley
 
 import qualified Cardano.CLI.Byron.Key as Byron
-import           Cardano.CLI.Legacy.Commands.Key
 import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Errors.CardanoAddressSigningKeyConversionError
 import           Cardano.CLI.Types.Errors.ItnKeyConversionError
@@ -44,25 +47,6 @@ import           Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import           System.Exit (exitFailure)
-
-runLegacyKeyCmds :: LegacyKeyCmds -> ExceptT ShelleyKeyCmdError IO ()
-runLegacyKeyCmds = \case
-  KeyGetVerificationKey skf vkf ->
-    runLegacyGetVerificationKeyCmd skf vkf
-  KeyNonExtendedKey evkf vkf ->
-    runLegacyConvertToNonExtendedKeyCmd evkf vkf
-  KeyConvertByronKey mPassword keytype skfOld skfNew ->
-    runLegacyConvertByronKeyCmd mPassword keytype skfOld skfNew
-  KeyConvertByronGenesisVKey oldVk newVkf ->
-    runLegacyConvertByronGenesisVerificationKeyCmd oldVk newVkf
-  KeyConvertITNStakeKey itnKeyFile outFile ->
-    runLegacyConvertITNStakeKeyCmd itnKeyFile outFile
-  KeyConvertITNExtendedToStakeKey itnPrivKeyFile outFile ->
-    runLegacyConvertITNExtendedToStakeKeyCmd itnPrivKeyFile outFile
-  KeyConvertITNBip32ToStakeKey itnPrivKeyFile outFile ->
-    runLegacyConvertITNBip32ToStakeKeyCmd itnPrivKeyFile outFile
-  KeyConvertCardanoAddressSigningKey keyType skfOld skfNew ->
-    runLegacyConvertCardanoAddressSigningKeyCmd keyType skfOld skfNew
 
 runLegacyGetVerificationKeyCmd :: SigningKeyFile In
                       -> VerificationKeyFile Out

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Key.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-module Cardano.CLI.Legacy.Run.Key
+module Cardano.CLI.EraBased.Run.Key
   ( SomeSigningKey(..)
   , runLegacyKeyCmds
   , readSigningKeyFile

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run.hs
@@ -4,11 +4,11 @@ module Cardano.CLI.Legacy.Run
   ( runLegacyCmds
   ) where
 
+import           Cardano.CLI.EraBased.Run.Key
 import           Cardano.CLI.Legacy.Options
 import           Cardano.CLI.Legacy.Run.Address
 import           Cardano.CLI.Legacy.Run.Genesis
 import           Cardano.CLI.Legacy.Run.Governance
-import           Cardano.CLI.Legacy.Run.Key
 import           Cardano.CLI.Legacy.Run.Node
 import           Cardano.CLI.Legacy.Run.Pool
 import           Cardano.CLI.Legacy.Run.Query

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run.hs
@@ -4,11 +4,11 @@ module Cardano.CLI.Legacy.Run
   ( runLegacyCmds
   ) where
 
-import           Cardano.CLI.EraBased.Run.Key
 import           Cardano.CLI.Legacy.Options
 import           Cardano.CLI.Legacy.Run.Address
 import           Cardano.CLI.Legacy.Run.Genesis
 import           Cardano.CLI.Legacy.Run.Governance
+import           Cardano.CLI.Legacy.Run.Key
 import           Cardano.CLI.Legacy.Run.Node
 import           Cardano.CLI.Legacy.Run.Pool
 import           Cardano.CLI.Legacy.Run.Query

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Key.hs
@@ -7,7 +7,7 @@ module Cardano.CLI.Legacy.Run.Key
 
 import           Cardano.Api
 
-import qualified Cardano.CLI.EraBased.Run.Key as EraBased
+import           Cardano.CLI.EraBased.Run.Key
 import           Cardano.CLI.Legacy.Commands.Key
 import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Errors.ShelleyKeyCmdError
@@ -37,13 +37,13 @@ runLegacyKeyCmds = \case
 runLegacyGetVerificationKeyCmd :: SigningKeyFile In
                       -> VerificationKeyFile Out
                       -> ExceptT ShelleyKeyCmdError IO ()
-runLegacyGetVerificationKeyCmd = EraBased.runLegacyGetVerificationKeyCmd
+runLegacyGetVerificationKeyCmd = runGetVerificationKeyCmd
 
 runLegacyConvertToNonExtendedKeyCmd
   :: VerificationKeyFile In
   -> VerificationKeyFile Out
   -> ExceptT ShelleyKeyCmdError IO ()
-runLegacyConvertToNonExtendedKeyCmd = EraBased.runLegacyConvertToNonExtendedKeyCmd
+runLegacyConvertToNonExtendedKeyCmd = runConvertToNonExtendedKeyCmd
 
 runLegacyConvertByronKeyCmd
   :: Maybe Text      -- ^ Password (if applicable)
@@ -51,13 +51,13 @@ runLegacyConvertByronKeyCmd
   -> SomeKeyFile In  -- ^ Input file: old format
   -> File () Out     -- ^ Output file: new format
   -> ExceptT ShelleyKeyCmdError IO ()
-runLegacyConvertByronKeyCmd = EraBased.runLegacyConvertByronKeyCmd
+runLegacyConvertByronKeyCmd = runConvertByronKeyCmd
 
 runLegacyConvertByronGenesisVerificationKeyCmd
   :: VerificationKeyBase64  -- ^ Input key raw old format
   -> File () Out            -- ^ Output file: new format
   -> ExceptT ShelleyKeyCmdError IO ()
-runLegacyConvertByronGenesisVerificationKeyCmd = EraBased.runLegacyConvertByronGenesisVerificationKeyCmd
+runLegacyConvertByronGenesisVerificationKeyCmd = runConvertByronGenesisVerificationKeyCmd
 
 --------------------------------------------------------------------------------
 -- ITN verification/signing key conversion to Haskell verficiation/signing keys
@@ -67,17 +67,17 @@ runLegacyConvertITNStakeKeyCmd
   :: SomeKeyFile In
   -> File () Out
   -> ExceptT ShelleyKeyCmdError IO ()
-runLegacyConvertITNStakeKeyCmd = EraBased.runLegacyConvertITNStakeKeyCmd
+runLegacyConvertITNStakeKeyCmd = runConvertITNStakeKeyCmd
 
 runLegacyConvertITNExtendedToStakeKeyCmd :: SomeKeyFile In -> File () Out -> ExceptT ShelleyKeyCmdError IO ()
-runLegacyConvertITNExtendedToStakeKeyCmd = EraBased.runLegacyConvertITNExtendedToStakeKeyCmd
+runLegacyConvertITNExtendedToStakeKeyCmd = runConvertITNExtendedToStakeKeyCmd
 
 runLegacyConvertITNBip32ToStakeKeyCmd :: SomeKeyFile In -> File () Out -> ExceptT ShelleyKeyCmdError IO ()
-runLegacyConvertITNBip32ToStakeKeyCmd = EraBased.runLegacyConvertITNBip32ToStakeKeyCmd
+runLegacyConvertITNBip32ToStakeKeyCmd = runConvertITNBip32ToStakeKeyCmd
 
 runLegacyConvertCardanoAddressSigningKeyCmd
   :: CardanoAddressKeyType
   -> SigningKeyFile In
   -> File () Out
   -> ExceptT ShelleyKeyCmdError IO ()
-runLegacyConvertCardanoAddressSigningKeyCmd = EraBased.runLegacyConvertCardanoAddressSigningKeyCmd
+runLegacyConvertCardanoAddressSigningKeyCmd = runConvertCardanoAddressSigningKeyCmd

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Key.hs
@@ -15,7 +15,9 @@ import           Cardano.CLI.Types.Errors.ShelleyKeyCmdError
 import           Control.Monad.Trans.Except (ExceptT)
 import           Data.Text (Text)
 
-runLegacyKeyCmds :: LegacyKeyCmds -> ExceptT ShelleyKeyCmdError IO ()
+runLegacyKeyCmds :: ()
+  => LegacyKeyCmds
+  -> ExceptT ShelleyKeyCmdError IO ()
 runLegacyKeyCmds = \case
   KeyGetVerificationKey skf vkf ->
     runLegacyGetVerificationKeyCmd skf vkf
@@ -34,27 +36,28 @@ runLegacyKeyCmds = \case
   KeyConvertCardanoAddressSigningKey keyType skfOld skfNew ->
     runLegacyConvertCardanoAddressSigningKeyCmd keyType skfOld skfNew
 
-runLegacyGetVerificationKeyCmd :: SigningKeyFile In
-                      -> VerificationKeyFile Out
-                      -> ExceptT ShelleyKeyCmdError IO ()
+runLegacyGetVerificationKeyCmd :: ()
+  => SigningKeyFile In
+  -> VerificationKeyFile Out
+  -> ExceptT ShelleyKeyCmdError IO ()
 runLegacyGetVerificationKeyCmd = runGetVerificationKeyCmd
 
-runLegacyConvertToNonExtendedKeyCmd
-  :: VerificationKeyFile In
+runLegacyConvertToNonExtendedKeyCmd :: ()
+  => VerificationKeyFile In
   -> VerificationKeyFile Out
   -> ExceptT ShelleyKeyCmdError IO ()
 runLegacyConvertToNonExtendedKeyCmd = runConvertToNonExtendedKeyCmd
 
-runLegacyConvertByronKeyCmd
-  :: Maybe Text      -- ^ Password (if applicable)
+runLegacyConvertByronKeyCmd :: ()
+  => Maybe Text      -- ^ Password (if applicable)
   -> ByronKeyType
   -> SomeKeyFile In  -- ^ Input file: old format
   -> File () Out     -- ^ Output file: new format
   -> ExceptT ShelleyKeyCmdError IO ()
 runLegacyConvertByronKeyCmd = runConvertByronKeyCmd
 
-runLegacyConvertByronGenesisVerificationKeyCmd
-  :: VerificationKeyBase64  -- ^ Input key raw old format
+runLegacyConvertByronGenesisVerificationKeyCmd :: ()
+  => VerificationKeyBase64  -- ^ Input key raw old format
   -> File () Out            -- ^ Output file: new format
   -> ExceptT ShelleyKeyCmdError IO ()
 runLegacyConvertByronGenesisVerificationKeyCmd = runConvertByronGenesisVerificationKeyCmd
@@ -63,20 +66,26 @@ runLegacyConvertByronGenesisVerificationKeyCmd = runConvertByronGenesisVerificat
 -- ITN verification/signing key conversion to Haskell verficiation/signing keys
 --------------------------------------------------------------------------------
 
-runLegacyConvertITNStakeKeyCmd
-  :: SomeKeyFile In
+runLegacyConvertITNStakeKeyCmd :: ()
+  => SomeKeyFile In
   -> File () Out
   -> ExceptT ShelleyKeyCmdError IO ()
 runLegacyConvertITNStakeKeyCmd = runConvertITNStakeKeyCmd
 
-runLegacyConvertITNExtendedToStakeKeyCmd :: SomeKeyFile In -> File () Out -> ExceptT ShelleyKeyCmdError IO ()
+runLegacyConvertITNExtendedToStakeKeyCmd :: ()
+  => SomeKeyFile In
+  -> File () Out
+  -> ExceptT ShelleyKeyCmdError IO ()
 runLegacyConvertITNExtendedToStakeKeyCmd = runConvertITNExtendedToStakeKeyCmd
 
-runLegacyConvertITNBip32ToStakeKeyCmd :: SomeKeyFile In -> File () Out -> ExceptT ShelleyKeyCmdError IO ()
+runLegacyConvertITNBip32ToStakeKeyCmd :: ()
+  => SomeKeyFile In
+  -> File () Out
+  -> ExceptT ShelleyKeyCmdError IO ()
 runLegacyConvertITNBip32ToStakeKeyCmd = runConvertITNBip32ToStakeKeyCmd
 
-runLegacyConvertCardanoAddressSigningKeyCmd
-  :: CardanoAddressKeyType
+runLegacyConvertCardanoAddressSigningKeyCmd :: ()
+  => CardanoAddressKeyType
   -> SigningKeyFile In
   -> File () Out
   -> ExceptT ShelleyKeyCmdError IO ()

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Key.hs
@@ -1,0 +1,83 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE LambdaCase #-}
+
+module Cardano.CLI.Legacy.Run.Key
+  ( runLegacyKeyCmds
+  ) where
+
+import           Cardano.Api
+
+import qualified Cardano.CLI.EraBased.Run.Key as EraBased
+import           Cardano.CLI.Legacy.Commands.Key
+import           Cardano.CLI.Types.Common
+import           Cardano.CLI.Types.Errors.ShelleyKeyCmdError
+
+import           Control.Monad.Trans.Except (ExceptT)
+import           Data.Text (Text)
+
+runLegacyKeyCmds :: LegacyKeyCmds -> ExceptT ShelleyKeyCmdError IO ()
+runLegacyKeyCmds = \case
+  KeyGetVerificationKey skf vkf ->
+    runLegacyGetVerificationKeyCmd skf vkf
+  KeyNonExtendedKey evkf vkf ->
+    runLegacyConvertToNonExtendedKeyCmd evkf vkf
+  KeyConvertByronKey mPassword keytype skfOld skfNew ->
+    runLegacyConvertByronKeyCmd mPassword keytype skfOld skfNew
+  KeyConvertByronGenesisVKey oldVk newVkf ->
+    runLegacyConvertByronGenesisVerificationKeyCmd oldVk newVkf
+  KeyConvertITNStakeKey itnKeyFile outFile ->
+    runLegacyConvertITNStakeKeyCmd itnKeyFile outFile
+  KeyConvertITNExtendedToStakeKey itnPrivKeyFile outFile ->
+    runLegacyConvertITNExtendedToStakeKeyCmd itnPrivKeyFile outFile
+  KeyConvertITNBip32ToStakeKey itnPrivKeyFile outFile ->
+    runLegacyConvertITNBip32ToStakeKeyCmd itnPrivKeyFile outFile
+  KeyConvertCardanoAddressSigningKey keyType skfOld skfNew ->
+    runLegacyConvertCardanoAddressSigningKeyCmd keyType skfOld skfNew
+
+runLegacyGetVerificationKeyCmd :: SigningKeyFile In
+                      -> VerificationKeyFile Out
+                      -> ExceptT ShelleyKeyCmdError IO ()
+runLegacyGetVerificationKeyCmd = EraBased.runLegacyGetVerificationKeyCmd
+
+runLegacyConvertToNonExtendedKeyCmd
+  :: VerificationKeyFile In
+  -> VerificationKeyFile Out
+  -> ExceptT ShelleyKeyCmdError IO ()
+runLegacyConvertToNonExtendedKeyCmd = EraBased.runLegacyConvertToNonExtendedKeyCmd
+
+runLegacyConvertByronKeyCmd
+  :: Maybe Text      -- ^ Password (if applicable)
+  -> ByronKeyType
+  -> SomeKeyFile In  -- ^ Input file: old format
+  -> File () Out     -- ^ Output file: new format
+  -> ExceptT ShelleyKeyCmdError IO ()
+runLegacyConvertByronKeyCmd = EraBased.runLegacyConvertByronKeyCmd
+
+runLegacyConvertByronGenesisVerificationKeyCmd
+  :: VerificationKeyBase64  -- ^ Input key raw old format
+  -> File () Out            -- ^ Output file: new format
+  -> ExceptT ShelleyKeyCmdError IO ()
+runLegacyConvertByronGenesisVerificationKeyCmd = EraBased.runLegacyConvertByronGenesisVerificationKeyCmd
+
+--------------------------------------------------------------------------------
+-- ITN verification/signing key conversion to Haskell verficiation/signing keys
+--------------------------------------------------------------------------------
+
+runLegacyConvertITNStakeKeyCmd
+  :: SomeKeyFile In
+  -> File () Out
+  -> ExceptT ShelleyKeyCmdError IO ()
+runLegacyConvertITNStakeKeyCmd = EraBased.runLegacyConvertITNStakeKeyCmd
+
+runLegacyConvertITNExtendedToStakeKeyCmd :: SomeKeyFile In -> File () Out -> ExceptT ShelleyKeyCmdError IO ()
+runLegacyConvertITNExtendedToStakeKeyCmd = EraBased.runLegacyConvertITNExtendedToStakeKeyCmd
+
+runLegacyConvertITNBip32ToStakeKeyCmd :: SomeKeyFile In -> File () Out -> ExceptT ShelleyKeyCmdError IO ()
+runLegacyConvertITNBip32ToStakeKeyCmd = EraBased.runLegacyConvertITNBip32ToStakeKeyCmd
+
+runLegacyConvertCardanoAddressSigningKeyCmd
+  :: CardanoAddressKeyType
+  -> SigningKeyFile In
+  -> File () Out
+  -> ExceptT ShelleyKeyCmdError IO ()
+runLegacyConvertCardanoAddressSigningKeyCmd = EraBased.runLegacyConvertCardanoAddressSigningKeyCmd

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/ITN.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/ITN.hs
@@ -7,7 +7,7 @@ module Test.Cli.ITN
   , hprop_golden_bech32Decode
   ) where
 
-import           Cardano.CLI.Legacy.Run.Key (decodeBech32)
+import           Cardano.CLI.EraBased.Run.Key (decodeBech32)
 
 import qualified Codec.Binary.Bech32 as Bech32
 import           Control.Monad (void)


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Move `key` run commands implementation into era based
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Only the implementation has been moved into era-based to minimise the size of the PR. The PR diff appears smaller if view by commits.

A future PR will make make the era-based run command era-sensitive and export them in the CLI.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
