### PR TITLE
Accept script hash in `stake-and-vote-delegation-certificate` command

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
@@ -2761,6 +2761,16 @@ pAlwaysNoConfidence =
     , Opt.help "Always vote no confidence"
     ]
 
+pDRepScriptHash :: Parser ScriptHash
+pDRepScriptHash =
+  Opt.option scriptHashReader $ mconcat
+    [ Opt.long "drep-script-hash"
+    , Opt.metavar "HASH"
+    , Opt.help $ mconcat
+        [ "DRep script hash (hex-encoded).  "
+        ]
+    ]
+
 pDRepVerificationKeyOrHashOrFile
   :: Parser (VerificationKeyOrHashOrFile DRepKey)
 pDRepVerificationKeyOrHashOrFile =

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
@@ -2738,11 +2738,10 @@ pVoterType =
 pVotingCredential :: Parser (VerificationKeyOrFile StakePoolKey)
 pVotingCredential = pStakePoolVerificationKeyOrFile
 
-pVoteDelegationTarget
-  :: Parser VoteDelegationTarget
+pVoteDelegationTarget :: Parser VoteDelegationTarget
 pVoteDelegationTarget =
   asum
-    [ VoteDelegationTargetOfDRep <$> pDRepVerificationKeyOrHashOrFile
+    [ VoteDelegationTargetOfDRep <$> pDRepHashSource
     , VoteDelegationTargetOfAbstain <$ pAlwaysAbstain
     , VoteDelegationTargetOfAbstain <$ pAlwaysNoConfidence
     ]
@@ -2761,13 +2760,20 @@ pAlwaysNoConfidence =
     , Opt.help "Always vote no confidence"
     ]
 
+pDRepHashSource :: Parser DRepHashSource
+pDRepHashSource =
+  asum
+    [ DRepHashSourceScript <$> pDRepScriptHash
+    , DRepHashSourceVerificationKey <$> pDRepVerificationKeyOrHashOrFile
+    ]
+
 pDRepScriptHash :: Parser ScriptHash
 pDRepScriptHash =
   Opt.option scriptHashReader $ mconcat
     [ Opt.long "drep-script-hash"
     , Opt.metavar "HASH"
     , Opt.help $ mconcat
-        [ "DRep script hash (hex-encoded).  "
+        [ "DRep script hash (hex-encoded)."
         ]
     ]
 

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/DRep.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/DRep.hs
@@ -183,16 +183,3 @@ pStakeTarget cOnwards =
 
     , TargetAlwaysNoConfidence cOnwards <$ pAlwaysNoConfidence
     ]
-
-pDRepScriptHash :: Parser ScriptHash
-pDRepScriptHash =
-  Opt.option scriptHashReader $ mconcat
-    [ Opt.long "drep-script-hash"
-    , Opt.metavar "HASH"
-    , Opt.help $ mconcat
-        [ "DRep script hash (hex-encoded).  "
-        ]
-    ]
-
-scriptHashReader :: Opt.ReadM ScriptHash
-scriptHashReader = Opt.eitherReader $ Right . fromString

--- a/cardano-cli/src/Cardano/CLI/Read.hs
+++ b/cardano-cli/src/Cardano/CLI/Read.hs
@@ -81,6 +81,8 @@ module Cardano.CLI.Read
   , ReadSafeHashError(..)
   , readHexAsSafeHash
   , readSafeHash
+
+  , scriptHashReader
   ) where
 
 import           Cardano.Api as Api
@@ -121,6 +123,7 @@ import           Data.Function ((&))
 import           Data.IORef (IORef, newIORef, readIORef, writeIORef)
 import qualified Data.List as List
 import qualified Data.Map.Strict as Map
+import           Data.String
 import           Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
@@ -1028,3 +1031,6 @@ readSafeHash =
   Opt.eitherReader $ \s ->
     readHexAsSafeHash (Text.pack s)
       & first (Text.unpack . renderReadSafeHashError)
+
+scriptHashReader :: Opt.ReadM ScriptHash
+scriptHashReader = Opt.eitherReader $ Right . fromString

--- a/cardano-cli/src/Cardano/CLI/Types/Governance.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Governance.hs
@@ -6,7 +6,8 @@ module Cardano.CLI.Types.Governance where
 import           Cardano.Api
 import           Cardano.Api.Shelley
 
-import           Cardano.CLI.Types.Key (VerificationKeyOrFile, VerificationKeyOrHashOrFile)
+import           Cardano.CLI.Types.Key (DRepHashSource, VerificationKeyOrFile,
+                   VerificationKeyOrHashOrFile)
 
 import           Data.Word
 
@@ -51,7 +52,7 @@ data AnyVotingStakeVerificationKeyOrHashOrFile where
     -> AnyVotingStakeVerificationKeyOrHashOrFile
 
 data VoteDelegationTarget
-  = VoteDelegationTargetOfDRep (VerificationKeyOrHashOrFile DRepKey)
+  = VoteDelegationTargetOfDRep DRepHashSource
   | VoteDelegationTargetOfAbstain
   | VoteDelegationTargetOfNoConfidence
   deriving (Eq, Show)

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -3706,7 +3706,8 @@ Usage: cardano-cli conway stake-address stake-and-vote-delegation-certificate
                                                                                 | --cold-verification-key-file FILE
                                                                                 | --stake-pool-id STAKE_POOL_ID
                                                                                 )
-                                                                                ( --drep-verification-key STRING
+                                                                                ( --drep-script-hash HASH
+                                                                                | --drep-verification-key STRING
                                                                                 | --drep-verification-key-file FILE
                                                                                 | --drep-key-hash HASH
                                                                                 | --always-abstain

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_stake-address_stake-and-vote-delegation-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_stake-address_stake-and-vote-delegation-certificate.cli
@@ -8,7 +8,8 @@ Usage: cardano-cli conway stake-address stake-and-vote-delegation-certificate
                                                                                 | --cold-verification-key-file FILE
                                                                                 | --stake-pool-id STAKE_POOL_ID
                                                                                 )
-                                                                                ( --drep-verification-key STRING
+                                                                                ( --drep-script-hash HASH
+                                                                                | --drep-verification-key STRING
                                                                                 | --drep-verification-key-file FILE
                                                                                 | --drep-key-hash HASH
                                                                                 | --always-abstain
@@ -34,6 +35,7 @@ Available options:
                            Stake pool ID/verification key hash (either
                            Bech32-encoded or hex-encoded). Zero or more
                            occurences of this option is allowed.
+  --drep-script-hash HASH  DRep script hash (hex-encoded).
   --drep-verification-key STRING
                            DRep verification key (Bech32 or hex-encoded).
   --drep-verification-key-file FILE


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Accept script hash in `stake-and-vote-delegation-certificate` command
# uncomment types applicable to the change:
  type:
  - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context


# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
