### PR TITLE
Inline command newtypes

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/Actions.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/Actions.hs
@@ -1,15 +1,10 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE StandaloneDeriving #-}
 
 module Cardano.CLI.EraBased.Commands.Governance.Actions
   ( AnyStakeIdentifier(..)
   , GovernanceActionCmds(..)
-  , EraBasedNewCommittee(..)
-  , EraBasedNewConstitution(..)
-  , EraBasedNoConfidence(..)
-  , EraBasedTreasuryWithdrawal(..)
   , renderGovernanceActionCmds
   ) where
 
@@ -26,13 +21,37 @@ import           Data.Word
 data GovernanceActionCmds era
   = GovernanceActionCreateConstitution
       (ConwayEraOnwards era)
-      EraBasedNewConstitution
+      Ledger.Network
+      Lovelace
+      AnyStakeIdentifier
+      (Maybe (TxId, Word32))
+      ProposalUrl
+      ProposalHashSource
+      ConstitutionUrl
+      ConstitutionHashSource
+      (File () Out)
   | GoveranceActionCreateNewCommittee
       (ConwayEraOnwards era)
-      EraBasedNewCommittee
+      Ledger.Network
+      Lovelace
+      AnyStakeIdentifier
+      ProposalUrl
+      ProposalHashSource
+      [AnyStakeIdentifier]
+      [(AnyStakeIdentifier, EpochNo)]
+      Rational
+      (Maybe (TxId, Word32))
+      (File () Out)
   | GovernanceActionCreateNoConfidence
       (ConwayEraOnwards era)
-      EraBasedNoConfidence
+      Ledger.Network
+      Lovelace
+      AnyStakeIdentifier
+      ProposalUrl
+      ProposalHashSource
+      TxId
+      Word32
+      (File () Out)
   | GovernanceActionProtocolParametersUpdate
       (ShelleyBasedEra era)
       EpochNo
@@ -41,64 +60,18 @@ data GovernanceActionCmds era
       (File () Out)
   | GovernanceActionTreasuryWithdrawal
       (ConwayEraOnwards era)
-      EraBasedTreasuryWithdrawal
+      Ledger.Network
+      Lovelace -- ^ Deposit
+      AnyStakeIdentifier -- ^ Return address
+      ProposalUrl
+      ProposalHashSource
+      [(AnyStakeIdentifier, Lovelace)]
+      (File () Out)
   | GoveranceActionInfo -- TODO: Conway era - ledger currently provides a placeholder constructor
       (ConwayEraOnwards era)
       (File () In)
       (File () Out)
   deriving Show
