### PR TITLE
New `--always-abstain` and `--always-no-confidence` options

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/StakeAddress.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/StakeAddress.hs
@@ -9,6 +9,7 @@ module Cardano.CLI.EraBased.Commands.StakeAddress
 import           Cardano.Api.Shelley
 
 import           Cardano.CLI.Types.Common
+import           Cardano.CLI.Types.Governance
 import           Cardano.CLI.Types.Key
 
 import           Prelude
@@ -44,7 +45,7 @@ data StakeAddressCmds era
       (ConwayEraOnwards era)
       StakeIdentifier
       (VerificationKeyOrHashOrFile StakePoolKey)
-      (VerificationKeyOrHashOrFile DRepKey)
+      VoteDelegationTarget
       (File () Out)
   | StakeAddressVoteDelegationCertificateCmd
       (ConwayEraOnwards era)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
@@ -2738,6 +2738,29 @@ pVoterType =
 pVotingCredential :: Parser (VerificationKeyOrFile StakePoolKey)
 pVotingCredential = pStakePoolVerificationKeyOrFile
 
+pVoteDelegationTarget
+  :: Parser VoteDelegationTarget
+pVoteDelegationTarget =
+  asum
+    [ VoteDelegationTargetOfDRep <$> pDRepVerificationKeyOrHashOrFile
+    , VoteDelegationTargetOfAbstain <$ pAlwaysAbstain
+    , VoteDelegationTargetOfAbstain <$ pAlwaysNoConfidence
+    ]
+
+pAlwaysAbstain :: Parser ()
+pAlwaysAbstain =
+  Opt.flag' () $ mconcat
+    [ Opt.long "always-abstain"
+    , Opt.help "Abstain from voting on all proposals."
+    ]
+
+pAlwaysNoConfidence :: Parser ()
+pAlwaysNoConfidence =
+  Opt.flag' () $ mconcat
+    [ Opt.long "always-no-confidence"
+    , Opt.help "Always vote no confidence"
+    ]
+
 pDRepVerificationKeyOrHashOrFile
   :: Parser (VerificationKeyOrHashOrFile DRepKey)
 pDRepVerificationKeyOrHashOrFile =

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/DRep.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/DRep.hs
@@ -184,20 +184,6 @@ pStakeTarget cOnwards =
     , TargetAlwaysNoConfidence cOnwards <$ pAlwaysNoConfidence
     ]
 
-pAlwaysAbstain :: Parser ()
-pAlwaysAbstain =
-  Opt.flag' () $ mconcat
-    [ Opt.long "always-abstain"
-    , Opt.help "Abstain from voting on all proposals."
-    ]
-
-pAlwaysNoConfidence :: Parser ()
-pAlwaysNoConfidence =
-  Opt.flag' () $ mconcat
-    [ Opt.long "always-no-confidence"
-    , Opt.help "Always vote no confidence"
-    ]
-
 pDRepScriptHash :: Parser ScriptHash
 pDRepScriptHash =
   Opt.option scriptHashReader $ mconcat

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/StakeAddress.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/StakeAddress.hs
@@ -141,7 +141,7 @@ pStakeAddressStakeAndVoteDelegationCertificateCmd era = do
         ( StakeAddressStakeAndVoteDelegationCertificateCmd w
             <$> pStakeIdentifier
             <*> pStakePoolVerificationKeyOrHashOrFile
-            <*> pDRepVerificationKeyOrHashOrFile
+            <*> pVoteDelegationTarget
             <*> pOutputFile
         )
     $ Opt.progDesc

--- a/cardano-cli/src/Cardano/CLI/Types/Governance.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Governance.hs
@@ -49,3 +49,9 @@ data AnyVotingStakeVerificationKeyOrHashOrFile where
   AnyCommitteeHotVerificationKeyOrHashOrFile
     :: VerificationKeyOrHashOrFile CommitteeHotKey
     -> AnyVotingStakeVerificationKeyOrHashOrFile
+
+data VoteDelegationTarget
+  = VoteDelegationTargetOfDRep (VerificationKeyOrHashOrFile DRepKey)
+  | VoteDelegationTargetOfAbstain
+  | VoteDelegationTargetOfNoConfidence
+  deriving (Eq, Show)

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -3709,6 +3709,8 @@ Usage: cardano-cli conway stake-address stake-and-vote-delegation-certificate
                                                                                 ( --drep-verification-key STRING
                                                                                 | --drep-verification-key-file FILE
                                                                                 | --drep-key-hash HASH
+                                                                                | --always-abstain
+                                                                                | --always-no-confidence
                                                                                 )
                                                                                 --out-file FILE
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_stake-address_stake-and-vote-delegation-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_stake-address_stake-and-vote-delegation-certificate.cli
@@ -11,6 +11,8 @@ Usage: cardano-cli conway stake-address stake-and-vote-delegation-certificate
                                                                                 ( --drep-verification-key STRING
                                                                                 | --drep-verification-key-file FILE
                                                                                 | --drep-key-hash HASH
+                                                                                | --always-abstain
+                                                                                | --always-no-confidence
                                                                                 )
                                                                                 --out-file FILE
 
@@ -39,5 +41,7 @@ Available options:
   --drep-key-hash HASH     DRep verification key hash (either Bech32-encoded or
                            hex-encoded). Zero or more occurences of this option
                            is allowed.
+  --always-abstain         Abstain from voting on all proposals.
+  --always-no-confidence   Always vote no confidence
   --out-file FILE          The output file.
   -h,--help                Show this help text


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    New `always-abstain-delegation-certificate` and `always-no-confidence-delegation-certificate` commands
# uncomment types applicable to the change:
  type:
  - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
