### PR TITLE
Update cardano-cli to newer cardano-ledger

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -20,7 +20,7 @@ jobs:
 
     env:
       # Modify this value to "invalidate" the cabal cache.
-      CABAL_CACHE_VERSION: "2023-08-29"
+      CABAL_CACHE_VERSION: "2023-09-12"
 
     concurrency:
       group: >

--- a/cabal.project
+++ b/cabal.project
@@ -14,7 +14,7 @@ repository cardano-haskell-packages
 -- you need to run if you change them
 index-state:
   , hackage.haskell.org 2023-08-08T19:56:09Z
-  , cardano-haskell-packages 2023-09-06T08:30:00Z
+  , cardano-haskell-packages 2023-09-12T15:59:42Z
 
 packages:
   cardano-cli
@@ -43,4 +43,3 @@ write-ghc-environment-files: always
 -- IMPORTANT
 -- Do NOT add more source-repository-package stanzas here unless they are strictly
 -- temporary! Please read the section in CONTRIBUTING about updating dependencies.
-

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -200,11 +200,11 @@ library
                       , binary
                       , bytestring
                       , canonical-json
-                      , cardano-api ^>= 8.19
+                      , cardano-api ^>= 8.20
                       , cardano-binary
                       , cardano-crypto
                       , cardano-crypto-class ^>= 2.1.2
-                      , cardano-crypto-wrapper ^>= 1.5
+                      , cardano-crypto-wrapper ^>= 1.5.1
                       , cardano-data >= 1.0
                       , cardano-git-rev
                       , cardano-ledger-alonzo >= 1.3.1.1
@@ -248,7 +248,6 @@ library
                       , transformers-except ^>= 0.1.3
                       , unliftio-core
                       , utf8-string
-                      , vector
                       , yaml
 
 executable cardano-cli
@@ -290,11 +289,11 @@ test-suite cardano-cli-test
                       , base16-bytestring
                       , bech32 >= 1.1.0
                       , bytestring
-                      , cardano-api:{cardano-api, internal} ^>= 8.19
+                      , cardano-api:{cardano-api, internal}
                       , cardano-api-gen ^>= 8.2.0.0
                       , cardano-cli
                       , cardano-cli:cardano-cli-test-lib
-                      , cardano-slotting ^>= 0.1
+                      , cardano-slotting
                       , containers
                       , filepath
                       , hedgehog
@@ -334,12 +333,12 @@ test-suite cardano-cli-golden
   build-depends:        aeson >= 1.5.6.0
                       , base16-bytestring
                       , bytestring
-                      , cardano-api:{cardano-api, gen} ^>= 8.19
+                      , cardano-api:{cardano-api, gen}
                       , cardano-binary
                       , cardano-cli
                       , cardano-cli:cardano-cli-test-lib
-                      , cardano-crypto-wrapper ^>= 1.5.1
-                      , cardano-ledger-byron ^>= 1.0.0.2
+                      , cardano-crypto-wrapper
+                      , cardano-ledger-byron
                       , cborg
                       , containers
                       , filepath

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Query.hs
@@ -112,7 +112,9 @@ runQueryDRepStakeDistribution w (DRepStakeDistributionQueryCmd socketPath (AnyCo
       cEra = conwayEraOnwardsToCardanoEra w
       cMode = consensusModeOnly cModeParams
 
-  let drepFromVrfKey = fmap Ledger.DRepCredential . firstExceptT GovernanceQueryDRepKeyError . getDRepCredentialFromVerKeyHashOrFile
+  let drepFromVrfKey = fmap Ledger.DRepCredential
+                     . firstExceptT GovernanceQueryDRepKeyError
+                     . getDRepCredentialFromVerKeyHashOrFile
   dreps <- Set.fromList <$> mapM drepFromVrfKey drepKeys
 
   eraInMode <- toEraInMode cEra cMode

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Query.hs
@@ -32,6 +32,7 @@ module Cardano.CLI.EraBased.Run.Query
   , DelegationsAndRewards(..)
   , renderQueryCmdError
   , renderLocalStateQueryError
+  , renderOpCertIntervalInformation
   , percentage
   ) where
 

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Transaction.hs
@@ -242,7 +242,7 @@ runTxBuildCmd
             & onLeft (left . TxCmdQueryConvenienceError . AcqFailure)
             & onLeft (left . TxCmdQueryConvenienceError . QceUnsupportedNtcVersion)
 
-          (nodeEraUTxO, _, eraHistory, systemStart, _, _) <-
+          (nodeEraUTxO, _, eraHistory, systemStart, _, _, _) <-
             lift (executeLocalStateQueryExpr localNodeConnInfo Nothing (queryStateForBalancedTx nodeEra allTxInputs []))
               & onLeft (left . TxCmdQueryConvenienceError . AcqFailure)
               & onLeft (left . TxCmdQueryConvenienceError)
@@ -566,7 +566,7 @@ runTxBuild
               TxCertificates _ cs _ -> cs
               _ -> []
 
-      (txEraUtxo, pparams, eraHistory, systemStart, stakePools, stakeDelegDeposits) <-
+      (txEraUtxo, pparams, eraHistory, systemStart, stakePools, stakeDelegDeposits, drepDelegDeposits) <-
         lift (executeLocalStateQueryExpr localNodeConnInfo Nothing $ queryStateForBalancedTx nodeEra allTxInputs certs)
           & onLeft (left . TxCmdQueryConvenienceError . AcqFailure)
           & onLeft (left . TxCmdQueryConvenienceError)
@@ -611,8 +611,8 @@ runTxBuild
         firstExceptT TxCmdBalanceTxBody
           . hoistEither
           $ makeTransactionBodyAutoBalance systemStart (toLedgerEpochInfo eraHistory)
-                                           pparams stakePools stakeDelegDeposits txEraUtxo
-                                           txBodyContent cAddr mOverrideWits
+                                           pparams stakePools stakeDelegDeposits drepDelegDeposits
+                                           txEraUtxo txBodyContent cAddr mOverrideWits
 
       liftIO $ putStrLn $ "Estimated transaction fee: " <> (show fee :: String)
 

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/JSON.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/JSON.hs
@@ -8,7 +8,6 @@ module Test.Cli.JSON
 
 import           Cardano.Api.Shelley
 
-import           Cardano.CLI.EraBased.Run.Query
 import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Output (QueryKesPeriodInfoOutput (..), createOpCertIntervalInfo)
 

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1693988844,
-        "narHash": "sha256-0fvQy6GxgSkpufa0QeEtYNEY4G5nSQ7L4VIkGdfTt+w=",
+        "lastModified": 1694535531,
+        "narHash": "sha256-bu48CjvcU4JQhvZJa/Dm/S3csvhC3ZC+7H7BfR44d+w=",
         "owner": "input-output-hk",
         "repo": "cardano-haskell-packages",
-        "rev": "27f047c00b5d079e6322a3eab53549cad9e77680",
+        "rev": "a9645b0501c45c34ba490beb14e3b13afa2a84fe",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    - Use `cardano-api-8.20`.
    - Export `renderOpCertIntervalInformation`.
    - `DelegationsAndRewards` and `mergeDelegsAndRewards` moved to `cardano-api` (`8.20.0.0`).
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
    - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
    - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

The PR is part of ongoing effort towards `cardano-node-8.4.0-pre`.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
