### PR TITLE
Era based `address` commands

### DIFF
--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -51,6 +51,9 @@ library
   if flag(unexpected_thunks)
     cpp-options:        -DUNEXPECTED_THUNKS
 
+  if impl(ghc < 9.6)
+    ghc-options:        -Wno-redundant-constraints
+
   hs-source-dirs:       src
 
   exposed-modules:      Cardano.CLI.Byron.Commands

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -69,6 +69,7 @@ library
                         Cardano.CLI.Byron.Vote
                         Cardano.CLI.Environment
                         Cardano.CLI.EraBased.Commands
+                        Cardano.CLI.EraBased.Commands.Address
                         Cardano.CLI.EraBased.Commands.Governance
                         Cardano.CLI.EraBased.Commands.Governance.Actions
                         Cardano.CLI.EraBased.Commands.Governance.Committee
@@ -77,6 +78,7 @@ library
                         Cardano.CLI.EraBased.Commands.Governance.Vote
                         Cardano.CLI.EraBased.Commands.StakeAddress
                         Cardano.CLI.EraBased.Commands.Transaction
+                        Cardano.CLI.EraBased.Options.Address
                         Cardano.CLI.EraBased.Options.Common
                         Cardano.CLI.EraBased.Options.Governance
                         Cardano.CLI.EraBased.Options.Governance.Actions

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands.hs
@@ -13,8 +13,10 @@ module Cardano.CLI.EraBased.Commands
 import           Cardano.Api (CardanoEra (..), ShelleyBasedEra (..))
 
 import           Cardano.CLI.Environment
+import           Cardano.CLI.EraBased.Commands.Address
 import           Cardano.CLI.EraBased.Commands.StakeAddress
 import           Cardano.CLI.EraBased.Commands.Transaction
+import           Cardano.CLI.EraBased.Options.Address
 import           Cardano.CLI.EraBased.Options.Common
 import           Cardano.CLI.EraBased.Options.Governance
 import           Cardano.CLI.EraBased.Options.StakeAddress
@@ -34,12 +36,15 @@ renderAnyEraCommand = \case
   AnyEraCommandOf _ cmd -> renderEraBasedCommand cmd
 
 data EraBasedCommand era
-  = EraBasedGovernanceCmds (EraBasedGovernanceCmds era)
+  = AddressCmds (AddressCmds era)
+  | EraBasedGovernanceCmds (EraBasedGovernanceCmds era)
   | TransactionCmds (TransactionCmds era)
   | StakeAddressCmds (StakeAddressCmds era)
 
 renderEraBasedCommand :: EraBasedCommand era -> Text
 renderEraBasedCommand = \case
+  AddressCmds cmd ->
+    renderAddressCmds cmd
   EraBasedGovernanceCmds cmd ->
     renderEraBasedGovernanceCmds cmd
   StakeAddressCmds cmd ->
