### PR TITLE
Disable `redundant-constraints` warning only on `ghc-8.10.7`

### DIFF
--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -51,6 +51,9 @@ library
   if flag(unexpected_thunks)
     cpp-options:        -DUNEXPECTED_THUNKS
 
+  if impl(ghc < 9.6)
+    ghc-options:        -Wno-redundant-constraints
+
   hs-source-dirs:       src
 
   exposed-modules:      Cardano.CLI.Byron.Commands

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Address.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Address.hs
@@ -14,11 +14,11 @@ import           Cardano.Api
 import           Cardano.Api.Shelley
 
 import           Cardano.CLI.Read
-import           Cardano.CLI.Types.Key (PaymentVerifier (..), StakeIdentifier (..),
-                   StakeVerifier (..), VerificationKeyTextOrFile, generateKeyPair, readVerificationKeyOrFile,
-                   readVerificationKeyTextOrFileAnyOf)
 import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Errors.ShelleyAddressCmdError
+import           Cardano.CLI.Types.Key (PaymentVerifier (..), StakeIdentifier (..),
+                   StakeVerifier (..), VerificationKeyTextOrFile, generateKeyPair,
+                   readVerificationKeyOrFile, readVerificationKeyTextOrFileAnyOf)
 
 import           Control.Monad.IO.Class (MonadIO (..))
 import           Control.Monad.Trans.Except (ExceptT)
@@ -37,13 +37,9 @@ runAddressKeyGenCmd fmt kt vkf skf = case kt of
   AddressKeyShelleyExtended -> generateAndWriteKeyFiles fmt  AsPaymentExtendedKey  vkf skf
   AddressKeyByron           -> generateAndWriteByronKeyFiles AsByronKey            vkf skf
 
-generateAndWriteByronKeyFiles
-  :: Key keyrole
-#if __GLASGOW_HASKELL__ >= 904
--- GHC 8.10 considers the HasTypeProxy constraint redundant but ghc-9.4 and above complains if its
--- not present.
+generateAndWriteByronKeyFiles :: ()
+  => Key keyrole
   => HasTypeProxy keyrole
-#endif
   => AsType keyrole
   -> VerificationKeyFile Out
   -> SigningKeyFile Out
@@ -51,13 +47,9 @@ generateAndWriteByronKeyFiles
 generateAndWriteByronKeyFiles asType vkf skf = do
   uncurry (writeByronPaymentKeyFiles vkf skf) =<< liftIO (generateKeyPair asType)
 
-generateAndWriteKeyFiles
-  :: Key keyrole
-#if __GLASGOW_HASKELL__ >= 904
--- GHC 8.10 considers the HasTypeProxy constraint redundant but ghc-9.4 and above complains if its
--- not present.
+generateAndWriteKeyFiles :: ()
+  => Key keyrole
   => HasTypeProxy keyrole
-#endif
   => SerialiseAsBech32 (SigningKey keyrole)
   => SerialiseAsBech32 (VerificationKey keyrole)
   => KeyOutputFormat

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Key.hs
@@ -76,9 +76,10 @@ data SomeSigningKey
   | AVrfSigningKey             (SigningKey VrfKey)
   | AKesSigningKey             (SigningKey KesKey)
 
-withSomeSigningKey :: SomeSigningKey
-                   -> (forall keyrole. (Key keyrole, HasTypeProxy keyrole) => SigningKey keyrole -> a)
-                   -> a
+withSomeSigningKey :: ()
+  => SomeSigningKey
+  -> (forall keyrole. (Key keyrole, HasTypeProxy keyrole) => SigningKey keyrole -> a)
+  -> a
 withSomeSigningKey ssk f =
     case ssk of
       AByronSigningKey           sk -> f sk

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Genesis.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE ConstraintKinds #-}
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
@@ -46,17 +45,17 @@ import           Cardano.Chain.Update hiding (ProtocolParameters)
 import           Cardano.CLI.Byron.Delegation
 import           Cardano.CLI.Byron.Genesis as Byron
 import qualified Cardano.CLI.Byron.Key as Byron