-
-data EraBasedNewCommittee
-  = EraBasedNewCommittee
-    { ebNetwork :: Ledger.Network
-    , ebDeposit :: Lovelace
-    , ebReturnAddress :: AnyStakeIdentifier
-    , ebProposalUrl :: ProposalUrl
-    , ebProposalHashSource :: ProposalHashSource
-    , ebOldCommittee :: [AnyStakeIdentifier]
-    , ebNewCommittee :: [(AnyStakeIdentifier, EpochNo)]
-    , ebRequiredQuorum :: Rational
-    , ebPreviousGovActionId :: Maybe (TxId, Word32)
-    , ebFilePath :: File () Out
-    } deriving Show
-
-data EraBasedNewConstitution
-  = EraBasedNewConstitution
-      { encNetwork :: Ledger.Network
-      , encDeposit :: Lovelace
-      , encStakeCredential :: AnyStakeIdentifier
-      , encPrevGovActId :: Maybe (TxId, Word32)
-      , encProposalUrl :: ProposalUrl
-      , encProposalHashSource :: ProposalHashSource
-      , encConstitutionUrl :: ConstitutionUrl
-      , encConstitutionHashSource :: ConstitutionHashSource
-      , encFilePath :: File () Out
-      } deriving Show
-
-data EraBasedNoConfidence
-  = EraBasedNoConfidence
-      { ncNetwork :: Ledger.Network
-      , ncDeposit :: Lovelace
-      , ncStakeCredential :: AnyStakeIdentifier
-      , ncProposalUrl :: ProposalUrl
-      , ncProposalHashSource :: ProposalHashSource
-      , ncGovAct :: TxId
-      , ncGovActIndex :: Word32
-      , ncFilePath :: File () Out
-      } deriving Show
-
-data EraBasedTreasuryWithdrawal where
-  EraBasedTreasuryWithdrawal
-    :: Ledger.Network
-    -> Lovelace -- ^ Deposit
-    -> AnyStakeIdentifier -- ^ Return address
-    -> ProposalUrl
-    -> ProposalHashSource
-    -> [(AnyStakeIdentifier, Lovelace)]
-    -> File () Out
-    -> EraBasedTreasuryWithdrawal
-
-deriving instance Show EraBasedTreasuryWithdrawal
 
 renderGovernanceActionCmds :: GovernanceActionCmds era -> Text
 renderGovernanceActionCmds = \case

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Actions.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Actions.hs
@@ -47,22 +47,19 @@ pGovernanceActionNewConstitution era = do
   cOn <- maybeFeatureInEra era
   pure
     $ subParser "create-constitution"
-    $ Opt.info (pCmd cOn)
+    $ Opt.info
+        ( GovernanceActionCreateConstitution cOn
+            <$> pNetwork
+            <*> pGovActionDeposit
+            <*> pAnyStakeIdentifier
+            <*> pPreviousGovernanceAction
+            <*> pProposalUrl
+            <*> pProposalHashSource
+            <*> pConstitutionUrl
+            <*> pConstitutionHashSource
+            <*> pFileOutDirection "out-file" "Output filepath of the constitution."
+        )
     $ Opt.progDesc "Create a constitution."
- where
-  pCmd :: ConwayEraOnwards era -> Parser (GovernanceActionCmds era)
-  pCmd cOn =
-    fmap (GovernanceActionCreateConstitution cOn) $
-      EraBasedNewConstitution
-        <$> pNetwork
-        <*> pGovActionDeposit
-        <*> pAnyStakeIdentifier
-        <*> pPreviousGovernanceAction
-        <*> pProposalUrl
-        <*> pProposalHashSource
-        <*> pConstitutionUrl
-        <*> pConstitutionHashSource
-        <*> pFileOutDirection "out-file" "Output filepath of the constitution."
 
 pGovernanceActionNewCommittee
   :: CardanoEra era
@@ -71,27 +68,20 @@ pGovernanceActionNewCommittee era = do
   cOn <- maybeFeatureInEra era
   pure
     $ subParser "create-new-committee"
-    $ Opt.info (pCmd cOn)
+    $ Opt.info
+        ( GoveranceActionCreateNewCommittee cOn
+            <$> pNetwork
+            <*> pGovActionDeposit
+            <*> pAnyStakeIdentifier
+            <*> pProposalUrl
+            <*> pProposalHashSource
+            <*> many pAnyStakeIdentifier
+            <*> many ((,) <$> pAnyStakeIdentifier <*> pEpochNo "Committee member expiry epoch")
+            <*> pRational "quorum" "Quorum of the committee that is necessary for a successful vote."
+            <*> pPreviousGovernanceAction
+            <*> pOutputFile
+        )
     $ Opt.progDesc "Create a new committee proposal."