@@ -80,6 +85,10 @@ pEraBasedCommand :: EnvCli -> CardanoEra era -> Parser (EraBasedCommand era)
 pEraBasedCommand envCli era =
   asum $ catMaybes
     [ Just
+        $ subParser "address"
+        $ Opt.info (AddressCmds <$> pAddressCmds era envCli)
+        $ Opt.progDesc "Era-based address commands"
+    , Just
         $ subParser "governance"
         $ Opt.info (EraBasedGovernanceCmds <$> pEraBasedGovernanceCmds envCli era)
         $ Opt.progDesc "Era-based governance commands"

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Address.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Address.hs
@@ -1,0 +1,42 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE LambdaCase #-}
+
+module Cardano.CLI.EraBased.Commands.Address
+  ( AddressCmds (..)
+  , renderAddressCmds
+  ) where
+
+import           Cardano.Api.Shelley hiding (QueryInShelleyBasedEra (..))
+
+import           Cardano.CLI.Types.Common
+import           Cardano.CLI.Types.Key
+
+import           Prelude
+
+import           Data.Text (Text)
+
+data AddressCmds era
+  = AddressKeyGen
+      KeyOutputFormat
+      AddressKeyType
+      (VerificationKeyFile Out)
+      (SigningKeyFile Out)
+  | AddressKeyHash
+      VerificationKeyTextOrFile
+      (Maybe (File () Out))
+  | AddressBuild
+      PaymentVerifier
+      (Maybe StakeIdentifier)
+      NetworkId
+      (Maybe (File () Out))
+  | AddressInfo
+      Text
+      (Maybe (File () Out))
+  deriving Show
+
+renderAddressCmds :: AddressCmds era -> Text
+renderAddressCmds = \case
+  AddressKeyGen {} -> "address key-gen"
+  AddressKeyHash {} -> "address key-hash"
+  AddressBuild {} -> "address build"
+  AddressInfo {} -> "address info"

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Address.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Address.hs
@@ -1,0 +1,63 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Cardano.CLI.EraBased.Options.Address
+  ( pAddressCmds
+  ) where
+
+import           Cardano.Api
+
+import           Cardano.CLI.Environment (EnvCli (..))
+import           Cardano.CLI.EraBased.Commands.Address
+import           Cardano.CLI.EraBased.Options.Common
+
+import           Data.Foldable
+import           Options.Applicative hiding (help, str)
+import qualified Options.Applicative as Opt
+
+pAddressCmds :: CardanoEra era -> EnvCli -> Parser (AddressCmds era)
+pAddressCmds _ envCli =
+  asum
+    [ subParser "key-gen"
+        $ Opt.info pAddressKeyGen
+        $ Opt.progDesc "Create an address key pair."
+    , subParser "key-hash"
+        $ Opt.info pAddressKeyHash
+        $ Opt.progDesc "Print the hash of an address key."
+    , subParser "build"
+        $ Opt.info (pAddressBuild envCli)
+        $ Opt.progDesc "Build a Shelley payment address, with optional delegation to a stake address."
+    , subParser "info"
+        $ Opt.info pAddressInfo
+        $ Opt.progDesc "Print information about an address."
+    ]
+
+pAddressKeyGen :: Parser (AddressCmds era)
+pAddressKeyGen =
+  AddressKeyGen
+    <$> pKeyOutputFormat
+    <*> pAddressKeyType
+    <*> pVerificationKeyFileOut
+    <*> pSigningKeyFileOut
+
+pAddressKeyHash :: Parser (AddressCmds era)
+pAddressKeyHash =
+  AddressKeyHash
+    <$> pPaymentVerificationKeyTextOrFile
+    <*> pMaybeOutputFile
+
+pAddressBuild :: EnvCli -> Parser (AddressCmds era)
+pAddressBuild envCli =
+  AddressBuild
+    <$> pPaymentVerifier
+    <*> Opt.optional pStakeIdentifier
+    <*> pNetworkId envCli
+    <*> pMaybeOutputFile
+
+pAddressInfo :: Parser (AddressCmds era)
+pAddressInfo =
+  AddressInfo
+    <$> pAddress
+    <*> pMaybeOutputFile

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run.hs
@@ -11,6 +11,7 @@ import           Cardano.Api
 
 import           Cardano.CLI.EraBased.Commands
 import           Cardano.CLI.EraBased.Options.Governance
+import           Cardano.CLI.EraBased.Run.Address
 import           Cardano.CLI.EraBased.Run.Governance
 import           Cardano.CLI.EraBased.Run.Governance.Actions
 import           Cardano.CLI.EraBased.Run.Governance.Committee
@@ -33,8 +34,11 @@ runAnyEraCommand = \case
     shelleyBasedEraConstraints sbe $ runEraBasedCommand cmd
 
 runEraBasedCommand :: ()
-  => EraBasedCommand era -> ExceptT CmdError IO ()
+  => EraBasedCommand era
+  -> ExceptT CmdError IO ()
 runEraBasedCommand = \case
+  AddressCmds cmd ->
+    runAddressCmds cmd & firstExceptT CmdAddressError
   EraBasedGovernanceCmds cmd ->
     runEraBasedGovernanceCmds cmd
   StakeAddressCmds cmd ->

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Address.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Address.hs
@@ -14,11 +14,11 @@ import           Cardano.Api
 import           Cardano.Api.Shelley
 
 import           Cardano.CLI.Read
-import           Cardano.CLI.Types.Key (PaymentVerifier (..), StakeIdentifier (..),
-                   StakeVerifier (..), VerificationKeyTextOrFile, generateKeyPair, readVerificationKeyOrFile,
-                   readVerificationKeyTextOrFileAnyOf)
 import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Errors.ShelleyAddressCmdError
+import           Cardano.CLI.Types.Key (PaymentVerifier (..), StakeIdentifier (..),
+                   StakeVerifier (..), VerificationKeyTextOrFile, generateKeyPair,
+                   readVerificationKeyOrFile, readVerificationKeyTextOrFileAnyOf)
 
 import           Control.Monad.IO.Class (MonadIO (..))
 import           Control.Monad.Trans.Except (ExceptT)
@@ -37,13 +37,9 @@ runAddressKeyGenCmd fmt kt vkf skf = case kt of
   AddressKeyShelleyExtended -> generateAndWriteKeyFiles fmt  AsPaymentExtendedKey  vkf skf
   AddressKeyByron           -> generateAndWriteByronKeyFiles AsByronKey            vkf skf
 
-generateAndWriteByronKeyFiles
-  :: Key keyrole
-#if __GLASGOW_HASKELL__ >= 904
--- GHC 8.10 considers the HasTypeProxy constraint redundant but ghc-9.4 and above complains if its
--- not present.
+generateAndWriteByronKeyFiles :: ()
+  => Key keyrole
   => HasTypeProxy keyrole
-#endif
   => AsType keyrole
   -> VerificationKeyFile Out
   -> SigningKeyFile Out
@@ -51,13 +47,9 @@ generateAndWriteByronKeyFiles
 generateAndWriteByronKeyFiles asType vkf skf = do
   uncurry (writeByronPaymentKeyFiles vkf skf) =<< liftIO (generateKeyPair asType)
 
-generateAndWriteKeyFiles
-  :: Key keyrole
-#if __GLASGOW_HASKELL__ >= 904
--- GHC 8.10 considers the HasTypeProxy constraint redundant but ghc-9.4 and above complains if its
--- not present.
+generateAndWriteKeyFiles :: ()
+  => Key keyrole
   => HasTypeProxy keyrole
-#endif
   => SerialiseAsBech32 (SigningKey keyrole)
   => SerialiseAsBech32 (VerificationKey keyrole)
   => KeyOutputFormat

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Address.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Address.hs
@@ -1,11 +1,14 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Cardano.CLI.EraBased.Run.Address
-  ( runAddressBuildCmd
+  ( runAddressCmds
+
+  , runAddressBuildCmd
   , runAddressKeyGenCmd
   , runAddressKeyHashCmd
   ) where
@@ -13,6 +16,8 @@ module Cardano.CLI.EraBased.Run.Address
 import           Cardano.Api
 import           Cardano.Api.Shelley
 
+import           Cardano.CLI.EraBased.Commands.Address
+import           Cardano.CLI.EraBased.Run.Address.Info
 import           Cardano.CLI.Read
 import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Errors.ShelleyAddressCmdError
@@ -24,7 +29,21 @@ import           Control.Monad.IO.Class (MonadIO (..))
 import           Control.Monad.Trans.Except (ExceptT)
 import           Control.Monad.Trans.Except.Extra (firstExceptT, left, newExceptT)
 import qualified Data.ByteString.Char8 as BS
+import           Data.Function
 import qualified Data.Text.IO as Text
+
+runAddressCmds :: ()
+  => AddressCmds era
+  -> ExceptT ShelleyAddressCmdError IO ()
+runAddressCmds = \case
+  AddressKeyGen fmt kt vkf skf ->
+    runAddressKeyGenCmd fmt kt vkf skf
+  AddressKeyHash vkf mOFp ->
+    runAddressKeyHashCmd vkf mOFp
+  AddressBuild paymentVerifier mbStakeVerifier nw mOutFp ->
+    runAddressBuildCmd paymentVerifier mbStakeVerifier nw mOutFp
+  AddressInfo txt mOFp ->
+    runAddressInfoCmd txt mOFp & firstExceptT ShelleyAddressCmdAddressInfoError
 
 runAddressKeyGenCmd
   :: KeyOutputFormat

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Key.hs
@@ -76,9 +76,10 @@ data SomeSigningKey
   | AVrfSigningKey             (SigningKey VrfKey)
   | AKesSigningKey             (SigningKey KesKey)
 
-withSomeSigningKey :: SomeSigningKey
-                   -> (forall keyrole. (Key keyrole, HasTypeProxy keyrole) => SigningKey keyrole -> a)
-                   -> a
+withSomeSigningKey :: ()
+  => SomeSigningKey
+  -> (forall keyrole. (Key keyrole, HasTypeProxy keyrole) => SigningKey keyrole -> a)
+  -> a
 withSomeSigningKey ssk f =
     case ssk of
       AByronSigningKey           sk -> f sk

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Genesis.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE ConstraintKinds #-}
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
@@ -46,17 +45,17 @@ import           Cardano.Chain.Update hiding (ProtocolParameters)
 import           Cardano.CLI.Byron.Delegation
 import           Cardano.CLI.Byron.Genesis as Byron
 import qualified Cardano.CLI.Byron.Key as Byron
+import           Cardano.CLI.EraBased.Run.StakeAddress (runStakeAddressKeyGenCmd)
 import qualified Cardano.CLI.IO.Lazy as Lazy
 import           Cardano.CLI.Legacy.Commands.Genesis
-import           Cardano.CLI.Legacy.Run.Node (
-                   runLegacyNodeIssueOpCertCmd, runLegacyNodeKeyGenColdCmd, runLegacyNodeKeyGenKesCmd, runLegacyNodeKeyGenVrfCmd)
-import           Cardano.CLI.EraBased.Run.StakeAddress (runStakeAddressKeyGenCmd)
+import           Cardano.CLI.Legacy.Run.Node (runLegacyNodeIssueOpCertCmd,
+                   runLegacyNodeKeyGenColdCmd, runLegacyNodeKeyGenKesCmd, runLegacyNodeKeyGenVrfCmd)
 import           Cardano.CLI.Orphans ()
 import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Errors.ProtocolParamsError
 import           Cardano.CLI.Types.Errors.ShelleyGenesisCmdError
-import           Cardano.CLI.Types.Errors.ShelleyPoolCmdError
 import           Cardano.CLI.Types.Errors.ShelleyNodeCmdError
+import           Cardano.CLI.Types.Errors.ShelleyPoolCmdError
 import           Cardano.CLI.Types.Key
 import qualified Cardano.Crypto as CC
 import           Cardano.Crypto.Hash (HashAlgorithm)
@@ -403,15 +402,11 @@ runLegacyGenesisCreateCmd
 toSKeyJSON :: Key a => SigningKey a -> ByteString
 toSKeyJSON = LBS.toStrict . textEnvelopeToJSON Nothing
 
-toVkeyJSON ::
-#if __GLASGOW_HASKELL__ >= 904
--- GHC 8.10 considers the HasTypeProxy constraint redundant but ghc-9.4 and above complains if its
--- not present.
-              (Key a, HasTypeProxy a) =>
-#else
-              (Key a) =>
-#endif
-              SigningKey a -> ByteString
+toVkeyJSON :: ()
+  => Key a
+  => HasTypeProxy a
+  => SigningKey a
+  -> ByteString
 toVkeyJSON = LBS.toStrict . textEnvelopeToJSON Nothing . getVerificationKey
 
 toVkeyJSON' :: Key a => VerificationKey a -> ByteString

--- a/cardano-cli/src/Cardano/CLI/Types/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Key.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
@@ -323,15 +322,11 @@ readVerificationKeyOrHashOrTextEnvFile asType verKeyOrHashOrFile =
       pure (verificationKeyHash <$> eitherVk)
     VerificationKeyHash vkHash -> pure (Right vkHash)
 
-generateKeyPair ::
-#if __GLASGOW_HASKELL__ >= 904
--- GHC 8.10 considers the HasTypeProxy constraint redundant but ghc-9.4 and above complains if its
--- not present.
-    (Key keyrole, HasTypeProxy keyrole) =>
-#else
-    Key keyrole =>
-#endif
-    AsType keyrole -> IO (VerificationKey keyrole, SigningKey keyrole)
+generateKeyPair :: ()
+  => Key keyrole
+  => HasTypeProxy keyrole
+  => AsType keyrole
+  -> IO (VerificationKey keyrole, SigningKey keyrole)
 generateKeyPair asType = do
   skey <- generateSigningKey asType
   return (getVerificationKey skey, skey)

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -13,9 +13,50 @@ Usage: cardano-cli
                      | version
                      )
 
-Usage: cardano-cli shelley (governance | stake-address | transaction)
+Usage: cardano-cli shelley (address | governance | stake-address | transaction)
 
   Shelley era commands
+
+Usage: cardano-cli shelley address (key-gen | key-hash | build | info)
+
+  Era-based address commands
+
+Usage: cardano-cli shelley address key-gen [--key-output-format STRING]
+                                             [ --normal-key
+                                             | --extended-key
+                                             | --byron-key
+                                             ]
+                                             --verification-key-file FILE
+                                             --signing-key-file FILE
+
+  Create an address key pair.
+
+Usage: cardano-cli shelley address key-hash 
+                                              ( --payment-verification-key STRING
+                                              | --payment-verification-key-file FILE
+                                              )
+                                              [--out-file FILE]
+
+  Print the hash of an address key.
+
+Usage: cardano-cli shelley address build 
+                                           ( --payment-verification-key STRING
+                                           | --payment-verification-key-file FILE
+                                           | --payment-script-file FILE
+                                           )
+                                           [ --stake-verification-key STRING
+                                           | --stake-verification-key-file FILE
+                                           | --stake-script-file FILE
+                                           | --stake-address ADDRESS
+                                           ]
+                                           (--mainnet | --testnet-magic NATURAL)
+                                           [--out-file FILE]
+
+  Build a Shelley payment address, with optional delegation to a stake address.
+
+Usage: cardano-cli shelley address info --address ADDRESS [--out-file FILE]
+
+  Print information about an address.
 
 Usage: cardano-cli shelley governance (create-mir-certificate | action | drep)
 
@@ -602,9 +643,50 @@ Usage: cardano-cli shelley transaction view
 
   Print a transaction.
 
-Usage: cardano-cli allegra (governance | stake-address | transaction)
+Usage: cardano-cli allegra (address | governance | stake-address | transaction)
 
   Allegra era commands
+
+Usage: cardano-cli allegra address (key-gen | key-hash | build | info)
+
+  Era-based address commands
+
+Usage: cardano-cli allegra address key-gen [--key-output-format STRING]
+                                             [ --normal-key
+                                             | --extended-key
+                                             | --byron-key
+                                             ]
+                                             --verification-key-file FILE
+                                             --signing-key-file FILE
+
+  Create an address key pair.
+
+Usage: cardano-cli allegra address key-hash 
+                                              ( --payment-verification-key STRING
+                                              | --payment-verification-key-file FILE
+                                              )
+                                              [--out-file FILE]
+
+  Print the hash of an address key.
+
+Usage: cardano-cli allegra address build 
+                                           ( --payment-verification-key STRING
+                                           | --payment-verification-key-file FILE
+                                           | --payment-script-file FILE
+                                           )
+                                           [ --stake-verification-key STRING
+                                           | --stake-verification-key-file FILE
+                                           | --stake-script-file FILE
+                                           | --stake-address ADDRESS
+                                           ]
+                                           (--mainnet | --testnet-magic NATURAL)
+                                           [--out-file FILE]
+
+  Build a Shelley payment address, with optional delegation to a stake address.
+
+Usage: cardano-cli allegra address info --address ADDRESS [--out-file FILE]
+
+  Print information about an address.
 
 Usage: cardano-cli allegra governance (create-mir-certificate | action | drep)
 
@@ -1191,9 +1273,50 @@ Usage: cardano-cli allegra transaction view
 
   Print a transaction.
 
-Usage: cardano-cli mary (governance | stake-address | transaction)
+Usage: cardano-cli mary (address | governance | stake-address | transaction)
 
   Mary era commands
+
+Usage: cardano-cli mary address (key-gen | key-hash | build | info)
+
+  Era-based address commands
+
+Usage: cardano-cli mary address key-gen [--key-output-format STRING]
+                                          [ --normal-key
+                                          | --extended-key
+                                          | --byron-key
+                                          ]
+                                          --verification-key-file FILE
+                                          --signing-key-file FILE
+
+  Create an address key pair.
+
+Usage: cardano-cli mary address key-hash 
+                                           ( --payment-verification-key STRING
+                                           | --payment-verification-key-file FILE
+                                           )
+                                           [--out-file FILE]
+
+  Print the hash of an address key.
+
+Usage: cardano-cli mary address build 
+                                        ( --payment-verification-key STRING
+                                        | --payment-verification-key-file FILE
+                                        | --payment-script-file FILE
+                                        )
+                                        [ --stake-verification-key STRING
+                                        | --stake-verification-key-file FILE
+                                        | --stake-script-file FILE
+                                        | --stake-address ADDRESS
+                                        ]
+                                        (--mainnet | --testnet-magic NATURAL)
+                                        [--out-file FILE]
+
+  Build a Shelley payment address, with optional delegation to a stake address.
+
+Usage: cardano-cli mary address info --address ADDRESS [--out-file FILE]
+
+  Print information about an address.
 
 Usage: cardano-cli mary governance (create-mir-certificate | action | drep)
 
@@ -1765,9 +1888,50 @@ Usage: cardano-cli mary transaction view (--tx-body-file FILE | --tx-file FILE)
 
   Print a transaction.
 
-Usage: cardano-cli alonzo (governance | stake-address | transaction)
+Usage: cardano-cli alonzo (address | governance | stake-address | transaction)
 
   Alonzo era commands
+
+Usage: cardano-cli alonzo address (key-gen | key-hash | build | info)
+
+  Era-based address commands
+
+Usage: cardano-cli alonzo address key-gen [--key-output-format STRING]
+                                            [ --normal-key
+                                            | --extended-key
+                                            | --byron-key
+                                            ]
+                                            --verification-key-file FILE
+                                            --signing-key-file FILE
+
+  Create an address key pair.
+
+Usage: cardano-cli alonzo address key-hash 
+                                             ( --payment-verification-key STRING
+                                             | --payment-verification-key-file FILE
+                                             )
+                                             [--out-file FILE]
+
+  Print the hash of an address key.
+
+Usage: cardano-cli alonzo address build 
+                                          ( --payment-verification-key STRING
+                                          | --payment-verification-key-file FILE
+                                          | --payment-script-file FILE
+                                          )
+                                          [ --stake-verification-key STRING
+                                          | --stake-verification-key-file FILE
+                                          | --stake-script-file FILE
+                                          | --stake-address ADDRESS
+                                          ]
+                                          (--mainnet | --testnet-magic NATURAL)
+                                          [--out-file FILE]
+
+  Build a Shelley payment address, with optional delegation to a stake address.
+
+Usage: cardano-cli alonzo address info --address ADDRESS [--out-file FILE]
+
+  Print information about an address.
 
 Usage: cardano-cli alonzo governance (create-mir-certificate | action | drep)
 
@@ -2361,9 +2525,50 @@ Usage: cardano-cli alonzo transaction view
 
   Print a transaction.
 
-Usage: cardano-cli babbage (governance | stake-address | transaction)
+Usage: cardano-cli babbage (address | governance | stake-address | transaction)
 
   Babbage era commands
+
+Usage: cardano-cli babbage address (key-gen | key-hash | build | info)
+
+  Era-based address commands
+
+Usage: cardano-cli babbage address key-gen [--key-output-format STRING]
+                                             [ --normal-key
+                                             | --extended-key
+                                             | --byron-key
+                                             ]
+                                             --verification-key-file FILE
+                                             --signing-key-file FILE
+
+  Create an address key pair.
+
+Usage: cardano-cli babbage address key-hash 
+                                              ( --payment-verification-key STRING
+                                              | --payment-verification-key-file FILE
+                                              )
+                                              [--out-file FILE]
+
+  Print the hash of an address key.
+
+Usage: cardano-cli babbage address build 
+                                           ( --payment-verification-key STRING
+                                           | --payment-verification-key-file FILE
+                                           | --payment-script-file FILE
+                                           )
+                                           [ --stake-verification-key STRING
+                                           | --stake-verification-key-file FILE
+                                           | --stake-script-file FILE
+                                           | --stake-address ADDRESS
+                                           ]
+                                           (--mainnet | --testnet-magic NATURAL)
+                                           [--out-file FILE]
+
+  Build a Shelley payment address, with optional delegation to a stake address.
+
+Usage: cardano-cli babbage address info --address ADDRESS [--out-file FILE]
+
+  Print information about an address.
 
 Usage: cardano-cli babbage governance (create-mir-certificate | action | drep)
 
@@ -2953,9 +3158,50 @@ Usage: cardano-cli babbage transaction view
 
   Print a transaction.
 
-Usage: cardano-cli conway (governance | stake-address | transaction)
+Usage: cardano-cli conway (address | governance | stake-address | transaction)
 
   Conway era commands
+
+Usage: cardano-cli conway address (key-gen | key-hash | build | info)
+
+  Era-based address commands
+
+Usage: cardano-cli conway address key-gen [--key-output-format STRING]
+                                            [ --normal-key
+                                            | --extended-key
+                                            | --byron-key
+                                            ]
+                                            --verification-key-file FILE
+                                            --signing-key-file FILE
+
+  Create an address key pair.
+
+Usage: cardano-cli conway address key-hash 
+                                             ( --payment-verification-key STRING
+                                             | --payment-verification-key-file FILE
+                                             )
+                                             [--out-file FILE]
+
+  Print the hash of an address key.
+
+Usage: cardano-cli conway address build 
+                                          ( --payment-verification-key STRING
+                                          | --payment-verification-key-file FILE
+                                          | --payment-script-file FILE
+                                          )
+                                          [ --stake-verification-key STRING
+                                          | --stake-verification-key-file FILE
+                                          | --stake-script-file FILE
+                                          | --stake-address ADDRESS
+                                          ]
+                                          (--mainnet | --testnet-magic NATURAL)
+                                          [--out-file FILE]
+
+  Build a Shelley payment address, with optional delegation to a stake address.
+
+Usage: cardano-cli conway address info --address ADDRESS [--out-file FILE]
+
+  Print information about an address.
 
 Usage: cardano-cli conway governance (query | action | committee | drep | vote)
 
@@ -3831,9 +4077,50 @@ Usage: cardano-cli conway transaction view
 
   Print a transaction.
 
-Usage: cardano-cli latest (governance | stake-address | transaction)
+Usage: cardano-cli latest (address | governance | stake-address | transaction)
 
   Latest era commands (Babbage)
+
+Usage: cardano-cli latest address (key-gen | key-hash | build | info)
+
+  Era-based address commands
+
+Usage: cardano-cli latest address key-gen [--key-output-format STRING]
+                                            [ --normal-key
+                                            | --extended-key
+                                            | --byron-key
+                                            ]
+                                            --verification-key-file FILE
+                                            --signing-key-file FILE
+
+  Create an address key pair.
+
+Usage: cardano-cli latest address key-hash 
+                                             ( --payment-verification-key STRING
+                                             | --payment-verification-key-file FILE
+                                             )
+                                             [--out-file FILE]
+
+  Print the hash of an address key.
+
+Usage: cardano-cli latest address build 
+                                          ( --payment-verification-key STRING
+                                          | --payment-verification-key-file FILE
+                                          | --payment-script-file FILE
+                                          )
+                                          [ --stake-verification-key STRING
+                                          | --stake-verification-key-file FILE
+                                          | --stake-script-file FILE
+                                          | --stake-address ADDRESS
+                                          ]
+                                          (--mainnet | --testnet-magic NATURAL)
+                                          [--out-file FILE]
+
+  Build a Shelley payment address, with optional delegation to a stake address.
+
+Usage: cardano-cli latest address info --address ADDRESS [--out-file FILE]
+
+  Print information about an address.
 
 Usage: cardano-cli latest governance (create-mir-certificate | action | drep)
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra.cli
@@ -1,4 +1,4 @@
-Usage: cardano-cli allegra (governance | stake-address | transaction)
+Usage: cardano-cli allegra (address | governance | stake-address | transaction)
 
   Allegra era commands
 
@@ -6,6 +6,7 @@ Available options:
   -h,--help                Show this help text
 
 Available commands:
+  address                  Era-based address commands
   governance               Era-based governance commands
   stake-address            Stake address commands.
   transaction              Era-based governance commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_address.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_address.cli
@@ -1,0 +1,13 @@
+Usage: cardano-cli allegra address (key-gen | key-hash | build | info)
+
+  Era-based address commands
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  key-gen                  Create an address key pair.
+  key-hash                 Print the hash of an address key.
+  build                    Build a Shelley payment address, with optional
+                           delegation to a stake address.
+  info                     Print information about an address.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_address_build.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_address_build.cli
@@ -1,0 +1,34 @@
+Usage: cardano-cli allegra address build 
+                                           ( --payment-verification-key STRING
+                                           | --payment-verification-key-file FILE
+                                           | --payment-script-file FILE
+                                           )
+                                           [ --stake-verification-key STRING
+                                           | --stake-verification-key-file FILE
+                                           | --stake-script-file FILE
+                                           | --stake-address ADDRESS
+                                           ]
+                                           (--mainnet | --testnet-magic NATURAL)
+                                           [--out-file FILE]
+
+  Build a Shelley payment address, with optional delegation to a stake address.
+
+Available options:
+  --payment-verification-key STRING
+                           Payment verification key (Bech32-encoded)
+  --payment-verification-key-file FILE
+                           Filepath of the payment verification key.
+  --payment-script-file FILE
+                           Filepath of the payment script.
+  --stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --stake-verification-key-file FILE
+                           Filepath of the staking verification key.
+  --stake-script-file FILE Filepath of the staking script.
+  --stake-address ADDRESS  Target stake address (bech32 format).
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_address_info.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_address_info.cli
@@ -1,0 +1,8 @@
+Usage: cardano-cli allegra address info --address ADDRESS [--out-file FILE]
+
+  Print information about an address.
+
+Available options:
+  --address ADDRESS        A Cardano address
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_address_key-gen.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_address_key-gen.cli
@@ -1,0 +1,22 @@
+Usage: cardano-cli allegra address key-gen [--key-output-format STRING]
+                                             [ --normal-key
+                                             | --extended-key
+                                             | --byron-key
+                                             ]
+                                             --verification-key-file FILE
+                                             --signing-key-file FILE
+
+  Create an address key pair.
+
+Available options:
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32" (default is
+                           "bech32").
+  --normal-key             Use a normal Shelley-era key (default).
+  --extended-key           Use an extended ed25519 Shelley-era key.
+  --byron-key              Use a Byron-era key.
+  --verification-key-file FILE
+                           Output filepath of the verification key.
+  --signing-key-file FILE  Output filepath of the signing key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_address_key-hash.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_address_key-hash.cli
@@ -1,0 +1,15 @@
+Usage: cardano-cli allegra address key-hash 
+                                              ( --payment-verification-key STRING
+                                              | --payment-verification-key-file FILE
+                                              )
+                                              [--out-file FILE]
+
+  Print the hash of an address key.
+
+Available options:
+  --payment-verification-key STRING
+                           Payment verification key (Bech32-encoded)
+  --payment-verification-key-file FILE
+                           Filepath of the payment verification key.
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo.cli
@@ -1,4 +1,4 @@
-Usage: cardano-cli alonzo (governance | stake-address | transaction)
+Usage: cardano-cli alonzo (address | governance | stake-address | transaction)
 
   Alonzo era commands
 
