### PR TITLE
Era-based `stake-address` command group

### DIFF
--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -72,6 +72,7 @@ library
                         Cardano.CLI.EraBased.Commands.Governance.DRep
                         Cardano.CLI.EraBased.Commands.Governance.Query
                         Cardano.CLI.EraBased.Commands.Governance.Vote
+                        Cardano.CLI.EraBased.Commands.StakeAddress
                         Cardano.CLI.EraBased.Commands.Transaction
                         Cardano.CLI.EraBased.Options.Common
                         Cardano.CLI.EraBased.Options.Governance

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -81,6 +81,7 @@ library
                         Cardano.CLI.EraBased.Options.Governance.DRep
                         Cardano.CLI.EraBased.Options.Governance.Query
                         Cardano.CLI.EraBased.Options.Governance.Vote
+                        Cardano.CLI.EraBased.Options.StakeAddress
                         Cardano.CLI.EraBased.Options.Transaction
                         Cardano.CLI.EraBased.Run
                         Cardano.CLI.EraBased.Run.Address

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands.hs
@@ -13,12 +13,15 @@ module Cardano.CLI.EraBased.Commands
 import           Cardano.Api (CardanoEra (..), ShelleyBasedEra (..))
 
 import           Cardano.CLI.Environment
+import           Cardano.CLI.EraBased.Commands.StakeAddress
 import           Cardano.CLI.EraBased.Commands.Transaction
 import           Cardano.CLI.EraBased.Options.Common
 import           Cardano.CLI.EraBased.Options.Governance
+import           Cardano.CLI.EraBased.Options.StakeAddress
 import           Cardano.CLI.EraBased.Options.Transaction
 
 import           Data.Foldable
+import           Data.Maybe
 import           Data.Text (Text)
 import           Options.Applicative (Parser)
 import qualified Options.Applicative as Opt
@@ -33,11 +36,16 @@ renderAnyEraCommand = \case
 data EraBasedCommand era
   = EraBasedGovernanceCmds (EraBasedGovernanceCmds era)
   | TransactionCmds (TransactionCmds era)
+  | StakeAddressCmds (StakeAddressCmds era)
 
 renderEraBasedCommand :: EraBasedCommand era -> Text
 renderEraBasedCommand = \case
-  EraBasedGovernanceCmds cmd -> renderEraBasedGovernanceCmds cmd
-  TransactionCmds cmd -> renderTransactionCmds cmd
+  EraBasedGovernanceCmds cmd ->
+    renderEraBasedGovernanceCmds cmd
+  StakeAddressCmds cmd ->
+    renderStakeAddressCmds cmd
+  TransactionCmds cmd ->
+    renderTransactionCmds cmd
 
 pAnyEraCommand :: EnvCli -> Parser AnyEraCommand
 pAnyEraCommand envCli =
@@ -70,11 +78,14 @@ pAnyEraCommand envCli =
 
 pEraBasedCommand :: EnvCli -> CardanoEra era -> Parser (EraBasedCommand era)
 pEraBasedCommand envCli era =