- where
-  pCmd :: ConwayEraOnwards era -> Parser (GovernanceActionCmds era)
-  pCmd cOn = GoveranceActionCreateNewCommittee cOn
-               <$> pEraBasedNewCommittee
-
-pEraBasedNewCommittee :: Parser EraBasedNewCommittee
-pEraBasedNewCommittee =
-  EraBasedNewCommittee
-    <$> pNetwork
-    <*> pGovActionDeposit
-    <*> pAnyStakeIdentifier
-    <*> pProposalUrl
-    <*> pProposalHashSource
-    <*> many pAnyStakeIdentifier
-    <*> many ((,) <$> pAnyStakeIdentifier <*> pEpochNo "Committee member expiry epoch")
-    <*> pRational "quorum" "Quorum of the committee that is necessary for a successful vote."
-    <*> pPreviousGovernanceAction
-    <*> pOutputFile
-
 
 pGovernanceActionNoConfidence
   :: CardanoEra era
@@ -100,21 +90,18 @@ pGovernanceActionNoConfidence era = do
   cOn <- maybeFeatureInEra era
   pure
     $ subParser "create-no-confidence"
-    $ Opt.info (pCmd cOn)
+    $ Opt.info
+        ( GovernanceActionCreateNoConfidence cOn
+            <$> pNetwork
+            <*> pGovActionDeposit
+            <*> pAnyStakeIdentifier
+            <*> pProposalUrl
+            <*> pProposalHashSource
+            <*> pTxId "governance-action-tx-id" "Previous txid of `NoConfidence` or `NewCommittee` governance action."
+            <*> pWord32 "governance-action-index" "Previous tx's governance action index of `NoConfidence` or `NewCommittee` governance action."
+            <*> pFileOutDirection "out-file" "Output filepath of the no confidence proposal."
+        )
     $ Opt.progDesc "Create a no confidence proposal."
- where
-  pCmd :: ConwayEraOnwards era -> Parser (GovernanceActionCmds era)
-  pCmd cOn =
-    fmap (GovernanceActionCreateNoConfidence cOn) $
-      EraBasedNoConfidence
-        <$> pNetwork
-        <*> pGovActionDeposit
-        <*> pAnyStakeIdentifier
-        <*> pProposalUrl
-        <*> pProposalHashSource
-        <*> pTxId "governance-action-tx-id" "Previous txid of `NoConfidence` or `NewCommittee` governance action."
-        <*> pWord32 "governance-action-index" "Previous tx's governance action index of `NoConfidence` or `NewCommittee` governance action."
-        <*> pFileOutDirection "out-file" "Output filepath of the no confidence proposal."
 
 pAnyStakeIdentifier :: Parser AnyStakeIdentifier
 pAnyStakeIdentifier =
@@ -302,19 +289,14 @@ pGovernanceActionTreasuryWithdrawal era = do
   cOn <- maybeFeatureInEra era
   pure
     $ subParser "create-treasury-withdrawal"
-    $ Opt.info (pCmd cOn)
+    $ Opt.info
+        ( GovernanceActionTreasuryWithdrawal cOn
+            <$> pNetwork
+            <*> pGovActionDeposit
+            <*> pAnyStakeIdentifier
+            <*> pProposalUrl
+            <*> pProposalHashSource
+            <*> many ((,) <$> pAnyStakeIdentifier <*> pTransferAmt)
+            <*> pFileOutDirection "out-file" "Output filepath of the treasury withdrawal."
+        )
     $ Opt.progDesc "Create a treasury withdrawal."
- where
-  pCmd :: ConwayEraOnwards era -> Parser (GovernanceActionCmds era)
-  pCmd cOn =
-    fmap (GovernanceActionTreasuryWithdrawal cOn) $
-      EraBasedTreasuryWithdrawal
-        <$> pNetwork
-        <*> pGovActionDeposit
-        <*> pAnyStakeIdentifier
-        <*> pProposalUrl
-        <*> pProposalHashSource
-        <*> many ((,) <$> pAnyStakeIdentifier <*> pTransferAmt)
-        <*> pFileOutDirection "out-file" "Output filepath of the treasury withdrawal."
-
-


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Inline command newtypes
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Inlines newtypes which also removed `EraBased` prefix incidentally.

This brings these commands in line to how other commands are set up.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