@@ -6,6 +6,7 @@ Available options:
   -h,--help                Show this help text
 
 Available commands:
+  address                  Era-based address commands
   governance               Era-based governance commands
   stake-address            Stake address commands.
   transaction              Era-based governance commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_address.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_address.cli
@@ -1,0 +1,13 @@
+Usage: cardano-cli alonzo address (key-gen | key-hash | build | info)
+
+  Era-based address commands
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  key-gen                  Create an address key pair.
+  key-hash                 Print the hash of an address key.
+  build                    Build a Shelley payment address, with optional
+                           delegation to a stake address.
+  info                     Print information about an address.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_address_build.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_address_build.cli
@@ -1,0 +1,34 @@
+Usage: cardano-cli alonzo address build 
+                                          ( --payment-verification-key STRING
+                                          | --payment-verification-key-file FILE
+                                          | --payment-script-file FILE
+                                          )
+                                          [ --stake-verification-key STRING
+                                          | --stake-verification-key-file FILE
+                                          | --stake-script-file FILE
+                                          | --stake-address ADDRESS
+                                          ]
+                                          (--mainnet | --testnet-magic NATURAL)
+                                          [--out-file FILE]
+
+  Build a Shelley payment address, with optional delegation to a stake address.
+
+Available options:
+  --payment-verification-key STRING
+                           Payment verification key (Bech32-encoded)
+  --payment-verification-key-file FILE
+                           Filepath of the payment verification key.
+  --payment-script-file FILE
+                           Filepath of the payment script.
+  --stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --stake-verification-key-file FILE
+                           Filepath of the staking verification key.
+  --stake-script-file FILE Filepath of the staking script.
+  --stake-address ADDRESS  Target stake address (bech32 format).
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_address_info.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_address_info.cli
@@ -1,0 +1,8 @@
+Usage: cardano-cli alonzo address info --address ADDRESS [--out-file FILE]
+
+  Print information about an address.
+
+Available options:
+  --address ADDRESS        A Cardano address
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_address_key-gen.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_address_key-gen.cli
@@ -1,0 +1,22 @@
+Usage: cardano-cli alonzo address key-gen [--key-output-format STRING]
+                                            [ --normal-key
+                                            | --extended-key
+                                            | --byron-key
+                                            ]
+                                            --verification-key-file FILE
+                                            --signing-key-file FILE
+
+  Create an address key pair.
+
+Available options:
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32" (default is
+                           "bech32").
+  --normal-key             Use a normal Shelley-era key (default).
+  --extended-key           Use an extended ed25519 Shelley-era key.
+  --byron-key              Use a Byron-era key.
+  --verification-key-file FILE
+                           Output filepath of the verification key.
+  --signing-key-file FILE  Output filepath of the signing key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_address_key-hash.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_address_key-hash.cli
@@ -1,0 +1,15 @@
+Usage: cardano-cli alonzo address key-hash 
+                                             ( --payment-verification-key STRING
+                                             | --payment-verification-key-file FILE
+                                             )
+                                             [--out-file FILE]
+
+  Print the hash of an address key.
+
+Available options:
+  --payment-verification-key STRING
+                           Payment verification key (Bech32-encoded)
+  --payment-verification-key-file FILE
+                           Filepath of the payment verification key.
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage.cli
@@ -1,4 +1,4 @@
-Usage: cardano-cli babbage (governance | stake-address | transaction)
+Usage: cardano-cli babbage (address | governance | stake-address | transaction)
 
   Babbage era commands
 
