### PR TITLE
Simplify `stake-address stake-delegation-certificate` command across eras

### DIFF
--- a/cardano-cli/src/Cardano/CLI/Types/Errors/ShelleyStakeAddressCmdError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/ShelleyStakeAddressCmdError.hs
@@ -7,7 +7,6 @@ module Cardano.CLI.Types.Errors.ShelleyStakeAddressCmdError
 import           Cardano.Api
 
 import           Cardano.CLI.Types.Errors.ScriptDecodeError
-import           Cardano.CLI.Types.Errors.StakeAddressDelegationError
 import           Cardano.CLI.Types.Errors.StakeAddressRegistrationError
 import           Cardano.CLI.Types.Errors.StakeCredentialError
 
@@ -17,7 +16,6 @@ data ShelleyStakeAddressCmdError
   | ShelleyStakeAddressCmdStakeCredentialError !StakeCredentialError
   | ShelleyStakeAddressCmdWriteFileError !(FileError ())
   | StakeRegistrationError !StakeAddressRegistrationError
-  | StakeDelegationError !StakeAddressDelegationError
   deriving Show
 
 instance Error ShelleyStakeAddressCmdError where
@@ -26,5 +24,4 @@ instance Error ShelleyStakeAddressCmdError where
     ShelleyStakeAddressCmdReadScriptFileError e   -> displayError e
     ShelleyStakeAddressCmdStakeCredentialError e  -> displayError e
     ShelleyStakeAddressCmdWriteFileError e        -> displayError e
-    StakeDelegationError e                        -> displayError e
     StakeRegistrationError e                      -> displayError e


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Simplify `stake-address stake-delegation-certificate` command across eras
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Originally the command constructed a `Delegatee` and a `Requirements`.

Both of these were unnecessary because we can construct the certificate directly from the stake pool key hash and the stake credentials.

This more direct method has the advantage of not having to handle unsupported delegatees so there are fewer error cases to handle.

The simplification allows an error constructor to be deleted.

The `caseShelleyToBabbageAndConwayEraOnwards` function is temporarily defined here pending introduction into `cardano-api`.  After moving that the new code is clearly much shorter.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