+import           Cardano.CLI.EraBased.Run.StakeAddress (runStakeAddressKeyGenCmd)
 import qualified Cardano.CLI.IO.Lazy as Lazy
 import           Cardano.CLI.Legacy.Commands.Genesis
-import           Cardano.CLI.Legacy.Run.Node (
-                   runLegacyNodeIssueOpCertCmd, runLegacyNodeKeyGenColdCmd, runLegacyNodeKeyGenKesCmd, runLegacyNodeKeyGenVrfCmd)
-import           Cardano.CLI.EraBased.Run.StakeAddress (runStakeAddressKeyGenCmd)
+import           Cardano.CLI.Legacy.Run.Node (runLegacyNodeIssueOpCertCmd,
+                   runLegacyNodeKeyGenColdCmd, runLegacyNodeKeyGenKesCmd, runLegacyNodeKeyGenVrfCmd)
 import           Cardano.CLI.Orphans ()
 import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Errors.ProtocolParamsError
 import           Cardano.CLI.Types.Errors.ShelleyGenesisCmdError
-import           Cardano.CLI.Types.Errors.ShelleyPoolCmdError
 import           Cardano.CLI.Types.Errors.ShelleyNodeCmdError
+import           Cardano.CLI.Types.Errors.ShelleyPoolCmdError
 import           Cardano.CLI.Types.Key
 import qualified Cardano.Crypto as CC
 import           Cardano.Crypto.Hash (HashAlgorithm)
@@ -403,15 +402,11 @@ runLegacyGenesisCreateCmd
 toSKeyJSON :: Key a => SigningKey a -> ByteString
 toSKeyJSON = LBS.toStrict . textEnvelopeToJSON Nothing
 
-toVkeyJSON ::
-#if __GLASGOW_HASKELL__ >= 904
--- GHC 8.10 considers the HasTypeProxy constraint redundant but ghc-9.4 and above complains if its
--- not present.
-              (Key a, HasTypeProxy a) =>
-#else
-              (Key a) =>
-#endif
-              SigningKey a -> ByteString
+toVkeyJSON :: ()
+  => Key a
+  => HasTypeProxy a
+  => SigningKey a
+  -> ByteString
 toVkeyJSON = LBS.toStrict . textEnvelopeToJSON Nothing . getVerificationKey
 
 toVkeyJSON' :: Key a => VerificationKey a -> ByteString

--- a/cardano-cli/src/Cardano/CLI/Types/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Key.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
@@ -323,15 +322,11 @@ readVerificationKeyOrHashOrTextEnvFile asType verKeyOrHashOrFile =
       pure (verificationKeyHash <$> eitherVk)
     VerificationKeyHash vkHash -> pure (Right vkHash)
 
-generateKeyPair ::
-#if __GLASGOW_HASKELL__ >= 904
--- GHC 8.10 considers the HasTypeProxy constraint redundant but ghc-9.4 and above complains if its
--- not present.
-    (Key keyrole, HasTypeProxy keyrole) =>
-#else
-    Key keyrole =>
-#endif
-    AsType keyrole -> IO (VerificationKey keyrole, SigningKey keyrole)
+generateKeyPair :: ()
+  => Key keyrole
+  => HasTypeProxy keyrole
+  => AsType keyrole
+  -> IO (VerificationKey keyrole, SigningKey keyrole)
 generateKeyPair asType = do
   skey <- generateSigningKey asType
   return (getVerificationKey skey, skey)


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Disable `redundant-constraints` warning only on `ghc-8.10.7`
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

It is not having this warning on in `ghc-8.10.7` if it incurs the use of `CPP`.  We can rely on new `ghc` compilers to prevent use merging redundant constraints code to `main`.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
