### PR TITLE
#221 Update description fields on delegation certificates

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/DRep.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/DRep.hs
@@ -78,8 +78,7 @@ runGovernanceDelegationCertificateCmd stakeIdentifier delegationTarget outFp = d
       delegatee <- toLedgerDelegatee target
       let req = StakeDelegationRequirementsConwayOnwards cOnwards stakeCred delegatee
           delegCert = makeStakeAddressDelegationCertificate req
-          -- TODO: Conway era - update description to say if its delegating voting stake or "regular" stake
-          description = Just @TextEnvelopeDescr "Stake Address Delegation Certificate"
+          description = Just $ toDelegateeEnvelope delegatee
       firstExceptT DelegationCertificateWriteFileError
         . newExceptT
         $ writeLazyByteStringFile outFp
@@ -124,6 +123,12 @@ toLedgerDelegatee t =
     TargetVotingDRepScriptHash cOn (ScriptHash scriptHash) ->
       conwayEraOnwardsConstraints cOn $
         right $ Ledger.DelegVote $ Ledger.DRepCredential $ Ledger.ScriptHashObj scriptHash
+
+toDelegateeEnvelope :: Ledger.Delegatee ledgerera -> TextEnvelopeDescr
+toDelegateeEnvelope = \case
+  Ledger.DelegStake{} -> "Stake Delegation Certificate"
+  Ledger.DelegVote{} -> "Vote Delegation Certificate"
+  Ledger.DelegStakeVote{} -> "Stake and Vote Delegation Certificate"
 
 runGovernanceDRepIdCmd :: ()
   => ConwayEraOnwards era


### PR DESCRIPTION
# Changelog

```yaml
- description: |
     Update description fields in delegation certificates from `Stake Address Delegation Certificate` to respectively (Conway onwards):
     - `Stake Delegation Certificate` 
     - `Vote Delegation Certificate`
     - `Stake and Vote Delegation Certificate`
  type:
   - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Closes #221 

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
