### PR TITLE
CONTRIBUTING.md: add reference to --sha256 example

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,8 @@ The differences are that it has an independent `index-state`, and that there is 
 Sometimes we need to use an unreleased version of one of our dependencies, either to fix an issue in a package that is not under our control, or to experiment with a pre-release version of one of our own packages.
 You can use a `source-repository-package` stanza to pull in the unreleased version.
 
-Try only to do this for a short time, as it does not play very well with tooling, and will interfere with the ability to release the `cardano-cli` itself.
+Try only to do this for a short time, as it does not play very well with tooling, and will interfere with the ability to release the `cardano-cli` itself. If you do add a temporary `source-repository-package` stanza, you need to
+provide a [`--sha256` comment in `cabal.project`](https://input-output-hk.github.io/haskell.nix/tutorials/source-repository-hashes.html#cabalproject).
 
 For packages that we do not control, we can end up in a situation where we have a fork that looks like it will be long-lived or permanent (e.g. the maintainer is unresponsive, or the change has been merged but not released).
 In that case, release a patched version to the [CHaP repository][CHaP], which allows us to remove the `source-repository-package` stanza.


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Explain source-repository-package's sha256 in CONTRIBUTING.md
  type:
  - maintenance    # not directly related to the code
```

> [!IMPORTANT]  
> I didn't push to the original repo https://github.com/input-output-hk/cardano-cli because I'm not a member yet.

# Context

As I was trying to use a source version of ouroboros-network, I stumbled upon the syntax of the sha256 field that needs to be added to `cabal.project`. So I added a bit of documentation that was already in [cardano-leger](https://github.com/input-output-hk/cardano-ledger/blob/b9221a7a233fe7b2080df35878810bffeffc50c3/CONTRIBUTING.md?plain=1#L80) and added a link to [this concrete example](https://input-output-hk.github.io/haskell.nix/tutorials/source-repository-hashes.html#cabalproject).

# How to trust this PR

This PR doesn't change any code. It's only a small documentation change.

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] The change log section in the PR description has been filled in
- NA New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- NA The version bounds in `.cabal` files are updated
- NA CI passes. See note on CI.  The following CI checks are required:
  - NA Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - NA Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - NA Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [X] The changelog section in the PR is updated to describe the change
- [X] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