@@ -6,6 +6,7 @@ Available options:
   -h,--help                Show this help text
 
 Available commands:
+  address                  Era-based address commands
   governance               Era-based governance commands
   stake-address            Stake address commands.
   transaction              Era-based governance commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_address.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_address.cli
@@ -1,0 +1,13 @@
+Usage: cardano-cli babbage address (key-gen | key-hash | build | info)
+
+  Era-based address commands
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  key-gen                  Create an address key pair.
+  key-hash                 Print the hash of an address key.
+  build                    Build a Shelley payment address, with optional
+                           delegation to a stake address.
+  info                     Print information about an address.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_address_build.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_address_build.cli
@@ -1,0 +1,34 @@
+Usage: cardano-cli babbage address build 
+                                           ( --payment-verification-key STRING
+                                           | --payment-verification-key-file FILE
+                                           | --payment-script-file FILE
+                                           )
+                                           [ --stake-verification-key STRING
+                                           | --stake-verification-key-file FILE
+                                           | --stake-script-file FILE
+                                           | --stake-address ADDRESS
+                                           ]
+                                           (--mainnet | --testnet-magic NATURAL)
+                                           [--out-file FILE]
+
+  Build a Shelley payment address, with optional delegation to a stake address.
+
+Available options:
+  --payment-verification-key STRING
+                           Payment verification key (Bech32-encoded)
+  --payment-verification-key-file FILE
+                           Filepath of the payment verification key.
+  --payment-script-file FILE
+                           Filepath of the payment script.
+  --stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --stake-verification-key-file FILE
+                           Filepath of the staking verification key.
+  --stake-script-file FILE Filepath of the staking script.
+  --stake-address ADDRESS  Target stake address (bech32 format).
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_address_info.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_address_info.cli
@@ -1,0 +1,8 @@
+Usage: cardano-cli babbage address info --address ADDRESS [--out-file FILE]
+
+  Print information about an address.
+
+Available options:
+  --address ADDRESS        A Cardano address
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_address_key-gen.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_address_key-gen.cli
@@ -1,0 +1,22 @@
+Usage: cardano-cli babbage address key-gen [--key-output-format STRING]
+                                             [ --normal-key
+                                             | --extended-key
+                                             | --byron-key
+                                             ]
+                                             --verification-key-file FILE
+                                             --signing-key-file FILE
+
+  Create an address key pair.
+
+Available options:
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32" (default is
+                           "bech32").
+  --normal-key             Use a normal Shelley-era key (default).
+  --extended-key           Use an extended ed25519 Shelley-era key.
+  --byron-key              Use a Byron-era key.
+  --verification-key-file FILE
+                           Output filepath of the verification key.
+  --signing-key-file FILE  Output filepath of the signing key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_address_key-hash.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_address_key-hash.cli
@@ -1,0 +1,15 @@
+Usage: cardano-cli babbage address key-hash 
+                                              ( --payment-verification-key STRING
+                                              | --payment-verification-key-file FILE
+                                              )
+                                              [--out-file FILE]
+
+  Print the hash of an address key.
+
+Available options:
+  --payment-verification-key STRING
+                           Payment verification key (Bech32-encoded)
+  --payment-verification-key-file FILE
+                           Filepath of the payment verification key.
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway.cli
@@ -1,4 +1,4 @@
-Usage: cardano-cli conway (governance | stake-address | transaction)
+Usage: cardano-cli conway (address | governance | stake-address | transaction)
 
   Conway era commands
 