-  asum
-    [ subParser "governance"
+  asum $ catMaybes
+    [ Just
+        $ subParser "governance"
         $ Opt.info (EraBasedGovernanceCmds <$> pEraBasedGovernanceCmds envCli era)
         $ Opt.progDesc "Era-based governance commands"
-    , subParser "transaction"
+    , fmap StakeAddressCmds <$> pStakeAddressCmds era envCli
+    , Just
+        $ subParser "transaction"
         $ Opt.info (TransactionCmds <$> pTransactionCmds envCli era)
         $ Opt.progDesc "Era-based governance commands"
     ]

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/StakeAddress.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/StakeAddress.hs
@@ -1,0 +1,57 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE LambdaCase #-}
+
+module Cardano.CLI.EraBased.Commands.StakeAddress
+  ( StakeAddressCmds (..)
+  , renderStakeAddressCmds
+  ) where
+
+import           Cardano.Api.Shelley
+
+import           Cardano.CLI.Types.Common
+import           Cardano.CLI.Types.Key
+
+import           Prelude
+
+import           Data.Text (Text)
+
+data StakeAddressCmds era
+  = StakeAddressKeyGen
+      (ShelleyBasedEra era)
+      KeyOutputFormat
+      (VerificationKeyFile Out)
+      (SigningKeyFile Out)
+  | StakeAddressKeyHash
+      (ShelleyBasedEra era)
+      (VerificationKeyOrFile StakeKey)
+      (Maybe (File () Out))
+  | StakeAddressBuild
+      (ShelleyBasedEra era)
+      StakeVerifier
+      NetworkId
+      (Maybe (File () Out))
+  | StakeRegistrationCert
+      (ShelleyBasedEra era)
+      StakeIdentifier
+      (Maybe Lovelace)
+      (File () Out)
+  | StakeCredentialDelegationCert
+      (ShelleyBasedEra era)
+      StakeIdentifier
+      DelegationTarget
+      (File () Out)
+  | StakeCredentialDeRegistrationCert
+      (ShelleyBasedEra era)
+      StakeIdentifier
+      (Maybe Lovelace)
+      (File () Out)
+  deriving Show
+
+renderStakeAddressCmds :: StakeAddressCmds era -> Text
+renderStakeAddressCmds = \case
+  StakeAddressKeyGen {} -> "stake-address key-gen"
+  StakeAddressKeyHash {} -> "stake-address key-hash"
+  StakeAddressBuild {} -> "stake-address build"
+  StakeRegistrationCert {} -> "stake-address registration-certificate"
+  StakeCredentialDelegationCert {} -> "stake-address delegation-certificate"
+  StakeCredentialDeRegistrationCert {} -> "stake-address deregistration-certificate"

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/StakeAddress.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/StakeAddress.hs
@@ -1,0 +1,125 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+
+module Cardano.CLI.EraBased.Options.StakeAddress
+  ( pStakeAddressCmds
+  ) where
+
+import           Cardano.Api
+
+import           Cardano.CLI.Environment
+import           Cardano.CLI.EraBased.Commands.StakeAddress
+import           Cardano.CLI.EraBased.Options.Common
+import           Cardano.CLI.Orphans ()
+
+import           Options.Applicative
+import qualified Options.Applicative as Opt
+
+pStakeAddressCmds :: ()
+  => CardanoEra era
+  -> EnvCli
+  -> Maybe (Parser (StakeAddressCmds era))
+pStakeAddressCmds era envCli =
+  subInfoParser "stake-address"
+    ( Opt.progDesc
+        $ mconcat
+          [ "Stake address commands."
+          ]
+    )
+    [ pStakeAddressKeyGenCmd era
+    , pStakeAddressKeyHashCmd era
+    , pStakeAddressBuildCmd era envCli
+    , pStakeAddressRegistrationCertificateCmd era
+    , pStakeAddressDeregistrationCertificateCmd era
+    , pStakeAddressDelegationCertificateCmd era
+    ]
+
+pStakeAddressKeyGenCmd :: ()
+  => CardanoEra era
+  -> Maybe (Parser (StakeAddressCmds era))
+pStakeAddressKeyGenCmd era = do
+  w <- maybeFeatureInEra era
+  pure
+    $ subParser "key-gen"
+    $ Opt.info
+        ( StakeAddressKeyGen w
+            <$> pKeyOutputFormat
+            <*> pVerificationKeyFileOut
+            <*> pSigningKeyFileOut
+        )
+    $ Opt.progDesc "Create a stake address key pair"
+
+pStakeAddressKeyHashCmd :: ()
+  => CardanoEra era
+  -> Maybe (Parser (StakeAddressCmds era))
+pStakeAddressKeyHashCmd era = do
+  w <- maybeFeatureInEra era
+  pure
+    $ subParser "key-hash"
+    $ Opt.info
+        ( StakeAddressKeyHash w
+            <$> pStakeVerificationKeyOrFile
+            <*> pMaybeOutputFile
+        )
+    $ Opt.progDesc "Print the hash of a stake address key"
+
+pStakeAddressBuildCmd :: ()
+  => CardanoEra era
+  -> EnvCli
+  -> Maybe (Parser (StakeAddressCmds era))
+pStakeAddressBuildCmd era envCli = do
+  w <- maybeFeatureInEra era
+  pure
+    $ subParser "build"
+    $ Opt.info
+        ( StakeAddressBuild w
+            <$> pStakeVerifier
+            <*> pNetworkId envCli
+            <*> pMaybeOutputFile
+        )
+    $ Opt.progDesc "Build a stake address"
+
+pStakeAddressRegistrationCertificateCmd :: ()
+  => CardanoEra era
+  -> Maybe (Parser (StakeAddressCmds era))
+pStakeAddressRegistrationCertificateCmd era = do
+  w <- maybeFeatureInEra era
+  pure
+    $ subParser "registration-certificate"
+    $ Opt.info
+        ( StakeRegistrationCert w
+            <$> pStakeIdentifier
+            <*> optional pKeyRegistDeposit
+            <*> pOutputFile
+        )
+    $ Opt.progDesc "Create a stake address registration certificate"
+
+pStakeAddressDeregistrationCertificateCmd :: ()
+  => CardanoEra era
+  -> Maybe (Parser (StakeAddressCmds era))
+pStakeAddressDeregistrationCertificateCmd era = do
+  w <- maybeFeatureInEra era
+  pure
+    $ subParser "deregistration-certificate"
+    $ Opt.info
+        ( StakeCredentialDeRegistrationCert w
+            <$> pStakeIdentifier
+            <*> optional pKeyRegistDeposit
+            <*> pOutputFile
+        )
+    $ Opt.progDesc "Create a stake address deregistration certificate"
+
+pStakeAddressDelegationCertificateCmd :: ()
+  => CardanoEra era
+  -> Maybe (Parser (StakeAddressCmds era))
+pStakeAddressDelegationCertificateCmd era = do
+  w <- maybeFeatureInEra era
+  pure
+    $ subParser "delegation-certificate"
+    $ Opt.info
+        ( StakeCredentialDelegationCert w
+            <$> pStakeIdentifier
+            <*> pDelegationTarget
+            <*> pOutputFile
+        )
+    $ Opt.progDesc "Create a stake address pool delegation certificate"

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run.hs
@@ -17,6 +17,7 @@ import           Cardano.CLI.EraBased.Run.Governance.Committee
 import           Cardano.CLI.EraBased.Run.Governance.DRep
 import           Cardano.CLI.EraBased.Run.Governance.Query
 import           Cardano.CLI.EraBased.Run.Governance.Vote
+import           Cardano.CLI.EraBased.Run.StakeAddress
 import           Cardano.CLI.EraBased.Run.Transaction
 import           Cardano.CLI.Types.Errors.CmdError
 
@@ -36,6 +37,9 @@ runEraBasedCommand :: ()
 runEraBasedCommand = \case
   EraBasedGovernanceCmds cmd ->
     runEraBasedGovernanceCmds cmd
+  StakeAddressCmds cmd ->
+    runStakeAddressCmds cmd
+      & firstExceptT CmdStakeAddressError
   TransactionCmds cmd ->
     runTransactionCmds cmd & firstExceptT CmdTransactionError
 

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/StakeAddress.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/StakeAddress.hs
@@ -7,7 +7,9 @@
 {- HLINT ignore "Monad law, left identity" -}
 
 module Cardano.CLI.EraBased.Run.StakeAddress
-  ( runStakeAddressBuildCmd
+  ( runStakeAddressCmds
+
+  , runStakeAddressBuildCmd
   , runStakeAddressKeyGenToFileCmd
   , runStakeAddressKeyHashCmd
   , runStakeCredentialDelegationCertCmd
@@ -19,6 +21,7 @@ import           Cardano.Api
 import qualified Cardano.Api.Ledger as Ledger
 import           Cardano.Api.Shelley
 
+import           Cardano.CLI.EraBased.Commands.StakeAddress
 import           Cardano.CLI.Read
 import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Errors.ShelleyStakeAddressCmdError
@@ -37,9 +40,22 @@ import qualified Data.ByteString.Char8 as BS
 import           Data.Function ((&))
 import qualified Data.Text.IO as Text
 
---
--- Stake address command implementations
---
+runStakeAddressCmds :: ()
+  => StakeAddressCmds era
+  -> ExceptT ShelleyStakeAddressCmdError IO ()
+runStakeAddressCmds = \case
+  StakeAddressKeyGen _ fmt vk sk ->
+    runStakeAddressKeyGenToFileCmd fmt vk sk
+  StakeAddressKeyHash _ vk mOutputFp ->
+    runStakeAddressKeyHashCmd vk mOutputFp
+  StakeAddressBuild _ stakeVerifier nw mOutputFp ->
+    runStakeAddressBuildCmd stakeVerifier nw mOutputFp
+  StakeRegistrationCert sbe stakeIdentifier mDeposit outputFp ->
+    runStakeCredentialRegistrationCertCmd sbe stakeIdentifier mDeposit outputFp
+  StakeCredentialDelegationCert sbe stakeIdentifier stkPoolVerKeyHashOrFp outputFp ->
+    runStakeCredentialDelegationCertCmd sbe stakeIdentifier stkPoolVerKeyHashOrFp outputFp
+  StakeCredentialDeRegistrationCert sbe stakeIdentifier mDeposit outputFp ->
+    runStakeCredentialDeRegistrationCertCmd sbe stakeIdentifier mDeposit outputFp
 
 runStakeAddressKeyGenToFileCmd :: ()
   => KeyOutputFormat

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/StakeAddress.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/StakeAddress.hs
@@ -38,20 +38,23 @@ runLegacyStakeAddressKeyGenToFileCmd :: ()
   -> VerificationKeyFile Out
   -> SigningKeyFile Out
   -> ExceptT ShelleyStakeAddressCmdError IO ()
-runLegacyStakeAddressKeyGenToFileCmd = runStakeAddressKeyGenToFileCmd
+runLegacyStakeAddressKeyGenToFileCmd =
+  runStakeAddressKeyGenToFileCmd
 
 runLegacyStakeAddressKeyHashCmd :: ()
   => VerificationKeyOrFile StakeKey
   -> Maybe (File () Out)
   -> ExceptT ShelleyStakeAddressCmdError IO ()
-runLegacyStakeAddressKeyHashCmd = runStakeAddressKeyHashCmd
+runLegacyStakeAddressKeyHashCmd =
+  runStakeAddressKeyHashCmd
 
 runLegacyStakeAddressBuildCmd :: ()
   => StakeVerifier
   -> NetworkId
   -> Maybe (File () Out)
   -> ExceptT ShelleyStakeAddressCmdError IO ()
-runLegacyStakeAddressBuildCmd = runStakeAddressBuildCmd
+runLegacyStakeAddressBuildCmd =
+  runStakeAddressBuildCmd
 
 runLegacyStakeCredentialRegistrationCertCmd :: ()
   => AnyShelleyBasedEra
@@ -59,7 +62,8 @@ runLegacyStakeCredentialRegistrationCertCmd :: ()
   -> Maybe Lovelace -- ^ Deposit required in conway era
   -> File () Out
   -> ExceptT ShelleyStakeAddressCmdError IO ()
-runLegacyStakeCredentialRegistrationCertCmd = runStakeCredentialRegistrationCertCmd
+runLegacyStakeCredentialRegistrationCertCmd (AnyShelleyBasedEra sbe) =
+  runStakeCredentialRegistrationCertCmd sbe
 
 runLegacyStakeCredentialDelegationCertCmd :: ()
   => AnyShelleyBasedEra
@@ -70,7 +74,8 @@ runLegacyStakeCredentialDelegationCertCmd :: ()
   -- verification key hash.
   -> File () Out
   -> ExceptT ShelleyStakeAddressCmdError IO ()
-runLegacyStakeCredentialDelegationCertCmd = runStakeCredentialDelegationCertCmd
+runLegacyStakeCredentialDelegationCertCmd (AnyShelleyBasedEra sbe) =
+  runStakeCredentialDelegationCertCmd sbe
 
 runLegacyStakeCredentialDeRegistrationCertCmd :: ()
   => AnyShelleyBasedEra
@@ -78,4 +83,5 @@ runLegacyStakeCredentialDeRegistrationCertCmd :: ()
   -> Maybe Lovelace -- ^ Deposit required in conway era
   -> File () Out
   -> ExceptT ShelleyStakeAddressCmdError IO ()
-runLegacyStakeCredentialDeRegistrationCertCmd = runStakeCredentialDeRegistrationCertCmd
+runLegacyStakeCredentialDeRegistrationCertCmd (AnyShelleyBasedEra sbe) =
+  runStakeCredentialDeRegistrationCertCmd sbe

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -13,7 +13,7 @@ Usage: cardano-cli
                      | version
                      )
 
-Usage: cardano-cli shelley (governance | transaction)
+Usage: cardano-cli shelley (governance | stake-address | transaction)
 
   Shelley era commands
 
@@ -144,6 +144,79 @@ Usage: cardano-cli shelley governance drep registration-certificate
                                                                       --out-file FILE
 
   Create a registration certificate.
+
+Usage: cardano-cli shelley stake-address 
+                                           ( key-gen
+                                           | key-hash
+                                           | build
+                                           | registration-certificate
+                                           | deregistration-certificate
+                                           | delegation-certificate
+                                           )
+
+  Stake address commands.
+
+Usage: cardano-cli shelley stake-address key-gen [--key-output-format STRING]
+                                                   --verification-key-file FILE
+                                                   --signing-key-file FILE
+
+  Create a stake address key pair
+
+Usage: cardano-cli shelley stake-address key-hash 
+                                                    ( --stake-verification-key STRING
+                                                    | --stake-verification-key-file FILE
+                                                    )
+                                                    [--out-file FILE]
+
+  Print the hash of a stake address key
+
+Usage: cardano-cli shelley stake-address build 
+                                                 ( --stake-verification-key STRING
+                                                 | --stake-verification-key-file FILE
+                                                 | --stake-script-file FILE
+                                                 )
+                                                 ( --mainnet
+                                                 | --testnet-magic NATURAL
+                                                 )
+                                                 [--out-file FILE]
+
+  Build a stake address
+
+Usage: cardano-cli shelley stake-address registration-certificate 
+                                                                    ( --stake-verification-key STRING
+                                                                    | --stake-verification-key-file FILE
+                                                                    | --stake-script-file FILE
+                                                                    | --stake-address ADDRESS
+                                                                    )
+                                                                    [--key-reg-deposit-amt NATURAL]
+                                                                    --out-file FILE
+
+  Create a stake address registration certificate
+
+Usage: cardano-cli shelley stake-address deregistration-certificate 
+                                                                      ( --stake-verification-key STRING
+                                                                      | --stake-verification-key-file FILE
+                                                                      | --stake-script-file FILE
+                                                                      | --stake-address ADDRESS
+                                                                      )
+                                                                      [--key-reg-deposit-amt NATURAL]
+                                                                      --out-file FILE
+
+  Create a stake address deregistration certificate
+
+Usage: cardano-cli shelley stake-address delegation-certificate 
+                                                                  ( --stake-verification-key STRING
+                                                                  | --stake-verification-key-file FILE
+                                                                  | --stake-script-file FILE
+                                                                  | --stake-address ADDRESS
+                                                                  )
+                                                                  ( --stake-pool-verification-key STRING
+                                                                  | --cold-verification-key-file FILE
+                                                                  | --stake-pool-id STAKE_POOL_ID
+                                                                  )
+                                                                  --out-file FILE
+
+  Create a stake address pool delegation certificate
 
 Usage: cardano-cli shelley transaction 
                                          ( build-raw
@@ -528,7 +601,7 @@ Usage: cardano-cli shelley transaction view
 
   Print a transaction.
 
-Usage: cardano-cli allegra (governance | transaction)
+Usage: cardano-cli allegra (governance | stake-address | transaction)
 
   Allegra era commands
 
@@ -659,6 +732,79 @@ Usage: cardano-cli allegra governance drep registration-certificate
                                                                       --out-file FILE
 
   Create a registration certificate.
+
+Usage: cardano-cli allegra stake-address 
+                                           ( key-gen
+                                           | key-hash
+                                           | build
+                                           | registration-certificate
+                                           | deregistration-certificate
+                                           | delegation-certificate
+                                           )
+
+  Stake address commands.
+
+Usage: cardano-cli allegra stake-address key-gen [--key-output-format STRING]
+                                                   --verification-key-file FILE
+                                                   --signing-key-file FILE
+
+  Create a stake address key pair
+
+Usage: cardano-cli allegra stake-address key-hash 
+                                                    ( --stake-verification-key STRING
+                                                    | --stake-verification-key-file FILE
+                                                    )
+                                                    [--out-file FILE]
+
+  Print the hash of a stake address key
+
+Usage: cardano-cli allegra stake-address build 
+                                                 ( --stake-verification-key STRING
+                                                 | --stake-verification-key-file FILE
+                                                 | --stake-script-file FILE
+                                                 )
+                                                 ( --mainnet
+                                                 | --testnet-magic NATURAL
+                                                 )
+                                                 [--out-file FILE]
+
+  Build a stake address
+
+Usage: cardano-cli allegra stake-address registration-certificate 
+                                                                    ( --stake-verification-key STRING
+                                                                    | --stake-verification-key-file FILE
+                                                                    | --stake-script-file FILE
+                                                                    | --stake-address ADDRESS
+                                                                    )
+                                                                    [--key-reg-deposit-amt NATURAL]
+                                                                    --out-file FILE
+
+  Create a stake address registration certificate
+
+Usage: cardano-cli allegra stake-address deregistration-certificate 
+                                                                      ( --stake-verification-key STRING
+                                                                      | --stake-verification-key-file FILE
+                                                                      | --stake-script-file FILE
+                                                                      | --stake-address ADDRESS
+                                                                      )
+                                                                      [--key-reg-deposit-amt NATURAL]
+                                                                      --out-file FILE
+
+  Create a stake address deregistration certificate
+
+Usage: cardano-cli allegra stake-address delegation-certificate 
+                                                                  ( --stake-verification-key STRING
+                                                                  | --stake-verification-key-file FILE
+                                                                  | --stake-script-file FILE
+                                                                  | --stake-address ADDRESS
+                                                                  )
+                                                                  ( --stake-pool-verification-key STRING
+                                                                  | --cold-verification-key-file FILE
+                                                                  | --stake-pool-id STAKE_POOL_ID
+                                                                  )
+                                                                  --out-file FILE
+
+  Create a stake address pool delegation certificate
 
 Usage: cardano-cli allegra transaction 
                                          ( build-raw
@@ -1043,7 +1189,7 @@ Usage: cardano-cli allegra transaction view
 
   Print a transaction.
 
-Usage: cardano-cli mary (governance | transaction)
+Usage: cardano-cli mary (governance | stake-address | transaction)
 
   Mary era commands
 
@@ -1174,6 +1320,79 @@ Usage: cardano-cli mary governance drep registration-certificate
                                                                    --out-file FILE
 
   Create a registration certificate.
+
+Usage: cardano-cli mary stake-address 
+                                        ( key-gen
+                                        | key-hash
+                                        | build
+                                        | registration-certificate
+                                        | deregistration-certificate
+                                        | delegation-certificate
+                                        )
+
+  Stake address commands.
+
+Usage: cardano-cli mary stake-address key-gen [--key-output-format STRING]
+                                                --verification-key-file FILE
+                                                --signing-key-file FILE
+
+  Create a stake address key pair
+
+Usage: cardano-cli mary stake-address key-hash 
+                                                 ( --stake-verification-key STRING
+                                                 | --stake-verification-key-file FILE
+                                                 )
+                                                 [--out-file FILE]
+
+  Print the hash of a stake address key
+
+Usage: cardano-cli mary stake-address build 
+                                              ( --stake-verification-key STRING
+                                              | --stake-verification-key-file FILE
+                                              | --stake-script-file FILE
+                                              )
+                                              ( --mainnet
+                                              | --testnet-magic NATURAL
+                                              )
+                                              [--out-file FILE]
+
+  Build a stake address
+
+Usage: cardano-cli mary stake-address registration-certificate 
+                                                                 ( --stake-verification-key STRING
+                                                                 | --stake-verification-key-file FILE
+                                                                 | --stake-script-file FILE
+                                                                 | --stake-address ADDRESS
+                                                                 )
+                                                                 [--key-reg-deposit-amt NATURAL]
+                                                                 --out-file FILE
+
+  Create a stake address registration certificate
+
+Usage: cardano-cli mary stake-address deregistration-certificate 
+                                                                   ( --stake-verification-key STRING
+                                                                   | --stake-verification-key-file FILE
+                                                                   | --stake-script-file FILE
+                                                                   | --stake-address ADDRESS
+                                                                   )
+                                                                   [--key-reg-deposit-amt NATURAL]
+                                                                   --out-file FILE
+
+  Create a stake address deregistration certificate
+
+Usage: cardano-cli mary stake-address delegation-certificate 
+                                                               ( --stake-verification-key STRING
+                                                               | --stake-verification-key-file FILE
+                                                               | --stake-script-file FILE
+                                                               | --stake-address ADDRESS
+                                                               )
+                                                               ( --stake-pool-verification-key STRING
+                                                               | --cold-verification-key-file FILE
+                                                               | --stake-pool-id STAKE_POOL_ID
+                                                               )
+                                                               --out-file FILE
+
+  Create a stake address pool delegation certificate
 
 Usage: cardano-cli mary transaction 
                                       ( build-raw
@@ -1543,7 +1762,7 @@ Usage: cardano-cli mary transaction view (--tx-body-file FILE | --tx-file FILE)
 
   Print a transaction.
 
-Usage: cardano-cli alonzo (governance | transaction)
+Usage: cardano-cli alonzo (governance | stake-address | transaction)
 
   Alonzo era commands
 
@@ -1681,6 +1900,79 @@ Usage: cardano-cli alonzo governance drep registration-certificate
                                                                      --out-file FILE
 
   Create a registration certificate.
+
+Usage: cardano-cli alonzo stake-address 
+                                          ( key-gen
+                                          | key-hash
+                                          | build
+                                          | registration-certificate
+                                          | deregistration-certificate
+                                          | delegation-certificate
+                                          )
+
+  Stake address commands.
+
+Usage: cardano-cli alonzo stake-address key-gen [--key-output-format STRING]
+                                                  --verification-key-file FILE
+                                                  --signing-key-file FILE
+
+  Create a stake address key pair
+
+Usage: cardano-cli alonzo stake-address key-hash 
+                                                   ( --stake-verification-key STRING
+                                                   | --stake-verification-key-file FILE
+                                                   )
+                                                   [--out-file FILE]
+
+  Print the hash of a stake address key
+
+Usage: cardano-cli alonzo stake-address build 
+                                                ( --stake-verification-key STRING
+                                                | --stake-verification-key-file FILE
+                                                | --stake-script-file FILE
+                                                )
+                                                ( --mainnet
+                                                | --testnet-magic NATURAL
+                                                )
+                                                [--out-file FILE]
+
+  Build a stake address
+
+Usage: cardano-cli alonzo stake-address registration-certificate 
+                                                                   ( --stake-verification-key STRING
+                                                                   | --stake-verification-key-file FILE
+                                                                   | --stake-script-file FILE
+                                                                   | --stake-address ADDRESS
+                                                                   )
+                                                                   [--key-reg-deposit-amt NATURAL]
+                                                                   --out-file FILE
+
+  Create a stake address registration certificate
+
+Usage: cardano-cli alonzo stake-address deregistration-certificate 
+                                                                     ( --stake-verification-key STRING
+                                                                     | --stake-verification-key-file FILE
+                                                                     | --stake-script-file FILE
+                                                                     | --stake-address ADDRESS
+                                                                     )
+                                                                     [--key-reg-deposit-amt NATURAL]
+                                                                     --out-file FILE
+
+  Create a stake address deregistration certificate
+
+Usage: cardano-cli alonzo stake-address delegation-certificate 
+                                                                 ( --stake-verification-key STRING
+                                                                 | --stake-verification-key-file FILE
+                                                                 | --stake-script-file FILE
+                                                                 | --stake-address ADDRESS
+                                                                 )
+                                                                 ( --stake-pool-verification-key STRING
+                                                                 | --cold-verification-key-file FILE
+                                                                 | --stake-pool-id STAKE_POOL_ID
+                                                                 )
+                                                                 --out-file FILE
+
+  Create a stake address pool delegation certificate
 
 Usage: cardano-cli alonzo transaction 
                                         ( build-raw
@@ -2065,7 +2357,7 @@ Usage: cardano-cli alonzo transaction view
 
   Print a transaction.
 
-Usage: cardano-cli babbage (governance | transaction)
+Usage: cardano-cli babbage (governance | stake-address | transaction)
 
   Babbage era commands
 
@@ -2199,6 +2491,79 @@ Usage: cardano-cli babbage governance drep registration-certificate
                                                                       --out-file FILE
 
   Create a registration certificate.
+
+Usage: cardano-cli babbage stake-address 
+                                           ( key-gen
+                                           | key-hash
+                                           | build
+                                           | registration-certificate
+                                           | deregistration-certificate
+                                           | delegation-certificate
+                                           )
+
+  Stake address commands.
+
+Usage: cardano-cli babbage stake-address key-gen [--key-output-format STRING]
+                                                   --verification-key-file FILE
+                                                   --signing-key-file FILE
+
+  Create a stake address key pair
+
+Usage: cardano-cli babbage stake-address key-hash 
+                                                    ( --stake-verification-key STRING
+                                                    | --stake-verification-key-file FILE
+                                                    )
+                                                    [--out-file FILE]
+
+  Print the hash of a stake address key
+
+Usage: cardano-cli babbage stake-address build 
+                                                 ( --stake-verification-key STRING
+                                                 | --stake-verification-key-file FILE
+                                                 | --stake-script-file FILE
+                                                 )
+                                                 ( --mainnet
+                                                 | --testnet-magic NATURAL
+                                                 )
+                                                 [--out-file FILE]
+
+  Build a stake address
+
+Usage: cardano-cli babbage stake-address registration-certificate 
+                                                                    ( --stake-verification-key STRING
+                                                                    | --stake-verification-key-file FILE
+                                                                    | --stake-script-file FILE
+                                                                    | --stake-address ADDRESS
+                                                                    )
+                                                                    [--key-reg-deposit-amt NATURAL]
+                                                                    --out-file FILE
+
+  Create a stake address registration certificate
+
+Usage: cardano-cli babbage stake-address deregistration-certificate 
+                                                                      ( --stake-verification-key STRING
+                                                                      | --stake-verification-key-file FILE
+                                                                      | --stake-script-file FILE
+                                                                      | --stake-address ADDRESS
+                                                                      )
+                                                                      [--key-reg-deposit-amt NATURAL]
+                                                                      --out-file FILE
+
+  Create a stake address deregistration certificate
+
+Usage: cardano-cli babbage stake-address delegation-certificate 
+                                                                  ( --stake-verification-key STRING
+                                                                  | --stake-verification-key-file FILE
+                                                                  | --stake-script-file FILE
+                                                                  | --stake-address ADDRESS
+                                                                  )
+                                                                  ( --stake-pool-verification-key STRING
+                                                                  | --cold-verification-key-file FILE
+                                                                  | --stake-pool-id STAKE_POOL_ID
+                                                                  )
+                                                                  --out-file FILE
+
+  Create a stake address pool delegation certificate
 
 Usage: cardano-cli babbage transaction 
                                          ( build-raw
@@ -2583,7 +2948,7 @@ Usage: cardano-cli babbage transaction view
 
   Print a transaction.
 
-Usage: cardano-cli conway (governance | transaction)
+Usage: cardano-cli conway (governance | stake-address | transaction)
 
   Conway era commands
 
@@ -3004,6 +3369,79 @@ Usage: cardano-cli conway governance vote create (--yes | --no | --abstain)
 
   Vote creation.
 
+Usage: cardano-cli conway stake-address 
+                                          ( key-gen
+                                          | key-hash
+                                          | build
+                                          | registration-certificate
+                                          | deregistration-certificate
+                                          | delegation-certificate
+                                          )
+
+  Stake address commands.
+
+Usage: cardano-cli conway stake-address key-gen [--key-output-format STRING]
+                                                  --verification-key-file FILE
+                                                  --signing-key-file FILE
+
+  Create a stake address key pair
+
+Usage: cardano-cli conway stake-address key-hash 
+                                                   ( --stake-verification-key STRING
+                                                   | --stake-verification-key-file FILE
+                                                   )
+                                                   [--out-file FILE]
+
+  Print the hash of a stake address key
+
+Usage: cardano-cli conway stake-address build 
+                                                ( --stake-verification-key STRING
+                                                | --stake-verification-key-file FILE
+                                                | --stake-script-file FILE
+                                                )
+                                                ( --mainnet
+                                                | --testnet-magic NATURAL
+                                                )
+                                                [--out-file FILE]
+
+  Build a stake address
+
+Usage: cardano-cli conway stake-address registration-certificate 
+                                                                   ( --stake-verification-key STRING
+                                                                   | --stake-verification-key-file FILE
+                                                                   | --stake-script-file FILE
+                                                                   | --stake-address ADDRESS
+                                                                   )
+                                                                   [--key-reg-deposit-amt NATURAL]
+                                                                   --out-file FILE
+
+  Create a stake address registration certificate
+
+Usage: cardano-cli conway stake-address deregistration-certificate 
+                                                                     ( --stake-verification-key STRING
+                                                                     | --stake-verification-key-file FILE
+                                                                     | --stake-script-file FILE
+                                                                     | --stake-address ADDRESS
+                                                                     )
+                                                                     [--key-reg-deposit-amt NATURAL]
+                                                                     --out-file FILE
+
+  Create a stake address deregistration certificate
+
+Usage: cardano-cli conway stake-address delegation-certificate 
+                                                                 ( --stake-verification-key STRING
+                                                                 | --stake-verification-key-file FILE
+                                                                 | --stake-script-file FILE
+                                                                 | --stake-address ADDRESS
+                                                                 )
+                                                                 ( --stake-pool-verification-key STRING
+                                                                 | --cold-verification-key-file FILE
+                                                                 | --stake-pool-id STAKE_POOL_ID
+                                                                 )
+                                                                 --out-file FILE
+
+  Create a stake address pool delegation certificate
+
 Usage: cardano-cli conway transaction 
                                         ( build-raw
                                         | build
@@ -3387,7 +3825,7 @@ Usage: cardano-cli conway transaction view
 
   Print a transaction.
 
-Usage: cardano-cli latest (governance | transaction)
+Usage: cardano-cli latest (governance | stake-address | transaction)
 
   Latest era commands (Babbage)
 
@@ -3521,6 +3959,79 @@ Usage: cardano-cli latest governance drep registration-certificate
                                                                      --out-file FILE
 
   Create a registration certificate.
+
+Usage: cardano-cli latest stake-address 
+                                          ( key-gen
+                                          | key-hash
+                                          | build
+                                          | registration-certificate
+                                          | deregistration-certificate
+                                          | delegation-certificate
+                                          )
+
+  Stake address commands.
+
+Usage: cardano-cli latest stake-address key-gen [--key-output-format STRING]
+                                                  --verification-key-file FILE
+                                                  --signing-key-file FILE
+
+  Create a stake address key pair
+
+Usage: cardano-cli latest stake-address key-hash 
+                                                   ( --stake-verification-key STRING
+                                                   | --stake-verification-key-file FILE
+                                                   )
+                                                   [--out-file FILE]
+
+  Print the hash of a stake address key
+
+Usage: cardano-cli latest stake-address build 
+                                                ( --stake-verification-key STRING
+                                                | --stake-verification-key-file FILE
+                                                | --stake-script-file FILE
+                                                )
+                                                ( --mainnet
+                                                | --testnet-magic NATURAL
+                                                )
+                                                [--out-file FILE]
+
+  Build a stake address
+
+Usage: cardano-cli latest stake-address registration-certificate 
+                                                                   ( --stake-verification-key STRING
+                                                                   | --stake-verification-key-file FILE
+                                                                   | --stake-script-file FILE
+                                                                   | --stake-address ADDRESS
+                                                                   )
+                                                                   [--key-reg-deposit-amt NATURAL]
+                                                                   --out-file FILE
+
+  Create a stake address registration certificate
+
+Usage: cardano-cli latest stake-address deregistration-certificate 
+                                                                     ( --stake-verification-key STRING
+                                                                     | --stake-verification-key-file FILE
+                                                                     | --stake-script-file FILE
+                                                                     | --stake-address ADDRESS
+                                                                     )
+                                                                     [--key-reg-deposit-amt NATURAL]
+                                                                     --out-file FILE
+
+  Create a stake address deregistration certificate
+
+Usage: cardano-cli latest stake-address delegation-certificate 
+                                                                 ( --stake-verification-key STRING
+                                                                 | --stake-verification-key-file FILE
+                                                                 | --stake-script-file FILE
+                                                                 | --stake-address ADDRESS
+                                                                 )
+                                                                 ( --stake-pool-verification-key STRING
+                                                                 | --cold-verification-key-file FILE
+                                                                 | --stake-pool-id STAKE_POOL_ID
+                                                                 )
+                                                                 --out-file FILE
+
+  Create a stake address pool delegation certificate
 
 Usage: cardano-cli latest transaction 
                                         ( build-raw

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra.cli
@@ -1,4 +1,4 @@
-Usage: cardano-cli allegra (governance | transaction)
+Usage: cardano-cli allegra (governance | stake-address | transaction)
 
   Allegra era commands
 
@@ -7,4 +7,5 @@ Available options:
 
 Available commands:
   governance               Era-based governance commands
+  stake-address            Stake address commands.
   transaction              Era-based governance commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_stake-address.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_stake-address.cli
@@ -1,0 +1,22 @@
+Usage: cardano-cli allegra stake-address 
+                                           ( key-gen
+                                           | key-hash
+                                           | build
+                                           | registration-certificate
+                                           | deregistration-certificate
+                                           | delegation-certificate
+                                           )
+
+  Stake address commands.
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  key-gen                  Create a stake address key pair
+  key-hash                 Print the hash of a stake address key
+  build                    Build a stake address
+  registration-certificate Create a stake address registration certificate
+  deregistration-certificate
+                           Create a stake address deregistration certificate
+  delegation-certificate   Create a stake address pool delegation certificate

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_stake-address_build.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_stake-address_build.cli
@@ -1,0 +1,24 @@
+Usage: cardano-cli allegra stake-address build 
+                                                 ( --stake-verification-key STRING
+                                                 | --stake-verification-key-file FILE
+                                                 | --stake-script-file FILE
+                                                 )
+                                                 ( --mainnet
+                                                 | --testnet-magic NATURAL
+                                                 )
+                                                 [--out-file FILE]
+
+  Build a stake address
+
+Available options:
+  --stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --stake-verification-key-file FILE
+                           Filepath of the staking verification key.
+  --stake-script-file FILE Filepath of the staking script.
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_stake-address_delegation-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_stake-address_delegation-certificate.cli
@@ -1,0 +1,31 @@
+Usage: cardano-cli allegra stake-address delegation-certificate 
+                                                                  ( --stake-verification-key STRING
+                                                                  | --stake-verification-key-file FILE
+                                                                  | --stake-script-file FILE
+                                                                  | --stake-address ADDRESS
+                                                                  )
+                                                                  ( --stake-pool-verification-key STRING
+                                                                  | --cold-verification-key-file FILE
+                                                                  | --stake-pool-id STAKE_POOL_ID
+                                                                  )
+                                                                  --out-file FILE
+
+  Create a stake address pool delegation certificate
+
+Available options:
+  --stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --stake-verification-key-file FILE
+                           Filepath of the staking verification key.
+  --stake-script-file FILE Filepath of the staking script.
+  --stake-address ADDRESS  Target stake address (bech32 format).
+  --stake-pool-verification-key STRING
+                           Stake pool verification key (Bech32 or hex-encoded).
+  --cold-verification-key-file FILE
+                           Filepath of the stake pool verification key.
+  --stake-pool-id STAKE_POOL_ID
+                           Stake pool ID/verification key hash (either
+                           Bech32-encoded or hex-encoded). Zero or more
+                           occurences of this option is allowed.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_stake-address_deregistration-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_stake-address_deregistration-certificate.cli
@@ -1,0 +1,22 @@
+Usage: cardano-cli allegra stake-address deregistration-certificate 
+                                                                      ( --stake-verification-key STRING
+                                                                      | --stake-verification-key-file FILE
+                                                                      | --stake-script-file FILE
+                                                                      | --stake-address ADDRESS
+                                                                      )
+                                                                      [--key-reg-deposit-amt NATURAL]
+                                                                      --out-file FILE
+
+  Create a stake address deregistration certificate
+
+Available options:
+  --stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --stake-verification-key-file FILE
+                           Filepath of the staking verification key.
+  --stake-script-file FILE Filepath of the staking script.
+  --stake-address ADDRESS  Target stake address (bech32 format).
+  --key-reg-deposit-amt NATURAL
+                           Key registration deposit amount.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_stake-address_key-gen.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_stake-address_key-gen.cli
@@ -1,0 +1,15 @@
+Usage: cardano-cli allegra stake-address key-gen [--key-output-format STRING]
+                                                   --verification-key-file FILE
+                                                   --signing-key-file FILE
+
+  Create a stake address key pair
+
+Available options:
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32" (default is
+                           "bech32").
+  --verification-key-file FILE
+                           Output filepath of the verification key.
+  --signing-key-file FILE  Output filepath of the signing key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_stake-address_key-hash.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_stake-address_key-hash.cli
@@ -1,0 +1,15 @@
+Usage: cardano-cli allegra stake-address key-hash 
+                                                    ( --stake-verification-key STRING
+                                                    | --stake-verification-key-file FILE
+                                                    )
+                                                    [--out-file FILE]
+
+  Print the hash of a stake address key
+
+Available options:
+  --stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --stake-verification-key-file FILE
+                           Filepath of the staking verification key.
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_stake-address_registration-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_stake-address_registration-certificate.cli
@@ -1,0 +1,22 @@
+Usage: cardano-cli allegra stake-address registration-certificate 
+                                                                    ( --stake-verification-key STRING
+                                                                    | --stake-verification-key-file FILE
+                                                                    | --stake-script-file FILE
+                                                                    | --stake-address ADDRESS
+                                                                    )
+                                                                    [--key-reg-deposit-amt NATURAL]
+                                                                    --out-file FILE
+
+  Create a stake address registration certificate
+
+Available options:
+  --stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --stake-verification-key-file FILE
+                           Filepath of the staking verification key.
+  --stake-script-file FILE Filepath of the staking script.
+  --stake-address ADDRESS  Target stake address (bech32 format).
+  --key-reg-deposit-amt NATURAL
+                           Key registration deposit amount.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo.cli
@@ -1,4 +1,4 @@
-Usage: cardano-cli alonzo (governance | transaction)
+Usage: cardano-cli alonzo (governance | stake-address | transaction)
 
   Alonzo era commands
 
@@ -7,4 +7,5 @@ Available options:
 
 Available commands:
   governance               Era-based governance commands
+  stake-address            Stake address commands.
   transaction              Era-based governance commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_stake-address.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_stake-address.cli
@@ -1,0 +1,22 @@
+Usage: cardano-cli alonzo stake-address 
+                                          ( key-gen
+                                          | key-hash
+                                          | build
+                                          | registration-certificate
+                                          | deregistration-certificate
+                                          | delegation-certificate
+                                          )
+
+  Stake address commands.
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  key-gen                  Create a stake address key pair
+  key-hash                 Print the hash of a stake address key
+  build                    Build a stake address
+  registration-certificate Create a stake address registration certificate
+  deregistration-certificate
+                           Create a stake address deregistration certificate
+  delegation-certificate   Create a stake address pool delegation certificate

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_stake-address_build.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_stake-address_build.cli
@@ -1,0 +1,24 @@
+Usage: cardano-cli alonzo stake-address build 
+                                                ( --stake-verification-key STRING
+                                                | --stake-verification-key-file FILE
+                                                | --stake-script-file FILE
+                                                )
+                                                ( --mainnet
+                                                | --testnet-magic NATURAL
+                                                )
+                                                [--out-file FILE]
+
+  Build a stake address
+
+Available options:
+  --stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --stake-verification-key-file FILE
+                           Filepath of the staking verification key.
+  --stake-script-file FILE Filepath of the staking script.
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_stake-address_delegation-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_stake-address_delegation-certificate.cli
@@ -1,0 +1,31 @@
+Usage: cardano-cli alonzo stake-address delegation-certificate 
+                                                                 ( --stake-verification-key STRING
+                                                                 | --stake-verification-key-file FILE
+                                                                 | --stake-script-file FILE
+                                                                 | --stake-address ADDRESS
+                                                                 )
+                                                                 ( --stake-pool-verification-key STRING
+                                                                 | --cold-verification-key-file FILE
+                                                                 | --stake-pool-id STAKE_POOL_ID
+                                                                 )
+                                                                 --out-file FILE
+
+  Create a stake address pool delegation certificate
+
+Available options:
+  --stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --stake-verification-key-file FILE
+                           Filepath of the staking verification key.
+  --stake-script-file FILE Filepath of the staking script.
+  --stake-address ADDRESS  Target stake address (bech32 format).
+  --stake-pool-verification-key STRING
+                           Stake pool verification key (Bech32 or hex-encoded).
+  --cold-verification-key-file FILE
+                           Filepath of the stake pool verification key.
+  --stake-pool-id STAKE_POOL_ID
+                           Stake pool ID/verification key hash (either
+                           Bech32-encoded or hex-encoded). Zero or more
+                           occurences of this option is allowed.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_stake-address_deregistration-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_stake-address_deregistration-certificate.cli
@@ -1,0 +1,22 @@
+Usage: cardano-cli alonzo stake-address deregistration-certificate 
+                                                                     ( --stake-verification-key STRING
+                                                                     | --stake-verification-key-file FILE
+                                                                     | --stake-script-file FILE
+                                                                     | --stake-address ADDRESS
+                                                                     )
+                                                                     [--key-reg-deposit-amt NATURAL]
+                                                                     --out-file FILE
+
+  Create a stake address deregistration certificate
+
+Available options:
+  --stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --stake-verification-key-file FILE
+                           Filepath of the staking verification key.
+  --stake-script-file FILE Filepath of the staking script.
+  --stake-address ADDRESS  Target stake address (bech32 format).
+  --key-reg-deposit-amt NATURAL
+                           Key registration deposit amount.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_stake-address_key-gen.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_stake-address_key-gen.cli
@@ -1,0 +1,15 @@
+Usage: cardano-cli alonzo stake-address key-gen [--key-output-format STRING]
+                                                  --verification-key-file FILE
+                                                  --signing-key-file FILE
+
+  Create a stake address key pair
+
+Available options:
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32" (default is
+                           "bech32").
+  --verification-key-file FILE
+                           Output filepath of the verification key.
+  --signing-key-file FILE  Output filepath of the signing key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_stake-address_key-hash.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_stake-address_key-hash.cli
@@ -1,0 +1,15 @@
+Usage: cardano-cli alonzo stake-address key-hash 
+                                                   ( --stake-verification-key STRING
+                                                   | --stake-verification-key-file FILE
+                                                   )
+                                                   [--out-file FILE]
+
+  Print the hash of a stake address key
+
+Available options:
+  --stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --stake-verification-key-file FILE
+                           Filepath of the staking verification key.
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_stake-address_registration-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_stake-address_registration-certificate.cli
@@ -1,0 +1,22 @@
+Usage: cardano-cli alonzo stake-address registration-certificate 
+                                                                   ( --stake-verification-key STRING
+                                                                   | --stake-verification-key-file FILE
+                                                                   | --stake-script-file FILE
+                                                                   | --stake-address ADDRESS
+                                                                   )
+                                                                   [--key-reg-deposit-amt NATURAL]
+                                                                   --out-file FILE
+
+  Create a stake address registration certificate
+
+Available options:
+  --stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --stake-verification-key-file FILE
+                           Filepath of the staking verification key.
+  --stake-script-file FILE Filepath of the staking script.
+  --stake-address ADDRESS  Target stake address (bech32 format).
+  --key-reg-deposit-amt NATURAL
+                           Key registration deposit amount.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage.cli
@@ -1,4 +1,4 @@
-Usage: cardano-cli babbage (governance | transaction)
+Usage: cardano-cli babbage (governance | stake-address | transaction)
 
   Babbage era commands
 
@@ -7,4 +7,5 @@ Available options:
 
 Available commands:
   governance               Era-based governance commands
+  stake-address            Stake address commands.
   transaction              Era-based governance commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_stake-address.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_stake-address.cli
@@ -1,0 +1,22 @@
+Usage: cardano-cli babbage stake-address 
+                                           ( key-gen
+                                           | key-hash
+                                           | build
+                                           | registration-certificate
+                                           | deregistration-certificate
+                                           | delegation-certificate
+                                           )
+
+  Stake address commands.
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  key-gen                  Create a stake address key pair
+  key-hash                 Print the hash of a stake address key
+  build                    Build a stake address
+  registration-certificate Create a stake address registration certificate
+  deregistration-certificate
+                           Create a stake address deregistration certificate
+  delegation-certificate   Create a stake address pool delegation certificate

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_stake-address_build.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_stake-address_build.cli
@@ -1,0 +1,24 @@
+Usage: cardano-cli babbage stake-address build 
+                                                 ( --stake-verification-key STRING
+                                                 | --stake-verification-key-file FILE
+                                                 | --stake-script-file FILE
+                                                 )
+                                                 ( --mainnet
+                                                 | --testnet-magic NATURAL
+                                                 )
+                                                 [--out-file FILE]
+
+  Build a stake address
+
+Available options:
+  --stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --stake-verification-key-file FILE
+                           Filepath of the staking verification key.
+  --stake-script-file FILE Filepath of the staking script.
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_stake-address_delegation-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_stake-address_delegation-certificate.cli
@@ -1,0 +1,31 @@
+Usage: cardano-cli babbage stake-address delegation-certificate 
+                                                                  ( --stake-verification-key STRING
+                                                                  | --stake-verification-key-file FILE
+                                                                  | --stake-script-file FILE
+                                                                  | --stake-address ADDRESS
+                                                                  )
+                                                                  ( --stake-pool-verification-key STRING
+                                                                  | --cold-verification-key-file FILE
+                                                                  | --stake-pool-id STAKE_POOL_ID
+                                                                  )
+                                                                  --out-file FILE
+
+  Create a stake address pool delegation certificate
+
+Available options:
+  --stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --stake-verification-key-file FILE
+                           Filepath of the staking verification key.
+  --stake-script-file FILE Filepath of the staking script.
+  --stake-address ADDRESS  Target stake address (bech32 format).
+  --stake-pool-verification-key STRING
+                           Stake pool verification key (Bech32 or hex-encoded).
+  --cold-verification-key-file FILE
+                           Filepath of the stake pool verification key.
+  --stake-pool-id STAKE_POOL_ID
+                           Stake pool ID/verification key hash (either
+                           Bech32-encoded or hex-encoded). Zero or more
+                           occurences of this option is allowed.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_stake-address_deregistration-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_stake-address_deregistration-certificate.cli
@@ -1,0 +1,22 @@
+Usage: cardano-cli babbage stake-address deregistration-certificate 
+                                                                      ( --stake-verification-key STRING
+                                                                      | --stake-verification-key-file FILE
+                                                                      | --stake-script-file FILE
+                                                                      | --stake-address ADDRESS
+                                                                      )
+                                                                      [--key-reg-deposit-amt NATURAL]
+                                                                      --out-file FILE
+
+  Create a stake address deregistration certificate
+
+Available options:
+  --stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --stake-verification-key-file FILE
+                           Filepath of the staking verification key.
+  --stake-script-file FILE Filepath of the staking script.
+  --stake-address ADDRESS  Target stake address (bech32 format).
+  --key-reg-deposit-amt NATURAL
+                           Key registration deposit amount.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_stake-address_key-gen.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_stake-address_key-gen.cli
@@ -1,0 +1,15 @@
+Usage: cardano-cli babbage stake-address key-gen [--key-output-format STRING]
+                                                   --verification-key-file FILE
+                                                   --signing-key-file FILE
+
+  Create a stake address key pair
+
+Available options:
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32" (default is
+                           "bech32").
+  --verification-key-file FILE
+                           Output filepath of the verification key.
+  --signing-key-file FILE  Output filepath of the signing key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_stake-address_key-hash.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_stake-address_key-hash.cli
@@ -1,0 +1,15 @@
+Usage: cardano-cli babbage stake-address key-hash 
+                                                    ( --stake-verification-key STRING
+                                                    | --stake-verification-key-file FILE
+                                                    )
+                                                    [--out-file FILE]
+
+  Print the hash of a stake address key
+
+Available options:
+  --stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --stake-verification-key-file FILE
+                           Filepath of the staking verification key.
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_stake-address_registration-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_stake-address_registration-certificate.cli
@@ -1,0 +1,22 @@
+Usage: cardano-cli babbage stake-address registration-certificate 
+                                                                    ( --stake-verification-key STRING
+                                                                    | --stake-verification-key-file FILE
+                                                                    | --stake-script-file FILE
+                                                                    | --stake-address ADDRESS
+                                                                    )
+                                                                    [--key-reg-deposit-amt NATURAL]
+                                                                    --out-file FILE
+
+  Create a stake address registration certificate
+
+Available options:
+  --stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --stake-verification-key-file FILE
+                           Filepath of the staking verification key.
+  --stake-script-file FILE Filepath of the staking script.
+  --stake-address ADDRESS  Target stake address (bech32 format).
+  --key-reg-deposit-amt NATURAL
+                           Key registration deposit amount.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway.cli
@@ -1,4 +1,4 @@
-Usage: cardano-cli conway (governance | transaction)
+Usage: cardano-cli conway (governance | stake-address | transaction)
 
   Conway era commands
 
@@ -7,4 +7,5 @@ Available options:
 
 Available commands:
   governance               Era-based governance commands
+  stake-address            Stake address commands.
   transaction              Era-based governance commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_stake-address.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_stake-address.cli
@@ -1,0 +1,22 @@
+Usage: cardano-cli conway stake-address 
+                                          ( key-gen
+                                          | key-hash
+                                          | build
+                                          | registration-certificate
+                                          | deregistration-certificate
+                                          | delegation-certificate
+                                          )
+
+  Stake address commands.
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  key-gen                  Create a stake address key pair
+  key-hash                 Print the hash of a stake address key
+  build                    Build a stake address
+  registration-certificate Create a stake address registration certificate
+  deregistration-certificate
+                           Create a stake address deregistration certificate
+  delegation-certificate   Create a stake address pool delegation certificate

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_stake-address_build.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_stake-address_build.cli
@@ -1,0 +1,24 @@
+Usage: cardano-cli conway stake-address build 
+                                                ( --stake-verification-key STRING
+                                                | --stake-verification-key-file FILE
+                                                | --stake-script-file FILE
+                                                )
+                                                ( --mainnet
+                                                | --testnet-magic NATURAL
+                                                )
+                                                [--out-file FILE]
+
+  Build a stake address
+
+Available options:
+  --stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --stake-verification-key-file FILE
+                           Filepath of the staking verification key.
+  --stake-script-file FILE Filepath of the staking script.
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_stake-address_delegation-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_stake-address_delegation-certificate.cli
@@ -1,0 +1,31 @@
+Usage: cardano-cli conway stake-address delegation-certificate 
+                                                                 ( --stake-verification-key STRING
+                                                                 | --stake-verification-key-file FILE
+                                                                 | --stake-script-file FILE
+                                                                 | --stake-address ADDRESS
+                                                                 )
+                                                                 ( --stake-pool-verification-key STRING
+                                                                 | --cold-verification-key-file FILE
+                                                                 | --stake-pool-id STAKE_POOL_ID
+                                                                 )
+                                                                 --out-file FILE
+
+  Create a stake address pool delegation certificate
+
+Available options:
+  --stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --stake-verification-key-file FILE
+                           Filepath of the staking verification key.
+  --stake-script-file FILE Filepath of the staking script.
+  --stake-address ADDRESS  Target stake address (bech32 format).
+  --stake-pool-verification-key STRING
+                           Stake pool verification key (Bech32 or hex-encoded).
+  --cold-verification-key-file FILE
+                           Filepath of the stake pool verification key.
+  --stake-pool-id STAKE_POOL_ID
+                           Stake pool ID/verification key hash (either
+                           Bech32-encoded or hex-encoded). Zero or more
+                           occurences of this option is allowed.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_stake-address_deregistration-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_stake-address_deregistration-certificate.cli
@@ -1,0 +1,22 @@
+Usage: cardano-cli conway stake-address deregistration-certificate 
+                                                                     ( --stake-verification-key STRING
+                                                                     | --stake-verification-key-file FILE
+                                                                     | --stake-script-file FILE
+                                                                     | --stake-address ADDRESS
+                                                                     )
+                                                                     [--key-reg-deposit-amt NATURAL]
+                                                                     --out-file FILE
+
+  Create a stake address deregistration certificate
+
+Available options:
+  --stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --stake-verification-key-file FILE
+                           Filepath of the staking verification key.
+  --stake-script-file FILE Filepath of the staking script.
+  --stake-address ADDRESS  Target stake address (bech32 format).
+  --key-reg-deposit-amt NATURAL
+                           Key registration deposit amount.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_stake-address_key-gen.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_stake-address_key-gen.cli
@@ -1,0 +1,15 @@
+Usage: cardano-cli conway stake-address key-gen [--key-output-format STRING]
+                                                  --verification-key-file FILE
+                                                  --signing-key-file FILE
+
+  Create a stake address key pair
+
+Available options:
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32" (default is
+                           "bech32").
+  --verification-key-file FILE
+                           Output filepath of the verification key.
+  --signing-key-file FILE  Output filepath of the signing key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_stake-address_key-hash.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_stake-address_key-hash.cli
@@ -1,0 +1,15 @@
+Usage: cardano-cli conway stake-address key-hash 
+                                                   ( --stake-verification-key STRING
+                                                   | --stake-verification-key-file FILE
+                                                   )
+                                                   [--out-file FILE]
+
+  Print the hash of a stake address key
+
+Available options:
+  --stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --stake-verification-key-file FILE
+                           Filepath of the staking verification key.
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_stake-address_registration-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_stake-address_registration-certificate.cli
@@ -1,0 +1,22 @@
+Usage: cardano-cli conway stake-address registration-certificate 
+                                                                   ( --stake-verification-key STRING
+                                                                   | --stake-verification-key-file FILE
+                                                                   | --stake-script-file FILE
+                                                                   | --stake-address ADDRESS
+                                                                   )
+                                                                   [--key-reg-deposit-amt NATURAL]
+                                                                   --out-file FILE
+
+  Create a stake address registration certificate
+
+Available options:
+  --stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --stake-verification-key-file FILE
+                           Filepath of the staking verification key.
+  --stake-script-file FILE Filepath of the staking script.
+  --stake-address ADDRESS  Target stake address (bech32 format).
+  --key-reg-deposit-amt NATURAL
+                           Key registration deposit amount.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest.cli
@@ -1,4 +1,4 @@
-Usage: cardano-cli latest (governance | transaction)
+Usage: cardano-cli latest (governance | stake-address | transaction)
 
   Latest era commands (Babbage)
 
@@ -7,4 +7,5 @@ Available options:
 
 Available commands:
   governance               Era-based governance commands
+  stake-address            Stake address commands.
   transaction              Era-based governance commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_stake-address.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_stake-address.cli
@@ -1,0 +1,22 @@
+Usage: cardano-cli latest stake-address 
+                                          ( key-gen
+                                          | key-hash
+                                          | build
+                                          | registration-certificate
+                                          | deregistration-certificate
+                                          | delegation-certificate
+                                          )
+
+  Stake address commands.
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  key-gen                  Create a stake address key pair
+  key-hash                 Print the hash of a stake address key
+  build                    Build a stake address
+  registration-certificate Create a stake address registration certificate
+  deregistration-certificate
+                           Create a stake address deregistration certificate
+  delegation-certificate   Create a stake address pool delegation certificate

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_stake-address_build.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_stake-address_build.cli
@@ -1,0 +1,24 @@
+Usage: cardano-cli latest stake-address build 
+                                                ( --stake-verification-key STRING
+                                                | --stake-verification-key-file FILE
+                                                | --stake-script-file FILE
+                                                )
+                                                ( --mainnet
+                                                | --testnet-magic NATURAL
+                                                )
+                                                [--out-file FILE]
+
+  Build a stake address
+
+Available options:
+  --stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --stake-verification-key-file FILE
+                           Filepath of the staking verification key.
+  --stake-script-file FILE Filepath of the staking script.
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_stake-address_delegation-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_stake-address_delegation-certificate.cli
@@ -1,0 +1,31 @@
+Usage: cardano-cli latest stake-address delegation-certificate 
+                                                                 ( --stake-verification-key STRING
+                                                                 | --stake-verification-key-file FILE
+                                                                 | --stake-script-file FILE
+                                                                 | --stake-address ADDRESS
+                                                                 )
+                                                                 ( --stake-pool-verification-key STRING
+                                                                 | --cold-verification-key-file FILE
+                                                                 | --stake-pool-id STAKE_POOL_ID
+                                                                 )
+                                                                 --out-file FILE
+
+  Create a stake address pool delegation certificate
+
+Available options:
+  --stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --stake-verification-key-file FILE
+                           Filepath of the staking verification key.
+  --stake-script-file FILE Filepath of the staking script.
+  --stake-address ADDRESS  Target stake address (bech32 format).
+  --stake-pool-verification-key STRING
+                           Stake pool verification key (Bech32 or hex-encoded).
+  --cold-verification-key-file FILE
+                           Filepath of the stake pool verification key.
+  --stake-pool-id STAKE_POOL_ID
+                           Stake pool ID/verification key hash (either
+                           Bech32-encoded or hex-encoded). Zero or more
+                           occurences of this option is allowed.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_stake-address_deregistration-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_stake-address_deregistration-certificate.cli
@@ -1,0 +1,22 @@
+Usage: cardano-cli latest stake-address deregistration-certificate 
+                                                                     ( --stake-verification-key STRING
+                                                                     | --stake-verification-key-file FILE
+                                                                     | --stake-script-file FILE
+                                                                     | --stake-address ADDRESS
+                                                                     )
+                                                                     [--key-reg-deposit-amt NATURAL]
+                                                                     --out-file FILE
+
+  Create a stake address deregistration certificate
+
+Available options:
+  --stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --stake-verification-key-file FILE
+                           Filepath of the staking verification key.
+  --stake-script-file FILE Filepath of the staking script.
+  --stake-address ADDRESS  Target stake address (bech32 format).
+  --key-reg-deposit-amt NATURAL
+                           Key registration deposit amount.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_stake-address_key-gen.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_stake-address_key-gen.cli
@@ -1,0 +1,15 @@
+Usage: cardano-cli latest stake-address key-gen [--key-output-format STRING]
+                                                  --verification-key-file FILE
+                                                  --signing-key-file FILE
+
+  Create a stake address key pair
+
+Available options:
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32" (default is
+                           "bech32").
+  --verification-key-file FILE
+                           Output filepath of the verification key.
+  --signing-key-file FILE  Output filepath of the signing key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_stake-address_key-hash.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_stake-address_key-hash.cli
@@ -1,0 +1,15 @@
+Usage: cardano-cli latest stake-address key-hash 
+                                                   ( --stake-verification-key STRING
+                                                   | --stake-verification-key-file FILE
+                                                   )
+                                                   [--out-file FILE]
+
+  Print the hash of a stake address key
+
+Available options:
+  --stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --stake-verification-key-file FILE
+                           Filepath of the staking verification key.
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_stake-address_registration-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_stake-address_registration-certificate.cli
@@ -1,0 +1,22 @@
+Usage: cardano-cli latest stake-address registration-certificate 
+                                                                   ( --stake-verification-key STRING
+                                                                   | --stake-verification-key-file FILE
+                                                                   | --stake-script-file FILE
+                                                                   | --stake-address ADDRESS
+                                                                   )
+                                                                   [--key-reg-deposit-amt NATURAL]
+                                                                   --out-file FILE
+
+  Create a stake address registration certificate
+
+Available options:
+  --stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --stake-verification-key-file FILE
+                           Filepath of the staking verification key.
+  --stake-script-file FILE Filepath of the staking script.
+  --stake-address ADDRESS  Target stake address (bech32 format).
+  --key-reg-deposit-amt NATURAL
+                           Key registration deposit amount.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary.cli
@@ -1,4 +1,4 @@
-Usage: cardano-cli mary (governance | transaction)
+Usage: cardano-cli mary (governance | stake-address | transaction)
 
   Mary era commands
 
@@ -7,4 +7,5 @@ Available options:
 
 Available commands:
   governance               Era-based governance commands
+  stake-address            Stake address commands.
   transaction              Era-based governance commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_stake-address.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_stake-address.cli
@@ -1,0 +1,22 @@
+Usage: cardano-cli mary stake-address 
+                                        ( key-gen
+                                        | key-hash
+                                        | build
+                                        | registration-certificate
+                                        | deregistration-certificate
+                                        | delegation-certificate
+                                        )
+
+  Stake address commands.
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  key-gen                  Create a stake address key pair
+  key-hash                 Print the hash of a stake address key
+  build                    Build a stake address
+  registration-certificate Create a stake address registration certificate
+  deregistration-certificate
+                           Create a stake address deregistration certificate
+  delegation-certificate   Create a stake address pool delegation certificate

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_stake-address_build.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_stake-address_build.cli
@@ -1,0 +1,24 @@
+Usage: cardano-cli mary stake-address build 
+                                              ( --stake-verification-key STRING
+                                              | --stake-verification-key-file FILE
+                                              | --stake-script-file FILE
+                                              )
+                                              ( --mainnet
+                                              | --testnet-magic NATURAL
+                                              )
+                                              [--out-file FILE]
+
+  Build a stake address
+
+Available options:
+  --stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --stake-verification-key-file FILE
+                           Filepath of the staking verification key.
+  --stake-script-file FILE Filepath of the staking script.
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_stake-address_delegation-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_stake-address_delegation-certificate.cli
@@ -1,0 +1,31 @@
+Usage: cardano-cli mary stake-address delegation-certificate 
+                                                               ( --stake-verification-key STRING
+                                                               | --stake-verification-key-file FILE
+                                                               | --stake-script-file FILE
+                                                               | --stake-address ADDRESS
+                                                               )
+                                                               ( --stake-pool-verification-key STRING
+                                                               | --cold-verification-key-file FILE
+                                                               | --stake-pool-id STAKE_POOL_ID
+                                                               )
+                                                               --out-file FILE
+
+  Create a stake address pool delegation certificate
+
+Available options:
+  --stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --stake-verification-key-file FILE
+                           Filepath of the staking verification key.
+  --stake-script-file FILE Filepath of the staking script.
+  --stake-address ADDRESS  Target stake address (bech32 format).
+  --stake-pool-verification-key STRING
+                           Stake pool verification key (Bech32 or hex-encoded).
+  --cold-verification-key-file FILE
+                           Filepath of the stake pool verification key.
+  --stake-pool-id STAKE_POOL_ID
+                           Stake pool ID/verification key hash (either
+                           Bech32-encoded or hex-encoded). Zero or more
+                           occurences of this option is allowed.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_stake-address_deregistration-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_stake-address_deregistration-certificate.cli
@@ -1,0 +1,22 @@
+Usage: cardano-cli mary stake-address deregistration-certificate 
+                                                                   ( --stake-verification-key STRING
+                                                                   | --stake-verification-key-file FILE
+                                                                   | --stake-script-file FILE
+                                                                   | --stake-address ADDRESS
+                                                                   )
+                                                                   [--key-reg-deposit-amt NATURAL]
+                                                                   --out-file FILE
+
+  Create a stake address deregistration certificate
+
+Available options:
+  --stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --stake-verification-key-file FILE
+                           Filepath of the staking verification key.
+  --stake-script-file FILE Filepath of the staking script.
+  --stake-address ADDRESS  Target stake address (bech32 format).
+  --key-reg-deposit-amt NATURAL
+                           Key registration deposit amount.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_stake-address_key-gen.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_stake-address_key-gen.cli
@@ -1,0 +1,15 @@
+Usage: cardano-cli mary stake-address key-gen [--key-output-format STRING]
+                                                --verification-key-file FILE
+                                                --signing-key-file FILE
+
+  Create a stake address key pair
+
+Available options:
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32" (default is
+                           "bech32").
+  --verification-key-file FILE
+                           Output filepath of the verification key.
+  --signing-key-file FILE  Output filepath of the signing key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_stake-address_key-hash.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_stake-address_key-hash.cli
@@ -1,0 +1,15 @@
+Usage: cardano-cli mary stake-address key-hash 
+                                                 ( --stake-verification-key STRING
+                                                 | --stake-verification-key-file FILE
+                                                 )
+                                                 [--out-file FILE]
+
+  Print the hash of a stake address key
+
+Available options:
+  --stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --stake-verification-key-file FILE
+                           Filepath of the staking verification key.
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_stake-address_registration-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_stake-address_registration-certificate.cli
@@ -1,0 +1,22 @@
+Usage: cardano-cli mary stake-address registration-certificate 
+                                                                 ( --stake-verification-key STRING
+                                                                 | --stake-verification-key-file FILE
+                                                                 | --stake-script-file FILE
+                                                                 | --stake-address ADDRESS
+                                                                 )
+                                                                 [--key-reg-deposit-amt NATURAL]
+                                                                 --out-file FILE
+
+  Create a stake address registration certificate
+
+Available options:
+  --stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --stake-verification-key-file FILE
+                           Filepath of the staking verification key.
+  --stake-script-file FILE Filepath of the staking script.
+  --stake-address ADDRESS  Target stake address (bech32 format).
+  --key-reg-deposit-amt NATURAL
+                           Key registration deposit amount.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley.cli
@@ -1,4 +1,4 @@
-Usage: cardano-cli shelley (governance | transaction)
+Usage: cardano-cli shelley (governance | stake-address | transaction)
 
   Shelley era commands
 
@@ -7,4 +7,5 @@ Available options:
 
 Available commands:
   governance               Era-based governance commands
+  stake-address            Stake address commands.
   transaction              Era-based governance commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_stake-address.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_stake-address.cli
@@ -1,0 +1,22 @@
+Usage: cardano-cli shelley stake-address 
+                                           ( key-gen
+                                           | key-hash
+                                           | build
+                                           | registration-certificate
+                                           | deregistration-certificate
+                                           | delegation-certificate
+                                           )
+
+  Stake address commands.
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  key-gen                  Create a stake address key pair
+  key-hash                 Print the hash of a stake address key
+  build                    Build a stake address
+  registration-certificate Create a stake address registration certificate
+  deregistration-certificate
+                           Create a stake address deregistration certificate
+  delegation-certificate   Create a stake address pool delegation certificate

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_stake-address_build.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_stake-address_build.cli
@@ -1,0 +1,24 @@
+Usage: cardano-cli shelley stake-address build 
+                                                 ( --stake-verification-key STRING
+                                                 | --stake-verification-key-file FILE
+                                                 | --stake-script-file FILE
+                                                 )
+                                                 ( --mainnet
+                                                 | --testnet-magic NATURAL
+                                                 )
+                                                 [--out-file FILE]
+
+  Build a stake address
+
+Available options:
+  --stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --stake-verification-key-file FILE
+                           Filepath of the staking verification key.
+  --stake-script-file FILE Filepath of the staking script.
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_stake-address_delegation-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_stake-address_delegation-certificate.cli
@@ -1,0 +1,31 @@
+Usage: cardano-cli shelley stake-address delegation-certificate 
+                                                                  ( --stake-verification-key STRING
+                                                                  | --stake-verification-key-file FILE
+                                                                  | --stake-script-file FILE
+                                                                  | --stake-address ADDRESS
+                                                                  )
+                                                                  ( --stake-pool-verification-key STRING
+                                                                  | --cold-verification-key-file FILE
+                                                                  | --stake-pool-id STAKE_POOL_ID
+                                                                  )
+                                                                  --out-file FILE
+
+  Create a stake address pool delegation certificate
+
+Available options:
+  --stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --stake-verification-key-file FILE
+                           Filepath of the staking verification key.
+  --stake-script-file FILE Filepath of the staking script.
+  --stake-address ADDRESS  Target stake address (bech32 format).
+  --stake-pool-verification-key STRING
+                           Stake pool verification key (Bech32 or hex-encoded).
+  --cold-verification-key-file FILE
+                           Filepath of the stake pool verification key.
+  --stake-pool-id STAKE_POOL_ID
+                           Stake pool ID/verification key hash (either
+                           Bech32-encoded or hex-encoded). Zero or more
+                           occurences of this option is allowed.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_stake-address_deregistration-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_stake-address_deregistration-certificate.cli
@@ -1,0 +1,22 @@
+Usage: cardano-cli shelley stake-address deregistration-certificate 
+                                                                      ( --stake-verification-key STRING
+                                                                      | --stake-verification-key-file FILE
+                                                                      | --stake-script-file FILE
+                                                                      | --stake-address ADDRESS
+                                                                      )
+                                                                      [--key-reg-deposit-amt NATURAL]
+                                                                      --out-file FILE
+
+  Create a stake address deregistration certificate
+
+Available options:
+  --stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --stake-verification-key-file FILE
+                           Filepath of the staking verification key.
+  --stake-script-file FILE Filepath of the staking script.
+  --stake-address ADDRESS  Target stake address (bech32 format).
+  --key-reg-deposit-amt NATURAL
+                           Key registration deposit amount.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_stake-address_key-gen.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_stake-address_key-gen.cli
@@ -1,0 +1,15 @@
+Usage: cardano-cli shelley stake-address key-gen [--key-output-format STRING]
+                                                   --verification-key-file FILE
+                                                   --signing-key-file FILE
+
+  Create a stake address key pair
+
+Available options:
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32" (default is
+                           "bech32").
+  --verification-key-file FILE
+                           Output filepath of the verification key.
+  --signing-key-file FILE  Output filepath of the signing key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_stake-address_key-hash.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_stake-address_key-hash.cli
@@ -1,0 +1,15 @@
+Usage: cardano-cli shelley stake-address key-hash 
+                                                    ( --stake-verification-key STRING
+                                                    | --stake-verification-key-file FILE
+                                                    )
+                                                    [--out-file FILE]
+
+  Print the hash of a stake address key
+
+Available options:
+  --stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --stake-verification-key-file FILE
+                           Filepath of the staking verification key.
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_stake-address_registration-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_stake-address_registration-certificate.cli
@@ -1,0 +1,22 @@
+Usage: cardano-cli shelley stake-address registration-certificate 
+                                                                    ( --stake-verification-key STRING
+                                                                    | --stake-verification-key-file FILE
+                                                                    | --stake-script-file FILE
+                                                                    | --stake-address ADDRESS
+                                                                    )
+                                                                    [--key-reg-deposit-amt NATURAL]
+                                                                    --out-file FILE
+
+  Create a stake address registration certificate
+
+Available options:
+  --stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --stake-verification-key-file FILE
+                           Filepath of the staking verification key.
+  --stake-script-file FILE Filepath of the staking script.
+  --stake-address ADDRESS  Target stake address (bech32 format).
+  --key-reg-deposit-amt NATURAL
+                           Key registration deposit amount.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Era-based `stake-address` command group
# uncomment types applicable to the change:
  type:
  - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
