### PR TITLE
Port more commands to era-based command structure

### DIFF
--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -70,23 +70,35 @@ library
                         Cardano.CLI.Environment
                         Cardano.CLI.EraBased.Commands
                         Cardano.CLI.EraBased.Commands.Address
+                        Cardano.CLI.EraBased.Commands.Genesis
                         Cardano.CLI.EraBased.Commands.Governance
                         Cardano.CLI.EraBased.Commands.Governance.Actions
                         Cardano.CLI.EraBased.Commands.Governance.Committee
                         Cardano.CLI.EraBased.Commands.Governance.DRep
                         Cardano.CLI.EraBased.Commands.Governance.Query
                         Cardano.CLI.EraBased.Commands.Governance.Vote
+                        Cardano.CLI.EraBased.Commands.Key
+                        Cardano.CLI.EraBased.Commands.Node
+                        Cardano.CLI.EraBased.Commands.Query
                         Cardano.CLI.EraBased.Commands.StakeAddress
+                        Cardano.CLI.EraBased.Commands.StakePool
+                        Cardano.CLI.EraBased.Commands.TextView
                         Cardano.CLI.EraBased.Commands.Transaction
                         Cardano.CLI.EraBased.Options.Address
                         Cardano.CLI.EraBased.Options.Common
+                        Cardano.CLI.EraBased.Options.Genesis
                         Cardano.CLI.EraBased.Options.Governance
                         Cardano.CLI.EraBased.Options.Governance.Actions
                         Cardano.CLI.EraBased.Options.Governance.Committee
                         Cardano.CLI.EraBased.Options.Governance.DRep
                         Cardano.CLI.EraBased.Options.Governance.Query
                         Cardano.CLI.EraBased.Options.Governance.Vote
+                        Cardano.CLI.EraBased.Options.Key
+                        Cardano.CLI.EraBased.Options.Node
+                        Cardano.CLI.EraBased.Options.Query
                         Cardano.CLI.EraBased.Options.StakeAddress
+                        Cardano.CLI.EraBased.Options.StakePool
+                        Cardano.CLI.EraBased.Options.TextView
                         Cardano.CLI.EraBased.Options.Transaction
                         Cardano.CLI.EraBased.Run
                         Cardano.CLI.EraBased.Run.Address

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands.hs
@@ -14,12 +14,22 @@ import           Cardano.Api (CardanoEra (..), ShelleyBasedEra (..))
 
 import           Cardano.CLI.Environment
 import           Cardano.CLI.EraBased.Commands.Address
+import           Cardano.CLI.EraBased.Commands.Genesis
+import           Cardano.CLI.EraBased.Commands.Key
+import           Cardano.CLI.EraBased.Commands.Node
+import           Cardano.CLI.EraBased.Commands.Query
 import           Cardano.CLI.EraBased.Commands.StakeAddress
+import           Cardano.CLI.EraBased.Commands.TextView
 import           Cardano.CLI.EraBased.Commands.Transaction
 import           Cardano.CLI.EraBased.Options.Address
 import           Cardano.CLI.EraBased.Options.Common
+import           Cardano.CLI.EraBased.Options.Genesis
 import           Cardano.CLI.EraBased.Options.Governance
+import           Cardano.CLI.EraBased.Options.Key
+import           Cardano.CLI.EraBased.Options.Node
+import           Cardano.CLI.EraBased.Options.Query
 import           Cardano.CLI.EraBased.Options.StakeAddress
+import           Cardano.CLI.EraBased.Options.TextView
 import           Cardano.CLI.EraBased.Options.Transaction
 
 import           Data.Foldable
@@ -37,18 +47,33 @@ renderAnyEraCommand = \case
 
 data Cmds era
   = AddressCmds         (AddressCmds era)
+  | KeyCmds             (KeyCmds era)
+  | GenesisCmds         (GenesisCmds era)
   | GovernanceCmds      (GovernanceCmds era)
+  | NodeCmds            (NodeCmds era)
+  | QueryCmds           (QueryCmds era)
   | StakeAddressCmds    (StakeAddressCmds era)
+  | TextViewCmds        (TextViewCmds era)
   | TransactionCmds     (TransactionCmds era)
 
 renderCmds :: Cmds era -> Text
 renderCmds = \case
   AddressCmds cmd ->
     renderAddressCmds cmd
+  KeyCmds cmd ->
+    renderKeyCmds cmd
+  GenesisCmds cmd ->
+    renderGenesisCmds cmd
   GovernanceCmds cmd ->
     renderGovernanceCmds cmd
+  NodeCmds cmd ->
+    renderNodeCmds cmd
+  QueryCmds cmd ->
+    renderQueryCmds cmd
   StakeAddressCmds cmd ->
     renderStakeAddressCmds cmd
+  TextViewCmds cmd ->
+    renderTextViewCmds cmd
   TransactionCmds cmd ->
     renderTransactionCmds cmd
 
@@ -89,12 +114,32 @@ pCmds envCli era =
         $ Opt.info (AddressCmds <$> pAddressCmds era envCli)
         $ Opt.progDesc "Era-based address commands"
     , Just
+        $ subParser "key"
+        $ Opt.info (KeyCmds <$> pKeyCmds)
+        $ Opt.progDesc "Era-based key commands"
+    , Just
+        $ subParser "genesis"
+        $ Opt.info (GenesisCmds <$> pGenesisCmds envCli)
+        $ Opt.progDesc "Era-based genesis commands"
+    , Just
         $ subParser "governance"
         $ Opt.info (GovernanceCmds <$> pGovernanceCmds envCli era)
         $ Opt.progDesc "Era-based governance commands"
+    , Just
+        $ subParser "node"
+        $ Opt.info (NodeCmds <$> pNodeCmds)
+        $ Opt.progDesc "Era-based node commands"
+    , Just
+        $ subParser "query"
+        $ Opt.info (QueryCmds <$> pQueryCmds envCli)
+        $ Opt.progDesc "Era-based query commands"
     , fmap StakeAddressCmds <$> pStakeAddressCmds era envCli
+    , Just
+        $ subParser "text-view"
+        $ Opt.info (TextViewCmds <$> pTextViewCmds)
+        $ Opt.progDesc "Era-based text-view commands"
     , Just
         $ subParser "transaction"
         $ Opt.info (TransactionCmds <$> pTransactionCmds envCli era)
-        $ Opt.progDesc "Era-based governance commands"
+        $ Opt.progDesc "Era-based transaction commands"
     ]

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Genesis.hs
@@ -1,0 +1,105 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE LambdaCase #-}
+
+module Cardano.CLI.EraBased.Commands.Genesis
+  ( GenesisCmds (..)
+  , renderGenesisCmds
+  ) where
+
+import           Cardano.Api.Shelley
+
+import           Cardano.Chain.Common (BlockCount)
+import           Cardano.CLI.Types.Common
+
+import           Data.Text (Text)
+
+data GenesisCmds era
+  = GenesisCreate
+      KeyOutputFormat
+      GenesisDir
+      Word
+      Word
+      (Maybe SystemStart)
+      (Maybe Lovelace)
+      NetworkId
+  | GenesisCreateCardano
+      GenesisDir
+      Word
+      Word
+      (Maybe SystemStart)
+      (Maybe Lovelace)
+      BlockCount
+      Word
+      Rational
+      NetworkId
+      FilePath
+      FilePath
+      FilePath
+      FilePath
+      (Maybe FilePath)
+  | GenesisCreateStaked
+      KeyOutputFormat
+      GenesisDir
+      Word
+      Word
+      Word
+      Word
+      (Maybe SystemStart)
+      (Maybe Lovelace)
+      Lovelace
+      NetworkId
+      Word
+      Word
+      Word
+      (Maybe FilePath) -- ^ Relay specification filepath
+  | GenesisKeyGenGenesis
+      (VerificationKeyFile Out)
+      (SigningKeyFile Out)
+  | GenesisKeyGenDelegate
+      (VerificationKeyFile Out)
+      (SigningKeyFile Out)
+      (OpCertCounterFile Out)
+  | GenesisKeyGenUTxO
+      (VerificationKeyFile Out)
+      (SigningKeyFile Out)
+  | GenesisCmdKeyHash
+      (VerificationKeyFile In)
+  | GenesisVerKey
+      (VerificationKeyFile Out)
+      (SigningKeyFile In)
+  | GenesisTxIn
+      (VerificationKeyFile In)
+      NetworkId
+      (Maybe (File () Out))
+  | GenesisAddr
+      (VerificationKeyFile In)
+      NetworkId
+      (Maybe (File () Out))
+  | GenesisHashFile
+      GenesisFile
+  deriving Show
+
+renderGenesisCmds :: GenesisCmds era -> Text
+renderGenesisCmds = \case
+  GenesisCreate {} ->
+    "genesis create"
+  GenesisCreateCardano {} ->
+    "genesis create-cardano"
+  GenesisCreateStaked {} ->
+    "genesis create-staked"
+  GenesisKeyGenGenesis {} ->
+    "genesis key-gen-genesis"
+  GenesisKeyGenDelegate {} ->
+    "genesis key-gen-delegate"
+  GenesisKeyGenUTxO {} ->
+    "genesis key-gen-utxo"
+  GenesisCmdKeyHash {} ->
+    "genesis key-hash"
+  GenesisVerKey {} ->
+    "genesis get-ver-key"
+  GenesisTxIn {} ->
+    "genesis initial-txin"
+  GenesisAddr {} ->
+    "genesis initial-addr"
+  GenesisHashFile {} ->
+    "genesis hash"

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Key.hs
@@ -1,0 +1,62 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE LambdaCase #-}
+
+module Cardano.CLI.EraBased.Commands.Key
+  ( KeyCmds (..)
+  , renderKeyCmds
+  ) where
+
+import           Cardano.Api.Shelley
+
+import           Cardano.CLI.Types.Common
+
+import           Data.Text (Text)
+
+data KeyCmds era
+  = KeyGetVerificationKey
+      (SigningKeyFile In)
+      (VerificationKeyFile Out)
+  | KeyNonExtendedKey
+      (VerificationKeyFile In)
+      (VerificationKeyFile Out)
+  | KeyConvertByronKey
+      (Maybe Text)
+      ByronKeyType
+      (SomeKeyFile In)
+      (File () Out)
+  | KeyConvertByronGenesisVKey
+      VerificationKeyBase64
+      (File () Out)
+  | KeyConvertITNStakeKey
+      (SomeKeyFile In)
+      (File () Out)
+  | KeyConvertITNExtendedToStakeKey
+      (SomeKeyFile In)
+      (File () Out)
+  | KeyConvertITNBip32ToStakeKey
+      (SomeKeyFile In)
+      (File () Out)
+  | KeyConvertCardanoAddressSigningKey
+      CardanoAddressKeyType
+      (SigningKeyFile In)
+      (File () Out)
+  deriving Show
+
+renderKeyCmds :: KeyCmds era -> Text
+renderKeyCmds = \case
+  KeyGetVerificationKey {} ->
+    "key verification-key"
+  KeyNonExtendedKey {} ->
+    "key non-extended-key"
+  KeyConvertByronKey {} ->
+    "key convert-byron-key"
+  KeyConvertByronGenesisVKey {} ->
+    "key convert-byron-genesis-key"
+  KeyConvertITNStakeKey {} ->
+    "key convert-itn-key"
+  KeyConvertITNExtendedToStakeKey {} ->
+    "key convert-itn-extended-key"
+  KeyConvertITNBip32ToStakeKey {} ->
+    "key convert-itn-bip32-key"
+  KeyConvertCardanoAddressSigningKey {} ->
+    "key convert-cardano-address-signing-key"

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Node.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Node.hs
@@ -1,0 +1,57 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE LambdaCase #-}
+
+module Cardano.CLI.EraBased.Commands.Node
+  ( NodeCmds (..)
+  , renderNodeCmds
+  ) where
+
+import           Cardano.Api.Shelley
+
+import           Cardano.CLI.Types.Common
+import           Cardano.CLI.Types.Key
+
+import           Data.Text (Text)
+
+data NodeCmds era
+  = NodeKeyGenCold
+      KeyOutputFormat
+      (VerificationKeyFile Out)
+      (SigningKeyFile Out)
+      (OpCertCounterFile Out)
+  | NodeKeyGenKES
+      KeyOutputFormat
+      (VerificationKeyFile Out)
+      (SigningKeyFile Out)
+  | NodeKeyGenVRF
+      KeyOutputFormat
+      (VerificationKeyFile Out)
+      (SigningKeyFile Out)
+  | NodeKeyHashVRF
+      (VerificationKeyOrFile VrfKey)
+      (Maybe (File () Out))
+  | NodeNewCounter
+      ColdVerificationKeyOrFile
+      Word
+      (OpCertCounterFile InOut)
+  | NodeIssueOpCert
+      (VerificationKeyOrFile KesKey)
+      (SigningKeyFile In)
+      (OpCertCounterFile InOut)
+      KESPeriod (File () Out)
+  deriving Show
+
+renderNodeCmds :: NodeCmds era -> Text
+renderNodeCmds = \case
+  NodeKeyGenCold {} ->
+    "node key-gen"
+  NodeKeyGenKES {} ->
+    "node key-gen-KES"
+  NodeKeyGenVRF {} ->
+    "node key-gen-VRF"
+  NodeKeyHashVRF {} ->
+    "node key-hash-VRF"
+  NodeNewCounter {} ->
+    "node new-counter"
+  NodeIssueOpCert{} ->
+    "node issue-op-cert"

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Query.hs
@@ -1,0 +1,142 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE LambdaCase #-}
+
+module Cardano.CLI.EraBased.Commands.Query
+  ( QueryCmds (..)
+  , renderQueryCmds
+  ) where
+
+import           Cardano.Api.Shelley hiding (QueryInShelleyBasedEra (..))
+
+import           Cardano.CLI.Types.Common
+import           Cardano.CLI.Types.Key
+
+import           Data.Text (Text)
+import           Data.Time.Clock
+
+data QueryCmds era =
+    QueryLeadershipSchedule
+      SocketPath
+      AnyConsensusModeParams
+      NetworkId
+      GenesisFile
+      (VerificationKeyOrHashOrFile StakePoolKey)
+      (SigningKeyFile In)
+      EpochLeadershipSchedule
+      (Maybe (File () Out))
+  | QueryProtocolParameters'
+      SocketPath
+      AnyConsensusModeParams
+      NetworkId
+      (Maybe (File () Out))
+  | QueryConstitutionHash
+      SocketPath
+      AnyConsensusModeParams
+      NetworkId
+      (Maybe (File () Out))
+  | QueryTip
+      SocketPath
+      AnyConsensusModeParams
+      NetworkId
+      (Maybe (File () Out))
+  | QueryStakePools'
+      SocketPath
+      AnyConsensusModeParams
+      NetworkId
+      (Maybe (File () Out))
+  | QueryStakeDistribution'
+      SocketPath
+      AnyConsensusModeParams
+      NetworkId
+      (Maybe (File () Out))
+  | QueryStakeAddressInfo
+      SocketPath
+      AnyConsensusModeParams
+      StakeAddress
+      NetworkId
+      (Maybe (File () Out))
+  | QueryUTxO'
+      SocketPath
+      AnyConsensusModeParams
+      QueryUTxOFilter
+      NetworkId
+      (Maybe (File () Out))
+  | QueryDebugLedgerState'
+      SocketPath
+      AnyConsensusModeParams
+      NetworkId
+      (Maybe (File () Out))
+  | QueryProtocolState'
+      SocketPath
+      AnyConsensusModeParams
+      NetworkId
+      (Maybe (File () Out))
+  | QueryStakeSnapshot'
+      SocketPath
+      AnyConsensusModeParams
+      NetworkId
+      (AllOrOnly [Hash StakePoolKey])
+      (Maybe (File () Out))
+  | QueryKesPeriodInfo
+      SocketPath
+      AnyConsensusModeParams
+      NetworkId
+      (File () In)
+      -- ^ Node operational certificate
+      (Maybe (File () Out))
+  | QueryPoolState'
+      SocketPath
+      AnyConsensusModeParams
+      NetworkId
+      [Hash StakePoolKey]
+  | QueryTxMempool
+      SocketPath
+      AnyConsensusModeParams
+      NetworkId
+      TxMempoolQuery
+      (Maybe (File () Out))
+  | QuerySlotNumber
+      SocketPath
+      AnyConsensusModeParams
+      NetworkId
+      UTCTime
+  deriving Show
+
+renderQueryCmds :: QueryCmds era -> Text
+renderQueryCmds = \case
+  QueryLeadershipSchedule {} ->
+    "query leadership-schedule"
+  QueryProtocolParameters' {} ->
+    "query protocol-parameters "
+  QueryConstitutionHash {} ->
+    "query constitution-hash "
+  QueryTip {} ->
+    "query tip"
+  QueryStakePools' {} ->
+    "query stake-pools"
+  QueryStakeDistribution' {} ->
+    "query stake-distribution"
+  QueryStakeAddressInfo {} ->
+    "query stake-address-info"
+  QueryUTxO' {} ->
+    "query utxo"
+  QueryDebugLedgerState' {} ->
+    "query ledger-state"
+  QueryProtocolState' {} ->
+    "query protocol-state"
+  QueryStakeSnapshot' {} ->
+    "query stake-snapshot"
+  QueryKesPeriodInfo {} ->
+    "query kes-period-info"
+  QueryPoolState' {} ->
+    "query pool-state"
+  QueryTxMempool _ _ _ query _ ->
+    "query tx-mempool" <> renderTxMempoolQuery query
+  QuerySlotNumber {} ->
+    "query slot-number"
+
+renderTxMempoolQuery :: TxMempoolQuery -> Text
+renderTxMempoolQuery = \case
+  TxMempoolQueryTxExists tx -> "tx-exists " <> serialiseToRawBytesHexText tx
+  TxMempoolQueryNextTx -> "next-tx"
+  TxMempoolQueryInfo -> "info"

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/StakePool.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/StakePool.hs
@@ -1,0 +1,68 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE LambdaCase #-}
+
+module Cardano.CLI.EraBased.Commands.StakePool
+  ( StakePoolCmds (..)
+  , renderStakePoolCmds
+  ) where
+
+import           Cardano.Api.Shelley hiding (QueryInShelleyBasedEra (..))
+
+import           Cardano.CLI.Types.Common
+import           Cardano.CLI.Types.Key
+
+import           Prelude
+
+import           Data.Text (Text)
+
+data StakePoolCmds era
+  = StakePoolDeregistrationCertificateCmd
+      (ShelleyBasedEra era)
+      -- ^ Era in which to retire the stake pool.
+      (VerificationKeyOrFile StakePoolKey)
+      -- ^ Stake pool verification key.
+      EpochNo
+      -- ^ Epoch in which to retire the stake pool.
+      (File () Out)
+  | StakePoolIdCmd
+      (VerificationKeyOrFile StakePoolKey)
+      IdOutputFormat
+      (Maybe (File () Out))
+  | StakePoolMetadataHashCmd
+      (StakePoolMetadataFile In)
+      (Maybe (File () Out))
+  | StakePoolRegistrationCertificateCmd
+      (ShelleyBasedEra era)
+      -- ^ Era in which to register the stake pool.
+      (VerificationKeyOrFile StakePoolKey)
+      -- ^ Stake pool verification key.
+      (VerificationKeyOrFile VrfKey)
+      -- ^ VRF Verification key.
+      Lovelace
+      -- ^ Pool pledge.
+      Lovelace
+      -- ^ Pool cost.
+      Rational
+      -- ^ Pool margin.
+      (VerificationKeyOrFile StakeKey)
+      -- ^ Reward account verification staking key.
+      [VerificationKeyOrFile StakeKey]
+      -- ^ Pool owner verification staking key(s).
+      [StakePoolRelay]
+      -- ^ Stake pool relays.
+      (Maybe StakePoolMetadataReference)
+      -- ^ Stake pool metadata.
+      NetworkId
+      (File () Out)
+  deriving Show
+
+renderStakePoolCmds :: StakePoolCmds era -> Text
+renderStakePoolCmds = \case
+  StakePoolDeregistrationCertificateCmd {} ->
+    "stake-pool deregistration-certificate"
+  StakePoolIdCmd {} ->
+    "stake-pool id"
+  StakePoolMetadataHashCmd {} ->
+    "stake-pool metadata-hash"
+  StakePoolRegistrationCertificateCmd {} ->
+    "stake-pool registration-certificate"

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/TextView.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/TextView.hs
@@ -1,0 +1,21 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE LambdaCase #-}
+
+module Cardano.CLI.EraBased.Commands.TextView
+  ( TextViewCmds (..)
+  , renderTextViewCmds
+  ) where
+
+import           Cardano.Api.Shelley
+
+import           Data.Text (Text)
+
+data TextViewCmds era
+  = TextViewInfo
+      !FilePath
+      (Maybe (File () Out))
+  deriving Show
+
+renderTextViewCmds :: TextViewCmds era -> Text
+renderTextViewCmds = \case
+  TextViewInfo _ _ -> "text-view decode-cbor"

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Genesis.hs
@@ -1,0 +1,315 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Cardano.CLI.EraBased.Options.Genesis
+  ( pGenesisCmds
+  ) where
+
+import           Cardano.Api hiding (QueryInShelleyBasedEra (..))
+
+import           Cardano.Chain.Common (BlockCount (BlockCount))
+import           Cardano.CLI.Environment (EnvCli (..))
+import           Cardano.CLI.EraBased.Commands.Genesis
+import           Cardano.CLI.EraBased.Options.Common
+import           Cardano.CLI.Parser
+import           Cardano.CLI.Types.Common
+
+import           Data.Foldable
+import           Data.Maybe (fromMaybe)
+import           Data.Word (Word64)
+import           Options.Applicative hiding (help, str)
+import qualified Options.Applicative as Opt
+
+{- HLINT ignore "Use <$>" -}
+{- HLINT ignore "Move brackets to avoid $" -}
+
+pGenesisCmds :: EnvCli -> Parser (GenesisCmds era)
+pGenesisCmds envCli =
+  asum
+    [ subParser "key-gen-genesis"
+        $ Opt.info pGenesisKeyGen
+        $ Opt.progDesc "Create a Shelley genesis key pair"
+    , subParser "key-gen-delegate"
+        $ Opt.info pGenesisDelegateKeyGen
+        $ Opt.progDesc "Create a Shelley genesis delegate key pair"
+    , subParser "key-gen-utxo"
+        $ Opt.info pGenesisUTxOKeyGen
+        $ Opt.progDesc "Create a Shelley genesis UTxO key pair"
+    , subParser "key-hash"
+        $ Opt.info pGenesisKeyHash
+        $ Opt.progDesc "Print the identifier (hash) of a public key"
+    , subParser "get-ver-key"
+        $ Opt.info pGenesisVerKey
+        $ Opt.progDesc "Derive the verification key from a signing key"
+    , subParser "initial-addr"
+        $ Opt.info (pGenesisAddr envCli)
+        $ Opt.progDesc "Get the address for an initial UTxO based on the verification key"
+    , subParser "initial-txin"
+        $ Opt.info (pGenesisTxIn envCli)
+        $ Opt.progDesc "Get the TxIn for an initial UTxO based on the verification key"
+    , subParser "create-cardano"
+        $ Opt.info (pGenesisCreateCardano envCli)
+        $ Opt.progDesc
+        $ mconcat
+            [ "Create a Byron and Shelley genesis file from a genesis "
+            , "template and genesis/delegation/spending keys."
+            ]
+    , subParser "create"
+        $ Opt.info (pGenesisCreate envCli)
+        $ Opt.progDesc
+        $ mconcat
+            [ "Create a Shelley genesis file from a genesis "
+            , "template and genesis/delegation/spending keys."
+            ]
+    , subParser "create-staked"
+        $ Opt.info (pGenesisCreateStaked envCli)
+        $ Opt.progDesc
+        $ mconcat
+            [ "Create a staked Shelley genesis file from a genesis "
+            , "template and genesis/delegation/spending keys."
+            ]
+    , subParser "hash"
+        $ Opt.info pGenesisHash
+        $ Opt.progDesc "Compute the hash of a genesis file"
+    ]
+
+pGenesisKeyGen :: Parser (GenesisCmds era)
+pGenesisKeyGen =
+  GenesisKeyGenGenesis
+    <$> pVerificationKeyFileOut
+    <*> pSigningKeyFileOut
+
+pGenesisDelegateKeyGen :: Parser (GenesisCmds era)
+pGenesisDelegateKeyGen =
+  GenesisKeyGenDelegate
+    <$> pVerificationKeyFileOut
+    <*> pSigningKeyFileOut
+    <*> pOperatorCertIssueCounterFile
+
+pGenesisUTxOKeyGen :: Parser (GenesisCmds era)
+pGenesisUTxOKeyGen =
+  GenesisKeyGenUTxO
+    <$> pVerificationKeyFileOut
+    <*> pSigningKeyFileOut
+
+pGenesisKeyHash :: Parser (GenesisCmds era)
+pGenesisKeyHash =
+  GenesisCmdKeyHash
+    <$> pVerificationKeyFileIn
+
+pGenesisVerKey :: Parser (GenesisCmds era)
+pGenesisVerKey =
+  GenesisVerKey
+    <$> pVerificationKeyFileOut
+    <*> pSigningKeyFileIn
+
+pGenesisAddr :: EnvCli -> Parser (GenesisCmds era)
+pGenesisAddr envCli =
+  GenesisAddr
+    <$> pVerificationKeyFileIn
+    <*> pNetworkId envCli
+    <*> pMaybeOutputFile
+
+pGenesisTxIn :: EnvCli -> Parser (GenesisCmds era)
+pGenesisTxIn envCli =
+  GenesisTxIn
+    <$> pVerificationKeyFileIn
+    <*> pNetworkId envCli
+    <*> pMaybeOutputFile
+
+pGenesisCreateCardano :: EnvCli -> Parser (GenesisCmds era)
+pGenesisCreateCardano envCli =
+  GenesisCreateCardano
+    <$> pGenesisDir
+    <*> pGenesisNumGenesisKeys
+    <*> pGenesisNumUTxOKeys
+    <*> pMaybeSystemStart
+    <*> pInitialSupplyNonDelegated
+    <*> (BlockCount <$> pSecurityParam)
+    <*> pSlotLength
+    <*> pSlotCoefficient
+    <*> pNetworkId envCli
+    <*> parseFilePath
+          "byron-template"
+          "JSON file with genesis defaults for each byron."
+    <*> parseFilePath
+          "shelley-template"
+          "JSON file with genesis defaults for each shelley."
+    <*> parseFilePath
+          "alonzo-template"
+          "JSON file with genesis defaults for alonzo."
+    <*> parseFilePath
+          "conway-template"
+          "JSON file with genesis defaults for conway."
+    <*> pNodeConfigTemplate
+
+pGenesisCreate :: EnvCli -> Parser (GenesisCmds era)
+pGenesisCreate envCli =
+  GenesisCreate
+    <$> pKeyOutputFormat
+    <*> pGenesisDir
+    <*> pGenesisNumGenesisKeys
+    <*> pGenesisNumUTxOKeys
+    <*> pMaybeSystemStart
+    <*> pInitialSupplyNonDelegated
+    <*> pNetworkId envCli
+
+pGenesisCreateStaked :: EnvCli -> Parser (GenesisCmds era)
+pGenesisCreateStaked envCli =
+  GenesisCreateStaked
+    <$> pKeyOutputFormat
+    <*> pGenesisDir
+    <*> pGenesisNumGenesisKeys
+    <*> pGenesisNumUTxOKeys
+    <*> pGenesisNumPools
+    <*> pGenesisNumStDelegs
+    <*> pMaybeSystemStart
+    <*> pInitialSupplyNonDelegated
+    <*> pInitialSupplyDelegated
+    <*> pNetworkId envCli
+    <*> pBulkPoolCredFiles
+    <*> pBulkPoolsPerFile
+    <*> pStuffedUtxoCount
+    <*> Opt.optional pRelayJsonFp
+
+pGenesisHash :: Parser (GenesisCmds era)
+pGenesisHash =
+  GenesisHashFile <$> pGenesisFile "The genesis file."
+
+pGenesisDir :: Parser GenesisDir
+pGenesisDir =
+  fmap GenesisDir $ Opt.strOption $ mconcat
+    [ Opt.long "genesis-dir"
+    , Opt.metavar "DIR"
+    , Opt.help "The genesis directory containing the genesis template and required genesis/delegation/spending keys."
+    ]
+
+pMaybeSystemStart :: Parser (Maybe SystemStart)
+pMaybeSystemStart =
+  Opt.optional $ fmap (SystemStart . convertTime) $ Opt.strOption $ mconcat
+    [ Opt.long "start-time"
+    , Opt.metavar "UTC-TIME"
+    , Opt.help "The genesis start time in YYYY-MM-DDThh:mm:ssZ format. If unspecified, will be the current time +30 seconds."
+    ]
+
+pGenesisNumGenesisKeys :: Parser Word
+pGenesisNumGenesisKeys =
+  Opt.option Opt.auto $ mconcat
+    [ Opt.long "gen-genesis-keys"
+    , Opt.metavar "INT"
+    , Opt.help "The number of genesis keys to make [default is 3]."
+    , Opt.value 3
+    ]
+
+pNodeConfigTemplate :: Parser (Maybe FilePath)
+pNodeConfigTemplate = optional $ parseFilePath "node-config-template" "the node config template"
+
+pGenesisNumUTxOKeys :: Parser Word
+pGenesisNumUTxOKeys =
+  Opt.option Opt.auto $ mconcat
+    [ Opt.long "gen-utxo-keys"
+    , Opt.metavar "INT"
+    , Opt.help "The number of UTxO keys to make [default is 0]."
+    , Opt.value 0
+    ]
+
+pGenesisNumPools :: Parser Word
+pGenesisNumPools =
+  Opt.option Opt.auto $ mconcat
+    [ Opt.long "gen-pools"
+    , Opt.metavar "INT"
+    , Opt.help "The number of stake pool credential sets to make [default is 0]."
+    , Opt.value 0
+    ]
+
+pGenesisNumStDelegs :: Parser Word
+pGenesisNumStDelegs =
+  Opt.option Opt.auto $ mconcat
+    [ Opt.long "gen-stake-delegs"
+    , Opt.metavar "INT"
+    , Opt.help "The number of stake delegator credential sets to make [default is 0]."
+    , Opt.value 0
+    ]
+
+pStuffedUtxoCount :: Parser Word
+pStuffedUtxoCount =
+  Opt.option Opt.auto $ mconcat
+    [ Opt.long "num-stuffed-utxo"
+    , Opt.metavar "INT"
+    , Opt.help "The number of fake UTxO entries to generate [default is 0]."
+    , Opt.value 0
+    ]
+
+pRelayJsonFp :: Parser FilePath
+pRelayJsonFp =
+  Opt.strOption $ mconcat
+    [ Opt.long "relay-specification-file"
+    , Opt.metavar "FILE"
+    , Opt.help "JSON file specified the relays of each stake pool."
+    , Opt.completer (Opt.bashCompleter "file")
+    ]
+
+pInitialSupplyNonDelegated :: Parser (Maybe Lovelace)
+pInitialSupplyNonDelegated =
+  Opt.optional $ fmap Lovelace $ Opt.option Opt.auto $ mconcat
+    [ Opt.long "supply"
+    , Opt.metavar "LOVELACE"
+    , Opt.help "The initial coin supply in Lovelace which will be evenly distributed across initial, non-delegating stake holders."
+    ]
+
+pInitialSupplyDelegated :: Parser Lovelace
+pInitialSupplyDelegated =
+  fmap (Lovelace . fromMaybe 0) $ Opt.optional $ Opt.option Opt.auto $ mconcat
+    [ Opt.long "supply-delegated"
+    , Opt.metavar "LOVELACE"
+    , Opt.help "The initial coin supply in Lovelace which will be evenly distributed across initial, delegating stake holders."
+    , Opt.value 0
+    ]
+
+pSecurityParam :: Parser Word64
+pSecurityParam =
+  Opt.option Opt.auto $ mconcat
+    [ Opt.long "security-param"
+    , Opt.metavar "INT"
+    , Opt.help "Security parameter for genesis file [default is 108]."
+    , Opt.value 108
+    ]
+
+pSlotLength :: Parser Word
+pSlotLength =
+  Opt.option Opt.auto $ mconcat
+    [ Opt.long "slot-length"
+    , Opt.metavar "INT"
+    , Opt.help "slot length (ms) parameter for genesis file [default is 1000]."
+    , Opt.value 1000
+    ]
+
+
+pSlotCoefficient :: Parser Rational
+pSlotCoefficient =
+  Opt.option readRationalUnitInterval $ mconcat
+    [ Opt.long "slot-coefficient"
+    , Opt.metavar "RATIONAL"
+    , Opt.help "Slot Coefficient for genesis file [default is .05]."
+    , Opt.value 0.05
+    ]
+
+pBulkPoolCredFiles :: Parser Word
+pBulkPoolCredFiles =
+  Opt.option Opt.auto $ mconcat
+    [ Opt.long "bulk-pool-cred-files"
+    , Opt.metavar "INT"
+    , Opt.help "Generate bulk pool credential files [default is 0]."
+    , Opt.value 0
+    ]
+
+pBulkPoolsPerFile :: Parser Word
+pBulkPoolsPerFile =
+  Opt.option Opt.auto $ mconcat
+    [ Opt.long "bulk-pools-per-file"
+    , Opt.metavar "INT"
+    , Opt.help "Each bulk pool to contain this many pool credential sets [default is 0]."
+    , Opt.value 0
+    ]

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Key.hs
@@ -1,0 +1,256 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Cardano.CLI.EraBased.Options.Key
+  ( pKeyCmds
+  ) where
+
+import           Cardano.Api hiding (QueryInShelleyBasedEra (..))
+
+import           Cardano.CLI.EraBased.Commands.Key
+import           Cardano.CLI.EraBased.Options.Common
+import           Cardano.CLI.Types.Common
+
+import           Data.Foldable
+import           Data.Text (Text)
+import           Options.Applicative hiding (help, str)
+import qualified Options.Applicative as Opt
+
+{- HLINT ignore "Use <$>" -}
+{- HLINT ignore "Move brackets to avoid $" -}
+
+pKeyCmds :: Parser (KeyCmds era)
+pKeyCmds =
+  asum
+    [ subParser "verification-key"
+        $ Opt.info pKeyGetVerificationKey
+        $ Opt.progDesc
+        $ mconcat
+            [ "Get a verification key from a signing key. This "
+            , " supports all key types."
+            ]
+    , subParser "non-extended-key"
+        $ Opt.info pKeyNonExtendedKey
+        $ Opt.progDesc
+        $ mconcat
+            [ "Get a non-extended verification key from an "
+            , "extended verification key. This supports all "
+            , "extended key types."
+            ]
+    , subParser "convert-byron-key"
+        $ Opt.info pKeyConvertByronKey
+        $ Opt.progDesc
+        $ mconcat
+            [ "Convert a Byron payment, genesis or genesis "
+            , "delegate key (signing or verification) to a "
+            , "corresponding Shelley-format key."
+            ]
+    , subParser "convert-byron-genesis-vkey"
+        $ Opt.info pKeyConvertByronGenesisVKey
+        $ Opt.progDesc
+        $ mconcat
+            [ "Convert a Base64-encoded Byron genesis "
+            , "verification key to a Shelley genesis "
+            , "verification key"
+            ]
+    , subParser "convert-itn-key"
+        $ Opt.info pKeyConvertITNKey
+        $ Opt.progDesc
+        $ mconcat
+            [ "Convert an Incentivized Testnet (ITN) non-extended "
+            , "(Ed25519) signing or verification key to a "
+            , "corresponding Shelley stake key"
+            ]
+    , subParser "convert-itn-extended-key"
+        $ Opt.info pKeyConvertITNExtendedKey
+        $ Opt.progDesc
+        $ mconcat
+            [ "Convert an Incentivized Testnet (ITN) extended "
+            , "(Ed25519Extended) signing key to a corresponding "
+            , "Shelley stake signing key"
+            ]
+    , subParser "convert-itn-bip32-key"
+        $ Opt.info pKeyConvertITNBip32Key
+        $ Opt.progDesc
+        $ mconcat
+            [ "Convert an Incentivized Testnet (ITN) BIP32 "
+            , "(Ed25519Bip32) signing key to a corresponding "
+            , "Shelley stake signing key"
+            ]
+    , subParser "convert-cardano-address-key"
+        $ Opt.info pKeyConvertCardanoAddressSigningKey
+        $ Opt.progDesc
+        $ mconcat
+            [ "Convert a cardano-address extended signing key "
+            , "to a corresponding Shelley-format key."
+            ]
+    ]
+
+pKeyGetVerificationKey :: Parser (KeyCmds era)
+pKeyGetVerificationKey =
+  KeyGetVerificationKey
+    <$> pSigningKeyFileIn
+    <*> pVerificationKeyFileOut
+
+pKeyNonExtendedKey :: Parser (KeyCmds era)
+pKeyNonExtendedKey =
+  KeyNonExtendedKey
+    <$> pExtendedVerificationKeyFileIn
+    <*> pVerificationKeyFileOut
+
+pKeyConvertByronKey :: Parser (KeyCmds era)
+pKeyConvertByronKey =
+  KeyConvertByronKey
+    <$> optional pPassword
+    <*> pByronKeyType
+    <*> pByronKeyFile
+    <*> pOutputFile
+
+pPassword :: Parser Text
+pPassword =
+  Opt.strOption $ mconcat
+    [ Opt.long "password"
+    , Opt.metavar "TEXT"
+    , Opt.help "Password for signing key (if applicable)."
+    ]
+
+pByronKeyType :: Parser ByronKeyType
+pByronKeyType =
+  asum
+    [ Opt.flag' (ByronPaymentKey NonLegacyByronKeyFormat) $ mconcat
+        [ Opt.long "byron-payment-key-type"
+        , Opt.help "Use a Byron-era payment key."
+        ]
+    , Opt.flag' (ByronPaymentKey LegacyByronKeyFormat) $ mconcat
+        [ Opt.long "legacy-byron-payment-key-type"
+        , Opt.help "Use a Byron-era payment key, in legacy SL format."
+        ]
+    , Opt.flag' (ByronGenesisKey NonLegacyByronKeyFormat) $ mconcat
+        [ Opt.long "byron-genesis-key-type"
+        , Opt.help "Use a Byron-era genesis key."
+        ]
+    , Opt.flag' (ByronGenesisKey LegacyByronKeyFormat) $ mconcat
+        [ Opt.long "legacy-byron-genesis-key-type"
+        , Opt.help "Use a Byron-era genesis key, in legacy SL format."
+        ]
+    , Opt.flag' (ByronDelegateKey NonLegacyByronKeyFormat) $ mconcat
+        [ Opt.long "byron-genesis-delegate-key-type"
+        , Opt.help "Use a Byron-era genesis delegate key."
+        ]
+    , Opt.flag' (ByronDelegateKey LegacyByronKeyFormat) $ mconcat
+        [ Opt.long "legacy-byron-genesis-delegate-key-type"
+        , Opt.help "Use a Byron-era genesis delegate key, in legacy SL format."
+        ]
+    ]
+
+pByronKeyFile :: Parser (SomeKeyFile In)
+pByronKeyFile =
+  asum
+    [ ASigningKeyFile      <$> pByronSigningKeyFile
+    , AVerificationKeyFile <$> pByronVerificationKeyFile
+    ]
+
+pByronSigningKeyFile :: Parser (SigningKeyFile In)
+pByronSigningKeyFile =
+  fmap File $ Opt.strOption $ mconcat
+    [ Opt.long "byron-signing-key-file"
+    , Opt.metavar "FILE"
+    , Opt.help "Input filepath of the Byron-format signing key."
+    , Opt.completer (Opt.bashCompleter "file")
+    ]
+
+pByronVerificationKeyFile :: Parser (VerificationKeyFile In)
+pByronVerificationKeyFile =
+  fmap File $ Opt.strOption $ mconcat
+    [ Opt.long "byron-verification-key-file"
+    , Opt.metavar "FILE"
+    , Opt.help "Input filepath of the Byron-format verification key."
+    , Opt.completer (Opt.bashCompleter "file")
+    ]
+
+pKeyConvertByronGenesisVKey :: Parser (KeyCmds era)
+pKeyConvertByronGenesisVKey =
+  KeyConvertByronGenesisVKey
+    <$> pByronGenesisVKeyBase64
+    <*> pOutputFile
+
+pByronGenesisVKeyBase64 :: Parser VerificationKeyBase64
+pByronGenesisVKeyBase64 =
+  fmap VerificationKeyBase64 $ Opt.strOption $ mconcat
+    [ Opt.long "byron-genesis-verification-key"
+    , Opt.metavar "BASE64"
+    , Opt.help "Base64 string for the Byron genesis verification key."
+    ]
+
+pKeyConvertITNKey :: Parser (KeyCmds era)
+pKeyConvertITNKey =
+  KeyConvertITNStakeKey
+    <$> pITNKeyFIle
+    <*> pOutputFile
+
+pKeyConvertITNExtendedKey :: Parser (KeyCmds era)
+pKeyConvertITNExtendedKey =
+  KeyConvertITNExtendedToStakeKey
+    <$> pITNSigningKeyFile
+    <*> pOutputFile
+
+pKeyConvertITNBip32Key :: Parser (KeyCmds era)
+pKeyConvertITNBip32Key =
+  KeyConvertITNBip32ToStakeKey
+    <$> pITNSigningKeyFile
+    <*> pOutputFile
+
+pITNKeyFIle :: Parser (SomeKeyFile direction)
+pITNKeyFIle =
+  asum
+    [ pITNSigningKeyFile
+    , pITNVerificationKeyFile
+    ]
+
+pITNSigningKeyFile :: Parser (SomeKeyFile direction)
+pITNSigningKeyFile =
+  fmap (ASigningKeyFile . File) $ Opt.strOption $ mconcat
+    [ Opt.long "itn-signing-key-file"
+    , Opt.metavar "FILE"
+    , Opt.help "Filepath of the ITN signing key."
+    , Opt.completer (Opt.bashCompleter "file")
+    ]
+
+pITNVerificationKeyFile :: Parser (SomeKeyFile direction)
+pITNVerificationKeyFile =
+  fmap (AVerificationKeyFile . File) $ Opt.strOption $ mconcat
+    [ Opt.long "itn-verification-key-file"
+    , Opt.metavar "FILE"
+    , Opt.help "Filepath of the ITN verification key."
+    , Opt.completer (Opt.bashCompleter "file")
+    ]
+
+pKeyConvertCardanoAddressSigningKey :: Parser (KeyCmds era)
+pKeyConvertCardanoAddressSigningKey =
+  KeyConvertCardanoAddressSigningKey
+    <$> pCardanoAddressKeyType
+    <*> pSigningKeyFileIn
+    <*> pOutputFile
+
+pCardanoAddressKeyType :: Parser CardanoAddressKeyType
+pCardanoAddressKeyType =
+  asum
+    [ Opt.flag' CardanoAddressShelleyPaymentKey $ mconcat
+        [ Opt.long "shelley-payment-key"
+        , Opt.help "Use a Shelley-era extended payment key."
+        ]
+    , Opt.flag' CardanoAddressShelleyStakeKey $ mconcat
+        [ Opt.long "shelley-stake-key"
+        , Opt.help "Use a Shelley-era extended stake key."
+        ]
+    , Opt.flag' CardanoAddressIcarusPaymentKey $ mconcat
+        [ Opt.long "icarus-payment-key"
+        , Opt.help "Use a Byron-era extended payment key formatted in the Icarus style."
+        ]
+    , Opt.flag' CardanoAddressByronPaymentKey $ mconcat
+        [ Opt.long "byron-payment-key"
+        , Opt.help "Use a Byron-era extended payment key formatted in the deprecated Byron style."
+        ]
+    ]

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Node.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Node.hs
@@ -1,0 +1,96 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Cardano.CLI.EraBased.Options.Node
+  ( pNodeCmds
+  ) where
+
+import           Cardano.Api hiding (QueryInShelleyBasedEra (..))
+
+import           Cardano.CLI.EraBased.Commands.Node
+import           Cardano.CLI.EraBased.Options.Common
+
+import           Data.Foldable
+import           Options.Applicative hiding (help, str)
+import qualified Options.Applicative as Opt
+
+{- HLINT ignore "Use <$>" -}
+{- HLINT ignore "Move brackets to avoid $" -}
+
+pNodeCmds :: Parser (NodeCmds era)
+pNodeCmds =
+  asum
+    [ subParser "key-gen" . Opt.info pKeyGenOperator . Opt.progDesc $ mconcat
+      [ "Create a key pair for a node operator's offline "
+      , "key and a new certificate issue counter"
+      ]
+    , subParser "key-gen-KES" . Opt.info pKeyGenKES . Opt.progDesc $ mconcat
+      [ "Create a key pair for a node KES operational key"
+      ]
+    , subParser "key-gen-VRF" . Opt.info pKeyGenVRF . Opt.progDesc $ mconcat
+      [ "Create a key pair for a node VRF operational key"
+      ]
+    , subParser "key-hash-VRF". Opt.info pKeyHashVRF . Opt.progDesc $ mconcat
+      [ "Print hash of a node's operational VRF key."
+      ]
+    , subParser "new-counter" . Opt.info pNewCounter . Opt.progDesc $ mconcat
+      [ "Create a new certificate issue counter"
+      ]
+    , subParser "issue-op-cert" . Opt.info pIssueOpCert . Opt.progDesc $ mconcat
+      [ "Issue a node operational certificate"
+      ]
+    ]
+
+pKeyGenOperator :: Parser (NodeCmds era)
+pKeyGenOperator =
+  NodeKeyGenCold
+    <$> pKeyOutputFormat
+    <*> pColdVerificationKeyFile
+    <*> pColdSigningKeyFile
+    <*> pOperatorCertIssueCounterFile
+
+pKeyGenKES :: Parser (NodeCmds era)
+pKeyGenKES =
+  NodeKeyGenKES
+    <$> pKeyOutputFormat
+    <*> pVerificationKeyFileOut
+    <*> pSigningKeyFileOut
+
+pKeyGenVRF :: Parser (NodeCmds era)
+pKeyGenVRF =
+  NodeKeyGenVRF
+    <$> pKeyOutputFormat
+    <*> pVerificationKeyFileOut
+    <*> pSigningKeyFileOut
+
+pKeyHashVRF :: Parser (NodeCmds era)
+pKeyHashVRF =
+  NodeKeyHashVRF
+    <$> pVerificationKeyOrFileIn AsVrfKey
+    <*> pMaybeOutputFile
+
+pNewCounter :: Parser (NodeCmds era)
+pNewCounter =
+  NodeNewCounter
+    <$> pColdVerificationKeyOrFile
+    <*> pCounterValue
+    <*> pOperatorCertIssueCounterFile
+
+pCounterValue :: Parser Word
+pCounterValue =
+  Opt.option Opt.auto $ mconcat
+    [ Opt.long "counter-value"
+    , Opt.metavar "INT"
+    , Opt.help "The next certificate issue counter value to use."
+    ]
+
+pIssueOpCert :: Parser (NodeCmds era)
+pIssueOpCert =
+  NodeIssueOpCert
+    <$> pKesVerificationKeyOrFile
+    <*> pColdSigningKeyFile
+    <*> pOperatorCertIssueCounterFile
+    <*> pKesPeriod
+    <*> pOutputFile

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Query.hs
@@ -1,0 +1,246 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Cardano.CLI.EraBased.Options.Query
+  ( pQueryCmds
+  ) where
+
+import           Cardano.Api hiding (QueryInShelleyBasedEra (..))
+import           Cardano.Api.Shelley hiding (QueryInShelleyBasedEra (..))
+
+import           Cardano.CLI.Environment (EnvCli (..))
+import           Cardano.CLI.EraBased.Commands.Query
+import           Cardano.CLI.EraBased.Options.Common
+import           Cardano.CLI.Types.Common
+
+import           Data.Foldable
+import           Options.Applicative hiding (help, str)
+import qualified Options.Applicative as Opt
+
+{- HLINT ignore "Use <$>" -}
+{- HLINT ignore "Move brackets to avoid $" -}
+
+pQueryCmds :: EnvCli -> Parser (QueryCmds era)
+pQueryCmds envCli =
+  asum
+    [ subParser "protocol-parameters"
+        $ Opt.info (pQueryProtocolParameters envCli)
+        $ Opt.progDesc "Get the node's current protocol parameters"
+    , subParser "constitution-hash"
+        $ Opt.info (pQueryConstitutionHash envCli)
+        $ Opt.progDesc "Get the constitution hash"
+    , subParser "tip"
+        $ Opt.info (pQueryTip envCli)
+        $ Opt.progDesc "Get the node's current tip (slot no, hash, block no)"
+    , subParser "stake-pools"
+        $ Opt.info (pQueryStakePools envCli)
+        $ Opt.progDesc "Get the node's current set of stake pool ids"
+    , subParser "stake-distribution"
+        $ Opt.info (pQueryStakeDistribution envCli)
+        $ Opt.progDesc "Get the node's current aggregated stake distribution"
+    , subParser "stake-address-info"
+        $ Opt.info (pQueryStakeAddressInfo envCli)
+        $ Opt.progDesc $ mconcat
+            [ "Get the current delegations and reward accounts filtered by stake address."
+            ]
+    , subParser "utxo"
+        $ Opt.info (pQueryUTxO envCli)
+        $ Opt.progDesc $ mconcat
+            [ "Get a portion of the current UTxO: by tx in, by address or the whole."
+            ]
+    , subParser "ledger-state"
+        $ Opt.info (pQueryLedgerState envCli)
+        $ Opt.progDesc $ mconcat
+            [ "Dump the current ledger state of the node (Ledger.NewEpochState -- advanced command)"
+            ]
+    , subParser "protocol-state"
+        $ Opt.info (pQueryProtocolState envCli)
+        $ Opt.progDesc $ mconcat
+            [ "Dump the current protocol state of the node (Ledger.ChainDepState -- advanced command)"
+            ]
+    , subParser "stake-snapshot"
+        $ Opt.info (pQueryStakeSnapshot envCli)
+        $ Opt.progDesc $ mconcat
+            [ "Obtain the three stake snapshots for a pool, plus the total active stake (advanced command)"
+            ]
+    , hiddenSubParser "pool-params"
+        $ Opt.info (pQueryPoolState envCli)
+        $ Opt.progDesc $ mconcat
+            [ "DEPRECATED.  Use query pool-state instead.  Dump the pool parameters "
+            , "(Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced command)"
+            ]
+    , subParser "leadership-schedule"
+        $ Opt.info (pLeadershipSchedule envCli)
+        $ Opt.progDesc "Get the slots the node is expected to mint a block in (advanced command)"
+    , subParser "kes-period-info"
+        $ Opt.info (pKesPeriodInfo envCli)
+        $ Opt.progDesc "Get information about the current KES period and your node's operational certificate."
+    , subParser "pool-state"
+        $ Opt.info (pQueryPoolState envCli)
+        $ Opt.progDesc "Dump the pool state"
+    , subParser "tx-mempool"
+        $ Opt.info (pQueryTxMempool envCli)
+        $ Opt.progDesc "Local Mempool info"
+    , subParser "slot-number"
+        $ Opt.info (pQuerySlotNumber envCli)
+        $ Opt.progDesc "Query slot number for UTC timestamp"
+    ]
+
+pQueryProtocolParameters :: EnvCli -> Parser (QueryCmds era)
+pQueryProtocolParameters envCli =
+  QueryProtocolParameters'
+    <$> pSocketPath envCli
+    <*> pConsensusModeParams
+    <*> pNetworkId envCli
+    <*> pMaybeOutputFile
+
+pQueryConstitutionHash :: EnvCli -> Parser (QueryCmds era)
+pQueryConstitutionHash envCli =
+  QueryConstitutionHash
+    <$> pSocketPath envCli
+    <*> pConsensusModeParams
+    <*> pNetworkId envCli
+    <*> pMaybeOutputFile
+
+pQueryTip :: EnvCli -> Parser (QueryCmds era)
+pQueryTip envCli =
+  QueryTip
+    <$> pSocketPath envCli
+    <*> pConsensusModeParams
+    <*> pNetworkId envCli
+    <*> pMaybeOutputFile
+
+pQueryUTxO :: EnvCli -> Parser (QueryCmds era)
+pQueryUTxO envCli =
+  QueryUTxO'
+    <$> pSocketPath envCli
+    <*> pConsensusModeParams
+    <*> pQueryUTxOFilter
+    <*> pNetworkId envCli
+    <*> pMaybeOutputFile
+
+pQueryStakePools :: EnvCli -> Parser (QueryCmds era)
+pQueryStakePools envCli =
+  QueryStakePools'
+    <$> pSocketPath envCli
+    <*> pConsensusModeParams
+    <*> pNetworkId envCli
+    <*> pMaybeOutputFile
+
+pQueryStakeDistribution :: EnvCli -> Parser (QueryCmds era)
+pQueryStakeDistribution envCli =
+  QueryStakeDistribution'
+    <$> pSocketPath envCli
+    <*> pConsensusModeParams
+    <*> pNetworkId envCli
+    <*> pMaybeOutputFile
+
+pQueryStakeAddressInfo :: EnvCli -> Parser (QueryCmds era)
+pQueryStakeAddressInfo envCli =
+  QueryStakeAddressInfo
+    <$> pSocketPath envCli
+    <*> pConsensusModeParams
+    <*> pFilterByStakeAddress
+    <*> pNetworkId envCli
+    <*> pMaybeOutputFile
+
+pQueryLedgerState :: EnvCli -> Parser (QueryCmds era)
+pQueryLedgerState envCli =
+  QueryDebugLedgerState'
+    <$> pSocketPath envCli
+    <*> pConsensusModeParams
+    <*> pNetworkId envCli
+    <*> pMaybeOutputFile
+
+pQueryProtocolState :: EnvCli -> Parser (QueryCmds era)
+pQueryProtocolState envCli =
+  QueryProtocolState'
+    <$> pSocketPath envCli
+    <*> pConsensusModeParams
+    <*> pNetworkId envCli
+    <*> pMaybeOutputFile
+
+pAllStakePoolsOrOnly :: Parser (AllOrOnly [Hash StakePoolKey])
+pAllStakePoolsOrOnly = pAll <|> pOnly
+  where pAll :: Parser (AllOrOnly [Hash StakePoolKey])
+        pAll = Opt.flag' All $ mconcat
+          [ Opt.long "all-stake-pools"
+          , Opt.help "Query for all stake pools"
+          ]
+        pOnly :: Parser (AllOrOnly [Hash StakePoolKey])
+        pOnly = Only <$> many pStakePoolVerificationKeyHash
+
+pQueryStakeSnapshot :: EnvCli -> Parser (QueryCmds era)
+pQueryStakeSnapshot envCli =
+  QueryStakeSnapshot'
+    <$> pSocketPath envCli
+    <*> pConsensusModeParams
+    <*> pNetworkId envCli
+    <*> pAllStakePoolsOrOnly
+    <*> pMaybeOutputFile
+
+pQueryPoolState :: EnvCli -> Parser (QueryCmds era)
+pQueryPoolState envCli =
+  QueryPoolState'
+    <$> pSocketPath envCli
+    <*> pConsensusModeParams
+    <*> pNetworkId envCli
+    <*> many pStakePoolVerificationKeyHash
+
+pQueryTxMempool :: EnvCli -> Parser (QueryCmds era)
+pQueryTxMempool envCli =
+  QueryTxMempool
+    <$> pSocketPath envCli
+    <*> pConsensusModeParams
+    <*> pNetworkId envCli
+    <*> pTxMempoolQuery
+    <*> pMaybeOutputFile
+  where
+    pTxMempoolQuery :: Parser TxMempoolQuery
+    pTxMempoolQuery = asum
+      [ subParser "info"
+          $ Opt.info (pure TxMempoolQueryInfo)
+          $ Opt.progDesc "Ask the node about the current mempool's capacity and sizes"
+      , subParser "next-tx"
+          $ Opt.info (pure TxMempoolQueryNextTx)
+          $ Opt.progDesc "Requests the next transaction from the mempool's current list"
+      , subParser "tx-exists"
+          $ Opt.info (TxMempoolQueryTxExists <$> argument Opt.str (metavar "TX_ID"))
+          $ Opt.progDesc "Query if a particular transaction exists in the mempool"
+      ]
+pLeadershipSchedule :: EnvCli -> Parser (QueryCmds era)
+pLeadershipSchedule envCli =
+  QueryLeadershipSchedule
+    <$> pSocketPath envCli
+    <*> pConsensusModeParams
+    <*> pNetworkId envCli
+    <*> pGenesisFile "Shelley genesis filepath"
+    <*> pStakePoolVerificationKeyOrHashOrFile
+    <*> pVrfSigningKeyFile
+    <*> pWhichLeadershipSchedule
+    <*> pMaybeOutputFile
+
+pKesPeriodInfo :: EnvCli -> Parser (QueryCmds era)
+pKesPeriodInfo envCli =
+  QueryKesPeriodInfo
+    <$> pSocketPath envCli
+    <*> pConsensusModeParams
+    <*> pNetworkId envCli
+    <*> pOperationalCertificateFile
+    <*> pMaybeOutputFile
+
+pQuerySlotNumber :: EnvCli -> Parser (QueryCmds era)
+pQuerySlotNumber envCli =
+  QuerySlotNumber
+    <$> pSocketPath envCli
+    <*> pConsensusModeParams
+    <*> pNetworkId envCli
+    <*> pUtcTimestamp
+      where
+        pUtcTimestamp =
+          convertTime <$> (Opt.strArgument . mconcat)
+            [ Opt.metavar "TIMESTAMP"
+            , Opt.help "UTC timestamp in YYYY-MM-DDThh:mm:ssZ format"
+            ]

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/StakePool.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/StakePool.hs
@@ -1,0 +1,84 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Cardano.CLI.EraBased.Options.StakePool
+  ( pStakePoolCmds
+  ) where
+
+import           Cardano.Api
+
+import           Cardano.CLI.Environment (EnvCli (..))
+import           Cardano.CLI.EraBased.Commands.StakePool
+import           Cardano.CLI.EraBased.Options.Common
+
+import           Data.Foldable
+import           Data.Maybe
+import           Options.Applicative hiding (help, str)
+import qualified Options.Applicative as Opt
+
+{- HLINT ignore "Use <$>" -}
+{- HLINT ignore "Move brackets to avoid $" -}
+
+pStakePoolCmds :: CardanoEra era -> EnvCli -> Parser (StakePoolCmds era)
+pStakePoolCmds era envCli =
+  asum $ catMaybes
+    [ pStakePoolRegistrationCertificiateCmd era envCli
+    , pStakePoolDeregistrationCertificateCmd era
+    , Just
+        $ subParser "id"
+        $ Opt.info pStakePoolId
+        $ Opt.progDesc "Build pool id from the offline key"
+    , Just
+        $ subParser "metadata-hash"
+        $ Opt.info pStakePoolMetadataHashCmd
+        $ Opt.progDesc "Print the hash of pool metadata."
+    ]
+
+pStakePoolId :: Parser (StakePoolCmds era)
+pStakePoolId =
+  StakePoolIdCmd
+    <$> pStakePoolVerificationKeyOrFile
+    <*> pPoolIdOutputFormat
+    <*> pMaybeOutputFile
+
+pStakePoolMetadataHashCmd :: Parser (StakePoolCmds era)
+pStakePoolMetadataHashCmd =
+  StakePoolMetadataHashCmd
+    <$> pPoolMetadataFile
+    <*> pMaybeOutputFile
+
+pStakePoolRegistrationCertificiateCmd :: CardanoEra era -> EnvCli -> Maybe (Parser (StakePoolCmds era))
+pStakePoolRegistrationCertificiateCmd era envCli = do
+  w <- maybeFeatureInEra era
+  pure
+    $ subParser "registration-certificate"
+    $ Opt.info
+        ( StakePoolRegistrationCertificateCmd w
+            <$> pStakePoolVerificationKeyOrFile
+            <*> pVrfVerificationKeyOrFile
+            <*> pPoolPledge
+            <*> pPoolCost
+            <*> pPoolMargin
+            <*> pRewardAcctVerificationKeyOrFile
+            <*> some pPoolOwnerVerificationKeyOrFile
+            <*> many pPoolRelay
+            <*> pStakePoolMetadataReference
+            <*> pNetworkId envCli
+            <*> pOutputFile
+        )
+    $ Opt.progDesc "Create a stake pool registration certificate"
+
+pStakePoolDeregistrationCertificateCmd :: CardanoEra era -> Maybe (Parser (StakePoolCmds era))
+pStakePoolDeregistrationCertificateCmd era = do
+  w <- maybeFeatureInEra era
+  pure
+    $ subParser "deregistration-certificate"
+    $ Opt.info
+        ( StakePoolDeregistrationCertificateCmd w
+            <$> pStakePoolVerificationKeyOrFile
+            <*> pEpochNo "The epoch number."
+            <*> pOutputFile
+        )
+    $ Opt.progDesc "Create a stake pool deregistration certificate"

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/TextView.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/TextView.hs
@@ -1,0 +1,26 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Cardano.CLI.EraBased.Options.TextView
+  ( pTextViewCmds
+  ) where
+
+import           Cardano.CLI.EraBased.Commands.TextView
+import           Cardano.CLI.EraBased.Options.Common
+
+import           Data.Foldable
+import           Options.Applicative hiding (help, str)
+import qualified Options.Applicative as Opt
+
+{- HLINT ignore "Use <$>" -}
+{- HLINT ignore "Move brackets to avoid $" -}
+
+pTextViewCmds :: Parser (TextViewCmds era)
+pTextViewCmds =
+  asum
+    [ subParser "decode-cbor"
+        $ Opt.info (TextViewInfo <$> pCBORInFile <*> pMaybeOutputFile)
+        $ Opt.progDesc "Print a TextView file as decoded CBOR."
+    ]

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run.hs
@@ -12,13 +12,18 @@ import           Cardano.Api
 import           Cardano.CLI.EraBased.Commands
 import           Cardano.CLI.EraBased.Options.Governance
 import           Cardano.CLI.EraBased.Run.Address
+import           Cardano.CLI.EraBased.Run.Genesis
 import           Cardano.CLI.EraBased.Run.Governance
 import           Cardano.CLI.EraBased.Run.Governance.Actions
 import           Cardano.CLI.EraBased.Run.Governance.Committee
 import           Cardano.CLI.EraBased.Run.Governance.DRep
 import           Cardano.CLI.EraBased.Run.Governance.Query
 import           Cardano.CLI.EraBased.Run.Governance.Vote
+import           Cardano.CLI.EraBased.Run.Key
+import           Cardano.CLI.EraBased.Run.Node
+import           Cardano.CLI.EraBased.Run.Query
 import           Cardano.CLI.EraBased.Run.StakeAddress
+import           Cardano.CLI.EraBased.Run.TextView
 import           Cardano.CLI.EraBased.Run.Transaction
 import           Cardano.CLI.Types.Errors.CmdError
 
@@ -39,13 +44,29 @@ runCmds :: ()
 runCmds = \case
   AddressCmds cmd ->
     runAddressCmds cmd & firstExceptT CmdAddressError
+  KeyCmds cmd ->
+    runKeyCmds cmd
+      & firstExceptT CmdKeyError
   GovernanceCmds cmd ->
     runGovernanceCmds cmd
+  GenesisCmds cmd ->
+    runGenesisCmds cmd
+      & firstExceptT CmdGenesisError
+  NodeCmds cmd ->
+    runNodeCmds cmd
+      & firstExceptT CmdNodeError
+  QueryCmds cmd ->
+    runQueryCmds cmd
+      & firstExceptT CmdQueryError
   StakeAddressCmds cmd ->
     runStakeAddressCmds cmd
       & firstExceptT CmdStakeAddressError
+  TextViewCmds cmd ->
+    runTextViewCmds cmd
+      & firstExceptT CmdTextViewError
   TransactionCmds cmd ->
-    runTransactionCmds cmd & firstExceptT CmdTransactionError
+    runTransactionCmds cmd
+      & firstExceptT CmdTransactionError
 
 runGovernanceCmds :: ()
   => GovernanceCmds era

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Genesis.hs
@@ -11,13 +11,16 @@
 
 {-# OPTIONS_GHC -Wno-unticked-promoted-constructors #-}
 {-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
+{-# LANGUAGE LambdaCase #-}
 
 {- HLINT ignore "Reduce duplication" -}
 {- HLINT ignore "Redundant <$>" -}
 {- HLINT ignore "Use let" -}
 
 module Cardano.CLI.EraBased.Run.Genesis
-  ( runGenesisAddrCmd
+  ( runGenesisCmds
+
+  , runGenesisAddrCmd
   , runGenesisCreateCardanoCmd
   , runGenesisCreateCmd
   , runGenesisCreateStakedCmd
@@ -51,6 +54,7 @@ import           Cardano.Chain.Update hiding (ProtocolParameters)
 import           Cardano.CLI.Byron.Delegation
 import           Cardano.CLI.Byron.Genesis as Byron
 import qualified Cardano.CLI.Byron.Key as Byron
+import           Cardano.CLI.EraBased.Commands.Genesis
 import           Cardano.CLI.EraBased.Run.Node (runNodeIssueOpCertCmd, runNodeKeyGenColdCmd,
                    runNodeKeyGenKesCmd, runNodeKeyGenVrfCmd)
 import           Cardano.CLI.EraBased.Run.StakeAddress (runStakeAddressKeyGenCmd)
@@ -135,6 +139,31 @@ import           Text.JSON.Canonical (parseCanonicalJSON, renderCanonicalJSON)
 import           Text.Read (readMaybe)
 
 import           Crypto.Random as Crypto
+
+runGenesisCmds :: GenesisCmds era -> ExceptT ShelleyGenesisCmdError IO ()
+runGenesisCmds = \case
+  GenesisKeyGenGenesis vk sk ->
+    runGenesisKeyGenGenesisCmd vk sk
+  GenesisKeyGenDelegate vk sk ctr ->
+    runGenesisKeyGenDelegateCmd vk sk ctr
+  GenesisKeyGenUTxO vk sk ->
+    runGenesisKeyGenUTxOCmd vk sk
+  GenesisCmdKeyHash vk ->
+    runGenesisKeyHashCmd vk
+  GenesisVerKey vk sk ->
+    runGenesisVerKeyCmd vk sk
+  GenesisTxIn vk nw mOutFile ->
+    runGenesisTxInCmd vk nw mOutFile
+  GenesisAddr vk nw mOutFile ->
+    runGenesisAddrCmd vk nw mOutFile
+  GenesisCreate fmt gd gn un ms am nw ->
+    runGenesisCreateCmd fmt gd gn un ms am nw
+  GenesisCreateCardano gd gn un ms am k slotLength sc nw bg sg ag cg mNodeCfg ->
+    runGenesisCreateCardanoCmd gd gn un ms am k slotLength sc nw bg sg ag cg mNodeCfg
+  GenesisCreateStaked fmt gd gn gp gl un ms am ds nw bf bp su relayJsonFp ->
+    runGenesisCreateStakedCmd fmt gd gn gp gl un ms am ds nw bf bp su relayJsonFp
+  GenesisHashFile gf ->
+    runGenesisHashFileCmd gf
 
 runGenesisKeyGenGenesisCmd ::
      VerificationKeyFile Out

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Node.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Node.hs
@@ -1,7 +1,10 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE LambdaCase #-}
 
 module Cardano.CLI.EraBased.Run.Node
-  ( runNodeIssueOpCertCmd
+  ( runNodeCmds
+
+  , runNodeIssueOpCertCmd
   , runNodeKeyGenColdCmd
   , runNodeKeyGenKesCmd
   , runNodeKeyGenVrfCmd
@@ -12,6 +15,7 @@ module Cardano.CLI.EraBased.Run.Node
 import           Cardano.Api
 import           Cardano.Api.Shelley
 
+import           Cardano.CLI.EraBased.Commands.Node
 import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Errors.ShelleyNodeCmdError
 import           Cardano.CLI.Types.Key
@@ -24,6 +28,23 @@ import           Data.String (fromString)
 import           Data.Word (Word64)
 
 {- HLINT ignore "Reduce duplication" -}
+
+runNodeCmds :: ()
+  => NodeCmds era
+  -> ExceptT ShelleyNodeCmdError IO ()
+runNodeCmds = \case
+  NodeKeyGenCold fmt vk sk ctr ->
+    runNodeKeyGenColdCmd fmt vk sk ctr
+  NodeKeyGenKES  fmt vk sk ->
+    runNodeKeyGenKesCmd fmt vk sk
+  NodeKeyGenVRF  fmt vk sk ->
+    runNodeKeyGenVrfCmd fmt vk sk
+  NodeKeyHashVRF vk mOutFp ->
+    runNodeKeyHashVrfCmd vk mOutFp
+  NodeNewCounter vk ctr out ->
+    runNodeNewCounterCmd vk ctr out
+  NodeIssueOpCert vk sk ctr p out ->
+    runNodeIssueOpCertCmd vk sk ctr p out
 
 runNodeKeyGenColdCmd
   :: KeyOutputFormat

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Query.hs
@@ -11,7 +11,9 @@
 {-# LANGUAGE TypeOperators #-}
 
 module Cardano.CLI.EraBased.Run.Query
-  ( runQueryConstitutionHashCmd
+  ( runQueryCmds
+
+  , runQueryConstitutionHashCmd
   , runQueryKesPeriodInfoCmd
   , runQueryLeadershipScheduleCmd
   , runQueryLedgerStateCmd
@@ -39,6 +41,7 @@ import           Cardano.Api.Byron hiding (QueryInShelleyBasedEra (..))
 import qualified Cardano.Api.Ledger as Ledger
 import           Cardano.Api.Shelley hiding (QueryInShelleyBasedEra (..))
 
+import           Cardano.CLI.EraBased.Commands.Query
 import           Cardano.CLI.EraBased.Run.Genesis (readAndDecodeShelleyGenesis)
 import           Cardano.CLI.Helpers (pPrintCBOR)
 import           Cardano.CLI.Pretty
@@ -102,6 +105,39 @@ import           Text.Printf (printf)
 
 {- HLINT ignore "Move brackets to avoid $" -}
 {- HLINT ignore "Redundant flip" -}
+
+runQueryCmds :: QueryCmds era -> ExceptT ShelleyQueryCmdError IO ()
+runQueryCmds = \case
+  QueryLeadershipSchedule mNodeSocketPath consensusModeParams network shelleyGenFp poolid vrkSkeyFp whichSchedule outputAs ->
+    runQueryLeadershipScheduleCmd mNodeSocketPath consensusModeParams network shelleyGenFp poolid vrkSkeyFp whichSchedule outputAs
+  QueryProtocolParameters' mNodeSocketPath consensusModeParams network mOutFile ->
+    runQueryProtocolParametersCmd mNodeSocketPath consensusModeParams network mOutFile
+  QueryConstitutionHash mNodeSocketPath consensusModeParams network mOutFile ->
+    runQueryConstitutionHashCmd mNodeSocketPath consensusModeParams network mOutFile
+  QueryTip mNodeSocketPath consensusModeParams network mOutFile ->
+    runQueryTipCmd mNodeSocketPath consensusModeParams network mOutFile
+  QueryStakePools' mNodeSocketPath consensusModeParams network mOutFile ->
+    runQueryStakePoolsCmd mNodeSocketPath consensusModeParams network mOutFile
+  QueryStakeDistribution' mNodeSocketPath consensusModeParams network mOutFile ->
+    runQueryStakeDistributionCmd mNodeSocketPath consensusModeParams network mOutFile
+  QueryStakeAddressInfo mNodeSocketPath consensusModeParams addr network mOutFile ->
+    runQueryStakeAddressInfoCmd mNodeSocketPath consensusModeParams addr network mOutFile
+  QueryDebugLedgerState' mNodeSocketPath consensusModeParams network mOutFile ->
+    runQueryLedgerStateCmd mNodeSocketPath consensusModeParams network mOutFile
+  QueryStakeSnapshot' mNodeSocketPath consensusModeParams network allOrOnlyPoolIds mOutFile ->
+    runQueryStakeSnapshotCmd mNodeSocketPath consensusModeParams network allOrOnlyPoolIds mOutFile
+  QueryProtocolState' mNodeSocketPath consensusModeParams network mOutFile ->
+    runQueryProtocolStateCmd mNodeSocketPath consensusModeParams network mOutFile
+  QueryUTxO' mNodeSocketPath consensusModeParams qFilter networkId mOutFile ->
+    runQueryUTxOCmd mNodeSocketPath consensusModeParams qFilter networkId mOutFile
+  QueryKesPeriodInfo mNodeSocketPath consensusModeParams network nodeOpCert mOutFile ->
+    runQueryKesPeriodInfoCmd mNodeSocketPath consensusModeParams network nodeOpCert mOutFile
+  QueryPoolState' mNodeSocketPath consensusModeParams network poolid ->
+    runQueryPoolStateCmd mNodeSocketPath consensusModeParams network poolid
+  QueryTxMempool mNodeSocketPath consensusModeParams network op mOutFile ->
+    runQueryTxMempoolCmd mNodeSocketPath consensusModeParams network op mOutFile
+  QuerySlotNumber mNodeSocketPath consensusModeParams network utcTime ->
+    runQuerySlotNumberCmd mNodeSocketPath consensusModeParams network utcTime
 
 runQueryConstitutionHashCmd
   :: SocketPath

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/TextView.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/TextView.hs
@@ -1,11 +1,15 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE LambdaCase #-}
 
 module Cardano.CLI.EraBased.Run.TextView
-  ( runTextViewInfoCmd
+  ( runTextViewCmds
+
+  , runTextViewInfoCmd
   ) where
 
 import           Cardano.Api
 
+import           Cardano.CLI.EraBased.Commands.TextView
 import           Cardano.CLI.Helpers (pPrintCBOR)
 import           Cardano.CLI.Types.Errors.ShelleyTextViewFileError
 
@@ -13,6 +17,10 @@ import           Control.Monad.IO.Class (MonadIO (..))
 import           Control.Monad.Trans.Except (ExceptT)
 import           Control.Monad.Trans.Except.Extra (firstExceptT, newExceptT)
 import qualified Data.ByteString.Lazy.Char8 as LBS
+
+runTextViewCmds :: TextViewCmds era -> ExceptT ShelleyTextViewFileError IO ()
+runTextViewCmds = \case
+  TextViewInfo fpath mOutfile -> runTextViewInfoCmd fpath mOutfile
 
 runTextViewInfoCmd :: ()
   => FilePath

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -13,7 +13,17 @@ Usage: cardano-cli
                      | version
                      )
 
-Usage: cardano-cli shelley (address | governance | stake-address | transaction)
+Usage: cardano-cli shelley 
+                             ( address
+                             | key
+                             | genesis
+                             | governance
+                             | node
+                             | query
+                             | stake-address
+                             | text-view
+                             | transaction
+                             )
 
   Shelley era commands
 
@@ -57,6 +67,199 @@ Usage: cardano-cli shelley address build
 Usage: cardano-cli shelley address info --address ADDRESS [--out-file FILE]
 
   Print information about an address.
+
+Usage: cardano-cli shelley key 
+                                 ( verification-key
+                                 | non-extended-key
+                                 | convert-byron-key
+                                 | convert-byron-genesis-vkey
+                                 | convert-itn-key
+                                 | convert-itn-extended-key
+                                 | convert-itn-bip32-key
+                                 | convert-cardano-address-key
+                                 )
+
+  Era-based key commands
+
+Usage: cardano-cli shelley key verification-key --signing-key-file FILE
+                                                  --verification-key-file FILE
+
+  Get a verification key from a signing key. This supports all key types.
+
+Usage: cardano-cli shelley key non-extended-key --extended-verification-key-file FILE
+                                                  --verification-key-file FILE
+
+  Get a non-extended verification key from an extended verification key. This
+  supports all extended key types.
+
+Usage: cardano-cli shelley key convert-byron-key [--password TEXT]
+                                                   ( --byron-payment-key-type
+                                                   | --legacy-byron-payment-key-type
+                                                   | --byron-genesis-key-type
+                                                   | --legacy-byron-genesis-key-type
+                                                   | --byron-genesis-delegate-key-type
+                                                   | --legacy-byron-genesis-delegate-key-type
+                                                   )
+                                                   ( --byron-signing-key-file FILE
+                                                   | --byron-verification-key-file FILE
+                                                   )
+                                                   --out-file FILE
+
+  Convert a Byron payment, genesis or genesis delegate key (signing or
+  verification) to a corresponding Shelley-format key.
+
+Usage: cardano-cli shelley key convert-byron-genesis-vkey --byron-genesis-verification-key BASE64
+                                                            --out-file FILE
+
+  Convert a Base64-encoded Byron genesis verification key to a Shelley genesis
+  verification key
+
+Usage: cardano-cli shelley key convert-itn-key 
+                                                 ( --itn-signing-key-file FILE
+                                                 | --itn-verification-key-file FILE
+                                                 )
+                                                 --out-file FILE
+
+  Convert an Incentivized Testnet (ITN) non-extended (Ed25519) signing or
+  verification key to a corresponding Shelley stake key
+
+Usage: cardano-cli shelley key convert-itn-extended-key --itn-signing-key-file FILE
+                                                          --out-file FILE
+
+  Convert an Incentivized Testnet (ITN) extended (Ed25519Extended) signing key
+  to a corresponding Shelley stake signing key
+
+Usage: cardano-cli shelley key convert-itn-bip32-key --itn-signing-key-file FILE
+                                                       --out-file FILE
+
+  Convert an Incentivized Testnet (ITN) BIP32 (Ed25519Bip32) signing key to a
+  corresponding Shelley stake signing key
+
+Usage: cardano-cli shelley key convert-cardano-address-key 
+                                                             ( --shelley-payment-key
+                                                             | --shelley-stake-key
+                                                             | --icarus-payment-key
+                                                             | --byron-payment-key
+                                                             )
+                                                             --signing-key-file FILE
+                                                             --out-file FILE
+
+  Convert a cardano-address extended signing key to a corresponding
+  Shelley-format key.
+
+Usage: cardano-cli shelley genesis 
+                                     ( key-gen-genesis
+                                     | key-gen-delegate
+                                     | key-gen-utxo
+                                     | key-hash
+                                     | get-ver-key
+                                     | initial-addr
+                                     | initial-txin
+                                     | create-cardano
+                                     | create
+                                     | create-staked
+                                     | hash
+                                     )
+
+  Era-based genesis commands
+
+Usage: cardano-cli shelley genesis key-gen-genesis --verification-key-file FILE
+                                                     --signing-key-file FILE
+
+  Create a Shelley genesis key pair
+
+Usage: cardano-cli shelley genesis key-gen-delegate --verification-key-file FILE
+                                                      --signing-key-file FILE
+                                                      --operational-certificate-issue-counter-file FILE
+
+  Create a Shelley genesis delegate key pair
+
+Usage: cardano-cli shelley genesis key-gen-utxo --verification-key-file FILE
+                                                  --signing-key-file FILE
+
+  Create a Shelley genesis UTxO key pair
+
+Usage: cardano-cli shelley genesis key-hash --verification-key-file FILE
+
+  Print the identifier (hash) of a public key
+
+Usage: cardano-cli shelley genesis get-ver-key --verification-key-file FILE
+                                                 --signing-key-file FILE
+
+  Derive the verification key from a signing key
+
+Usage: cardano-cli shelley genesis initial-addr --verification-key-file FILE
+                                                  ( --mainnet
+                                                  | --testnet-magic NATURAL
+                                                  )
+                                                  [--out-file FILE]
+
+  Get the address for an initial UTxO based on the verification key
+
+Usage: cardano-cli shelley genesis initial-txin --verification-key-file FILE
+                                                  ( --mainnet
+                                                  | --testnet-magic NATURAL
+                                                  )
+                                                  [--out-file FILE]
+
+  Get the TxIn for an initial UTxO based on the verification key
+
+Usage: cardano-cli shelley genesis create-cardano --genesis-dir DIR
+                                                    [--gen-genesis-keys INT]
+                                                    [--gen-utxo-keys INT]
+                                                    [--start-time UTC-TIME]
+                                                    [--supply LOVELACE]
+                                                    [--security-param INT]
+                                                    [--slot-length INT]
+                                                    [--slot-coefficient RATIONAL]
+                                                    ( --mainnet
+                                                    | --testnet-magic NATURAL
+                                                    )
+                                                    --byron-template FILEPATH
+                                                    --shelley-template FILEPATH
+                                                    --alonzo-template FILEPATH
+                                                    --conway-template FILEPATH
+                                                    [--node-config-template FILEPATH]
+
+  Create a Byron and Shelley genesis file from a genesis template and
+  genesis/delegation/spending keys.
+
+Usage: cardano-cli shelley genesis create [--key-output-format STRING]
+                                            --genesis-dir DIR
+                                            [--gen-genesis-keys INT]
+                                            [--gen-utxo-keys INT]
+                                            [--start-time UTC-TIME]
+                                            [--supply LOVELACE]
+                                            ( --mainnet
+                                            | --testnet-magic NATURAL
+                                            )
+
+  Create a Shelley genesis file from a genesis template and
+  genesis/delegation/spending keys.
+
+Usage: cardano-cli shelley genesis create-staked [--key-output-format STRING]
+                                                   --genesis-dir DIR
+                                                   [--gen-genesis-keys INT]
+                                                   [--gen-utxo-keys INT]
+                                                   [--gen-pools INT]
+                                                   [--gen-stake-delegs INT]
+                                                   [--start-time UTC-TIME]
+                                                   [--supply LOVELACE]
+                                                   [--supply-delegated LOVELACE]
+                                                   ( --mainnet
+                                                   | --testnet-magic NATURAL
+                                                   )
+                                                   [--bulk-pool-cred-files INT]
+                                                   [--bulk-pools-per-file INT]
+                                                   [--num-stuffed-utxo INT]
+                                                   [--relay-specification-file FILE]
+
+  Create a staked Shelley genesis file from a genesis template and
+  genesis/delegation/spending keys.
+
+Usage: cardano-cli shelley genesis hash --genesis FILE
+
+  Compute the hash of a genesis file
 
 Usage: cardano-cli shelley governance (create-mir-certificate | action | drep)
 
@@ -186,6 +389,338 @@ Usage: cardano-cli shelley governance drep registration-certificate
 
   Create a registration certificate.
 
+Usage: cardano-cli shelley node 
+                                  ( key-gen
+                                  | key-gen-KES
+                                  | key-gen-VRF
+                                  | key-hash-VRF
+                                  | new-counter
+                                  | issue-op-cert
+                                  )
+
+  Era-based node commands
+
+Usage: cardano-cli shelley node key-gen [--key-output-format STRING]
+                                          --cold-verification-key-file FILE
+                                          --cold-signing-key-file FILE
+                                          --operational-certificate-issue-counter-file FILE
+
+  Create a key pair for a node operator's offline key and a new certificate
+  issue counter
+
+Usage: cardano-cli shelley node key-gen-KES [--key-output-format STRING]
+                                              --verification-key-file FILE
+                                              --signing-key-file FILE
+
+  Create a key pair for a node KES operational key
+
+Usage: cardano-cli shelley node key-gen-VRF [--key-output-format STRING]
+                                              --verification-key-file FILE
+                                              --signing-key-file FILE
+
+  Create a key pair for a node VRF operational key
+
+Usage: cardano-cli shelley node key-hash-VRF 
+                                               ( --verification-key STRING
+                                               | --verification-key-file FILE
+                                               )
+                                               [--out-file FILE]
+
+  Print hash of a node's operational VRF key.
+
+Usage: cardano-cli shelley node new-counter 
+                                              ( --stake-pool-verification-key STRING
+                                              | --genesis-delegate-verification-key STRING
+                                              | --cold-verification-key-file FILE
+                                              )
+                                              --counter-value INT
+                                              --operational-certificate-issue-counter-file FILE
+
+  Create a new certificate issue counter
+
+Usage: cardano-cli shelley node issue-op-cert 
+                                                ( --kes-verification-key STRING
+                                                | --kes-verification-key-file FILE
+                                                )
+                                                --cold-signing-key-file FILE
+                                                --operational-certificate-issue-counter-file FILE
+                                                --kes-period NATURAL
+                                                --out-file FILE
+
+  Issue a node operational certificate
+
+Usage: cardano-cli shelley query 
+                                   ( protocol-parameters
+                                   | constitution-hash
+                                   | tip
+                                   | stake-pools
+                                   | stake-distribution
+                                   | stake-address-info
+                                   | utxo
+                                   | ledger-state
+                                   | protocol-state
+                                   | stake-snapshot
+                                   | leadership-schedule
+                                   | kes-period-info
+                                   | pool-state
+                                   | tx-mempool
+                                   | slot-number
+                                   )
+
+  Era-based query commands
+
+Usage: cardano-cli shelley query protocol-parameters --socket-path SOCKET_PATH
+                                                       [ --shelley-mode
+                                                       | --byron-mode
+                                                         [--epoch-slots SLOTS]
+                                                       | --cardano-mode
+                                                         [--epoch-slots SLOTS]
+                                                       ]
+                                                       ( --mainnet
+                                                       | --testnet-magic NATURAL
+                                                       )
+                                                       [--out-file FILE]
+
+  Get the node's current protocol parameters
+
+Usage: cardano-cli shelley query constitution-hash --socket-path SOCKET_PATH
+                                                     [ --shelley-mode
+                                                     | --byron-mode
+                                                       [--epoch-slots SLOTS]
+                                                     | --cardano-mode
+                                                       [--epoch-slots SLOTS]
+                                                     ]
+                                                     ( --mainnet
+                                                     | --testnet-magic NATURAL
+                                                     )
+                                                     [--out-file FILE]
+
+  Get the constitution hash
+
+Usage: cardano-cli shelley query tip --socket-path SOCKET_PATH
+                                       [ --shelley-mode
+                                       | --byron-mode [--epoch-slots SLOTS]
+                                       | --cardano-mode [--epoch-slots SLOTS]
+                                       ]
+                                       (--mainnet | --testnet-magic NATURAL)
+                                       [--out-file FILE]
+
+  Get the node's current tip (slot no, hash, block no)
+
+Usage: cardano-cli shelley query stake-pools --socket-path SOCKET_PATH
+                                               [ --shelley-mode
+                                               | --byron-mode
+                                                 [--epoch-slots SLOTS]
+                                               | --cardano-mode
+                                                 [--epoch-slots SLOTS]
+                                               ]
+                                               ( --mainnet
+                                               | --testnet-magic NATURAL
+                                               )
+                                               [--out-file FILE]
+
+  Get the node's current set of stake pool ids
+
+Usage: cardano-cli shelley query stake-distribution --socket-path SOCKET_PATH
+                                                      [ --shelley-mode
+                                                      | --byron-mode
+                                                        [--epoch-slots SLOTS]
+                                                      | --cardano-mode
+                                                        [--epoch-slots SLOTS]
+                                                      ]
+                                                      ( --mainnet
+                                                      | --testnet-magic NATURAL
+                                                      )
+                                                      [--out-file FILE]
+
+  Get the node's current aggregated stake distribution
+
+Usage: cardano-cli shelley query stake-address-info --socket-path SOCKET_PATH
+                                                      [ --shelley-mode
+                                                      | --byron-mode
+                                                        [--epoch-slots SLOTS]
+                                                      | --cardano-mode
+                                                        [--epoch-slots SLOTS]
+                                                      ]
+                                                      --address ADDRESS
+                                                      ( --mainnet
+                                                      | --testnet-magic NATURAL
+                                                      )
+                                                      [--out-file FILE]
+
+  Get the current delegations and reward accounts filtered by stake address.
+
+Usage: cardano-cli shelley query utxo --socket-path SOCKET_PATH
+                                        [ --shelley-mode
+                                        | --byron-mode [--epoch-slots SLOTS]
+                                        | --cardano-mode [--epoch-slots SLOTS]
+                                        ]
+                                        ( --whole-utxo
+                                        | (--address ADDRESS)
+                                        | (--tx-in TX-IN)
+                                        )
+                                        (--mainnet | --testnet-magic NATURAL)
+                                        [--out-file FILE]
+
+  Get a portion of the current UTxO: by tx in, by address or the whole.
+
+Usage: cardano-cli shelley query ledger-state --socket-path SOCKET_PATH
+                                                [ --shelley-mode
+                                                | --byron-mode
+                                                  [--epoch-slots SLOTS]
+                                                | --cardano-mode
+                                                  [--epoch-slots SLOTS]
+                                                ]
+                                                ( --mainnet
+                                                | --testnet-magic NATURAL
+                                                )
+                                                [--out-file FILE]
+
+  Dump the current ledger state of the node (Ledger.NewEpochState -- advanced
+  command)
+
+Usage: cardano-cli shelley query protocol-state --socket-path SOCKET_PATH
+                                                  [ --shelley-mode
+                                                  | --byron-mode
+                                                    [--epoch-slots SLOTS]
+                                                  | --cardano-mode
+                                                    [--epoch-slots SLOTS]
+                                                  ]
+                                                  ( --mainnet
+                                                  | --testnet-magic NATURAL
+                                                  )
+                                                  [--out-file FILE]
+
+  Dump the current protocol state of the node (Ledger.ChainDepState -- advanced
+  command)
+
+Usage: cardano-cli shelley query stake-snapshot --socket-path SOCKET_PATH
+                                                  [ --shelley-mode
+                                                  | --byron-mode
+                                                    [--epoch-slots SLOTS]
+                                                  | --cardano-mode
+                                                    [--epoch-slots SLOTS]
+                                                  ]
+                                                  ( --mainnet
+                                                  | --testnet-magic NATURAL
+                                                  )
+                                                  [ --all-stake-pools
+                                                  | 
+                                                  [--stake-pool-id STAKE_POOL_ID]
+                                                  ]
+                                                  [--out-file FILE]
+
+  Obtain the three stake snapshots for a pool, plus the total active stake
+  (advanced command)
+
+Usage: cardano-cli shelley query pool-params --socket-path SOCKET_PATH
+                                               [ --shelley-mode
+                                               | --byron-mode
+                                                 [--epoch-slots SLOTS]
+                                               | --cardano-mode
+                                                 [--epoch-slots SLOTS]
+                                               ]
+                                               ( --mainnet
+                                               | --testnet-magic NATURAL
+                                               )
+                                               [--stake-pool-id STAKE_POOL_ID]
+
+  DEPRECATED. Use query pool-state instead. Dump the pool parameters
+  (Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced
+  command)
+
+Usage: cardano-cli shelley query leadership-schedule --socket-path SOCKET_PATH
+                                                       [ --shelley-mode
+                                                       | --byron-mode
+                                                         [--epoch-slots SLOTS]
+                                                       | --cardano-mode
+                                                         [--epoch-slots SLOTS]
+                                                       ]
+                                                       ( --mainnet
+                                                       | --testnet-magic NATURAL
+                                                       )
+                                                       --genesis FILE
+                                                       ( --stake-pool-verification-key STRING
+                                                       | --cold-verification-key-file FILE
+                                                       | --stake-pool-id STAKE_POOL_ID
+                                                       )
+                                                       --vrf-signing-key-file FILE
+                                                       (--current | --next)
+                                                       [--out-file FILE]
+
+  Get the slots the node is expected to mint a block in (advanced command)
+
+Usage: cardano-cli shelley query kes-period-info --socket-path SOCKET_PATH
+                                                   [ --shelley-mode
+                                                   | --byron-mode
+                                                     [--epoch-slots SLOTS]
+                                                   | --cardano-mode
+                                                     [--epoch-slots SLOTS]
+                                                   ]
+                                                   ( --mainnet
+                                                   | --testnet-magic NATURAL
+                                                   )
+                                                   --op-cert-file FILE
+                                                   [--out-file FILE]
+
+  Get information about the current KES period and your node's operational
+  certificate.
+
+Usage: cardano-cli shelley query pool-state --socket-path SOCKET_PATH
+                                              [ --shelley-mode
+                                              | --byron-mode
+                                                [--epoch-slots SLOTS]
+                                              | --cardano-mode
+                                                [--epoch-slots SLOTS]
+                                              ]
+                                              ( --mainnet
+                                              | --testnet-magic NATURAL
+                                              )
+                                              [--stake-pool-id STAKE_POOL_ID]
+
+  Dump the pool state
+
+Usage: cardano-cli shelley query tx-mempool --socket-path SOCKET_PATH
+                                              [ --shelley-mode
+                                              | --byron-mode
+                                                [--epoch-slots SLOTS]
+                                              | --cardano-mode
+                                                [--epoch-slots SLOTS]
+                                              ]
+                                              ( --mainnet
+                                              | --testnet-magic NATURAL
+                                              )
+                                              (info | next-tx | tx-exists)
+                                              [--out-file FILE]
+
+  Local Mempool info
+
+Usage: cardano-cli shelley query tx-mempool info 
+
+  Ask the node about the current mempool's capacity and sizes
+
+Usage: cardano-cli shelley query tx-mempool next-tx 
+
+  Requests the next transaction from the mempool's current list
+
+Usage: cardano-cli shelley query tx-mempool tx-exists TX_ID
+
+  Query if a particular transaction exists in the mempool
+
+Usage: cardano-cli shelley query slot-number --socket-path SOCKET_PATH
+                                               [ --shelley-mode
+                                               | --byron-mode
+                                                 [--epoch-slots SLOTS]
+                                               | --cardano-mode
+                                                 [--epoch-slots SLOTS]
+                                               ]
+                                               ( --mainnet
+                                               | --testnet-magic NATURAL
+                                               )
+                                               TIMESTAMP
+
+  Query slot number for UTC timestamp
+
 Usage: cardano-cli shelley stake-address 
                                            ( key-gen
                                            | key-hash
@@ -260,6 +795,15 @@ Usage: cardano-cli shelley stake-address stake-delegation-certificate
   Create a stake address stake delegation certificate, which when submitted in a
   transaction delegates stake to a stake pool.
 
+Usage: cardano-cli shelley text-view decode-cbor
+
+  Era-based text-view commands
+
+Usage: cardano-cli shelley text-view decode-cbor --in-file FILE
+                                                   [--out-file FILE]
+
+  Print a TextView file as decoded CBOR.
+
 Usage: cardano-cli shelley transaction 
                                          ( build-raw
                                          | build
@@ -275,7 +819,7 @@ Usage: cardano-cli shelley transaction
                                          | view
                                          )
 
-  Era-based governance commands
+  Era-based transaction commands
 
 Usage: cardano-cli shelley transaction build-raw 
                                                    [ --script-valid
@@ -643,7 +1187,17 @@ Usage: cardano-cli shelley transaction view
 
   Print a transaction.
 
-Usage: cardano-cli allegra (address | governance | stake-address | transaction)
+Usage: cardano-cli allegra 
+                             ( address
+                             | key
+                             | genesis
+                             | governance
+                             | node
+                             | query
+                             | stake-address
+                             | text-view
+                             | transaction
+                             )
 
   Allegra era commands
 
@@ -687,6 +1241,199 @@ Usage: cardano-cli allegra address build
 Usage: cardano-cli allegra address info --address ADDRESS [--out-file FILE]
 
   Print information about an address.
+
+Usage: cardano-cli allegra key 
+                                 ( verification-key
+                                 | non-extended-key
+                                 | convert-byron-key
+                                 | convert-byron-genesis-vkey
+                                 | convert-itn-key
+                                 | convert-itn-extended-key
+                                 | convert-itn-bip32-key
+                                 | convert-cardano-address-key
+                                 )
+
+  Era-based key commands
+
+Usage: cardano-cli allegra key verification-key --signing-key-file FILE
+                                                  --verification-key-file FILE
+
+  Get a verification key from a signing key. This supports all key types.
+
+Usage: cardano-cli allegra key non-extended-key --extended-verification-key-file FILE
+                                                  --verification-key-file FILE
+
+  Get a non-extended verification key from an extended verification key. This
+  supports all extended key types.
+
+Usage: cardano-cli allegra key convert-byron-key [--password TEXT]
+                                                   ( --byron-payment-key-type
+                                                   | --legacy-byron-payment-key-type
+                                                   | --byron-genesis-key-type
+                                                   | --legacy-byron-genesis-key-type
+                                                   | --byron-genesis-delegate-key-type
+                                                   | --legacy-byron-genesis-delegate-key-type
+                                                   )
+                                                   ( --byron-signing-key-file FILE
+                                                   | --byron-verification-key-file FILE
+                                                   )
+                                                   --out-file FILE
+
+  Convert a Byron payment, genesis or genesis delegate key (signing or
+  verification) to a corresponding Shelley-format key.
+
+Usage: cardano-cli allegra key convert-byron-genesis-vkey --byron-genesis-verification-key BASE64
+                                                            --out-file FILE
+
+  Convert a Base64-encoded Byron genesis verification key to a Shelley genesis
+  verification key
+
+Usage: cardano-cli allegra key convert-itn-key 
+                                                 ( --itn-signing-key-file FILE
+                                                 | --itn-verification-key-file FILE
+                                                 )
+                                                 --out-file FILE
+
+  Convert an Incentivized Testnet (ITN) non-extended (Ed25519) signing or
+  verification key to a corresponding Shelley stake key
+
+Usage: cardano-cli allegra key convert-itn-extended-key --itn-signing-key-file FILE
+                                                          --out-file FILE
+
+  Convert an Incentivized Testnet (ITN) extended (Ed25519Extended) signing key
+  to a corresponding Shelley stake signing key
+
+Usage: cardano-cli allegra key convert-itn-bip32-key --itn-signing-key-file FILE
+                                                       --out-file FILE
+
+  Convert an Incentivized Testnet (ITN) BIP32 (Ed25519Bip32) signing key to a
+  corresponding Shelley stake signing key
+
+Usage: cardano-cli allegra key convert-cardano-address-key 
+                                                             ( --shelley-payment-key
+                                                             | --shelley-stake-key
+                                                             | --icarus-payment-key
+                                                             | --byron-payment-key
+                                                             )
+                                                             --signing-key-file FILE
+                                                             --out-file FILE
+
+  Convert a cardano-address extended signing key to a corresponding
+  Shelley-format key.
+
+Usage: cardano-cli allegra genesis 
+                                     ( key-gen-genesis
+                                     | key-gen-delegate
+                                     | key-gen-utxo
+                                     | key-hash
+                                     | get-ver-key
+                                     | initial-addr
+                                     | initial-txin
+                                     | create-cardano
+                                     | create
+                                     | create-staked
+                                     | hash
+                                     )
+
+  Era-based genesis commands
+
+Usage: cardano-cli allegra genesis key-gen-genesis --verification-key-file FILE
+                                                     --signing-key-file FILE
+
+  Create a Shelley genesis key pair
+
+Usage: cardano-cli allegra genesis key-gen-delegate --verification-key-file FILE
+                                                      --signing-key-file FILE
+                                                      --operational-certificate-issue-counter-file FILE
+
+  Create a Shelley genesis delegate key pair
+
+Usage: cardano-cli allegra genesis key-gen-utxo --verification-key-file FILE
+                                                  --signing-key-file FILE
+
+  Create a Shelley genesis UTxO key pair
+
+Usage: cardano-cli allegra genesis key-hash --verification-key-file FILE
+
+  Print the identifier (hash) of a public key
+
+Usage: cardano-cli allegra genesis get-ver-key --verification-key-file FILE
+                                                 --signing-key-file FILE
+
+  Derive the verification key from a signing key
+
+Usage: cardano-cli allegra genesis initial-addr --verification-key-file FILE
+                                                  ( --mainnet
+                                                  | --testnet-magic NATURAL
+                                                  )
+                                                  [--out-file FILE]
+
+  Get the address for an initial UTxO based on the verification key
+
+Usage: cardano-cli allegra genesis initial-txin --verification-key-file FILE
+                                                  ( --mainnet
+                                                  | --testnet-magic NATURAL
+                                                  )
+                                                  [--out-file FILE]
+
+  Get the TxIn for an initial UTxO based on the verification key
+
+Usage: cardano-cli allegra genesis create-cardano --genesis-dir DIR
+                                                    [--gen-genesis-keys INT]
+                                                    [--gen-utxo-keys INT]
+                                                    [--start-time UTC-TIME]
+                                                    [--supply LOVELACE]
+                                                    [--security-param INT]
+                                                    [--slot-length INT]
+                                                    [--slot-coefficient RATIONAL]
+                                                    ( --mainnet
+                                                    | --testnet-magic NATURAL
+                                                    )
+                                                    --byron-template FILEPATH
+                                                    --shelley-template FILEPATH
+                                                    --alonzo-template FILEPATH
+                                                    --conway-template FILEPATH
+                                                    [--node-config-template FILEPATH]
+
+  Create a Byron and Shelley genesis file from a genesis template and
+  genesis/delegation/spending keys.
+
+Usage: cardano-cli allegra genesis create [--key-output-format STRING]
+                                            --genesis-dir DIR
+                                            [--gen-genesis-keys INT]
+                                            [--gen-utxo-keys INT]
+                                            [--start-time UTC-TIME]
+                                            [--supply LOVELACE]
+                                            ( --mainnet
+                                            | --testnet-magic NATURAL
+                                            )
+
+  Create a Shelley genesis file from a genesis template and
+  genesis/delegation/spending keys.
+
+Usage: cardano-cli allegra genesis create-staked [--key-output-format STRING]
+                                                   --genesis-dir DIR
+                                                   [--gen-genesis-keys INT]
+                                                   [--gen-utxo-keys INT]
+                                                   [--gen-pools INT]
+                                                   [--gen-stake-delegs INT]
+                                                   [--start-time UTC-TIME]
+                                                   [--supply LOVELACE]
+                                                   [--supply-delegated LOVELACE]
+                                                   ( --mainnet
+                                                   | --testnet-magic NATURAL
+                                                   )
+                                                   [--bulk-pool-cred-files INT]
+                                                   [--bulk-pools-per-file INT]
+                                                   [--num-stuffed-utxo INT]
+                                                   [--relay-specification-file FILE]
+
+  Create a staked Shelley genesis file from a genesis template and
+  genesis/delegation/spending keys.
+
+Usage: cardano-cli allegra genesis hash --genesis FILE
+
+  Compute the hash of a genesis file
 
 Usage: cardano-cli allegra governance (create-mir-certificate | action | drep)
 
@@ -816,6 +1563,338 @@ Usage: cardano-cli allegra governance drep registration-certificate
 
   Create a registration certificate.
 
+Usage: cardano-cli allegra node 
+                                  ( key-gen
+                                  | key-gen-KES
+                                  | key-gen-VRF
+                                  | key-hash-VRF
+                                  | new-counter
+                                  | issue-op-cert
+                                  )
+
+  Era-based node commands
+
+Usage: cardano-cli allegra node key-gen [--key-output-format STRING]
+                                          --cold-verification-key-file FILE
+                                          --cold-signing-key-file FILE
+                                          --operational-certificate-issue-counter-file FILE
+
+  Create a key pair for a node operator's offline key and a new certificate
+  issue counter
+
+Usage: cardano-cli allegra node key-gen-KES [--key-output-format STRING]
+                                              --verification-key-file FILE
+                                              --signing-key-file FILE
+
+  Create a key pair for a node KES operational key
+
+Usage: cardano-cli allegra node key-gen-VRF [--key-output-format STRING]
+                                              --verification-key-file FILE
+                                              --signing-key-file FILE
+
+  Create a key pair for a node VRF operational key
+
+Usage: cardano-cli allegra node key-hash-VRF 
+                                               ( --verification-key STRING
+                                               | --verification-key-file FILE
+                                               )
+                                               [--out-file FILE]
+
+  Print hash of a node's operational VRF key.
+
+Usage: cardano-cli allegra node new-counter 
+                                              ( --stake-pool-verification-key STRING
+                                              | --genesis-delegate-verification-key STRING
+                                              | --cold-verification-key-file FILE
+                                              )
+                                              --counter-value INT
+                                              --operational-certificate-issue-counter-file FILE
+
+  Create a new certificate issue counter
+
+Usage: cardano-cli allegra node issue-op-cert 
+                                                ( --kes-verification-key STRING
+                                                | --kes-verification-key-file FILE
+                                                )
+                                                --cold-signing-key-file FILE
+                                                --operational-certificate-issue-counter-file FILE
+                                                --kes-period NATURAL
+                                                --out-file FILE
+
+  Issue a node operational certificate
+
+Usage: cardano-cli allegra query 
+                                   ( protocol-parameters
+                                   | constitution-hash
+                                   | tip
+                                   | stake-pools
+                                   | stake-distribution
+                                   | stake-address-info
+                                   | utxo
+                                   | ledger-state
+                                   | protocol-state
+                                   | stake-snapshot
+                                   | leadership-schedule
+                                   | kes-period-info
+                                   | pool-state
+                                   | tx-mempool
+                                   | slot-number
+                                   )
+
+  Era-based query commands
+
+Usage: cardano-cli allegra query protocol-parameters --socket-path SOCKET_PATH
+                                                       [ --shelley-mode
+                                                       | --byron-mode
+                                                         [--epoch-slots SLOTS]
+                                                       | --cardano-mode
+                                                         [--epoch-slots SLOTS]
+                                                       ]
+                                                       ( --mainnet
+                                                       | --testnet-magic NATURAL
+                                                       )
+                                                       [--out-file FILE]
+
+  Get the node's current protocol parameters
+
+Usage: cardano-cli allegra query constitution-hash --socket-path SOCKET_PATH
+                                                     [ --shelley-mode
+                                                     | --byron-mode
+                                                       [--epoch-slots SLOTS]
+                                                     | --cardano-mode
+                                                       [--epoch-slots SLOTS]
+                                                     ]
+                                                     ( --mainnet
+                                                     | --testnet-magic NATURAL
+                                                     )
+                                                     [--out-file FILE]
+
+  Get the constitution hash
+
+Usage: cardano-cli allegra query tip --socket-path SOCKET_PATH
+                                       [ --shelley-mode
+                                       | --byron-mode [--epoch-slots SLOTS]
+                                       | --cardano-mode [--epoch-slots SLOTS]
+                                       ]
+                                       (--mainnet | --testnet-magic NATURAL)
+                                       [--out-file FILE]
+
+  Get the node's current tip (slot no, hash, block no)
+
+Usage: cardano-cli allegra query stake-pools --socket-path SOCKET_PATH
+                                               [ --shelley-mode
+                                               | --byron-mode
+                                                 [--epoch-slots SLOTS]
+                                               | --cardano-mode
+                                                 [--epoch-slots SLOTS]
+                                               ]
+                                               ( --mainnet
+                                               | --testnet-magic NATURAL
+                                               )
+                                               [--out-file FILE]
+
+  Get the node's current set of stake pool ids
+
+Usage: cardano-cli allegra query stake-distribution --socket-path SOCKET_PATH
+                                                      [ --shelley-mode
+                                                      | --byron-mode
+                                                        [--epoch-slots SLOTS]
+                                                      | --cardano-mode
+                                                        [--epoch-slots SLOTS]
+                                                      ]
+                                                      ( --mainnet
+                                                      | --testnet-magic NATURAL
+                                                      )
+                                                      [--out-file FILE]
+
+  Get the node's current aggregated stake distribution
+
+Usage: cardano-cli allegra query stake-address-info --socket-path SOCKET_PATH
+                                                      [ --shelley-mode
+                                                      | --byron-mode
+                                                        [--epoch-slots SLOTS]
+                                                      | --cardano-mode
+                                                        [--epoch-slots SLOTS]
+                                                      ]
+                                                      --address ADDRESS
+                                                      ( --mainnet
+                                                      | --testnet-magic NATURAL
+                                                      )
+                                                      [--out-file FILE]
+
+  Get the current delegations and reward accounts filtered by stake address.
+
+Usage: cardano-cli allegra query utxo --socket-path SOCKET_PATH
+                                        [ --shelley-mode
+                                        | --byron-mode [--epoch-slots SLOTS]
+                                        | --cardano-mode [--epoch-slots SLOTS]
+                                        ]
+                                        ( --whole-utxo
+                                        | (--address ADDRESS)
+                                        | (--tx-in TX-IN)
+                                        )
+                                        (--mainnet | --testnet-magic NATURAL)
+                                        [--out-file FILE]
+
+  Get a portion of the current UTxO: by tx in, by address or the whole.
+
+Usage: cardano-cli allegra query ledger-state --socket-path SOCKET_PATH
+                                                [ --shelley-mode
+                                                | --byron-mode
+                                                  [--epoch-slots SLOTS]
+                                                | --cardano-mode
+                                                  [--epoch-slots SLOTS]
+                                                ]
+                                                ( --mainnet
+                                                | --testnet-magic NATURAL
+                                                )
+                                                [--out-file FILE]
+
+  Dump the current ledger state of the node (Ledger.NewEpochState -- advanced
+  command)
+
+Usage: cardano-cli allegra query protocol-state --socket-path SOCKET_PATH
+                                                  [ --shelley-mode
+                                                  | --byron-mode
+                                                    [--epoch-slots SLOTS]
+                                                  | --cardano-mode
+                                                    [--epoch-slots SLOTS]
+                                                  ]
+                                                  ( --mainnet
+                                                  | --testnet-magic NATURAL
+                                                  )
+                                                  [--out-file FILE]
+
+  Dump the current protocol state of the node (Ledger.ChainDepState -- advanced
+  command)
+
+Usage: cardano-cli allegra query stake-snapshot --socket-path SOCKET_PATH
+                                                  [ --shelley-mode
+                                                  | --byron-mode
+                                                    [--epoch-slots SLOTS]
+                                                  | --cardano-mode
+                                                    [--epoch-slots SLOTS]
+                                                  ]
+                                                  ( --mainnet
+                                                  | --testnet-magic NATURAL
+                                                  )
+                                                  [ --all-stake-pools
+                                                  | 
+                                                  [--stake-pool-id STAKE_POOL_ID]
+                                                  ]
+                                                  [--out-file FILE]
+
+  Obtain the three stake snapshots for a pool, plus the total active stake
+  (advanced command)
+
+Usage: cardano-cli allegra query pool-params --socket-path SOCKET_PATH
+                                               [ --shelley-mode
+                                               | --byron-mode
+                                                 [--epoch-slots SLOTS]
+                                               | --cardano-mode
+                                                 [--epoch-slots SLOTS]
+                                               ]
+                                               ( --mainnet
+                                               | --testnet-magic NATURAL
+                                               )
+                                               [--stake-pool-id STAKE_POOL_ID]
+
+  DEPRECATED. Use query pool-state instead. Dump the pool parameters
+  (Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced
+  command)
+
+Usage: cardano-cli allegra query leadership-schedule --socket-path SOCKET_PATH
+                                                       [ --shelley-mode
+                                                       | --byron-mode
+                                                         [--epoch-slots SLOTS]
+                                                       | --cardano-mode
+                                                         [--epoch-slots SLOTS]
+                                                       ]
+                                                       ( --mainnet
+                                                       | --testnet-magic NATURAL
+                                                       )
+                                                       --genesis FILE
+                                                       ( --stake-pool-verification-key STRING
+                                                       | --cold-verification-key-file FILE
+                                                       | --stake-pool-id STAKE_POOL_ID
+                                                       )
+                                                       --vrf-signing-key-file FILE
+                                                       (--current | --next)
+                                                       [--out-file FILE]
+
+  Get the slots the node is expected to mint a block in (advanced command)
+
+Usage: cardano-cli allegra query kes-period-info --socket-path SOCKET_PATH
+                                                   [ --shelley-mode
+                                                   | --byron-mode
+                                                     [--epoch-slots SLOTS]
+                                                   | --cardano-mode
+                                                     [--epoch-slots SLOTS]
+                                                   ]
+                                                   ( --mainnet
+                                                   | --testnet-magic NATURAL
+                                                   )
+                                                   --op-cert-file FILE
+                                                   [--out-file FILE]
+
+  Get information about the current KES period and your node's operational
+  certificate.
+
+Usage: cardano-cli allegra query pool-state --socket-path SOCKET_PATH
+                                              [ --shelley-mode
+                                              | --byron-mode
+                                                [--epoch-slots SLOTS]
+                                              | --cardano-mode
+                                                [--epoch-slots SLOTS]
+                                              ]
+                                              ( --mainnet
+                                              | --testnet-magic NATURAL
+                                              )
+                                              [--stake-pool-id STAKE_POOL_ID]
+
+  Dump the pool state
+
+Usage: cardano-cli allegra query tx-mempool --socket-path SOCKET_PATH
+                                              [ --shelley-mode
+                                              | --byron-mode
+                                                [--epoch-slots SLOTS]
+                                              | --cardano-mode
+                                                [--epoch-slots SLOTS]
+                                              ]
+                                              ( --mainnet
+                                              | --testnet-magic NATURAL
+                                              )
+                                              (info | next-tx | tx-exists)
+                                              [--out-file FILE]
+
+  Local Mempool info
+
+Usage: cardano-cli allegra query tx-mempool info 
+
+  Ask the node about the current mempool's capacity and sizes
+
+Usage: cardano-cli allegra query tx-mempool next-tx 
+
+  Requests the next transaction from the mempool's current list
+
+Usage: cardano-cli allegra query tx-mempool tx-exists TX_ID
+
+  Query if a particular transaction exists in the mempool
+
+Usage: cardano-cli allegra query slot-number --socket-path SOCKET_PATH
+                                               [ --shelley-mode
+                                               | --byron-mode
+                                                 [--epoch-slots SLOTS]
+                                               | --cardano-mode
+                                                 [--epoch-slots SLOTS]
+                                               ]
+                                               ( --mainnet
+                                               | --testnet-magic NATURAL
+                                               )
+                                               TIMESTAMP
+
+  Query slot number for UTC timestamp
+
 Usage: cardano-cli allegra stake-address 
                                            ( key-gen
                                            | key-hash
@@ -890,6 +1969,15 @@ Usage: cardano-cli allegra stake-address stake-delegation-certificate
   Create a stake address stake delegation certificate, which when submitted in a
   transaction delegates stake to a stake pool.
 
+Usage: cardano-cli allegra text-view decode-cbor
+
+  Era-based text-view commands
+
+Usage: cardano-cli allegra text-view decode-cbor --in-file FILE
+                                                   [--out-file FILE]
+
+  Print a TextView file as decoded CBOR.
+
 Usage: cardano-cli allegra transaction 
                                          ( build-raw
                                          | build
@@ -905,7 +1993,7 @@ Usage: cardano-cli allegra transaction
                                          | view
                                          )
 
-  Era-based governance commands
+  Era-based transaction commands
 
 Usage: cardano-cli allegra transaction build-raw 
                                                    [ --script-valid
@@ -1273,7 +2361,17 @@ Usage: cardano-cli allegra transaction view
 
   Print a transaction.
 
-Usage: cardano-cli mary (address | governance | stake-address | transaction)
+Usage: cardano-cli mary 
+                          ( address
+                          | key
+                          | genesis
+                          | governance
+                          | node
+                          | query
+                          | stake-address
+                          | text-view
+                          | transaction
+                          )
 
   Mary era commands
 
@@ -1317,6 +2415,197 @@ Usage: cardano-cli mary address build
 Usage: cardano-cli mary address info --address ADDRESS [--out-file FILE]
 
   Print information about an address.
+
+Usage: cardano-cli mary key 
+                              ( verification-key
+                              | non-extended-key
+                              | convert-byron-key
+                              | convert-byron-genesis-vkey
+                              | convert-itn-key
+                              | convert-itn-extended-key
+                              | convert-itn-bip32-key
+                              | convert-cardano-address-key
+                              )
+
+  Era-based key commands
+
+Usage: cardano-cli mary key verification-key --signing-key-file FILE
+                                               --verification-key-file FILE
+
+  Get a verification key from a signing key. This supports all key types.
+
+Usage: cardano-cli mary key non-extended-key --extended-verification-key-file FILE
+                                               --verification-key-file FILE
+
+  Get a non-extended verification key from an extended verification key. This
+  supports all extended key types.
+
+Usage: cardano-cli mary key convert-byron-key [--password TEXT]
+                                                ( --byron-payment-key-type
+                                                | --legacy-byron-payment-key-type
+                                                | --byron-genesis-key-type
+                                                | --legacy-byron-genesis-key-type
+                                                | --byron-genesis-delegate-key-type
+                                                | --legacy-byron-genesis-delegate-key-type
+                                                )
+                                                ( --byron-signing-key-file FILE
+                                                | --byron-verification-key-file FILE
+                                                )
+                                                --out-file FILE
+
+  Convert a Byron payment, genesis or genesis delegate key (signing or
+  verification) to a corresponding Shelley-format key.
+
+Usage: cardano-cli mary key convert-byron-genesis-vkey --byron-genesis-verification-key BASE64
+                                                         --out-file FILE
+
+  Convert a Base64-encoded Byron genesis verification key to a Shelley genesis
+  verification key
+
+Usage: cardano-cli mary key convert-itn-key 
+                                              ( --itn-signing-key-file FILE
+                                              | --itn-verification-key-file FILE
+                                              )
+                                              --out-file FILE
+
+  Convert an Incentivized Testnet (ITN) non-extended (Ed25519) signing or
+  verification key to a corresponding Shelley stake key
+
+Usage: cardano-cli mary key convert-itn-extended-key --itn-signing-key-file FILE
+                                                       --out-file FILE
+
+  Convert an Incentivized Testnet (ITN) extended (Ed25519Extended) signing key
+  to a corresponding Shelley stake signing key
+
+Usage: cardano-cli mary key convert-itn-bip32-key --itn-signing-key-file FILE
+                                                    --out-file FILE
+
+  Convert an Incentivized Testnet (ITN) BIP32 (Ed25519Bip32) signing key to a
+  corresponding Shelley stake signing key
+
+Usage: cardano-cli mary key convert-cardano-address-key 
+                                                          ( --shelley-payment-key
+                                                          | --shelley-stake-key
+                                                          | --icarus-payment-key
+                                                          | --byron-payment-key
+                                                          )
+                                                          --signing-key-file FILE
+                                                          --out-file FILE
+
+  Convert a cardano-address extended signing key to a corresponding
+  Shelley-format key.
+
+Usage: cardano-cli mary genesis 
+                                  ( key-gen-genesis
+                                  | key-gen-delegate
+                                  | key-gen-utxo
+                                  | key-hash
+                                  | get-ver-key
+                                  | initial-addr
+                                  | initial-txin
+                                  | create-cardano
+                                  | create
+                                  | create-staked
+                                  | hash
+                                  )
+
+  Era-based genesis commands
+
+Usage: cardano-cli mary genesis key-gen-genesis --verification-key-file FILE
+                                                  --signing-key-file FILE
+
+  Create a Shelley genesis key pair
+
+Usage: cardano-cli mary genesis key-gen-delegate --verification-key-file FILE
+                                                   --signing-key-file FILE
+                                                   --operational-certificate-issue-counter-file FILE
+
+  Create a Shelley genesis delegate key pair
+
+Usage: cardano-cli mary genesis key-gen-utxo --verification-key-file FILE
+                                               --signing-key-file FILE
+
+  Create a Shelley genesis UTxO key pair
+
+Usage: cardano-cli mary genesis key-hash --verification-key-file FILE
+
+  Print the identifier (hash) of a public key
+
+Usage: cardano-cli mary genesis get-ver-key --verification-key-file FILE
+                                              --signing-key-file FILE
+
+  Derive the verification key from a signing key
+
+Usage: cardano-cli mary genesis initial-addr --verification-key-file FILE
+                                               ( --mainnet
+                                               | --testnet-magic NATURAL
+                                               )
+                                               [--out-file FILE]
+
+  Get the address for an initial UTxO based on the verification key
+
+Usage: cardano-cli mary genesis initial-txin --verification-key-file FILE
+                                               ( --mainnet
+                                               | --testnet-magic NATURAL
+                                               )
+                                               [--out-file FILE]
+
+  Get the TxIn for an initial UTxO based on the verification key
+
+Usage: cardano-cli mary genesis create-cardano --genesis-dir DIR
+                                                 [--gen-genesis-keys INT]
+                                                 [--gen-utxo-keys INT]
+                                                 [--start-time UTC-TIME]
+                                                 [--supply LOVELACE]
+                                                 [--security-param INT]
+                                                 [--slot-length INT]
+                                                 [--slot-coefficient RATIONAL]
+                                                 ( --mainnet
+                                                 | --testnet-magic NATURAL
+                                                 )
+                                                 --byron-template FILEPATH
+                                                 --shelley-template FILEPATH
+                                                 --alonzo-template FILEPATH
+                                                 --conway-template FILEPATH
+                                                 [--node-config-template FILEPATH]
+
+  Create a Byron and Shelley genesis file from a genesis template and
+  genesis/delegation/spending keys.
+
+Usage: cardano-cli mary genesis create [--key-output-format STRING]
+                                         --genesis-dir DIR
+                                         [--gen-genesis-keys INT]
+                                         [--gen-utxo-keys INT]
+                                         [--start-time UTC-TIME]
+                                         [--supply LOVELACE]
+                                         (--mainnet | --testnet-magic NATURAL)
+
+  Create a Shelley genesis file from a genesis template and
+  genesis/delegation/spending keys.
+
+Usage: cardano-cli mary genesis create-staked [--key-output-format STRING]
+                                                --genesis-dir DIR
+                                                [--gen-genesis-keys INT]
+                                                [--gen-utxo-keys INT]
+                                                [--gen-pools INT]
+                                                [--gen-stake-delegs INT]
+                                                [--start-time UTC-TIME]
+                                                [--supply LOVELACE]
+                                                [--supply-delegated LOVELACE]
+                                                ( --mainnet
+                                                | --testnet-magic NATURAL
+                                                )
+                                                [--bulk-pool-cred-files INT]
+                                                [--bulk-pools-per-file INT]
+                                                [--num-stuffed-utxo INT]
+                                                [--relay-specification-file FILE]
+
+  Create a staked Shelley genesis file from a genesis template and
+  genesis/delegation/spending keys.
+
+Usage: cardano-cli mary genesis hash --genesis FILE
+
+  Compute the hash of a genesis file
 
 Usage: cardano-cli mary governance (create-mir-certificate | action | drep)
 
@@ -1446,6 +2735,328 @@ Usage: cardano-cli mary governance drep registration-certificate
 
   Create a registration certificate.
 
+Usage: cardano-cli mary node 
+                               ( key-gen
+                               | key-gen-KES
+                               | key-gen-VRF
+                               | key-hash-VRF
+                               | new-counter
+                               | issue-op-cert
+                               )
+
+  Era-based node commands
+
+Usage: cardano-cli mary node key-gen [--key-output-format STRING]
+                                       --cold-verification-key-file FILE
+                                       --cold-signing-key-file FILE
+                                       --operational-certificate-issue-counter-file FILE
+
+  Create a key pair for a node operator's offline key and a new certificate
+  issue counter
+
+Usage: cardano-cli mary node key-gen-KES [--key-output-format STRING]
+                                           --verification-key-file FILE
+                                           --signing-key-file FILE
+
+  Create a key pair for a node KES operational key
+
+Usage: cardano-cli mary node key-gen-VRF [--key-output-format STRING]
+                                           --verification-key-file FILE
+                                           --signing-key-file FILE
+
+  Create a key pair for a node VRF operational key
+
+Usage: cardano-cli mary node key-hash-VRF 
+                                            ( --verification-key STRING
+                                            | --verification-key-file FILE
+                                            )
+                                            [--out-file FILE]
+
+  Print hash of a node's operational VRF key.
+
+Usage: cardano-cli mary node new-counter 
+                                           ( --stake-pool-verification-key STRING
+                                           | --genesis-delegate-verification-key STRING
+                                           | --cold-verification-key-file FILE
+                                           )
+                                           --counter-value INT
+                                           --operational-certificate-issue-counter-file FILE
+
+  Create a new certificate issue counter
+
+Usage: cardano-cli mary node issue-op-cert 
+                                             ( --kes-verification-key STRING
+                                             | --kes-verification-key-file FILE
+                                             )
+                                             --cold-signing-key-file FILE
+                                             --operational-certificate-issue-counter-file FILE
+                                             --kes-period NATURAL
+                                             --out-file FILE
+
+  Issue a node operational certificate
+
+Usage: cardano-cli mary query 
+                                ( protocol-parameters
+                                | constitution-hash
+                                | tip
+                                | stake-pools
+                                | stake-distribution
+                                | stake-address-info
+                                | utxo
+                                | ledger-state
+                                | protocol-state
+                                | stake-snapshot
+                                | leadership-schedule
+                                | kes-period-info
+                                | pool-state
+                                | tx-mempool
+                                | slot-number
+                                )
+
+  Era-based query commands
+
+Usage: cardano-cli mary query protocol-parameters --socket-path SOCKET_PATH
+                                                    [ --shelley-mode
+                                                    | --byron-mode
+                                                      [--epoch-slots SLOTS]
+                                                    | --cardano-mode
+                                                      [--epoch-slots SLOTS]
+                                                    ]
+                                                    ( --mainnet
+                                                    | --testnet-magic NATURAL
+                                                    )
+                                                    [--out-file FILE]
+
+  Get the node's current protocol parameters
+
+Usage: cardano-cli mary query constitution-hash --socket-path SOCKET_PATH
+                                                  [ --shelley-mode
+                                                  | --byron-mode
+                                                    [--epoch-slots SLOTS]
+                                                  | --cardano-mode
+                                                    [--epoch-slots SLOTS]
+                                                  ]
+                                                  ( --mainnet
+                                                  | --testnet-magic NATURAL
+                                                  )
+                                                  [--out-file FILE]
+
+  Get the constitution hash
+
+Usage: cardano-cli mary query tip --socket-path SOCKET_PATH
+                                    [ --shelley-mode
+                                    | --byron-mode [--epoch-slots SLOTS]
+                                    | --cardano-mode [--epoch-slots SLOTS]
+                                    ]
+                                    (--mainnet | --testnet-magic NATURAL)
+                                    [--out-file FILE]
+
+  Get the node's current tip (slot no, hash, block no)
+
+Usage: cardano-cli mary query stake-pools --socket-path SOCKET_PATH
+                                            [ --shelley-mode
+                                            | --byron-mode [--epoch-slots SLOTS]
+                                            | --cardano-mode
+                                              [--epoch-slots SLOTS]
+                                            ]
+                                            ( --mainnet
+                                            | --testnet-magic NATURAL
+                                            )
+                                            [--out-file FILE]
+
+  Get the node's current set of stake pool ids
+
+Usage: cardano-cli mary query stake-distribution --socket-path SOCKET_PATH
+                                                   [ --shelley-mode
+                                                   | --byron-mode
+                                                     [--epoch-slots SLOTS]
+                                                   | --cardano-mode
+                                                     [--epoch-slots SLOTS]
+                                                   ]
+                                                   ( --mainnet
+                                                   | --testnet-magic NATURAL
+                                                   )
+                                                   [--out-file FILE]
+
+  Get the node's current aggregated stake distribution
+
+Usage: cardano-cli mary query stake-address-info --socket-path SOCKET_PATH
+                                                   [ --shelley-mode
+                                                   | --byron-mode
+                                                     [--epoch-slots SLOTS]
+                                                   | --cardano-mode
+                                                     [--epoch-slots SLOTS]
+                                                   ]
+                                                   --address ADDRESS
+                                                   ( --mainnet
+                                                   | --testnet-magic NATURAL
+                                                   )
+                                                   [--out-file FILE]
+
+  Get the current delegations and reward accounts filtered by stake address.
+
+Usage: cardano-cli mary query utxo --socket-path SOCKET_PATH
+                                     [ --shelley-mode
+                                     | --byron-mode [--epoch-slots SLOTS]
+                                     | --cardano-mode [--epoch-slots SLOTS]
+                                     ]
+                                     ( --whole-utxo
+                                     | (--address ADDRESS)
+                                     | (--tx-in TX-IN)
+                                     )
+                                     (--mainnet | --testnet-magic NATURAL)
+                                     [--out-file FILE]
+
+  Get a portion of the current UTxO: by tx in, by address or the whole.
+
+Usage: cardano-cli mary query ledger-state --socket-path SOCKET_PATH
+                                             [ --shelley-mode
+                                             | --byron-mode
+                                               [--epoch-slots SLOTS]
+                                             | --cardano-mode
+                                               [--epoch-slots SLOTS]
+                                             ]
+                                             ( --mainnet
+                                             | --testnet-magic NATURAL
+                                             )
+                                             [--out-file FILE]
+
+  Dump the current ledger state of the node (Ledger.NewEpochState -- advanced
+  command)
+
+Usage: cardano-cli mary query protocol-state --socket-path SOCKET_PATH
+                                               [ --shelley-mode
+                                               | --byron-mode
+                                                 [--epoch-slots SLOTS]
+                                               | --cardano-mode
+                                                 [--epoch-slots SLOTS]
+                                               ]
+                                               ( --mainnet
+                                               | --testnet-magic NATURAL
+                                               )
+                                               [--out-file FILE]
+
+  Dump the current protocol state of the node (Ledger.ChainDepState -- advanced
+  command)
+
+Usage: cardano-cli mary query stake-snapshot --socket-path SOCKET_PATH
+                                               [ --shelley-mode
+                                               | --byron-mode
+                                                 [--epoch-slots SLOTS]
+                                               | --cardano-mode
+                                                 [--epoch-slots SLOTS]
+                                               ]
+                                               ( --mainnet
+                                               | --testnet-magic NATURAL
+                                               )
+                                               [ --all-stake-pools
+                                               | [--stake-pool-id STAKE_POOL_ID]
+                                               ]
+                                               [--out-file FILE]
+
+  Obtain the three stake snapshots for a pool, plus the total active stake
+  (advanced command)
+
+Usage: cardano-cli mary query pool-params --socket-path SOCKET_PATH
+                                            [ --shelley-mode
+                                            | --byron-mode [--epoch-slots SLOTS]
+                                            | --cardano-mode
+                                              [--epoch-slots SLOTS]
+                                            ]
+                                            ( --mainnet
+                                            | --testnet-magic NATURAL
+                                            )
+                                            [--stake-pool-id STAKE_POOL_ID]
+
+  DEPRECATED. Use query pool-state instead. Dump the pool parameters
+  (Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced
+  command)
+
+Usage: cardano-cli mary query leadership-schedule --socket-path SOCKET_PATH
+                                                    [ --shelley-mode
+                                                    | --byron-mode
+                                                      [--epoch-slots SLOTS]
+                                                    | --cardano-mode
+                                                      [--epoch-slots SLOTS]
+                                                    ]
+                                                    ( --mainnet
+                                                    | --testnet-magic NATURAL
+                                                    )
+                                                    --genesis FILE
+                                                    ( --stake-pool-verification-key STRING
+                                                    | --cold-verification-key-file FILE
+                                                    | --stake-pool-id STAKE_POOL_ID
+                                                    )
+                                                    --vrf-signing-key-file FILE
+                                                    (--current | --next)
+                                                    [--out-file FILE]
+
+  Get the slots the node is expected to mint a block in (advanced command)
+
+Usage: cardano-cli mary query kes-period-info --socket-path SOCKET_PATH
+                                                [ --shelley-mode
+                                                | --byron-mode
+                                                  [--epoch-slots SLOTS]
+                                                | --cardano-mode
+                                                  [--epoch-slots SLOTS]
+                                                ]
+                                                ( --mainnet
+                                                | --testnet-magic NATURAL
+                                                )
+                                                --op-cert-file FILE
+                                                [--out-file FILE]
+
+  Get information about the current KES period and your node's operational
+  certificate.
+
+Usage: cardano-cli mary query pool-state --socket-path SOCKET_PATH
+                                           [ --shelley-mode
+                                           | --byron-mode [--epoch-slots SLOTS]
+                                           | --cardano-mode
+                                             [--epoch-slots SLOTS]
+                                           ]
+                                           (--mainnet | --testnet-magic NATURAL)
+                                           [--stake-pool-id STAKE_POOL_ID]
+
+  Dump the pool state
+
+Usage: cardano-cli mary query tx-mempool --socket-path SOCKET_PATH
+                                           [ --shelley-mode
+                                           | --byron-mode [--epoch-slots SLOTS]
+                                           | --cardano-mode
+                                             [--epoch-slots SLOTS]
+                                           ]
+                                           (--mainnet | --testnet-magic NATURAL)
+                                           (info | next-tx | tx-exists)
+                                           [--out-file FILE]
+
+  Local Mempool info
+
+Usage: cardano-cli mary query tx-mempool info 
+
+  Ask the node about the current mempool's capacity and sizes
+
+Usage: cardano-cli mary query tx-mempool next-tx 
+
+  Requests the next transaction from the mempool's current list
+
+Usage: cardano-cli mary query tx-mempool tx-exists TX_ID
+
+  Query if a particular transaction exists in the mempool
+
+Usage: cardano-cli mary query slot-number --socket-path SOCKET_PATH
+                                            [ --shelley-mode
+                                            | --byron-mode [--epoch-slots SLOTS]
+                                            | --cardano-mode
+                                              [--epoch-slots SLOTS]
+                                            ]
+                                            ( --mainnet
+                                            | --testnet-magic NATURAL
+                                            )
+                                            TIMESTAMP
+
+  Query slot number for UTC timestamp
+
 Usage: cardano-cli mary stake-address 
                                         ( key-gen
                                         | key-hash
@@ -1520,6 +3131,14 @@ Usage: cardano-cli mary stake-address stake-delegation-certificate
   Create a stake address stake delegation certificate, which when submitted in a
   transaction delegates stake to a stake pool.
 
+Usage: cardano-cli mary text-view decode-cbor
+
+  Era-based text-view commands
+
+Usage: cardano-cli mary text-view decode-cbor --in-file FILE [--out-file FILE]
+
+  Print a TextView file as decoded CBOR.
+
 Usage: cardano-cli mary transaction 
                                       ( build-raw
                                       | build
@@ -1535,7 +3154,7 @@ Usage: cardano-cli mary transaction
                                       | view
                                       )
 
-  Era-based governance commands
+  Era-based transaction commands
 
 Usage: cardano-cli mary transaction build-raw 
                                                 [ --script-valid
@@ -1888,7 +3507,17 @@ Usage: cardano-cli mary transaction view (--tx-body-file FILE | --tx-file FILE)
 
   Print a transaction.
 
-Usage: cardano-cli alonzo (address | governance | stake-address | transaction)
+Usage: cardano-cli alonzo 
+                            ( address
+                            | key
+                            | genesis
+                            | governance
+                            | node
+                            | query
+                            | stake-address
+                            | text-view
+                            | transaction
+                            )
 
   Alonzo era commands
 
@@ -1932,6 +3561,197 @@ Usage: cardano-cli alonzo address build
 Usage: cardano-cli alonzo address info --address ADDRESS [--out-file FILE]
 
   Print information about an address.
+
+Usage: cardano-cli alonzo key 
+                                ( verification-key
+                                | non-extended-key
+                                | convert-byron-key
+                                | convert-byron-genesis-vkey
+                                | convert-itn-key
+                                | convert-itn-extended-key
+                                | convert-itn-bip32-key
+                                | convert-cardano-address-key
+                                )
+
+  Era-based key commands
+
+Usage: cardano-cli alonzo key verification-key --signing-key-file FILE
+                                                 --verification-key-file FILE
+
+  Get a verification key from a signing key. This supports all key types.
+
+Usage: cardano-cli alonzo key non-extended-key --extended-verification-key-file FILE
+                                                 --verification-key-file FILE
+
+  Get a non-extended verification key from an extended verification key. This
+  supports all extended key types.
+
+Usage: cardano-cli alonzo key convert-byron-key [--password TEXT]
+                                                  ( --byron-payment-key-type
+                                                  | --legacy-byron-payment-key-type
+                                                  | --byron-genesis-key-type
+                                                  | --legacy-byron-genesis-key-type
+                                                  | --byron-genesis-delegate-key-type
+                                                  | --legacy-byron-genesis-delegate-key-type
+                                                  )
+                                                  ( --byron-signing-key-file FILE
+                                                  | --byron-verification-key-file FILE
+                                                  )
+                                                  --out-file FILE
+
+  Convert a Byron payment, genesis or genesis delegate key (signing or
+  verification) to a corresponding Shelley-format key.
+
+Usage: cardano-cli alonzo key convert-byron-genesis-vkey --byron-genesis-verification-key BASE64
+                                                           --out-file FILE
+
+  Convert a Base64-encoded Byron genesis verification key to a Shelley genesis
+  verification key
+
+Usage: cardano-cli alonzo key convert-itn-key 
+                                                ( --itn-signing-key-file FILE
+                                                | --itn-verification-key-file FILE
+                                                )
+                                                --out-file FILE
+
+  Convert an Incentivized Testnet (ITN) non-extended (Ed25519) signing or
+  verification key to a corresponding Shelley stake key
+
+Usage: cardano-cli alonzo key convert-itn-extended-key --itn-signing-key-file FILE
+                                                         --out-file FILE
+
+  Convert an Incentivized Testnet (ITN) extended (Ed25519Extended) signing key
+  to a corresponding Shelley stake signing key
+
+Usage: cardano-cli alonzo key convert-itn-bip32-key --itn-signing-key-file FILE
+                                                      --out-file FILE
+
+  Convert an Incentivized Testnet (ITN) BIP32 (Ed25519Bip32) signing key to a
+  corresponding Shelley stake signing key
+
+Usage: cardano-cli alonzo key convert-cardano-address-key 
+                                                            ( --shelley-payment-key
+                                                            | --shelley-stake-key
+                                                            | --icarus-payment-key
+                                                            | --byron-payment-key
+                                                            )
+                                                            --signing-key-file FILE
+                                                            --out-file FILE
+
+  Convert a cardano-address extended signing key to a corresponding
+  Shelley-format key.
+
+Usage: cardano-cli alonzo genesis 
+                                    ( key-gen-genesis
+                                    | key-gen-delegate
+                                    | key-gen-utxo
+                                    | key-hash
+                                    | get-ver-key
+                                    | initial-addr
+                                    | initial-txin
+                                    | create-cardano
+                                    | create
+                                    | create-staked
+                                    | hash
+                                    )
+
+  Era-based genesis commands
+
+Usage: cardano-cli alonzo genesis key-gen-genesis --verification-key-file FILE
+                                                    --signing-key-file FILE
+
+  Create a Shelley genesis key pair
+
+Usage: cardano-cli alonzo genesis key-gen-delegate --verification-key-file FILE
+                                                     --signing-key-file FILE
+                                                     --operational-certificate-issue-counter-file FILE
+
+  Create a Shelley genesis delegate key pair
+
+Usage: cardano-cli alonzo genesis key-gen-utxo --verification-key-file FILE
+                                                 --signing-key-file FILE
+
+  Create a Shelley genesis UTxO key pair
+
+Usage: cardano-cli alonzo genesis key-hash --verification-key-file FILE
+
+  Print the identifier (hash) of a public key
+
+Usage: cardano-cli alonzo genesis get-ver-key --verification-key-file FILE
+                                                --signing-key-file FILE
+
+  Derive the verification key from a signing key
+
+Usage: cardano-cli alonzo genesis initial-addr --verification-key-file FILE
+                                                 ( --mainnet
+                                                 | --testnet-magic NATURAL
+                                                 )
+                                                 [--out-file FILE]
+
+  Get the address for an initial UTxO based on the verification key
+
+Usage: cardano-cli alonzo genesis initial-txin --verification-key-file FILE
+                                                 ( --mainnet
+                                                 | --testnet-magic NATURAL
+                                                 )
+                                                 [--out-file FILE]
+
+  Get the TxIn for an initial UTxO based on the verification key
+
+Usage: cardano-cli alonzo genesis create-cardano --genesis-dir DIR
+                                                   [--gen-genesis-keys INT]
+                                                   [--gen-utxo-keys INT]
+                                                   [--start-time UTC-TIME]
+                                                   [--supply LOVELACE]
+                                                   [--security-param INT]
+                                                   [--slot-length INT]
+                                                   [--slot-coefficient RATIONAL]
+                                                   ( --mainnet
+                                                   | --testnet-magic NATURAL
+                                                   )
+                                                   --byron-template FILEPATH
+                                                   --shelley-template FILEPATH
+                                                   --alonzo-template FILEPATH
+                                                   --conway-template FILEPATH
+                                                   [--node-config-template FILEPATH]
+
+  Create a Byron and Shelley genesis file from a genesis template and
+  genesis/delegation/spending keys.
+
+Usage: cardano-cli alonzo genesis create [--key-output-format STRING]
+                                           --genesis-dir DIR
+                                           [--gen-genesis-keys INT]
+                                           [--gen-utxo-keys INT]
+                                           [--start-time UTC-TIME]
+                                           [--supply LOVELACE]
+                                           (--mainnet | --testnet-magic NATURAL)
+
+  Create a Shelley genesis file from a genesis template and
+  genesis/delegation/spending keys.
+
+Usage: cardano-cli alonzo genesis create-staked [--key-output-format STRING]
+                                                  --genesis-dir DIR
+                                                  [--gen-genesis-keys INT]
+                                                  [--gen-utxo-keys INT]
+                                                  [--gen-pools INT]
+                                                  [--gen-stake-delegs INT]
+                                                  [--start-time UTC-TIME]
+                                                  [--supply LOVELACE]
+                                                  [--supply-delegated LOVELACE]
+                                                  ( --mainnet
+                                                  | --testnet-magic NATURAL
+                                                  )
+                                                  [--bulk-pool-cred-files INT]
+                                                  [--bulk-pools-per-file INT]
+                                                  [--num-stuffed-utxo INT]
+                                                  [--relay-specification-file FILE]
+
+  Create a staked Shelley genesis file from a genesis template and
+  genesis/delegation/spending keys.
+
+Usage: cardano-cli alonzo genesis hash --genesis FILE
+
+  Compute the hash of a genesis file
 
 Usage: cardano-cli alonzo governance (create-mir-certificate | action | drep)
 
@@ -2068,6 +3888,338 @@ Usage: cardano-cli alonzo governance drep registration-certificate
 
   Create a registration certificate.
 
+Usage: cardano-cli alonzo node 
+                                 ( key-gen
+                                 | key-gen-KES
+                                 | key-gen-VRF
+                                 | key-hash-VRF
+                                 | new-counter
+                                 | issue-op-cert
+                                 )
+
+  Era-based node commands
+
+Usage: cardano-cli alonzo node key-gen [--key-output-format STRING]
+                                         --cold-verification-key-file FILE
+                                         --cold-signing-key-file FILE
+                                         --operational-certificate-issue-counter-file FILE
+
+  Create a key pair for a node operator's offline key and a new certificate
+  issue counter
+
+Usage: cardano-cli alonzo node key-gen-KES [--key-output-format STRING]
+                                             --verification-key-file FILE
+                                             --signing-key-file FILE
+
+  Create a key pair for a node KES operational key
+
+Usage: cardano-cli alonzo node key-gen-VRF [--key-output-format STRING]
+                                             --verification-key-file FILE
+                                             --signing-key-file FILE
+
+  Create a key pair for a node VRF operational key
+
+Usage: cardano-cli alonzo node key-hash-VRF 
+                                              ( --verification-key STRING
+                                              | --verification-key-file FILE
+                                              )
+                                              [--out-file FILE]
+
+  Print hash of a node's operational VRF key.
+
+Usage: cardano-cli alonzo node new-counter 
+                                             ( --stake-pool-verification-key STRING
+                                             | --genesis-delegate-verification-key STRING
+                                             | --cold-verification-key-file FILE
+                                             )
+                                             --counter-value INT
+                                             --operational-certificate-issue-counter-file FILE
+
+  Create a new certificate issue counter
+
+Usage: cardano-cli alonzo node issue-op-cert 
+                                               ( --kes-verification-key STRING
+                                               | --kes-verification-key-file FILE
+                                               )
+                                               --cold-signing-key-file FILE
+                                               --operational-certificate-issue-counter-file FILE
+                                               --kes-period NATURAL
+                                               --out-file FILE
+
+  Issue a node operational certificate
+
+Usage: cardano-cli alonzo query 
+                                  ( protocol-parameters
+                                  | constitution-hash
+                                  | tip
+                                  | stake-pools
+                                  | stake-distribution
+                                  | stake-address-info
+                                  | utxo
+                                  | ledger-state
+                                  | protocol-state
+                                  | stake-snapshot
+                                  | leadership-schedule
+                                  | kes-period-info
+                                  | pool-state
+                                  | tx-mempool
+                                  | slot-number
+                                  )
+
+  Era-based query commands
+
+Usage: cardano-cli alonzo query protocol-parameters --socket-path SOCKET_PATH
+                                                      [ --shelley-mode
+                                                      | --byron-mode
+                                                        [--epoch-slots SLOTS]
+                                                      | --cardano-mode
+                                                        [--epoch-slots SLOTS]
+                                                      ]
+                                                      ( --mainnet
+                                                      | --testnet-magic NATURAL
+                                                      )
+                                                      [--out-file FILE]
+
+  Get the node's current protocol parameters
+
+Usage: cardano-cli alonzo query constitution-hash --socket-path SOCKET_PATH
+                                                    [ --shelley-mode
+                                                    | --byron-mode
+                                                      [--epoch-slots SLOTS]
+                                                    | --cardano-mode
+                                                      [--epoch-slots SLOTS]
+                                                    ]
+                                                    ( --mainnet
+                                                    | --testnet-magic NATURAL
+                                                    )
+                                                    [--out-file FILE]
+
+  Get the constitution hash
+
+Usage: cardano-cli alonzo query tip --socket-path SOCKET_PATH
+                                      [ --shelley-mode
+                                      | --byron-mode [--epoch-slots SLOTS]
+                                      | --cardano-mode [--epoch-slots SLOTS]
+                                      ]
+                                      (--mainnet | --testnet-magic NATURAL)
+                                      [--out-file FILE]
+
+  Get the node's current tip (slot no, hash, block no)
+
+Usage: cardano-cli alonzo query stake-pools --socket-path SOCKET_PATH
+                                              [ --shelley-mode
+                                              | --byron-mode
+                                                [--epoch-slots SLOTS]
+                                              | --cardano-mode
+                                                [--epoch-slots SLOTS]
+                                              ]
+                                              ( --mainnet
+                                              | --testnet-magic NATURAL
+                                              )
+                                              [--out-file FILE]
+
+  Get the node's current set of stake pool ids
+
+Usage: cardano-cli alonzo query stake-distribution --socket-path SOCKET_PATH
+                                                     [ --shelley-mode
+                                                     | --byron-mode
+                                                       [--epoch-slots SLOTS]
+                                                     | --cardano-mode
+                                                       [--epoch-slots SLOTS]
+                                                     ]
+                                                     ( --mainnet
+                                                     | --testnet-magic NATURAL
+                                                     )
+                                                     [--out-file FILE]
+
+  Get the node's current aggregated stake distribution
+
+Usage: cardano-cli alonzo query stake-address-info --socket-path SOCKET_PATH
+                                                     [ --shelley-mode
+                                                     | --byron-mode
+                                                       [--epoch-slots SLOTS]
+                                                     | --cardano-mode
+                                                       [--epoch-slots SLOTS]
+                                                     ]
+                                                     --address ADDRESS
+                                                     ( --mainnet
+                                                     | --testnet-magic NATURAL
+                                                     )
+                                                     [--out-file FILE]
+
+  Get the current delegations and reward accounts filtered by stake address.
+
+Usage: cardano-cli alonzo query utxo --socket-path SOCKET_PATH
+                                       [ --shelley-mode
+                                       | --byron-mode [--epoch-slots SLOTS]
+                                       | --cardano-mode [--epoch-slots SLOTS]
+                                       ]
+                                       ( --whole-utxo
+                                       | (--address ADDRESS)
+                                       | (--tx-in TX-IN)
+                                       )
+                                       (--mainnet | --testnet-magic NATURAL)
+                                       [--out-file FILE]
+
+  Get a portion of the current UTxO: by tx in, by address or the whole.
+
+Usage: cardano-cli alonzo query ledger-state --socket-path SOCKET_PATH
+                                               [ --shelley-mode
+                                               | --byron-mode
+                                                 [--epoch-slots SLOTS]
+                                               | --cardano-mode
+                                                 [--epoch-slots SLOTS]
+                                               ]
+                                               ( --mainnet
+                                               | --testnet-magic NATURAL
+                                               )
+                                               [--out-file FILE]
+
+  Dump the current ledger state of the node (Ledger.NewEpochState -- advanced
+  command)
+
+Usage: cardano-cli alonzo query protocol-state --socket-path SOCKET_PATH
+                                                 [ --shelley-mode
+                                                 | --byron-mode
+                                                   [--epoch-slots SLOTS]
+                                                 | --cardano-mode
+                                                   [--epoch-slots SLOTS]
+                                                 ]
+                                                 ( --mainnet
+                                                 | --testnet-magic NATURAL
+                                                 )
+                                                 [--out-file FILE]
+
+  Dump the current protocol state of the node (Ledger.ChainDepState -- advanced
+  command)
+
+Usage: cardano-cli alonzo query stake-snapshot --socket-path SOCKET_PATH
+                                                 [ --shelley-mode
+                                                 | --byron-mode
+                                                   [--epoch-slots SLOTS]
+                                                 | --cardano-mode
+                                                   [--epoch-slots SLOTS]
+                                                 ]
+                                                 ( --mainnet
+                                                 | --testnet-magic NATURAL
+                                                 )
+                                                 [ --all-stake-pools
+                                                 | 
+                                                 [--stake-pool-id STAKE_POOL_ID]
+                                                 ]
+                                                 [--out-file FILE]
+
+  Obtain the three stake snapshots for a pool, plus the total active stake
+  (advanced command)
+
+Usage: cardano-cli alonzo query pool-params --socket-path SOCKET_PATH
+                                              [ --shelley-mode
+                                              | --byron-mode
+                                                [--epoch-slots SLOTS]
+                                              | --cardano-mode
+                                                [--epoch-slots SLOTS]
+                                              ]
+                                              ( --mainnet
+                                              | --testnet-magic NATURAL
+                                              )
+                                              [--stake-pool-id STAKE_POOL_ID]
+
+  DEPRECATED. Use query pool-state instead. Dump the pool parameters
+  (Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced
+  command)
+
+Usage: cardano-cli alonzo query leadership-schedule --socket-path SOCKET_PATH
+                                                      [ --shelley-mode
+                                                      | --byron-mode
+                                                        [--epoch-slots SLOTS]
+                                                      | --cardano-mode
+                                                        [--epoch-slots SLOTS]
+                                                      ]
+                                                      ( --mainnet
+                                                      | --testnet-magic NATURAL
+                                                      )
+                                                      --genesis FILE
+                                                      ( --stake-pool-verification-key STRING
+                                                      | --cold-verification-key-file FILE
+                                                      | --stake-pool-id STAKE_POOL_ID
+                                                      )
+                                                      --vrf-signing-key-file FILE
+                                                      (--current | --next)
+                                                      [--out-file FILE]
+
+  Get the slots the node is expected to mint a block in (advanced command)
+
+Usage: cardano-cli alonzo query kes-period-info --socket-path SOCKET_PATH
+                                                  [ --shelley-mode
+                                                  | --byron-mode
+                                                    [--epoch-slots SLOTS]
+                                                  | --cardano-mode
+                                                    [--epoch-slots SLOTS]
+                                                  ]
+                                                  ( --mainnet
+                                                  | --testnet-magic NATURAL
+                                                  )
+                                                  --op-cert-file FILE
+                                                  [--out-file FILE]
+
+  Get information about the current KES period and your node's operational
+  certificate.
+
+Usage: cardano-cli alonzo query pool-state --socket-path SOCKET_PATH
+                                             [ --shelley-mode
+                                             | --byron-mode
+                                               [--epoch-slots SLOTS]
+                                             | --cardano-mode
+                                               [--epoch-slots SLOTS]
+                                             ]
+                                             ( --mainnet
+                                             | --testnet-magic NATURAL
+                                             )
+                                             [--stake-pool-id STAKE_POOL_ID]
+
+  Dump the pool state
+
+Usage: cardano-cli alonzo query tx-mempool --socket-path SOCKET_PATH
+                                             [ --shelley-mode
+                                             | --byron-mode
+                                               [--epoch-slots SLOTS]
+                                             | --cardano-mode
+                                               [--epoch-slots SLOTS]
+                                             ]
+                                             ( --mainnet
+                                             | --testnet-magic NATURAL
+                                             )
+                                             (info | next-tx | tx-exists)
+                                             [--out-file FILE]
+
+  Local Mempool info
+
+Usage: cardano-cli alonzo query tx-mempool info 
+
+  Ask the node about the current mempool's capacity and sizes
+
+Usage: cardano-cli alonzo query tx-mempool next-tx 
+
+  Requests the next transaction from the mempool's current list
+
+Usage: cardano-cli alonzo query tx-mempool tx-exists TX_ID
+
+  Query if a particular transaction exists in the mempool
+
+Usage: cardano-cli alonzo query slot-number --socket-path SOCKET_PATH
+                                              [ --shelley-mode
+                                              | --byron-mode
+                                                [--epoch-slots SLOTS]
+                                              | --cardano-mode
+                                                [--epoch-slots SLOTS]
+                                              ]
+                                              ( --mainnet
+                                              | --testnet-magic NATURAL
+                                              )
+                                              TIMESTAMP
+
+  Query slot number for UTC timestamp
+
 Usage: cardano-cli alonzo stake-address 
                                           ( key-gen
                                           | key-hash
@@ -2142,6 +4294,14 @@ Usage: cardano-cli alonzo stake-address stake-delegation-certificate
   Create a stake address stake delegation certificate, which when submitted in a
   transaction delegates stake to a stake pool.
 
+Usage: cardano-cli alonzo text-view decode-cbor
+
+  Era-based text-view commands
+
+Usage: cardano-cli alonzo text-view decode-cbor --in-file FILE [--out-file FILE]
+
+  Print a TextView file as decoded CBOR.
+
 Usage: cardano-cli alonzo transaction 
                                         ( build-raw
                                         | build
@@ -2157,7 +4317,7 @@ Usage: cardano-cli alonzo transaction
                                         | view
                                         )
 
-  Era-based governance commands
+  Era-based transaction commands
 
 Usage: cardano-cli alonzo transaction build-raw 
                                                   [ --script-valid
@@ -2525,7 +4685,17 @@ Usage: cardano-cli alonzo transaction view
 
   Print a transaction.
 
-Usage: cardano-cli babbage (address | governance | stake-address | transaction)
+Usage: cardano-cli babbage 
+                             ( address
+                             | key
+                             | genesis
+                             | governance
+                             | node
+                             | query
+                             | stake-address
+                             | text-view
+                             | transaction
+                             )
 
   Babbage era commands
 
@@ -2569,6 +4739,199 @@ Usage: cardano-cli babbage address build
 Usage: cardano-cli babbage address info --address ADDRESS [--out-file FILE]
 
   Print information about an address.
+
+Usage: cardano-cli babbage key 
+                                 ( verification-key
+                                 | non-extended-key
+                                 | convert-byron-key
+                                 | convert-byron-genesis-vkey
+                                 | convert-itn-key
+                                 | convert-itn-extended-key
+                                 | convert-itn-bip32-key
+                                 | convert-cardano-address-key
+                                 )
+
+  Era-based key commands
+
+Usage: cardano-cli babbage key verification-key --signing-key-file FILE
+                                                  --verification-key-file FILE
+
+  Get a verification key from a signing key. This supports all key types.
+
+Usage: cardano-cli babbage key non-extended-key --extended-verification-key-file FILE
+                                                  --verification-key-file FILE
+
+  Get a non-extended verification key from an extended verification key. This
+  supports all extended key types.
+
+Usage: cardano-cli babbage key convert-byron-key [--password TEXT]
+                                                   ( --byron-payment-key-type
+                                                   | --legacy-byron-payment-key-type
+                                                   | --byron-genesis-key-type
+                                                   | --legacy-byron-genesis-key-type
+                                                   | --byron-genesis-delegate-key-type
+                                                   | --legacy-byron-genesis-delegate-key-type
+                                                   )
+                                                   ( --byron-signing-key-file FILE
+                                                   | --byron-verification-key-file FILE
+                                                   )
+                                                   --out-file FILE
+
+  Convert a Byron payment, genesis or genesis delegate key (signing or
+  verification) to a corresponding Shelley-format key.
+
+Usage: cardano-cli babbage key convert-byron-genesis-vkey --byron-genesis-verification-key BASE64
+                                                            --out-file FILE
+
+  Convert a Base64-encoded Byron genesis verification key to a Shelley genesis
+  verification key
+
+Usage: cardano-cli babbage key convert-itn-key 
+                                                 ( --itn-signing-key-file FILE
+                                                 | --itn-verification-key-file FILE
+                                                 )
+                                                 --out-file FILE
+
+  Convert an Incentivized Testnet (ITN) non-extended (Ed25519) signing or
+  verification key to a corresponding Shelley stake key
+
+Usage: cardano-cli babbage key convert-itn-extended-key --itn-signing-key-file FILE
+                                                          --out-file FILE
+
+  Convert an Incentivized Testnet (ITN) extended (Ed25519Extended) signing key
+  to a corresponding Shelley stake signing key
+
+Usage: cardano-cli babbage key convert-itn-bip32-key --itn-signing-key-file FILE
+                                                       --out-file FILE
+
+  Convert an Incentivized Testnet (ITN) BIP32 (Ed25519Bip32) signing key to a
+  corresponding Shelley stake signing key
+
+Usage: cardano-cli babbage key convert-cardano-address-key 
+                                                             ( --shelley-payment-key
+                                                             | --shelley-stake-key
+                                                             | --icarus-payment-key
+                                                             | --byron-payment-key
+                                                             )
+                                                             --signing-key-file FILE
+                                                             --out-file FILE
+
+  Convert a cardano-address extended signing key to a corresponding
+  Shelley-format key.
+
+Usage: cardano-cli babbage genesis 
+                                     ( key-gen-genesis
+                                     | key-gen-delegate
+                                     | key-gen-utxo
+                                     | key-hash
+                                     | get-ver-key
+                                     | initial-addr
+                                     | initial-txin
+                                     | create-cardano
+                                     | create
+                                     | create-staked
+                                     | hash
+                                     )
+
+  Era-based genesis commands
+
+Usage: cardano-cli babbage genesis key-gen-genesis --verification-key-file FILE
+                                                     --signing-key-file FILE
+
+  Create a Shelley genesis key pair
+
+Usage: cardano-cli babbage genesis key-gen-delegate --verification-key-file FILE
+                                                      --signing-key-file FILE
+                                                      --operational-certificate-issue-counter-file FILE
+
+  Create a Shelley genesis delegate key pair
+
+Usage: cardano-cli babbage genesis key-gen-utxo --verification-key-file FILE
+                                                  --signing-key-file FILE
+
+  Create a Shelley genesis UTxO key pair
+
+Usage: cardano-cli babbage genesis key-hash --verification-key-file FILE
+
+  Print the identifier (hash) of a public key
+
+Usage: cardano-cli babbage genesis get-ver-key --verification-key-file FILE
+                                                 --signing-key-file FILE
+
+  Derive the verification key from a signing key
+
+Usage: cardano-cli babbage genesis initial-addr --verification-key-file FILE
+                                                  ( --mainnet
+                                                  | --testnet-magic NATURAL
+                                                  )
+                                                  [--out-file FILE]
+
+  Get the address for an initial UTxO based on the verification key
+
+Usage: cardano-cli babbage genesis initial-txin --verification-key-file FILE
+                                                  ( --mainnet
+                                                  | --testnet-magic NATURAL
+                                                  )
+                                                  [--out-file FILE]
+
+  Get the TxIn for an initial UTxO based on the verification key
+
+Usage: cardano-cli babbage genesis create-cardano --genesis-dir DIR
+                                                    [--gen-genesis-keys INT]
+                                                    [--gen-utxo-keys INT]
+                                                    [--start-time UTC-TIME]
+                                                    [--supply LOVELACE]
+                                                    [--security-param INT]
+                                                    [--slot-length INT]
+                                                    [--slot-coefficient RATIONAL]
+                                                    ( --mainnet
+                                                    | --testnet-magic NATURAL
+                                                    )
+                                                    --byron-template FILEPATH
+                                                    --shelley-template FILEPATH
+                                                    --alonzo-template FILEPATH
+                                                    --conway-template FILEPATH
+                                                    [--node-config-template FILEPATH]
+
+  Create a Byron and Shelley genesis file from a genesis template and
+  genesis/delegation/spending keys.
+
+Usage: cardano-cli babbage genesis create [--key-output-format STRING]
+                                            --genesis-dir DIR
+                                            [--gen-genesis-keys INT]
+                                            [--gen-utxo-keys INT]
+                                            [--start-time UTC-TIME]
+                                            [--supply LOVELACE]
+                                            ( --mainnet
+                                            | --testnet-magic NATURAL
+                                            )
+
+  Create a Shelley genesis file from a genesis template and
+  genesis/delegation/spending keys.
+
+Usage: cardano-cli babbage genesis create-staked [--key-output-format STRING]
+                                                   --genesis-dir DIR
+                                                   [--gen-genesis-keys INT]
+                                                   [--gen-utxo-keys INT]
+                                                   [--gen-pools INT]
+                                                   [--gen-stake-delegs INT]
+                                                   [--start-time UTC-TIME]
+                                                   [--supply LOVELACE]
+                                                   [--supply-delegated LOVELACE]
+                                                   ( --mainnet
+                                                   | --testnet-magic NATURAL
+                                                   )
+                                                   [--bulk-pool-cred-files INT]
+                                                   [--bulk-pools-per-file INT]
+                                                   [--num-stuffed-utxo INT]
+                                                   [--relay-specification-file FILE]
+
+  Create a staked Shelley genesis file from a genesis template and
+  genesis/delegation/spending keys.
+
+Usage: cardano-cli babbage genesis hash --genesis FILE
+
+  Compute the hash of a genesis file
 
 Usage: cardano-cli babbage governance (create-mir-certificate | action | drep)
 
@@ -2701,6 +5064,338 @@ Usage: cardano-cli babbage governance drep registration-certificate
 
   Create a registration certificate.
 
+Usage: cardano-cli babbage node 
+                                  ( key-gen
+                                  | key-gen-KES
+                                  | key-gen-VRF
+                                  | key-hash-VRF
+                                  | new-counter
+                                  | issue-op-cert
+                                  )
+
+  Era-based node commands
+
+Usage: cardano-cli babbage node key-gen [--key-output-format STRING]
+                                          --cold-verification-key-file FILE
+                                          --cold-signing-key-file FILE
+                                          --operational-certificate-issue-counter-file FILE
+
+  Create a key pair for a node operator's offline key and a new certificate
+  issue counter
+
+Usage: cardano-cli babbage node key-gen-KES [--key-output-format STRING]
+                                              --verification-key-file FILE
+                                              --signing-key-file FILE
+
+  Create a key pair for a node KES operational key
+
+Usage: cardano-cli babbage node key-gen-VRF [--key-output-format STRING]
+                                              --verification-key-file FILE
+                                              --signing-key-file FILE
+
+  Create a key pair for a node VRF operational key
+
+Usage: cardano-cli babbage node key-hash-VRF 
+                                               ( --verification-key STRING
+                                               | --verification-key-file FILE
+                                               )
+                                               [--out-file FILE]
+
+  Print hash of a node's operational VRF key.
+
+Usage: cardano-cli babbage node new-counter 
+                                              ( --stake-pool-verification-key STRING
+                                              | --genesis-delegate-verification-key STRING
+                                              | --cold-verification-key-file FILE
+                                              )
+                                              --counter-value INT
+                                              --operational-certificate-issue-counter-file FILE
+
+  Create a new certificate issue counter
+
+Usage: cardano-cli babbage node issue-op-cert 
+                                                ( --kes-verification-key STRING
+                                                | --kes-verification-key-file FILE
+                                                )
+                                                --cold-signing-key-file FILE
+                                                --operational-certificate-issue-counter-file FILE
+                                                --kes-period NATURAL
+                                                --out-file FILE
+
+  Issue a node operational certificate
+
+Usage: cardano-cli babbage query 
+                                   ( protocol-parameters
+                                   | constitution-hash
+                                   | tip
+                                   | stake-pools
+                                   | stake-distribution
+                                   | stake-address-info
+                                   | utxo
+                                   | ledger-state
+                                   | protocol-state
+                                   | stake-snapshot
+                                   | leadership-schedule
+                                   | kes-period-info
+                                   | pool-state
+                                   | tx-mempool
+                                   | slot-number
+                                   )
+
+  Era-based query commands
+
+Usage: cardano-cli babbage query protocol-parameters --socket-path SOCKET_PATH
+                                                       [ --shelley-mode
+                                                       | --byron-mode
+                                                         [--epoch-slots SLOTS]
+                                                       | --cardano-mode
+                                                         [--epoch-slots SLOTS]
+                                                       ]
+                                                       ( --mainnet
+                                                       | --testnet-magic NATURAL
+                                                       )
+                                                       [--out-file FILE]
+
+  Get the node's current protocol parameters
+
+Usage: cardano-cli babbage query constitution-hash --socket-path SOCKET_PATH
+                                                     [ --shelley-mode
+                                                     | --byron-mode
+                                                       [--epoch-slots SLOTS]
+                                                     | --cardano-mode
+                                                       [--epoch-slots SLOTS]
+                                                     ]
+                                                     ( --mainnet
+                                                     | --testnet-magic NATURAL
+                                                     )
+                                                     [--out-file FILE]
+
+  Get the constitution hash
+
+Usage: cardano-cli babbage query tip --socket-path SOCKET_PATH
+                                       [ --shelley-mode
+                                       | --byron-mode [--epoch-slots SLOTS]
+                                       | --cardano-mode [--epoch-slots SLOTS]
+                                       ]
+                                       (--mainnet | --testnet-magic NATURAL)
+                                       [--out-file FILE]
+
+  Get the node's current tip (slot no, hash, block no)
+
+Usage: cardano-cli babbage query stake-pools --socket-path SOCKET_PATH
+                                               [ --shelley-mode
+                                               | --byron-mode
+                                                 [--epoch-slots SLOTS]
+                                               | --cardano-mode
+                                                 [--epoch-slots SLOTS]
+                                               ]
+                                               ( --mainnet
+                                               | --testnet-magic NATURAL
+                                               )
+                                               [--out-file FILE]
+
+  Get the node's current set of stake pool ids
+
+Usage: cardano-cli babbage query stake-distribution --socket-path SOCKET_PATH
+                                                      [ --shelley-mode
+                                                      | --byron-mode
+                                                        [--epoch-slots SLOTS]
+                                                      | --cardano-mode
+                                                        [--epoch-slots SLOTS]
+                                                      ]
+                                                      ( --mainnet
+                                                      | --testnet-magic NATURAL
+                                                      )
+                                                      [--out-file FILE]
+
+  Get the node's current aggregated stake distribution
+
+Usage: cardano-cli babbage query stake-address-info --socket-path SOCKET_PATH
+                                                      [ --shelley-mode
+                                                      | --byron-mode
+                                                        [--epoch-slots SLOTS]
+                                                      | --cardano-mode
+                                                        [--epoch-slots SLOTS]
+                                                      ]
+                                                      --address ADDRESS
+                                                      ( --mainnet
+                                                      | --testnet-magic NATURAL
+                                                      )
+                                                      [--out-file FILE]
+
+  Get the current delegations and reward accounts filtered by stake address.
+
+Usage: cardano-cli babbage query utxo --socket-path SOCKET_PATH
+                                        [ --shelley-mode
+                                        | --byron-mode [--epoch-slots SLOTS]
+                                        | --cardano-mode [--epoch-slots SLOTS]
+                                        ]
+                                        ( --whole-utxo
+                                        | (--address ADDRESS)
+                                        | (--tx-in TX-IN)
+                                        )
+                                        (--mainnet | --testnet-magic NATURAL)
+                                        [--out-file FILE]
+
+  Get a portion of the current UTxO: by tx in, by address or the whole.
+
+Usage: cardano-cli babbage query ledger-state --socket-path SOCKET_PATH
+                                                [ --shelley-mode
+                                                | --byron-mode
+                                                  [--epoch-slots SLOTS]
+                                                | --cardano-mode
+                                                  [--epoch-slots SLOTS]
+                                                ]
+                                                ( --mainnet
+                                                | --testnet-magic NATURAL
+                                                )
+                                                [--out-file FILE]
+
+  Dump the current ledger state of the node (Ledger.NewEpochState -- advanced
+  command)
+
+Usage: cardano-cli babbage query protocol-state --socket-path SOCKET_PATH
+                                                  [ --shelley-mode
+                                                  | --byron-mode
+                                                    [--epoch-slots SLOTS]
+                                                  | --cardano-mode
+                                                    [--epoch-slots SLOTS]
+                                                  ]
+                                                  ( --mainnet
+                                                  | --testnet-magic NATURAL
+                                                  )
+                                                  [--out-file FILE]
+
+  Dump the current protocol state of the node (Ledger.ChainDepState -- advanced
+  command)
+
+Usage: cardano-cli babbage query stake-snapshot --socket-path SOCKET_PATH
+                                                  [ --shelley-mode
+                                                  | --byron-mode
+                                                    [--epoch-slots SLOTS]
+                                                  | --cardano-mode
+                                                    [--epoch-slots SLOTS]
+                                                  ]
+                                                  ( --mainnet
+                                                  | --testnet-magic NATURAL
+                                                  )
+                                                  [ --all-stake-pools
+                                                  | 
+                                                  [--stake-pool-id STAKE_POOL_ID]
+                                                  ]
+                                                  [--out-file FILE]
+
+  Obtain the three stake snapshots for a pool, plus the total active stake
+  (advanced command)
+
+Usage: cardano-cli babbage query pool-params --socket-path SOCKET_PATH
+                                               [ --shelley-mode
+                                               | --byron-mode
+                                                 [--epoch-slots SLOTS]
+                                               | --cardano-mode
+                                                 [--epoch-slots SLOTS]
+                                               ]
+                                               ( --mainnet
+                                               | --testnet-magic NATURAL
+                                               )
+                                               [--stake-pool-id STAKE_POOL_ID]
+
+  DEPRECATED. Use query pool-state instead. Dump the pool parameters
+  (Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced
+  command)
+
+Usage: cardano-cli babbage query leadership-schedule --socket-path SOCKET_PATH
+                                                       [ --shelley-mode
+                                                       | --byron-mode
+                                                         [--epoch-slots SLOTS]
+                                                       | --cardano-mode
+                                                         [--epoch-slots SLOTS]
+                                                       ]
+                                                       ( --mainnet
+                                                       | --testnet-magic NATURAL
+                                                       )
+                                                       --genesis FILE
+                                                       ( --stake-pool-verification-key STRING
+                                                       | --cold-verification-key-file FILE
+                                                       | --stake-pool-id STAKE_POOL_ID
+                                                       )
+                                                       --vrf-signing-key-file FILE
+                                                       (--current | --next)
+                                                       [--out-file FILE]
+
+  Get the slots the node is expected to mint a block in (advanced command)
+
+Usage: cardano-cli babbage query kes-period-info --socket-path SOCKET_PATH
+                                                   [ --shelley-mode
+                                                   | --byron-mode
+                                                     [--epoch-slots SLOTS]
+                                                   | --cardano-mode
+                                                     [--epoch-slots SLOTS]
+                                                   ]
+                                                   ( --mainnet
+                                                   | --testnet-magic NATURAL
+                                                   )
+                                                   --op-cert-file FILE
+                                                   [--out-file FILE]
+
+  Get information about the current KES period and your node's operational
+  certificate.
+
+Usage: cardano-cli babbage query pool-state --socket-path SOCKET_PATH
+                                              [ --shelley-mode
+                                              | --byron-mode
+                                                [--epoch-slots SLOTS]
+                                              | --cardano-mode
+                                                [--epoch-slots SLOTS]
+                                              ]
+                                              ( --mainnet
+                                              | --testnet-magic NATURAL
+                                              )
+                                              [--stake-pool-id STAKE_POOL_ID]
+
+  Dump the pool state
+
+Usage: cardano-cli babbage query tx-mempool --socket-path SOCKET_PATH
+                                              [ --shelley-mode
+                                              | --byron-mode
+                                                [--epoch-slots SLOTS]
+                                              | --cardano-mode
+                                                [--epoch-slots SLOTS]
+                                              ]
+                                              ( --mainnet
+                                              | --testnet-magic NATURAL
+                                              )
+                                              (info | next-tx | tx-exists)
+                                              [--out-file FILE]
+
+  Local Mempool info
+
+Usage: cardano-cli babbage query tx-mempool info 
+
+  Ask the node about the current mempool's capacity and sizes
+
+Usage: cardano-cli babbage query tx-mempool next-tx 
+
+  Requests the next transaction from the mempool's current list
+
+Usage: cardano-cli babbage query tx-mempool tx-exists TX_ID
+
+  Query if a particular transaction exists in the mempool
+
+Usage: cardano-cli babbage query slot-number --socket-path SOCKET_PATH
+                                               [ --shelley-mode
+                                               | --byron-mode
+                                                 [--epoch-slots SLOTS]
+                                               | --cardano-mode
+                                                 [--epoch-slots SLOTS]
+                                               ]
+                                               ( --mainnet
+                                               | --testnet-magic NATURAL
+                                               )
+                                               TIMESTAMP
+
+  Query slot number for UTC timestamp
+
 Usage: cardano-cli babbage stake-address 
                                            ( key-gen
                                            | key-hash
@@ -2775,6 +5470,15 @@ Usage: cardano-cli babbage stake-address stake-delegation-certificate
   Create a stake address stake delegation certificate, which when submitted in a
   transaction delegates stake to a stake pool.
 
+Usage: cardano-cli babbage text-view decode-cbor
+
+  Era-based text-view commands
+
+Usage: cardano-cli babbage text-view decode-cbor --in-file FILE
+                                                   [--out-file FILE]
+
+  Print a TextView file as decoded CBOR.
+
 Usage: cardano-cli babbage transaction 
                                          ( build-raw
                                          | build
@@ -2790,7 +5494,7 @@ Usage: cardano-cli babbage transaction
                                          | view
                                          )
 
-  Era-based governance commands
+  Era-based transaction commands
 
 Usage: cardano-cli babbage transaction build-raw 
                                                    [ --script-valid
@@ -3158,7 +5862,17 @@ Usage: cardano-cli babbage transaction view
 
   Print a transaction.
 
-Usage: cardano-cli conway (address | governance | stake-address | transaction)
+Usage: cardano-cli conway 
+                            ( address
+                            | key
+                            | genesis
+                            | governance
+                            | node
+                            | query
+                            | stake-address
+                            | text-view
+                            | transaction
+                            )
 
   Conway era commands
 
@@ -3202,6 +5916,197 @@ Usage: cardano-cli conway address build
 Usage: cardano-cli conway address info --address ADDRESS [--out-file FILE]
 
   Print information about an address.
+
+Usage: cardano-cli conway key 
+                                ( verification-key
+                                | non-extended-key
+                                | convert-byron-key
+                                | convert-byron-genesis-vkey
+                                | convert-itn-key
+                                | convert-itn-extended-key
+                                | convert-itn-bip32-key
+                                | convert-cardano-address-key
+                                )
+
+  Era-based key commands
+
+Usage: cardano-cli conway key verification-key --signing-key-file FILE
+                                                 --verification-key-file FILE
+
+  Get a verification key from a signing key. This supports all key types.
+
+Usage: cardano-cli conway key non-extended-key --extended-verification-key-file FILE
+                                                 --verification-key-file FILE
+
+  Get a non-extended verification key from an extended verification key. This
+  supports all extended key types.
+
+Usage: cardano-cli conway key convert-byron-key [--password TEXT]
+                                                  ( --byron-payment-key-type
+                                                  | --legacy-byron-payment-key-type
+                                                  | --byron-genesis-key-type
+                                                  | --legacy-byron-genesis-key-type
+                                                  | --byron-genesis-delegate-key-type
+                                                  | --legacy-byron-genesis-delegate-key-type
+                                                  )
+                                                  ( --byron-signing-key-file FILE
+                                                  | --byron-verification-key-file FILE
+                                                  )
+                                                  --out-file FILE
+
+  Convert a Byron payment, genesis or genesis delegate key (signing or
+  verification) to a corresponding Shelley-format key.
+
+Usage: cardano-cli conway key convert-byron-genesis-vkey --byron-genesis-verification-key BASE64
+                                                           --out-file FILE
+
+  Convert a Base64-encoded Byron genesis verification key to a Shelley genesis
+  verification key
+
+Usage: cardano-cli conway key convert-itn-key 
+                                                ( --itn-signing-key-file FILE
+                                                | --itn-verification-key-file FILE
+                                                )
+                                                --out-file FILE
+
+  Convert an Incentivized Testnet (ITN) non-extended (Ed25519) signing or
+  verification key to a corresponding Shelley stake key
+
+Usage: cardano-cli conway key convert-itn-extended-key --itn-signing-key-file FILE
+                                                         --out-file FILE
+
+  Convert an Incentivized Testnet (ITN) extended (Ed25519Extended) signing key
+  to a corresponding Shelley stake signing key
+
+Usage: cardano-cli conway key convert-itn-bip32-key --itn-signing-key-file FILE
+                                                      --out-file FILE
+
+  Convert an Incentivized Testnet (ITN) BIP32 (Ed25519Bip32) signing key to a
+  corresponding Shelley stake signing key
+
+Usage: cardano-cli conway key convert-cardano-address-key 
+                                                            ( --shelley-payment-key
+                                                            | --shelley-stake-key
+                                                            | --icarus-payment-key
+                                                            | --byron-payment-key
+                                                            )
+                                                            --signing-key-file FILE
+                                                            --out-file FILE
+
+  Convert a cardano-address extended signing key to a corresponding
+  Shelley-format key.
+
+Usage: cardano-cli conway genesis 
+                                    ( key-gen-genesis
+                                    | key-gen-delegate
+                                    | key-gen-utxo
+                                    | key-hash
+                                    | get-ver-key
+                                    | initial-addr
+                                    | initial-txin
+                                    | create-cardano
+                                    | create
+                                    | create-staked
+                                    | hash
+                                    )
+
+  Era-based genesis commands
+
+Usage: cardano-cli conway genesis key-gen-genesis --verification-key-file FILE
+                                                    --signing-key-file FILE
+
+  Create a Shelley genesis key pair
+
+Usage: cardano-cli conway genesis key-gen-delegate --verification-key-file FILE
+                                                     --signing-key-file FILE
+                                                     --operational-certificate-issue-counter-file FILE
+
+  Create a Shelley genesis delegate key pair
+
+Usage: cardano-cli conway genesis key-gen-utxo --verification-key-file FILE
+                                                 --signing-key-file FILE
+
+  Create a Shelley genesis UTxO key pair
+
+Usage: cardano-cli conway genesis key-hash --verification-key-file FILE
+
+  Print the identifier (hash) of a public key
+
+Usage: cardano-cli conway genesis get-ver-key --verification-key-file FILE
+                                                --signing-key-file FILE
+
+  Derive the verification key from a signing key
+
+Usage: cardano-cli conway genesis initial-addr --verification-key-file FILE
+                                                 ( --mainnet
+                                                 | --testnet-magic NATURAL
+                                                 )
+                                                 [--out-file FILE]
+
+  Get the address for an initial UTxO based on the verification key
+
+Usage: cardano-cli conway genesis initial-txin --verification-key-file FILE
+                                                 ( --mainnet
+                                                 | --testnet-magic NATURAL
+                                                 )
+                                                 [--out-file FILE]
+
+  Get the TxIn for an initial UTxO based on the verification key
+
+Usage: cardano-cli conway genesis create-cardano --genesis-dir DIR
+                                                   [--gen-genesis-keys INT]
+                                                   [--gen-utxo-keys INT]
+                                                   [--start-time UTC-TIME]
+                                                   [--supply LOVELACE]
+                                                   [--security-param INT]
+                                                   [--slot-length INT]
+                                                   [--slot-coefficient RATIONAL]
+                                                   ( --mainnet
+                                                   | --testnet-magic NATURAL
+                                                   )
+                                                   --byron-template FILEPATH
+                                                   --shelley-template FILEPATH
+                                                   --alonzo-template FILEPATH
+                                                   --conway-template FILEPATH
+                                                   [--node-config-template FILEPATH]
+
+  Create a Byron and Shelley genesis file from a genesis template and
+  genesis/delegation/spending keys.
+
+Usage: cardano-cli conway genesis create [--key-output-format STRING]
+                                           --genesis-dir DIR
+                                           [--gen-genesis-keys INT]
+                                           [--gen-utxo-keys INT]
+                                           [--start-time UTC-TIME]
+                                           [--supply LOVELACE]
+                                           (--mainnet | --testnet-magic NATURAL)
+
+  Create a Shelley genesis file from a genesis template and
+  genesis/delegation/spending keys.
+
+Usage: cardano-cli conway genesis create-staked [--key-output-format STRING]
+                                                  --genesis-dir DIR
+                                                  [--gen-genesis-keys INT]
+                                                  [--gen-utxo-keys INT]
+                                                  [--gen-pools INT]
+                                                  [--gen-stake-delegs INT]
+                                                  [--start-time UTC-TIME]
+                                                  [--supply LOVELACE]
+                                                  [--supply-delegated LOVELACE]
+                                                  ( --mainnet
+                                                  | --testnet-magic NATURAL
+                                                  )
+                                                  [--bulk-pool-cred-files INT]
+                                                  [--bulk-pools-per-file INT]
+                                                  [--num-stuffed-utxo INT]
+                                                  [--relay-specification-file FILE]
+
+  Create a staked Shelley genesis file from a genesis template and
+  genesis/delegation/spending keys.
+
+Usage: cardano-cli conway genesis hash --genesis FILE
+
+  Compute the hash of a genesis file
 
 Usage: cardano-cli conway governance (query | action | committee | drep | vote)
 
@@ -3620,6 +6525,338 @@ Usage: cardano-cli conway governance vote create (--yes | --no | --abstain)
 
   Vote creation.
 
+Usage: cardano-cli conway node 
+                                 ( key-gen
+                                 | key-gen-KES
+                                 | key-gen-VRF
+                                 | key-hash-VRF
+                                 | new-counter
+                                 | issue-op-cert
+                                 )
+
+  Era-based node commands
+
+Usage: cardano-cli conway node key-gen [--key-output-format STRING]
+                                         --cold-verification-key-file FILE
+                                         --cold-signing-key-file FILE
+                                         --operational-certificate-issue-counter-file FILE
+
+  Create a key pair for a node operator's offline key and a new certificate
+  issue counter
+
+Usage: cardano-cli conway node key-gen-KES [--key-output-format STRING]
+                                             --verification-key-file FILE
+                                             --signing-key-file FILE
+
+  Create a key pair for a node KES operational key
+
+Usage: cardano-cli conway node key-gen-VRF [--key-output-format STRING]
+                                             --verification-key-file FILE
+                                             --signing-key-file FILE
+
+  Create a key pair for a node VRF operational key
+
+Usage: cardano-cli conway node key-hash-VRF 
+                                              ( --verification-key STRING
+                                              | --verification-key-file FILE
+                                              )
+                                              [--out-file FILE]
+
+  Print hash of a node's operational VRF key.
+
+Usage: cardano-cli conway node new-counter 
+                                             ( --stake-pool-verification-key STRING
+                                             | --genesis-delegate-verification-key STRING
+                                             | --cold-verification-key-file FILE
+                                             )
+                                             --counter-value INT
+                                             --operational-certificate-issue-counter-file FILE
+
+  Create a new certificate issue counter
+
+Usage: cardano-cli conway node issue-op-cert 
+                                               ( --kes-verification-key STRING
+                                               | --kes-verification-key-file FILE
+                                               )
+                                               --cold-signing-key-file FILE
+                                               --operational-certificate-issue-counter-file FILE
+                                               --kes-period NATURAL
+                                               --out-file FILE
+
+  Issue a node operational certificate
+
+Usage: cardano-cli conway query 
+                                  ( protocol-parameters
+                                  | constitution-hash
+                                  | tip
+                                  | stake-pools
+                                  | stake-distribution
+                                  | stake-address-info
+                                  | utxo
+                                  | ledger-state
+                                  | protocol-state
+                                  | stake-snapshot
+                                  | leadership-schedule
+                                  | kes-period-info
+                                  | pool-state
+                                  | tx-mempool
+                                  | slot-number
+                                  )
+
+  Era-based query commands
+
+Usage: cardano-cli conway query protocol-parameters --socket-path SOCKET_PATH
+                                                      [ --shelley-mode
+                                                      | --byron-mode
+                                                        [--epoch-slots SLOTS]
+                                                      | --cardano-mode
+                                                        [--epoch-slots SLOTS]
+                                                      ]
+                                                      ( --mainnet
+                                                      | --testnet-magic NATURAL
+                                                      )
+                                                      [--out-file FILE]
+
+  Get the node's current protocol parameters
+
+Usage: cardano-cli conway query constitution-hash --socket-path SOCKET_PATH
+                                                    [ --shelley-mode
+                                                    | --byron-mode
+                                                      [--epoch-slots SLOTS]
+                                                    | --cardano-mode
+                                                      [--epoch-slots SLOTS]
+                                                    ]
+                                                    ( --mainnet
+                                                    | --testnet-magic NATURAL
+                                                    )
+                                                    [--out-file FILE]
+
+  Get the constitution hash
+
+Usage: cardano-cli conway query tip --socket-path SOCKET_PATH
+                                      [ --shelley-mode
+                                      | --byron-mode [--epoch-slots SLOTS]
+                                      | --cardano-mode [--epoch-slots SLOTS]
+                                      ]
+                                      (--mainnet | --testnet-magic NATURAL)
+                                      [--out-file FILE]
+
+  Get the node's current tip (slot no, hash, block no)
+
+Usage: cardano-cli conway query stake-pools --socket-path SOCKET_PATH
+                                              [ --shelley-mode
+                                              | --byron-mode
+                                                [--epoch-slots SLOTS]
+                                              | --cardano-mode
+                                                [--epoch-slots SLOTS]
+                                              ]
+                                              ( --mainnet
+                                              | --testnet-magic NATURAL
+                                              )
+                                              [--out-file FILE]
+
+  Get the node's current set of stake pool ids
+
+Usage: cardano-cli conway query stake-distribution --socket-path SOCKET_PATH
+                                                     [ --shelley-mode
+                                                     | --byron-mode
+                                                       [--epoch-slots SLOTS]
+                                                     | --cardano-mode
+                                                       [--epoch-slots SLOTS]
+                                                     ]
+                                                     ( --mainnet
+                                                     | --testnet-magic NATURAL
+                                                     )
+                                                     [--out-file FILE]
+
+  Get the node's current aggregated stake distribution
+
+Usage: cardano-cli conway query stake-address-info --socket-path SOCKET_PATH
+                                                     [ --shelley-mode
+                                                     | --byron-mode
+                                                       [--epoch-slots SLOTS]
+                                                     | --cardano-mode
+                                                       [--epoch-slots SLOTS]
+                                                     ]
+                                                     --address ADDRESS
+                                                     ( --mainnet
+                                                     | --testnet-magic NATURAL
+                                                     )
+                                                     [--out-file FILE]
+
+  Get the current delegations and reward accounts filtered by stake address.
+
+Usage: cardano-cli conway query utxo --socket-path SOCKET_PATH
+                                       [ --shelley-mode
+                                       | --byron-mode [--epoch-slots SLOTS]
+                                       | --cardano-mode [--epoch-slots SLOTS]
+                                       ]
+                                       ( --whole-utxo
+                                       | (--address ADDRESS)
+                                       | (--tx-in TX-IN)
+                                       )
+                                       (--mainnet | --testnet-magic NATURAL)
+                                       [--out-file FILE]
+
+  Get a portion of the current UTxO: by tx in, by address or the whole.
+
+Usage: cardano-cli conway query ledger-state --socket-path SOCKET_PATH
+                                               [ --shelley-mode
+                                               | --byron-mode
+                                                 [--epoch-slots SLOTS]
+                                               | --cardano-mode
+                                                 [--epoch-slots SLOTS]
+                                               ]
+                                               ( --mainnet
+                                               | --testnet-magic NATURAL
+                                               )
+                                               [--out-file FILE]
+
+  Dump the current ledger state of the node (Ledger.NewEpochState -- advanced
+  command)
+
+Usage: cardano-cli conway query protocol-state --socket-path SOCKET_PATH
+                                                 [ --shelley-mode
+                                                 | --byron-mode
+                                                   [--epoch-slots SLOTS]
+                                                 | --cardano-mode
+                                                   [--epoch-slots SLOTS]
+                                                 ]
+                                                 ( --mainnet
+                                                 | --testnet-magic NATURAL
+                                                 )
+                                                 [--out-file FILE]
+
+  Dump the current protocol state of the node (Ledger.ChainDepState -- advanced
+  command)
+
+Usage: cardano-cli conway query stake-snapshot --socket-path SOCKET_PATH
+                                                 [ --shelley-mode
+                                                 | --byron-mode
+                                                   [--epoch-slots SLOTS]
+                                                 | --cardano-mode
+                                                   [--epoch-slots SLOTS]
+                                                 ]
+                                                 ( --mainnet
+                                                 | --testnet-magic NATURAL
+                                                 )
+                                                 [ --all-stake-pools
+                                                 | 
+                                                 [--stake-pool-id STAKE_POOL_ID]
+                                                 ]
+                                                 [--out-file FILE]
+
+  Obtain the three stake snapshots for a pool, plus the total active stake
+  (advanced command)
+
+Usage: cardano-cli conway query pool-params --socket-path SOCKET_PATH
+                                              [ --shelley-mode
+                                              | --byron-mode
+                                                [--epoch-slots SLOTS]
+                                              | --cardano-mode
+                                                [--epoch-slots SLOTS]
+                                              ]
+                                              ( --mainnet
+                                              | --testnet-magic NATURAL
+                                              )
+                                              [--stake-pool-id STAKE_POOL_ID]
+
+  DEPRECATED. Use query pool-state instead. Dump the pool parameters
+  (Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced
+  command)
+
+Usage: cardano-cli conway query leadership-schedule --socket-path SOCKET_PATH
+                                                      [ --shelley-mode
+                                                      | --byron-mode
+                                                        [--epoch-slots SLOTS]
+                                                      | --cardano-mode
+                                                        [--epoch-slots SLOTS]
+                                                      ]
+                                                      ( --mainnet
+                                                      | --testnet-magic NATURAL
+                                                      )
+                                                      --genesis FILE
+                                                      ( --stake-pool-verification-key STRING
+                                                      | --cold-verification-key-file FILE
+                                                      | --stake-pool-id STAKE_POOL_ID
+                                                      )
+                                                      --vrf-signing-key-file FILE
+                                                      (--current | --next)
+                                                      [--out-file FILE]
+
+  Get the slots the node is expected to mint a block in (advanced command)
+
+Usage: cardano-cli conway query kes-period-info --socket-path SOCKET_PATH
+                                                  [ --shelley-mode
+                                                  | --byron-mode
+                                                    [--epoch-slots SLOTS]
+                                                  | --cardano-mode
+                                                    [--epoch-slots SLOTS]
+                                                  ]
+                                                  ( --mainnet
+                                                  | --testnet-magic NATURAL
+                                                  )
+                                                  --op-cert-file FILE
+                                                  [--out-file FILE]
+
+  Get information about the current KES period and your node's operational
+  certificate.
+
+Usage: cardano-cli conway query pool-state --socket-path SOCKET_PATH
+                                             [ --shelley-mode
+                                             | --byron-mode
+                                               [--epoch-slots SLOTS]
+                                             | --cardano-mode
+                                               [--epoch-slots SLOTS]
+                                             ]
+                                             ( --mainnet
+                                             | --testnet-magic NATURAL
+                                             )
+                                             [--stake-pool-id STAKE_POOL_ID]
+
+  Dump the pool state
+
+Usage: cardano-cli conway query tx-mempool --socket-path SOCKET_PATH
+                                             [ --shelley-mode
+                                             | --byron-mode
+                                               [--epoch-slots SLOTS]
+                                             | --cardano-mode
+                                               [--epoch-slots SLOTS]
+                                             ]
+                                             ( --mainnet
+                                             | --testnet-magic NATURAL
+                                             )
+                                             (info | next-tx | tx-exists)
+                                             [--out-file FILE]
+
+  Local Mempool info
+
+Usage: cardano-cli conway query tx-mempool info 
+
+  Ask the node about the current mempool's capacity and sizes
+
+Usage: cardano-cli conway query tx-mempool next-tx 
+
+  Requests the next transaction from the mempool's current list
+
+Usage: cardano-cli conway query tx-mempool tx-exists TX_ID
+
+  Query if a particular transaction exists in the mempool
+
+Usage: cardano-cli conway query slot-number --socket-path SOCKET_PATH
+                                              [ --shelley-mode
+                                              | --byron-mode
+                                                [--epoch-slots SLOTS]
+                                              | --cardano-mode
+                                                [--epoch-slots SLOTS]
+                                              ]
+                                              ( --mainnet
+                                              | --testnet-magic NATURAL
+                                              )
+                                              TIMESTAMP
+
+  Query slot number for UTC timestamp
+
 Usage: cardano-cli conway stake-address 
                                           ( key-gen
                                           | key-hash
@@ -3730,6 +6967,14 @@ Usage: cardano-cli conway stake-address vote-delegation-certificate
   Create a stake address vote delegation certificate, which when submitted in a
   transaction delegates stake to a stake pool and a DRep.
 
+Usage: cardano-cli conway text-view decode-cbor
+
+  Era-based text-view commands
+
+Usage: cardano-cli conway text-view decode-cbor --in-file FILE [--out-file FILE]
+
+  Print a TextView file as decoded CBOR.
+
 Usage: cardano-cli conway transaction 
                                         ( build-raw
                                         | build
@@ -3745,7 +6990,7 @@ Usage: cardano-cli conway transaction
                                         | view
                                         )
 
-  Era-based governance commands
+  Era-based transaction commands
 
 Usage: cardano-cli conway transaction build-raw 
                                                   [ --script-valid
@@ -4113,7 +7358,17 @@ Usage: cardano-cli conway transaction view
 
   Print a transaction.
 
-Usage: cardano-cli latest (address | governance | stake-address | transaction)
+Usage: cardano-cli latest 
+                            ( address
+                            | key
+                            | genesis
+                            | governance
+                            | node
+                            | query
+                            | stake-address
+                            | text-view
+                            | transaction
+                            )
 
   Latest era commands (Babbage)
 
@@ -4157,6 +7412,197 @@ Usage: cardano-cli latest address build
 Usage: cardano-cli latest address info --address ADDRESS [--out-file FILE]
 
   Print information about an address.
+
+Usage: cardano-cli latest key 
+                                ( verification-key
+                                | non-extended-key
+                                | convert-byron-key
+                                | convert-byron-genesis-vkey
+                                | convert-itn-key
+                                | convert-itn-extended-key
+                                | convert-itn-bip32-key
+                                | convert-cardano-address-key
+                                )
+
+  Era-based key commands
+
+Usage: cardano-cli latest key verification-key --signing-key-file FILE
+                                                 --verification-key-file FILE
+
+  Get a verification key from a signing key. This supports all key types.
+
+Usage: cardano-cli latest key non-extended-key --extended-verification-key-file FILE
+                                                 --verification-key-file FILE
+
+  Get a non-extended verification key from an extended verification key. This
+  supports all extended key types.
+
+Usage: cardano-cli latest key convert-byron-key [--password TEXT]
+                                                  ( --byron-payment-key-type
+                                                  | --legacy-byron-payment-key-type
+                                                  | --byron-genesis-key-type
+                                                  | --legacy-byron-genesis-key-type
+                                                  | --byron-genesis-delegate-key-type
+                                                  | --legacy-byron-genesis-delegate-key-type
+                                                  )
+                                                  ( --byron-signing-key-file FILE
+                                                  | --byron-verification-key-file FILE
+                                                  )
+                                                  --out-file FILE
+
+  Convert a Byron payment, genesis or genesis delegate key (signing or
+  verification) to a corresponding Shelley-format key.
+
+Usage: cardano-cli latest key convert-byron-genesis-vkey --byron-genesis-verification-key BASE64
+                                                           --out-file FILE
+
+  Convert a Base64-encoded Byron genesis verification key to a Shelley genesis
+  verification key
+
+Usage: cardano-cli latest key convert-itn-key 
+                                                ( --itn-signing-key-file FILE
+                                                | --itn-verification-key-file FILE
+                                                )
+                                                --out-file FILE
+
+  Convert an Incentivized Testnet (ITN) non-extended (Ed25519) signing or
+  verification key to a corresponding Shelley stake key
+
+Usage: cardano-cli latest key convert-itn-extended-key --itn-signing-key-file FILE
+                                                         --out-file FILE
+
+  Convert an Incentivized Testnet (ITN) extended (Ed25519Extended) signing key
+  to a corresponding Shelley stake signing key
+
+Usage: cardano-cli latest key convert-itn-bip32-key --itn-signing-key-file FILE
+                                                      --out-file FILE
+
+  Convert an Incentivized Testnet (ITN) BIP32 (Ed25519Bip32) signing key to a
+  corresponding Shelley stake signing key
+
+Usage: cardano-cli latest key convert-cardano-address-key 
+                                                            ( --shelley-payment-key
+                                                            | --shelley-stake-key
+                                                            | --icarus-payment-key
+                                                            | --byron-payment-key
+                                                            )
+                                                            --signing-key-file FILE
+                                                            --out-file FILE
+
+  Convert a cardano-address extended signing key to a corresponding
+  Shelley-format key.
+
+Usage: cardano-cli latest genesis 
+                                    ( key-gen-genesis
+                                    | key-gen-delegate
+                                    | key-gen-utxo
+                                    | key-hash
+                                    | get-ver-key
+                                    | initial-addr
+                                    | initial-txin
+                                    | create-cardano
+                                    | create
+                                    | create-staked
+                                    | hash
+                                    )
+
+  Era-based genesis commands
+
+Usage: cardano-cli latest genesis key-gen-genesis --verification-key-file FILE
+                                                    --signing-key-file FILE
+
+  Create a Shelley genesis key pair
+
+Usage: cardano-cli latest genesis key-gen-delegate --verification-key-file FILE
+                                                     --signing-key-file FILE
+                                                     --operational-certificate-issue-counter-file FILE
+
+  Create a Shelley genesis delegate key pair
+
+Usage: cardano-cli latest genesis key-gen-utxo --verification-key-file FILE
+                                                 --signing-key-file FILE
+
+  Create a Shelley genesis UTxO key pair
+
+Usage: cardano-cli latest genesis key-hash --verification-key-file FILE
+
+  Print the identifier (hash) of a public key
+
+Usage: cardano-cli latest genesis get-ver-key --verification-key-file FILE
+                                                --signing-key-file FILE
+
+  Derive the verification key from a signing key
+
+Usage: cardano-cli latest genesis initial-addr --verification-key-file FILE
+                                                 ( --mainnet
+                                                 | --testnet-magic NATURAL
+                                                 )
+                                                 [--out-file FILE]
+
+  Get the address for an initial UTxO based on the verification key
+
+Usage: cardano-cli latest genesis initial-txin --verification-key-file FILE
+                                                 ( --mainnet
+                                                 | --testnet-magic NATURAL
+                                                 )
+                                                 [--out-file FILE]
+
+  Get the TxIn for an initial UTxO based on the verification key
+
+Usage: cardano-cli latest genesis create-cardano --genesis-dir DIR
+                                                   [--gen-genesis-keys INT]
+                                                   [--gen-utxo-keys INT]
+                                                   [--start-time UTC-TIME]
+                                                   [--supply LOVELACE]
+                                                   [--security-param INT]
+                                                   [--slot-length INT]
+                                                   [--slot-coefficient RATIONAL]
+                                                   ( --mainnet
+                                                   | --testnet-magic NATURAL
+                                                   )
+                                                   --byron-template FILEPATH
+                                                   --shelley-template FILEPATH
+                                                   --alonzo-template FILEPATH
+                                                   --conway-template FILEPATH
+                                                   [--node-config-template FILEPATH]
+
+  Create a Byron and Shelley genesis file from a genesis template and
+  genesis/delegation/spending keys.
+
+Usage: cardano-cli latest genesis create [--key-output-format STRING]
+                                           --genesis-dir DIR
+                                           [--gen-genesis-keys INT]
+                                           [--gen-utxo-keys INT]
+                                           [--start-time UTC-TIME]
+                                           [--supply LOVELACE]
+                                           (--mainnet | --testnet-magic NATURAL)
+
+  Create a Shelley genesis file from a genesis template and
+  genesis/delegation/spending keys.
+
+Usage: cardano-cli latest genesis create-staked [--key-output-format STRING]
+                                                  --genesis-dir DIR
+                                                  [--gen-genesis-keys INT]
+                                                  [--gen-utxo-keys INT]
+                                                  [--gen-pools INT]
+                                                  [--gen-stake-delegs INT]
+                                                  [--start-time UTC-TIME]
+                                                  [--supply LOVELACE]
+                                                  [--supply-delegated LOVELACE]
+                                                  ( --mainnet
+                                                  | --testnet-magic NATURAL
+                                                  )
+                                                  [--bulk-pool-cred-files INT]
+                                                  [--bulk-pools-per-file INT]
+                                                  [--num-stuffed-utxo INT]
+                                                  [--relay-specification-file FILE]
+
+  Create a staked Shelley genesis file from a genesis template and
+  genesis/delegation/spending keys.
+
+Usage: cardano-cli latest genesis hash --genesis FILE
+
+  Compute the hash of a genesis file
 
 Usage: cardano-cli latest governance (create-mir-certificate | action | drep)
 
@@ -4289,6 +7735,338 @@ Usage: cardano-cli latest governance drep registration-certificate
 
   Create a registration certificate.
 
+Usage: cardano-cli latest node 
+                                 ( key-gen
+                                 | key-gen-KES
+                                 | key-gen-VRF
+                                 | key-hash-VRF
+                                 | new-counter
+                                 | issue-op-cert
+                                 )
+
+  Era-based node commands
+
+Usage: cardano-cli latest node key-gen [--key-output-format STRING]
+                                         --cold-verification-key-file FILE
+                                         --cold-signing-key-file FILE
+                                         --operational-certificate-issue-counter-file FILE
+
+  Create a key pair for a node operator's offline key and a new certificate
+  issue counter
+
+Usage: cardano-cli latest node key-gen-KES [--key-output-format STRING]
+                                             --verification-key-file FILE
+                                             --signing-key-file FILE
+
+  Create a key pair for a node KES operational key
+
+Usage: cardano-cli latest node key-gen-VRF [--key-output-format STRING]
+                                             --verification-key-file FILE
+                                             --signing-key-file FILE
+
+  Create a key pair for a node VRF operational key
+
+Usage: cardano-cli latest node key-hash-VRF 
+                                              ( --verification-key STRING
+                                              | --verification-key-file FILE
+                                              )
+                                              [--out-file FILE]
+
+  Print hash of a node's operational VRF key.
+
+Usage: cardano-cli latest node new-counter 
+                                             ( --stake-pool-verification-key STRING
+                                             | --genesis-delegate-verification-key STRING
+                                             | --cold-verification-key-file FILE
+                                             )
+                                             --counter-value INT
+                                             --operational-certificate-issue-counter-file FILE
+
+  Create a new certificate issue counter
+
+Usage: cardano-cli latest node issue-op-cert 
+                                               ( --kes-verification-key STRING
+                                               | --kes-verification-key-file FILE
+                                               )
+                                               --cold-signing-key-file FILE
+                                               --operational-certificate-issue-counter-file FILE
+                                               --kes-period NATURAL
+                                               --out-file FILE
+
+  Issue a node operational certificate
+
+Usage: cardano-cli latest query 
+                                  ( protocol-parameters
+                                  | constitution-hash
+                                  | tip
+                                  | stake-pools
+                                  | stake-distribution
+                                  | stake-address-info
+                                  | utxo
+                                  | ledger-state
+                                  | protocol-state
+                                  | stake-snapshot
+                                  | leadership-schedule
+                                  | kes-period-info
+                                  | pool-state
+                                  | tx-mempool
+                                  | slot-number
+                                  )
+
+  Era-based query commands
+
+Usage: cardano-cli latest query protocol-parameters --socket-path SOCKET_PATH
+                                                      [ --shelley-mode
+                                                      | --byron-mode
+                                                        [--epoch-slots SLOTS]
+                                                      | --cardano-mode
+                                                        [--epoch-slots SLOTS]
+                                                      ]
+                                                      ( --mainnet
+                                                      | --testnet-magic NATURAL
+                                                      )
+                                                      [--out-file FILE]
+
+  Get the node's current protocol parameters
+
+Usage: cardano-cli latest query constitution-hash --socket-path SOCKET_PATH
+                                                    [ --shelley-mode
+                                                    | --byron-mode
+                                                      [--epoch-slots SLOTS]
+                                                    | --cardano-mode
+                                                      [--epoch-slots SLOTS]
+                                                    ]
+                                                    ( --mainnet
+                                                    | --testnet-magic NATURAL
+                                                    )
+                                                    [--out-file FILE]
+
+  Get the constitution hash
+
+Usage: cardano-cli latest query tip --socket-path SOCKET_PATH
+                                      [ --shelley-mode
+                                      | --byron-mode [--epoch-slots SLOTS]
+                                      | --cardano-mode [--epoch-slots SLOTS]
+                                      ]
+                                      (--mainnet | --testnet-magic NATURAL)
+                                      [--out-file FILE]
+
+  Get the node's current tip (slot no, hash, block no)
+
+Usage: cardano-cli latest query stake-pools --socket-path SOCKET_PATH
+                                              [ --shelley-mode
+                                              | --byron-mode
+                                                [--epoch-slots SLOTS]
+                                              | --cardano-mode
+                                                [--epoch-slots SLOTS]
+                                              ]
+                                              ( --mainnet
+                                              | --testnet-magic NATURAL
+                                              )
+                                              [--out-file FILE]
+
+  Get the node's current set of stake pool ids
+
+Usage: cardano-cli latest query stake-distribution --socket-path SOCKET_PATH
+                                                     [ --shelley-mode
+                                                     | --byron-mode
+                                                       [--epoch-slots SLOTS]
+                                                     | --cardano-mode
+                                                       [--epoch-slots SLOTS]
+                                                     ]
+                                                     ( --mainnet
+                                                     | --testnet-magic NATURAL
+                                                     )
+                                                     [--out-file FILE]
+
+  Get the node's current aggregated stake distribution
+
+Usage: cardano-cli latest query stake-address-info --socket-path SOCKET_PATH
+                                                     [ --shelley-mode
+                                                     | --byron-mode
+                                                       [--epoch-slots SLOTS]
+                                                     | --cardano-mode
+                                                       [--epoch-slots SLOTS]
+                                                     ]
+                                                     --address ADDRESS
+                                                     ( --mainnet
+                                                     | --testnet-magic NATURAL
+                                                     )
+                                                     [--out-file FILE]
+
+  Get the current delegations and reward accounts filtered by stake address.
+
+Usage: cardano-cli latest query utxo --socket-path SOCKET_PATH
+                                       [ --shelley-mode
+                                       | --byron-mode [--epoch-slots SLOTS]
+                                       | --cardano-mode [--epoch-slots SLOTS]
+                                       ]
+                                       ( --whole-utxo
+                                       | (--address ADDRESS)
+                                       | (--tx-in TX-IN)
+                                       )
+                                       (--mainnet | --testnet-magic NATURAL)
+                                       [--out-file FILE]
+
+  Get a portion of the current UTxO: by tx in, by address or the whole.
+
+Usage: cardano-cli latest query ledger-state --socket-path SOCKET_PATH
+                                               [ --shelley-mode
+                                               | --byron-mode
+                                                 [--epoch-slots SLOTS]
+                                               | --cardano-mode
+                                                 [--epoch-slots SLOTS]
+                                               ]
+                                               ( --mainnet
+                                               | --testnet-magic NATURAL
+                                               )
+                                               [--out-file FILE]
+
+  Dump the current ledger state of the node (Ledger.NewEpochState -- advanced
+  command)
+
+Usage: cardano-cli latest query protocol-state --socket-path SOCKET_PATH
+                                                 [ --shelley-mode
+                                                 | --byron-mode
+                                                   [--epoch-slots SLOTS]
+                                                 | --cardano-mode
+                                                   [--epoch-slots SLOTS]
+                                                 ]
+                                                 ( --mainnet
+                                                 | --testnet-magic NATURAL
+                                                 )
+                                                 [--out-file FILE]
+
+  Dump the current protocol state of the node (Ledger.ChainDepState -- advanced
+  command)
+
+Usage: cardano-cli latest query stake-snapshot --socket-path SOCKET_PATH
+                                                 [ --shelley-mode
+                                                 | --byron-mode
+                                                   [--epoch-slots SLOTS]
+                                                 | --cardano-mode
+                                                   [--epoch-slots SLOTS]
+                                                 ]
+                                                 ( --mainnet
+                                                 | --testnet-magic NATURAL
+                                                 )
+                                                 [ --all-stake-pools
+                                                 | 
+                                                 [--stake-pool-id STAKE_POOL_ID]
+                                                 ]
+                                                 [--out-file FILE]
+
+  Obtain the three stake snapshots for a pool, plus the total active stake
+  (advanced command)
+
+Usage: cardano-cli latest query pool-params --socket-path SOCKET_PATH
+                                              [ --shelley-mode
+                                              | --byron-mode
+                                                [--epoch-slots SLOTS]
+                                              | --cardano-mode
+                                                [--epoch-slots SLOTS]
+                                              ]
+                                              ( --mainnet
+                                              | --testnet-magic NATURAL
+                                              )
+                                              [--stake-pool-id STAKE_POOL_ID]
+
+  DEPRECATED. Use query pool-state instead. Dump the pool parameters
+  (Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced
+  command)
+
+Usage: cardano-cli latest query leadership-schedule --socket-path SOCKET_PATH
+                                                      [ --shelley-mode
+                                                      | --byron-mode
+                                                        [--epoch-slots SLOTS]
+                                                      | --cardano-mode
+                                                        [--epoch-slots SLOTS]
+                                                      ]
+                                                      ( --mainnet
+                                                      | --testnet-magic NATURAL
+                                                      )
+                                                      --genesis FILE
+                                                      ( --stake-pool-verification-key STRING
+                                                      | --cold-verification-key-file FILE
+                                                      | --stake-pool-id STAKE_POOL_ID
+                                                      )
+                                                      --vrf-signing-key-file FILE
+                                                      (--current | --next)
+                                                      [--out-file FILE]
+
+  Get the slots the node is expected to mint a block in (advanced command)
+
+Usage: cardano-cli latest query kes-period-info --socket-path SOCKET_PATH
+                                                  [ --shelley-mode
+                                                  | --byron-mode
+                                                    [--epoch-slots SLOTS]
+                                                  | --cardano-mode
+                                                    [--epoch-slots SLOTS]
+                                                  ]
+                                                  ( --mainnet
+                                                  | --testnet-magic NATURAL
+                                                  )
+                                                  --op-cert-file FILE
+                                                  [--out-file FILE]
+
+  Get information about the current KES period and your node's operational
+  certificate.
+
+Usage: cardano-cli latest query pool-state --socket-path SOCKET_PATH
+                                             [ --shelley-mode
+                                             | --byron-mode
+                                               [--epoch-slots SLOTS]
+                                             | --cardano-mode
+                                               [--epoch-slots SLOTS]
+                                             ]
+                                             ( --mainnet
+                                             | --testnet-magic NATURAL
+                                             )
+                                             [--stake-pool-id STAKE_POOL_ID]
+
+  Dump the pool state
+
+Usage: cardano-cli latest query tx-mempool --socket-path SOCKET_PATH
+                                             [ --shelley-mode
+                                             | --byron-mode
+                                               [--epoch-slots SLOTS]
+                                             | --cardano-mode
+                                               [--epoch-slots SLOTS]
+                                             ]
+                                             ( --mainnet
+                                             | --testnet-magic NATURAL
+                                             )
+                                             (info | next-tx | tx-exists)
+                                             [--out-file FILE]
+
+  Local Mempool info
+
+Usage: cardano-cli latest query tx-mempool info 
+
+  Ask the node about the current mempool's capacity and sizes
+
+Usage: cardano-cli latest query tx-mempool next-tx 
+
+  Requests the next transaction from the mempool's current list
+
+Usage: cardano-cli latest query tx-mempool tx-exists TX_ID
+
+  Query if a particular transaction exists in the mempool
+
+Usage: cardano-cli latest query slot-number --socket-path SOCKET_PATH
+                                              [ --shelley-mode
+                                              | --byron-mode
+                                                [--epoch-slots SLOTS]
+                                              | --cardano-mode
+                                                [--epoch-slots SLOTS]
+                                              ]
+                                              ( --mainnet
+                                              | --testnet-magic NATURAL
+                                              )
+                                              TIMESTAMP
+
+  Query slot number for UTC timestamp
+
 Usage: cardano-cli latest stake-address 
                                           ( key-gen
                                           | key-hash
@@ -4363,6 +8141,14 @@ Usage: cardano-cli latest stake-address stake-delegation-certificate
   Create a stake address stake delegation certificate, which when submitted in a
   transaction delegates stake to a stake pool.
 
+Usage: cardano-cli latest text-view decode-cbor
+
+  Era-based text-view commands
+
+Usage: cardano-cli latest text-view decode-cbor --in-file FILE [--out-file FILE]
+
+  Print a TextView file as decoded CBOR.
+
 Usage: cardano-cli latest transaction 
                                         ( build-raw
                                         | build
@@ -4378,7 +8164,7 @@ Usage: cardano-cli latest transaction
                                         | view
                                         )
 
-  Era-based governance commands
+  Era-based transaction commands
 
 Usage: cardano-cli latest transaction build-raw 
                                                   [ --script-valid

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra.cli
@@ -1,4 +1,14 @@
-Usage: cardano-cli allegra (address | governance | stake-address | transaction)
+Usage: cardano-cli allegra 
+                             ( address
+                             | key
+                             | genesis
+                             | governance
+                             | node
+                             | query
+                             | stake-address
+                             | text-view
+                             | transaction
+                             )
 
   Allegra era commands
 
@@ -7,6 +17,11 @@ Available options:
 
 Available commands:
   address                  Era-based address commands
+  key                      Era-based key commands
+  genesis                  Era-based genesis commands
   governance               Era-based governance commands
+  node                     Era-based node commands
+  query                    Era-based query commands
   stake-address            Stake address commands.
-  transaction              Era-based governance commands
+  text-view                Era-based text-view commands
+  transaction              Era-based transaction commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_genesis.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_genesis.cli
@@ -1,0 +1,37 @@
+Usage: cardano-cli allegra genesis 
+                                     ( key-gen-genesis
+                                     | key-gen-delegate
+                                     | key-gen-utxo
+                                     | key-hash
+                                     | get-ver-key
+                                     | initial-addr
+                                     | initial-txin
+                                     | create-cardano
+                                     | create
+                                     | create-staked
+                                     | hash
+                                     )
+
+  Era-based genesis commands
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  key-gen-genesis          Create a Shelley genesis key pair
+  key-gen-delegate         Create a Shelley genesis delegate key pair
+  key-gen-utxo             Create a Shelley genesis UTxO key pair
+  key-hash                 Print the identifier (hash) of a public key
+  get-ver-key              Derive the verification key from a signing key
+  initial-addr             Get the address for an initial UTxO based on the
+                           verification key
+  initial-txin             Get the TxIn for an initial UTxO based on the
+                           verification key
+  create-cardano           Create a Byron and Shelley genesis file from a
+                           genesis template and genesis/delegation/spending
+                           keys.
+  create                   Create a Shelley genesis file from a genesis template
+                           and genesis/delegation/spending keys.
+  create-staked            Create a staked Shelley genesis file from a genesis
+                           template and genesis/delegation/spending keys.
+  hash                     Compute the hash of a genesis file

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_genesis_create-cardano.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_genesis_create-cardano.cli
@@ -1,0 +1,51 @@
+Usage: cardano-cli allegra genesis create-cardano --genesis-dir DIR
+                                                    [--gen-genesis-keys INT]
+                                                    [--gen-utxo-keys INT]
+                                                    [--start-time UTC-TIME]
+                                                    [--supply LOVELACE]
+                                                    [--security-param INT]
+                                                    [--slot-length INT]
+                                                    [--slot-coefficient RATIONAL]
+                                                    ( --mainnet
+                                                    | --testnet-magic NATURAL
+                                                    )
+                                                    --byron-template FILEPATH
+                                                    --shelley-template FILEPATH
+                                                    --alonzo-template FILEPATH
+                                                    --conway-template FILEPATH
+                                                    [--node-config-template FILEPATH]
+
+  Create a Byron and Shelley genesis file from a genesis template and
+  genesis/delegation/spending keys.
+
+Available options:
+  --genesis-dir DIR        The genesis directory containing the genesis template
+                           and required genesis/delegation/spending keys.
+  --gen-genesis-keys INT   The number of genesis keys to make [default is 3].
+  --gen-utxo-keys INT      The number of UTxO keys to make [default is 0].
+  --start-time UTC-TIME    The genesis start time in YYYY-MM-DDThh:mm:ssZ
+                           format. If unspecified, will be the current time +30
+                           seconds.
+  --supply LOVELACE        The initial coin supply in Lovelace which will be
+                           evenly distributed across initial, non-delegating
+                           stake holders.
+  --security-param INT     Security parameter for genesis file [default is 108].
+  --slot-length INT        slot length (ms) parameter for genesis file [default
+                           is 1000].
+  --slot-coefficient RATIONAL
+                           Slot Coefficient for genesis file [default is .05].
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --byron-template FILEPATH
+                           JSON file with genesis defaults for each byron.
+  --shelley-template FILEPATH
+                           JSON file with genesis defaults for each shelley.
+  --alonzo-template FILEPATH
+                           JSON file with genesis defaults for alonzo.
+  --conway-template FILEPATH
+                           JSON file with genesis defaults for conway.
+  --node-config-template FILEPATH
+                           the node config template
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_genesis_create-staked.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_genesis_create-staked.cli
@@ -1,0 +1,57 @@
+Usage: cardano-cli allegra genesis create-staked [--key-output-format STRING]
+                                                   --genesis-dir DIR
+                                                   [--gen-genesis-keys INT]
+                                                   [--gen-utxo-keys INT]
+                                                   [--gen-pools INT]
+                                                   [--gen-stake-delegs INT]
+                                                   [--start-time UTC-TIME]
+                                                   [--supply LOVELACE]
+                                                   [--supply-delegated LOVELACE]
+                                                   ( --mainnet
+                                                   | --testnet-magic NATURAL
+                                                   )
+                                                   [--bulk-pool-cred-files INT]
+                                                   [--bulk-pools-per-file INT]
+                                                   [--num-stuffed-utxo INT]
+                                                   [--relay-specification-file FILE]
+
+  Create a staked Shelley genesis file from a genesis template and
+  genesis/delegation/spending keys.
+
+Available options:
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32" (default is
+                           "bech32").
+  --genesis-dir DIR        The genesis directory containing the genesis template
+                           and required genesis/delegation/spending keys.
+  --gen-genesis-keys INT   The number of genesis keys to make [default is 3].
+  --gen-utxo-keys INT      The number of UTxO keys to make [default is 0].
+  --gen-pools INT          The number of stake pool credential sets to make
+                           [default is 0].
+  --gen-stake-delegs INT   The number of stake delegator credential sets to make
+                           [default is 0].
+  --start-time UTC-TIME    The genesis start time in YYYY-MM-DDThh:mm:ssZ
+                           format. If unspecified, will be the current time +30
+                           seconds.
+  --supply LOVELACE        The initial coin supply in Lovelace which will be
+                           evenly distributed across initial, non-delegating
+                           stake holders.
+  --supply-delegated LOVELACE
+                           The initial coin supply in Lovelace which will be
+                           evenly distributed across initial, delegating stake
+                           holders.
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --bulk-pool-cred-files INT
+                           Generate bulk pool credential files [default is 0].
+  --bulk-pools-per-file INT
+                           Each bulk pool to contain this many pool credential
+                           sets [default is 0].
+  --num-stuffed-utxo INT   The number of fake UTxO entries to generate [default
+                           is 0].
+  --relay-specification-file FILE
+                           JSON file specified the relays of each stake pool.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_genesis_create.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_genesis_create.cli
@@ -1,0 +1,33 @@
+Usage: cardano-cli allegra genesis create [--key-output-format STRING]
+                                            --genesis-dir DIR
+                                            [--gen-genesis-keys INT]
+                                            [--gen-utxo-keys INT]
+                                            [--start-time UTC-TIME]
+                                            [--supply LOVELACE]
+                                            ( --mainnet
+                                            | --testnet-magic NATURAL
+                                            )
+
+  Create a Shelley genesis file from a genesis template and
+  genesis/delegation/spending keys.
+
+Available options:
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32" (default is
+                           "bech32").
+  --genesis-dir DIR        The genesis directory containing the genesis template
+                           and required genesis/delegation/spending keys.
+  --gen-genesis-keys INT   The number of genesis keys to make [default is 3].
+  --gen-utxo-keys INT      The number of UTxO keys to make [default is 0].
+  --start-time UTC-TIME    The genesis start time in YYYY-MM-DDThh:mm:ssZ
+                           format. If unspecified, will be the current time +30
+                           seconds.
+  --supply LOVELACE        The initial coin supply in Lovelace which will be
+                           evenly distributed across initial, non-delegating
+                           stake holders.
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_genesis_get-ver-key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_genesis_get-ver-key.cli
@@ -1,0 +1,10 @@
+Usage: cardano-cli allegra genesis get-ver-key --verification-key-file FILE
+                                                 --signing-key-file FILE
+
+  Derive the verification key from a signing key
+
+Available options:
+  --verification-key-file FILE
+                           Output filepath of the verification key.
+  --signing-key-file FILE  Input filepath of the signing key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_genesis_hash.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_genesis_hash.cli
@@ -1,0 +1,7 @@
+Usage: cardano-cli allegra genesis hash --genesis FILE
+
+  Compute the hash of a genesis file
+
+Available options:
+  --genesis FILE           The genesis file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_genesis_initial-addr.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_genesis_initial-addr.cli
@@ -1,0 +1,17 @@
+Usage: cardano-cli allegra genesis initial-addr --verification-key-file FILE
+                                                  ( --mainnet
+                                                  | --testnet-magic NATURAL
+                                                  )
+                                                  [--out-file FILE]
+
+  Get the address for an initial UTxO based on the verification key
+
+Available options:
+  --verification-key-file FILE
+                           Input filepath of the verification key.
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_genesis_initial-txin.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_genesis_initial-txin.cli
@@ -1,0 +1,17 @@
+Usage: cardano-cli allegra genesis initial-txin --verification-key-file FILE
+                                                  ( --mainnet
+                                                  | --testnet-magic NATURAL
+                                                  )
+                                                  [--out-file FILE]
+
+  Get the TxIn for an initial UTxO based on the verification key
+
+Available options:
+  --verification-key-file FILE
+                           Input filepath of the verification key.
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_genesis_key-gen-delegate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_genesis_key-gen-delegate.cli
@@ -1,0 +1,14 @@
+Usage: cardano-cli allegra genesis key-gen-delegate --verification-key-file FILE
+                                                      --signing-key-file FILE
+                                                      --operational-certificate-issue-counter-file FILE
+
+  Create a Shelley genesis delegate key pair
+
+Available options:
+  --verification-key-file FILE
+                           Output filepath of the verification key.
+  --signing-key-file FILE  Output filepath of the signing key.
+  --operational-certificate-issue-counter-file FILE
+                           The file with the issue counter for the operational
+                           certificate.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_genesis_key-gen-genesis.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_genesis_key-gen-genesis.cli
@@ -1,0 +1,10 @@
+Usage: cardano-cli allegra genesis key-gen-genesis --verification-key-file FILE
+                                                     --signing-key-file FILE
+
+  Create a Shelley genesis key pair
+
+Available options:
+  --verification-key-file FILE
+                           Output filepath of the verification key.
+  --signing-key-file FILE  Output filepath of the signing key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_genesis_key-gen-utxo.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_genesis_key-gen-utxo.cli
@@ -1,0 +1,10 @@
+Usage: cardano-cli allegra genesis key-gen-utxo --verification-key-file FILE
+                                                  --signing-key-file FILE
+
+  Create a Shelley genesis UTxO key pair
+
+Available options:
+  --verification-key-file FILE
+                           Output filepath of the verification key.
+  --signing-key-file FILE  Output filepath of the signing key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_genesis_key-hash.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_genesis_key-hash.cli
@@ -1,0 +1,8 @@
+Usage: cardano-cli allegra genesis key-hash --verification-key-file FILE
+
+  Print the identifier (hash) of a public key
+
+Available options:
+  --verification-key-file FILE
+                           Input filepath of the verification key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_key.cli
@@ -1,0 +1,40 @@
+Usage: cardano-cli allegra key 
+                                 ( verification-key
+                                 | non-extended-key
+                                 | convert-byron-key
+                                 | convert-byron-genesis-vkey
+                                 | convert-itn-key
+                                 | convert-itn-extended-key
+                                 | convert-itn-bip32-key
+                                 | convert-cardano-address-key
+                                 )
+
+  Era-based key commands
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  verification-key         Get a verification key from a signing key. This
+                           supports all key types.
+  non-extended-key         Get a non-extended verification key from an extended
+                           verification key. This supports all extended key
+                           types.
+  convert-byron-key        Convert a Byron payment, genesis or genesis delegate
+                           key (signing or verification) to a corresponding
+                           Shelley-format key.
+  convert-byron-genesis-vkey
+                           Convert a Base64-encoded Byron genesis verification
+                           key to a Shelley genesis verification key
+  convert-itn-key          Convert an Incentivized Testnet (ITN) non-extended
+                           (Ed25519) signing or verification key to a
+                           corresponding Shelley stake key
+  convert-itn-extended-key Convert an Incentivized Testnet (ITN) extended
+                           (Ed25519Extended) signing key to a corresponding
+                           Shelley stake signing key
+  convert-itn-bip32-key    Convert an Incentivized Testnet (ITN) BIP32
+                           (Ed25519Bip32) signing key to a corresponding Shelley
+                           stake signing key
+  convert-cardano-address-key
+                           Convert a cardano-address extended signing key to a
+                           corresponding Shelley-format key.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_key_convert-byron-genesis-vkey.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_key_convert-byron-genesis-vkey.cli
@@ -1,0 +1,11 @@
+Usage: cardano-cli allegra key convert-byron-genesis-vkey --byron-genesis-verification-key BASE64
+                                                            --out-file FILE
+
+  Convert a Base64-encoded Byron genesis verification key to a Shelley genesis
+  verification key
+
+Available options:
+  --byron-genesis-verification-key BASE64
+                           Base64 string for the Byron genesis verification key.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_key_convert-byron-key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_key_convert-byron-key.cli
@@ -1,0 +1,35 @@
+Usage: cardano-cli allegra key convert-byron-key [--password TEXT]
+                                                   ( --byron-payment-key-type
+                                                   | --legacy-byron-payment-key-type
+                                                   | --byron-genesis-key-type
+                                                   | --legacy-byron-genesis-key-type
+                                                   | --byron-genesis-delegate-key-type
+                                                   | --legacy-byron-genesis-delegate-key-type
+                                                   )
+                                                   ( --byron-signing-key-file FILE
+                                                   | --byron-verification-key-file FILE
+                                                   )
+                                                   --out-file FILE
+
+  Convert a Byron payment, genesis or genesis delegate key (signing or
+  verification) to a corresponding Shelley-format key.
+
+Available options:
+  --password TEXT          Password for signing key (if applicable).
+  --byron-payment-key-type Use a Byron-era payment key.
+  --legacy-byron-payment-key-type
+                           Use a Byron-era payment key, in legacy SL format.
+  --byron-genesis-key-type Use a Byron-era genesis key.
+  --legacy-byron-genesis-key-type
+                           Use a Byron-era genesis key, in legacy SL format.
+  --byron-genesis-delegate-key-type
+                           Use a Byron-era genesis delegate key.
+  --legacy-byron-genesis-delegate-key-type
+                           Use a Byron-era genesis delegate key, in legacy SL
+                           format.
+  --byron-signing-key-file FILE
+                           Input filepath of the Byron-format signing key.
+  --byron-verification-key-file FILE
+                           Input filepath of the Byron-format verification key.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_key_convert-cardano-address-key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_key_convert-cardano-address-key.cli
@@ -1,0 +1,22 @@
+Usage: cardano-cli allegra key convert-cardano-address-key 
+                                                             ( --shelley-payment-key
+                                                             | --shelley-stake-key
+                                                             | --icarus-payment-key
+                                                             | --byron-payment-key
+                                                             )
+                                                             --signing-key-file FILE
+                                                             --out-file FILE
+
+  Convert a cardano-address extended signing key to a corresponding
+  Shelley-format key.
+
+Available options:
+  --shelley-payment-key    Use a Shelley-era extended payment key.
+  --shelley-stake-key      Use a Shelley-era extended stake key.
+  --icarus-payment-key     Use a Byron-era extended payment key formatted in the
+                           Icarus style.
+  --byron-payment-key      Use a Byron-era extended payment key formatted in the
+                           deprecated Byron style.
+  --signing-key-file FILE  Input filepath of the signing key.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_key_convert-itn-bip32-key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_key_convert-itn-bip32-key.cli
@@ -1,0 +1,11 @@
+Usage: cardano-cli allegra key convert-itn-bip32-key --itn-signing-key-file FILE
+                                                       --out-file FILE
+
+  Convert an Incentivized Testnet (ITN) BIP32 (Ed25519Bip32) signing key to a
+  corresponding Shelley stake signing key
+
+Available options:
+  --itn-signing-key-file FILE
+                           Filepath of the ITN signing key.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_key_convert-itn-extended-key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_key_convert-itn-extended-key.cli
@@ -1,0 +1,11 @@
+Usage: cardano-cli allegra key convert-itn-extended-key --itn-signing-key-file FILE
+                                                          --out-file FILE
+
+  Convert an Incentivized Testnet (ITN) extended (Ed25519Extended) signing key
+  to a corresponding Shelley stake signing key
+
+Available options:
+  --itn-signing-key-file FILE
+                           Filepath of the ITN signing key.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_key_convert-itn-key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_key_convert-itn-key.cli
@@ -1,0 +1,16 @@
+Usage: cardano-cli allegra key convert-itn-key 
+                                                 ( --itn-signing-key-file FILE
+                                                 | --itn-verification-key-file FILE
+                                                 )
+                                                 --out-file FILE
+
+  Convert an Incentivized Testnet (ITN) non-extended (Ed25519) signing or
+  verification key to a corresponding Shelley stake key
+
+Available options:
+  --itn-signing-key-file FILE
+                           Filepath of the ITN signing key.
+  --itn-verification-key-file FILE
+                           Filepath of the ITN verification key.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_key_non-extended-key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_key_non-extended-key.cli
@@ -1,0 +1,12 @@
+Usage: cardano-cli allegra key non-extended-key --extended-verification-key-file FILE
+                                                  --verification-key-file FILE
+
+  Get a non-extended verification key from an extended verification key. This
+  supports all extended key types.
+
+Available options:
+  --extended-verification-key-file FILE
+                           Input filepath of the ed25519-bip32 verification key.
+  --verification-key-file FILE
+                           Output filepath of the verification key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_key_verification-key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_key_verification-key.cli
@@ -1,0 +1,10 @@
+Usage: cardano-cli allegra key verification-key --signing-key-file FILE
+                                                  --verification-key-file FILE
+
+  Get a verification key from a signing key. This supports all key types.
+
+Available options:
+  --signing-key-file FILE  Input filepath of the signing key.
+  --verification-key-file FILE
+                           Output filepath of the verification key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_node.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_node.cli
@@ -1,0 +1,22 @@
+Usage: cardano-cli allegra node 
+                                  ( key-gen
+                                  | key-gen-KES
+                                  | key-gen-VRF
+                                  | key-hash-VRF
+                                  | new-counter
+                                  | issue-op-cert
+                                  )
+
+  Era-based node commands
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  key-gen                  Create a key pair for a node operator's offline key
+                           and a new certificate issue counter
+  key-gen-KES              Create a key pair for a node KES operational key
+  key-gen-VRF              Create a key pair for a node VRF operational key
+  key-hash-VRF             Print hash of a node's operational VRF key.
+  new-counter              Create a new certificate issue counter
+  issue-op-cert            Issue a node operational certificate

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_node_issue-op-cert.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_node_issue-op-cert.cli
@@ -1,0 +1,24 @@
+Usage: cardano-cli allegra node issue-op-cert 
+                                                ( --kes-verification-key STRING
+                                                | --kes-verification-key-file FILE
+                                                )
+                                                --cold-signing-key-file FILE
+                                                --operational-certificate-issue-counter-file FILE
+                                                --kes-period NATURAL
+                                                --out-file FILE
+
+  Issue a node operational certificate
+
+Available options:
+  --kes-verification-key STRING
+                           A Bech32 or hex-encoded hot KES verification key.
+  --kes-verification-key-file FILE
+                           Filepath of the hot KES verification key.
+  --cold-signing-key-file FILE
+                           Filepath of the cold signing key.
+  --operational-certificate-issue-counter-file FILE
+                           The file with the issue counter for the operational
+                           certificate.
+  --kes-period NATURAL     The start of the KES key validity period.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_node_key-gen-KES.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_node_key-gen-KES.cli
@@ -1,0 +1,15 @@
+Usage: cardano-cli allegra node key-gen-KES [--key-output-format STRING]
+                                              --verification-key-file FILE
+                                              --signing-key-file FILE
+
+  Create a key pair for a node KES operational key
+
+Available options:
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32" (default is
+                           "bech32").
+  --verification-key-file FILE
+                           Output filepath of the verification key.
+  --signing-key-file FILE  Output filepath of the signing key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_node_key-gen-VRF.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_node_key-gen-VRF.cli
@@ -1,0 +1,15 @@
+Usage: cardano-cli allegra node key-gen-VRF [--key-output-format STRING]
+                                              --verification-key-file FILE
+                                              --signing-key-file FILE
+
+  Create a key pair for a node VRF operational key
+
+Available options:
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32" (default is
+                           "bech32").
+  --verification-key-file FILE
+                           Output filepath of the verification key.
+  --signing-key-file FILE  Output filepath of the signing key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_node_key-gen.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_node_key-gen.cli
@@ -1,0 +1,21 @@
+Usage: cardano-cli allegra node key-gen [--key-output-format STRING]
+                                          --cold-verification-key-file FILE
+                                          --cold-signing-key-file FILE
+                                          --operational-certificate-issue-counter-file FILE
+
+  Create a key pair for a node operator's offline key and a new certificate
+  issue counter
+
+Available options:
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32" (default is
+                           "bech32").
+  --cold-verification-key-file FILE
+                           Filepath of the cold verification key.
+  --cold-signing-key-file FILE
+                           Filepath of the cold signing key.
+  --operational-certificate-issue-counter-file FILE
+                           The file with the issue counter for the operational
+                           certificate.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_node_key-hash-VRF.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_node_key-hash-VRF.cli
@@ -1,0 +1,15 @@
+Usage: cardano-cli allegra node key-hash-VRF 
+                                               ( --verification-key STRING
+                                               | --verification-key-file FILE
+                                               )
+                                               [--out-file FILE]
+
+  Print hash of a node's operational VRF key.
+
+Available options:
+  --verification-key STRING
+                           Verification key (Bech32 or hex-encoded).
+  --verification-key-file FILE
+                           Input filepath of the verification key.
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_node_new-counter.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_node_new-counter.cli
@@ -1,0 +1,22 @@
+Usage: cardano-cli allegra node new-counter 
+                                              ( --stake-pool-verification-key STRING
+                                              | --genesis-delegate-verification-key STRING
+                                              | --cold-verification-key-file FILE
+                                              )
+                                              --counter-value INT
+                                              --operational-certificate-issue-counter-file FILE
+
+  Create a new certificate issue counter
+
+Available options:
+  --stake-pool-verification-key STRING
+                           Stake pool verification key (Bech32 or hex-encoded).
+  --genesis-delegate-verification-key STRING
+                           Genesis delegate verification key (hex-encoded).
+  --cold-verification-key-file FILE
+                           Filepath of the cold verification key.
+  --counter-value INT      The next certificate issue counter value to use.
+  --operational-certificate-issue-counter-file FILE
+                           The file with the issue counter for the operational
+                           certificate.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query.cli
@@ -1,0 +1,50 @@
+Usage: cardano-cli allegra query 
+                                   ( protocol-parameters
+                                   | constitution-hash
+                                   | tip
+                                   | stake-pools
+                                   | stake-distribution
+                                   | stake-address-info
+                                   | utxo
+                                   | ledger-state
+                                   | protocol-state
+                                   | stake-snapshot
+                                   | leadership-schedule
+                                   | kes-period-info
+                                   | pool-state
+                                   | tx-mempool
+                                   | slot-number
+                                   )
+
+  Era-based query commands
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  protocol-parameters      Get the node's current protocol parameters
+  constitution-hash        Get the constitution hash
+  tip                      Get the node's current tip (slot no, hash, block no)
+  stake-pools              Get the node's current set of stake pool ids
+  stake-distribution       Get the node's current aggregated stake distribution
+  stake-address-info       Get the current delegations and reward accounts
+                           filtered by stake address.
+  utxo                     Get a portion of the current UTxO: by tx in, by
+                           address or the whole.
+  ledger-state             Dump the current ledger state of the node
+                           (Ledger.NewEpochState -- advanced command)
+  protocol-state           Dump the current protocol state of the node
+                           (Ledger.ChainDepState -- advanced command)
+  stake-snapshot           Obtain the three stake snapshots for a pool, plus the
+                           total active stake (advanced command)
+  pool-params              DEPRECATED. Use query pool-state instead. Dump the
+                           pool parameters
+                           (Ledger.NewEpochState.esLState._delegationState._pState._pParams
+                           -- advanced command)
+  leadership-schedule      Get the slots the node is expected to mint a block in
+                           (advanced command)
+  kes-period-info          Get information about the current KES period and your
+                           node's operational certificate.
+  pool-state               Dump the pool state
+  tx-mempool               Local Mempool info
+  slot-number              Query slot number for UTC timestamp

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_constitution-hash.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_constitution-hash.cli
@@ -1,0 +1,34 @@
+Usage: cardano-cli allegra query constitution-hash --socket-path SOCKET_PATH
+                                                     [ --shelley-mode
+                                                     | --byron-mode
+                                                       [--epoch-slots SLOTS]
+                                                     | --cardano-mode
+                                                       [--epoch-slots SLOTS]
+                                                     ]
+                                                     ( --mainnet
+                                                     | --testnet-magic NATURAL
+                                                     )
+                                                     [--out-file FILE]
+
+  Get the constitution hash
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_kes-period-info.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_kes-period-info.cli
@@ -1,0 +1,37 @@
+Usage: cardano-cli allegra query kes-period-info --socket-path SOCKET_PATH
+                                                   [ --shelley-mode
+                                                   | --byron-mode
+                                                     [--epoch-slots SLOTS]
+                                                   | --cardano-mode
+                                                     [--epoch-slots SLOTS]
+                                                   ]
+                                                   ( --mainnet
+                                                   | --testnet-magic NATURAL
+                                                   )
+                                                   --op-cert-file FILE
+                                                   [--out-file FILE]
+
+  Get information about the current KES period and your node's operational
+  certificate.
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --op-cert-file FILE      Filepath of the node's operational certificate.
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_leadership-schedule.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_leadership-schedule.cli
@@ -1,0 +1,54 @@
+Usage: cardano-cli allegra query leadership-schedule --socket-path SOCKET_PATH
+                                                       [ --shelley-mode
+                                                       | --byron-mode
+                                                         [--epoch-slots SLOTS]
+                                                       | --cardano-mode
+                                                         [--epoch-slots SLOTS]
+                                                       ]
+                                                       ( --mainnet
+                                                       | --testnet-magic NATURAL
+                                                       )
+                                                       --genesis FILE
+                                                       ( --stake-pool-verification-key STRING
+                                                       | --cold-verification-key-file FILE
+                                                       | --stake-pool-id STAKE_POOL_ID
+                                                       )
+                                                       --vrf-signing-key-file FILE
+                                                       (--current | --next)
+                                                       [--out-file FILE]
+
+  Get the slots the node is expected to mint a block in (advanced command)
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --genesis FILE           Shelley genesis filepath
+  --stake-pool-verification-key STRING
+                           Stake pool verification key (Bech32 or hex-encoded).
+  --cold-verification-key-file FILE
+                           Filepath of the stake pool verification key.
+  --stake-pool-id STAKE_POOL_ID
+                           Stake pool ID/verification key hash (either
+                           Bech32-encoded or hex-encoded). Zero or more
+                           occurences of this option is allowed.
+  --vrf-signing-key-file FILE
+                           Input filepath of the VRF signing key.
+  --current                Get the leadership schedule for the current epoch.
+  --next                   Get the leadership schedule for the following epoch.
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_ledger-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_ledger-state.cli
@@ -1,0 +1,35 @@
+Usage: cardano-cli allegra query ledger-state --socket-path SOCKET_PATH
+                                                [ --shelley-mode
+                                                | --byron-mode
+                                                  [--epoch-slots SLOTS]
+                                                | --cardano-mode
+                                                  [--epoch-slots SLOTS]
+                                                ]
+                                                ( --mainnet
+                                                | --testnet-magic NATURAL
+                                                )
+                                                [--out-file FILE]
+
+  Dump the current ledger state of the node (Ledger.NewEpochState -- advanced
+  command)
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_pool-params.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_pool-params.cli
@@ -1,0 +1,39 @@
+Usage: cardano-cli allegra query pool-params --socket-path SOCKET_PATH
+                                               [ --shelley-mode
+                                               | --byron-mode
+                                                 [--epoch-slots SLOTS]
+                                               | --cardano-mode
+                                                 [--epoch-slots SLOTS]
+                                               ]
+                                               ( --mainnet
+                                               | --testnet-magic NATURAL
+                                               )
+                                               [--stake-pool-id STAKE_POOL_ID]
+
+  DEPRECATED. Use query pool-state instead. Dump the pool parameters
+  (Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced
+  command)
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --stake-pool-id STAKE_POOL_ID
+                           Stake pool ID/verification key hash (either
+                           Bech32-encoded or hex-encoded). Zero or more
+                           occurences of this option is allowed.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_pool-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_pool-state.cli
@@ -1,0 +1,37 @@
+Usage: cardano-cli allegra query pool-state --socket-path SOCKET_PATH
+                                              [ --shelley-mode
+                                              | --byron-mode
+                                                [--epoch-slots SLOTS]
+                                              | --cardano-mode
+                                                [--epoch-slots SLOTS]
+                                              ]
+                                              ( --mainnet
+                                              | --testnet-magic NATURAL
+                                              )
+                                              [--stake-pool-id STAKE_POOL_ID]
+
+  Dump the pool state
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --stake-pool-id STAKE_POOL_ID
+                           Stake pool ID/verification key hash (either
+                           Bech32-encoded or hex-encoded). Zero or more
+                           occurences of this option is allowed.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_protocol-parameters.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_protocol-parameters.cli
@@ -1,0 +1,34 @@
+Usage: cardano-cli allegra query protocol-parameters --socket-path SOCKET_PATH
+                                                       [ --shelley-mode
+                                                       | --byron-mode
+                                                         [--epoch-slots SLOTS]
+                                                       | --cardano-mode
+                                                         [--epoch-slots SLOTS]
+                                                       ]
+                                                       ( --mainnet
+                                                       | --testnet-magic NATURAL
+                                                       )
+                                                       [--out-file FILE]
+
+  Get the node's current protocol parameters
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_protocol-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_protocol-state.cli
@@ -1,0 +1,35 @@
+Usage: cardano-cli allegra query protocol-state --socket-path SOCKET_PATH
+                                                  [ --shelley-mode
+                                                  | --byron-mode
+                                                    [--epoch-slots SLOTS]
+                                                  | --cardano-mode
+                                                    [--epoch-slots SLOTS]
+                                                  ]
+                                                  ( --mainnet
+                                                  | --testnet-magic NATURAL
+                                                  )
+                                                  [--out-file FILE]
+
+  Dump the current protocol state of the node (Ledger.ChainDepState -- advanced
+  command)
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_slot-number.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_slot-number.cli
@@ -1,0 +1,34 @@
+Usage: cardano-cli allegra query slot-number --socket-path SOCKET_PATH
+                                               [ --shelley-mode
+                                               | --byron-mode
+                                                 [--epoch-slots SLOTS]
+                                               | --cardano-mode
+                                                 [--epoch-slots SLOTS]
+                                               ]
+                                               ( --mainnet
+                                               | --testnet-magic NATURAL
+                                               )
+                                               TIMESTAMP
+
+  Query slot number for UTC timestamp
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  TIMESTAMP                UTC timestamp in YYYY-MM-DDThh:mm:ssZ format
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_stake-address-info.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_stake-address-info.cli
@@ -1,0 +1,36 @@
+Usage: cardano-cli allegra query stake-address-info --socket-path SOCKET_PATH
+                                                      [ --shelley-mode
+                                                      | --byron-mode
+                                                        [--epoch-slots SLOTS]
+                                                      | --cardano-mode
+                                                        [--epoch-slots SLOTS]
+                                                      ]
+                                                      --address ADDRESS
+                                                      ( --mainnet
+                                                      | --testnet-magic NATURAL
+                                                      )
+                                                      [--out-file FILE]
+
+  Get the current delegations and reward accounts filtered by stake address.
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --address ADDRESS        Filter by Cardano stake address (Bech32-encoded).
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_stake-distribution.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_stake-distribution.cli
@@ -1,0 +1,34 @@
+Usage: cardano-cli allegra query stake-distribution --socket-path SOCKET_PATH
+                                                      [ --shelley-mode
+                                                      | --byron-mode
+                                                        [--epoch-slots SLOTS]
+                                                      | --cardano-mode
+                                                        [--epoch-slots SLOTS]
+                                                      ]
+                                                      ( --mainnet
+                                                      | --testnet-magic NATURAL
+                                                      )
+                                                      [--out-file FILE]
+
+  Get the node's current aggregated stake distribution
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_stake-pools.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_stake-pools.cli
@@ -1,0 +1,34 @@
+Usage: cardano-cli allegra query stake-pools --socket-path SOCKET_PATH
+                                               [ --shelley-mode
+                                               | --byron-mode
+                                                 [--epoch-slots SLOTS]
+                                               | --cardano-mode
+                                                 [--epoch-slots SLOTS]
+                                               ]
+                                               ( --mainnet
+                                               | --testnet-magic NATURAL
+                                               )
+                                               [--out-file FILE]
+
+  Get the node's current set of stake pool ids
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_stake-snapshot.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_stake-snapshot.cli
@@ -1,0 +1,44 @@
+Usage: cardano-cli allegra query stake-snapshot --socket-path SOCKET_PATH
+                                                  [ --shelley-mode
+                                                  | --byron-mode
+                                                    [--epoch-slots SLOTS]
+                                                  | --cardano-mode
+                                                    [--epoch-slots SLOTS]
+                                                  ]
+                                                  ( --mainnet
+                                                  | --testnet-magic NATURAL
+                                                  )
+                                                  [ --all-stake-pools
+                                                  | 
+                                                  [--stake-pool-id STAKE_POOL_ID]
+                                                  ]
+                                                  [--out-file FILE]
+
+  Obtain the three stake snapshots for a pool, plus the total active stake
+  (advanced command)
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --all-stake-pools        Query for all stake pools
+  --stake-pool-id STAKE_POOL_ID
+                           Stake pool ID/verification key hash (either
+                           Bech32-encoded or hex-encoded). Zero or more
+                           occurences of this option is allowed.
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_tip.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_tip.cli
@@ -1,0 +1,30 @@
+Usage: cardano-cli allegra query tip --socket-path SOCKET_PATH
+                                       [ --shelley-mode
+                                       | --byron-mode [--epoch-slots SLOTS]
+                                       | --cardano-mode [--epoch-slots SLOTS]
+                                       ]
+                                       (--mainnet | --testnet-magic NATURAL)
+                                       [--out-file FILE]
+
+  Get the node's current tip (slot no, hash, block no)
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_tx-mempool.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_tx-mempool.cli
@@ -1,0 +1,43 @@
+Usage: cardano-cli allegra query tx-mempool --socket-path SOCKET_PATH
+                                              [ --shelley-mode
+                                              | --byron-mode
+                                                [--epoch-slots SLOTS]
+                                              | --cardano-mode
+                                                [--epoch-slots SLOTS]
+                                              ]
+                                              ( --mainnet
+                                              | --testnet-magic NATURAL
+                                              )
+                                              (info | next-tx | tx-exists)
+                                              [--out-file FILE]
+
+  Local Mempool info
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text
+
+Available commands:
+  info                     Ask the node about the current mempool's capacity and
+                           sizes
+  next-tx                  Requests the next transaction from the mempool's
+                           current list
+  tx-exists                Query if a particular transaction exists in the
+                           mempool

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_tx-mempool_info.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_tx-mempool_info.cli
@@ -1,0 +1,16 @@
+Missing: --socket-path SOCKET_PATH (--mainnet | --testnet-magic NATURAL)
+
+Usage: cardano-cli allegra query tx-mempool --socket-path SOCKET_PATH
+                                              [ --shelley-mode
+                                              | --byron-mode
+                                                [--epoch-slots SLOTS]
+                                              | --cardano-mode
+                                                [--epoch-slots SLOTS]
+                                              ]
+                                              ( --mainnet
+                                              | --testnet-magic NATURAL
+                                              )
+                                              (info | next-tx | tx-exists)
+                                              [--out-file FILE]
+
+  Local Mempool info

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_tx-mempool_next-tx.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_tx-mempool_next-tx.cli
@@ -1,0 +1,16 @@
+Missing: --socket-path SOCKET_PATH (--mainnet | --testnet-magic NATURAL)
+
+Usage: cardano-cli allegra query tx-mempool --socket-path SOCKET_PATH
+                                              [ --shelley-mode
+                                              | --byron-mode
+                                                [--epoch-slots SLOTS]
+                                              | --cardano-mode
+                                                [--epoch-slots SLOTS]
+                                              ]
+                                              ( --mainnet
+                                              | --testnet-magic NATURAL
+                                              )
+                                              (info | next-tx | tx-exists)
+                                              [--out-file FILE]
+
+  Local Mempool info

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_tx-mempool_tx-exists_TX_ID.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_tx-mempool_tx-exists_TX_ID.cli
@@ -1,0 +1,16 @@
+Missing: --socket-path SOCKET_PATH (--mainnet | --testnet-magic NATURAL)
+
+Usage: cardano-cli allegra query tx-mempool --socket-path SOCKET_PATH
+                                              [ --shelley-mode
+                                              | --byron-mode
+                                                [--epoch-slots SLOTS]
+                                              | --cardano-mode
+                                                [--epoch-slots SLOTS]
+                                              ]
+                                              ( --mainnet
+                                              | --testnet-magic NATURAL
+                                              )
+                                              (info | next-tx | tx-exists)
+                                              [--out-file FILE]
+
+  Local Mempool info

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_utxo.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_utxo.cli
@@ -1,0 +1,38 @@
+Usage: cardano-cli allegra query utxo --socket-path SOCKET_PATH
+                                        [ --shelley-mode
+                                        | --byron-mode [--epoch-slots SLOTS]
+                                        | --cardano-mode [--epoch-slots SLOTS]
+                                        ]
+                                        ( --whole-utxo
+                                        | (--address ADDRESS)
+                                        | (--tx-in TX-IN)
+                                        )
+                                        (--mainnet | --testnet-magic NATURAL)
+                                        [--out-file FILE]
+
+  Get a portion of the current UTxO: by tx in, by address or the whole.
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --whole-utxo             Return the whole UTxO (only appropriate on small
+                           testnets).
+  --address ADDRESS        Filter by Cardano address(es) (Bech32-encoded).
+  --tx-in TX-IN            Filter by transaction input (TxId#TxIx).
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_text-view_decode-cbor.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_text-view_decode-cbor.cli
@@ -1,0 +1,9 @@
+Usage: cardano-cli allegra text-view decode-cbor --in-file FILE
+                                                   [--out-file FILE]
+
+  Print a TextView file as decoded CBOR.
+
+Available options:
+  --in-file FILE           CBOR input file.
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_transaction.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_transaction.cli
@@ -13,7 +13,7 @@ Usage: cardano-cli allegra transaction
                                          | view
                                          )
 
-  Era-based governance commands
+  Era-based transaction commands
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo.cli
@@ -1,4 +1,14 @@
-Usage: cardano-cli alonzo (address | governance | stake-address | transaction)
+Usage: cardano-cli alonzo 
+                            ( address
+                            | key
+                            | genesis
+                            | governance
+                            | node
+                            | query
+                            | stake-address
+                            | text-view
+                            | transaction
+                            )
 
   Alonzo era commands
 
@@ -7,6 +17,11 @@ Available options:
 
 Available commands:
   address                  Era-based address commands
+  key                      Era-based key commands
+  genesis                  Era-based genesis commands
   governance               Era-based governance commands
+  node                     Era-based node commands
+  query                    Era-based query commands
   stake-address            Stake address commands.
-  transaction              Era-based governance commands
+  text-view                Era-based text-view commands
+  transaction              Era-based transaction commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_genesis.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_genesis.cli
@@ -1,0 +1,37 @@
+Usage: cardano-cli alonzo genesis 
+                                    ( key-gen-genesis
+                                    | key-gen-delegate
+                                    | key-gen-utxo
+                                    | key-hash
+                                    | get-ver-key
+                                    | initial-addr
+                                    | initial-txin
+                                    | create-cardano
+                                    | create
+                                    | create-staked
+                                    | hash
+                                    )
+
+  Era-based genesis commands
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  key-gen-genesis          Create a Shelley genesis key pair
+  key-gen-delegate         Create a Shelley genesis delegate key pair
+  key-gen-utxo             Create a Shelley genesis UTxO key pair
+  key-hash                 Print the identifier (hash) of a public key
+  get-ver-key              Derive the verification key from a signing key
+  initial-addr             Get the address for an initial UTxO based on the
+                           verification key
+  initial-txin             Get the TxIn for an initial UTxO based on the
+                           verification key
+  create-cardano           Create a Byron and Shelley genesis file from a
+                           genesis template and genesis/delegation/spending
+                           keys.
+  create                   Create a Shelley genesis file from a genesis template
+                           and genesis/delegation/spending keys.
+  create-staked            Create a staked Shelley genesis file from a genesis
+                           template and genesis/delegation/spending keys.
+  hash                     Compute the hash of a genesis file

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_genesis_create-cardano.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_genesis_create-cardano.cli
@@ -1,0 +1,51 @@
+Usage: cardano-cli alonzo genesis create-cardano --genesis-dir DIR
+                                                   [--gen-genesis-keys INT]
+                                                   [--gen-utxo-keys INT]
+                                                   [--start-time UTC-TIME]
+                                                   [--supply LOVELACE]
+                                                   [--security-param INT]
+                                                   [--slot-length INT]
+                                                   [--slot-coefficient RATIONAL]
+                                                   ( --mainnet
+                                                   | --testnet-magic NATURAL
+                                                   )
+                                                   --byron-template FILEPATH
+                                                   --shelley-template FILEPATH
+                                                   --alonzo-template FILEPATH
+                                                   --conway-template FILEPATH
+                                                   [--node-config-template FILEPATH]
+
+  Create a Byron and Shelley genesis file from a genesis template and
+  genesis/delegation/spending keys.
+
+Available options:
+  --genesis-dir DIR        The genesis directory containing the genesis template
+                           and required genesis/delegation/spending keys.
+  --gen-genesis-keys INT   The number of genesis keys to make [default is 3].
+  --gen-utxo-keys INT      The number of UTxO keys to make [default is 0].
+  --start-time UTC-TIME    The genesis start time in YYYY-MM-DDThh:mm:ssZ
+                           format. If unspecified, will be the current time +30
+                           seconds.
+  --supply LOVELACE        The initial coin supply in Lovelace which will be
+                           evenly distributed across initial, non-delegating
+                           stake holders.
+  --security-param INT     Security parameter for genesis file [default is 108].
+  --slot-length INT        slot length (ms) parameter for genesis file [default
+                           is 1000].
+  --slot-coefficient RATIONAL
+                           Slot Coefficient for genesis file [default is .05].
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --byron-template FILEPATH
+                           JSON file with genesis defaults for each byron.
+  --shelley-template FILEPATH
+                           JSON file with genesis defaults for each shelley.
+  --alonzo-template FILEPATH
+                           JSON file with genesis defaults for alonzo.
+  --conway-template FILEPATH
+                           JSON file with genesis defaults for conway.
+  --node-config-template FILEPATH
+                           the node config template
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_genesis_create-staked.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_genesis_create-staked.cli
@@ -1,0 +1,57 @@
+Usage: cardano-cli alonzo genesis create-staked [--key-output-format STRING]
+                                                  --genesis-dir DIR
+                                                  [--gen-genesis-keys INT]
+                                                  [--gen-utxo-keys INT]
+                                                  [--gen-pools INT]
+                                                  [--gen-stake-delegs INT]
+                                                  [--start-time UTC-TIME]
+                                                  [--supply LOVELACE]
+                                                  [--supply-delegated LOVELACE]
+                                                  ( --mainnet
+                                                  | --testnet-magic NATURAL
+                                                  )
+                                                  [--bulk-pool-cred-files INT]
+                                                  [--bulk-pools-per-file INT]
+                                                  [--num-stuffed-utxo INT]
+                                                  [--relay-specification-file FILE]
+
+  Create a staked Shelley genesis file from a genesis template and
+  genesis/delegation/spending keys.
+
+Available options:
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32" (default is
+                           "bech32").
+  --genesis-dir DIR        The genesis directory containing the genesis template
+                           and required genesis/delegation/spending keys.
+  --gen-genesis-keys INT   The number of genesis keys to make [default is 3].
+  --gen-utxo-keys INT      The number of UTxO keys to make [default is 0].
+  --gen-pools INT          The number of stake pool credential sets to make
+                           [default is 0].
+  --gen-stake-delegs INT   The number of stake delegator credential sets to make
+                           [default is 0].
+  --start-time UTC-TIME    The genesis start time in YYYY-MM-DDThh:mm:ssZ
+                           format. If unspecified, will be the current time +30
+                           seconds.
+  --supply LOVELACE        The initial coin supply in Lovelace which will be
+                           evenly distributed across initial, non-delegating
+                           stake holders.
+  --supply-delegated LOVELACE
+                           The initial coin supply in Lovelace which will be
+                           evenly distributed across initial, delegating stake
+                           holders.
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --bulk-pool-cred-files INT
+                           Generate bulk pool credential files [default is 0].
+  --bulk-pools-per-file INT
+                           Each bulk pool to contain this many pool credential
+                           sets [default is 0].
+  --num-stuffed-utxo INT   The number of fake UTxO entries to generate [default
+                           is 0].
+  --relay-specification-file FILE
+                           JSON file specified the relays of each stake pool.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_genesis_create.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_genesis_create.cli
@@ -1,0 +1,31 @@
+Usage: cardano-cli alonzo genesis create [--key-output-format STRING]
+                                           --genesis-dir DIR
+                                           [--gen-genesis-keys INT]
+                                           [--gen-utxo-keys INT]
+                                           [--start-time UTC-TIME]
+                                           [--supply LOVELACE]
+                                           (--mainnet | --testnet-magic NATURAL)
+
+  Create a Shelley genesis file from a genesis template and
+  genesis/delegation/spending keys.
+
+Available options:
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32" (default is
+                           "bech32").
+  --genesis-dir DIR        The genesis directory containing the genesis template
+                           and required genesis/delegation/spending keys.
+  --gen-genesis-keys INT   The number of genesis keys to make [default is 3].
+  --gen-utxo-keys INT      The number of UTxO keys to make [default is 0].
+  --start-time UTC-TIME    The genesis start time in YYYY-MM-DDThh:mm:ssZ
+                           format. If unspecified, will be the current time +30
+                           seconds.
+  --supply LOVELACE        The initial coin supply in Lovelace which will be
+                           evenly distributed across initial, non-delegating
+                           stake holders.
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_genesis_get-ver-key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_genesis_get-ver-key.cli
@@ -1,0 +1,10 @@
+Usage: cardano-cli alonzo genesis get-ver-key --verification-key-file FILE
+                                                --signing-key-file FILE
+
+  Derive the verification key from a signing key
+
+Available options:
+  --verification-key-file FILE
+                           Output filepath of the verification key.
+  --signing-key-file FILE  Input filepath of the signing key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_genesis_hash.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_genesis_hash.cli
@@ -1,0 +1,7 @@
+Usage: cardano-cli alonzo genesis hash --genesis FILE
+
+  Compute the hash of a genesis file
+
+Available options:
+  --genesis FILE           The genesis file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_genesis_initial-addr.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_genesis_initial-addr.cli
@@ -1,0 +1,17 @@
+Usage: cardano-cli alonzo genesis initial-addr --verification-key-file FILE
+                                                 ( --mainnet
+                                                 | --testnet-magic NATURAL
+                                                 )
+                                                 [--out-file FILE]
+
+  Get the address for an initial UTxO based on the verification key
+
+Available options:
+  --verification-key-file FILE
+                           Input filepath of the verification key.
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_genesis_initial-txin.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_genesis_initial-txin.cli
@@ -1,0 +1,17 @@
+Usage: cardano-cli alonzo genesis initial-txin --verification-key-file FILE
+                                                 ( --mainnet
+                                                 | --testnet-magic NATURAL
+                                                 )
+                                                 [--out-file FILE]
+
+  Get the TxIn for an initial UTxO based on the verification key
+
+Available options:
+  --verification-key-file FILE
+                           Input filepath of the verification key.
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_genesis_key-gen-delegate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_genesis_key-gen-delegate.cli
@@ -1,0 +1,14 @@
+Usage: cardano-cli alonzo genesis key-gen-delegate --verification-key-file FILE
+                                                     --signing-key-file FILE
+                                                     --operational-certificate-issue-counter-file FILE
+
+  Create a Shelley genesis delegate key pair
+
+Available options:
+  --verification-key-file FILE
+                           Output filepath of the verification key.
+  --signing-key-file FILE  Output filepath of the signing key.
+  --operational-certificate-issue-counter-file FILE
+                           The file with the issue counter for the operational
+                           certificate.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_genesis_key-gen-genesis.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_genesis_key-gen-genesis.cli
@@ -1,0 +1,10 @@
+Usage: cardano-cli alonzo genesis key-gen-genesis --verification-key-file FILE
+                                                    --signing-key-file FILE
+
+  Create a Shelley genesis key pair
+
+Available options:
+  --verification-key-file FILE
+                           Output filepath of the verification key.
+  --signing-key-file FILE  Output filepath of the signing key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_genesis_key-gen-utxo.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_genesis_key-gen-utxo.cli
@@ -1,0 +1,10 @@
+Usage: cardano-cli alonzo genesis key-gen-utxo --verification-key-file FILE
+                                                 --signing-key-file FILE
+
+  Create a Shelley genesis UTxO key pair
+
+Available options:
+  --verification-key-file FILE
+                           Output filepath of the verification key.
+  --signing-key-file FILE  Output filepath of the signing key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_genesis_key-hash.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_genesis_key-hash.cli
@@ -1,0 +1,8 @@
+Usage: cardano-cli alonzo genesis key-hash --verification-key-file FILE
+
+  Print the identifier (hash) of a public key
+
+Available options:
+  --verification-key-file FILE
+                           Input filepath of the verification key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_key.cli
@@ -1,0 +1,40 @@
+Usage: cardano-cli alonzo key 
+                                ( verification-key
+                                | non-extended-key
+                                | convert-byron-key
+                                | convert-byron-genesis-vkey
+                                | convert-itn-key
+                                | convert-itn-extended-key
+                                | convert-itn-bip32-key
+                                | convert-cardano-address-key
+                                )
+
+  Era-based key commands
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  verification-key         Get a verification key from a signing key. This
+                           supports all key types.
+  non-extended-key         Get a non-extended verification key from an extended
+                           verification key. This supports all extended key
+                           types.
+  convert-byron-key        Convert a Byron payment, genesis or genesis delegate
+                           key (signing or verification) to a corresponding
+                           Shelley-format key.
+  convert-byron-genesis-vkey
+                           Convert a Base64-encoded Byron genesis verification
+                           key to a Shelley genesis verification key
+  convert-itn-key          Convert an Incentivized Testnet (ITN) non-extended
+                           (Ed25519) signing or verification key to a
+                           corresponding Shelley stake key
+  convert-itn-extended-key Convert an Incentivized Testnet (ITN) extended
+                           (Ed25519Extended) signing key to a corresponding
+                           Shelley stake signing key
+  convert-itn-bip32-key    Convert an Incentivized Testnet (ITN) BIP32
+                           (Ed25519Bip32) signing key to a corresponding Shelley
+                           stake signing key
+  convert-cardano-address-key
+                           Convert a cardano-address extended signing key to a
+                           corresponding Shelley-format key.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_key_convert-byron-genesis-vkey.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_key_convert-byron-genesis-vkey.cli
@@ -1,0 +1,11 @@
+Usage: cardano-cli alonzo key convert-byron-genesis-vkey --byron-genesis-verification-key BASE64
+                                                           --out-file FILE
+
+  Convert a Base64-encoded Byron genesis verification key to a Shelley genesis
+  verification key
+
+Available options:
+  --byron-genesis-verification-key BASE64
+                           Base64 string for the Byron genesis verification key.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_key_convert-byron-key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_key_convert-byron-key.cli
@@ -1,0 +1,35 @@
+Usage: cardano-cli alonzo key convert-byron-key [--password TEXT]
+                                                  ( --byron-payment-key-type
+                                                  | --legacy-byron-payment-key-type
+                                                  | --byron-genesis-key-type
+                                                  | --legacy-byron-genesis-key-type
+                                                  | --byron-genesis-delegate-key-type
+                                                  | --legacy-byron-genesis-delegate-key-type
+                                                  )
+                                                  ( --byron-signing-key-file FILE
+                                                  | --byron-verification-key-file FILE
+                                                  )
+                                                  --out-file FILE
+
+  Convert a Byron payment, genesis or genesis delegate key (signing or
+  verification) to a corresponding Shelley-format key.
+
+Available options:
+  --password TEXT          Password for signing key (if applicable).
+  --byron-payment-key-type Use a Byron-era payment key.
+  --legacy-byron-payment-key-type
+                           Use a Byron-era payment key, in legacy SL format.
+  --byron-genesis-key-type Use a Byron-era genesis key.
+  --legacy-byron-genesis-key-type
+                           Use a Byron-era genesis key, in legacy SL format.
+  --byron-genesis-delegate-key-type
+                           Use a Byron-era genesis delegate key.
+  --legacy-byron-genesis-delegate-key-type
+                           Use a Byron-era genesis delegate key, in legacy SL
+                           format.
+  --byron-signing-key-file FILE
+                           Input filepath of the Byron-format signing key.
+  --byron-verification-key-file FILE
+                           Input filepath of the Byron-format verification key.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_key_convert-cardano-address-key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_key_convert-cardano-address-key.cli
@@ -1,0 +1,22 @@
+Usage: cardano-cli alonzo key convert-cardano-address-key 
+                                                            ( --shelley-payment-key
+                                                            | --shelley-stake-key
+                                                            | --icarus-payment-key
+                                                            | --byron-payment-key
+                                                            )
+                                                            --signing-key-file FILE
+                                                            --out-file FILE
+
+  Convert a cardano-address extended signing key to a corresponding
+  Shelley-format key.
+
+Available options:
+  --shelley-payment-key    Use a Shelley-era extended payment key.
+  --shelley-stake-key      Use a Shelley-era extended stake key.
+  --icarus-payment-key     Use a Byron-era extended payment key formatted in the
+                           Icarus style.
+  --byron-payment-key      Use a Byron-era extended payment key formatted in the
+                           deprecated Byron style.
+  --signing-key-file FILE  Input filepath of the signing key.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_key_convert-itn-bip32-key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_key_convert-itn-bip32-key.cli
@@ -1,0 +1,11 @@
+Usage: cardano-cli alonzo key convert-itn-bip32-key --itn-signing-key-file FILE
+                                                      --out-file FILE
+
+  Convert an Incentivized Testnet (ITN) BIP32 (Ed25519Bip32) signing key to a
+  corresponding Shelley stake signing key
+
+Available options:
+  --itn-signing-key-file FILE
+                           Filepath of the ITN signing key.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_key_convert-itn-extended-key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_key_convert-itn-extended-key.cli
@@ -1,0 +1,11 @@
+Usage: cardano-cli alonzo key convert-itn-extended-key --itn-signing-key-file FILE
+                                                         --out-file FILE
+
+  Convert an Incentivized Testnet (ITN) extended (Ed25519Extended) signing key
+  to a corresponding Shelley stake signing key
+
+Available options:
+  --itn-signing-key-file FILE
+                           Filepath of the ITN signing key.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_key_convert-itn-key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_key_convert-itn-key.cli
@@ -1,0 +1,16 @@
+Usage: cardano-cli alonzo key convert-itn-key 
+                                                ( --itn-signing-key-file FILE
+                                                | --itn-verification-key-file FILE
+                                                )
+                                                --out-file FILE
+
+  Convert an Incentivized Testnet (ITN) non-extended (Ed25519) signing or
+  verification key to a corresponding Shelley stake key
+
+Available options:
+  --itn-signing-key-file FILE
+                           Filepath of the ITN signing key.
+  --itn-verification-key-file FILE
+                           Filepath of the ITN verification key.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_key_non-extended-key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_key_non-extended-key.cli
@@ -1,0 +1,12 @@
+Usage: cardano-cli alonzo key non-extended-key --extended-verification-key-file FILE
+                                                 --verification-key-file FILE
+
+  Get a non-extended verification key from an extended verification key. This
+  supports all extended key types.
+
+Available options:
+  --extended-verification-key-file FILE
+                           Input filepath of the ed25519-bip32 verification key.
+  --verification-key-file FILE
+                           Output filepath of the verification key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_key_verification-key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_key_verification-key.cli
@@ -1,0 +1,10 @@
+Usage: cardano-cli alonzo key verification-key --signing-key-file FILE
+                                                 --verification-key-file FILE
+
+  Get a verification key from a signing key. This supports all key types.
+
+Available options:
+  --signing-key-file FILE  Input filepath of the signing key.
+  --verification-key-file FILE
+                           Output filepath of the verification key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_node.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_node.cli
@@ -1,0 +1,22 @@
+Usage: cardano-cli alonzo node 
+                                 ( key-gen
+                                 | key-gen-KES
+                                 | key-gen-VRF
+                                 | key-hash-VRF
+                                 | new-counter
+                                 | issue-op-cert
+                                 )
+
+  Era-based node commands
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  key-gen                  Create a key pair for a node operator's offline key
+                           and a new certificate issue counter
+  key-gen-KES              Create a key pair for a node KES operational key
+  key-gen-VRF              Create a key pair for a node VRF operational key
+  key-hash-VRF             Print hash of a node's operational VRF key.
+  new-counter              Create a new certificate issue counter
+  issue-op-cert            Issue a node operational certificate

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_node_issue-op-cert.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_node_issue-op-cert.cli
@@ -1,0 +1,24 @@
+Usage: cardano-cli alonzo node issue-op-cert 
+                                               ( --kes-verification-key STRING
+                                               | --kes-verification-key-file FILE
+                                               )
+                                               --cold-signing-key-file FILE
+                                               --operational-certificate-issue-counter-file FILE
+                                               --kes-period NATURAL
+                                               --out-file FILE
+
+  Issue a node operational certificate
+
+Available options:
+  --kes-verification-key STRING
+                           A Bech32 or hex-encoded hot KES verification key.
+  --kes-verification-key-file FILE
+                           Filepath of the hot KES verification key.
+  --cold-signing-key-file FILE
+                           Filepath of the cold signing key.
+  --operational-certificate-issue-counter-file FILE
+                           The file with the issue counter for the operational
+                           certificate.
+  --kes-period NATURAL     The start of the KES key validity period.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_node_key-gen-KES.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_node_key-gen-KES.cli
@@ -1,0 +1,15 @@
+Usage: cardano-cli alonzo node key-gen-KES [--key-output-format STRING]
+                                             --verification-key-file FILE
+                                             --signing-key-file FILE
+
+  Create a key pair for a node KES operational key
+
+Available options:
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32" (default is
+                           "bech32").
+  --verification-key-file FILE
+                           Output filepath of the verification key.
+  --signing-key-file FILE  Output filepath of the signing key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_node_key-gen-VRF.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_node_key-gen-VRF.cli
@@ -1,0 +1,15 @@
+Usage: cardano-cli alonzo node key-gen-VRF [--key-output-format STRING]
+                                             --verification-key-file FILE
+                                             --signing-key-file FILE
+
+  Create a key pair for a node VRF operational key
+
+Available options:
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32" (default is
+                           "bech32").
+  --verification-key-file FILE
+                           Output filepath of the verification key.
+  --signing-key-file FILE  Output filepath of the signing key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_node_key-gen.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_node_key-gen.cli
@@ -1,0 +1,21 @@
+Usage: cardano-cli alonzo node key-gen [--key-output-format STRING]
+                                         --cold-verification-key-file FILE
+                                         --cold-signing-key-file FILE
+                                         --operational-certificate-issue-counter-file FILE
+
+  Create a key pair for a node operator's offline key and a new certificate
+  issue counter
+
+Available options:
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32" (default is
+                           "bech32").
+  --cold-verification-key-file FILE
+                           Filepath of the cold verification key.
+  --cold-signing-key-file FILE
+                           Filepath of the cold signing key.
+  --operational-certificate-issue-counter-file FILE
+                           The file with the issue counter for the operational
+                           certificate.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_node_key-hash-VRF.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_node_key-hash-VRF.cli
@@ -1,0 +1,15 @@
+Usage: cardano-cli alonzo node key-hash-VRF 
+                                              ( --verification-key STRING
+                                              | --verification-key-file FILE
+                                              )
+                                              [--out-file FILE]
+
+  Print hash of a node's operational VRF key.
+
+Available options:
+  --verification-key STRING
+                           Verification key (Bech32 or hex-encoded).
+  --verification-key-file FILE
+                           Input filepath of the verification key.
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_node_new-counter.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_node_new-counter.cli
@@ -1,0 +1,22 @@
+Usage: cardano-cli alonzo node new-counter 
+                                             ( --stake-pool-verification-key STRING
+                                             | --genesis-delegate-verification-key STRING
+                                             | --cold-verification-key-file FILE
+                                             )
+                                             --counter-value INT
+                                             --operational-certificate-issue-counter-file FILE
+
+  Create a new certificate issue counter
+
+Available options:
+  --stake-pool-verification-key STRING
+                           Stake pool verification key (Bech32 or hex-encoded).
+  --genesis-delegate-verification-key STRING
+                           Genesis delegate verification key (hex-encoded).
+  --cold-verification-key-file FILE
+                           Filepath of the cold verification key.
+  --counter-value INT      The next certificate issue counter value to use.
+  --operational-certificate-issue-counter-file FILE
+                           The file with the issue counter for the operational
+                           certificate.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query.cli
@@ -1,0 +1,50 @@
+Usage: cardano-cli alonzo query 
+                                  ( protocol-parameters
+                                  | constitution-hash
+                                  | tip
+                                  | stake-pools
+                                  | stake-distribution
+                                  | stake-address-info
+                                  | utxo
+                                  | ledger-state
+                                  | protocol-state
+                                  | stake-snapshot
+                                  | leadership-schedule
+                                  | kes-period-info
+                                  | pool-state
+                                  | tx-mempool
+                                  | slot-number
+                                  )
+
+  Era-based query commands
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  protocol-parameters      Get the node's current protocol parameters
+  constitution-hash        Get the constitution hash
+  tip                      Get the node's current tip (slot no, hash, block no)
+  stake-pools              Get the node's current set of stake pool ids
+  stake-distribution       Get the node's current aggregated stake distribution
+  stake-address-info       Get the current delegations and reward accounts
+                           filtered by stake address.
+  utxo                     Get a portion of the current UTxO: by tx in, by
+                           address or the whole.
+  ledger-state             Dump the current ledger state of the node
+                           (Ledger.NewEpochState -- advanced command)
+  protocol-state           Dump the current protocol state of the node
+                           (Ledger.ChainDepState -- advanced command)
+  stake-snapshot           Obtain the three stake snapshots for a pool, plus the
+                           total active stake (advanced command)
+  pool-params              DEPRECATED. Use query pool-state instead. Dump the
+                           pool parameters
+                           (Ledger.NewEpochState.esLState._delegationState._pState._pParams
+                           -- advanced command)
+  leadership-schedule      Get the slots the node is expected to mint a block in
+                           (advanced command)
+  kes-period-info          Get information about the current KES period and your
+                           node's operational certificate.
+  pool-state               Dump the pool state
+  tx-mempool               Local Mempool info
+  slot-number              Query slot number for UTC timestamp

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_constitution-hash.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_constitution-hash.cli
@@ -1,0 +1,34 @@
+Usage: cardano-cli alonzo query constitution-hash --socket-path SOCKET_PATH
+                                                    [ --shelley-mode
+                                                    | --byron-mode
+                                                      [--epoch-slots SLOTS]
+                                                    | --cardano-mode
+                                                      [--epoch-slots SLOTS]
+                                                    ]
+                                                    ( --mainnet
+                                                    | --testnet-magic NATURAL
+                                                    )
+                                                    [--out-file FILE]
+
+  Get the constitution hash
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_kes-period-info.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_kes-period-info.cli
@@ -1,0 +1,37 @@
+Usage: cardano-cli alonzo query kes-period-info --socket-path SOCKET_PATH
+                                                  [ --shelley-mode
+                                                  | --byron-mode
+                                                    [--epoch-slots SLOTS]
+                                                  | --cardano-mode
+                                                    [--epoch-slots SLOTS]
+                                                  ]
+                                                  ( --mainnet
+                                                  | --testnet-magic NATURAL
+                                                  )
+                                                  --op-cert-file FILE
+                                                  [--out-file FILE]
+
+  Get information about the current KES period and your node's operational
+  certificate.
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --op-cert-file FILE      Filepath of the node's operational certificate.
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_leadership-schedule.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_leadership-schedule.cli
@@ -1,0 +1,54 @@
+Usage: cardano-cli alonzo query leadership-schedule --socket-path SOCKET_PATH
+                                                      [ --shelley-mode
+                                                      | --byron-mode
+                                                        [--epoch-slots SLOTS]
+                                                      | --cardano-mode
+                                                        [--epoch-slots SLOTS]
+                                                      ]
+                                                      ( --mainnet
+                                                      | --testnet-magic NATURAL
+                                                      )
+                                                      --genesis FILE
+                                                      ( --stake-pool-verification-key STRING
+                                                      | --cold-verification-key-file FILE
+                                                      | --stake-pool-id STAKE_POOL_ID
+                                                      )
+                                                      --vrf-signing-key-file FILE
+                                                      (--current | --next)
+                                                      [--out-file FILE]
+
+  Get the slots the node is expected to mint a block in (advanced command)
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --genesis FILE           Shelley genesis filepath
+  --stake-pool-verification-key STRING
+                           Stake pool verification key (Bech32 or hex-encoded).
+  --cold-verification-key-file FILE
+                           Filepath of the stake pool verification key.
+  --stake-pool-id STAKE_POOL_ID
+                           Stake pool ID/verification key hash (either
+                           Bech32-encoded or hex-encoded). Zero or more
+                           occurences of this option is allowed.
+  --vrf-signing-key-file FILE
+                           Input filepath of the VRF signing key.
+  --current                Get the leadership schedule for the current epoch.
+  --next                   Get the leadership schedule for the following epoch.
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_ledger-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_ledger-state.cli
@@ -1,0 +1,35 @@
+Usage: cardano-cli alonzo query ledger-state --socket-path SOCKET_PATH
+                                               [ --shelley-mode
+                                               | --byron-mode
+                                                 [--epoch-slots SLOTS]
+                                               | --cardano-mode
+                                                 [--epoch-slots SLOTS]
+                                               ]
+                                               ( --mainnet
+                                               | --testnet-magic NATURAL
+                                               )
+                                               [--out-file FILE]
+
+  Dump the current ledger state of the node (Ledger.NewEpochState -- advanced
+  command)
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_pool-params.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_pool-params.cli
@@ -1,0 +1,39 @@
+Usage: cardano-cli alonzo query pool-params --socket-path SOCKET_PATH
+                                              [ --shelley-mode
+                                              | --byron-mode
+                                                [--epoch-slots SLOTS]
+                                              | --cardano-mode
+                                                [--epoch-slots SLOTS]
+                                              ]
+                                              ( --mainnet
+                                              | --testnet-magic NATURAL
+                                              )
+                                              [--stake-pool-id STAKE_POOL_ID]
+
+  DEPRECATED. Use query pool-state instead. Dump the pool parameters
+  (Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced
+  command)
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --stake-pool-id STAKE_POOL_ID
+                           Stake pool ID/verification key hash (either
+                           Bech32-encoded or hex-encoded). Zero or more
+                           occurences of this option is allowed.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_pool-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_pool-state.cli
@@ -1,0 +1,37 @@
+Usage: cardano-cli alonzo query pool-state --socket-path SOCKET_PATH
+                                             [ --shelley-mode
+                                             | --byron-mode
+                                               [--epoch-slots SLOTS]
+                                             | --cardano-mode
+                                               [--epoch-slots SLOTS]
+                                             ]
+                                             ( --mainnet
+                                             | --testnet-magic NATURAL
+                                             )
+                                             [--stake-pool-id STAKE_POOL_ID]
+
+  Dump the pool state
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --stake-pool-id STAKE_POOL_ID
+                           Stake pool ID/verification key hash (either
+                           Bech32-encoded or hex-encoded). Zero or more
+                           occurences of this option is allowed.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_protocol-parameters.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_protocol-parameters.cli
@@ -1,0 +1,34 @@
+Usage: cardano-cli alonzo query protocol-parameters --socket-path SOCKET_PATH
+                                                      [ --shelley-mode
+                                                      | --byron-mode
+                                                        [--epoch-slots SLOTS]
+                                                      | --cardano-mode
+                                                        [--epoch-slots SLOTS]
+                                                      ]
+                                                      ( --mainnet
+                                                      | --testnet-magic NATURAL
+                                                      )
+                                                      [--out-file FILE]
+
+  Get the node's current protocol parameters
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_protocol-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_protocol-state.cli
@@ -1,0 +1,35 @@
+Usage: cardano-cli alonzo query protocol-state --socket-path SOCKET_PATH
+                                                 [ --shelley-mode
+                                                 | --byron-mode
+                                                   [--epoch-slots SLOTS]
+                                                 | --cardano-mode
+                                                   [--epoch-slots SLOTS]
+                                                 ]
+                                                 ( --mainnet
+                                                 | --testnet-magic NATURAL
+                                                 )
+                                                 [--out-file FILE]
+
+  Dump the current protocol state of the node (Ledger.ChainDepState -- advanced
+  command)
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_slot-number.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_slot-number.cli
@@ -1,0 +1,34 @@
+Usage: cardano-cli alonzo query slot-number --socket-path SOCKET_PATH
+                                              [ --shelley-mode
+                                              | --byron-mode
+                                                [--epoch-slots SLOTS]
+                                              | --cardano-mode
+                                                [--epoch-slots SLOTS]
+                                              ]
+                                              ( --mainnet
+                                              | --testnet-magic NATURAL
+                                              )
+                                              TIMESTAMP
+
+  Query slot number for UTC timestamp
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  TIMESTAMP                UTC timestamp in YYYY-MM-DDThh:mm:ssZ format
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_stake-address-info.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_stake-address-info.cli
@@ -1,0 +1,36 @@
+Usage: cardano-cli alonzo query stake-address-info --socket-path SOCKET_PATH
+                                                     [ --shelley-mode
+                                                     | --byron-mode
+                                                       [--epoch-slots SLOTS]
+                                                     | --cardano-mode
+                                                       [--epoch-slots SLOTS]
+                                                     ]
+                                                     --address ADDRESS
+                                                     ( --mainnet
+                                                     | --testnet-magic NATURAL
+                                                     )
+                                                     [--out-file FILE]
+
+  Get the current delegations and reward accounts filtered by stake address.
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --address ADDRESS        Filter by Cardano stake address (Bech32-encoded).
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_stake-distribution.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_stake-distribution.cli
@@ -1,0 +1,34 @@
+Usage: cardano-cli alonzo query stake-distribution --socket-path SOCKET_PATH
+                                                     [ --shelley-mode
+                                                     | --byron-mode
+                                                       [--epoch-slots SLOTS]
+                                                     | --cardano-mode
+                                                       [--epoch-slots SLOTS]
+                                                     ]
+                                                     ( --mainnet
+                                                     | --testnet-magic NATURAL
+                                                     )
+                                                     [--out-file FILE]
+
+  Get the node's current aggregated stake distribution
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_stake-pools.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_stake-pools.cli
@@ -1,0 +1,34 @@
+Usage: cardano-cli alonzo query stake-pools --socket-path SOCKET_PATH
+                                              [ --shelley-mode
+                                              | --byron-mode
+                                                [--epoch-slots SLOTS]
+                                              | --cardano-mode
+                                                [--epoch-slots SLOTS]
+                                              ]
+                                              ( --mainnet
+                                              | --testnet-magic NATURAL
+                                              )
+                                              [--out-file FILE]
+
+  Get the node's current set of stake pool ids
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_stake-snapshot.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_stake-snapshot.cli
@@ -1,0 +1,44 @@
+Usage: cardano-cli alonzo query stake-snapshot --socket-path SOCKET_PATH
+                                                 [ --shelley-mode
+                                                 | --byron-mode
+                                                   [--epoch-slots SLOTS]
+                                                 | --cardano-mode
+                                                   [--epoch-slots SLOTS]
+                                                 ]
+                                                 ( --mainnet
+                                                 | --testnet-magic NATURAL
+                                                 )
+                                                 [ --all-stake-pools
+                                                 | 
+                                                 [--stake-pool-id STAKE_POOL_ID]
+                                                 ]
+                                                 [--out-file FILE]
+
+  Obtain the three stake snapshots for a pool, plus the total active stake
+  (advanced command)
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --all-stake-pools        Query for all stake pools
+  --stake-pool-id STAKE_POOL_ID
+                           Stake pool ID/verification key hash (either
+                           Bech32-encoded or hex-encoded). Zero or more
+                           occurences of this option is allowed.
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_tip.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_tip.cli
@@ -1,0 +1,30 @@
+Usage: cardano-cli alonzo query tip --socket-path SOCKET_PATH
+                                      [ --shelley-mode
+                                      | --byron-mode [--epoch-slots SLOTS]
+                                      | --cardano-mode [--epoch-slots SLOTS]
+                                      ]
+                                      (--mainnet | --testnet-magic NATURAL)
+                                      [--out-file FILE]
+
+  Get the node's current tip (slot no, hash, block no)
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_tx-mempool.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_tx-mempool.cli
@@ -1,0 +1,43 @@
+Usage: cardano-cli alonzo query tx-mempool --socket-path SOCKET_PATH
+                                             [ --shelley-mode
+                                             | --byron-mode
+                                               [--epoch-slots SLOTS]
+                                             | --cardano-mode
+                                               [--epoch-slots SLOTS]
+                                             ]
+                                             ( --mainnet
+                                             | --testnet-magic NATURAL
+                                             )
+                                             (info | next-tx | tx-exists)
+                                             [--out-file FILE]
+
+  Local Mempool info
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text
+
+Available commands:
+  info                     Ask the node about the current mempool's capacity and
+                           sizes
+  next-tx                  Requests the next transaction from the mempool's
+                           current list
+  tx-exists                Query if a particular transaction exists in the
+                           mempool

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_tx-mempool_info.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_tx-mempool_info.cli
@@ -1,0 +1,16 @@
+Missing: --socket-path SOCKET_PATH (--mainnet | --testnet-magic NATURAL)
+
+Usage: cardano-cli alonzo query tx-mempool --socket-path SOCKET_PATH
+                                             [ --shelley-mode
+                                             | --byron-mode
+                                               [--epoch-slots SLOTS]
+                                             | --cardano-mode
+                                               [--epoch-slots SLOTS]
+                                             ]
+                                             ( --mainnet
+                                             | --testnet-magic NATURAL
+                                             )
+                                             (info | next-tx | tx-exists)
+                                             [--out-file FILE]
+
+  Local Mempool info

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_tx-mempool_next-tx.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_tx-mempool_next-tx.cli
@@ -1,0 +1,16 @@
+Missing: --socket-path SOCKET_PATH (--mainnet | --testnet-magic NATURAL)
+
+Usage: cardano-cli alonzo query tx-mempool --socket-path SOCKET_PATH
+                                             [ --shelley-mode
+                                             | --byron-mode
+                                               [--epoch-slots SLOTS]
+                                             | --cardano-mode
+                                               [--epoch-slots SLOTS]
+                                             ]
+                                             ( --mainnet
+                                             | --testnet-magic NATURAL
+                                             )
+                                             (info | next-tx | tx-exists)
+                                             [--out-file FILE]
+
+  Local Mempool info

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_tx-mempool_tx-exists_TX_ID.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_tx-mempool_tx-exists_TX_ID.cli
@@ -1,0 +1,16 @@
+Missing: --socket-path SOCKET_PATH (--mainnet | --testnet-magic NATURAL)
+
+Usage: cardano-cli alonzo query tx-mempool --socket-path SOCKET_PATH
+                                             [ --shelley-mode
+                                             | --byron-mode
+                                               [--epoch-slots SLOTS]
+                                             | --cardano-mode
+                                               [--epoch-slots SLOTS]
+                                             ]
+                                             ( --mainnet
+                                             | --testnet-magic NATURAL
+                                             )
+                                             (info | next-tx | tx-exists)
+                                             [--out-file FILE]
+
+  Local Mempool info

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_utxo.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_utxo.cli
@@ -1,0 +1,38 @@
+Usage: cardano-cli alonzo query utxo --socket-path SOCKET_PATH
+                                       [ --shelley-mode
+                                       | --byron-mode [--epoch-slots SLOTS]
+                                       | --cardano-mode [--epoch-slots SLOTS]
+                                       ]
+                                       ( --whole-utxo
+                                       | (--address ADDRESS)
+                                       | (--tx-in TX-IN)
+                                       )
+                                       (--mainnet | --testnet-magic NATURAL)
+                                       [--out-file FILE]
+
+  Get a portion of the current UTxO: by tx in, by address or the whole.
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --whole-utxo             Return the whole UTxO (only appropriate on small
+                           testnets).
+  --address ADDRESS        Filter by Cardano address(es) (Bech32-encoded).
+  --tx-in TX-IN            Filter by transaction input (TxId#TxIx).
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_text-view_decode-cbor.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_text-view_decode-cbor.cli
@@ -1,0 +1,8 @@
+Usage: cardano-cli alonzo text-view decode-cbor --in-file FILE [--out-file FILE]
+
+  Print a TextView file as decoded CBOR.
+
+Available options:
+  --in-file FILE           CBOR input file.
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_transaction.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_transaction.cli
@@ -13,7 +13,7 @@ Usage: cardano-cli alonzo transaction
                                         | view
                                         )
 
-  Era-based governance commands
+  Era-based transaction commands
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage.cli
@@ -1,4 +1,14 @@
-Usage: cardano-cli babbage (address | governance | stake-address | transaction)
+Usage: cardano-cli babbage 
+                             ( address
+                             | key
+                             | genesis
+                             | governance
+                             | node
+                             | query
+                             | stake-address
+                             | text-view
+                             | transaction
+                             )
 
   Babbage era commands
 
@@ -7,6 +17,11 @@ Available options:
 
 Available commands:
   address                  Era-based address commands
+  key                      Era-based key commands
+  genesis                  Era-based genesis commands
   governance               Era-based governance commands
+  node                     Era-based node commands
+  query                    Era-based query commands
   stake-address            Stake address commands.
-  transaction              Era-based governance commands
+  text-view                Era-based text-view commands
+  transaction              Era-based transaction commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_genesis.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_genesis.cli
@@ -1,0 +1,37 @@
+Usage: cardano-cli babbage genesis 
+                                     ( key-gen-genesis
+                                     | key-gen-delegate
+                                     | key-gen-utxo
+                                     | key-hash
+                                     | get-ver-key
+                                     | initial-addr
+                                     | initial-txin
+                                     | create-cardano
+                                     | create
+                                     | create-staked
+                                     | hash
+                                     )
+
+  Era-based genesis commands
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  key-gen-genesis          Create a Shelley genesis key pair
+  key-gen-delegate         Create a Shelley genesis delegate key pair
+  key-gen-utxo             Create a Shelley genesis UTxO key pair
+  key-hash                 Print the identifier (hash) of a public key
+  get-ver-key              Derive the verification key from a signing key
+  initial-addr             Get the address for an initial UTxO based on the
+                           verification key
+  initial-txin             Get the TxIn for an initial UTxO based on the
+                           verification key
+  create-cardano           Create a Byron and Shelley genesis file from a
+                           genesis template and genesis/delegation/spending
+                           keys.
+  create                   Create a Shelley genesis file from a genesis template
+                           and genesis/delegation/spending keys.
+  create-staked            Create a staked Shelley genesis file from a genesis
+                           template and genesis/delegation/spending keys.
+  hash                     Compute the hash of a genesis file

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_genesis_create-cardano.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_genesis_create-cardano.cli
@@ -1,0 +1,51 @@
+Usage: cardano-cli babbage genesis create-cardano --genesis-dir DIR
+                                                    [--gen-genesis-keys INT]
+                                                    [--gen-utxo-keys INT]
+                                                    [--start-time UTC-TIME]
+                                                    [--supply LOVELACE]
+                                                    [--security-param INT]
+                                                    [--slot-length INT]
+                                                    [--slot-coefficient RATIONAL]
+                                                    ( --mainnet
+                                                    | --testnet-magic NATURAL
+                                                    )
+                                                    --byron-template FILEPATH
+                                                    --shelley-template FILEPATH
+                                                    --alonzo-template FILEPATH
+                                                    --conway-template FILEPATH
+                                                    [--node-config-template FILEPATH]
+
+  Create a Byron and Shelley genesis file from a genesis template and
+  genesis/delegation/spending keys.
+
+Available options:
+  --genesis-dir DIR        The genesis directory containing the genesis template
+                           and required genesis/delegation/spending keys.
+  --gen-genesis-keys INT   The number of genesis keys to make [default is 3].
+  --gen-utxo-keys INT      The number of UTxO keys to make [default is 0].
+  --start-time UTC-TIME    The genesis start time in YYYY-MM-DDThh:mm:ssZ
+                           format. If unspecified, will be the current time +30
+                           seconds.
+  --supply LOVELACE        The initial coin supply in Lovelace which will be
+                           evenly distributed across initial, non-delegating
+                           stake holders.
+  --security-param INT     Security parameter for genesis file [default is 108].
+  --slot-length INT        slot length (ms) parameter for genesis file [default
+                           is 1000].
+  --slot-coefficient RATIONAL
+                           Slot Coefficient for genesis file [default is .05].
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --byron-template FILEPATH
+                           JSON file with genesis defaults for each byron.
+  --shelley-template FILEPATH
+                           JSON file with genesis defaults for each shelley.
+  --alonzo-template FILEPATH
+                           JSON file with genesis defaults for alonzo.
+  --conway-template FILEPATH
+                           JSON file with genesis defaults for conway.
+  --node-config-template FILEPATH
+                           the node config template
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_genesis_create-staked.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_genesis_create-staked.cli
@@ -1,0 +1,57 @@
+Usage: cardano-cli babbage genesis create-staked [--key-output-format STRING]
+                                                   --genesis-dir DIR
+                                                   [--gen-genesis-keys INT]
+                                                   [--gen-utxo-keys INT]
+                                                   [--gen-pools INT]
+                                                   [--gen-stake-delegs INT]
+                                                   [--start-time UTC-TIME]
+                                                   [--supply LOVELACE]
+                                                   [--supply-delegated LOVELACE]
+                                                   ( --mainnet
+                                                   | --testnet-magic NATURAL
+                                                   )
+                                                   [--bulk-pool-cred-files INT]
+                                                   [--bulk-pools-per-file INT]
+                                                   [--num-stuffed-utxo INT]
+                                                   [--relay-specification-file FILE]
+
+  Create a staked Shelley genesis file from a genesis template and
+  genesis/delegation/spending keys.
+
+Available options:
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32" (default is
+                           "bech32").
+  --genesis-dir DIR        The genesis directory containing the genesis template
+                           and required genesis/delegation/spending keys.
+  --gen-genesis-keys INT   The number of genesis keys to make [default is 3].
+  --gen-utxo-keys INT      The number of UTxO keys to make [default is 0].
+  --gen-pools INT          The number of stake pool credential sets to make
+                           [default is 0].
+  --gen-stake-delegs INT   The number of stake delegator credential sets to make
+                           [default is 0].
+  --start-time UTC-TIME    The genesis start time in YYYY-MM-DDThh:mm:ssZ
+                           format. If unspecified, will be the current time +30
+                           seconds.
+  --supply LOVELACE        The initial coin supply in Lovelace which will be
+                           evenly distributed across initial, non-delegating
+                           stake holders.
+  --supply-delegated LOVELACE
+                           The initial coin supply in Lovelace which will be
+                           evenly distributed across initial, delegating stake
+                           holders.
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --bulk-pool-cred-files INT
+                           Generate bulk pool credential files [default is 0].
+  --bulk-pools-per-file INT
+                           Each bulk pool to contain this many pool credential
+                           sets [default is 0].
+  --num-stuffed-utxo INT   The number of fake UTxO entries to generate [default
+                           is 0].
+  --relay-specification-file FILE
+                           JSON file specified the relays of each stake pool.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_genesis_create.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_genesis_create.cli
@@ -1,0 +1,33 @@
+Usage: cardano-cli babbage genesis create [--key-output-format STRING]
+                                            --genesis-dir DIR
+                                            [--gen-genesis-keys INT]
+                                            [--gen-utxo-keys INT]
+                                            [--start-time UTC-TIME]
+                                            [--supply LOVELACE]
+                                            ( --mainnet
+                                            | --testnet-magic NATURAL
+                                            )
+
+  Create a Shelley genesis file from a genesis template and
+  genesis/delegation/spending keys.
+
+Available options:
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32" (default is
+                           "bech32").
+  --genesis-dir DIR        The genesis directory containing the genesis template
+                           and required genesis/delegation/spending keys.
+  --gen-genesis-keys INT   The number of genesis keys to make [default is 3].
+  --gen-utxo-keys INT      The number of UTxO keys to make [default is 0].
+  --start-time UTC-TIME    The genesis start time in YYYY-MM-DDThh:mm:ssZ
+                           format. If unspecified, will be the current time +30
+                           seconds.
+  --supply LOVELACE        The initial coin supply in Lovelace which will be
+                           evenly distributed across initial, non-delegating
+                           stake holders.
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_genesis_get-ver-key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_genesis_get-ver-key.cli
@@ -1,0 +1,10 @@
+Usage: cardano-cli babbage genesis get-ver-key --verification-key-file FILE
+                                                 --signing-key-file FILE
+
+  Derive the verification key from a signing key
+
+Available options:
+  --verification-key-file FILE
+                           Output filepath of the verification key.
+  --signing-key-file FILE  Input filepath of the signing key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_genesis_hash.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_genesis_hash.cli
@@ -1,0 +1,7 @@
+Usage: cardano-cli babbage genesis hash --genesis FILE
+
+  Compute the hash of a genesis file
+
+Available options:
+  --genesis FILE           The genesis file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_genesis_initial-addr.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_genesis_initial-addr.cli
@@ -1,0 +1,17 @@
+Usage: cardano-cli babbage genesis initial-addr --verification-key-file FILE
+                                                  ( --mainnet
+                                                  | --testnet-magic NATURAL
+                                                  )
+                                                  [--out-file FILE]
+
+  Get the address for an initial UTxO based on the verification key
+
+Available options:
+  --verification-key-file FILE
+                           Input filepath of the verification key.
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_genesis_initial-txin.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_genesis_initial-txin.cli
@@ -1,0 +1,17 @@
+Usage: cardano-cli babbage genesis initial-txin --verification-key-file FILE
+                                                  ( --mainnet
+                                                  | --testnet-magic NATURAL
+                                                  )
+                                                  [--out-file FILE]
+
+  Get the TxIn for an initial UTxO based on the verification key
+
+Available options:
+  --verification-key-file FILE
+                           Input filepath of the verification key.
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_genesis_key-gen-delegate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_genesis_key-gen-delegate.cli
@@ -1,0 +1,14 @@
+Usage: cardano-cli babbage genesis key-gen-delegate --verification-key-file FILE
+                                                      --signing-key-file FILE
+                                                      --operational-certificate-issue-counter-file FILE
+
+  Create a Shelley genesis delegate key pair
+
+Available options:
+  --verification-key-file FILE
+                           Output filepath of the verification key.
+  --signing-key-file FILE  Output filepath of the signing key.
+  --operational-certificate-issue-counter-file FILE
+                           The file with the issue counter for the operational
+                           certificate.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_genesis_key-gen-genesis.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_genesis_key-gen-genesis.cli
@@ -1,0 +1,10 @@
+Usage: cardano-cli babbage genesis key-gen-genesis --verification-key-file FILE
+                                                     --signing-key-file FILE
+
+  Create a Shelley genesis key pair
+
+Available options:
+  --verification-key-file FILE
+                           Output filepath of the verification key.
+  --signing-key-file FILE  Output filepath of the signing key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_genesis_key-gen-utxo.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_genesis_key-gen-utxo.cli
@@ -1,0 +1,10 @@
+Usage: cardano-cli babbage genesis key-gen-utxo --verification-key-file FILE
+                                                  --signing-key-file FILE
+
+  Create a Shelley genesis UTxO key pair
+
+Available options:
+  --verification-key-file FILE
+                           Output filepath of the verification key.
+  --signing-key-file FILE  Output filepath of the signing key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_genesis_key-hash.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_genesis_key-hash.cli
@@ -1,0 +1,8 @@
+Usage: cardano-cli babbage genesis key-hash --verification-key-file FILE
+
+  Print the identifier (hash) of a public key
+
+Available options:
+  --verification-key-file FILE
+                           Input filepath of the verification key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_key.cli
@@ -1,0 +1,40 @@
+Usage: cardano-cli babbage key 
+                                 ( verification-key
+                                 | non-extended-key
+                                 | convert-byron-key
+                                 | convert-byron-genesis-vkey
+                                 | convert-itn-key
+                                 | convert-itn-extended-key
+                                 | convert-itn-bip32-key
+                                 | convert-cardano-address-key
+                                 )
+
+  Era-based key commands
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  verification-key         Get a verification key from a signing key. This
+                           supports all key types.
+  non-extended-key         Get a non-extended verification key from an extended
+                           verification key. This supports all extended key
+                           types.
+  convert-byron-key        Convert a Byron payment, genesis or genesis delegate
+                           key (signing or verification) to a corresponding
+                           Shelley-format key.
+  convert-byron-genesis-vkey
+                           Convert a Base64-encoded Byron genesis verification
+                           key to a Shelley genesis verification key
+  convert-itn-key          Convert an Incentivized Testnet (ITN) non-extended
+                           (Ed25519) signing or verification key to a
+                           corresponding Shelley stake key
+  convert-itn-extended-key Convert an Incentivized Testnet (ITN) extended
+                           (Ed25519Extended) signing key to a corresponding
+                           Shelley stake signing key
+  convert-itn-bip32-key    Convert an Incentivized Testnet (ITN) BIP32
+                           (Ed25519Bip32) signing key to a corresponding Shelley
+                           stake signing key
+  convert-cardano-address-key
+                           Convert a cardano-address extended signing key to a
+                           corresponding Shelley-format key.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_key_convert-byron-genesis-vkey.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_key_convert-byron-genesis-vkey.cli
@@ -1,0 +1,11 @@
+Usage: cardano-cli babbage key convert-byron-genesis-vkey --byron-genesis-verification-key BASE64
+                                                            --out-file FILE
+
+  Convert a Base64-encoded Byron genesis verification key to a Shelley genesis
+  verification key
+
+Available options:
+  --byron-genesis-verification-key BASE64
+                           Base64 string for the Byron genesis verification key.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_key_convert-byron-key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_key_convert-byron-key.cli
@@ -1,0 +1,35 @@
+Usage: cardano-cli babbage key convert-byron-key [--password TEXT]
+                                                   ( --byron-payment-key-type
+                                                   | --legacy-byron-payment-key-type
+                                                   | --byron-genesis-key-type
+                                                   | --legacy-byron-genesis-key-type
+                                                   | --byron-genesis-delegate-key-type
+                                                   | --legacy-byron-genesis-delegate-key-type
+                                                   )
+                                                   ( --byron-signing-key-file FILE
+                                                   | --byron-verification-key-file FILE
+                                                   )
+                                                   --out-file FILE
+
+  Convert a Byron payment, genesis or genesis delegate key (signing or
+  verification) to a corresponding Shelley-format key.
+
+Available options:
+  --password TEXT          Password for signing key (if applicable).
+  --byron-payment-key-type Use a Byron-era payment key.
+  --legacy-byron-payment-key-type
+                           Use a Byron-era payment key, in legacy SL format.
+  --byron-genesis-key-type Use a Byron-era genesis key.
+  --legacy-byron-genesis-key-type
+                           Use a Byron-era genesis key, in legacy SL format.
+  --byron-genesis-delegate-key-type
+                           Use a Byron-era genesis delegate key.
+  --legacy-byron-genesis-delegate-key-type
+                           Use a Byron-era genesis delegate key, in legacy SL
+                           format.
+  --byron-signing-key-file FILE
+                           Input filepath of the Byron-format signing key.
+  --byron-verification-key-file FILE
+                           Input filepath of the Byron-format verification key.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_key_convert-cardano-address-key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_key_convert-cardano-address-key.cli
@@ -1,0 +1,22 @@
+Usage: cardano-cli babbage key convert-cardano-address-key 
+                                                             ( --shelley-payment-key
+                                                             | --shelley-stake-key
+                                                             | --icarus-payment-key
+                                                             | --byron-payment-key
+                                                             )
+                                                             --signing-key-file FILE
+                                                             --out-file FILE
+
+  Convert a cardano-address extended signing key to a corresponding
+  Shelley-format key.
+
+Available options:
+  --shelley-payment-key    Use a Shelley-era extended payment key.
+  --shelley-stake-key      Use a Shelley-era extended stake key.
+  --icarus-payment-key     Use a Byron-era extended payment key formatted in the
+                           Icarus style.
+  --byron-payment-key      Use a Byron-era extended payment key formatted in the
+                           deprecated Byron style.
+  --signing-key-file FILE  Input filepath of the signing key.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_key_convert-itn-bip32-key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_key_convert-itn-bip32-key.cli
@@ -1,0 +1,11 @@
+Usage: cardano-cli babbage key convert-itn-bip32-key --itn-signing-key-file FILE
+                                                       --out-file FILE
+
+  Convert an Incentivized Testnet (ITN) BIP32 (Ed25519Bip32) signing key to a
+  corresponding Shelley stake signing key
+
+Available options:
+  --itn-signing-key-file FILE
+                           Filepath of the ITN signing key.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_key_convert-itn-extended-key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_key_convert-itn-extended-key.cli
@@ -1,0 +1,11 @@
+Usage: cardano-cli babbage key convert-itn-extended-key --itn-signing-key-file FILE
+                                                          --out-file FILE
+
+  Convert an Incentivized Testnet (ITN) extended (Ed25519Extended) signing key
+  to a corresponding Shelley stake signing key
+
+Available options:
+  --itn-signing-key-file FILE
+                           Filepath of the ITN signing key.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_key_convert-itn-key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_key_convert-itn-key.cli
@@ -1,0 +1,16 @@
+Usage: cardano-cli babbage key convert-itn-key 
+                                                 ( --itn-signing-key-file FILE
+                                                 | --itn-verification-key-file FILE
+                                                 )
+                                                 --out-file FILE
+
+  Convert an Incentivized Testnet (ITN) non-extended (Ed25519) signing or
+  verification key to a corresponding Shelley stake key
+
+Available options:
+  --itn-signing-key-file FILE
+                           Filepath of the ITN signing key.
+  --itn-verification-key-file FILE
+                           Filepath of the ITN verification key.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_key_non-extended-key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_key_non-extended-key.cli
@@ -1,0 +1,12 @@
+Usage: cardano-cli babbage key non-extended-key --extended-verification-key-file FILE
+                                                  --verification-key-file FILE
+
+  Get a non-extended verification key from an extended verification key. This
+  supports all extended key types.
+
+Available options:
+  --extended-verification-key-file FILE
+                           Input filepath of the ed25519-bip32 verification key.
+  --verification-key-file FILE
+                           Output filepath of the verification key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_key_verification-key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_key_verification-key.cli
@@ -1,0 +1,10 @@
+Usage: cardano-cli babbage key verification-key --signing-key-file FILE
+                                                  --verification-key-file FILE
+
+  Get a verification key from a signing key. This supports all key types.
+
+Available options:
+  --signing-key-file FILE  Input filepath of the signing key.
+  --verification-key-file FILE
+                           Output filepath of the verification key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_node.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_node.cli
@@ -1,0 +1,22 @@
+Usage: cardano-cli babbage node 
+                                  ( key-gen
+                                  | key-gen-KES
+                                  | key-gen-VRF
+                                  | key-hash-VRF
+                                  | new-counter
+                                  | issue-op-cert
+                                  )
+
+  Era-based node commands
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  key-gen                  Create a key pair for a node operator's offline key
+                           and a new certificate issue counter
+  key-gen-KES              Create a key pair for a node KES operational key
+  key-gen-VRF              Create a key pair for a node VRF operational key
+  key-hash-VRF             Print hash of a node's operational VRF key.
+  new-counter              Create a new certificate issue counter
+  issue-op-cert            Issue a node operational certificate

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_node_issue-op-cert.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_node_issue-op-cert.cli
@@ -1,0 +1,24 @@
+Usage: cardano-cli babbage node issue-op-cert 
+                                                ( --kes-verification-key STRING
+                                                | --kes-verification-key-file FILE
+                                                )
+                                                --cold-signing-key-file FILE
+                                                --operational-certificate-issue-counter-file FILE
+                                                --kes-period NATURAL
+                                                --out-file FILE
+
+  Issue a node operational certificate
+
+Available options:
+  --kes-verification-key STRING
+                           A Bech32 or hex-encoded hot KES verification key.
+  --kes-verification-key-file FILE
+                           Filepath of the hot KES verification key.
+  --cold-signing-key-file FILE
+                           Filepath of the cold signing key.
+  --operational-certificate-issue-counter-file FILE
+                           The file with the issue counter for the operational
+                           certificate.
+  --kes-period NATURAL     The start of the KES key validity period.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_node_key-gen-KES.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_node_key-gen-KES.cli
@@ -1,0 +1,15 @@
+Usage: cardano-cli babbage node key-gen-KES [--key-output-format STRING]
+                                              --verification-key-file FILE
+                                              --signing-key-file FILE
+
+  Create a key pair for a node KES operational key
+
+Available options:
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32" (default is
+                           "bech32").
+  --verification-key-file FILE
+                           Output filepath of the verification key.
+  --signing-key-file FILE  Output filepath of the signing key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_node_key-gen-VRF.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_node_key-gen-VRF.cli
@@ -1,0 +1,15 @@
+Usage: cardano-cli babbage node key-gen-VRF [--key-output-format STRING]
+                                              --verification-key-file FILE
+                                              --signing-key-file FILE
+
+  Create a key pair for a node VRF operational key
+
+Available options:
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32" (default is
+                           "bech32").
+  --verification-key-file FILE
+                           Output filepath of the verification key.
+  --signing-key-file FILE  Output filepath of the signing key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_node_key-gen.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_node_key-gen.cli
@@ -1,0 +1,21 @@
+Usage: cardano-cli babbage node key-gen [--key-output-format STRING]
+                                          --cold-verification-key-file FILE
+                                          --cold-signing-key-file FILE
+                                          --operational-certificate-issue-counter-file FILE
+
+  Create a key pair for a node operator's offline key and a new certificate
+  issue counter
+
+Available options:
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32" (default is
+                           "bech32").
+  --cold-verification-key-file FILE
+                           Filepath of the cold verification key.
+  --cold-signing-key-file FILE
+                           Filepath of the cold signing key.
+  --operational-certificate-issue-counter-file FILE
+                           The file with the issue counter for the operational
+                           certificate.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_node_key-hash-VRF.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_node_key-hash-VRF.cli
@@ -1,0 +1,15 @@
+Usage: cardano-cli babbage node key-hash-VRF 
+                                               ( --verification-key STRING
+                                               | --verification-key-file FILE
+                                               )
+                                               [--out-file FILE]
+
+  Print hash of a node's operational VRF key.
+
+Available options:
+  --verification-key STRING
+                           Verification key (Bech32 or hex-encoded).
+  --verification-key-file FILE
+                           Input filepath of the verification key.
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_node_new-counter.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_node_new-counter.cli
@@ -1,0 +1,22 @@
+Usage: cardano-cli babbage node new-counter 
+                                              ( --stake-pool-verification-key STRING
+                                              | --genesis-delegate-verification-key STRING
+                                              | --cold-verification-key-file FILE
+                                              )
+                                              --counter-value INT
+                                              --operational-certificate-issue-counter-file FILE
+
+  Create a new certificate issue counter
+
+Available options:
+  --stake-pool-verification-key STRING
+                           Stake pool verification key (Bech32 or hex-encoded).
+  --genesis-delegate-verification-key STRING
+                           Genesis delegate verification key (hex-encoded).
+  --cold-verification-key-file FILE
+                           Filepath of the cold verification key.
+  --counter-value INT      The next certificate issue counter value to use.
+  --operational-certificate-issue-counter-file FILE
+                           The file with the issue counter for the operational
+                           certificate.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query.cli
@@ -1,0 +1,50 @@
+Usage: cardano-cli babbage query 
+                                   ( protocol-parameters
+                                   | constitution-hash
+                                   | tip
+                                   | stake-pools
+                                   | stake-distribution
+                                   | stake-address-info
+                                   | utxo
+                                   | ledger-state
+                                   | protocol-state
+                                   | stake-snapshot
+                                   | leadership-schedule
+                                   | kes-period-info
+                                   | pool-state
+                                   | tx-mempool
+                                   | slot-number
+                                   )
+
+  Era-based query commands
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  protocol-parameters      Get the node's current protocol parameters
+  constitution-hash        Get the constitution hash
+  tip                      Get the node's current tip (slot no, hash, block no)
+  stake-pools              Get the node's current set of stake pool ids
+  stake-distribution       Get the node's current aggregated stake distribution
+  stake-address-info       Get the current delegations and reward accounts
+                           filtered by stake address.
+  utxo                     Get a portion of the current UTxO: by tx in, by
+                           address or the whole.
+  ledger-state             Dump the current ledger state of the node
+                           (Ledger.NewEpochState -- advanced command)
+  protocol-state           Dump the current protocol state of the node
+                           (Ledger.ChainDepState -- advanced command)
+  stake-snapshot           Obtain the three stake snapshots for a pool, plus the
+                           total active stake (advanced command)
+  pool-params              DEPRECATED. Use query pool-state instead. Dump the
+                           pool parameters
+                           (Ledger.NewEpochState.esLState._delegationState._pState._pParams
+                           -- advanced command)
+  leadership-schedule      Get the slots the node is expected to mint a block in
+                           (advanced command)
+  kes-period-info          Get information about the current KES period and your
+                           node's operational certificate.
+  pool-state               Dump the pool state
+  tx-mempool               Local Mempool info
+  slot-number              Query slot number for UTC timestamp

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_constitution-hash.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_constitution-hash.cli
@@ -1,0 +1,34 @@
+Usage: cardano-cli babbage query constitution-hash --socket-path SOCKET_PATH
+                                                     [ --shelley-mode
+                                                     | --byron-mode
+                                                       [--epoch-slots SLOTS]
+                                                     | --cardano-mode
+                                                       [--epoch-slots SLOTS]
+                                                     ]
+                                                     ( --mainnet
+                                                     | --testnet-magic NATURAL
+                                                     )
+                                                     [--out-file FILE]
+
+  Get the constitution hash
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_kes-period-info.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_kes-period-info.cli
@@ -1,0 +1,37 @@
+Usage: cardano-cli babbage query kes-period-info --socket-path SOCKET_PATH
+                                                   [ --shelley-mode
+                                                   | --byron-mode
+                                                     [--epoch-slots SLOTS]
+                                                   | --cardano-mode
+                                                     [--epoch-slots SLOTS]
+                                                   ]
+                                                   ( --mainnet
+                                                   | --testnet-magic NATURAL
+                                                   )
+                                                   --op-cert-file FILE
+                                                   [--out-file FILE]
+
+  Get information about the current KES period and your node's operational
+  certificate.
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --op-cert-file FILE      Filepath of the node's operational certificate.
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_leadership-schedule.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_leadership-schedule.cli
@@ -1,0 +1,54 @@
+Usage: cardano-cli babbage query leadership-schedule --socket-path SOCKET_PATH
+                                                       [ --shelley-mode
+                                                       | --byron-mode
+                                                         [--epoch-slots SLOTS]
+                                                       | --cardano-mode
+                                                         [--epoch-slots SLOTS]
+                                                       ]
+                                                       ( --mainnet
+                                                       | --testnet-magic NATURAL
+                                                       )
+                                                       --genesis FILE
+                                                       ( --stake-pool-verification-key STRING
+                                                       | --cold-verification-key-file FILE
+                                                       | --stake-pool-id STAKE_POOL_ID
+                                                       )
+                                                       --vrf-signing-key-file FILE
+                                                       (--current | --next)
+                                                       [--out-file FILE]
+
+  Get the slots the node is expected to mint a block in (advanced command)
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --genesis FILE           Shelley genesis filepath
+  --stake-pool-verification-key STRING
+                           Stake pool verification key (Bech32 or hex-encoded).
+  --cold-verification-key-file FILE
+                           Filepath of the stake pool verification key.
+  --stake-pool-id STAKE_POOL_ID
+                           Stake pool ID/verification key hash (either
+                           Bech32-encoded or hex-encoded). Zero or more
+                           occurences of this option is allowed.
+  --vrf-signing-key-file FILE
+                           Input filepath of the VRF signing key.
+  --current                Get the leadership schedule for the current epoch.
+  --next                   Get the leadership schedule for the following epoch.
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_ledger-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_ledger-state.cli
@@ -1,0 +1,35 @@
+Usage: cardano-cli babbage query ledger-state --socket-path SOCKET_PATH
+                                                [ --shelley-mode
+                                                | --byron-mode
+                                                  [--epoch-slots SLOTS]
+                                                | --cardano-mode
+                                                  [--epoch-slots SLOTS]
+                                                ]
+                                                ( --mainnet
+                                                | --testnet-magic NATURAL
+                                                )
+                                                [--out-file FILE]
+
+  Dump the current ledger state of the node (Ledger.NewEpochState -- advanced
+  command)
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_pool-params.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_pool-params.cli
@@ -1,0 +1,39 @@
+Usage: cardano-cli babbage query pool-params --socket-path SOCKET_PATH
+                                               [ --shelley-mode
+                                               | --byron-mode
+                                                 [--epoch-slots SLOTS]
+                                               | --cardano-mode
+                                                 [--epoch-slots SLOTS]
+                                               ]
+                                               ( --mainnet
+                                               | --testnet-magic NATURAL
+                                               )
+                                               [--stake-pool-id STAKE_POOL_ID]
+
+  DEPRECATED. Use query pool-state instead. Dump the pool parameters
+  (Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced
+  command)
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --stake-pool-id STAKE_POOL_ID
+                           Stake pool ID/verification key hash (either
+                           Bech32-encoded or hex-encoded). Zero or more
+                           occurences of this option is allowed.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_pool-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_pool-state.cli
@@ -1,0 +1,37 @@
+Usage: cardano-cli babbage query pool-state --socket-path SOCKET_PATH
+                                              [ --shelley-mode
+                                              | --byron-mode
+                                                [--epoch-slots SLOTS]
+                                              | --cardano-mode
+                                                [--epoch-slots SLOTS]
+                                              ]
+                                              ( --mainnet
+                                              | --testnet-magic NATURAL
+                                              )
+                                              [--stake-pool-id STAKE_POOL_ID]
+
+  Dump the pool state
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --stake-pool-id STAKE_POOL_ID
+                           Stake pool ID/verification key hash (either
+                           Bech32-encoded or hex-encoded). Zero or more
+                           occurences of this option is allowed.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_protocol-parameters.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_protocol-parameters.cli
@@ -1,0 +1,34 @@
+Usage: cardano-cli babbage query protocol-parameters --socket-path SOCKET_PATH
+                                                       [ --shelley-mode
+                                                       | --byron-mode
+                                                         [--epoch-slots SLOTS]
+                                                       | --cardano-mode
+                                                         [--epoch-slots SLOTS]
+                                                       ]
+                                                       ( --mainnet
+                                                       | --testnet-magic NATURAL
+                                                       )
+                                                       [--out-file FILE]
+
+  Get the node's current protocol parameters
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_protocol-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_protocol-state.cli
@@ -1,0 +1,35 @@
+Usage: cardano-cli babbage query protocol-state --socket-path SOCKET_PATH
+                                                  [ --shelley-mode
+                                                  | --byron-mode
+                                                    [--epoch-slots SLOTS]
+                                                  | --cardano-mode
+                                                    [--epoch-slots SLOTS]
+                                                  ]
+                                                  ( --mainnet
+                                                  | --testnet-magic NATURAL
+                                                  )
+                                                  [--out-file FILE]
+
+  Dump the current protocol state of the node (Ledger.ChainDepState -- advanced
+  command)
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_slot-number.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_slot-number.cli
@@ -1,0 +1,34 @@
+Usage: cardano-cli babbage query slot-number --socket-path SOCKET_PATH
+                                               [ --shelley-mode
+                                               | --byron-mode
+                                                 [--epoch-slots SLOTS]
+                                               | --cardano-mode
+                                                 [--epoch-slots SLOTS]
+                                               ]
+                                               ( --mainnet
+                                               | --testnet-magic NATURAL
+                                               )
+                                               TIMESTAMP
+
+  Query slot number for UTC timestamp
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  TIMESTAMP                UTC timestamp in YYYY-MM-DDThh:mm:ssZ format
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_stake-address-info.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_stake-address-info.cli
@@ -1,0 +1,36 @@
+Usage: cardano-cli babbage query stake-address-info --socket-path SOCKET_PATH
+                                                      [ --shelley-mode
+                                                      | --byron-mode
+                                                        [--epoch-slots SLOTS]
+                                                      | --cardano-mode
+                                                        [--epoch-slots SLOTS]
+                                                      ]
+                                                      --address ADDRESS
+                                                      ( --mainnet
+                                                      | --testnet-magic NATURAL
+                                                      )
+                                                      [--out-file FILE]
+
+  Get the current delegations and reward accounts filtered by stake address.
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --address ADDRESS        Filter by Cardano stake address (Bech32-encoded).
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_stake-distribution.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_stake-distribution.cli
@@ -1,0 +1,34 @@
+Usage: cardano-cli babbage query stake-distribution --socket-path SOCKET_PATH
+                                                      [ --shelley-mode
+                                                      | --byron-mode
+                                                        [--epoch-slots SLOTS]
+                                                      | --cardano-mode
+                                                        [--epoch-slots SLOTS]
+                                                      ]
+                                                      ( --mainnet
+                                                      | --testnet-magic NATURAL
+                                                      )
+                                                      [--out-file FILE]
+
+  Get the node's current aggregated stake distribution
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_stake-pools.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_stake-pools.cli
@@ -1,0 +1,34 @@
+Usage: cardano-cli babbage query stake-pools --socket-path SOCKET_PATH
+                                               [ --shelley-mode
+                                               | --byron-mode
+                                                 [--epoch-slots SLOTS]
+                                               | --cardano-mode
+                                                 [--epoch-slots SLOTS]
+                                               ]
+                                               ( --mainnet
+                                               | --testnet-magic NATURAL
+                                               )
+                                               [--out-file FILE]
+
+  Get the node's current set of stake pool ids
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_stake-snapshot.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_stake-snapshot.cli
@@ -1,0 +1,44 @@
+Usage: cardano-cli babbage query stake-snapshot --socket-path SOCKET_PATH
+                                                  [ --shelley-mode
+                                                  | --byron-mode
+                                                    [--epoch-slots SLOTS]
+                                                  | --cardano-mode
+                                                    [--epoch-slots SLOTS]
+                                                  ]
+                                                  ( --mainnet
+                                                  | --testnet-magic NATURAL
+                                                  )
+                                                  [ --all-stake-pools
+                                                  | 
+                                                  [--stake-pool-id STAKE_POOL_ID]
+                                                  ]
+                                                  [--out-file FILE]
+
+  Obtain the three stake snapshots for a pool, plus the total active stake
+  (advanced command)
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --all-stake-pools        Query for all stake pools
+  --stake-pool-id STAKE_POOL_ID
+                           Stake pool ID/verification key hash (either
+                           Bech32-encoded or hex-encoded). Zero or more
+                           occurences of this option is allowed.
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_tip.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_tip.cli
@@ -1,0 +1,30 @@
+Usage: cardano-cli babbage query tip --socket-path SOCKET_PATH
+                                       [ --shelley-mode
+                                       | --byron-mode [--epoch-slots SLOTS]
+                                       | --cardano-mode [--epoch-slots SLOTS]
+                                       ]
+                                       (--mainnet | --testnet-magic NATURAL)
+                                       [--out-file FILE]
+
+  Get the node's current tip (slot no, hash, block no)
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_tx-mempool.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_tx-mempool.cli
@@ -1,0 +1,43 @@
+Usage: cardano-cli babbage query tx-mempool --socket-path SOCKET_PATH
+                                              [ --shelley-mode
+                                              | --byron-mode
+                                                [--epoch-slots SLOTS]
+                                              | --cardano-mode
+                                                [--epoch-slots SLOTS]
+                                              ]
+                                              ( --mainnet
+                                              | --testnet-magic NATURAL
+                                              )
+                                              (info | next-tx | tx-exists)
+                                              [--out-file FILE]
+
+  Local Mempool info
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text
+
+Available commands:
+  info                     Ask the node about the current mempool's capacity and
+                           sizes
+  next-tx                  Requests the next transaction from the mempool's
+                           current list
+  tx-exists                Query if a particular transaction exists in the
+                           mempool

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_tx-mempool_info.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_tx-mempool_info.cli
@@ -1,0 +1,16 @@
+Missing: --socket-path SOCKET_PATH (--mainnet | --testnet-magic NATURAL)
+
+Usage: cardano-cli babbage query tx-mempool --socket-path SOCKET_PATH
+                                              [ --shelley-mode
+                                              | --byron-mode
+                                                [--epoch-slots SLOTS]
+                                              | --cardano-mode
+                                                [--epoch-slots SLOTS]
+                                              ]
+                                              ( --mainnet
+                                              | --testnet-magic NATURAL
+                                              )
+                                              (info | next-tx | tx-exists)
+                                              [--out-file FILE]
+
+  Local Mempool info

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_tx-mempool_next-tx.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_tx-mempool_next-tx.cli
@@ -1,0 +1,16 @@
+Missing: --socket-path SOCKET_PATH (--mainnet | --testnet-magic NATURAL)
+
+Usage: cardano-cli babbage query tx-mempool --socket-path SOCKET_PATH
+                                              [ --shelley-mode
+                                              | --byron-mode
+                                                [--epoch-slots SLOTS]
+                                              | --cardano-mode
+                                                [--epoch-slots SLOTS]
+                                              ]
+                                              ( --mainnet
+                                              | --testnet-magic NATURAL
+                                              )
+                                              (info | next-tx | tx-exists)
+                                              [--out-file FILE]
+
+  Local Mempool info

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_tx-mempool_tx-exists_TX_ID.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_tx-mempool_tx-exists_TX_ID.cli
@@ -1,0 +1,16 @@
+Missing: --socket-path SOCKET_PATH (--mainnet | --testnet-magic NATURAL)
+
+Usage: cardano-cli babbage query tx-mempool --socket-path SOCKET_PATH
+                                              [ --shelley-mode
+                                              | --byron-mode
+                                                [--epoch-slots SLOTS]
+                                              | --cardano-mode
+                                                [--epoch-slots SLOTS]
+                                              ]
+                                              ( --mainnet
+                                              | --testnet-magic NATURAL
+                                              )
+                                              (info | next-tx | tx-exists)
+                                              [--out-file FILE]
+
+  Local Mempool info

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_utxo.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_utxo.cli
@@ -1,0 +1,38 @@
+Usage: cardano-cli babbage query utxo --socket-path SOCKET_PATH
+                                        [ --shelley-mode
+                                        | --byron-mode [--epoch-slots SLOTS]
+                                        | --cardano-mode [--epoch-slots SLOTS]
+                                        ]
+                                        ( --whole-utxo
+                                        | (--address ADDRESS)
+                                        | (--tx-in TX-IN)
+                                        )
+                                        (--mainnet | --testnet-magic NATURAL)
+                                        [--out-file FILE]
+
+  Get a portion of the current UTxO: by tx in, by address or the whole.
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --whole-utxo             Return the whole UTxO (only appropriate on small
+                           testnets).
+  --address ADDRESS        Filter by Cardano address(es) (Bech32-encoded).
+  --tx-in TX-IN            Filter by transaction input (TxId#TxIx).
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_text-view_decode-cbor.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_text-view_decode-cbor.cli
@@ -1,0 +1,9 @@
+Usage: cardano-cli babbage text-view decode-cbor --in-file FILE
+                                                   [--out-file FILE]
+
+  Print a TextView file as decoded CBOR.
+
+Available options:
+  --in-file FILE           CBOR input file.
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_transaction.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_transaction.cli
@@ -13,7 +13,7 @@ Usage: cardano-cli babbage transaction
                                          | view
                                          )
 
-  Era-based governance commands
+  Era-based transaction commands
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway.cli
@@ -1,4 +1,14 @@
-Usage: cardano-cli conway (address | governance | stake-address | transaction)
+Usage: cardano-cli conway 
+                            ( address
+                            | key
+                            | genesis
+                            | governance
+                            | node
+                            | query
+                            | stake-address
+                            | text-view
+                            | transaction
+                            )
 
   Conway era commands
 
@@ -7,6 +17,11 @@ Available options:
 
 Available commands:
   address                  Era-based address commands
+  key                      Era-based key commands
+  genesis                  Era-based genesis commands
   governance               Era-based governance commands
+  node                     Era-based node commands
+  query                    Era-based query commands
   stake-address            Stake address commands.
-  transaction              Era-based governance commands
+  text-view                Era-based text-view commands
+  transaction              Era-based transaction commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_genesis.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_genesis.cli
@@ -1,0 +1,37 @@
+Usage: cardano-cli conway genesis 
+                                    ( key-gen-genesis
+                                    | key-gen-delegate
+                                    | key-gen-utxo
+                                    | key-hash
+                                    | get-ver-key
+                                    | initial-addr
+                                    | initial-txin
+                                    | create-cardano
+                                    | create
+                                    | create-staked
+                                    | hash
+                                    )
+
+  Era-based genesis commands
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  key-gen-genesis          Create a Shelley genesis key pair
+  key-gen-delegate         Create a Shelley genesis delegate key pair
+  key-gen-utxo             Create a Shelley genesis UTxO key pair
+  key-hash                 Print the identifier (hash) of a public key
+  get-ver-key              Derive the verification key from a signing key
+  initial-addr             Get the address for an initial UTxO based on the
+                           verification key
+  initial-txin             Get the TxIn for an initial UTxO based on the
+                           verification key
+  create-cardano           Create a Byron and Shelley genesis file from a
+                           genesis template and genesis/delegation/spending
+                           keys.
+  create                   Create a Shelley genesis file from a genesis template
+                           and genesis/delegation/spending keys.
+  create-staked            Create a staked Shelley genesis file from a genesis
+                           template and genesis/delegation/spending keys.
+  hash                     Compute the hash of a genesis file

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_genesis_create-cardano.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_genesis_create-cardano.cli
@@ -1,0 +1,51 @@
+Usage: cardano-cli conway genesis create-cardano --genesis-dir DIR
+                                                   [--gen-genesis-keys INT]
+                                                   [--gen-utxo-keys INT]
+                                                   [--start-time UTC-TIME]
+                                                   [--supply LOVELACE]
+                                                   [--security-param INT]
+                                                   [--slot-length INT]
+                                                   [--slot-coefficient RATIONAL]
+                                                   ( --mainnet
+                                                   | --testnet-magic NATURAL
+                                                   )
+                                                   --byron-template FILEPATH
+                                                   --shelley-template FILEPATH
+                                                   --alonzo-template FILEPATH
+                                                   --conway-template FILEPATH
+                                                   [--node-config-template FILEPATH]
+
+  Create a Byron and Shelley genesis file from a genesis template and
+  genesis/delegation/spending keys.
+
+Available options:
+  --genesis-dir DIR        The genesis directory containing the genesis template
+                           and required genesis/delegation/spending keys.
+  --gen-genesis-keys INT   The number of genesis keys to make [default is 3].
+  --gen-utxo-keys INT      The number of UTxO keys to make [default is 0].
+  --start-time UTC-TIME    The genesis start time in YYYY-MM-DDThh:mm:ssZ
+                           format. If unspecified, will be the current time +30
+                           seconds.
+  --supply LOVELACE        The initial coin supply in Lovelace which will be
+                           evenly distributed across initial, non-delegating
+                           stake holders.
+  --security-param INT     Security parameter for genesis file [default is 108].
+  --slot-length INT        slot length (ms) parameter for genesis file [default
+                           is 1000].
+  --slot-coefficient RATIONAL
+                           Slot Coefficient for genesis file [default is .05].
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --byron-template FILEPATH
+                           JSON file with genesis defaults for each byron.
+  --shelley-template FILEPATH
+                           JSON file with genesis defaults for each shelley.
+  --alonzo-template FILEPATH
+                           JSON file with genesis defaults for alonzo.
+  --conway-template FILEPATH
+                           JSON file with genesis defaults for conway.
+  --node-config-template FILEPATH
+                           the node config template
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_genesis_create-staked.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_genesis_create-staked.cli
@@ -1,0 +1,57 @@
+Usage: cardano-cli conway genesis create-staked [--key-output-format STRING]
+                                                  --genesis-dir DIR
+                                                  [--gen-genesis-keys INT]
+                                                  [--gen-utxo-keys INT]
+                                                  [--gen-pools INT]
+                                                  [--gen-stake-delegs INT]
+                                                  [--start-time UTC-TIME]
+                                                  [--supply LOVELACE]
+                                                  [--supply-delegated LOVELACE]
+                                                  ( --mainnet
+                                                  | --testnet-magic NATURAL
+                                                  )
+                                                  [--bulk-pool-cred-files INT]
+                                                  [--bulk-pools-per-file INT]
+                                                  [--num-stuffed-utxo INT]
+                                                  [--relay-specification-file FILE]
+
+  Create a staked Shelley genesis file from a genesis template and
+  genesis/delegation/spending keys.
+
+Available options:
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32" (default is
+                           "bech32").
+  --genesis-dir DIR        The genesis directory containing the genesis template
+                           and required genesis/delegation/spending keys.
+  --gen-genesis-keys INT   The number of genesis keys to make [default is 3].
+  --gen-utxo-keys INT      The number of UTxO keys to make [default is 0].
+  --gen-pools INT          The number of stake pool credential sets to make
+                           [default is 0].
+  --gen-stake-delegs INT   The number of stake delegator credential sets to make
+                           [default is 0].
+  --start-time UTC-TIME    The genesis start time in YYYY-MM-DDThh:mm:ssZ
+                           format. If unspecified, will be the current time +30
+                           seconds.
+  --supply LOVELACE        The initial coin supply in Lovelace which will be
+                           evenly distributed across initial, non-delegating
+                           stake holders.
+  --supply-delegated LOVELACE
+                           The initial coin supply in Lovelace which will be
+                           evenly distributed across initial, delegating stake
+                           holders.
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --bulk-pool-cred-files INT
+                           Generate bulk pool credential files [default is 0].
+  --bulk-pools-per-file INT
+                           Each bulk pool to contain this many pool credential
+                           sets [default is 0].
+  --num-stuffed-utxo INT   The number of fake UTxO entries to generate [default
+                           is 0].
+  --relay-specification-file FILE
+                           JSON file specified the relays of each stake pool.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_genesis_create.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_genesis_create.cli
@@ -1,0 +1,31 @@
+Usage: cardano-cli conway genesis create [--key-output-format STRING]
+                                           --genesis-dir DIR
+                                           [--gen-genesis-keys INT]
+                                           [--gen-utxo-keys INT]
+                                           [--start-time UTC-TIME]
+                                           [--supply LOVELACE]
+                                           (--mainnet | --testnet-magic NATURAL)
+
+  Create a Shelley genesis file from a genesis template and
+  genesis/delegation/spending keys.
+
+Available options:
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32" (default is
+                           "bech32").
+  --genesis-dir DIR        The genesis directory containing the genesis template
+                           and required genesis/delegation/spending keys.
+  --gen-genesis-keys INT   The number of genesis keys to make [default is 3].
+  --gen-utxo-keys INT      The number of UTxO keys to make [default is 0].
+  --start-time UTC-TIME    The genesis start time in YYYY-MM-DDThh:mm:ssZ
+                           format. If unspecified, will be the current time +30
+                           seconds.
+  --supply LOVELACE        The initial coin supply in Lovelace which will be
+                           evenly distributed across initial, non-delegating
+                           stake holders.
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_genesis_get-ver-key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_genesis_get-ver-key.cli
@@ -1,0 +1,10 @@
+Usage: cardano-cli conway genesis get-ver-key --verification-key-file FILE
+                                                --signing-key-file FILE
+
+  Derive the verification key from a signing key
+
+Available options:
+  --verification-key-file FILE
+                           Output filepath of the verification key.
+  --signing-key-file FILE  Input filepath of the signing key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_genesis_hash.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_genesis_hash.cli
@@ -1,0 +1,7 @@
+Usage: cardano-cli conway genesis hash --genesis FILE
+
+  Compute the hash of a genesis file
+
+Available options:
+  --genesis FILE           The genesis file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_genesis_initial-addr.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_genesis_initial-addr.cli
@@ -1,0 +1,17 @@
+Usage: cardano-cli conway genesis initial-addr --verification-key-file FILE
+                                                 ( --mainnet
+                                                 | --testnet-magic NATURAL
+                                                 )
+                                                 [--out-file FILE]
+
+  Get the address for an initial UTxO based on the verification key
+
+Available options:
+  --verification-key-file FILE
+                           Input filepath of the verification key.
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_genesis_initial-txin.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_genesis_initial-txin.cli
@@ -1,0 +1,17 @@
+Usage: cardano-cli conway genesis initial-txin --verification-key-file FILE
+                                                 ( --mainnet
+                                                 | --testnet-magic NATURAL
+                                                 )
+                                                 [--out-file FILE]
+
+  Get the TxIn for an initial UTxO based on the verification key
+
+Available options:
+  --verification-key-file FILE
+                           Input filepath of the verification key.
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_genesis_key-gen-delegate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_genesis_key-gen-delegate.cli
@@ -1,0 +1,14 @@
+Usage: cardano-cli conway genesis key-gen-delegate --verification-key-file FILE
+                                                     --signing-key-file FILE
+                                                     --operational-certificate-issue-counter-file FILE
+
+  Create a Shelley genesis delegate key pair
+
+Available options:
+  --verification-key-file FILE
+                           Output filepath of the verification key.
+  --signing-key-file FILE  Output filepath of the signing key.
+  --operational-certificate-issue-counter-file FILE
+                           The file with the issue counter for the operational
+                           certificate.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_genesis_key-gen-genesis.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_genesis_key-gen-genesis.cli
@@ -1,0 +1,10 @@
+Usage: cardano-cli conway genesis key-gen-genesis --verification-key-file FILE
+                                                    --signing-key-file FILE
+
+  Create a Shelley genesis key pair
+
+Available options:
+  --verification-key-file FILE
+                           Output filepath of the verification key.
+  --signing-key-file FILE  Output filepath of the signing key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_genesis_key-gen-utxo.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_genesis_key-gen-utxo.cli
@@ -1,0 +1,10 @@
+Usage: cardano-cli conway genesis key-gen-utxo --verification-key-file FILE
+                                                 --signing-key-file FILE
+
+  Create a Shelley genesis UTxO key pair
+
+Available options:
+  --verification-key-file FILE
+                           Output filepath of the verification key.
+  --signing-key-file FILE  Output filepath of the signing key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_genesis_key-hash.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_genesis_key-hash.cli
@@ -1,0 +1,8 @@
+Usage: cardano-cli conway genesis key-hash --verification-key-file FILE
+
+  Print the identifier (hash) of a public key
+
+Available options:
+  --verification-key-file FILE
+                           Input filepath of the verification key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_key.cli
@@ -1,0 +1,40 @@
+Usage: cardano-cli conway key 
+                                ( verification-key
+                                | non-extended-key
+                                | convert-byron-key
+                                | convert-byron-genesis-vkey
+                                | convert-itn-key
+                                | convert-itn-extended-key
+                                | convert-itn-bip32-key
+                                | convert-cardano-address-key
+                                )
+
+  Era-based key commands
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  verification-key         Get a verification key from a signing key. This
+                           supports all key types.
+  non-extended-key         Get a non-extended verification key from an extended
+                           verification key. This supports all extended key
+                           types.
+  convert-byron-key        Convert a Byron payment, genesis or genesis delegate
+                           key (signing or verification) to a corresponding
+                           Shelley-format key.
+  convert-byron-genesis-vkey
+                           Convert a Base64-encoded Byron genesis verification
+                           key to a Shelley genesis verification key
+  convert-itn-key          Convert an Incentivized Testnet (ITN) non-extended
+                           (Ed25519) signing or verification key to a
+                           corresponding Shelley stake key
+  convert-itn-extended-key Convert an Incentivized Testnet (ITN) extended
+                           (Ed25519Extended) signing key to a corresponding
+                           Shelley stake signing key
+  convert-itn-bip32-key    Convert an Incentivized Testnet (ITN) BIP32
+                           (Ed25519Bip32) signing key to a corresponding Shelley
+                           stake signing key
+  convert-cardano-address-key
+                           Convert a cardano-address extended signing key to a
+                           corresponding Shelley-format key.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_key_convert-byron-genesis-vkey.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_key_convert-byron-genesis-vkey.cli
@@ -1,0 +1,11 @@
+Usage: cardano-cli conway key convert-byron-genesis-vkey --byron-genesis-verification-key BASE64
+                                                           --out-file FILE
+
+  Convert a Base64-encoded Byron genesis verification key to a Shelley genesis
+  verification key
+
+Available options:
+  --byron-genesis-verification-key BASE64
+                           Base64 string for the Byron genesis verification key.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_key_convert-byron-key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_key_convert-byron-key.cli
@@ -1,0 +1,35 @@
+Usage: cardano-cli conway key convert-byron-key [--password TEXT]
+                                                  ( --byron-payment-key-type
+                                                  | --legacy-byron-payment-key-type
+                                                  | --byron-genesis-key-type
+                                                  | --legacy-byron-genesis-key-type
+                                                  | --byron-genesis-delegate-key-type
+                                                  | --legacy-byron-genesis-delegate-key-type
+                                                  )
+                                                  ( --byron-signing-key-file FILE
+                                                  | --byron-verification-key-file FILE
+                                                  )
+                                                  --out-file FILE
+
+  Convert a Byron payment, genesis or genesis delegate key (signing or
+  verification) to a corresponding Shelley-format key.
+
+Available options:
+  --password TEXT          Password for signing key (if applicable).
+  --byron-payment-key-type Use a Byron-era payment key.
+  --legacy-byron-payment-key-type
+                           Use a Byron-era payment key, in legacy SL format.
+  --byron-genesis-key-type Use a Byron-era genesis key.
+  --legacy-byron-genesis-key-type
+                           Use a Byron-era genesis key, in legacy SL format.
+  --byron-genesis-delegate-key-type
+                           Use a Byron-era genesis delegate key.
+  --legacy-byron-genesis-delegate-key-type
+                           Use a Byron-era genesis delegate key, in legacy SL
+                           format.
+  --byron-signing-key-file FILE
+                           Input filepath of the Byron-format signing key.
+  --byron-verification-key-file FILE
+                           Input filepath of the Byron-format verification key.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_key_convert-cardano-address-key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_key_convert-cardano-address-key.cli
@@ -1,0 +1,22 @@
+Usage: cardano-cli conway key convert-cardano-address-key 
+                                                            ( --shelley-payment-key
+                                                            | --shelley-stake-key
+                                                            | --icarus-payment-key
+                                                            | --byron-payment-key
+                                                            )
+                                                            --signing-key-file FILE
+                                                            --out-file FILE
+
+  Convert a cardano-address extended signing key to a corresponding
+  Shelley-format key.
+
+Available options:
+  --shelley-payment-key    Use a Shelley-era extended payment key.
+  --shelley-stake-key      Use a Shelley-era extended stake key.
+  --icarus-payment-key     Use a Byron-era extended payment key formatted in the
+                           Icarus style.
+  --byron-payment-key      Use a Byron-era extended payment key formatted in the
+                           deprecated Byron style.
+  --signing-key-file FILE  Input filepath of the signing key.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_key_convert-itn-bip32-key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_key_convert-itn-bip32-key.cli
@@ -1,0 +1,11 @@
+Usage: cardano-cli conway key convert-itn-bip32-key --itn-signing-key-file FILE
+                                                      --out-file FILE
+
+  Convert an Incentivized Testnet (ITN) BIP32 (Ed25519Bip32) signing key to a
+  corresponding Shelley stake signing key
+
+Available options:
+  --itn-signing-key-file FILE
+                           Filepath of the ITN signing key.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_key_convert-itn-extended-key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_key_convert-itn-extended-key.cli
@@ -1,0 +1,11 @@
+Usage: cardano-cli conway key convert-itn-extended-key --itn-signing-key-file FILE
+                                                         --out-file FILE
+
+  Convert an Incentivized Testnet (ITN) extended (Ed25519Extended) signing key
+  to a corresponding Shelley stake signing key
+
+Available options:
+  --itn-signing-key-file FILE
+                           Filepath of the ITN signing key.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_key_convert-itn-key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_key_convert-itn-key.cli
@@ -1,0 +1,16 @@
+Usage: cardano-cli conway key convert-itn-key 
+                                                ( --itn-signing-key-file FILE
+                                                | --itn-verification-key-file FILE
+                                                )
+                                                --out-file FILE
+
+  Convert an Incentivized Testnet (ITN) non-extended (Ed25519) signing or
+  verification key to a corresponding Shelley stake key
+
+Available options:
+  --itn-signing-key-file FILE
+                           Filepath of the ITN signing key.
+  --itn-verification-key-file FILE
+                           Filepath of the ITN verification key.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_key_non-extended-key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_key_non-extended-key.cli
@@ -1,0 +1,12 @@
+Usage: cardano-cli conway key non-extended-key --extended-verification-key-file FILE
+                                                 --verification-key-file FILE
+
+  Get a non-extended verification key from an extended verification key. This
+  supports all extended key types.
+
+Available options:
+  --extended-verification-key-file FILE
+                           Input filepath of the ed25519-bip32 verification key.
+  --verification-key-file FILE
+                           Output filepath of the verification key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_key_verification-key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_key_verification-key.cli
@@ -1,0 +1,10 @@
+Usage: cardano-cli conway key verification-key --signing-key-file FILE
+                                                 --verification-key-file FILE
+
+  Get a verification key from a signing key. This supports all key types.
+
+Available options:
+  --signing-key-file FILE  Input filepath of the signing key.
+  --verification-key-file FILE
+                           Output filepath of the verification key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_node.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_node.cli
@@ -1,0 +1,22 @@
+Usage: cardano-cli conway node 
+                                 ( key-gen
+                                 | key-gen-KES
+                                 | key-gen-VRF
+                                 | key-hash-VRF
+                                 | new-counter
+                                 | issue-op-cert
+                                 )
+
+  Era-based node commands
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  key-gen                  Create a key pair for a node operator's offline key
+                           and a new certificate issue counter
+  key-gen-KES              Create a key pair for a node KES operational key
+  key-gen-VRF              Create a key pair for a node VRF operational key
+  key-hash-VRF             Print hash of a node's operational VRF key.
+  new-counter              Create a new certificate issue counter
+  issue-op-cert            Issue a node operational certificate

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_node_issue-op-cert.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_node_issue-op-cert.cli
@@ -1,0 +1,24 @@
+Usage: cardano-cli conway node issue-op-cert 
+                                               ( --kes-verification-key STRING
+                                               | --kes-verification-key-file FILE
+                                               )
+                                               --cold-signing-key-file FILE
+                                               --operational-certificate-issue-counter-file FILE
+                                               --kes-period NATURAL
+                                               --out-file FILE
+
+  Issue a node operational certificate
+
+Available options:
+  --kes-verification-key STRING
+                           A Bech32 or hex-encoded hot KES verification key.
+  --kes-verification-key-file FILE
+                           Filepath of the hot KES verification key.
+  --cold-signing-key-file FILE
+                           Filepath of the cold signing key.
+  --operational-certificate-issue-counter-file FILE
+                           The file with the issue counter for the operational
+                           certificate.
+  --kes-period NATURAL     The start of the KES key validity period.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_node_key-gen-KES.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_node_key-gen-KES.cli
@@ -1,0 +1,15 @@
+Usage: cardano-cli conway node key-gen-KES [--key-output-format STRING]
+                                             --verification-key-file FILE
+                                             --signing-key-file FILE
+
+  Create a key pair for a node KES operational key
+
+Available options:
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32" (default is
+                           "bech32").
+  --verification-key-file FILE
+                           Output filepath of the verification key.
+  --signing-key-file FILE  Output filepath of the signing key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_node_key-gen-VRF.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_node_key-gen-VRF.cli
@@ -1,0 +1,15 @@
+Usage: cardano-cli conway node key-gen-VRF [--key-output-format STRING]
+                                             --verification-key-file FILE
+                                             --signing-key-file FILE
+
+  Create a key pair for a node VRF operational key
+
+Available options:
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32" (default is
+                           "bech32").
+  --verification-key-file FILE
+                           Output filepath of the verification key.
+  --signing-key-file FILE  Output filepath of the signing key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_node_key-gen.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_node_key-gen.cli
@@ -1,0 +1,21 @@
+Usage: cardano-cli conway node key-gen [--key-output-format STRING]
+                                         --cold-verification-key-file FILE
+                                         --cold-signing-key-file FILE
+                                         --operational-certificate-issue-counter-file FILE
+
+  Create a key pair for a node operator's offline key and a new certificate
+  issue counter
+
+Available options:
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32" (default is
+                           "bech32").
+  --cold-verification-key-file FILE
+                           Filepath of the cold verification key.
+  --cold-signing-key-file FILE
+                           Filepath of the cold signing key.
+  --operational-certificate-issue-counter-file FILE
+                           The file with the issue counter for the operational
+                           certificate.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_node_key-hash-VRF.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_node_key-hash-VRF.cli
@@ -1,0 +1,15 @@
+Usage: cardano-cli conway node key-hash-VRF 
+                                              ( --verification-key STRING
+                                              | --verification-key-file FILE
+                                              )
+                                              [--out-file FILE]
+
+  Print hash of a node's operational VRF key.
+
+Available options:
+  --verification-key STRING
+                           Verification key (Bech32 or hex-encoded).
+  --verification-key-file FILE
+                           Input filepath of the verification key.
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_node_new-counter.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_node_new-counter.cli
@@ -1,0 +1,22 @@
+Usage: cardano-cli conway node new-counter 
+                                             ( --stake-pool-verification-key STRING
+                                             | --genesis-delegate-verification-key STRING
+                                             | --cold-verification-key-file FILE
+                                             )
+                                             --counter-value INT
+                                             --operational-certificate-issue-counter-file FILE
+
+  Create a new certificate issue counter
+
+Available options:
+  --stake-pool-verification-key STRING
+                           Stake pool verification key (Bech32 or hex-encoded).
+  --genesis-delegate-verification-key STRING
+                           Genesis delegate verification key (hex-encoded).
+  --cold-verification-key-file FILE
+                           Filepath of the cold verification key.
+  --counter-value INT      The next certificate issue counter value to use.
+  --operational-certificate-issue-counter-file FILE
+                           The file with the issue counter for the operational
+                           certificate.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query.cli
@@ -1,0 +1,50 @@
+Usage: cardano-cli conway query 
+                                  ( protocol-parameters
+                                  | constitution-hash
+                                  | tip
+                                  | stake-pools
+                                  | stake-distribution
+                                  | stake-address-info
+                                  | utxo
+                                  | ledger-state
+                                  | protocol-state
+                                  | stake-snapshot
+                                  | leadership-schedule
+                                  | kes-period-info
+                                  | pool-state
+                                  | tx-mempool
+                                  | slot-number
+                                  )
+
+  Era-based query commands
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  protocol-parameters      Get the node's current protocol parameters
+  constitution-hash        Get the constitution hash
+  tip                      Get the node's current tip (slot no, hash, block no)
+  stake-pools              Get the node's current set of stake pool ids
+  stake-distribution       Get the node's current aggregated stake distribution
+  stake-address-info       Get the current delegations and reward accounts
+                           filtered by stake address.
+  utxo                     Get a portion of the current UTxO: by tx in, by
+                           address or the whole.
+  ledger-state             Dump the current ledger state of the node
+                           (Ledger.NewEpochState -- advanced command)
+  protocol-state           Dump the current protocol state of the node
+                           (Ledger.ChainDepState -- advanced command)
+  stake-snapshot           Obtain the three stake snapshots for a pool, plus the
+                           total active stake (advanced command)
+  pool-params              DEPRECATED. Use query pool-state instead. Dump the
+                           pool parameters
+                           (Ledger.NewEpochState.esLState._delegationState._pState._pParams
+                           -- advanced command)
+  leadership-schedule      Get the slots the node is expected to mint a block in
+                           (advanced command)
+  kes-period-info          Get information about the current KES period and your
+                           node's operational certificate.
+  pool-state               Dump the pool state
+  tx-mempool               Local Mempool info
+  slot-number              Query slot number for UTC timestamp

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_constitution-hash.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_constitution-hash.cli
@@ -1,0 +1,34 @@
+Usage: cardano-cli conway query constitution-hash --socket-path SOCKET_PATH
+                                                    [ --shelley-mode
+                                                    | --byron-mode
+                                                      [--epoch-slots SLOTS]
+                                                    | --cardano-mode
+                                                      [--epoch-slots SLOTS]
+                                                    ]
+                                                    ( --mainnet
+                                                    | --testnet-magic NATURAL
+                                                    )
+                                                    [--out-file FILE]
+
+  Get the constitution hash
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_kes-period-info.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_kes-period-info.cli
@@ -1,0 +1,37 @@
+Usage: cardano-cli conway query kes-period-info --socket-path SOCKET_PATH
+                                                  [ --shelley-mode
+                                                  | --byron-mode
+                                                    [--epoch-slots SLOTS]
+                                                  | --cardano-mode
+                                                    [--epoch-slots SLOTS]
+                                                  ]
+                                                  ( --mainnet
+                                                  | --testnet-magic NATURAL
+                                                  )
+                                                  --op-cert-file FILE
+                                                  [--out-file FILE]
+
+  Get information about the current KES period and your node's operational
+  certificate.
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --op-cert-file FILE      Filepath of the node's operational certificate.
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_leadership-schedule.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_leadership-schedule.cli
@@ -1,0 +1,54 @@
+Usage: cardano-cli conway query leadership-schedule --socket-path SOCKET_PATH
+                                                      [ --shelley-mode
+                                                      | --byron-mode
+                                                        [--epoch-slots SLOTS]
+                                                      | --cardano-mode
+                                                        [--epoch-slots SLOTS]
+                                                      ]
+                                                      ( --mainnet
+                                                      | --testnet-magic NATURAL
+                                                      )
+                                                      --genesis FILE
+                                                      ( --stake-pool-verification-key STRING
+                                                      | --cold-verification-key-file FILE
+                                                      | --stake-pool-id STAKE_POOL_ID
+                                                      )
+                                                      --vrf-signing-key-file FILE
+                                                      (--current | --next)
+                                                      [--out-file FILE]
+
+  Get the slots the node is expected to mint a block in (advanced command)
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --genesis FILE           Shelley genesis filepath
+  --stake-pool-verification-key STRING
+                           Stake pool verification key (Bech32 or hex-encoded).
+  --cold-verification-key-file FILE
+                           Filepath of the stake pool verification key.
+  --stake-pool-id STAKE_POOL_ID
+                           Stake pool ID/verification key hash (either
+                           Bech32-encoded or hex-encoded). Zero or more
+                           occurences of this option is allowed.
+  --vrf-signing-key-file FILE
+                           Input filepath of the VRF signing key.
+  --current                Get the leadership schedule for the current epoch.
+  --next                   Get the leadership schedule for the following epoch.
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_ledger-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_ledger-state.cli
@@ -1,0 +1,35 @@
+Usage: cardano-cli conway query ledger-state --socket-path SOCKET_PATH
+                                               [ --shelley-mode
+                                               | --byron-mode
+                                                 [--epoch-slots SLOTS]
+                                               | --cardano-mode
+                                                 [--epoch-slots SLOTS]
+                                               ]
+                                               ( --mainnet
+                                               | --testnet-magic NATURAL
+                                               )
+                                               [--out-file FILE]
+
+  Dump the current ledger state of the node (Ledger.NewEpochState -- advanced
+  command)
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_pool-params.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_pool-params.cli
@@ -1,0 +1,39 @@
+Usage: cardano-cli conway query pool-params --socket-path SOCKET_PATH
+                                              [ --shelley-mode
+                                              | --byron-mode
+                                                [--epoch-slots SLOTS]
+                                              | --cardano-mode
+                                                [--epoch-slots SLOTS]
+                                              ]
+                                              ( --mainnet
+                                              | --testnet-magic NATURAL
+                                              )
+                                              [--stake-pool-id STAKE_POOL_ID]
+
+  DEPRECATED. Use query pool-state instead. Dump the pool parameters
+  (Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced
+  command)
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --stake-pool-id STAKE_POOL_ID
+                           Stake pool ID/verification key hash (either
+                           Bech32-encoded or hex-encoded). Zero or more
+                           occurences of this option is allowed.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_pool-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_pool-state.cli
@@ -1,0 +1,37 @@
+Usage: cardano-cli conway query pool-state --socket-path SOCKET_PATH
+                                             [ --shelley-mode
+                                             | --byron-mode
+                                               [--epoch-slots SLOTS]
+                                             | --cardano-mode
+                                               [--epoch-slots SLOTS]
+                                             ]
+                                             ( --mainnet
+                                             | --testnet-magic NATURAL
+                                             )
+                                             [--stake-pool-id STAKE_POOL_ID]
+
+  Dump the pool state
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --stake-pool-id STAKE_POOL_ID
+                           Stake pool ID/verification key hash (either
+                           Bech32-encoded or hex-encoded). Zero or more
+                           occurences of this option is allowed.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_protocol-parameters.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_protocol-parameters.cli
@@ -1,0 +1,34 @@
+Usage: cardano-cli conway query protocol-parameters --socket-path SOCKET_PATH
+                                                      [ --shelley-mode
+                                                      | --byron-mode
+                                                        [--epoch-slots SLOTS]
+                                                      | --cardano-mode
+                                                        [--epoch-slots SLOTS]
+                                                      ]
+                                                      ( --mainnet
+                                                      | --testnet-magic NATURAL
+                                                      )
+                                                      [--out-file FILE]
+
+  Get the node's current protocol parameters
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_protocol-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_protocol-state.cli
@@ -1,0 +1,35 @@
+Usage: cardano-cli conway query protocol-state --socket-path SOCKET_PATH
+                                                 [ --shelley-mode
+                                                 | --byron-mode
+                                                   [--epoch-slots SLOTS]
+                                                 | --cardano-mode
+                                                   [--epoch-slots SLOTS]
+                                                 ]
+                                                 ( --mainnet
+                                                 | --testnet-magic NATURAL
+                                                 )
+                                                 [--out-file FILE]
+
+  Dump the current protocol state of the node (Ledger.ChainDepState -- advanced
+  command)
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_slot-number.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_slot-number.cli
@@ -1,0 +1,34 @@
+Usage: cardano-cli conway query slot-number --socket-path SOCKET_PATH
+                                              [ --shelley-mode
+                                              | --byron-mode
+                                                [--epoch-slots SLOTS]
+                                              | --cardano-mode
+                                                [--epoch-slots SLOTS]
+                                              ]
+                                              ( --mainnet
+                                              | --testnet-magic NATURAL
+                                              )
+                                              TIMESTAMP
+
+  Query slot number for UTC timestamp
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  TIMESTAMP                UTC timestamp in YYYY-MM-DDThh:mm:ssZ format
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_stake-address-info.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_stake-address-info.cli
@@ -1,0 +1,36 @@
+Usage: cardano-cli conway query stake-address-info --socket-path SOCKET_PATH
+                                                     [ --shelley-mode
+                                                     | --byron-mode
+                                                       [--epoch-slots SLOTS]
+                                                     | --cardano-mode
+                                                       [--epoch-slots SLOTS]
+                                                     ]
+                                                     --address ADDRESS
+                                                     ( --mainnet
+                                                     | --testnet-magic NATURAL
+                                                     )
+                                                     [--out-file FILE]
+
+  Get the current delegations and reward accounts filtered by stake address.
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --address ADDRESS        Filter by Cardano stake address (Bech32-encoded).
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_stake-distribution.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_stake-distribution.cli
@@ -1,0 +1,34 @@
+Usage: cardano-cli conway query stake-distribution --socket-path SOCKET_PATH
+                                                     [ --shelley-mode
+                                                     | --byron-mode
+                                                       [--epoch-slots SLOTS]
+                                                     | --cardano-mode
+                                                       [--epoch-slots SLOTS]
+                                                     ]
+                                                     ( --mainnet
+                                                     | --testnet-magic NATURAL
+                                                     )
+                                                     [--out-file FILE]
+
+  Get the node's current aggregated stake distribution
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_stake-pools.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_stake-pools.cli
@@ -1,0 +1,34 @@
+Usage: cardano-cli conway query stake-pools --socket-path SOCKET_PATH
+                                              [ --shelley-mode
+                                              | --byron-mode
+                                                [--epoch-slots SLOTS]
+                                              | --cardano-mode
+                                                [--epoch-slots SLOTS]
+                                              ]
+                                              ( --mainnet
+                                              | --testnet-magic NATURAL
+                                              )
+                                              [--out-file FILE]
+
+  Get the node's current set of stake pool ids
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_stake-snapshot.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_stake-snapshot.cli
@@ -1,0 +1,44 @@
+Usage: cardano-cli conway query stake-snapshot --socket-path SOCKET_PATH
+                                                 [ --shelley-mode
+                                                 | --byron-mode
+                                                   [--epoch-slots SLOTS]
+                                                 | --cardano-mode
+                                                   [--epoch-slots SLOTS]
+                                                 ]
+                                                 ( --mainnet
+                                                 | --testnet-magic NATURAL
+                                                 )
+                                                 [ --all-stake-pools
+                                                 | 
+                                                 [--stake-pool-id STAKE_POOL_ID]
+                                                 ]
+                                                 [--out-file FILE]
+
+  Obtain the three stake snapshots for a pool, plus the total active stake
+  (advanced command)
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --all-stake-pools        Query for all stake pools
+  --stake-pool-id STAKE_POOL_ID
+                           Stake pool ID/verification key hash (either
+                           Bech32-encoded or hex-encoded). Zero or more
+                           occurences of this option is allowed.
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_tip.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_tip.cli
@@ -1,0 +1,30 @@
+Usage: cardano-cli conway query tip --socket-path SOCKET_PATH
+                                      [ --shelley-mode
+                                      | --byron-mode [--epoch-slots SLOTS]
+                                      | --cardano-mode [--epoch-slots SLOTS]
+                                      ]
+                                      (--mainnet | --testnet-magic NATURAL)
+                                      [--out-file FILE]
+
+  Get the node's current tip (slot no, hash, block no)
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_tx-mempool.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_tx-mempool.cli
@@ -1,0 +1,43 @@
+Usage: cardano-cli conway query tx-mempool --socket-path SOCKET_PATH
+                                             [ --shelley-mode
+                                             | --byron-mode
+                                               [--epoch-slots SLOTS]
+                                             | --cardano-mode
+                                               [--epoch-slots SLOTS]
+                                             ]
+                                             ( --mainnet
+                                             | --testnet-magic NATURAL
+                                             )
+                                             (info | next-tx | tx-exists)
+                                             [--out-file FILE]
+
+  Local Mempool info
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text
+
+Available commands:
+  info                     Ask the node about the current mempool's capacity and
+                           sizes
+  next-tx                  Requests the next transaction from the mempool's
+                           current list
+  tx-exists                Query if a particular transaction exists in the
+                           mempool

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_tx-mempool_info.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_tx-mempool_info.cli
@@ -1,0 +1,16 @@
+Missing: --socket-path SOCKET_PATH (--mainnet | --testnet-magic NATURAL)
+
+Usage: cardano-cli conway query tx-mempool --socket-path SOCKET_PATH
+                                             [ --shelley-mode
+                                             | --byron-mode
+                                               [--epoch-slots SLOTS]
+                                             | --cardano-mode
+                                               [--epoch-slots SLOTS]
+                                             ]
+                                             ( --mainnet
+                                             | --testnet-magic NATURAL
+                                             )
+                                             (info | next-tx | tx-exists)
+                                             [--out-file FILE]
+
+  Local Mempool info

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_tx-mempool_next-tx.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_tx-mempool_next-tx.cli
@@ -1,0 +1,16 @@
+Missing: --socket-path SOCKET_PATH (--mainnet | --testnet-magic NATURAL)
+
+Usage: cardano-cli conway query tx-mempool --socket-path SOCKET_PATH
+                                             [ --shelley-mode
+                                             | --byron-mode
+                                               [--epoch-slots SLOTS]
+                                             | --cardano-mode
+                                               [--epoch-slots SLOTS]
+                                             ]
+                                             ( --mainnet
+                                             | --testnet-magic NATURAL
+                                             )
+                                             (info | next-tx | tx-exists)
+                                             [--out-file FILE]
+
+  Local Mempool info

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_tx-mempool_tx-exists_TX_ID.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_tx-mempool_tx-exists_TX_ID.cli
@@ -1,0 +1,16 @@
+Missing: --socket-path SOCKET_PATH (--mainnet | --testnet-magic NATURAL)
+
+Usage: cardano-cli conway query tx-mempool --socket-path SOCKET_PATH
+                                             [ --shelley-mode
+                                             | --byron-mode
+                                               [--epoch-slots SLOTS]
+                                             | --cardano-mode
+                                               [--epoch-slots SLOTS]
+                                             ]
+                                             ( --mainnet
+                                             | --testnet-magic NATURAL
+                                             )
+                                             (info | next-tx | tx-exists)
+                                             [--out-file FILE]
+
+  Local Mempool info

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_utxo.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_utxo.cli
@@ -1,0 +1,38 @@
+Usage: cardano-cli conway query utxo --socket-path SOCKET_PATH
+                                       [ --shelley-mode
+                                       | --byron-mode [--epoch-slots SLOTS]
+                                       | --cardano-mode [--epoch-slots SLOTS]
+                                       ]
+                                       ( --whole-utxo
+                                       | (--address ADDRESS)
+                                       | (--tx-in TX-IN)
+                                       )
+                                       (--mainnet | --testnet-magic NATURAL)
+                                       [--out-file FILE]
+
+  Get a portion of the current UTxO: by tx in, by address or the whole.
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --whole-utxo             Return the whole UTxO (only appropriate on small
+                           testnets).
+  --address ADDRESS        Filter by Cardano address(es) (Bech32-encoded).
+  --tx-in TX-IN            Filter by transaction input (TxId#TxIx).
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_text-view_decode-cbor.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_text-view_decode-cbor.cli
@@ -1,0 +1,8 @@
+Usage: cardano-cli conway text-view decode-cbor --in-file FILE [--out-file FILE]
+
+  Print a TextView file as decoded CBOR.
+
+Available options:
+  --in-file FILE           CBOR input file.
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction.cli
@@ -13,7 +13,7 @@ Usage: cardano-cli conway transaction
                                         | view
                                         )
 
-  Era-based governance commands
+  Era-based transaction commands
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest.cli
@@ -1,4 +1,14 @@
-Usage: cardano-cli latest (address | governance | stake-address | transaction)
+Usage: cardano-cli latest 
+                            ( address
+                            | key
+                            | genesis
+                            | governance
+                            | node
+                            | query
+                            | stake-address
+                            | text-view
+                            | transaction
+                            )
 
   Latest era commands (Babbage)
 
@@ -7,6 +17,11 @@ Available options:
 
 Available commands:
   address                  Era-based address commands
+  key                      Era-based key commands
+  genesis                  Era-based genesis commands
   governance               Era-based governance commands
+  node                     Era-based node commands
+  query                    Era-based query commands
   stake-address            Stake address commands.
-  transaction              Era-based governance commands
+  text-view                Era-based text-view commands
+  transaction              Era-based transaction commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_genesis.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_genesis.cli
@@ -1,0 +1,37 @@
+Usage: cardano-cli latest genesis 
+                                    ( key-gen-genesis
+                                    | key-gen-delegate
+                                    | key-gen-utxo
+                                    | key-hash
+                                    | get-ver-key
+                                    | initial-addr
+                                    | initial-txin
+                                    | create-cardano
+                                    | create
+                                    | create-staked
+                                    | hash
+                                    )
+
+  Era-based genesis commands
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  key-gen-genesis          Create a Shelley genesis key pair
+  key-gen-delegate         Create a Shelley genesis delegate key pair
+  key-gen-utxo             Create a Shelley genesis UTxO key pair
+  key-hash                 Print the identifier (hash) of a public key
+  get-ver-key              Derive the verification key from a signing key
+  initial-addr             Get the address for an initial UTxO based on the
+                           verification key
+  initial-txin             Get the TxIn for an initial UTxO based on the
+                           verification key
+  create-cardano           Create a Byron and Shelley genesis file from a
+                           genesis template and genesis/delegation/spending
+                           keys.
+  create                   Create a Shelley genesis file from a genesis template
+                           and genesis/delegation/spending keys.
+  create-staked            Create a staked Shelley genesis file from a genesis
+                           template and genesis/delegation/spending keys.
+  hash                     Compute the hash of a genesis file

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_genesis_create-cardano.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_genesis_create-cardano.cli
@@ -1,0 +1,51 @@
+Usage: cardano-cli latest genesis create-cardano --genesis-dir DIR
+                                                   [--gen-genesis-keys INT]
+                                                   [--gen-utxo-keys INT]
+                                                   [--start-time UTC-TIME]
+                                                   [--supply LOVELACE]
+                                                   [--security-param INT]
+                                                   [--slot-length INT]
+                                                   [--slot-coefficient RATIONAL]
+                                                   ( --mainnet
+                                                   | --testnet-magic NATURAL
+                                                   )
+                                                   --byron-template FILEPATH
+                                                   --shelley-template FILEPATH
+                                                   --alonzo-template FILEPATH
+                                                   --conway-template FILEPATH
+                                                   [--node-config-template FILEPATH]
+
+  Create a Byron and Shelley genesis file from a genesis template and
+  genesis/delegation/spending keys.
+
+Available options:
+  --genesis-dir DIR        The genesis directory containing the genesis template
+                           and required genesis/delegation/spending keys.
+  --gen-genesis-keys INT   The number of genesis keys to make [default is 3].
+  --gen-utxo-keys INT      The number of UTxO keys to make [default is 0].
+  --start-time UTC-TIME    The genesis start time in YYYY-MM-DDThh:mm:ssZ
+                           format. If unspecified, will be the current time +30
+                           seconds.
+  --supply LOVELACE        The initial coin supply in Lovelace which will be
+                           evenly distributed across initial, non-delegating
+                           stake holders.
+  --security-param INT     Security parameter for genesis file [default is 108].
+  --slot-length INT        slot length (ms) parameter for genesis file [default
+                           is 1000].
+  --slot-coefficient RATIONAL
+                           Slot Coefficient for genesis file [default is .05].
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --byron-template FILEPATH
+                           JSON file with genesis defaults for each byron.
+  --shelley-template FILEPATH
+                           JSON file with genesis defaults for each shelley.
+  --alonzo-template FILEPATH
+                           JSON file with genesis defaults for alonzo.
+  --conway-template FILEPATH
+                           JSON file with genesis defaults for conway.
+  --node-config-template FILEPATH
+                           the node config template
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_genesis_create-staked.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_genesis_create-staked.cli
@@ -1,0 +1,57 @@
+Usage: cardano-cli latest genesis create-staked [--key-output-format STRING]
+                                                  --genesis-dir DIR
+                                                  [--gen-genesis-keys INT]
+                                                  [--gen-utxo-keys INT]
+                                                  [--gen-pools INT]
+                                                  [--gen-stake-delegs INT]
+                                                  [--start-time UTC-TIME]
+                                                  [--supply LOVELACE]
+                                                  [--supply-delegated LOVELACE]
+                                                  ( --mainnet
+                                                  | --testnet-magic NATURAL
+                                                  )
+                                                  [--bulk-pool-cred-files INT]
+                                                  [--bulk-pools-per-file INT]
+                                                  [--num-stuffed-utxo INT]
+                                                  [--relay-specification-file FILE]
+
+  Create a staked Shelley genesis file from a genesis template and
+  genesis/delegation/spending keys.
+
+Available options:
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32" (default is
+                           "bech32").
+  --genesis-dir DIR        The genesis directory containing the genesis template
+                           and required genesis/delegation/spending keys.
+  --gen-genesis-keys INT   The number of genesis keys to make [default is 3].
+  --gen-utxo-keys INT      The number of UTxO keys to make [default is 0].
+  --gen-pools INT          The number of stake pool credential sets to make
+                           [default is 0].
+  --gen-stake-delegs INT   The number of stake delegator credential sets to make
+                           [default is 0].
+  --start-time UTC-TIME    The genesis start time in YYYY-MM-DDThh:mm:ssZ
+                           format. If unspecified, will be the current time +30
+                           seconds.
+  --supply LOVELACE        The initial coin supply in Lovelace which will be
+                           evenly distributed across initial, non-delegating
+                           stake holders.
+  --supply-delegated LOVELACE
+                           The initial coin supply in Lovelace which will be
+                           evenly distributed across initial, delegating stake
+                           holders.
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --bulk-pool-cred-files INT
+                           Generate bulk pool credential files [default is 0].
+  --bulk-pools-per-file INT
+                           Each bulk pool to contain this many pool credential
+                           sets [default is 0].
+  --num-stuffed-utxo INT   The number of fake UTxO entries to generate [default
+                           is 0].
+  --relay-specification-file FILE
+                           JSON file specified the relays of each stake pool.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_genesis_create.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_genesis_create.cli
@@ -1,0 +1,31 @@
+Usage: cardano-cli latest genesis create [--key-output-format STRING]
+                                           --genesis-dir DIR
+                                           [--gen-genesis-keys INT]
+                                           [--gen-utxo-keys INT]
+                                           [--start-time UTC-TIME]
+                                           [--supply LOVELACE]
+                                           (--mainnet | --testnet-magic NATURAL)
+
+  Create a Shelley genesis file from a genesis template and
+  genesis/delegation/spending keys.
+
+Available options:
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32" (default is
+                           "bech32").
+  --genesis-dir DIR        The genesis directory containing the genesis template
+                           and required genesis/delegation/spending keys.
+  --gen-genesis-keys INT   The number of genesis keys to make [default is 3].
+  --gen-utxo-keys INT      The number of UTxO keys to make [default is 0].
+  --start-time UTC-TIME    The genesis start time in YYYY-MM-DDThh:mm:ssZ
+                           format. If unspecified, will be the current time +30
+                           seconds.
+  --supply LOVELACE        The initial coin supply in Lovelace which will be
+                           evenly distributed across initial, non-delegating
+                           stake holders.
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_genesis_get-ver-key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_genesis_get-ver-key.cli
@@ -1,0 +1,10 @@
+Usage: cardano-cli latest genesis get-ver-key --verification-key-file FILE
+                                                --signing-key-file FILE
+
+  Derive the verification key from a signing key
+
+Available options:
+  --verification-key-file FILE
+                           Output filepath of the verification key.
+  --signing-key-file FILE  Input filepath of the signing key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_genesis_hash.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_genesis_hash.cli
@@ -1,0 +1,7 @@
+Usage: cardano-cli latest genesis hash --genesis FILE
+
+  Compute the hash of a genesis file
+
+Available options:
+  --genesis FILE           The genesis file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_genesis_initial-addr.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_genesis_initial-addr.cli
@@ -1,0 +1,17 @@
+Usage: cardano-cli latest genesis initial-addr --verification-key-file FILE
+                                                 ( --mainnet
+                                                 | --testnet-magic NATURAL
+                                                 )
+                                                 [--out-file FILE]
+
+  Get the address for an initial UTxO based on the verification key
+
+Available options:
+  --verification-key-file FILE
+                           Input filepath of the verification key.
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_genesis_initial-txin.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_genesis_initial-txin.cli
@@ -1,0 +1,17 @@
+Usage: cardano-cli latest genesis initial-txin --verification-key-file FILE
+                                                 ( --mainnet
+                                                 | --testnet-magic NATURAL
+                                                 )
+                                                 [--out-file FILE]
+
+  Get the TxIn for an initial UTxO based on the verification key
+
+Available options:
+  --verification-key-file FILE
+                           Input filepath of the verification key.
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_genesis_key-gen-delegate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_genesis_key-gen-delegate.cli
@@ -1,0 +1,14 @@
+Usage: cardano-cli latest genesis key-gen-delegate --verification-key-file FILE
+                                                     --signing-key-file FILE
+                                                     --operational-certificate-issue-counter-file FILE
+
+  Create a Shelley genesis delegate key pair
+
+Available options:
+  --verification-key-file FILE
+                           Output filepath of the verification key.
+  --signing-key-file FILE  Output filepath of the signing key.
+  --operational-certificate-issue-counter-file FILE
+                           The file with the issue counter for the operational
+                           certificate.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_genesis_key-gen-genesis.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_genesis_key-gen-genesis.cli
@@ -1,0 +1,10 @@
+Usage: cardano-cli latest genesis key-gen-genesis --verification-key-file FILE
+                                                    --signing-key-file FILE
+
+  Create a Shelley genesis key pair
+
+Available options:
+  --verification-key-file FILE
+                           Output filepath of the verification key.
+  --signing-key-file FILE  Output filepath of the signing key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_genesis_key-gen-utxo.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_genesis_key-gen-utxo.cli
@@ -1,0 +1,10 @@
+Usage: cardano-cli latest genesis key-gen-utxo --verification-key-file FILE
+                                                 --signing-key-file FILE
+
+  Create a Shelley genesis UTxO key pair
+
+Available options:
+  --verification-key-file FILE
+                           Output filepath of the verification key.
+  --signing-key-file FILE  Output filepath of the signing key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_genesis_key-hash.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_genesis_key-hash.cli
@@ -1,0 +1,8 @@
+Usage: cardano-cli latest genesis key-hash --verification-key-file FILE
+
+  Print the identifier (hash) of a public key
+
+Available options:
+  --verification-key-file FILE
+                           Input filepath of the verification key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_key.cli
@@ -1,0 +1,40 @@
+Usage: cardano-cli latest key 
+                                ( verification-key
+                                | non-extended-key
+                                | convert-byron-key
+                                | convert-byron-genesis-vkey
+                                | convert-itn-key
+                                | convert-itn-extended-key
+                                | convert-itn-bip32-key
+                                | convert-cardano-address-key
+                                )
+
+  Era-based key commands
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  verification-key         Get a verification key from a signing key. This
+                           supports all key types.
+  non-extended-key         Get a non-extended verification key from an extended
+                           verification key. This supports all extended key
+                           types.
+  convert-byron-key        Convert a Byron payment, genesis or genesis delegate
+                           key (signing or verification) to a corresponding
+                           Shelley-format key.
+  convert-byron-genesis-vkey
+                           Convert a Base64-encoded Byron genesis verification
+                           key to a Shelley genesis verification key
+  convert-itn-key          Convert an Incentivized Testnet (ITN) non-extended
+                           (Ed25519) signing or verification key to a
+                           corresponding Shelley stake key
+  convert-itn-extended-key Convert an Incentivized Testnet (ITN) extended
+                           (Ed25519Extended) signing key to a corresponding
+                           Shelley stake signing key
+  convert-itn-bip32-key    Convert an Incentivized Testnet (ITN) BIP32
+                           (Ed25519Bip32) signing key to a corresponding Shelley
+                           stake signing key
+  convert-cardano-address-key
+                           Convert a cardano-address extended signing key to a
+                           corresponding Shelley-format key.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_key_convert-byron-genesis-vkey.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_key_convert-byron-genesis-vkey.cli
@@ -1,0 +1,11 @@
+Usage: cardano-cli latest key convert-byron-genesis-vkey --byron-genesis-verification-key BASE64
+                                                           --out-file FILE
+
+  Convert a Base64-encoded Byron genesis verification key to a Shelley genesis
+  verification key
+
+Available options:
+  --byron-genesis-verification-key BASE64
+                           Base64 string for the Byron genesis verification key.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_key_convert-byron-key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_key_convert-byron-key.cli
@@ -1,0 +1,35 @@
+Usage: cardano-cli latest key convert-byron-key [--password TEXT]
+                                                  ( --byron-payment-key-type
+                                                  | --legacy-byron-payment-key-type
+                                                  | --byron-genesis-key-type
+                                                  | --legacy-byron-genesis-key-type
+                                                  | --byron-genesis-delegate-key-type
+                                                  | --legacy-byron-genesis-delegate-key-type
+                                                  )
+                                                  ( --byron-signing-key-file FILE
+                                                  | --byron-verification-key-file FILE
+                                                  )
+                                                  --out-file FILE
+
+  Convert a Byron payment, genesis or genesis delegate key (signing or
+  verification) to a corresponding Shelley-format key.
+
+Available options:
+  --password TEXT          Password for signing key (if applicable).
+  --byron-payment-key-type Use a Byron-era payment key.
+  --legacy-byron-payment-key-type
+                           Use a Byron-era payment key, in legacy SL format.
+  --byron-genesis-key-type Use a Byron-era genesis key.
+  --legacy-byron-genesis-key-type
+                           Use a Byron-era genesis key, in legacy SL format.
+  --byron-genesis-delegate-key-type
+                           Use a Byron-era genesis delegate key.
+  --legacy-byron-genesis-delegate-key-type
+                           Use a Byron-era genesis delegate key, in legacy SL
+                           format.
+  --byron-signing-key-file FILE
+                           Input filepath of the Byron-format signing key.
+  --byron-verification-key-file FILE
+                           Input filepath of the Byron-format verification key.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_key_convert-cardano-address-key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_key_convert-cardano-address-key.cli
@@ -1,0 +1,22 @@
+Usage: cardano-cli latest key convert-cardano-address-key 
+                                                            ( --shelley-payment-key
+                                                            | --shelley-stake-key
+                                                            | --icarus-payment-key
+                                                            | --byron-payment-key
+                                                            )
+                                                            --signing-key-file FILE
+                                                            --out-file FILE
+
+  Convert a cardano-address extended signing key to a corresponding
+  Shelley-format key.
+
+Available options:
+  --shelley-payment-key    Use a Shelley-era extended payment key.
+  --shelley-stake-key      Use a Shelley-era extended stake key.
+  --icarus-payment-key     Use a Byron-era extended payment key formatted in the
+                           Icarus style.
+  --byron-payment-key      Use a Byron-era extended payment key formatted in the
+                           deprecated Byron style.
+  --signing-key-file FILE  Input filepath of the signing key.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_key_convert-itn-bip32-key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_key_convert-itn-bip32-key.cli
@@ -1,0 +1,11 @@
+Usage: cardano-cli latest key convert-itn-bip32-key --itn-signing-key-file FILE
+                                                      --out-file FILE
+
+  Convert an Incentivized Testnet (ITN) BIP32 (Ed25519Bip32) signing key to a
+  corresponding Shelley stake signing key
+
+Available options:
+  --itn-signing-key-file FILE
+                           Filepath of the ITN signing key.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_key_convert-itn-extended-key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_key_convert-itn-extended-key.cli
@@ -1,0 +1,11 @@
+Usage: cardano-cli latest key convert-itn-extended-key --itn-signing-key-file FILE
+                                                         --out-file FILE
+
+  Convert an Incentivized Testnet (ITN) extended (Ed25519Extended) signing key
+  to a corresponding Shelley stake signing key
+
+Available options:
+  --itn-signing-key-file FILE
+                           Filepath of the ITN signing key.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_key_convert-itn-key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_key_convert-itn-key.cli
@@ -1,0 +1,16 @@
+Usage: cardano-cli latest key convert-itn-key 
+                                                ( --itn-signing-key-file FILE
+                                                | --itn-verification-key-file FILE
+                                                )
+                                                --out-file FILE
+
+  Convert an Incentivized Testnet (ITN) non-extended (Ed25519) signing or
+  verification key to a corresponding Shelley stake key
+
+Available options:
+  --itn-signing-key-file FILE
+                           Filepath of the ITN signing key.
+  --itn-verification-key-file FILE
+                           Filepath of the ITN verification key.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_key_non-extended-key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_key_non-extended-key.cli
@@ -1,0 +1,12 @@
+Usage: cardano-cli latest key non-extended-key --extended-verification-key-file FILE
+                                                 --verification-key-file FILE
+
+  Get a non-extended verification key from an extended verification key. This
+  supports all extended key types.
+
+Available options:
+  --extended-verification-key-file FILE
+                           Input filepath of the ed25519-bip32 verification key.
+  --verification-key-file FILE
+                           Output filepath of the verification key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_key_verification-key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_key_verification-key.cli
@@ -1,0 +1,10 @@
+Usage: cardano-cli latest key verification-key --signing-key-file FILE
+                                                 --verification-key-file FILE
+
+  Get a verification key from a signing key. This supports all key types.
+
+Available options:
+  --signing-key-file FILE  Input filepath of the signing key.
+  --verification-key-file FILE
+                           Output filepath of the verification key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_node.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_node.cli
@@ -1,0 +1,22 @@
+Usage: cardano-cli latest node 
+                                 ( key-gen
+                                 | key-gen-KES
+                                 | key-gen-VRF
+                                 | key-hash-VRF
+                                 | new-counter
+                                 | issue-op-cert
+                                 )
+
+  Era-based node commands
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  key-gen                  Create a key pair for a node operator's offline key
+                           and a new certificate issue counter
+  key-gen-KES              Create a key pair for a node KES operational key
+  key-gen-VRF              Create a key pair for a node VRF operational key
+  key-hash-VRF             Print hash of a node's operational VRF key.
+  new-counter              Create a new certificate issue counter
+  issue-op-cert            Issue a node operational certificate

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_node_issue-op-cert.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_node_issue-op-cert.cli
@@ -1,0 +1,24 @@
+Usage: cardano-cli latest node issue-op-cert 
+                                               ( --kes-verification-key STRING
+                                               | --kes-verification-key-file FILE
+                                               )
+                                               --cold-signing-key-file FILE
+                                               --operational-certificate-issue-counter-file FILE
+                                               --kes-period NATURAL
+                                               --out-file FILE
+
+  Issue a node operational certificate
+
+Available options:
+  --kes-verification-key STRING
+                           A Bech32 or hex-encoded hot KES verification key.
+  --kes-verification-key-file FILE
+                           Filepath of the hot KES verification key.
+  --cold-signing-key-file FILE
+                           Filepath of the cold signing key.
+  --operational-certificate-issue-counter-file FILE
+                           The file with the issue counter for the operational
+                           certificate.
+  --kes-period NATURAL     The start of the KES key validity period.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_node_key-gen-KES.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_node_key-gen-KES.cli
@@ -1,0 +1,15 @@
+Usage: cardano-cli latest node key-gen-KES [--key-output-format STRING]
+                                             --verification-key-file FILE
+                                             --signing-key-file FILE
+
+  Create a key pair for a node KES operational key
+
+Available options:
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32" (default is
+                           "bech32").
+  --verification-key-file FILE
+                           Output filepath of the verification key.
+  --signing-key-file FILE  Output filepath of the signing key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_node_key-gen-VRF.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_node_key-gen-VRF.cli
@@ -1,0 +1,15 @@
+Usage: cardano-cli latest node key-gen-VRF [--key-output-format STRING]
+                                             --verification-key-file FILE
+                                             --signing-key-file FILE
+
+  Create a key pair for a node VRF operational key
+
+Available options:
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32" (default is
+                           "bech32").
+  --verification-key-file FILE
+                           Output filepath of the verification key.
+  --signing-key-file FILE  Output filepath of the signing key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_node_key-gen.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_node_key-gen.cli
@@ -1,0 +1,21 @@
+Usage: cardano-cli latest node key-gen [--key-output-format STRING]
+                                         --cold-verification-key-file FILE
+                                         --cold-signing-key-file FILE
+                                         --operational-certificate-issue-counter-file FILE
+
+  Create a key pair for a node operator's offline key and a new certificate
+  issue counter
+
+Available options:
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32" (default is
+                           "bech32").
+  --cold-verification-key-file FILE
+                           Filepath of the cold verification key.
+  --cold-signing-key-file FILE
+                           Filepath of the cold signing key.
+  --operational-certificate-issue-counter-file FILE
+                           The file with the issue counter for the operational
+                           certificate.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_node_key-hash-VRF.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_node_key-hash-VRF.cli
@@ -1,0 +1,15 @@
+Usage: cardano-cli latest node key-hash-VRF 
+                                              ( --verification-key STRING
+                                              | --verification-key-file FILE
+                                              )
+                                              [--out-file FILE]
+
+  Print hash of a node's operational VRF key.
+
+Available options:
+  --verification-key STRING
+                           Verification key (Bech32 or hex-encoded).
+  --verification-key-file FILE
+                           Input filepath of the verification key.
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_node_new-counter.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_node_new-counter.cli
@@ -1,0 +1,22 @@
+Usage: cardano-cli latest node new-counter 
+                                             ( --stake-pool-verification-key STRING
+                                             | --genesis-delegate-verification-key STRING
+                                             | --cold-verification-key-file FILE
+                                             )
+                                             --counter-value INT
+                                             --operational-certificate-issue-counter-file FILE
+
+  Create a new certificate issue counter
+
+Available options:
+  --stake-pool-verification-key STRING
+                           Stake pool verification key (Bech32 or hex-encoded).
+  --genesis-delegate-verification-key STRING
+                           Genesis delegate verification key (hex-encoded).
+  --cold-verification-key-file FILE
+                           Filepath of the cold verification key.
+  --counter-value INT      The next certificate issue counter value to use.
+  --operational-certificate-issue-counter-file FILE
+                           The file with the issue counter for the operational
+                           certificate.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query.cli
@@ -1,0 +1,50 @@
+Usage: cardano-cli latest query 
+                                  ( protocol-parameters
+                                  | constitution-hash
+                                  | tip
+                                  | stake-pools
+                                  | stake-distribution
+                                  | stake-address-info
+                                  | utxo
+                                  | ledger-state
+                                  | protocol-state
+                                  | stake-snapshot
+                                  | leadership-schedule
+                                  | kes-period-info
+                                  | pool-state
+                                  | tx-mempool
+                                  | slot-number
+                                  )
+
+  Era-based query commands
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  protocol-parameters      Get the node's current protocol parameters
+  constitution-hash        Get the constitution hash
+  tip                      Get the node's current tip (slot no, hash, block no)
+  stake-pools              Get the node's current set of stake pool ids
+  stake-distribution       Get the node's current aggregated stake distribution
+  stake-address-info       Get the current delegations and reward accounts
+                           filtered by stake address.
+  utxo                     Get a portion of the current UTxO: by tx in, by
+                           address or the whole.
+  ledger-state             Dump the current ledger state of the node
+                           (Ledger.NewEpochState -- advanced command)
+  protocol-state           Dump the current protocol state of the node
+                           (Ledger.ChainDepState -- advanced command)
+  stake-snapshot           Obtain the three stake snapshots for a pool, plus the
+                           total active stake (advanced command)
+  pool-params              DEPRECATED. Use query pool-state instead. Dump the
+                           pool parameters
+                           (Ledger.NewEpochState.esLState._delegationState._pState._pParams
+                           -- advanced command)
+  leadership-schedule      Get the slots the node is expected to mint a block in
+                           (advanced command)
+  kes-period-info          Get information about the current KES period and your
+                           node's operational certificate.
+  pool-state               Dump the pool state
+  tx-mempool               Local Mempool info
+  slot-number              Query slot number for UTC timestamp

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_constitution-hash.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_constitution-hash.cli
@@ -1,0 +1,34 @@
+Usage: cardano-cli latest query constitution-hash --socket-path SOCKET_PATH
+                                                    [ --shelley-mode
+                                                    | --byron-mode
+                                                      [--epoch-slots SLOTS]
+                                                    | --cardano-mode
+                                                      [--epoch-slots SLOTS]
+                                                    ]
+                                                    ( --mainnet
+                                                    | --testnet-magic NATURAL
+                                                    )
+                                                    [--out-file FILE]
+
+  Get the constitution hash
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_kes-period-info.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_kes-period-info.cli
@@ -1,0 +1,37 @@
+Usage: cardano-cli latest query kes-period-info --socket-path SOCKET_PATH
+                                                  [ --shelley-mode
+                                                  | --byron-mode
+                                                    [--epoch-slots SLOTS]
+                                                  | --cardano-mode
+                                                    [--epoch-slots SLOTS]
+                                                  ]
+                                                  ( --mainnet
+                                                  | --testnet-magic NATURAL
+                                                  )
+                                                  --op-cert-file FILE
+                                                  [--out-file FILE]
+
+  Get information about the current KES period and your node's operational
+  certificate.
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --op-cert-file FILE      Filepath of the node's operational certificate.
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_leadership-schedule.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_leadership-schedule.cli
@@ -1,0 +1,54 @@
+Usage: cardano-cli latest query leadership-schedule --socket-path SOCKET_PATH
+                                                      [ --shelley-mode
+                                                      | --byron-mode
+                                                        [--epoch-slots SLOTS]
+                                                      | --cardano-mode
+                                                        [--epoch-slots SLOTS]
+                                                      ]
+                                                      ( --mainnet
+                                                      | --testnet-magic NATURAL
+                                                      )
+                                                      --genesis FILE
+                                                      ( --stake-pool-verification-key STRING
+                                                      | --cold-verification-key-file FILE
+                                                      | --stake-pool-id STAKE_POOL_ID
+                                                      )
+                                                      --vrf-signing-key-file FILE
+                                                      (--current | --next)
+                                                      [--out-file FILE]
+
+  Get the slots the node is expected to mint a block in (advanced command)
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --genesis FILE           Shelley genesis filepath
+  --stake-pool-verification-key STRING
+                           Stake pool verification key (Bech32 or hex-encoded).
+  --cold-verification-key-file FILE
+                           Filepath of the stake pool verification key.
+  --stake-pool-id STAKE_POOL_ID
+                           Stake pool ID/verification key hash (either
+                           Bech32-encoded or hex-encoded). Zero or more
+                           occurences of this option is allowed.
+  --vrf-signing-key-file FILE
+                           Input filepath of the VRF signing key.
+  --current                Get the leadership schedule for the current epoch.
+  --next                   Get the leadership schedule for the following epoch.
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_ledger-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_ledger-state.cli
@@ -1,0 +1,35 @@
+Usage: cardano-cli latest query ledger-state --socket-path SOCKET_PATH
+                                               [ --shelley-mode
+                                               | --byron-mode
+                                                 [--epoch-slots SLOTS]
+                                               | --cardano-mode
+                                                 [--epoch-slots SLOTS]
+                                               ]
+                                               ( --mainnet
+                                               | --testnet-magic NATURAL
+                                               )
+                                               [--out-file FILE]
+
+  Dump the current ledger state of the node (Ledger.NewEpochState -- advanced
+  command)
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_pool-params.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_pool-params.cli
@@ -1,0 +1,39 @@
+Usage: cardano-cli latest query pool-params --socket-path SOCKET_PATH
+                                              [ --shelley-mode
+                                              | --byron-mode
+                                                [--epoch-slots SLOTS]
+                                              | --cardano-mode
+                                                [--epoch-slots SLOTS]
+                                              ]
+                                              ( --mainnet
+                                              | --testnet-magic NATURAL
+                                              )
+                                              [--stake-pool-id STAKE_POOL_ID]
+
+  DEPRECATED. Use query pool-state instead. Dump the pool parameters
+  (Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced
+  command)
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --stake-pool-id STAKE_POOL_ID
+                           Stake pool ID/verification key hash (either
+                           Bech32-encoded or hex-encoded). Zero or more
+                           occurences of this option is allowed.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_pool-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_pool-state.cli
@@ -1,0 +1,37 @@
+Usage: cardano-cli latest query pool-state --socket-path SOCKET_PATH
+                                             [ --shelley-mode
+                                             | --byron-mode
+                                               [--epoch-slots SLOTS]
+                                             | --cardano-mode
+                                               [--epoch-slots SLOTS]
+                                             ]
+                                             ( --mainnet
+                                             | --testnet-magic NATURAL
+                                             )
+                                             [--stake-pool-id STAKE_POOL_ID]
+
+  Dump the pool state
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --stake-pool-id STAKE_POOL_ID
+                           Stake pool ID/verification key hash (either
+                           Bech32-encoded or hex-encoded). Zero or more
+                           occurences of this option is allowed.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_protocol-parameters.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_protocol-parameters.cli
@@ -1,0 +1,34 @@
+Usage: cardano-cli latest query protocol-parameters --socket-path SOCKET_PATH
+                                                      [ --shelley-mode
+                                                      | --byron-mode
+                                                        [--epoch-slots SLOTS]
+                                                      | --cardano-mode
+                                                        [--epoch-slots SLOTS]
+                                                      ]
+                                                      ( --mainnet
+                                                      | --testnet-magic NATURAL
+                                                      )
+                                                      [--out-file FILE]
+
+  Get the node's current protocol parameters
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_protocol-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_protocol-state.cli
@@ -1,0 +1,35 @@
+Usage: cardano-cli latest query protocol-state --socket-path SOCKET_PATH
+                                                 [ --shelley-mode
+                                                 | --byron-mode
+                                                   [--epoch-slots SLOTS]
+                                                 | --cardano-mode
+                                                   [--epoch-slots SLOTS]
+                                                 ]
+                                                 ( --mainnet
+                                                 | --testnet-magic NATURAL
+                                                 )
+                                                 [--out-file FILE]
+
+  Dump the current protocol state of the node (Ledger.ChainDepState -- advanced
+  command)
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_slot-number.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_slot-number.cli
@@ -1,0 +1,34 @@
+Usage: cardano-cli latest query slot-number --socket-path SOCKET_PATH
+                                              [ --shelley-mode
+                                              | --byron-mode
+                                                [--epoch-slots SLOTS]
+                                              | --cardano-mode
+                                                [--epoch-slots SLOTS]
+                                              ]
+                                              ( --mainnet
+                                              | --testnet-magic NATURAL
+                                              )
+                                              TIMESTAMP
+
+  Query slot number for UTC timestamp
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  TIMESTAMP                UTC timestamp in YYYY-MM-DDThh:mm:ssZ format
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_stake-address-info.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_stake-address-info.cli
@@ -1,0 +1,36 @@
+Usage: cardano-cli latest query stake-address-info --socket-path SOCKET_PATH
+                                                     [ --shelley-mode
+                                                     | --byron-mode
+                                                       [--epoch-slots SLOTS]
+                                                     | --cardano-mode
+                                                       [--epoch-slots SLOTS]
+                                                     ]
+                                                     --address ADDRESS
+                                                     ( --mainnet
+                                                     | --testnet-magic NATURAL
+                                                     )
+                                                     [--out-file FILE]
+
+  Get the current delegations and reward accounts filtered by stake address.
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --address ADDRESS        Filter by Cardano stake address (Bech32-encoded).
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_stake-distribution.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_stake-distribution.cli
@@ -1,0 +1,34 @@
+Usage: cardano-cli latest query stake-distribution --socket-path SOCKET_PATH
+                                                     [ --shelley-mode
+                                                     | --byron-mode
+                                                       [--epoch-slots SLOTS]
+                                                     | --cardano-mode
+                                                       [--epoch-slots SLOTS]
+                                                     ]
+                                                     ( --mainnet
+                                                     | --testnet-magic NATURAL
+                                                     )
+                                                     [--out-file FILE]
+
+  Get the node's current aggregated stake distribution
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_stake-pools.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_stake-pools.cli
@@ -1,0 +1,34 @@
+Usage: cardano-cli latest query stake-pools --socket-path SOCKET_PATH
+                                              [ --shelley-mode
+                                              | --byron-mode
+                                                [--epoch-slots SLOTS]
+                                              | --cardano-mode
+                                                [--epoch-slots SLOTS]
+                                              ]
+                                              ( --mainnet
+                                              | --testnet-magic NATURAL
+                                              )
+                                              [--out-file FILE]
+
+  Get the node's current set of stake pool ids
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_stake-snapshot.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_stake-snapshot.cli
@@ -1,0 +1,44 @@
+Usage: cardano-cli latest query stake-snapshot --socket-path SOCKET_PATH
+                                                 [ --shelley-mode
+                                                 | --byron-mode
+                                                   [--epoch-slots SLOTS]
+                                                 | --cardano-mode
+                                                   [--epoch-slots SLOTS]
+                                                 ]
+                                                 ( --mainnet
+                                                 | --testnet-magic NATURAL
+                                                 )
+                                                 [ --all-stake-pools
+                                                 | 
+                                                 [--stake-pool-id STAKE_POOL_ID]
+                                                 ]
+                                                 [--out-file FILE]
+
+  Obtain the three stake snapshots for a pool, plus the total active stake
+  (advanced command)
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --all-stake-pools        Query for all stake pools
+  --stake-pool-id STAKE_POOL_ID
+                           Stake pool ID/verification key hash (either
+                           Bech32-encoded or hex-encoded). Zero or more
+                           occurences of this option is allowed.
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_tip.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_tip.cli
@@ -1,0 +1,30 @@
+Usage: cardano-cli latest query tip --socket-path SOCKET_PATH
+                                      [ --shelley-mode
+                                      | --byron-mode [--epoch-slots SLOTS]
+                                      | --cardano-mode [--epoch-slots SLOTS]
+                                      ]
+                                      (--mainnet | --testnet-magic NATURAL)
+                                      [--out-file FILE]
+
+  Get the node's current tip (slot no, hash, block no)
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_tx-mempool.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_tx-mempool.cli
@@ -1,0 +1,43 @@
+Usage: cardano-cli latest query tx-mempool --socket-path SOCKET_PATH
+                                             [ --shelley-mode
+                                             | --byron-mode
+                                               [--epoch-slots SLOTS]
+                                             | --cardano-mode
+                                               [--epoch-slots SLOTS]
+                                             ]
+                                             ( --mainnet
+                                             | --testnet-magic NATURAL
+                                             )
+                                             (info | next-tx | tx-exists)
+                                             [--out-file FILE]
+
+  Local Mempool info
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text
+
+Available commands:
+  info                     Ask the node about the current mempool's capacity and
+                           sizes
+  next-tx                  Requests the next transaction from the mempool's
+                           current list
+  tx-exists                Query if a particular transaction exists in the
+                           mempool

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_tx-mempool_info.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_tx-mempool_info.cli
@@ -1,0 +1,16 @@
+Missing: --socket-path SOCKET_PATH (--mainnet | --testnet-magic NATURAL)
+
+Usage: cardano-cli latest query tx-mempool --socket-path SOCKET_PATH
+                                             [ --shelley-mode
+                                             | --byron-mode
+                                               [--epoch-slots SLOTS]
+                                             | --cardano-mode
+                                               [--epoch-slots SLOTS]
+                                             ]
+                                             ( --mainnet
+                                             | --testnet-magic NATURAL
+                                             )
+                                             (info | next-tx | tx-exists)
+                                             [--out-file FILE]
+
+  Local Mempool info

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_tx-mempool_next-tx.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_tx-mempool_next-tx.cli
@@ -1,0 +1,16 @@
+Missing: --socket-path SOCKET_PATH (--mainnet | --testnet-magic NATURAL)
+
+Usage: cardano-cli latest query tx-mempool --socket-path SOCKET_PATH
+                                             [ --shelley-mode
+                                             | --byron-mode
+                                               [--epoch-slots SLOTS]
+                                             | --cardano-mode
+                                               [--epoch-slots SLOTS]
+                                             ]
+                                             ( --mainnet
+                                             | --testnet-magic NATURAL
+                                             )
+                                             (info | next-tx | tx-exists)
+                                             [--out-file FILE]
+
+  Local Mempool info

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_tx-mempool_tx-exists_TX_ID.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_tx-mempool_tx-exists_TX_ID.cli
@@ -1,0 +1,16 @@
+Missing: --socket-path SOCKET_PATH (--mainnet | --testnet-magic NATURAL)
+
+Usage: cardano-cli latest query tx-mempool --socket-path SOCKET_PATH
+                                             [ --shelley-mode
+                                             | --byron-mode
+                                               [--epoch-slots SLOTS]
+                                             | --cardano-mode
+                                               [--epoch-slots SLOTS]
+                                             ]
+                                             ( --mainnet
+                                             | --testnet-magic NATURAL
+                                             )
+                                             (info | next-tx | tx-exists)
+                                             [--out-file FILE]
+
+  Local Mempool info

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_utxo.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_utxo.cli
@@ -1,0 +1,38 @@
+Usage: cardano-cli latest query utxo --socket-path SOCKET_PATH
+                                       [ --shelley-mode
+                                       | --byron-mode [--epoch-slots SLOTS]
+                                       | --cardano-mode [--epoch-slots SLOTS]
+                                       ]
+                                       ( --whole-utxo
+                                       | (--address ADDRESS)
+                                       | (--tx-in TX-IN)
+                                       )
+                                       (--mainnet | --testnet-magic NATURAL)
+                                       [--out-file FILE]
+
+  Get a portion of the current UTxO: by tx in, by address or the whole.
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --whole-utxo             Return the whole UTxO (only appropriate on small
+                           testnets).
+  --address ADDRESS        Filter by Cardano address(es) (Bech32-encoded).
+  --tx-in TX-IN            Filter by transaction input (TxId#TxIx).
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_text-view_decode-cbor.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_text-view_decode-cbor.cli
@@ -1,0 +1,8 @@
+Usage: cardano-cli latest text-view decode-cbor --in-file FILE [--out-file FILE]
+
+  Print a TextView file as decoded CBOR.
+
+Available options:
+  --in-file FILE           CBOR input file.
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_transaction.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_transaction.cli
@@ -13,7 +13,7 @@ Usage: cardano-cli latest transaction
                                         | view
                                         )
 
-  Era-based governance commands
+  Era-based transaction commands
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary.cli
@@ -1,4 +1,14 @@
-Usage: cardano-cli mary (address | governance | stake-address | transaction)
+Usage: cardano-cli mary 
+                          ( address
+                          | key
+                          | genesis
+                          | governance
+                          | node
+                          | query
+                          | stake-address
+                          | text-view
+                          | transaction
+                          )
 
   Mary era commands
 
@@ -7,6 +17,11 @@ Available options:
 
 Available commands:
   address                  Era-based address commands
+  key                      Era-based key commands
+  genesis                  Era-based genesis commands
   governance               Era-based governance commands
+  node                     Era-based node commands
+  query                    Era-based query commands
   stake-address            Stake address commands.
-  transaction              Era-based governance commands
+  text-view                Era-based text-view commands
+  transaction              Era-based transaction commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_genesis.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_genesis.cli
@@ -1,0 +1,37 @@
+Usage: cardano-cli mary genesis 
+                                  ( key-gen-genesis
+                                  | key-gen-delegate
+                                  | key-gen-utxo
+                                  | key-hash
+                                  | get-ver-key
+                                  | initial-addr
+                                  | initial-txin
+                                  | create-cardano
+                                  | create
+                                  | create-staked
+                                  | hash
+                                  )
+
+  Era-based genesis commands
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  key-gen-genesis          Create a Shelley genesis key pair
+  key-gen-delegate         Create a Shelley genesis delegate key pair
+  key-gen-utxo             Create a Shelley genesis UTxO key pair
+  key-hash                 Print the identifier (hash) of a public key
+  get-ver-key              Derive the verification key from a signing key
+  initial-addr             Get the address for an initial UTxO based on the
+                           verification key
+  initial-txin             Get the TxIn for an initial UTxO based on the
+                           verification key
+  create-cardano           Create a Byron and Shelley genesis file from a
+                           genesis template and genesis/delegation/spending
+                           keys.
+  create                   Create a Shelley genesis file from a genesis template
+                           and genesis/delegation/spending keys.
+  create-staked            Create a staked Shelley genesis file from a genesis
+                           template and genesis/delegation/spending keys.
+  hash                     Compute the hash of a genesis file

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_genesis_create-cardano.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_genesis_create-cardano.cli
@@ -1,0 +1,51 @@
+Usage: cardano-cli mary genesis create-cardano --genesis-dir DIR
+                                                 [--gen-genesis-keys INT]
+                                                 [--gen-utxo-keys INT]
+                                                 [--start-time UTC-TIME]
+                                                 [--supply LOVELACE]
+                                                 [--security-param INT]
+                                                 [--slot-length INT]
+                                                 [--slot-coefficient RATIONAL]
+                                                 ( --mainnet
+                                                 | --testnet-magic NATURAL
+                                                 )
+                                                 --byron-template FILEPATH
+                                                 --shelley-template FILEPATH
+                                                 --alonzo-template FILEPATH
+                                                 --conway-template FILEPATH
+                                                 [--node-config-template FILEPATH]
+
+  Create a Byron and Shelley genesis file from a genesis template and
+  genesis/delegation/spending keys.
+
+Available options:
+  --genesis-dir DIR        The genesis directory containing the genesis template
+                           and required genesis/delegation/spending keys.
+  --gen-genesis-keys INT   The number of genesis keys to make [default is 3].
+  --gen-utxo-keys INT      The number of UTxO keys to make [default is 0].
+  --start-time UTC-TIME    The genesis start time in YYYY-MM-DDThh:mm:ssZ
+                           format. If unspecified, will be the current time +30
+                           seconds.
+  --supply LOVELACE        The initial coin supply in Lovelace which will be
+                           evenly distributed across initial, non-delegating
+                           stake holders.
+  --security-param INT     Security parameter for genesis file [default is 108].
+  --slot-length INT        slot length (ms) parameter for genesis file [default
+                           is 1000].
+  --slot-coefficient RATIONAL
+                           Slot Coefficient for genesis file [default is .05].
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --byron-template FILEPATH
+                           JSON file with genesis defaults for each byron.
+  --shelley-template FILEPATH
+                           JSON file with genesis defaults for each shelley.
+  --alonzo-template FILEPATH
+                           JSON file with genesis defaults for alonzo.
+  --conway-template FILEPATH
+                           JSON file with genesis defaults for conway.
+  --node-config-template FILEPATH
+                           the node config template
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_genesis_create-staked.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_genesis_create-staked.cli
@@ -1,0 +1,57 @@
+Usage: cardano-cli mary genesis create-staked [--key-output-format STRING]
+                                                --genesis-dir DIR
+                                                [--gen-genesis-keys INT]
+                                                [--gen-utxo-keys INT]
+                                                [--gen-pools INT]
+                                                [--gen-stake-delegs INT]
+                                                [--start-time UTC-TIME]
+                                                [--supply LOVELACE]
+                                                [--supply-delegated LOVELACE]
+                                                ( --mainnet
+                                                | --testnet-magic NATURAL
+                                                )
+                                                [--bulk-pool-cred-files INT]
+                                                [--bulk-pools-per-file INT]
+                                                [--num-stuffed-utxo INT]
+                                                [--relay-specification-file FILE]
+
+  Create a staked Shelley genesis file from a genesis template and
+  genesis/delegation/spending keys.
+
+Available options:
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32" (default is
+                           "bech32").
+  --genesis-dir DIR        The genesis directory containing the genesis template
+                           and required genesis/delegation/spending keys.
+  --gen-genesis-keys INT   The number of genesis keys to make [default is 3].
+  --gen-utxo-keys INT      The number of UTxO keys to make [default is 0].
+  --gen-pools INT          The number of stake pool credential sets to make
+                           [default is 0].
+  --gen-stake-delegs INT   The number of stake delegator credential sets to make
+                           [default is 0].
+  --start-time UTC-TIME    The genesis start time in YYYY-MM-DDThh:mm:ssZ
+                           format. If unspecified, will be the current time +30
+                           seconds.
+  --supply LOVELACE        The initial coin supply in Lovelace which will be
+                           evenly distributed across initial, non-delegating
+                           stake holders.
+  --supply-delegated LOVELACE
+                           The initial coin supply in Lovelace which will be
+                           evenly distributed across initial, delegating stake
+                           holders.
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --bulk-pool-cred-files INT
+                           Generate bulk pool credential files [default is 0].
+  --bulk-pools-per-file INT
+                           Each bulk pool to contain this many pool credential
+                           sets [default is 0].
+  --num-stuffed-utxo INT   The number of fake UTxO entries to generate [default
+                           is 0].
+  --relay-specification-file FILE
+                           JSON file specified the relays of each stake pool.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_genesis_create.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_genesis_create.cli
@@ -1,0 +1,31 @@
+Usage: cardano-cli mary genesis create [--key-output-format STRING]
+                                         --genesis-dir DIR
+                                         [--gen-genesis-keys INT]
+                                         [--gen-utxo-keys INT]
+                                         [--start-time UTC-TIME]
+                                         [--supply LOVELACE]
+                                         (--mainnet | --testnet-magic NATURAL)
+
+  Create a Shelley genesis file from a genesis template and
+  genesis/delegation/spending keys.
+
+Available options:
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32" (default is
+                           "bech32").
+  --genesis-dir DIR        The genesis directory containing the genesis template
+                           and required genesis/delegation/spending keys.
+  --gen-genesis-keys INT   The number of genesis keys to make [default is 3].
+  --gen-utxo-keys INT      The number of UTxO keys to make [default is 0].
+  --start-time UTC-TIME    The genesis start time in YYYY-MM-DDThh:mm:ssZ
+                           format. If unspecified, will be the current time +30
+                           seconds.
+  --supply LOVELACE        The initial coin supply in Lovelace which will be
+                           evenly distributed across initial, non-delegating
+                           stake holders.
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_genesis_get-ver-key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_genesis_get-ver-key.cli
@@ -1,0 +1,10 @@
+Usage: cardano-cli mary genesis get-ver-key --verification-key-file FILE
+                                              --signing-key-file FILE
+
+  Derive the verification key from a signing key
+
+Available options:
+  --verification-key-file FILE
+                           Output filepath of the verification key.
+  --signing-key-file FILE  Input filepath of the signing key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_genesis_hash.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_genesis_hash.cli
@@ -1,0 +1,7 @@
+Usage: cardano-cli mary genesis hash --genesis FILE
+
+  Compute the hash of a genesis file
+
+Available options:
+  --genesis FILE           The genesis file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_genesis_initial-addr.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_genesis_initial-addr.cli
@@ -1,0 +1,17 @@
+Usage: cardano-cli mary genesis initial-addr --verification-key-file FILE
+                                               ( --mainnet
+                                               | --testnet-magic NATURAL
+                                               )
+                                               [--out-file FILE]
+
+  Get the address for an initial UTxO based on the verification key
+
+Available options:
+  --verification-key-file FILE
+                           Input filepath of the verification key.
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_genesis_initial-txin.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_genesis_initial-txin.cli
@@ -1,0 +1,17 @@
+Usage: cardano-cli mary genesis initial-txin --verification-key-file FILE
+                                               ( --mainnet
+                                               | --testnet-magic NATURAL
+                                               )
+                                               [--out-file FILE]
+
+  Get the TxIn for an initial UTxO based on the verification key
+
+Available options:
+  --verification-key-file FILE
+                           Input filepath of the verification key.
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_genesis_key-gen-delegate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_genesis_key-gen-delegate.cli
@@ -1,0 +1,14 @@
+Usage: cardano-cli mary genesis key-gen-delegate --verification-key-file FILE
+                                                   --signing-key-file FILE
+                                                   --operational-certificate-issue-counter-file FILE
+
+  Create a Shelley genesis delegate key pair
+
+Available options:
+  --verification-key-file FILE
+                           Output filepath of the verification key.
+  --signing-key-file FILE  Output filepath of the signing key.
+  --operational-certificate-issue-counter-file FILE
+                           The file with the issue counter for the operational
+                           certificate.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_genesis_key-gen-genesis.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_genesis_key-gen-genesis.cli
@@ -1,0 +1,10 @@
+Usage: cardano-cli mary genesis key-gen-genesis --verification-key-file FILE
+                                                  --signing-key-file FILE
+
+  Create a Shelley genesis key pair
+
+Available options:
+  --verification-key-file FILE
+                           Output filepath of the verification key.
+  --signing-key-file FILE  Output filepath of the signing key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_genesis_key-gen-utxo.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_genesis_key-gen-utxo.cli
@@ -1,0 +1,10 @@
+Usage: cardano-cli mary genesis key-gen-utxo --verification-key-file FILE
+                                               --signing-key-file FILE
+
+  Create a Shelley genesis UTxO key pair
+
+Available options:
+  --verification-key-file FILE
+                           Output filepath of the verification key.
+  --signing-key-file FILE  Output filepath of the signing key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_genesis_key-hash.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_genesis_key-hash.cli
@@ -1,0 +1,8 @@
+Usage: cardano-cli mary genesis key-hash --verification-key-file FILE
+
+  Print the identifier (hash) of a public key
+
+Available options:
+  --verification-key-file FILE
+                           Input filepath of the verification key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_key.cli
@@ -1,0 +1,40 @@
+Usage: cardano-cli mary key 
+                              ( verification-key
+                              | non-extended-key
+                              | convert-byron-key
+                              | convert-byron-genesis-vkey
+                              | convert-itn-key
+                              | convert-itn-extended-key
+                              | convert-itn-bip32-key
+                              | convert-cardano-address-key
+                              )
+
+  Era-based key commands
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  verification-key         Get a verification key from a signing key. This
+                           supports all key types.
+  non-extended-key         Get a non-extended verification key from an extended
+                           verification key. This supports all extended key
+                           types.
+  convert-byron-key        Convert a Byron payment, genesis or genesis delegate
+                           key (signing or verification) to a corresponding
+                           Shelley-format key.
+  convert-byron-genesis-vkey
+                           Convert a Base64-encoded Byron genesis verification
+                           key to a Shelley genesis verification key
+  convert-itn-key          Convert an Incentivized Testnet (ITN) non-extended
+                           (Ed25519) signing or verification key to a
+                           corresponding Shelley stake key
+  convert-itn-extended-key Convert an Incentivized Testnet (ITN) extended
+                           (Ed25519Extended) signing key to a corresponding
+                           Shelley stake signing key
+  convert-itn-bip32-key    Convert an Incentivized Testnet (ITN) BIP32
+                           (Ed25519Bip32) signing key to a corresponding Shelley
+                           stake signing key
+  convert-cardano-address-key
+                           Convert a cardano-address extended signing key to a
+                           corresponding Shelley-format key.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_key_convert-byron-genesis-vkey.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_key_convert-byron-genesis-vkey.cli
@@ -1,0 +1,11 @@
+Usage: cardano-cli mary key convert-byron-genesis-vkey --byron-genesis-verification-key BASE64
+                                                         --out-file FILE
+
+  Convert a Base64-encoded Byron genesis verification key to a Shelley genesis
+  verification key
+
+Available options:
+  --byron-genesis-verification-key BASE64
+                           Base64 string for the Byron genesis verification key.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_key_convert-byron-key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_key_convert-byron-key.cli
@@ -1,0 +1,35 @@
+Usage: cardano-cli mary key convert-byron-key [--password TEXT]
+                                                ( --byron-payment-key-type
+                                                | --legacy-byron-payment-key-type
+                                                | --byron-genesis-key-type
+                                                | --legacy-byron-genesis-key-type
+                                                | --byron-genesis-delegate-key-type
+                                                | --legacy-byron-genesis-delegate-key-type
+                                                )
+                                                ( --byron-signing-key-file FILE
+                                                | --byron-verification-key-file FILE
+                                                )
+                                                --out-file FILE
+
+  Convert a Byron payment, genesis or genesis delegate key (signing or
+  verification) to a corresponding Shelley-format key.
+
+Available options:
+  --password TEXT          Password for signing key (if applicable).
+  --byron-payment-key-type Use a Byron-era payment key.
+  --legacy-byron-payment-key-type
+                           Use a Byron-era payment key, in legacy SL format.
+  --byron-genesis-key-type Use a Byron-era genesis key.
+  --legacy-byron-genesis-key-type
+                           Use a Byron-era genesis key, in legacy SL format.
+  --byron-genesis-delegate-key-type
+                           Use a Byron-era genesis delegate key.
+  --legacy-byron-genesis-delegate-key-type
+                           Use a Byron-era genesis delegate key, in legacy SL
+                           format.
+  --byron-signing-key-file FILE
+                           Input filepath of the Byron-format signing key.
+  --byron-verification-key-file FILE
+                           Input filepath of the Byron-format verification key.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_key_convert-cardano-address-key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_key_convert-cardano-address-key.cli
@@ -1,0 +1,22 @@
+Usage: cardano-cli mary key convert-cardano-address-key 
+                                                          ( --shelley-payment-key
+                                                          | --shelley-stake-key
+                                                          | --icarus-payment-key
+                                                          | --byron-payment-key
+                                                          )
+                                                          --signing-key-file FILE
+                                                          --out-file FILE
+
+  Convert a cardano-address extended signing key to a corresponding
+  Shelley-format key.
+
+Available options:
+  --shelley-payment-key    Use a Shelley-era extended payment key.
+  --shelley-stake-key      Use a Shelley-era extended stake key.
+  --icarus-payment-key     Use a Byron-era extended payment key formatted in the
+                           Icarus style.
+  --byron-payment-key      Use a Byron-era extended payment key formatted in the
+                           deprecated Byron style.
+  --signing-key-file FILE  Input filepath of the signing key.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_key_convert-itn-bip32-key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_key_convert-itn-bip32-key.cli
@@ -1,0 +1,11 @@
+Usage: cardano-cli mary key convert-itn-bip32-key --itn-signing-key-file FILE
+                                                    --out-file FILE
+
+  Convert an Incentivized Testnet (ITN) BIP32 (Ed25519Bip32) signing key to a
+  corresponding Shelley stake signing key
+
+Available options:
+  --itn-signing-key-file FILE
+                           Filepath of the ITN signing key.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_key_convert-itn-extended-key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_key_convert-itn-extended-key.cli
@@ -1,0 +1,11 @@
+Usage: cardano-cli mary key convert-itn-extended-key --itn-signing-key-file FILE
+                                                       --out-file FILE
+
+  Convert an Incentivized Testnet (ITN) extended (Ed25519Extended) signing key
+  to a corresponding Shelley stake signing key
+
+Available options:
+  --itn-signing-key-file FILE
+                           Filepath of the ITN signing key.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_key_convert-itn-key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_key_convert-itn-key.cli
@@ -1,0 +1,16 @@
+Usage: cardano-cli mary key convert-itn-key 
+                                              ( --itn-signing-key-file FILE
+                                              | --itn-verification-key-file FILE
+                                              )
+                                              --out-file FILE
+
+  Convert an Incentivized Testnet (ITN) non-extended (Ed25519) signing or
+  verification key to a corresponding Shelley stake key
+
+Available options:
+  --itn-signing-key-file FILE
+                           Filepath of the ITN signing key.
+  --itn-verification-key-file FILE
+                           Filepath of the ITN verification key.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_key_non-extended-key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_key_non-extended-key.cli
@@ -1,0 +1,12 @@
+Usage: cardano-cli mary key non-extended-key --extended-verification-key-file FILE
+                                               --verification-key-file FILE
+
+  Get a non-extended verification key from an extended verification key. This
+  supports all extended key types.
+
+Available options:
+  --extended-verification-key-file FILE
+                           Input filepath of the ed25519-bip32 verification key.
+  --verification-key-file FILE
+                           Output filepath of the verification key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_key_verification-key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_key_verification-key.cli
@@ -1,0 +1,10 @@
+Usage: cardano-cli mary key verification-key --signing-key-file FILE
+                                               --verification-key-file FILE
+
+  Get a verification key from a signing key. This supports all key types.
+
+Available options:
+  --signing-key-file FILE  Input filepath of the signing key.
+  --verification-key-file FILE
+                           Output filepath of the verification key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_node.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_node.cli
@@ -1,0 +1,22 @@
+Usage: cardano-cli mary node 
+                               ( key-gen
+                               | key-gen-KES
+                               | key-gen-VRF
+                               | key-hash-VRF
+                               | new-counter
+                               | issue-op-cert
+                               )
+
+  Era-based node commands
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  key-gen                  Create a key pair for a node operator's offline key
+                           and a new certificate issue counter
+  key-gen-KES              Create a key pair for a node KES operational key
+  key-gen-VRF              Create a key pair for a node VRF operational key
+  key-hash-VRF             Print hash of a node's operational VRF key.
+  new-counter              Create a new certificate issue counter
+  issue-op-cert            Issue a node operational certificate

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_node_issue-op-cert.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_node_issue-op-cert.cli
@@ -1,0 +1,24 @@
+Usage: cardano-cli mary node issue-op-cert 
+                                             ( --kes-verification-key STRING
+                                             | --kes-verification-key-file FILE
+                                             )
+                                             --cold-signing-key-file FILE
+                                             --operational-certificate-issue-counter-file FILE
+                                             --kes-period NATURAL
+                                             --out-file FILE
+
+  Issue a node operational certificate
+
+Available options:
+  --kes-verification-key STRING
+                           A Bech32 or hex-encoded hot KES verification key.
+  --kes-verification-key-file FILE
+                           Filepath of the hot KES verification key.
+  --cold-signing-key-file FILE
+                           Filepath of the cold signing key.
+  --operational-certificate-issue-counter-file FILE
+                           The file with the issue counter for the operational
+                           certificate.
+  --kes-period NATURAL     The start of the KES key validity period.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_node_key-gen-KES.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_node_key-gen-KES.cli
@@ -1,0 +1,15 @@
+Usage: cardano-cli mary node key-gen-KES [--key-output-format STRING]
+                                           --verification-key-file FILE
+                                           --signing-key-file FILE
+
+  Create a key pair for a node KES operational key
+
+Available options:
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32" (default is
+                           "bech32").
+  --verification-key-file FILE
+                           Output filepath of the verification key.
+  --signing-key-file FILE  Output filepath of the signing key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_node_key-gen-VRF.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_node_key-gen-VRF.cli
@@ -1,0 +1,15 @@
+Usage: cardano-cli mary node key-gen-VRF [--key-output-format STRING]
+                                           --verification-key-file FILE
+                                           --signing-key-file FILE
+
+  Create a key pair for a node VRF operational key
+
+Available options:
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32" (default is
+                           "bech32").
+  --verification-key-file FILE
+                           Output filepath of the verification key.
+  --signing-key-file FILE  Output filepath of the signing key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_node_key-gen.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_node_key-gen.cli
@@ -1,0 +1,21 @@
+Usage: cardano-cli mary node key-gen [--key-output-format STRING]
+                                       --cold-verification-key-file FILE
+                                       --cold-signing-key-file FILE
+                                       --operational-certificate-issue-counter-file FILE
+
+  Create a key pair for a node operator's offline key and a new certificate
+  issue counter
+
+Available options:
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32" (default is
+                           "bech32").
+  --cold-verification-key-file FILE
+                           Filepath of the cold verification key.
+  --cold-signing-key-file FILE
+                           Filepath of the cold signing key.
+  --operational-certificate-issue-counter-file FILE
+                           The file with the issue counter for the operational
+                           certificate.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_node_key-hash-VRF.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_node_key-hash-VRF.cli
@@ -1,0 +1,15 @@
+Usage: cardano-cli mary node key-hash-VRF 
+                                            ( --verification-key STRING
+                                            | --verification-key-file FILE
+                                            )
+                                            [--out-file FILE]
+
+  Print hash of a node's operational VRF key.
+
+Available options:
+  --verification-key STRING
+                           Verification key (Bech32 or hex-encoded).
+  --verification-key-file FILE
+                           Input filepath of the verification key.
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_node_new-counter.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_node_new-counter.cli
@@ -1,0 +1,22 @@
+Usage: cardano-cli mary node new-counter 
+                                           ( --stake-pool-verification-key STRING
+                                           | --genesis-delegate-verification-key STRING
+                                           | --cold-verification-key-file FILE
+                                           )
+                                           --counter-value INT
+                                           --operational-certificate-issue-counter-file FILE
+
+  Create a new certificate issue counter
+
+Available options:
+  --stake-pool-verification-key STRING
+                           Stake pool verification key (Bech32 or hex-encoded).
+  --genesis-delegate-verification-key STRING
+                           Genesis delegate verification key (hex-encoded).
+  --cold-verification-key-file FILE
+                           Filepath of the cold verification key.
+  --counter-value INT      The next certificate issue counter value to use.
+  --operational-certificate-issue-counter-file FILE
+                           The file with the issue counter for the operational
+                           certificate.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query.cli
@@ -1,0 +1,50 @@
+Usage: cardano-cli mary query 
+                                ( protocol-parameters
+                                | constitution-hash
+                                | tip
+                                | stake-pools
+                                | stake-distribution
+                                | stake-address-info
+                                | utxo
+                                | ledger-state
+                                | protocol-state
+                                | stake-snapshot
+                                | leadership-schedule
+                                | kes-period-info
+                                | pool-state
+                                | tx-mempool
+                                | slot-number
+                                )
+
+  Era-based query commands
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  protocol-parameters      Get the node's current protocol parameters
+  constitution-hash        Get the constitution hash
+  tip                      Get the node's current tip (slot no, hash, block no)
+  stake-pools              Get the node's current set of stake pool ids
+  stake-distribution       Get the node's current aggregated stake distribution
+  stake-address-info       Get the current delegations and reward accounts
+                           filtered by stake address.
+  utxo                     Get a portion of the current UTxO: by tx in, by
+                           address or the whole.
+  ledger-state             Dump the current ledger state of the node
+                           (Ledger.NewEpochState -- advanced command)
+  protocol-state           Dump the current protocol state of the node
+                           (Ledger.ChainDepState -- advanced command)
+  stake-snapshot           Obtain the three stake snapshots for a pool, plus the
+                           total active stake (advanced command)
+  pool-params              DEPRECATED. Use query pool-state instead. Dump the
+                           pool parameters
+                           (Ledger.NewEpochState.esLState._delegationState._pState._pParams
+                           -- advanced command)
+  leadership-schedule      Get the slots the node is expected to mint a block in
+                           (advanced command)
+  kes-period-info          Get information about the current KES period and your
+                           node's operational certificate.
+  pool-state               Dump the pool state
+  tx-mempool               Local Mempool info
+  slot-number              Query slot number for UTC timestamp

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_constitution-hash.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_constitution-hash.cli
@@ -1,0 +1,34 @@
+Usage: cardano-cli mary query constitution-hash --socket-path SOCKET_PATH
+                                                  [ --shelley-mode
+                                                  | --byron-mode
+                                                    [--epoch-slots SLOTS]
+                                                  | --cardano-mode
+                                                    [--epoch-slots SLOTS]
+                                                  ]
+                                                  ( --mainnet
+                                                  | --testnet-magic NATURAL
+                                                  )
+                                                  [--out-file FILE]
+
+  Get the constitution hash
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_kes-period-info.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_kes-period-info.cli
@@ -1,0 +1,37 @@
+Usage: cardano-cli mary query kes-period-info --socket-path SOCKET_PATH
+                                                [ --shelley-mode
+                                                | --byron-mode
+                                                  [--epoch-slots SLOTS]
+                                                | --cardano-mode
+                                                  [--epoch-slots SLOTS]
+                                                ]
+                                                ( --mainnet
+                                                | --testnet-magic NATURAL
+                                                )
+                                                --op-cert-file FILE
+                                                [--out-file FILE]
+
+  Get information about the current KES period and your node's operational
+  certificate.
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --op-cert-file FILE      Filepath of the node's operational certificate.
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_leadership-schedule.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_leadership-schedule.cli
@@ -1,0 +1,54 @@
+Usage: cardano-cli mary query leadership-schedule --socket-path SOCKET_PATH
+                                                    [ --shelley-mode
+                                                    | --byron-mode
+                                                      [--epoch-slots SLOTS]
+                                                    | --cardano-mode
+                                                      [--epoch-slots SLOTS]
+                                                    ]
+                                                    ( --mainnet
+                                                    | --testnet-magic NATURAL
+                                                    )
+                                                    --genesis FILE
+                                                    ( --stake-pool-verification-key STRING
+                                                    | --cold-verification-key-file FILE
+                                                    | --stake-pool-id STAKE_POOL_ID
+                                                    )
+                                                    --vrf-signing-key-file FILE
+                                                    (--current | --next)
+                                                    [--out-file FILE]
+
+  Get the slots the node is expected to mint a block in (advanced command)
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --genesis FILE           Shelley genesis filepath
+  --stake-pool-verification-key STRING
+                           Stake pool verification key (Bech32 or hex-encoded).
+  --cold-verification-key-file FILE
+                           Filepath of the stake pool verification key.
+  --stake-pool-id STAKE_POOL_ID
+                           Stake pool ID/verification key hash (either
+                           Bech32-encoded or hex-encoded). Zero or more
+                           occurences of this option is allowed.
+  --vrf-signing-key-file FILE
+                           Input filepath of the VRF signing key.
+  --current                Get the leadership schedule for the current epoch.
+  --next                   Get the leadership schedule for the following epoch.
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_ledger-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_ledger-state.cli
@@ -1,0 +1,35 @@
+Usage: cardano-cli mary query ledger-state --socket-path SOCKET_PATH
+                                             [ --shelley-mode
+                                             | --byron-mode
+                                               [--epoch-slots SLOTS]
+                                             | --cardano-mode
+                                               [--epoch-slots SLOTS]
+                                             ]
+                                             ( --mainnet
+                                             | --testnet-magic NATURAL
+                                             )
+                                             [--out-file FILE]
+
+  Dump the current ledger state of the node (Ledger.NewEpochState -- advanced
+  command)
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_pool-params.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_pool-params.cli
@@ -1,0 +1,38 @@
+Usage: cardano-cli mary query pool-params --socket-path SOCKET_PATH
+                                            [ --shelley-mode
+                                            | --byron-mode [--epoch-slots SLOTS]
+                                            | --cardano-mode
+                                              [--epoch-slots SLOTS]
+                                            ]
+                                            ( --mainnet
+                                            | --testnet-magic NATURAL
+                                            )
+                                            [--stake-pool-id STAKE_POOL_ID]
+
+  DEPRECATED. Use query pool-state instead. Dump the pool parameters
+  (Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced
+  command)
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --stake-pool-id STAKE_POOL_ID
+                           Stake pool ID/verification key hash (either
+                           Bech32-encoded or hex-encoded). Zero or more
+                           occurences of this option is allowed.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_pool-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_pool-state.cli
@@ -1,0 +1,34 @@
+Usage: cardano-cli mary query pool-state --socket-path SOCKET_PATH
+                                           [ --shelley-mode
+                                           | --byron-mode [--epoch-slots SLOTS]
+                                           | --cardano-mode
+                                             [--epoch-slots SLOTS]
+                                           ]
+                                           (--mainnet | --testnet-magic NATURAL)
+                                           [--stake-pool-id STAKE_POOL_ID]
+
+  Dump the pool state
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --stake-pool-id STAKE_POOL_ID
+                           Stake pool ID/verification key hash (either
+                           Bech32-encoded or hex-encoded). Zero or more
+                           occurences of this option is allowed.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_protocol-parameters.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_protocol-parameters.cli
@@ -1,0 +1,34 @@
+Usage: cardano-cli mary query protocol-parameters --socket-path SOCKET_PATH
+                                                    [ --shelley-mode
+                                                    | --byron-mode
+                                                      [--epoch-slots SLOTS]
+                                                    | --cardano-mode
+                                                      [--epoch-slots SLOTS]
+                                                    ]
+                                                    ( --mainnet
+                                                    | --testnet-magic NATURAL
+                                                    )
+                                                    [--out-file FILE]
+
+  Get the node's current protocol parameters
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_protocol-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_protocol-state.cli
@@ -1,0 +1,35 @@
+Usage: cardano-cli mary query protocol-state --socket-path SOCKET_PATH
+                                               [ --shelley-mode
+                                               | --byron-mode
+                                                 [--epoch-slots SLOTS]
+                                               | --cardano-mode
+                                                 [--epoch-slots SLOTS]
+                                               ]
+                                               ( --mainnet
+                                               | --testnet-magic NATURAL
+                                               )
+                                               [--out-file FILE]
+
+  Dump the current protocol state of the node (Ledger.ChainDepState -- advanced
+  command)
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_slot-number.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_slot-number.cli
@@ -1,0 +1,33 @@
+Usage: cardano-cli mary query slot-number --socket-path SOCKET_PATH
+                                            [ --shelley-mode
+                                            | --byron-mode [--epoch-slots SLOTS]
+                                            | --cardano-mode
+                                              [--epoch-slots SLOTS]
+                                            ]
+                                            ( --mainnet
+                                            | --testnet-magic NATURAL
+                                            )
+                                            TIMESTAMP
+
+  Query slot number for UTC timestamp
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  TIMESTAMP                UTC timestamp in YYYY-MM-DDThh:mm:ssZ format
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_stake-address-info.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_stake-address-info.cli
@@ -1,0 +1,36 @@
+Usage: cardano-cli mary query stake-address-info --socket-path SOCKET_PATH
+                                                   [ --shelley-mode
+                                                   | --byron-mode
+                                                     [--epoch-slots SLOTS]
+                                                   | --cardano-mode
+                                                     [--epoch-slots SLOTS]
+                                                   ]
+                                                   --address ADDRESS
+                                                   ( --mainnet
+                                                   | --testnet-magic NATURAL
+                                                   )
+                                                   [--out-file FILE]
+
+  Get the current delegations and reward accounts filtered by stake address.
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --address ADDRESS        Filter by Cardano stake address (Bech32-encoded).
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_stake-distribution.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_stake-distribution.cli
@@ -1,0 +1,34 @@
+Usage: cardano-cli mary query stake-distribution --socket-path SOCKET_PATH
+                                                   [ --shelley-mode
+                                                   | --byron-mode
+                                                     [--epoch-slots SLOTS]
+                                                   | --cardano-mode
+                                                     [--epoch-slots SLOTS]
+                                                   ]
+                                                   ( --mainnet
+                                                   | --testnet-magic NATURAL
+                                                   )
+                                                   [--out-file FILE]
+
+  Get the node's current aggregated stake distribution
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_stake-pools.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_stake-pools.cli
@@ -1,0 +1,33 @@
+Usage: cardano-cli mary query stake-pools --socket-path SOCKET_PATH
+                                            [ --shelley-mode
+                                            | --byron-mode [--epoch-slots SLOTS]
+                                            | --cardano-mode
+                                              [--epoch-slots SLOTS]
+                                            ]
+                                            ( --mainnet
+                                            | --testnet-magic NATURAL
+                                            )
+                                            [--out-file FILE]
+
+  Get the node's current set of stake pool ids
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_stake-snapshot.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_stake-snapshot.cli
@@ -1,0 +1,43 @@
+Usage: cardano-cli mary query stake-snapshot --socket-path SOCKET_PATH
+                                               [ --shelley-mode
+                                               | --byron-mode
+                                                 [--epoch-slots SLOTS]
+                                               | --cardano-mode
+                                                 [--epoch-slots SLOTS]
+                                               ]
+                                               ( --mainnet
+                                               | --testnet-magic NATURAL
+                                               )
+                                               [ --all-stake-pools
+                                               | [--stake-pool-id STAKE_POOL_ID]
+                                               ]
+                                               [--out-file FILE]
+
+  Obtain the three stake snapshots for a pool, plus the total active stake
+  (advanced command)
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --all-stake-pools        Query for all stake pools
+  --stake-pool-id STAKE_POOL_ID
+                           Stake pool ID/verification key hash (either
+                           Bech32-encoded or hex-encoded). Zero or more
+                           occurences of this option is allowed.
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_tip.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_tip.cli
@@ -1,0 +1,30 @@
+Usage: cardano-cli mary query tip --socket-path SOCKET_PATH
+                                    [ --shelley-mode
+                                    | --byron-mode [--epoch-slots SLOTS]
+                                    | --cardano-mode [--epoch-slots SLOTS]
+                                    ]
+                                    (--mainnet | --testnet-magic NATURAL)
+                                    [--out-file FILE]
+
+  Get the node's current tip (slot no, hash, block no)
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_tx-mempool.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_tx-mempool.cli
@@ -1,0 +1,40 @@
+Usage: cardano-cli mary query tx-mempool --socket-path SOCKET_PATH
+                                           [ --shelley-mode
+                                           | --byron-mode [--epoch-slots SLOTS]
+                                           | --cardano-mode
+                                             [--epoch-slots SLOTS]
+                                           ]
+                                           (--mainnet | --testnet-magic NATURAL)
+                                           (info | next-tx | tx-exists)
+                                           [--out-file FILE]
+
+  Local Mempool info
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text
+
+Available commands:
+  info                     Ask the node about the current mempool's capacity and
+                           sizes
+  next-tx                  Requests the next transaction from the mempool's
+                           current list
+  tx-exists                Query if a particular transaction exists in the
+                           mempool

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_tx-mempool_info.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_tx-mempool_info.cli
@@ -1,0 +1,13 @@
+Missing: --socket-path SOCKET_PATH (--mainnet | --testnet-magic NATURAL)
+
+Usage: cardano-cli mary query tx-mempool --socket-path SOCKET_PATH
+                                           [ --shelley-mode
+                                           | --byron-mode [--epoch-slots SLOTS]
+                                           | --cardano-mode
+                                             [--epoch-slots SLOTS]
+                                           ]
+                                           (--mainnet | --testnet-magic NATURAL)
+                                           (info | next-tx | tx-exists)
+                                           [--out-file FILE]
+
+  Local Mempool info

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_tx-mempool_next-tx.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_tx-mempool_next-tx.cli
@@ -1,0 +1,13 @@
+Missing: --socket-path SOCKET_PATH (--mainnet | --testnet-magic NATURAL)
+
+Usage: cardano-cli mary query tx-mempool --socket-path SOCKET_PATH
+                                           [ --shelley-mode
+                                           | --byron-mode [--epoch-slots SLOTS]
+                                           | --cardano-mode
+                                             [--epoch-slots SLOTS]
+                                           ]
+                                           (--mainnet | --testnet-magic NATURAL)
+                                           (info | next-tx | tx-exists)
+                                           [--out-file FILE]
+
+  Local Mempool info

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_tx-mempool_tx-exists_TX_ID.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_tx-mempool_tx-exists_TX_ID.cli
@@ -1,0 +1,13 @@
+Missing: --socket-path SOCKET_PATH (--mainnet | --testnet-magic NATURAL)
+
+Usage: cardano-cli mary query tx-mempool --socket-path SOCKET_PATH
+                                           [ --shelley-mode
+                                           | --byron-mode [--epoch-slots SLOTS]
+                                           | --cardano-mode
+                                             [--epoch-slots SLOTS]
+                                           ]
+                                           (--mainnet | --testnet-magic NATURAL)
+                                           (info | next-tx | tx-exists)
+                                           [--out-file FILE]
+
+  Local Mempool info

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_utxo.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_utxo.cli
@@ -1,0 +1,38 @@
+Usage: cardano-cli mary query utxo --socket-path SOCKET_PATH
+                                     [ --shelley-mode
+                                     | --byron-mode [--epoch-slots SLOTS]
+                                     | --cardano-mode [--epoch-slots SLOTS]
+                                     ]
+                                     ( --whole-utxo
+                                     | (--address ADDRESS)
+                                     | (--tx-in TX-IN)
+                                     )
+                                     (--mainnet | --testnet-magic NATURAL)
+                                     [--out-file FILE]
+
+  Get a portion of the current UTxO: by tx in, by address or the whole.
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --whole-utxo             Return the whole UTxO (only appropriate on small
+                           testnets).
+  --address ADDRESS        Filter by Cardano address(es) (Bech32-encoded).
+  --tx-in TX-IN            Filter by transaction input (TxId#TxIx).
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_text-view_decode-cbor.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_text-view_decode-cbor.cli
@@ -1,0 +1,8 @@
+Usage: cardano-cli mary text-view decode-cbor --in-file FILE [--out-file FILE]
+
+  Print a TextView file as decoded CBOR.
+
+Available options:
+  --in-file FILE           CBOR input file.
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_transaction.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_transaction.cli
@@ -13,7 +13,7 @@ Usage: cardano-cli mary transaction
                                       | view
                                       )
 
-  Era-based governance commands
+  Era-based transaction commands
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley.cli
@@ -1,4 +1,14 @@
-Usage: cardano-cli shelley (address | governance | stake-address | transaction)
+Usage: cardano-cli shelley 
+                             ( address
+                             | key
+                             | genesis
+                             | governance
+                             | node
+                             | query
+                             | stake-address
+                             | text-view
+                             | transaction
+                             )
 
   Shelley era commands
 
@@ -7,6 +17,11 @@ Available options:
 
 Available commands:
   address                  Era-based address commands
+  key                      Era-based key commands
+  genesis                  Era-based genesis commands
   governance               Era-based governance commands
+  node                     Era-based node commands
+  query                    Era-based query commands
   stake-address            Stake address commands.
-  transaction              Era-based governance commands
+  text-view                Era-based text-view commands
+  transaction              Era-based transaction commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_genesis.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_genesis.cli
@@ -1,0 +1,37 @@
+Usage: cardano-cli shelley genesis 
+                                     ( key-gen-genesis
+                                     | key-gen-delegate
+                                     | key-gen-utxo
+                                     | key-hash
+                                     | get-ver-key
+                                     | initial-addr
+                                     | initial-txin
+                                     | create-cardano
+                                     | create
+                                     | create-staked
+                                     | hash
+                                     )
+
+  Era-based genesis commands
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  key-gen-genesis          Create a Shelley genesis key pair
+  key-gen-delegate         Create a Shelley genesis delegate key pair
+  key-gen-utxo             Create a Shelley genesis UTxO key pair
+  key-hash                 Print the identifier (hash) of a public key
+  get-ver-key              Derive the verification key from a signing key
+  initial-addr             Get the address for an initial UTxO based on the
+                           verification key
+  initial-txin             Get the TxIn for an initial UTxO based on the
+                           verification key
+  create-cardano           Create a Byron and Shelley genesis file from a
+                           genesis template and genesis/delegation/spending
+                           keys.
+  create                   Create a Shelley genesis file from a genesis template
+                           and genesis/delegation/spending keys.
+  create-staked            Create a staked Shelley genesis file from a genesis
+                           template and genesis/delegation/spending keys.
+  hash                     Compute the hash of a genesis file

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_genesis_create-cardano.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_genesis_create-cardano.cli
@@ -1,0 +1,51 @@
+Usage: cardano-cli shelley genesis create-cardano --genesis-dir DIR
+                                                    [--gen-genesis-keys INT]
+                                                    [--gen-utxo-keys INT]
+                                                    [--start-time UTC-TIME]
+                                                    [--supply LOVELACE]
+                                                    [--security-param INT]
+                                                    [--slot-length INT]
+                                                    [--slot-coefficient RATIONAL]
+                                                    ( --mainnet
+                                                    | --testnet-magic NATURAL
+                                                    )
+                                                    --byron-template FILEPATH
+                                                    --shelley-template FILEPATH
+                                                    --alonzo-template FILEPATH
+                                                    --conway-template FILEPATH
+                                                    [--node-config-template FILEPATH]
+
+  Create a Byron and Shelley genesis file from a genesis template and
+  genesis/delegation/spending keys.
+
+Available options:
+  --genesis-dir DIR        The genesis directory containing the genesis template
+                           and required genesis/delegation/spending keys.
+  --gen-genesis-keys INT   The number of genesis keys to make [default is 3].
+  --gen-utxo-keys INT      The number of UTxO keys to make [default is 0].
+  --start-time UTC-TIME    The genesis start time in YYYY-MM-DDThh:mm:ssZ
+                           format. If unspecified, will be the current time +30
+                           seconds.
+  --supply LOVELACE        The initial coin supply in Lovelace which will be
+                           evenly distributed across initial, non-delegating
+                           stake holders.
+  --security-param INT     Security parameter for genesis file [default is 108].
+  --slot-length INT        slot length (ms) parameter for genesis file [default
+                           is 1000].
+  --slot-coefficient RATIONAL
+                           Slot Coefficient for genesis file [default is .05].
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --byron-template FILEPATH
+                           JSON file with genesis defaults for each byron.
+  --shelley-template FILEPATH
+                           JSON file with genesis defaults for each shelley.
+  --alonzo-template FILEPATH
+                           JSON file with genesis defaults for alonzo.
+  --conway-template FILEPATH
+                           JSON file with genesis defaults for conway.
+  --node-config-template FILEPATH
+                           the node config template
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_genesis_create-staked.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_genesis_create-staked.cli
@@ -1,0 +1,57 @@
+Usage: cardano-cli shelley genesis create-staked [--key-output-format STRING]
+                                                   --genesis-dir DIR
+                                                   [--gen-genesis-keys INT]
+                                                   [--gen-utxo-keys INT]
+                                                   [--gen-pools INT]
+                                                   [--gen-stake-delegs INT]
+                                                   [--start-time UTC-TIME]
+                                                   [--supply LOVELACE]
+                                                   [--supply-delegated LOVELACE]
+                                                   ( --mainnet
+                                                   | --testnet-magic NATURAL
+                                                   )
+                                                   [--bulk-pool-cred-files INT]
+                                                   [--bulk-pools-per-file INT]
+                                                   [--num-stuffed-utxo INT]
+                                                   [--relay-specification-file FILE]
+
+  Create a staked Shelley genesis file from a genesis template and
+  genesis/delegation/spending keys.
+
+Available options:
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32" (default is
+                           "bech32").
+  --genesis-dir DIR        The genesis directory containing the genesis template
+                           and required genesis/delegation/spending keys.
+  --gen-genesis-keys INT   The number of genesis keys to make [default is 3].
+  --gen-utxo-keys INT      The number of UTxO keys to make [default is 0].
+  --gen-pools INT          The number of stake pool credential sets to make
+                           [default is 0].
+  --gen-stake-delegs INT   The number of stake delegator credential sets to make
+                           [default is 0].
+  --start-time UTC-TIME    The genesis start time in YYYY-MM-DDThh:mm:ssZ
+                           format. If unspecified, will be the current time +30
+                           seconds.
+  --supply LOVELACE        The initial coin supply in Lovelace which will be
+                           evenly distributed across initial, non-delegating
+                           stake holders.
+  --supply-delegated LOVELACE
+                           The initial coin supply in Lovelace which will be
+                           evenly distributed across initial, delegating stake
+                           holders.
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --bulk-pool-cred-files INT
+                           Generate bulk pool credential files [default is 0].
+  --bulk-pools-per-file INT
+                           Each bulk pool to contain this many pool credential
+                           sets [default is 0].
+  --num-stuffed-utxo INT   The number of fake UTxO entries to generate [default
+                           is 0].
+  --relay-specification-file FILE
+                           JSON file specified the relays of each stake pool.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_genesis_create.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_genesis_create.cli
@@ -1,0 +1,33 @@
+Usage: cardano-cli shelley genesis create [--key-output-format STRING]
+                                            --genesis-dir DIR
+                                            [--gen-genesis-keys INT]
+                                            [--gen-utxo-keys INT]
+                                            [--start-time UTC-TIME]
+                                            [--supply LOVELACE]
+                                            ( --mainnet
+                                            | --testnet-magic NATURAL
+                                            )
+
+  Create a Shelley genesis file from a genesis template and
+  genesis/delegation/spending keys.
+
+Available options:
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32" (default is
+                           "bech32").
+  --genesis-dir DIR        The genesis directory containing the genesis template
+                           and required genesis/delegation/spending keys.
+  --gen-genesis-keys INT   The number of genesis keys to make [default is 3].
+  --gen-utxo-keys INT      The number of UTxO keys to make [default is 0].
+  --start-time UTC-TIME    The genesis start time in YYYY-MM-DDThh:mm:ssZ
+                           format. If unspecified, will be the current time +30
+                           seconds.
+  --supply LOVELACE        The initial coin supply in Lovelace which will be
+                           evenly distributed across initial, non-delegating
+                           stake holders.
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_genesis_get-ver-key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_genesis_get-ver-key.cli
@@ -1,0 +1,10 @@
+Usage: cardano-cli shelley genesis get-ver-key --verification-key-file FILE
+                                                 --signing-key-file FILE
+
+  Derive the verification key from a signing key
+
+Available options:
+  --verification-key-file FILE
+                           Output filepath of the verification key.
+  --signing-key-file FILE  Input filepath of the signing key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_genesis_hash.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_genesis_hash.cli
@@ -1,0 +1,7 @@
+Usage: cardano-cli shelley genesis hash --genesis FILE
+
+  Compute the hash of a genesis file
+
+Available options:
+  --genesis FILE           The genesis file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_genesis_initial-addr.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_genesis_initial-addr.cli
@@ -1,0 +1,17 @@
+Usage: cardano-cli shelley genesis initial-addr --verification-key-file FILE
+                                                  ( --mainnet
+                                                  | --testnet-magic NATURAL
+                                                  )
+                                                  [--out-file FILE]
+
+  Get the address for an initial UTxO based on the verification key
+
+Available options:
+  --verification-key-file FILE
+                           Input filepath of the verification key.
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_genesis_initial-txin.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_genesis_initial-txin.cli
@@ -1,0 +1,17 @@
+Usage: cardano-cli shelley genesis initial-txin --verification-key-file FILE
+                                                  ( --mainnet
+                                                  | --testnet-magic NATURAL
+                                                  )
+                                                  [--out-file FILE]
+
+  Get the TxIn for an initial UTxO based on the verification key
+
+Available options:
+  --verification-key-file FILE
+                           Input filepath of the verification key.
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_genesis_key-gen-delegate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_genesis_key-gen-delegate.cli
@@ -1,0 +1,14 @@
+Usage: cardano-cli shelley genesis key-gen-delegate --verification-key-file FILE
+                                                      --signing-key-file FILE
+                                                      --operational-certificate-issue-counter-file FILE
+
+  Create a Shelley genesis delegate key pair
+
+Available options:
+  --verification-key-file FILE
+                           Output filepath of the verification key.
+  --signing-key-file FILE  Output filepath of the signing key.
+  --operational-certificate-issue-counter-file FILE
+                           The file with the issue counter for the operational
+                           certificate.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_genesis_key-gen-genesis.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_genesis_key-gen-genesis.cli
@@ -1,0 +1,10 @@
+Usage: cardano-cli shelley genesis key-gen-genesis --verification-key-file FILE
+                                                     --signing-key-file FILE
+
+  Create a Shelley genesis key pair
+
+Available options:
+  --verification-key-file FILE
+                           Output filepath of the verification key.
+  --signing-key-file FILE  Output filepath of the signing key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_genesis_key-gen-utxo.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_genesis_key-gen-utxo.cli
@@ -1,0 +1,10 @@
+Usage: cardano-cli shelley genesis key-gen-utxo --verification-key-file FILE
+                                                  --signing-key-file FILE
+
+  Create a Shelley genesis UTxO key pair
+
+Available options:
+  --verification-key-file FILE
+                           Output filepath of the verification key.
+  --signing-key-file FILE  Output filepath of the signing key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_genesis_key-hash.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_genesis_key-hash.cli
@@ -1,0 +1,8 @@
+Usage: cardano-cli shelley genesis key-hash --verification-key-file FILE
+
+  Print the identifier (hash) of a public key
+
+Available options:
+  --verification-key-file FILE
+                           Input filepath of the verification key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_key.cli
@@ -1,0 +1,40 @@
+Usage: cardano-cli shelley key 
+                                 ( verification-key
+                                 | non-extended-key
+                                 | convert-byron-key
+                                 | convert-byron-genesis-vkey
+                                 | convert-itn-key
+                                 | convert-itn-extended-key
+                                 | convert-itn-bip32-key
+                                 | convert-cardano-address-key
+                                 )
+
+  Era-based key commands
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  verification-key         Get a verification key from a signing key. This
+                           supports all key types.
+  non-extended-key         Get a non-extended verification key from an extended
+                           verification key. This supports all extended key
+                           types.
+  convert-byron-key        Convert a Byron payment, genesis or genesis delegate
+                           key (signing or verification) to a corresponding
+                           Shelley-format key.
+  convert-byron-genesis-vkey
+                           Convert a Base64-encoded Byron genesis verification
+                           key to a Shelley genesis verification key
+  convert-itn-key          Convert an Incentivized Testnet (ITN) non-extended
+                           (Ed25519) signing or verification key to a
+                           corresponding Shelley stake key
+  convert-itn-extended-key Convert an Incentivized Testnet (ITN) extended
+                           (Ed25519Extended) signing key to a corresponding
+                           Shelley stake signing key
+  convert-itn-bip32-key    Convert an Incentivized Testnet (ITN) BIP32
+                           (Ed25519Bip32) signing key to a corresponding Shelley
+                           stake signing key
+  convert-cardano-address-key
+                           Convert a cardano-address extended signing key to a
+                           corresponding Shelley-format key.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_key_convert-byron-genesis-vkey.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_key_convert-byron-genesis-vkey.cli
@@ -1,0 +1,11 @@
+Usage: cardano-cli shelley key convert-byron-genesis-vkey --byron-genesis-verification-key BASE64
+                                                            --out-file FILE
+
+  Convert a Base64-encoded Byron genesis verification key to a Shelley genesis
+  verification key
+
+Available options:
+  --byron-genesis-verification-key BASE64
+                           Base64 string for the Byron genesis verification key.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_key_convert-byron-key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_key_convert-byron-key.cli
@@ -1,0 +1,35 @@
+Usage: cardano-cli shelley key convert-byron-key [--password TEXT]
+                                                   ( --byron-payment-key-type
+                                                   | --legacy-byron-payment-key-type
+                                                   | --byron-genesis-key-type
+                                                   | --legacy-byron-genesis-key-type
+                                                   | --byron-genesis-delegate-key-type
+                                                   | --legacy-byron-genesis-delegate-key-type
+                                                   )
+                                                   ( --byron-signing-key-file FILE
+                                                   | --byron-verification-key-file FILE
+                                                   )
+                                                   --out-file FILE
+
+  Convert a Byron payment, genesis or genesis delegate key (signing or
+  verification) to a corresponding Shelley-format key.
+
+Available options:
+  --password TEXT          Password for signing key (if applicable).
+  --byron-payment-key-type Use a Byron-era payment key.
+  --legacy-byron-payment-key-type
+                           Use a Byron-era payment key, in legacy SL format.
+  --byron-genesis-key-type Use a Byron-era genesis key.
+  --legacy-byron-genesis-key-type
+                           Use a Byron-era genesis key, in legacy SL format.
+  --byron-genesis-delegate-key-type
+                           Use a Byron-era genesis delegate key.
+  --legacy-byron-genesis-delegate-key-type
+                           Use a Byron-era genesis delegate key, in legacy SL
+                           format.
+  --byron-signing-key-file FILE
+                           Input filepath of the Byron-format signing key.
+  --byron-verification-key-file FILE
+                           Input filepath of the Byron-format verification key.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_key_convert-cardano-address-key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_key_convert-cardano-address-key.cli
@@ -1,0 +1,22 @@
+Usage: cardano-cli shelley key convert-cardano-address-key 
+                                                             ( --shelley-payment-key
+                                                             | --shelley-stake-key
+                                                             | --icarus-payment-key
+                                                             | --byron-payment-key
+                                                             )
+                                                             --signing-key-file FILE
+                                                             --out-file FILE
+
+  Convert a cardano-address extended signing key to a corresponding
+  Shelley-format key.
+
+Available options:
+  --shelley-payment-key    Use a Shelley-era extended payment key.
+  --shelley-stake-key      Use a Shelley-era extended stake key.
+  --icarus-payment-key     Use a Byron-era extended payment key formatted in the
+                           Icarus style.
+  --byron-payment-key      Use a Byron-era extended payment key formatted in the
+                           deprecated Byron style.
+  --signing-key-file FILE  Input filepath of the signing key.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_key_convert-itn-bip32-key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_key_convert-itn-bip32-key.cli
@@ -1,0 +1,11 @@
+Usage: cardano-cli shelley key convert-itn-bip32-key --itn-signing-key-file FILE
+                                                       --out-file FILE
+
+  Convert an Incentivized Testnet (ITN) BIP32 (Ed25519Bip32) signing key to a
+  corresponding Shelley stake signing key
+
+Available options:
+  --itn-signing-key-file FILE
+                           Filepath of the ITN signing key.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_key_convert-itn-extended-key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_key_convert-itn-extended-key.cli
@@ -1,0 +1,11 @@
+Usage: cardano-cli shelley key convert-itn-extended-key --itn-signing-key-file FILE
+                                                          --out-file FILE
+
+  Convert an Incentivized Testnet (ITN) extended (Ed25519Extended) signing key
+  to a corresponding Shelley stake signing key
+
+Available options:
+  --itn-signing-key-file FILE
+                           Filepath of the ITN signing key.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_key_convert-itn-key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_key_convert-itn-key.cli
@@ -1,0 +1,16 @@
+Usage: cardano-cli shelley key convert-itn-key 
+                                                 ( --itn-signing-key-file FILE
+                                                 | --itn-verification-key-file FILE
+                                                 )
+                                                 --out-file FILE
+
+  Convert an Incentivized Testnet (ITN) non-extended (Ed25519) signing or
+  verification key to a corresponding Shelley stake key
+
+Available options:
+  --itn-signing-key-file FILE
+                           Filepath of the ITN signing key.
+  --itn-verification-key-file FILE
+                           Filepath of the ITN verification key.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_key_non-extended-key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_key_non-extended-key.cli
@@ -1,0 +1,12 @@
+Usage: cardano-cli shelley key non-extended-key --extended-verification-key-file FILE
+                                                  --verification-key-file FILE
+
+  Get a non-extended verification key from an extended verification key. This
+  supports all extended key types.
+
+Available options:
+  --extended-verification-key-file FILE
+                           Input filepath of the ed25519-bip32 verification key.
+  --verification-key-file FILE
+                           Output filepath of the verification key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_key_verification-key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_key_verification-key.cli
@@ -1,0 +1,10 @@
+Usage: cardano-cli shelley key verification-key --signing-key-file FILE
+                                                  --verification-key-file FILE
+
+  Get a verification key from a signing key. This supports all key types.
+
+Available options:
+  --signing-key-file FILE  Input filepath of the signing key.
+  --verification-key-file FILE
+                           Output filepath of the verification key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_node.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_node.cli
@@ -1,0 +1,22 @@
+Usage: cardano-cli shelley node 
+                                  ( key-gen
+                                  | key-gen-KES
+                                  | key-gen-VRF
+                                  | key-hash-VRF
+                                  | new-counter
+                                  | issue-op-cert
+                                  )
+
+  Era-based node commands
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  key-gen                  Create a key pair for a node operator's offline key
+                           and a new certificate issue counter
+  key-gen-KES              Create a key pair for a node KES operational key
+  key-gen-VRF              Create a key pair for a node VRF operational key
+  key-hash-VRF             Print hash of a node's operational VRF key.
+  new-counter              Create a new certificate issue counter
+  issue-op-cert            Issue a node operational certificate

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_node_issue-op-cert.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_node_issue-op-cert.cli
@@ -1,0 +1,24 @@
+Usage: cardano-cli shelley node issue-op-cert 
+                                                ( --kes-verification-key STRING
+                                                | --kes-verification-key-file FILE
+                                                )
+                                                --cold-signing-key-file FILE
+                                                --operational-certificate-issue-counter-file FILE
+                                                --kes-period NATURAL
+                                                --out-file FILE
+
+  Issue a node operational certificate
+
+Available options:
+  --kes-verification-key STRING
+                           A Bech32 or hex-encoded hot KES verification key.
+  --kes-verification-key-file FILE
+                           Filepath of the hot KES verification key.
+  --cold-signing-key-file FILE
+                           Filepath of the cold signing key.
+  --operational-certificate-issue-counter-file FILE
+                           The file with the issue counter for the operational
+                           certificate.
+  --kes-period NATURAL     The start of the KES key validity period.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_node_key-gen-KES.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_node_key-gen-KES.cli
@@ -1,0 +1,15 @@
+Usage: cardano-cli shelley node key-gen-KES [--key-output-format STRING]
+                                              --verification-key-file FILE
+                                              --signing-key-file FILE
+
+  Create a key pair for a node KES operational key
+
+Available options:
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32" (default is
+                           "bech32").
+  --verification-key-file FILE
+                           Output filepath of the verification key.
+  --signing-key-file FILE  Output filepath of the signing key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_node_key-gen-VRF.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_node_key-gen-VRF.cli
@@ -1,0 +1,15 @@
+Usage: cardano-cli shelley node key-gen-VRF [--key-output-format STRING]
+                                              --verification-key-file FILE
+                                              --signing-key-file FILE
+
+  Create a key pair for a node VRF operational key
+
+Available options:
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32" (default is
+                           "bech32").
+  --verification-key-file FILE
+                           Output filepath of the verification key.
+  --signing-key-file FILE  Output filepath of the signing key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_node_key-gen.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_node_key-gen.cli
@@ -1,0 +1,21 @@
+Usage: cardano-cli shelley node key-gen [--key-output-format STRING]
+                                          --cold-verification-key-file FILE
+                                          --cold-signing-key-file FILE
+                                          --operational-certificate-issue-counter-file FILE
+
+  Create a key pair for a node operator's offline key and a new certificate
+  issue counter
+
+Available options:
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32" (default is
+                           "bech32").
+  --cold-verification-key-file FILE
+                           Filepath of the cold verification key.
+  --cold-signing-key-file FILE
+                           Filepath of the cold signing key.
+  --operational-certificate-issue-counter-file FILE
+                           The file with the issue counter for the operational
+                           certificate.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_node_key-hash-VRF.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_node_key-hash-VRF.cli
@@ -1,0 +1,15 @@
+Usage: cardano-cli shelley node key-hash-VRF 
+                                               ( --verification-key STRING
+                                               | --verification-key-file FILE
+                                               )
+                                               [--out-file FILE]
+
+  Print hash of a node's operational VRF key.
+
+Available options:
+  --verification-key STRING
+                           Verification key (Bech32 or hex-encoded).
+  --verification-key-file FILE
+                           Input filepath of the verification key.
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_node_new-counter.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_node_new-counter.cli
@@ -1,0 +1,22 @@
+Usage: cardano-cli shelley node new-counter 
+                                              ( --stake-pool-verification-key STRING
+                                              | --genesis-delegate-verification-key STRING
+                                              | --cold-verification-key-file FILE
+                                              )
+                                              --counter-value INT
+                                              --operational-certificate-issue-counter-file FILE
+
+  Create a new certificate issue counter
+
+Available options:
+  --stake-pool-verification-key STRING
+                           Stake pool verification key (Bech32 or hex-encoded).
+  --genesis-delegate-verification-key STRING
+                           Genesis delegate verification key (hex-encoded).
+  --cold-verification-key-file FILE
+                           Filepath of the cold verification key.
+  --counter-value INT      The next certificate issue counter value to use.
+  --operational-certificate-issue-counter-file FILE
+                           The file with the issue counter for the operational
+                           certificate.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query.cli
@@ -1,0 +1,50 @@
+Usage: cardano-cli shelley query 
+                                   ( protocol-parameters
+                                   | constitution-hash
+                                   | tip
+                                   | stake-pools
+                                   | stake-distribution
+                                   | stake-address-info
+                                   | utxo
+                                   | ledger-state
+                                   | protocol-state
+                                   | stake-snapshot
+                                   | leadership-schedule
+                                   | kes-period-info
+                                   | pool-state
+                                   | tx-mempool
+                                   | slot-number
+                                   )
+
+  Era-based query commands
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  protocol-parameters      Get the node's current protocol parameters
+  constitution-hash        Get the constitution hash
+  tip                      Get the node's current tip (slot no, hash, block no)
+  stake-pools              Get the node's current set of stake pool ids
+  stake-distribution       Get the node's current aggregated stake distribution
+  stake-address-info       Get the current delegations and reward accounts
+                           filtered by stake address.
+  utxo                     Get a portion of the current UTxO: by tx in, by
+                           address or the whole.
+  ledger-state             Dump the current ledger state of the node
+                           (Ledger.NewEpochState -- advanced command)
+  protocol-state           Dump the current protocol state of the node
+                           (Ledger.ChainDepState -- advanced command)
+  stake-snapshot           Obtain the three stake snapshots for a pool, plus the
+                           total active stake (advanced command)
+  pool-params              DEPRECATED. Use query pool-state instead. Dump the
+                           pool parameters
+                           (Ledger.NewEpochState.esLState._delegationState._pState._pParams
+                           -- advanced command)
+  leadership-schedule      Get the slots the node is expected to mint a block in
+                           (advanced command)
+  kes-period-info          Get information about the current KES period and your
+                           node's operational certificate.
+  pool-state               Dump the pool state
+  tx-mempool               Local Mempool info
+  slot-number              Query slot number for UTC timestamp

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_constitution-hash.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_constitution-hash.cli
@@ -1,0 +1,34 @@
+Usage: cardano-cli shelley query constitution-hash --socket-path SOCKET_PATH
+                                                     [ --shelley-mode
+                                                     | --byron-mode
+                                                       [--epoch-slots SLOTS]
+                                                     | --cardano-mode
+                                                       [--epoch-slots SLOTS]
+                                                     ]
+                                                     ( --mainnet
+                                                     | --testnet-magic NATURAL
+                                                     )
+                                                     [--out-file FILE]
+
+  Get the constitution hash
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_kes-period-info.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_kes-period-info.cli
@@ -1,0 +1,37 @@
+Usage: cardano-cli shelley query kes-period-info --socket-path SOCKET_PATH
+                                                   [ --shelley-mode
+                                                   | --byron-mode
+                                                     [--epoch-slots SLOTS]
+                                                   | --cardano-mode
+                                                     [--epoch-slots SLOTS]
+                                                   ]
+                                                   ( --mainnet
+                                                   | --testnet-magic NATURAL
+                                                   )
+                                                   --op-cert-file FILE
+                                                   [--out-file FILE]
+
+  Get information about the current KES period and your node's operational
+  certificate.
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --op-cert-file FILE      Filepath of the node's operational certificate.
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_leadership-schedule.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_leadership-schedule.cli
@@ -1,0 +1,54 @@
+Usage: cardano-cli shelley query leadership-schedule --socket-path SOCKET_PATH
+                                                       [ --shelley-mode
+                                                       | --byron-mode
+                                                         [--epoch-slots SLOTS]
+                                                       | --cardano-mode
+                                                         [--epoch-slots SLOTS]
+                                                       ]
+                                                       ( --mainnet
+                                                       | --testnet-magic NATURAL
+                                                       )
+                                                       --genesis FILE
+                                                       ( --stake-pool-verification-key STRING
+                                                       | --cold-verification-key-file FILE
+                                                       | --stake-pool-id STAKE_POOL_ID
+                                                       )
+                                                       --vrf-signing-key-file FILE
+                                                       (--current | --next)
+                                                       [--out-file FILE]
+
+  Get the slots the node is expected to mint a block in (advanced command)
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --genesis FILE           Shelley genesis filepath
+  --stake-pool-verification-key STRING
+                           Stake pool verification key (Bech32 or hex-encoded).
+  --cold-verification-key-file FILE
+                           Filepath of the stake pool verification key.
+  --stake-pool-id STAKE_POOL_ID
+                           Stake pool ID/verification key hash (either
+                           Bech32-encoded or hex-encoded). Zero or more
+                           occurences of this option is allowed.
+  --vrf-signing-key-file FILE
+                           Input filepath of the VRF signing key.
+  --current                Get the leadership schedule for the current epoch.
+  --next                   Get the leadership schedule for the following epoch.
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_ledger-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_ledger-state.cli
@@ -1,0 +1,35 @@
+Usage: cardano-cli shelley query ledger-state --socket-path SOCKET_PATH
+                                                [ --shelley-mode
+                                                | --byron-mode
+                                                  [--epoch-slots SLOTS]
+                                                | --cardano-mode
+                                                  [--epoch-slots SLOTS]
+                                                ]
+                                                ( --mainnet
+                                                | --testnet-magic NATURAL
+                                                )
+                                                [--out-file FILE]
+
+  Dump the current ledger state of the node (Ledger.NewEpochState -- advanced
+  command)
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_pool-params.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_pool-params.cli
@@ -1,0 +1,39 @@
+Usage: cardano-cli shelley query pool-params --socket-path SOCKET_PATH
+                                               [ --shelley-mode
+                                               | --byron-mode
+                                                 [--epoch-slots SLOTS]
+                                               | --cardano-mode
+                                                 [--epoch-slots SLOTS]
+                                               ]
+                                               ( --mainnet
+                                               | --testnet-magic NATURAL
+                                               )
+                                               [--stake-pool-id STAKE_POOL_ID]
+
+  DEPRECATED. Use query pool-state instead. Dump the pool parameters
+  (Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced
+  command)
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --stake-pool-id STAKE_POOL_ID
+                           Stake pool ID/verification key hash (either
+                           Bech32-encoded or hex-encoded). Zero or more
+                           occurences of this option is allowed.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_pool-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_pool-state.cli
@@ -1,0 +1,37 @@
+Usage: cardano-cli shelley query pool-state --socket-path SOCKET_PATH
+                                              [ --shelley-mode
+                                              | --byron-mode
+                                                [--epoch-slots SLOTS]
+                                              | --cardano-mode
+                                                [--epoch-slots SLOTS]
+                                              ]
+                                              ( --mainnet
+                                              | --testnet-magic NATURAL
+                                              )
+                                              [--stake-pool-id STAKE_POOL_ID]
+
+  Dump the pool state
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --stake-pool-id STAKE_POOL_ID
+                           Stake pool ID/verification key hash (either
+                           Bech32-encoded or hex-encoded). Zero or more
+                           occurences of this option is allowed.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_protocol-parameters.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_protocol-parameters.cli
@@ -1,0 +1,34 @@
+Usage: cardano-cli shelley query protocol-parameters --socket-path SOCKET_PATH
+                                                       [ --shelley-mode
+                                                       | --byron-mode
+                                                         [--epoch-slots SLOTS]
+                                                       | --cardano-mode
+                                                         [--epoch-slots SLOTS]
+                                                       ]
+                                                       ( --mainnet
+                                                       | --testnet-magic NATURAL
+                                                       )
+                                                       [--out-file FILE]
+
+  Get the node's current protocol parameters
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_protocol-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_protocol-state.cli
@@ -1,0 +1,35 @@
+Usage: cardano-cli shelley query protocol-state --socket-path SOCKET_PATH
+                                                  [ --shelley-mode
+                                                  | --byron-mode
+                                                    [--epoch-slots SLOTS]
+                                                  | --cardano-mode
+                                                    [--epoch-slots SLOTS]
+                                                  ]
+                                                  ( --mainnet
+                                                  | --testnet-magic NATURAL
+                                                  )
+                                                  [--out-file FILE]
+
+  Dump the current protocol state of the node (Ledger.ChainDepState -- advanced
+  command)
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_slot-number.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_slot-number.cli
@@ -1,0 +1,34 @@
+Usage: cardano-cli shelley query slot-number --socket-path SOCKET_PATH
+                                               [ --shelley-mode
+                                               | --byron-mode
+                                                 [--epoch-slots SLOTS]
+                                               | --cardano-mode
+                                                 [--epoch-slots SLOTS]
+                                               ]
+                                               ( --mainnet
+                                               | --testnet-magic NATURAL
+                                               )
+                                               TIMESTAMP
+
+  Query slot number for UTC timestamp
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  TIMESTAMP                UTC timestamp in YYYY-MM-DDThh:mm:ssZ format
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_stake-address-info.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_stake-address-info.cli
@@ -1,0 +1,36 @@
+Usage: cardano-cli shelley query stake-address-info --socket-path SOCKET_PATH
+                                                      [ --shelley-mode
+                                                      | --byron-mode
+                                                        [--epoch-slots SLOTS]
+                                                      | --cardano-mode
+                                                        [--epoch-slots SLOTS]
+                                                      ]
+                                                      --address ADDRESS
+                                                      ( --mainnet
+                                                      | --testnet-magic NATURAL
+                                                      )
+                                                      [--out-file FILE]
+
+  Get the current delegations and reward accounts filtered by stake address.
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --address ADDRESS        Filter by Cardano stake address (Bech32-encoded).
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_stake-distribution.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_stake-distribution.cli
@@ -1,0 +1,34 @@
+Usage: cardano-cli shelley query stake-distribution --socket-path SOCKET_PATH
+                                                      [ --shelley-mode
+                                                      | --byron-mode
+                                                        [--epoch-slots SLOTS]
+                                                      | --cardano-mode
+                                                        [--epoch-slots SLOTS]
+                                                      ]
+                                                      ( --mainnet
+                                                      | --testnet-magic NATURAL
+                                                      )
+                                                      [--out-file FILE]
+
+  Get the node's current aggregated stake distribution
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_stake-pools.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_stake-pools.cli
@@ -1,0 +1,34 @@
+Usage: cardano-cli shelley query stake-pools --socket-path SOCKET_PATH
+                                               [ --shelley-mode
+                                               | --byron-mode
+                                                 [--epoch-slots SLOTS]
+                                               | --cardano-mode
+                                                 [--epoch-slots SLOTS]
+                                               ]
+                                               ( --mainnet
+                                               | --testnet-magic NATURAL
+                                               )
+                                               [--out-file FILE]
+
+  Get the node's current set of stake pool ids
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_stake-snapshot.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_stake-snapshot.cli
@@ -1,0 +1,44 @@
+Usage: cardano-cli shelley query stake-snapshot --socket-path SOCKET_PATH
+                                                  [ --shelley-mode
+                                                  | --byron-mode
+                                                    [--epoch-slots SLOTS]
+                                                  | --cardano-mode
+                                                    [--epoch-slots SLOTS]
+                                                  ]
+                                                  ( --mainnet
+                                                  | --testnet-magic NATURAL
+                                                  )
+                                                  [ --all-stake-pools
+                                                  | 
+                                                  [--stake-pool-id STAKE_POOL_ID]
+                                                  ]
+                                                  [--out-file FILE]
+
+  Obtain the three stake snapshots for a pool, plus the total active stake
+  (advanced command)
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --all-stake-pools        Query for all stake pools
+  --stake-pool-id STAKE_POOL_ID
+                           Stake pool ID/verification key hash (either
+                           Bech32-encoded or hex-encoded). Zero or more
+                           occurences of this option is allowed.
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_tip.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_tip.cli
@@ -1,0 +1,30 @@
+Usage: cardano-cli shelley query tip --socket-path SOCKET_PATH
+                                       [ --shelley-mode
+                                       | --byron-mode [--epoch-slots SLOTS]
+                                       | --cardano-mode [--epoch-slots SLOTS]
+                                       ]
+                                       (--mainnet | --testnet-magic NATURAL)
+                                       [--out-file FILE]
+
+  Get the node's current tip (slot no, hash, block no)
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_tx-mempool.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_tx-mempool.cli
@@ -1,0 +1,43 @@
+Usage: cardano-cli shelley query tx-mempool --socket-path SOCKET_PATH
+                                              [ --shelley-mode
+                                              | --byron-mode
+                                                [--epoch-slots SLOTS]
+                                              | --cardano-mode
+                                                [--epoch-slots SLOTS]
+                                              ]
+                                              ( --mainnet
+                                              | --testnet-magic NATURAL
+                                              )
+                                              (info | next-tx | tx-exists)
+                                              [--out-file FILE]
+
+  Local Mempool info
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text
+
+Available commands:
+  info                     Ask the node about the current mempool's capacity and
+                           sizes
+  next-tx                  Requests the next transaction from the mempool's
+                           current list
+  tx-exists                Query if a particular transaction exists in the
+                           mempool

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_tx-mempool_info.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_tx-mempool_info.cli
@@ -1,0 +1,16 @@
+Missing: --socket-path SOCKET_PATH (--mainnet | --testnet-magic NATURAL)
+
+Usage: cardano-cli shelley query tx-mempool --socket-path SOCKET_PATH
+                                              [ --shelley-mode
+                                              | --byron-mode
+                                                [--epoch-slots SLOTS]
+                                              | --cardano-mode
+                                                [--epoch-slots SLOTS]
+                                              ]
+                                              ( --mainnet
+                                              | --testnet-magic NATURAL
+                                              )
+                                              (info | next-tx | tx-exists)
+                                              [--out-file FILE]
+
+  Local Mempool info

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_tx-mempool_next-tx.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_tx-mempool_next-tx.cli
@@ -1,0 +1,16 @@
+Missing: --socket-path SOCKET_PATH (--mainnet | --testnet-magic NATURAL)
+
+Usage: cardano-cli shelley query tx-mempool --socket-path SOCKET_PATH
+                                              [ --shelley-mode
+                                              | --byron-mode
+                                                [--epoch-slots SLOTS]
+                                              | --cardano-mode
+                                                [--epoch-slots SLOTS]
+                                              ]
+                                              ( --mainnet
+                                              | --testnet-magic NATURAL
+                                              )
+                                              (info | next-tx | tx-exists)
+                                              [--out-file FILE]
+
+  Local Mempool info

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_tx-mempool_tx-exists_TX_ID.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_tx-mempool_tx-exists_TX_ID.cli
@@ -1,0 +1,16 @@
+Missing: --socket-path SOCKET_PATH (--mainnet | --testnet-magic NATURAL)
+
+Usage: cardano-cli shelley query tx-mempool --socket-path SOCKET_PATH
+                                              [ --shelley-mode
+                                              | --byron-mode
+                                                [--epoch-slots SLOTS]
+                                              | --cardano-mode
+                                                [--epoch-slots SLOTS]
+                                              ]
+                                              ( --mainnet
+                                              | --testnet-magic NATURAL
+                                              )
+                                              (info | next-tx | tx-exists)
+                                              [--out-file FILE]
+
+  Local Mempool info

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_utxo.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_utxo.cli
@@ -1,0 +1,38 @@
+Usage: cardano-cli shelley query utxo --socket-path SOCKET_PATH
+                                        [ --shelley-mode
+                                        | --byron-mode [--epoch-slots SLOTS]
+                                        | --cardano-mode [--epoch-slots SLOTS]
+                                        ]
+                                        ( --whole-utxo
+                                        | (--address ADDRESS)
+                                        | (--tx-in TX-IN)
+                                        )
+                                        (--mainnet | --testnet-magic NATURAL)
+                                        [--out-file FILE]
+
+  Get a portion of the current UTxO: by tx in, by address or the whole.
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --shelley-mode           For talking to a node running in Shelley-only mode.
+  --byron-mode             For talking to a node running in Byron-only mode.
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --whole-utxo             Return the whole UTxO (only appropriate on small
+                           testnets).
+  --address ADDRESS        Filter by Cardano address(es) (Bech32-encoded).
+  --tx-in TX-IN            Filter by transaction input (TxId#TxIx).
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_text-view_decode-cbor.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_text-view_decode-cbor.cli
@@ -1,0 +1,9 @@
+Usage: cardano-cli shelley text-view decode-cbor --in-file FILE
+                                                   [--out-file FILE]
+
+  Print a TextView file as decoded CBOR.
+
+Available options:
+  --in-file FILE           CBOR input file.
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_transaction.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_transaction.cli
@@ -13,7 +13,7 @@ Usage: cardano-cli shelley transaction
                                          | view
                                          )
 
-  Era-based governance commands
+  Era-based transaction commands
 
 Available options:
   -h,--help                Show this help text


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Port more commands to era-based command structure:
    * key
    * genesis
    * node
    * query
    * stake-pool
    * text-view
# uncomment types applicable to the change:
  type:
  - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context


# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