@@ -6,6 +6,7 @@ Available options:
   -h,--help                Show this help text
 
 Available commands:
+  address                  Era-based address commands
   governance               Era-based governance commands
   stake-address            Stake address commands.
   transaction              Era-based governance commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_address.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_address.cli
@@ -1,0 +1,13 @@
+Usage: cardano-cli conway address (key-gen | key-hash | build | info)
+
+  Era-based address commands
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  key-gen                  Create an address key pair.
+  key-hash                 Print the hash of an address key.
+  build                    Build a Shelley payment address, with optional
+                           delegation to a stake address.
+  info                     Print information about an address.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_address_build.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_address_build.cli
@@ -1,0 +1,34 @@
+Usage: cardano-cli conway address build 
+                                          ( --payment-verification-key STRING
+                                          | --payment-verification-key-file FILE
+                                          | --payment-script-file FILE
+                                          )
+                                          [ --stake-verification-key STRING
+                                          | --stake-verification-key-file FILE
+                                          | --stake-script-file FILE
+                                          | --stake-address ADDRESS
+                                          ]
+                                          (--mainnet | --testnet-magic NATURAL)
+                                          [--out-file FILE]
+
+  Build a Shelley payment address, with optional delegation to a stake address.
+
+Available options:
+  --payment-verification-key STRING
+                           Payment verification key (Bech32-encoded)
+  --payment-verification-key-file FILE
+                           Filepath of the payment verification key.
+  --payment-script-file FILE
+                           Filepath of the payment script.
+  --stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --stake-verification-key-file FILE
+                           Filepath of the staking verification key.
+  --stake-script-file FILE Filepath of the staking script.
+  --stake-address ADDRESS  Target stake address (bech32 format).
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_address_info.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_address_info.cli
@@ -1,0 +1,8 @@
+Usage: cardano-cli conway address info --address ADDRESS [--out-file FILE]
+
+  Print information about an address.
+
+Available options:
+  --address ADDRESS        A Cardano address
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_address_key-gen.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_address_key-gen.cli
@@ -1,0 +1,22 @@
+Usage: cardano-cli conway address key-gen [--key-output-format STRING]
+                                            [ --normal-key
+                                            | --extended-key
+                                            | --byron-key
+                                            ]
+                                            --verification-key-file FILE
+                                            --signing-key-file FILE
+
+  Create an address key pair.
+
+Available options:
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32" (default is
+                           "bech32").
+  --normal-key             Use a normal Shelley-era key (default).
+  --extended-key           Use an extended ed25519 Shelley-era key.
+  --byron-key              Use a Byron-era key.
+  --verification-key-file FILE
+                           Output filepath of the verification key.
+  --signing-key-file FILE  Output filepath of the signing key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_address_key-hash.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_address_key-hash.cli
@@ -1,0 +1,15 @@
+Usage: cardano-cli conway address key-hash 
+                                             ( --payment-verification-key STRING
+                                             | --payment-verification-key-file FILE
+                                             )
+                                             [--out-file FILE]
+
+  Print the hash of an address key.
+
+Available options:
+  --payment-verification-key STRING
+                           Payment verification key (Bech32-encoded)
+  --payment-verification-key-file FILE
+                           Filepath of the payment verification key.
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest.cli
@@ -1,4 +1,4 @@
-Usage: cardano-cli latest (governance | stake-address | transaction)
+Usage: cardano-cli latest (address | governance | stake-address | transaction)
 
   Latest era commands (Babbage)
 
