### PR TITLE
Move `text-view` run commands implementation into era-based

### DIFF
--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -89,6 +89,7 @@ library
                         Cardano.CLI.EraBased.Run.Governance.Query
                         Cardano.CLI.EraBased.Run.Governance.Vote
                         Cardano.CLI.EraBased.Run.StakeAddress
+                        Cardano.CLI.EraBased.Run.TextView
                         Cardano.CLI.EraBased.Run.Transaction
                         Cardano.CLI.Helpers
                         Cardano.CLI.IO.Lazy

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/TextView.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/TextView.hs
@@ -1,0 +1,26 @@
+{-# LANGUAGE DataKinds #-}
+
+module Cardano.CLI.EraBased.Run.TextView
+  ( runTextViewInfoCmd
+  ) where
+
+import           Cardano.Api
+
+import           Cardano.CLI.Helpers (pPrintCBOR)
+import           Cardano.CLI.Types.Errors.ShelleyTextViewFileError
+
+import           Control.Monad.IO.Class (MonadIO (..))
+import           Control.Monad.Trans.Except (ExceptT)
+import           Control.Monad.Trans.Except.Extra (firstExceptT, newExceptT)
+import qualified Data.ByteString.Lazy.Char8 as LBS
+
+runTextViewInfoCmd :: ()
+  => FilePath
+  -> Maybe (File () Out)
+  -> ExceptT ShelleyTextViewFileError IO ()
+runTextViewInfoCmd fpath mOutFile = do
+  tv <- firstExceptT TextViewReadFileError $ newExceptT (readTextEnvelopeFromFile fpath)
+  let lbCBOR = LBS.fromStrict (textEnvelopeRawCBOR tv)
+  case mOutFile of
+    Just (File oFpath) -> liftIO $ LBS.writeFile oFpath lbCBOR
+    Nothing -> firstExceptT TextViewCBORPrettyPrintError $ pPrintCBOR lbCBOR

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/TextView.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/TextView.hs
@@ -7,23 +7,18 @@ module Cardano.CLI.Legacy.Run.TextView
 
 import           Cardano.Api
 
-import           Cardano.CLI.Helpers (pPrintCBOR)
+import           Cardano.CLI.EraBased.Run.TextView
 import           Cardano.CLI.Legacy.Commands.TextView
 import           Cardano.CLI.Types.Errors.ShelleyTextViewFileError
 
-import           Control.Monad.IO.Class (MonadIO (..))
 import           Control.Monad.Trans.Except (ExceptT)
-import           Control.Monad.Trans.Except.Extra (firstExceptT, newExceptT)
-import qualified Data.ByteString.Lazy.Char8 as LBS
 
 runLegacyTextViewCmds :: LegacyTextViewCmds -> ExceptT ShelleyTextViewFileError IO ()
 runLegacyTextViewCmds = \case
   TextViewInfo fpath mOutfile -> runLegacyTextViewInfoCmd fpath mOutfile
 
-runLegacyTextViewInfoCmd :: FilePath -> Maybe (File () Out) -> ExceptT ShelleyTextViewFileError IO ()
-runLegacyTextViewInfoCmd fpath mOutFile = do
-  tv <- firstExceptT TextViewReadFileError $ newExceptT (readTextEnvelopeFromFile fpath)
-  let lbCBOR = LBS.fromStrict (textEnvelopeRawCBOR tv)
-  case mOutFile of
-    Just (File oFpath) -> liftIO $ LBS.writeFile oFpath lbCBOR
-    Nothing -> firstExceptT TextViewCBORPrettyPrintError $ pPrintCBOR lbCBOR
+runLegacyTextViewInfoCmd :: ()
+  => FilePath
+  -> Maybe (File () Out)
+  -> ExceptT ShelleyTextViewFileError IO ()
+runLegacyTextViewInfoCmd = runTextViewInfoCmd


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Move `text-view` run commands implementation into era-based
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Only the implementation has been moved into era-based to minimise the size of the PR.

A future PR will make make the era-based run command era-sensitive and export them in the CLI.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
