### PR TITLE
Update error message for eras mismatch between node and cli

### DIFF
--- a/cardano-cli/src/Cardano/CLI/Types/Errors/ShelleyTxCmdError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/ShelleyTxCmdError.hs
@@ -168,7 +168,8 @@ renderShelleyTxCmdError err =
       , "likely due to not being in the Alonzo era"
       ]
     ShelleyTxCmdTxEraCastErr (EraCastError value fromEra toEra) ->
-      "Unable to cast era from " <> textShow fromEra <> " to " <> textShow toEra <> " the value " <> textShow value
+      "Transactions can only be produced in the same era as the node. Mismatched eras of "
+      <> textShow value <> ". Requested era: " <> renderEra (AnyCardanoEra toEra) <> ", node era: " <> renderEra (AnyCardanoEra fromEra) <> "."
     ShelleyTxCmdQueryConvenienceError e ->
       renderQueryConvenienceError e
     ShelleyTxCmdQueryNotScriptLocked e ->


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Update error message for eras mismatch between node and cli
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
   - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

n/a

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