@@ -6,6 +6,7 @@ Available options:
   -h,--help                Show this help text
 
 Available commands:
+  address                  Era-based address commands
   governance               Era-based governance commands
   stake-address            Stake address commands.
   transaction              Era-based governance commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_address.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_address.cli
@@ -1,0 +1,13 @@
+Usage: cardano-cli latest address (key-gen | key-hash | build | info)
+
+  Era-based address commands
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  key-gen                  Create an address key pair.
+  key-hash                 Print the hash of an address key.
+  build                    Build a Shelley payment address, with optional
+                           delegation to a stake address.
+  info                     Print information about an address.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_address_build.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_address_build.cli
@@ -1,0 +1,34 @@
+Usage: cardano-cli latest address build 
+                                          ( --payment-verification-key STRING
+                                          | --payment-verification-key-file FILE
+                                          | --payment-script-file FILE
+                                          )
+                                          [ --stake-verification-key STRING
+                                          | --stake-verification-key-file FILE
+                                          | --stake-script-file FILE
+                                          | --stake-address ADDRESS
+                                          ]
+                                          (--mainnet | --testnet-magic NATURAL)
+                                          [--out-file FILE]
+
+  Build a Shelley payment address, with optional delegation to a stake address.
+
+Available options:
+  --payment-verification-key STRING
+                           Payment verification key (Bech32-encoded)
+  --payment-verification-key-file FILE
+                           Filepath of the payment verification key.
+  --payment-script-file FILE
+                           Filepath of the payment script.
+  --stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --stake-verification-key-file FILE
+                           Filepath of the staking verification key.
+  --stake-script-file FILE Filepath of the staking script.
+  --stake-address ADDRESS  Target stake address (bech32 format).
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_address_info.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_address_info.cli
@@ -1,0 +1,8 @@
+Usage: cardano-cli latest address info --address ADDRESS [--out-file FILE]
+
+  Print information about an address.
+
+Available options:
+  --address ADDRESS        A Cardano address
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_address_key-gen.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_address_key-gen.cli
@@ -1,0 +1,22 @@
+Usage: cardano-cli latest address key-gen [--key-output-format STRING]
+                                            [ --normal-key
+                                            | --extended-key
+                                            | --byron-key
+                                            ]
+                                            --verification-key-file FILE
+                                            --signing-key-file FILE
+
+  Create an address key pair.
+
+Available options:
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32" (default is
+                           "bech32").
+  --normal-key             Use a normal Shelley-era key (default).
+  --extended-key           Use an extended ed25519 Shelley-era key.
+  --byron-key              Use a Byron-era key.
+  --verification-key-file FILE
+                           Output filepath of the verification key.
+  --signing-key-file FILE  Output filepath of the signing key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_address_key-hash.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_address_key-hash.cli
@@ -1,0 +1,15 @@
+Usage: cardano-cli latest address key-hash 
+                                             ( --payment-verification-key STRING
+                                             | --payment-verification-key-file FILE
+                                             )
+                                             [--out-file FILE]
+
+  Print the hash of an address key.
+
+Available options:
+  --payment-verification-key STRING
+                           Payment verification key (Bech32-encoded)
+  --payment-verification-key-file FILE
+                           Filepath of the payment verification key.
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary.cli
@@ -1,4 +1,4 @@
-Usage: cardano-cli mary (governance | stake-address | transaction)
+Usage: cardano-cli mary (address | governance | stake-address | transaction)
 
   Mary era commands
 
