### PR TITLE
Fix git revision in `version` command

### DIFF
--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -118,6 +118,7 @@ library
                         Cardano.CLI.EraBased.Run.TextView
                         Cardano.CLI.EraBased.Run.Transaction
                         Cardano.CLI.Helpers
+                        Cardano.CLI.IO.GitRev
                         Cardano.CLI.IO.Lazy
                         Cardano.CLI.Json.Friendly
                         Cardano.CLI.Legacy.Commands

--- a/cardano-cli/src/Cardano/CLI/IO/GitRev.hs
+++ b/cardano-cli/src/Cardano/CLI/IO/GitRev.hs
@@ -1,0 +1,42 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE ForeignFunctionInterface #-}
+
+module Cardano.CLI.IO.GitRev
+  ( gitRev
+  ) where
+
+import           Data.Text (Text)
+import qualified Data.Text as T
+
+import           Cardano.Git.RevFromGit (gitRevFromGit)
+import           GHC.Foreign (peekCStringLen)
+import           Foreign.C.String (CString)
+import           System.IO (utf8)
+import           System.IO.Unsafe (unsafeDupablePerformIO)
+
+foreign import ccall "&_cardano_git_rev" c_gitrev :: CString
+
+gitRev :: Text
+gitRev | gitRevEmbed /= zeroRev = gitRevEmbed
+       | T.null fromGit         = zeroRev
+       | otherwise              = fromGit
+ where
+  -- Git revision embedded after compilation using
+  -- Data.FileEmbed.injectWith. If nothing has been injected,
+  -- this will be filled with 0 characters.
+  gitRevEmbed :: Text
+  gitRevEmbed = T.pack $ drop 28 $ unsafeDupablePerformIO (peekCStringLen utf8 (c_gitrev, 68))
+
+  -- Git revision found during compilation by running git. If
+  -- git could not be run, then this will be empty.
+#if defined(arm_HOST_ARCH)
+  -- cross compiling to arm fails; due to a linker bug
+  fromGit = ""
+#else
+  fromGit = T.strip (T.pack $(gitRevFromGit))
+#endif
+
+zeroRev :: Text
+zeroRev = "0000000000000000000000000000000000000000"

--- a/cardano-cli/src/Cardano/CLI/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Run.hs
@@ -14,13 +14,13 @@ import           Cardano.CLI.Byron.Run (ByronClientCmdError, renderByronClientCm
                    runByronClientCommand)
 import           Cardano.CLI.EraBased.Commands
 import           Cardano.CLI.EraBased.Run
+import           Cardano.CLI.IO.GitRev (gitRev)
 import           Cardano.CLI.Legacy.Commands
 import           Cardano.CLI.Legacy.Run (runLegacyCmds)
 import           Cardano.CLI.Render (customRenderHelp)
 import           Cardano.CLI.Run.Ping (PingClientCmdError (..), PingCmd (..),
                    renderPingClientCmdError, runPingCmd)
 import           Cardano.CLI.Types.Errors.CmdError
-import           Cardano.Git.Rev (gitRev)
 
 import           Control.Monad (forM_)
 import           Control.Monad.IO.Unlift (MonadIO (..))


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Fix git revision in `version` command
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Now that `cardano-cli` is in a separate repository from `cardano-git-rev`, it must invoke the Template Haskell function directly instead of via the `gitRev` function wrapper to get the correct git hash.

```
$ git log | head
commit faf0b83446351931f9de8357230c4b271a6e526b
Author: John Ky <john.ky@iohk.io>
Date:   Thu Sep 14 13:34:02 2023 +1000

    Fix git revision in version command

commit f02fe9c4494c1096b25ce72fc761730d702df3e1
Merge: 095fc4ae9 8bbf60211
Author: John Ky <newhoggy@gmail.com>
Date:   Thu Sep 14 02:29:20 2023 +0000
$ cabal exec -- cardano-cli version
cardano-cli 8.8.0.0 - linux-x86_64 - ghc-8.10
git rev f02fe9c4494c1096b25ce72fc761730d702df3e1
```

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
