### PR TITLE
Move `node` run commands implementation into era based

### DIFF
--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -124,6 +124,7 @@ library
                         Cardano.CLI.Legacy.Run.Genesis
                         Cardano.CLI.Legacy.Run.Governance
                         Cardano.CLI.Legacy.Run.Key
+                        Cardano.CLI.Legacy.Run.Node
                         Cardano.CLI.Legacy.Run.Query
                         Cardano.CLI.Legacy.Run.StakeAddress
                         Cardano.CLI.Legacy.Run.StakePool

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -98,6 +98,7 @@ library
                         Cardano.CLI.EraBased.Run.Governance.Query
                         Cardano.CLI.EraBased.Run.Governance.Vote
                         Cardano.CLI.EraBased.Run.Key
+                        Cardano.CLI.EraBased.Run.Node
                         Cardano.CLI.EraBased.Run.Query
                         Cardano.CLI.EraBased.Run.StakeAddress
                         Cardano.CLI.EraBased.Run.StakePool
@@ -123,7 +124,6 @@ library
                         Cardano.CLI.Legacy.Run.Genesis
                         Cardano.CLI.Legacy.Run.Governance
                         Cardano.CLI.Legacy.Run.Key
-                        Cardano.CLI.Legacy.Run.Node
                         Cardano.CLI.Legacy.Run.Query
                         Cardano.CLI.Legacy.Run.StakeAddress
                         Cardano.CLI.Legacy.Run.StakePool

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Node.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Node.hs
@@ -1,13 +1,12 @@
 {-# LANGUAGE DataKinds #-}
 
 module Cardano.CLI.EraBased.Run.Node
-  ( runLegacyNodeIssueOpCertCmd
-  , runLegacyNodeKeyGenColdCmd
-  , runLegacyNodeKeyGenKesCmd
-  , runLegacyNodeKeyGenVrfCmd
-  , runLegacyNodeKeyHashVrfCmd
-  , runLegacyNodeNewCounterCmd
-  , readColdVerificationKeyOrFile
+  ( runNodeIssueOpCertCmd
+  , runNodeKeyGenColdCmd
+  , runNodeKeyGenKesCmd
+  , runNodeKeyGenVrfCmd
+  , runNodeKeyHashVrfCmd
+  , runNodeNewCounterCmd
   ) where
 
 import           Cardano.Api
@@ -26,13 +25,13 @@ import           Data.Word (Word64)
 
 {- HLINT ignore "Reduce duplication" -}
 
-runLegacyNodeKeyGenColdCmd
+runNodeKeyGenColdCmd
   :: KeyOutputFormat
   -> VerificationKeyFile Out
   -> SigningKeyFile Out
   -> OpCertCounterFile Out
   -> ExceptT ShelleyNodeCmdError IO ()
-runLegacyNodeKeyGenColdCmd fmt vkeyPath skeyPath ocertCtrPath = do
+runNodeKeyGenColdCmd fmt vkeyPath skeyPath ocertCtrPath = do
     skey <- liftIO $ generateSigningKey AsStakePoolKey
     let vkey = getVerificationKey skey
 
@@ -80,12 +79,12 @@ runLegacyNodeKeyGenColdCmd fmt vkeyPath skeyPath ocertCtrPath = do
     initialCounter = 0
 
 
-runLegacyNodeKeyGenKesCmd
+runNodeKeyGenKesCmd
   :: KeyOutputFormat
   -> VerificationKeyFile Out
   -> SigningKeyFile Out
   -> ExceptT ShelleyNodeCmdError IO ()
-runLegacyNodeKeyGenKesCmd fmt vkeyPath skeyPath = do
+runNodeKeyGenKesCmd fmt vkeyPath skeyPath = do
   skey <- liftIO $ generateSigningKey AsKesKey
 
   let vkey = getVerificationKey skey
@@ -121,12 +120,12 @@ runLegacyNodeKeyGenKesCmd fmt vkeyPath skeyPath = do
     vkeyDesc :: TextEnvelopeDescr
     vkeyDesc = "KES Verification Key"
 
-runLegacyNodeKeyGenVrfCmd
+runNodeKeyGenVrfCmd
   :: KeyOutputFormat
   -> VerificationKeyFile Out
   -> SigningKeyFile Out
   -> ExceptT ShelleyNodeCmdError IO ()
-runLegacyNodeKeyGenVrfCmd fmt vkeyPath skeyPath = do
+runNodeKeyGenVrfCmd fmt vkeyPath skeyPath = do
   skey <- liftIO $ generateSigningKey AsVrfKey
 
   let vkey = getVerificationKey skey
@@ -159,10 +158,10 @@ runLegacyNodeKeyGenVrfCmd fmt vkeyPath skeyPath = do
     skeyDesc = "VRF Signing Key"
     vkeyDesc = "VRF Verification Key"
 
-runLegacyNodeKeyHashVrfCmd :: VerificationKeyOrFile VrfKey
+runNodeKeyHashVrfCmd :: VerificationKeyOrFile VrfKey
                   -> Maybe (File () Out)
                   -> ExceptT ShelleyNodeCmdError IO ()
-runLegacyNodeKeyHashVrfCmd verKeyOrFile mOutputFp = do
+runNodeKeyHashVrfCmd verKeyOrFile mOutputFp = do
   vkey <- firstExceptT ShelleyNodeCmdReadKeyFileError
     . newExceptT
     $ readVerificationKeyOrFile AsVrfKey verKeyOrFile
@@ -174,11 +173,11 @@ runLegacyNodeKeyHashVrfCmd verKeyOrFile mOutputFp = do
     Nothing -> liftIO $ BS.putStrLn hexKeyHash
 
 
-runLegacyNodeNewCounterCmd :: ColdVerificationKeyOrFile
+runNodeNewCounterCmd :: ColdVerificationKeyOrFile
                   -> Word
                   -> OpCertCounterFile InOut
                   -> ExceptT ShelleyNodeCmdError IO ()
-runLegacyNodeNewCounterCmd coldVerKeyOrFile counter ocertCtrPath = do
+runNodeNewCounterCmd coldVerKeyOrFile counter ocertCtrPath = do
 
     vkey <- firstExceptT ShelleyNodeCmdReadFileError . newExceptT $
       readColdVerificationKeyOrFile coldVerKeyOrFile
@@ -191,7 +190,7 @@ runLegacyNodeNewCounterCmd coldVerKeyOrFile counter ocertCtrPath = do
       $ textEnvelopeToJSON Nothing ocertIssueCounter
 
 
-runLegacyNodeIssueOpCertCmd :: VerificationKeyOrFile KesKey
+runNodeIssueOpCertCmd :: VerificationKeyOrFile KesKey
                    -- ^ This is the hot KES verification key.
                    -> SigningKeyFile In
                    -- ^ This is the cold signing key.
@@ -202,7 +201,7 @@ runLegacyNodeIssueOpCertCmd :: VerificationKeyOrFile KesKey
                    -- ^ Start of the validity period for this certificate.
                    -> File () Out
                    -> ExceptT ShelleyNodeCmdError IO ()
-runLegacyNodeIssueOpCertCmd kesVerKeyOrFile stakePoolSKeyFile ocertCtrPath kesPeriod certFile = do
+runNodeIssueOpCertCmd kesVerKeyOrFile stakePoolSKeyFile ocertCtrPath kesPeriod certFile = do
 
     ocertIssueCounter <- firstExceptT ShelleyNodeCmdReadFileError
       . newExceptT

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Node.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Node.hs
@@ -1,19 +1,18 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE LambdaCase #-}
 
 module Cardano.CLI.EraBased.Run.Node
-  ( runLegacyNodeCmds
-  , runLegacyNodeIssueOpCertCmd
+  ( runLegacyNodeIssueOpCertCmd
   , runLegacyNodeKeyGenColdCmd
   , runLegacyNodeKeyGenKesCmd
   , runLegacyNodeKeyGenVrfCmd
+  , runLegacyNodeKeyHashVrfCmd
+  , runLegacyNodeNewCounterCmd
   , readColdVerificationKeyOrFile
   ) where
 
 import           Cardano.Api
 import           Cardano.Api.Shelley
 
-import           Cardano.CLI.Legacy.Commands.Node
 import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Errors.ShelleyNodeCmdError
 import           Cardano.CLI.Types.Key
@@ -26,25 +25,6 @@ import           Data.String (fromString)
 import           Data.Word (Word64)
 
 {- HLINT ignore "Reduce duplication" -}
-
-runLegacyNodeCmds :: LegacyNodeCmds -> ExceptT ShelleyNodeCmdError IO ()
-runLegacyNodeCmds = \case
-  NodeKeyGenCold fmt vk sk ctr ->
-    runLegacyNodeKeyGenColdCmd fmt vk sk ctr
-  NodeKeyGenKES  fmt vk sk ->
-    runLegacyNodeKeyGenKesCmd fmt vk sk
-  NodeKeyGenVRF  fmt vk sk ->
-    runLegacyNodeKeyGenVrfCmd fmt vk sk
-  NodeKeyHashVRF vk mOutFp ->
-    runLegacyNodeKeyHashVrfCmd vk mOutFp
-  NodeNewCounter vk ctr out ->
-    runLegacyNodeNewCounterCmd vk ctr out
-  NodeIssueOpCert vk sk ctr p out ->
-    runLegacyNodeIssueOpCertCmd vk sk ctr p out
-
---
--- Node command implementations
---
 
 runLegacyNodeKeyGenColdCmd
   :: KeyOutputFormat

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Node.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Node.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE LambdaCase #-}
 
-module Cardano.CLI.Legacy.Run.Node
+module Cardano.CLI.EraBased.Run.Node
   ( runLegacyNodeCmds
   , runLegacyNodeIssueOpCertCmd
   , runLegacyNodeKeyGenColdCmd

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run.hs
@@ -4,12 +4,12 @@ module Cardano.CLI.Legacy.Run
   ( runLegacyCmds
   ) where
 
-import           Cardano.CLI.EraBased.Run.Node
 import           Cardano.CLI.Legacy.Options
 import           Cardano.CLI.Legacy.Run.Address
 import           Cardano.CLI.Legacy.Run.Genesis
 import           Cardano.CLI.Legacy.Run.Governance
 import           Cardano.CLI.Legacy.Run.Key
+import           Cardano.CLI.Legacy.Run.Node
 import           Cardano.CLI.Legacy.Run.Query
 import           Cardano.CLI.Legacy.Run.StakeAddress
 import           Cardano.CLI.Legacy.Run.StakePool

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run.hs
@@ -4,12 +4,12 @@ module Cardano.CLI.Legacy.Run
   ( runLegacyCmds
   ) where
 
+import           Cardano.CLI.EraBased.Run.Node
 import           Cardano.CLI.Legacy.Options
 import           Cardano.CLI.Legacy.Run.Address
 import           Cardano.CLI.Legacy.Run.Genesis
 import           Cardano.CLI.Legacy.Run.Governance
 import           Cardano.CLI.Legacy.Run.Key
-import           Cardano.CLI.Legacy.Run.Node
 import           Cardano.CLI.Legacy.Run.Query
 import           Cardano.CLI.Legacy.Run.StakeAddress
 import           Cardano.CLI.Legacy.Run.StakePool

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Genesis.hs
@@ -45,8 +45,8 @@ import           Cardano.Chain.Update hiding (ProtocolParameters)
 import           Cardano.CLI.Byron.Delegation
 import           Cardano.CLI.Byron.Genesis as Byron
 import qualified Cardano.CLI.Byron.Key as Byron
-import           Cardano.CLI.EraBased.Run.Node (runLegacyNodeIssueOpCertCmd,
-                   runLegacyNodeKeyGenColdCmd, runLegacyNodeKeyGenKesCmd, runLegacyNodeKeyGenVrfCmd)
+import           Cardano.CLI.EraBased.Run.Node (runNodeIssueOpCertCmd, runNodeKeyGenColdCmd,
+                   runNodeKeyGenKesCmd, runNodeKeyGenVrfCmd)
 import           Cardano.CLI.EraBased.Run.StakeAddress (runStakeAddressKeyGenCmd)
 import qualified Cardano.CLI.IO.Lazy as Lazy
 import           Cardano.CLI.Legacy.Commands.Genesis
@@ -787,11 +787,11 @@ createDelegateKeys fmt dir index = do
         (File @(VerificationKey ()) $ dir </> "delegate" ++ strIndex ++ ".vrf.vkey")
         (File @(SigningKey ()) $ dir </> "delegate" ++ strIndex ++ ".vrf.skey")
   firstExceptT ShelleyGenesisCmdNodeCmdError $ do
-    runLegacyNodeKeyGenKesCmd
+    runNodeKeyGenKesCmd
         fmt
         (onlyOut kesVK)
         (File @(SigningKey ()) $ dir </> "delegate" ++ strIndex ++ ".kes.skey")
-    runLegacyNodeIssueOpCertCmd
+    runNodeIssueOpCertCmd
         (VerificationKeyFilePath (onlyIn kesVK))
         (onlyIn coldSK)
         opCertCtr
@@ -824,20 +824,20 @@ createPoolCredentials :: KeyOutputFormat -> FilePath -> Word -> ExceptT ShelleyG
 createPoolCredentials fmt dir index = do
   liftIO $ createDirectoryIfMissing False dir
   firstExceptT ShelleyGenesisCmdNodeCmdError $ do
-    runLegacyNodeKeyGenKesCmd
+    runNodeKeyGenKesCmd
         fmt
         (onlyOut kesVK)
         (File @(SigningKey ()) $ dir </> "kes" ++ strIndex ++ ".skey")
-    runLegacyNodeKeyGenVrfCmd
+    runNodeKeyGenVrfCmd
         fmt
         (File @(VerificationKey ()) $ dir </> "vrf" ++ strIndex ++ ".vkey")
         (File @(SigningKey ()) $ dir </> "vrf" ++ strIndex ++ ".skey")
-    runLegacyNodeKeyGenColdCmd
+    runNodeKeyGenColdCmd
         fmt
         (File @(VerificationKey ()) $ dir </> "cold" ++ strIndex ++ ".vkey")
         (onlyOut coldSK)
         (onlyOut opCertCtr)
-    runLegacyNodeIssueOpCertCmd
+    runNodeIssueOpCertCmd
         (VerificationKeyFilePath (onlyIn kesVK))
         (onlyIn coldSK)
         opCertCtr

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Genesis.hs
@@ -45,11 +45,11 @@ import           Cardano.Chain.Update hiding (ProtocolParameters)
 import           Cardano.CLI.Byron.Delegation
 import           Cardano.CLI.Byron.Genesis as Byron
 import qualified Cardano.CLI.Byron.Key as Byron
+import           Cardano.CLI.EraBased.Run.Node (runLegacyNodeIssueOpCertCmd,
+                   runLegacyNodeKeyGenColdCmd, runLegacyNodeKeyGenKesCmd, runLegacyNodeKeyGenVrfCmd)
 import           Cardano.CLI.EraBased.Run.StakeAddress (runStakeAddressKeyGenCmd)
 import qualified Cardano.CLI.IO.Lazy as Lazy
 import           Cardano.CLI.Legacy.Commands.Genesis
-import           Cardano.CLI.Legacy.Run.Node (runLegacyNodeIssueOpCertCmd,
-                   runLegacyNodeKeyGenColdCmd, runLegacyNodeKeyGenKesCmd, runLegacyNodeKeyGenVrfCmd)
 import           Cardano.CLI.Orphans ()
 import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Errors.ProtocolParamsError

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Node.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Node.hs
@@ -1,0 +1,86 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE LambdaCase #-}
+
+module Cardano.CLI.Legacy.Run.Node
+  ( runLegacyNodeCmds
+
+  ) where
+
+import           Cardano.Api
+import           Cardano.Api.Shelley
+
+import qualified Cardano.CLI.EraBased.Run.Node as EraBased
+import           Cardano.CLI.Legacy.Commands.Node
+import           Cardano.CLI.Types.Common
+import           Cardano.CLI.Types.Errors.ShelleyNodeCmdError
+import           Cardano.CLI.Types.Key
+
+import           Control.Monad.Trans.Except (ExceptT)
+
+{- HLINT ignore "Reduce duplication" -}
+
+runLegacyNodeCmds :: ()
+  => LegacyNodeCmds
+  -> ExceptT ShelleyNodeCmdError IO ()
+runLegacyNodeCmds = \case
+  NodeKeyGenCold fmt vk sk ctr ->
+    runLegacyNodeKeyGenColdCmd fmt vk sk ctr
+  NodeKeyGenKES  fmt vk sk ->
+    runLegacyNodeKeyGenKesCmd fmt vk sk
+  NodeKeyGenVRF  fmt vk sk ->
+    runLegacyNodeKeyGenVrfCmd fmt vk sk
+  NodeKeyHashVRF vk mOutFp ->
+    runLegacyNodeKeyHashVrfCmd vk mOutFp
+  NodeNewCounter vk ctr out ->
+    runLegacyNodeNewCounterCmd vk ctr out
+  NodeIssueOpCert vk sk ctr p out ->
+    runLegacyNodeIssueOpCertCmd vk sk ctr p out
+
+runLegacyNodeKeyGenColdCmd :: ()
+  => KeyOutputFormat
+  -> VerificationKeyFile Out
+  -> SigningKeyFile Out
+  -> OpCertCounterFile Out
+  -> ExceptT ShelleyNodeCmdError IO ()
+runLegacyNodeKeyGenColdCmd = EraBased.runLegacyNodeKeyGenColdCmd
+
+runLegacyNodeKeyGenKesCmd :: ()
+  => KeyOutputFormat
+  -> VerificationKeyFile Out
+  -> SigningKeyFile Out
+  -> ExceptT ShelleyNodeCmdError IO ()
+runLegacyNodeKeyGenKesCmd = EraBased.runLegacyNodeKeyGenKesCmd
+
+runLegacyNodeKeyGenVrfCmd :: ()
+  => KeyOutputFormat
+  -> VerificationKeyFile Out
+  -> SigningKeyFile Out
+  -> ExceptT ShelleyNodeCmdError IO ()
+runLegacyNodeKeyGenVrfCmd = EraBased.runLegacyNodeKeyGenVrfCmd
+
+runLegacyNodeKeyHashVrfCmd :: ()
+  => VerificationKeyOrFile VrfKey
+  -> Maybe (File () Out)
+  -> ExceptT ShelleyNodeCmdError IO ()
+runLegacyNodeKeyHashVrfCmd = EraBased.runLegacyNodeKeyHashVrfCmd
+
+runLegacyNodeNewCounterCmd :: ()
+  => ColdVerificationKeyOrFile
+  -> Word
+  -> OpCertCounterFile InOut
+  -> ExceptT ShelleyNodeCmdError IO ()
+runLegacyNodeNewCounterCmd = EraBased.runLegacyNodeNewCounterCmd
+
+runLegacyNodeIssueOpCertCmd :: ()
+  => VerificationKeyOrFile KesKey
+  -- ^ This is the hot KES verification key.
+  -> SigningKeyFile In
+  -- ^ This is the cold signing key.
+  -> OpCertCounterFile InOut
+  -- ^ Counter that establishes the precedence
+  -- of the operational certificate.
+  -> KESPeriod
+  -- ^ Start of the validity period for this certificate.
+  -> File () Out
+  -> ExceptT ShelleyNodeCmdError IO ()
+runLegacyNodeIssueOpCertCmd = EraBased.runLegacyNodeIssueOpCertCmd

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Node.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Node.hs
@@ -3,13 +3,12 @@
 
 module Cardano.CLI.Legacy.Run.Node
   ( runLegacyNodeCmds
-
   ) where
 
 import           Cardano.Api
 import           Cardano.Api.Shelley
 
-import qualified Cardano.CLI.EraBased.Run.Node as EraBased
+import           Cardano.CLI.EraBased.Run.Node
 import           Cardano.CLI.Legacy.Commands.Node
 import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Errors.ShelleyNodeCmdError
@@ -42,34 +41,34 @@ runLegacyNodeKeyGenColdCmd :: ()
   -> SigningKeyFile Out
   -> OpCertCounterFile Out
   -> ExceptT ShelleyNodeCmdError IO ()
-runLegacyNodeKeyGenColdCmd = EraBased.runLegacyNodeKeyGenColdCmd
+runLegacyNodeKeyGenColdCmd = runNodeKeyGenColdCmd
 
 runLegacyNodeKeyGenKesCmd :: ()
   => KeyOutputFormat
   -> VerificationKeyFile Out
   -> SigningKeyFile Out
   -> ExceptT ShelleyNodeCmdError IO ()
-runLegacyNodeKeyGenKesCmd = EraBased.runLegacyNodeKeyGenKesCmd
+runLegacyNodeKeyGenKesCmd = runNodeKeyGenKesCmd
 
 runLegacyNodeKeyGenVrfCmd :: ()
   => KeyOutputFormat
   -> VerificationKeyFile Out
   -> SigningKeyFile Out
   -> ExceptT ShelleyNodeCmdError IO ()
-runLegacyNodeKeyGenVrfCmd = EraBased.runLegacyNodeKeyGenVrfCmd
+runLegacyNodeKeyGenVrfCmd = runNodeKeyGenVrfCmd
 
 runLegacyNodeKeyHashVrfCmd :: ()
   => VerificationKeyOrFile VrfKey
   -> Maybe (File () Out)
   -> ExceptT ShelleyNodeCmdError IO ()
-runLegacyNodeKeyHashVrfCmd = EraBased.runLegacyNodeKeyHashVrfCmd
+runLegacyNodeKeyHashVrfCmd = runNodeKeyHashVrfCmd
 
 runLegacyNodeNewCounterCmd :: ()
   => ColdVerificationKeyOrFile
   -> Word
   -> OpCertCounterFile InOut
   -> ExceptT ShelleyNodeCmdError IO ()
-runLegacyNodeNewCounterCmd = EraBased.runLegacyNodeNewCounterCmd
+runLegacyNodeNewCounterCmd = runNodeNewCounterCmd
 
 runLegacyNodeIssueOpCertCmd :: ()
   => VerificationKeyOrFile KesKey
@@ -83,4 +82,4 @@ runLegacyNodeIssueOpCertCmd :: ()
   -- ^ Start of the validity period for this certificate.
   -> File () Out
   -> ExceptT ShelleyNodeCmdError IO ()
-runLegacyNodeIssueOpCertCmd = EraBased.runLegacyNodeIssueOpCertCmd
+runLegacyNodeIssueOpCertCmd = runNodeIssueOpCertCmd


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Move `node` run commands implementation into era based
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context


# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