@@ -6,6 +6,7 @@ Available options:
   -h,--help                Show this help text
 
 Available commands:
+  address                  Era-based address commands
   governance               Era-based governance commands
   stake-address            Stake address commands.
   transaction              Era-based governance commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_address.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_address.cli
@@ -1,0 +1,13 @@
+Usage: cardano-cli mary address (key-gen | key-hash | build | info)
+
+  Era-based address commands
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  key-gen                  Create an address key pair.
+  key-hash                 Print the hash of an address key.
+  build                    Build a Shelley payment address, with optional
+                           delegation to a stake address.
+  info                     Print information about an address.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_address_build.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_address_build.cli
@@ -1,0 +1,34 @@
+Usage: cardano-cli mary address build 
+                                        ( --payment-verification-key STRING
+                                        | --payment-verification-key-file FILE
+                                        | --payment-script-file FILE
+                                        )
+                                        [ --stake-verification-key STRING
+                                        | --stake-verification-key-file FILE
+                                        | --stake-script-file FILE
+                                        | --stake-address ADDRESS
+                                        ]
+                                        (--mainnet | --testnet-magic NATURAL)
+                                        [--out-file FILE]
+
+  Build a Shelley payment address, with optional delegation to a stake address.
+
+Available options:
+  --payment-verification-key STRING
+                           Payment verification key (Bech32-encoded)
+  --payment-verification-key-file FILE
+                           Filepath of the payment verification key.
+  --payment-script-file FILE
+                           Filepath of the payment script.
+  --stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --stake-verification-key-file FILE
+                           Filepath of the staking verification key.
+  --stake-script-file FILE Filepath of the staking script.
+  --stake-address ADDRESS  Target stake address (bech32 format).
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_address_info.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_address_info.cli
@@ -1,0 +1,8 @@
+Usage: cardano-cli mary address info --address ADDRESS [--out-file FILE]
+
+  Print information about an address.
+
+Available options:
+  --address ADDRESS        A Cardano address
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_address_key-gen.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_address_key-gen.cli
@@ -1,0 +1,22 @@
+Usage: cardano-cli mary address key-gen [--key-output-format STRING]
+                                          [ --normal-key
+                                          | --extended-key
+                                          | --byron-key
+                                          ]
+                                          --verification-key-file FILE
+                                          --signing-key-file FILE
+
+  Create an address key pair.
+
+Available options:
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32" (default is
+                           "bech32").
+  --normal-key             Use a normal Shelley-era key (default).
+  --extended-key           Use an extended ed25519 Shelley-era key.
+  --byron-key              Use a Byron-era key.
+  --verification-key-file FILE
+                           Output filepath of the verification key.
+  --signing-key-file FILE  Output filepath of the signing key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_address_key-hash.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_address_key-hash.cli
@@ -1,0 +1,15 @@
+Usage: cardano-cli mary address key-hash 
+                                           ( --payment-verification-key STRING
+                                           | --payment-verification-key-file FILE
+                                           )
+                                           [--out-file FILE]
+
+  Print the hash of an address key.
+
+Available options:
+  --payment-verification-key STRING
+                           Payment verification key (Bech32-encoded)
+  --payment-verification-key-file FILE
+                           Filepath of the payment verification key.
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley.cli
@@ -1,4 +1,4 @@
-Usage: cardano-cli shelley (governance | stake-address | transaction)
+Usage: cardano-cli shelley (address | governance | stake-address | transaction)
 
   Shelley era commands
 
@@ -6,6 +6,7 @@ Available options:
   -h,--help                Show this help text
 
 Available commands:
+  address                  Era-based address commands
   governance               Era-based governance commands
   stake-address            Stake address commands.
   transaction              Era-based governance commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_address.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_address.cli
@@ -1,0 +1,13 @@
+Usage: cardano-cli shelley address (key-gen | key-hash | build | info)
+
+  Era-based address commands
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  key-gen                  Create an address key pair.
+  key-hash                 Print the hash of an address key.
+  build                    Build a Shelley payment address, with optional
+                           delegation to a stake address.
+  info                     Print information about an address.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_address_build.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_address_build.cli
@@ -1,0 +1,34 @@
+Usage: cardano-cli shelley address build 
+                                           ( --payment-verification-key STRING
+                                           | --payment-verification-key-file FILE
+                                           | --payment-script-file FILE
+                                           )
+                                           [ --stake-verification-key STRING
+                                           | --stake-verification-key-file FILE
+                                           | --stake-script-file FILE
+                                           | --stake-address ADDRESS
+                                           ]
+                                           (--mainnet | --testnet-magic NATURAL)
+                                           [--out-file FILE]
+
+  Build a Shelley payment address, with optional delegation to a stake address.
+
+Available options:
+  --payment-verification-key STRING
+                           Payment verification key (Bech32-encoded)
+  --payment-verification-key-file FILE
+                           Filepath of the payment verification key.
+  --payment-script-file FILE
+                           Filepath of the payment script.
+  --stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --stake-verification-key-file FILE
+                           Filepath of the staking verification key.
+  --stake-script-file FILE Filepath of the staking script.
+  --stake-address ADDRESS  Target stake address (bech32 format).
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_address_info.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_address_info.cli
@@ -1,0 +1,8 @@
+Usage: cardano-cli shelley address info --address ADDRESS [--out-file FILE]
+
+  Print information about an address.
+
+Available options:
+  --address ADDRESS        A Cardano address
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_address_key-gen.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_address_key-gen.cli
@@ -1,0 +1,22 @@
+Usage: cardano-cli shelley address key-gen [--key-output-format STRING]
+                                             [ --normal-key
+                                             | --extended-key
+                                             | --byron-key
+                                             ]
+                                             --verification-key-file FILE
+                                             --signing-key-file FILE
+
+  Create an address key pair.
+
+Available options:
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32" (default is
+                           "bech32").
+  --normal-key             Use a normal Shelley-era key (default).
+  --extended-key           Use an extended ed25519 Shelley-era key.
+  --byron-key              Use a Byron-era key.
+  --verification-key-file FILE
+                           Output filepath of the verification key.
+  --signing-key-file FILE  Output filepath of the signing key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_address_key-hash.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_address_key-hash.cli
@@ -1,0 +1,15 @@
+Usage: cardano-cli shelley address key-hash 
+                                              ( --payment-verification-key STRING
+                                              | --payment-verification-key-file FILE
+                                              )
+                                              [--out-file FILE]
+
+  Print the hash of an address key.
+
+Available options:
+  --payment-verification-key STRING
+                           Payment verification key (Bech32-encoded)
+  --payment-verification-key-file FILE
+                           Filepath of the payment verification key.
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Era based `address` commands
# uncomment types applicable to the change:
  type:
  - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Adding era-based versions of `address` commands.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
