### PR TITLE
Era-based `stake-pool` command

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands.hs
@@ -19,6 +19,7 @@ import           Cardano.CLI.EraBased.Commands.Key
 import           Cardano.CLI.EraBased.Commands.Node
 import           Cardano.CLI.EraBased.Commands.Query
 import           Cardano.CLI.EraBased.Commands.StakeAddress
+import           Cardano.CLI.EraBased.Commands.StakePool
 import           Cardano.CLI.EraBased.Commands.TextView
 import           Cardano.CLI.EraBased.Commands.Transaction
 import           Cardano.CLI.EraBased.Options.Address
@@ -29,6 +30,7 @@ import           Cardano.CLI.EraBased.Options.Key
 import           Cardano.CLI.EraBased.Options.Node
 import           Cardano.CLI.EraBased.Options.Query
 import           Cardano.CLI.EraBased.Options.StakeAddress
+import           Cardano.CLI.EraBased.Options.StakePool
 import           Cardano.CLI.EraBased.Options.TextView
 import           Cardano.CLI.EraBased.Options.Transaction
 
@@ -53,6 +55,7 @@ data Cmds era
   | NodeCmds            (NodeCmds era)
   | QueryCmds           (QueryCmds era)
   | StakeAddressCmds    (StakeAddressCmds era)
+  | StakePoolCmds       (StakePoolCmds era)
   | TextViewCmds        (TextViewCmds era)
   | TransactionCmds     (TransactionCmds era)
 
@@ -72,6 +75,8 @@ renderCmds = \case
     renderQueryCmds cmd
   StakeAddressCmds cmd ->
     renderStakeAddressCmds cmd
+  StakePoolCmds cmd ->
+    renderStakePoolCmds cmd
   TextViewCmds cmd ->
     renderTextViewCmds cmd
   TransactionCmds cmd ->
@@ -134,6 +139,10 @@ pCmds envCli era =
         $ Opt.info (QueryCmds <$> pQueryCmds envCli)
         $ Opt.progDesc "Era-based query commands"
     , fmap StakeAddressCmds <$> pStakeAddressCmds era envCli
+    , Just
+        $ subParser "stake-pool"
+        $ Opt.info (StakePoolCmds <$> pStakePoolCmds era envCli)
+        $ Opt.progDesc "Era-based text-view commands"
     , Just
         $ subParser "text-view"
         $ Opt.info (TextViewCmds <$> pTextViewCmds)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run.hs
@@ -23,6 +23,7 @@ import           Cardano.CLI.EraBased.Run.Key
 import           Cardano.CLI.EraBased.Run.Node
 import           Cardano.CLI.EraBased.Run.Query
 import           Cardano.CLI.EraBased.Run.StakeAddress
+import           Cardano.CLI.EraBased.Run.StakePool
 import           Cardano.CLI.EraBased.Run.TextView
 import           Cardano.CLI.EraBased.Run.Transaction
 import           Cardano.CLI.Types.Errors.CmdError
@@ -61,6 +62,9 @@ runCmds = \case
   StakeAddressCmds cmd ->
     runStakeAddressCmds cmd
       & firstExceptT CmdStakeAddressError
+  StakePoolCmds cmd ->
+    runStakePoolCmds cmd
+      & firstExceptT CmdStakePoolError
   TextViewCmds cmd ->
     runTextViewCmds cmd
       & firstExceptT CmdTextViewError

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/StakePool.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/StakePool.hs
@@ -57,8 +57,9 @@ runLegacyStakePoolRegistrationCertificateCmd :: ()
   -> NetworkId
   -> File () Out
   -> ExceptT StakePoolCmdError IO ()
-runLegacyStakePoolRegistrationCertificateCmd =
-  runStakePoolRegistrationCertificateCmd
+runLegacyStakePoolRegistrationCertificateCmd = \case
+  AnyShelleyBasedEra sbe ->
+    runStakePoolRegistrationCertificateCmd sbe
 
 runLegacyStakePoolDeregistrationCertificateCmd :: ()
   => AnyShelleyBasedEra
@@ -66,8 +67,9 @@ runLegacyStakePoolDeregistrationCertificateCmd :: ()
   -> Shelley.EpochNo
   -> File () Out
   -> ExceptT StakePoolCmdError IO ()
-runLegacyStakePoolDeregistrationCertificateCmd =
-  runStakePoolRetirementCertificateCmd
+runLegacyStakePoolDeregistrationCertificateCmd = \case
+  AnyShelleyBasedEra sbe ->
+    runStakePoolRetirementCertificateCmd sbe
 
 runLegacyStakePoolIdCmd :: ()
   => VerificationKeyOrFile StakePoolKey

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -21,6 +21,7 @@ Usage: cardano-cli shelley
                              | node
                              | query
                              | stake-address
+                             | stake-pool
                              | text-view
                              | transaction
                              )
@@ -778,6 +779,70 @@ Usage: cardano-cli shelley stake-address stake-delegation-certificate
   Create a stake address stake delegation certificate, which when submitted in a
   transaction delegates stake to a stake pool.
 
+Usage: cardano-cli shelley stake-pool 
+                                        ( registration-certificate
+                                        | deregistration-certificate
+                                        | id
+                                        | metadata-hash
+                                        )
+
+  Era-based text-view commands
+
+Usage: cardano-cli shelley stake-pool registration-certificate 
+                                                                 ( --stake-pool-verification-key STRING
+                                                                 | --cold-verification-key-file FILE
+                                                                 )
+                                                                 ( --vrf-verification-key STRING
+                                                                 | --vrf-verification-key-file FILE
+                                                                 )
+                                                                 --pool-pledge LOVELACE
+                                                                 --pool-cost LOVELACE
+                                                                 --pool-margin RATIONAL
+                                                                 ( --pool-reward-account-verification-key STRING
+                                                                 | --pool-reward-account-verification-key-file FILE
+                                                                 )
+                                                                 ( --pool-owner-verification-key STRING
+                                                                 | --pool-owner-stake-verification-key-file FILE
+                                                                 )
+                                                                 [ [--pool-relay-ipv4 STRING]
+                                                                   [--pool-relay-ipv6 STRING]
+                                                                   --pool-relay-port INT
+                                                                 | --single-host-pool-relay STRING
+                                                                   [--pool-relay-port INT]
+                                                                 | --multi-host-pool-relay STRING
+                                                                 ]
+                                                                 [--metadata-url URL
+                                                                   --metadata-hash HASH]
+                                                                 ( --mainnet
+                                                                 | --testnet-magic NATURAL
+                                                                 )
+                                                                 --out-file FILE
+
+  Create a stake pool registration certificate
+
+Usage: cardano-cli shelley stake-pool deregistration-certificate 
+                                                                   ( --stake-pool-verification-key STRING
+                                                                   | --cold-verification-key-file FILE
+                                                                   )
+                                                                   --epoch NATURAL
+                                                                   --out-file FILE
+
+  Create a stake pool deregistration certificate
+
+Usage: cardano-cli shelley stake-pool id 
+                                           ( --stake-pool-verification-key STRING
+                                           | --cold-verification-key-file FILE
+                                           )
+                                           [--output-format STRING]
+                                           [--out-file FILE]
+
+  Build pool id from the offline key
+
+Usage: cardano-cli shelley stake-pool metadata-hash --pool-metadata-file FILE
+                                                      [--out-file FILE]
+
+  Print the hash of pool metadata.
+
 Usage: cardano-cli shelley text-view decode-cbor
 
   Era-based text-view commands
@@ -1178,6 +1243,7 @@ Usage: cardano-cli allegra
                              | node
                              | query
                              | stake-address
+                             | stake-pool
                              | text-view
                              | transaction
                              )
@@ -1935,6 +2001,70 @@ Usage: cardano-cli allegra stake-address stake-delegation-certificate
   Create a stake address stake delegation certificate, which when submitted in a
   transaction delegates stake to a stake pool.
 
+Usage: cardano-cli allegra stake-pool 
+                                        ( registration-certificate
+                                        | deregistration-certificate
+                                        | id
+                                        | metadata-hash
+                                        )
+
+  Era-based text-view commands
+
+Usage: cardano-cli allegra stake-pool registration-certificate 
+                                                                 ( --stake-pool-verification-key STRING
+                                                                 | --cold-verification-key-file FILE
+                                                                 )
+                                                                 ( --vrf-verification-key STRING
+                                                                 | --vrf-verification-key-file FILE
+                                                                 )
+                                                                 --pool-pledge LOVELACE
+                                                                 --pool-cost LOVELACE
+                                                                 --pool-margin RATIONAL
+                                                                 ( --pool-reward-account-verification-key STRING
+                                                                 | --pool-reward-account-verification-key-file FILE
+                                                                 )
+                                                                 ( --pool-owner-verification-key STRING
+                                                                 | --pool-owner-stake-verification-key-file FILE
+                                                                 )
+                                                                 [ [--pool-relay-ipv4 STRING]
+                                                                   [--pool-relay-ipv6 STRING]
+                                                                   --pool-relay-port INT
+                                                                 | --single-host-pool-relay STRING
+                                                                   [--pool-relay-port INT]
+                                                                 | --multi-host-pool-relay STRING
+                                                                 ]
+                                                                 [--metadata-url URL
+                                                                   --metadata-hash HASH]
+                                                                 ( --mainnet
+                                                                 | --testnet-magic NATURAL
+                                                                 )
+                                                                 --out-file FILE
+
+  Create a stake pool registration certificate
+
+Usage: cardano-cli allegra stake-pool deregistration-certificate 
+                                                                   ( --stake-pool-verification-key STRING
+                                                                   | --cold-verification-key-file FILE
+                                                                   )
+                                                                   --epoch NATURAL
+                                                                   --out-file FILE
+
+  Create a stake pool deregistration certificate
+
+Usage: cardano-cli allegra stake-pool id 
+                                           ( --stake-pool-verification-key STRING
+                                           | --cold-verification-key-file FILE
+                                           )
+                                           [--output-format STRING]
+                                           [--out-file FILE]
+
+  Build pool id from the offline key
+
+Usage: cardano-cli allegra stake-pool metadata-hash --pool-metadata-file FILE
+                                                      [--out-file FILE]
+
+  Print the hash of pool metadata.
+
 Usage: cardano-cli allegra text-view decode-cbor
 
   Era-based text-view commands
@@ -2335,6 +2465,7 @@ Usage: cardano-cli mary
                           | node
                           | query
                           | stake-address
+                          | stake-pool
                           | text-view
                           | transaction
                           )
@@ -3080,6 +3211,70 @@ Usage: cardano-cli mary stake-address stake-delegation-certificate
   Create a stake address stake delegation certificate, which when submitted in a
   transaction delegates stake to a stake pool.
 
+Usage: cardano-cli mary stake-pool 
+                                     ( registration-certificate
+                                     | deregistration-certificate
+                                     | id
+                                     | metadata-hash
+                                     )
+
+  Era-based text-view commands
+
+Usage: cardano-cli mary stake-pool registration-certificate 
+                                                              ( --stake-pool-verification-key STRING
+                                                              | --cold-verification-key-file FILE
+                                                              )
+                                                              ( --vrf-verification-key STRING
+                                                              | --vrf-verification-key-file FILE
+                                                              )
+                                                              --pool-pledge LOVELACE
+                                                              --pool-cost LOVELACE
+                                                              --pool-margin RATIONAL
+                                                              ( --pool-reward-account-verification-key STRING
+                                                              | --pool-reward-account-verification-key-file FILE
+                                                              )
+                                                              ( --pool-owner-verification-key STRING
+                                                              | --pool-owner-stake-verification-key-file FILE
+                                                              )
+                                                              [ [--pool-relay-ipv4 STRING]
+                                                                [--pool-relay-ipv6 STRING]
+                                                                --pool-relay-port INT
+                                                              | --single-host-pool-relay STRING
+                                                                [--pool-relay-port INT]
+                                                              | --multi-host-pool-relay STRING
+                                                              ]
+                                                              [--metadata-url URL
+                                                                --metadata-hash HASH]
+                                                              ( --mainnet
+                                                              | --testnet-magic NATURAL
+                                                              )
+                                                              --out-file FILE
+
+  Create a stake pool registration certificate
+
+Usage: cardano-cli mary stake-pool deregistration-certificate 
+                                                                ( --stake-pool-verification-key STRING
+                                                                | --cold-verification-key-file FILE
+                                                                )
+                                                                --epoch NATURAL
+                                                                --out-file FILE
+
+  Create a stake pool deregistration certificate
+
+Usage: cardano-cli mary stake-pool id 
+                                        ( --stake-pool-verification-key STRING
+                                        | --cold-verification-key-file FILE
+                                        )
+                                        [--output-format STRING]
+                                        [--out-file FILE]
+
+  Build pool id from the offline key
+
+Usage: cardano-cli mary stake-pool metadata-hash --pool-metadata-file FILE
+                                                   [--out-file FILE]
+
+  Print the hash of pool metadata.
+
 Usage: cardano-cli mary text-view decode-cbor
 
   Era-based text-view commands
@@ -3464,6 +3659,7 @@ Usage: cardano-cli alonzo
                             | node
                             | query
                             | stake-address
+                            | stake-pool
                             | text-view
                             | transaction
                             )
@@ -4226,6 +4422,70 @@ Usage: cardano-cli alonzo stake-address stake-delegation-certificate
   Create a stake address stake delegation certificate, which when submitted in a
   transaction delegates stake to a stake pool.
 
+Usage: cardano-cli alonzo stake-pool 
+                                       ( registration-certificate
+                                       | deregistration-certificate
+                                       | id
+                                       | metadata-hash
+                                       )
+
+  Era-based text-view commands
+
+Usage: cardano-cli alonzo stake-pool registration-certificate 
+                                                                ( --stake-pool-verification-key STRING
+                                                                | --cold-verification-key-file FILE
+                                                                )
+                                                                ( --vrf-verification-key STRING
+                                                                | --vrf-verification-key-file FILE
+                                                                )
+                                                                --pool-pledge LOVELACE
+                                                                --pool-cost LOVELACE
+                                                                --pool-margin RATIONAL
+                                                                ( --pool-reward-account-verification-key STRING
+                                                                | --pool-reward-account-verification-key-file FILE
+                                                                )
+                                                                ( --pool-owner-verification-key STRING
+                                                                | --pool-owner-stake-verification-key-file FILE
+                                                                )
+                                                                [ [--pool-relay-ipv4 STRING]
+                                                                  [--pool-relay-ipv6 STRING]
+                                                                  --pool-relay-port INT
+                                                                | --single-host-pool-relay STRING
+                                                                  [--pool-relay-port INT]
+                                                                | --multi-host-pool-relay STRING
+                                                                ]
+                                                                [--metadata-url URL
+                                                                  --metadata-hash HASH]
+                                                                ( --mainnet
+                                                                | --testnet-magic NATURAL
+                                                                )
+                                                                --out-file FILE
+
+  Create a stake pool registration certificate
+
+Usage: cardano-cli alonzo stake-pool deregistration-certificate 
+                                                                  ( --stake-pool-verification-key STRING
+                                                                  | --cold-verification-key-file FILE
+                                                                  )
+                                                                  --epoch NATURAL
+                                                                  --out-file FILE
+
+  Create a stake pool deregistration certificate
+
+Usage: cardano-cli alonzo stake-pool id 
+                                          ( --stake-pool-verification-key STRING
+                                          | --cold-verification-key-file FILE
+                                          )
+                                          [--output-format STRING]
+                                          [--out-file FILE]
+
+  Build pool id from the offline key
+
+Usage: cardano-cli alonzo stake-pool metadata-hash --pool-metadata-file FILE
+                                                     [--out-file FILE]
+
+  Print the hash of pool metadata.
+
 Usage: cardano-cli alonzo text-view decode-cbor
 
   Era-based text-view commands
@@ -4625,6 +4885,7 @@ Usage: cardano-cli babbage
                              | node
                              | query
                              | stake-address
+                             | stake-pool
                              | text-view
                              | transaction
                              )
@@ -5385,6 +5646,70 @@ Usage: cardano-cli babbage stake-address stake-delegation-certificate
   Create a stake address stake delegation certificate, which when submitted in a
   transaction delegates stake to a stake pool.
 
+Usage: cardano-cli babbage stake-pool 
+                                        ( registration-certificate
+                                        | deregistration-certificate
+                                        | id
+                                        | metadata-hash
+                                        )
+
+  Era-based text-view commands
+
+Usage: cardano-cli babbage stake-pool registration-certificate 
+                                                                 ( --stake-pool-verification-key STRING
+                                                                 | --cold-verification-key-file FILE
+                                                                 )
+                                                                 ( --vrf-verification-key STRING
+                                                                 | --vrf-verification-key-file FILE
+                                                                 )
+                                                                 --pool-pledge LOVELACE
+                                                                 --pool-cost LOVELACE
+                                                                 --pool-margin RATIONAL
+                                                                 ( --pool-reward-account-verification-key STRING
+                                                                 | --pool-reward-account-verification-key-file FILE
+                                                                 )
+                                                                 ( --pool-owner-verification-key STRING
+                                                                 | --pool-owner-stake-verification-key-file FILE
+                                                                 )
+                                                                 [ [--pool-relay-ipv4 STRING]
+                                                                   [--pool-relay-ipv6 STRING]
+                                                                   --pool-relay-port INT
+                                                                 | --single-host-pool-relay STRING
+                                                                   [--pool-relay-port INT]
+                                                                 | --multi-host-pool-relay STRING
+                                                                 ]
+                                                                 [--metadata-url URL
+                                                                   --metadata-hash HASH]
+                                                                 ( --mainnet
+                                                                 | --testnet-magic NATURAL
+                                                                 )
+                                                                 --out-file FILE
+
+  Create a stake pool registration certificate
+
+Usage: cardano-cli babbage stake-pool deregistration-certificate 
+                                                                   ( --stake-pool-verification-key STRING
+                                                                   | --cold-verification-key-file FILE
+                                                                   )
+                                                                   --epoch NATURAL
+                                                                   --out-file FILE
+
+  Create a stake pool deregistration certificate
+
+Usage: cardano-cli babbage stake-pool id 
+                                           ( --stake-pool-verification-key STRING
+                                           | --cold-verification-key-file FILE
+                                           )
+                                           [--output-format STRING]
+                                           [--out-file FILE]
+
+  Build pool id from the offline key
+
+Usage: cardano-cli babbage stake-pool metadata-hash --pool-metadata-file FILE
+                                                      [--out-file FILE]
+
+  Print the hash of pool metadata.
+
 Usage: cardano-cli babbage text-view decode-cbor
 
   Era-based text-view commands
@@ -5785,6 +6110,7 @@ Usage: cardano-cli conway
                             | node
                             | query
                             | stake-address
+                            | stake-pool
                             | text-view
                             | transaction
                             )
@@ -6859,6 +7185,70 @@ Usage: cardano-cli conway stake-address vote-delegation-certificate
   Create a stake address vote delegation certificate, which when submitted in a
   transaction delegates stake to a stake pool and a DRep.
 
+Usage: cardano-cli conway stake-pool 
+                                       ( registration-certificate
+                                       | deregistration-certificate
+                                       | id
+                                       | metadata-hash
+                                       )
+
+  Era-based text-view commands
+
+Usage: cardano-cli conway stake-pool registration-certificate 
+                                                                ( --stake-pool-verification-key STRING
+                                                                | --cold-verification-key-file FILE
+                                                                )
+                                                                ( --vrf-verification-key STRING
+                                                                | --vrf-verification-key-file FILE
+                                                                )
+                                                                --pool-pledge LOVELACE
+                                                                --pool-cost LOVELACE
+                                                                --pool-margin RATIONAL
+                                                                ( --pool-reward-account-verification-key STRING
+                                                                | --pool-reward-account-verification-key-file FILE
+                                                                )
+                                                                ( --pool-owner-verification-key STRING
+                                                                | --pool-owner-stake-verification-key-file FILE
+                                                                )
+                                                                [ [--pool-relay-ipv4 STRING]
+                                                                  [--pool-relay-ipv6 STRING]
+                                                                  --pool-relay-port INT
+                                                                | --single-host-pool-relay STRING
+                                                                  [--pool-relay-port INT]
+                                                                | --multi-host-pool-relay STRING
+                                                                ]
+                                                                [--metadata-url URL
+                                                                  --metadata-hash HASH]
+                                                                ( --mainnet
+                                                                | --testnet-magic NATURAL
+                                                                )
+                                                                --out-file FILE
+
+  Create a stake pool registration certificate
+
+Usage: cardano-cli conway stake-pool deregistration-certificate 
+                                                                  ( --stake-pool-verification-key STRING
+                                                                  | --cold-verification-key-file FILE
+                                                                  )
+                                                                  --epoch NATURAL
+                                                                  --out-file FILE
+
+  Create a stake pool deregistration certificate
+
+Usage: cardano-cli conway stake-pool id 
+                                          ( --stake-pool-verification-key STRING
+                                          | --cold-verification-key-file FILE
+                                          )
+                                          [--output-format STRING]
+                                          [--out-file FILE]
+
+  Build pool id from the offline key
+
+Usage: cardano-cli conway stake-pool metadata-hash --pool-metadata-file FILE
+                                                     [--out-file FILE]
+
+  Print the hash of pool metadata.
+
 Usage: cardano-cli conway text-view decode-cbor
 
   Era-based text-view commands
@@ -7258,6 +7648,7 @@ Usage: cardano-cli latest
                             | node
                             | query
                             | stake-address
+                            | stake-pool
                             | text-view
                             | transaction
                             )
@@ -8015,6 +8406,70 @@ Usage: cardano-cli latest stake-address stake-delegation-certificate
 
   Create a stake address stake delegation certificate, which when submitted in a
   transaction delegates stake to a stake pool.
+
+Usage: cardano-cli latest stake-pool 
+                                       ( registration-certificate
+                                       | deregistration-certificate
+                                       | id
+                                       | metadata-hash
+                                       )
+
+  Era-based text-view commands
+
+Usage: cardano-cli latest stake-pool registration-certificate 
+                                                                ( --stake-pool-verification-key STRING
+                                                                | --cold-verification-key-file FILE
+                                                                )
+                                                                ( --vrf-verification-key STRING
+                                                                | --vrf-verification-key-file FILE
+                                                                )
+                                                                --pool-pledge LOVELACE
+                                                                --pool-cost LOVELACE
+                                                                --pool-margin RATIONAL
+                                                                ( --pool-reward-account-verification-key STRING
+                                                                | --pool-reward-account-verification-key-file FILE
+                                                                )
+                                                                ( --pool-owner-verification-key STRING
+                                                                | --pool-owner-stake-verification-key-file FILE
+                                                                )
+                                                                [ [--pool-relay-ipv4 STRING]
+                                                                  [--pool-relay-ipv6 STRING]
+                                                                  --pool-relay-port INT
+                                                                | --single-host-pool-relay STRING
+                                                                  [--pool-relay-port INT]
+                                                                | --multi-host-pool-relay STRING
+                                                                ]
+                                                                [--metadata-url URL
+                                                                  --metadata-hash HASH]
+                                                                ( --mainnet
+                                                                | --testnet-magic NATURAL
+                                                                )
+                                                                --out-file FILE
+
+  Create a stake pool registration certificate
+
+Usage: cardano-cli latest stake-pool deregistration-certificate 
+                                                                  ( --stake-pool-verification-key STRING
+                                                                  | --cold-verification-key-file FILE
+                                                                  )
+                                                                  --epoch NATURAL
+                                                                  --out-file FILE
+
+  Create a stake pool deregistration certificate
+
+Usage: cardano-cli latest stake-pool id 
+                                          ( --stake-pool-verification-key STRING
+                                          | --cold-verification-key-file FILE
+                                          )
+                                          [--output-format STRING]
+                                          [--out-file FILE]
+
+  Build pool id from the offline key
+
+Usage: cardano-cli latest stake-pool metadata-hash --pool-metadata-file FILE
+                                                     [--out-file FILE]
+
+  Print the hash of pool metadata.
 
 Usage: cardano-cli latest text-view decode-cbor
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra.cli
@@ -6,6 +6,7 @@ Usage: cardano-cli allegra
                              | node
                              | query
                              | stake-address
+                             | stake-pool
                              | text-view
                              | transaction
                              )
@@ -23,5 +24,6 @@ Available commands:
   node                     Era-based node commands
   query                    Era-based query commands
   stake-address            Stake address commands.
+  stake-pool               Era-based text-view commands
   text-view                Era-based text-view commands
   transaction              Era-based transaction commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_stake-pool.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_stake-pool.cli
@@ -1,0 +1,18 @@
+Usage: cardano-cli allegra stake-pool 
+                                        ( registration-certificate
+                                        | deregistration-certificate
+                                        | id
+                                        | metadata-hash
+                                        )
+
+  Era-based text-view commands
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  registration-certificate Create a stake pool registration certificate
+  deregistration-certificate
+                           Create a stake pool deregistration certificate
+  id                       Build pool id from the offline key
+  metadata-hash            Print the hash of pool metadata.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_stake-pool_deregistration-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_stake-pool_deregistration-certificate.cli
@@ -1,0 +1,17 @@
+Usage: cardano-cli allegra stake-pool deregistration-certificate 
+                                                                   ( --stake-pool-verification-key STRING
+                                                                   | --cold-verification-key-file FILE
+                                                                   )
+                                                                   --epoch NATURAL
+                                                                   --out-file FILE
+
+  Create a stake pool deregistration certificate
+
+Available options:
+  --stake-pool-verification-key STRING
+                           Stake pool verification key (Bech32 or hex-encoded).
+  --cold-verification-key-file FILE
+                           Filepath of the stake pool verification key.
+  --epoch NATURAL          The epoch number.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_stake-pool_id.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_stake-pool_id.cli
@@ -1,0 +1,18 @@
+Usage: cardano-cli allegra stake-pool id 
+                                           ( --stake-pool-verification-key STRING
+                                           | --cold-verification-key-file FILE
+                                           )
+                                           [--output-format STRING]
+                                           [--out-file FILE]
+
+  Build pool id from the offline key
+
+Available options:
+  --stake-pool-verification-key STRING
+                           Stake pool verification key (Bech32 or hex-encoded).
+  --cold-verification-key-file FILE
+                           Filepath of the stake pool verification key.
+  --output-format STRING   Optional pool id output format. Accepted output
+                           formats are "hex" and "bech32" (default is "bech32").
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_stake-pool_metadata-hash.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_stake-pool_metadata-hash.cli
@@ -1,0 +1,10 @@
+Usage: cardano-cli allegra stake-pool metadata-hash --pool-metadata-file FILE
+                                                      [--out-file FILE]
+
+  Print the hash of pool metadata.
+
+Available options:
+  --pool-metadata-file FILE
+                           Filepath of the pool metadata.
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_stake-pool_registration-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_stake-pool_registration-certificate.cli
@@ -1,0 +1,73 @@
+Usage: cardano-cli allegra stake-pool registration-certificate 
+                                                                 ( --stake-pool-verification-key STRING
+                                                                 | --cold-verification-key-file FILE
+                                                                 )
+                                                                 ( --vrf-verification-key STRING
+                                                                 | --vrf-verification-key-file FILE
+                                                                 )
+                                                                 --pool-pledge LOVELACE
+                                                                 --pool-cost LOVELACE
+                                                                 --pool-margin RATIONAL
+                                                                 ( --pool-reward-account-verification-key STRING
+                                                                 | --pool-reward-account-verification-key-file FILE
+                                                                 )
+                                                                 ( --pool-owner-verification-key STRING
+                                                                 | --pool-owner-stake-verification-key-file FILE
+                                                                 )
+                                                                 [ [--pool-relay-ipv4 STRING]
+                                                                   [--pool-relay-ipv6 STRING]
+                                                                   --pool-relay-port INT
+                                                                 | --single-host-pool-relay STRING
+                                                                   [--pool-relay-port INT]
+                                                                 | --multi-host-pool-relay STRING
+                                                                 ]
+                                                                 [--metadata-url URL
+                                                                   --metadata-hash HASH]
+                                                                 ( --mainnet
+                                                                 | --testnet-magic NATURAL
+                                                                 )
+                                                                 --out-file FILE
+
+  Create a stake pool registration certificate
+
+Available options:
+  --stake-pool-verification-key STRING
+                           Stake pool verification key (Bech32 or hex-encoded).
+  --cold-verification-key-file FILE
+                           Filepath of the stake pool verification key.
+  --vrf-verification-key STRING
+                           VRF verification key (Bech32 or hex-encoded).
+  --vrf-verification-key-file FILE
+                           Filepath of the VRF verification key.
+  --pool-pledge LOVELACE   The stake pool's pledge.
+  --pool-cost LOVELACE     The stake pool's cost.
+  --pool-margin RATIONAL   The stake pool's margin.
+  --pool-reward-account-verification-key STRING
+                           Reward account stake verification key (Bech32 or
+                           hex-encoded).
+  --pool-reward-account-verification-key-file FILE
+                           Filepath of the reward account stake verification
+                           key.
+  --pool-owner-verification-key STRING
+                           Pool owner stake verification key (Bech32 or
+                           hex-encoded).
+  --pool-owner-stake-verification-key-file FILE
+                           Filepath of the pool owner stake verification key.
+  --pool-relay-ipv4 STRING The stake pool relay's IPv4 address
+  --pool-relay-ipv6 STRING The stake pool relay's IPv6 address
+  --pool-relay-port INT    The stake pool relay's port
+  --single-host-pool-relay STRING
+                           The stake pool relay's DNS name that corresponds to
+                           an A or AAAA DNS record
+  --pool-relay-port INT    The stake pool relay's port
+  --multi-host-pool-relay STRING
+                           The stake pool relay's DNS name that corresponds to
+                           an SRV DNS record
+  --metadata-url URL       Pool metadata URL (maximum length of 64 characters).
+  --metadata-hash HASH     Pool metadata hash.
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo.cli
@@ -6,6 +6,7 @@ Usage: cardano-cli alonzo
                             | node
                             | query
                             | stake-address
+                            | stake-pool
                             | text-view
                             | transaction
                             )
@@ -23,5 +24,6 @@ Available commands:
   node                     Era-based node commands
   query                    Era-based query commands
   stake-address            Stake address commands.
+  stake-pool               Era-based text-view commands
   text-view                Era-based text-view commands
   transaction              Era-based transaction commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_stake-pool.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_stake-pool.cli
@@ -1,0 +1,18 @@
+Usage: cardano-cli alonzo stake-pool 
+                                       ( registration-certificate
+                                       | deregistration-certificate
+                                       | id
+                                       | metadata-hash
+                                       )
+
+  Era-based text-view commands
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  registration-certificate Create a stake pool registration certificate
+  deregistration-certificate
+                           Create a stake pool deregistration certificate
+  id                       Build pool id from the offline key
+  metadata-hash            Print the hash of pool metadata.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_stake-pool_deregistration-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_stake-pool_deregistration-certificate.cli
@@ -1,0 +1,17 @@
+Usage: cardano-cli alonzo stake-pool deregistration-certificate 
+                                                                  ( --stake-pool-verification-key STRING
+                                                                  | --cold-verification-key-file FILE
+                                                                  )
+                                                                  --epoch NATURAL
+                                                                  --out-file FILE
+
+  Create a stake pool deregistration certificate
+
+Available options:
+  --stake-pool-verification-key STRING
+                           Stake pool verification key (Bech32 or hex-encoded).
+  --cold-verification-key-file FILE
+                           Filepath of the stake pool verification key.
+  --epoch NATURAL          The epoch number.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_stake-pool_id.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_stake-pool_id.cli
@@ -1,0 +1,18 @@
+Usage: cardano-cli alonzo stake-pool id 
+                                          ( --stake-pool-verification-key STRING
+                                          | --cold-verification-key-file FILE
+                                          )
+                                          [--output-format STRING]
+                                          [--out-file FILE]
+
+  Build pool id from the offline key
+
+Available options:
+  --stake-pool-verification-key STRING
+                           Stake pool verification key (Bech32 or hex-encoded).
+  --cold-verification-key-file FILE
+                           Filepath of the stake pool verification key.
+  --output-format STRING   Optional pool id output format. Accepted output
+                           formats are "hex" and "bech32" (default is "bech32").
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_stake-pool_metadata-hash.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_stake-pool_metadata-hash.cli
@@ -1,0 +1,10 @@
+Usage: cardano-cli alonzo stake-pool metadata-hash --pool-metadata-file FILE
+                                                     [--out-file FILE]
+
+  Print the hash of pool metadata.
+
+Available options:
+  --pool-metadata-file FILE
+                           Filepath of the pool metadata.
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_stake-pool_registration-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_stake-pool_registration-certificate.cli
@@ -1,0 +1,73 @@
+Usage: cardano-cli alonzo stake-pool registration-certificate 
+                                                                ( --stake-pool-verification-key STRING
+                                                                | --cold-verification-key-file FILE
+                                                                )
+                                                                ( --vrf-verification-key STRING
+                                                                | --vrf-verification-key-file FILE
+                                                                )
+                                                                --pool-pledge LOVELACE
+                                                                --pool-cost LOVELACE
+                                                                --pool-margin RATIONAL
+                                                                ( --pool-reward-account-verification-key STRING
+                                                                | --pool-reward-account-verification-key-file FILE
+                                                                )
+                                                                ( --pool-owner-verification-key STRING
+                                                                | --pool-owner-stake-verification-key-file FILE
+                                                                )
+                                                                [ [--pool-relay-ipv4 STRING]
+                                                                  [--pool-relay-ipv6 STRING]
+                                                                  --pool-relay-port INT
+                                                                | --single-host-pool-relay STRING
+                                                                  [--pool-relay-port INT]
+                                                                | --multi-host-pool-relay STRING
+                                                                ]
+                                                                [--metadata-url URL
+                                                                  --metadata-hash HASH]
+                                                                ( --mainnet
+                                                                | --testnet-magic NATURAL
+                                                                )
+                                                                --out-file FILE
+
+  Create a stake pool registration certificate
+
+Available options:
+  --stake-pool-verification-key STRING
+                           Stake pool verification key (Bech32 or hex-encoded).
+  --cold-verification-key-file FILE
+                           Filepath of the stake pool verification key.
+  --vrf-verification-key STRING
+                           VRF verification key (Bech32 or hex-encoded).
+  --vrf-verification-key-file FILE
+                           Filepath of the VRF verification key.
+  --pool-pledge LOVELACE   The stake pool's pledge.
+  --pool-cost LOVELACE     The stake pool's cost.
+  --pool-margin RATIONAL   The stake pool's margin.
+  --pool-reward-account-verification-key STRING
+                           Reward account stake verification key (Bech32 or
+                           hex-encoded).
+  --pool-reward-account-verification-key-file FILE
+                           Filepath of the reward account stake verification
+                           key.
+  --pool-owner-verification-key STRING
+                           Pool owner stake verification key (Bech32 or
+                           hex-encoded).
+  --pool-owner-stake-verification-key-file FILE
+                           Filepath of the pool owner stake verification key.
+  --pool-relay-ipv4 STRING The stake pool relay's IPv4 address
+  --pool-relay-ipv6 STRING The stake pool relay's IPv6 address
+  --pool-relay-port INT    The stake pool relay's port
+  --single-host-pool-relay STRING
+                           The stake pool relay's DNS name that corresponds to
+                           an A or AAAA DNS record
+  --pool-relay-port INT    The stake pool relay's port
+  --multi-host-pool-relay STRING
+                           The stake pool relay's DNS name that corresponds to
+                           an SRV DNS record
+  --metadata-url URL       Pool metadata URL (maximum length of 64 characters).
+  --metadata-hash HASH     Pool metadata hash.
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage.cli
@@ -6,6 +6,7 @@ Usage: cardano-cli babbage
                              | node
                              | query
                              | stake-address
+                             | stake-pool
                              | text-view
                              | transaction
                              )
@@ -23,5 +24,6 @@ Available commands:
   node                     Era-based node commands
   query                    Era-based query commands
   stake-address            Stake address commands.
+  stake-pool               Era-based text-view commands
   text-view                Era-based text-view commands
   transaction              Era-based transaction commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_stake-pool.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_stake-pool.cli
@@ -1,0 +1,18 @@
+Usage: cardano-cli babbage stake-pool 
+                                        ( registration-certificate
+                                        | deregistration-certificate
+                                        | id
+                                        | metadata-hash
+                                        )
+
+  Era-based text-view commands
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  registration-certificate Create a stake pool registration certificate
+  deregistration-certificate
+                           Create a stake pool deregistration certificate
+  id                       Build pool id from the offline key
+  metadata-hash            Print the hash of pool metadata.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_stake-pool_deregistration-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_stake-pool_deregistration-certificate.cli
@@ -1,0 +1,17 @@
+Usage: cardano-cli babbage stake-pool deregistration-certificate 
+                                                                   ( --stake-pool-verification-key STRING
+                                                                   | --cold-verification-key-file FILE
+                                                                   )
+                                                                   --epoch NATURAL
+                                                                   --out-file FILE
+
+  Create a stake pool deregistration certificate
+
+Available options:
+  --stake-pool-verification-key STRING
+                           Stake pool verification key (Bech32 or hex-encoded).
+  --cold-verification-key-file FILE
+                           Filepath of the stake pool verification key.
+  --epoch NATURAL          The epoch number.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_stake-pool_id.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_stake-pool_id.cli
@@ -1,0 +1,18 @@
+Usage: cardano-cli babbage stake-pool id 
+                                           ( --stake-pool-verification-key STRING
+                                           | --cold-verification-key-file FILE
+                                           )
+                                           [--output-format STRING]
+                                           [--out-file FILE]
+
+  Build pool id from the offline key
+
+Available options:
+  --stake-pool-verification-key STRING
+                           Stake pool verification key (Bech32 or hex-encoded).
+  --cold-verification-key-file FILE
+                           Filepath of the stake pool verification key.
+  --output-format STRING   Optional pool id output format. Accepted output
+                           formats are "hex" and "bech32" (default is "bech32").
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_stake-pool_metadata-hash.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_stake-pool_metadata-hash.cli
@@ -1,0 +1,10 @@
+Usage: cardano-cli babbage stake-pool metadata-hash --pool-metadata-file FILE
+                                                      [--out-file FILE]
+
+  Print the hash of pool metadata.
+
+Available options:
+  --pool-metadata-file FILE
+                           Filepath of the pool metadata.
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_stake-pool_registration-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_stake-pool_registration-certificate.cli
@@ -1,0 +1,73 @@
+Usage: cardano-cli babbage stake-pool registration-certificate 
+                                                                 ( --stake-pool-verification-key STRING
+                                                                 | --cold-verification-key-file FILE
+                                                                 )
+                                                                 ( --vrf-verification-key STRING
+                                                                 | --vrf-verification-key-file FILE
+                                                                 )
+                                                                 --pool-pledge LOVELACE
+                                                                 --pool-cost LOVELACE
+                                                                 --pool-margin RATIONAL
+                                                                 ( --pool-reward-account-verification-key STRING
+                                                                 | --pool-reward-account-verification-key-file FILE
+                                                                 )
+                                                                 ( --pool-owner-verification-key STRING
+                                                                 | --pool-owner-stake-verification-key-file FILE
+                                                                 )
+                                                                 [ [--pool-relay-ipv4 STRING]
+                                                                   [--pool-relay-ipv6 STRING]
+                                                                   --pool-relay-port INT
+                                                                 | --single-host-pool-relay STRING
+                                                                   [--pool-relay-port INT]
+                                                                 | --multi-host-pool-relay STRING
+                                                                 ]
+                                                                 [--metadata-url URL
+                                                                   --metadata-hash HASH]
+                                                                 ( --mainnet
+                                                                 | --testnet-magic NATURAL
+                                                                 )
+                                                                 --out-file FILE
+
+  Create a stake pool registration certificate
+
+Available options:
+  --stake-pool-verification-key STRING
+                           Stake pool verification key (Bech32 or hex-encoded).
+  --cold-verification-key-file FILE
+                           Filepath of the stake pool verification key.
+  --vrf-verification-key STRING
+                           VRF verification key (Bech32 or hex-encoded).
+  --vrf-verification-key-file FILE
+                           Filepath of the VRF verification key.
+  --pool-pledge LOVELACE   The stake pool's pledge.
+  --pool-cost LOVELACE     The stake pool's cost.
+  --pool-margin RATIONAL   The stake pool's margin.
+  --pool-reward-account-verification-key STRING
+                           Reward account stake verification key (Bech32 or
+                           hex-encoded).
+  --pool-reward-account-verification-key-file FILE
+                           Filepath of the reward account stake verification
+                           key.
+  --pool-owner-verification-key STRING
+                           Pool owner stake verification key (Bech32 or
+                           hex-encoded).
+  --pool-owner-stake-verification-key-file FILE
+                           Filepath of the pool owner stake verification key.
+  --pool-relay-ipv4 STRING The stake pool relay's IPv4 address
+  --pool-relay-ipv6 STRING The stake pool relay's IPv6 address
+  --pool-relay-port INT    The stake pool relay's port
+  --single-host-pool-relay STRING
+                           The stake pool relay's DNS name that corresponds to
+                           an A or AAAA DNS record
+  --pool-relay-port INT    The stake pool relay's port
+  --multi-host-pool-relay STRING
+                           The stake pool relay's DNS name that corresponds to
+                           an SRV DNS record
+  --metadata-url URL       Pool metadata URL (maximum length of 64 characters).
+  --metadata-hash HASH     Pool metadata hash.
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway.cli
@@ -6,6 +6,7 @@ Usage: cardano-cli conway
                             | node
                             | query
                             | stake-address
+                            | stake-pool
                             | text-view
                             | transaction
                             )
@@ -23,5 +24,6 @@ Available commands:
   node                     Era-based node commands
   query                    Era-based query commands
   stake-address            Stake address commands.
+  stake-pool               Era-based text-view commands
   text-view                Era-based text-view commands
   transaction              Era-based transaction commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_stake-pool.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_stake-pool.cli
@@ -1,0 +1,18 @@
+Usage: cardano-cli conway stake-pool 
+                                       ( registration-certificate
+                                       | deregistration-certificate
+                                       | id
+                                       | metadata-hash
+                                       )
+
+  Era-based text-view commands
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  registration-certificate Create a stake pool registration certificate
+  deregistration-certificate
+                           Create a stake pool deregistration certificate
+  id                       Build pool id from the offline key
+  metadata-hash            Print the hash of pool metadata.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_stake-pool_deregistration-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_stake-pool_deregistration-certificate.cli
@@ -1,0 +1,17 @@
+Usage: cardano-cli conway stake-pool deregistration-certificate 
+                                                                  ( --stake-pool-verification-key STRING
+                                                                  | --cold-verification-key-file FILE
+                                                                  )
+                                                                  --epoch NATURAL
+                                                                  --out-file FILE
+
+  Create a stake pool deregistration certificate
+
+Available options:
+  --stake-pool-verification-key STRING
+                           Stake pool verification key (Bech32 or hex-encoded).
+  --cold-verification-key-file FILE
+                           Filepath of the stake pool verification key.
+  --epoch NATURAL          The epoch number.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_stake-pool_id.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_stake-pool_id.cli
@@ -1,0 +1,18 @@
+Usage: cardano-cli conway stake-pool id 
+                                          ( --stake-pool-verification-key STRING
+                                          | --cold-verification-key-file FILE
+                                          )
+                                          [--output-format STRING]
+                                          [--out-file FILE]
+
+  Build pool id from the offline key
+
+Available options:
+  --stake-pool-verification-key STRING
+                           Stake pool verification key (Bech32 or hex-encoded).
+  --cold-verification-key-file FILE
+                           Filepath of the stake pool verification key.
+  --output-format STRING   Optional pool id output format. Accepted output
+                           formats are "hex" and "bech32" (default is "bech32").
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_stake-pool_metadata-hash.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_stake-pool_metadata-hash.cli
@@ -1,0 +1,10 @@
+Usage: cardano-cli conway stake-pool metadata-hash --pool-metadata-file FILE
+                                                     [--out-file FILE]
+
+  Print the hash of pool metadata.
+
+Available options:
+  --pool-metadata-file FILE
+                           Filepath of the pool metadata.
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_stake-pool_registration-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_stake-pool_registration-certificate.cli
@@ -1,0 +1,73 @@
+Usage: cardano-cli conway stake-pool registration-certificate 
+                                                                ( --stake-pool-verification-key STRING
+                                                                | --cold-verification-key-file FILE
+                                                                )
+                                                                ( --vrf-verification-key STRING
+                                                                | --vrf-verification-key-file FILE
+                                                                )
+                                                                --pool-pledge LOVELACE
+                                                                --pool-cost LOVELACE
+                                                                --pool-margin RATIONAL
+                                                                ( --pool-reward-account-verification-key STRING
+                                                                | --pool-reward-account-verification-key-file FILE
+                                                                )
+                                                                ( --pool-owner-verification-key STRING
+                                                                | --pool-owner-stake-verification-key-file FILE
+                                                                )
+                                                                [ [--pool-relay-ipv4 STRING]
+                                                                  [--pool-relay-ipv6 STRING]
+                                                                  --pool-relay-port INT
+                                                                | --single-host-pool-relay STRING
+                                                                  [--pool-relay-port INT]
+                                                                | --multi-host-pool-relay STRING
+                                                                ]
+                                                                [--metadata-url URL
+                                                                  --metadata-hash HASH]
+                                                                ( --mainnet
+                                                                | --testnet-magic NATURAL
+                                                                )
+                                                                --out-file FILE
+
+  Create a stake pool registration certificate
+
+Available options:
+  --stake-pool-verification-key STRING
+                           Stake pool verification key (Bech32 or hex-encoded).
+  --cold-verification-key-file FILE
+                           Filepath of the stake pool verification key.
+  --vrf-verification-key STRING
+                           VRF verification key (Bech32 or hex-encoded).
+  --vrf-verification-key-file FILE
+                           Filepath of the VRF verification key.
+  --pool-pledge LOVELACE   The stake pool's pledge.
+  --pool-cost LOVELACE     The stake pool's cost.
+  --pool-margin RATIONAL   The stake pool's margin.
+  --pool-reward-account-verification-key STRING
+                           Reward account stake verification key (Bech32 or
+                           hex-encoded).
+  --pool-reward-account-verification-key-file FILE
+                           Filepath of the reward account stake verification
+                           key.
+  --pool-owner-verification-key STRING
+                           Pool owner stake verification key (Bech32 or
+                           hex-encoded).
+  --pool-owner-stake-verification-key-file FILE
+                           Filepath of the pool owner stake verification key.
+  --pool-relay-ipv4 STRING The stake pool relay's IPv4 address
+  --pool-relay-ipv6 STRING The stake pool relay's IPv6 address
+  --pool-relay-port INT    The stake pool relay's port
+  --single-host-pool-relay STRING
+                           The stake pool relay's DNS name that corresponds to
+                           an A or AAAA DNS record
+  --pool-relay-port INT    The stake pool relay's port
+  --multi-host-pool-relay STRING
+                           The stake pool relay's DNS name that corresponds to
+                           an SRV DNS record
+  --metadata-url URL       Pool metadata URL (maximum length of 64 characters).
+  --metadata-hash HASH     Pool metadata hash.
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest.cli
@@ -6,6 +6,7 @@ Usage: cardano-cli latest
                             | node
                             | query
                             | stake-address
+                            | stake-pool
                             | text-view
                             | transaction
                             )
@@ -23,5 +24,6 @@ Available commands:
   node                     Era-based node commands
   query                    Era-based query commands
   stake-address            Stake address commands.
+  stake-pool               Era-based text-view commands
   text-view                Era-based text-view commands
   transaction              Era-based transaction commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_stake-pool.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_stake-pool.cli
@@ -1,0 +1,18 @@
+Usage: cardano-cli latest stake-pool 
+                                       ( registration-certificate
+                                       | deregistration-certificate
+                                       | id
+                                       | metadata-hash
+                                       )
+
+  Era-based text-view commands
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  registration-certificate Create a stake pool registration certificate
+  deregistration-certificate
+                           Create a stake pool deregistration certificate
+  id                       Build pool id from the offline key
+  metadata-hash            Print the hash of pool metadata.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_stake-pool_deregistration-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_stake-pool_deregistration-certificate.cli
@@ -1,0 +1,17 @@
+Usage: cardano-cli latest stake-pool deregistration-certificate 
+                                                                  ( --stake-pool-verification-key STRING
+                                                                  | --cold-verification-key-file FILE
+                                                                  )
+                                                                  --epoch NATURAL
+                                                                  --out-file FILE
+
+  Create a stake pool deregistration certificate
+
+Available options:
+  --stake-pool-verification-key STRING
+                           Stake pool verification key (Bech32 or hex-encoded).
+  --cold-verification-key-file FILE
+                           Filepath of the stake pool verification key.
+  --epoch NATURAL          The epoch number.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_stake-pool_id.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_stake-pool_id.cli
@@ -1,0 +1,18 @@
+Usage: cardano-cli latest stake-pool id 
+                                          ( --stake-pool-verification-key STRING
+                                          | --cold-verification-key-file FILE
+                                          )
+                                          [--output-format STRING]
+                                          [--out-file FILE]
+
+  Build pool id from the offline key
+
+Available options:
+  --stake-pool-verification-key STRING
+                           Stake pool verification key (Bech32 or hex-encoded).
+  --cold-verification-key-file FILE
+                           Filepath of the stake pool verification key.
+  --output-format STRING   Optional pool id output format. Accepted output
+                           formats are "hex" and "bech32" (default is "bech32").
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_stake-pool_metadata-hash.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_stake-pool_metadata-hash.cli
@@ -1,0 +1,10 @@
+Usage: cardano-cli latest stake-pool metadata-hash --pool-metadata-file FILE
+                                                     [--out-file FILE]
+
+  Print the hash of pool metadata.
+
+Available options:
+  --pool-metadata-file FILE
+                           Filepath of the pool metadata.
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_stake-pool_registration-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_stake-pool_registration-certificate.cli
@@ -1,0 +1,73 @@
+Usage: cardano-cli latest stake-pool registration-certificate 
+                                                                ( --stake-pool-verification-key STRING
+                                                                | --cold-verification-key-file FILE
+                                                                )
+                                                                ( --vrf-verification-key STRING
+                                                                | --vrf-verification-key-file FILE
+                                                                )
+                                                                --pool-pledge LOVELACE
+                                                                --pool-cost LOVELACE
+                                                                --pool-margin RATIONAL
+                                                                ( --pool-reward-account-verification-key STRING
+                                                                | --pool-reward-account-verification-key-file FILE
+                                                                )
+                                                                ( --pool-owner-verification-key STRING
+                                                                | --pool-owner-stake-verification-key-file FILE
+                                                                )
+                                                                [ [--pool-relay-ipv4 STRING]
+                                                                  [--pool-relay-ipv6 STRING]
+                                                                  --pool-relay-port INT
+                                                                | --single-host-pool-relay STRING
+                                                                  [--pool-relay-port INT]
+                                                                | --multi-host-pool-relay STRING
+                                                                ]
+                                                                [--metadata-url URL
+                                                                  --metadata-hash HASH]
+                                                                ( --mainnet
+                                                                | --testnet-magic NATURAL
+                                                                )
+                                                                --out-file FILE
+
+  Create a stake pool registration certificate
+
+Available options:
+  --stake-pool-verification-key STRING
+                           Stake pool verification key (Bech32 or hex-encoded).
+  --cold-verification-key-file FILE
+                           Filepath of the stake pool verification key.
+  --vrf-verification-key STRING
+                           VRF verification key (Bech32 or hex-encoded).
+  --vrf-verification-key-file FILE
+                           Filepath of the VRF verification key.
+  --pool-pledge LOVELACE   The stake pool's pledge.
+  --pool-cost LOVELACE     The stake pool's cost.
+  --pool-margin RATIONAL   The stake pool's margin.
+  --pool-reward-account-verification-key STRING
+                           Reward account stake verification key (Bech32 or
+                           hex-encoded).
+  --pool-reward-account-verification-key-file FILE
+                           Filepath of the reward account stake verification
+                           key.
+  --pool-owner-verification-key STRING
+                           Pool owner stake verification key (Bech32 or
+                           hex-encoded).
+  --pool-owner-stake-verification-key-file FILE
+                           Filepath of the pool owner stake verification key.
+  --pool-relay-ipv4 STRING The stake pool relay's IPv4 address
+  --pool-relay-ipv6 STRING The stake pool relay's IPv6 address
+  --pool-relay-port INT    The stake pool relay's port
+  --single-host-pool-relay STRING
+                           The stake pool relay's DNS name that corresponds to
+                           an A or AAAA DNS record
+  --pool-relay-port INT    The stake pool relay's port
+  --multi-host-pool-relay STRING
+                           The stake pool relay's DNS name that corresponds to
+                           an SRV DNS record
+  --metadata-url URL       Pool metadata URL (maximum length of 64 characters).
+  --metadata-hash HASH     Pool metadata hash.
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary.cli
@@ -6,6 +6,7 @@ Usage: cardano-cli mary
                           | node
                           | query
                           | stake-address
+                          | stake-pool
                           | text-view
                           | transaction
                           )
@@ -23,5 +24,6 @@ Available commands:
   node                     Era-based node commands
   query                    Era-based query commands
   stake-address            Stake address commands.
+  stake-pool               Era-based text-view commands
   text-view                Era-based text-view commands
   transaction              Era-based transaction commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_stake-pool.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_stake-pool.cli
@@ -1,0 +1,18 @@
+Usage: cardano-cli mary stake-pool 
+                                     ( registration-certificate
+                                     | deregistration-certificate
+                                     | id
+                                     | metadata-hash
+                                     )
+
+  Era-based text-view commands
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  registration-certificate Create a stake pool registration certificate
+  deregistration-certificate
+                           Create a stake pool deregistration certificate
+  id                       Build pool id from the offline key
+  metadata-hash            Print the hash of pool metadata.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_stake-pool_deregistration-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_stake-pool_deregistration-certificate.cli
@@ -1,0 +1,17 @@
+Usage: cardano-cli mary stake-pool deregistration-certificate 
+                                                                ( --stake-pool-verification-key STRING
+                                                                | --cold-verification-key-file FILE
+                                                                )
+                                                                --epoch NATURAL
+                                                                --out-file FILE
+
+  Create a stake pool deregistration certificate
+
+Available options:
+  --stake-pool-verification-key STRING
+                           Stake pool verification key (Bech32 or hex-encoded).
+  --cold-verification-key-file FILE
+                           Filepath of the stake pool verification key.
+  --epoch NATURAL          The epoch number.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_stake-pool_id.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_stake-pool_id.cli
@@ -1,0 +1,18 @@
+Usage: cardano-cli mary stake-pool id 
+                                        ( --stake-pool-verification-key STRING
+                                        | --cold-verification-key-file FILE
+                                        )
+                                        [--output-format STRING]
+                                        [--out-file FILE]
+
+  Build pool id from the offline key
+
+Available options:
+  --stake-pool-verification-key STRING
+                           Stake pool verification key (Bech32 or hex-encoded).
+  --cold-verification-key-file FILE
+                           Filepath of the stake pool verification key.
+  --output-format STRING   Optional pool id output format. Accepted output
+                           formats are "hex" and "bech32" (default is "bech32").
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_stake-pool_metadata-hash.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_stake-pool_metadata-hash.cli
@@ -1,0 +1,10 @@
+Usage: cardano-cli mary stake-pool metadata-hash --pool-metadata-file FILE
+                                                   [--out-file FILE]
+
+  Print the hash of pool metadata.
+
+Available options:
+  --pool-metadata-file FILE
+                           Filepath of the pool metadata.
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_stake-pool_registration-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_stake-pool_registration-certificate.cli
@@ -1,0 +1,73 @@
+Usage: cardano-cli mary stake-pool registration-certificate 
+                                                              ( --stake-pool-verification-key STRING
+                                                              | --cold-verification-key-file FILE
+                                                              )
+                                                              ( --vrf-verification-key STRING
+                                                              | --vrf-verification-key-file FILE
+                                                              )
+                                                              --pool-pledge LOVELACE
+                                                              --pool-cost LOVELACE
+                                                              --pool-margin RATIONAL
+                                                              ( --pool-reward-account-verification-key STRING
+                                                              | --pool-reward-account-verification-key-file FILE
+                                                              )
+                                                              ( --pool-owner-verification-key STRING
+                                                              | --pool-owner-stake-verification-key-file FILE
+                                                              )
+                                                              [ [--pool-relay-ipv4 STRING]
+                                                                [--pool-relay-ipv6 STRING]
+                                                                --pool-relay-port INT
+                                                              | --single-host-pool-relay STRING
+                                                                [--pool-relay-port INT]
+                                                              | --multi-host-pool-relay STRING
+                                                              ]
+                                                              [--metadata-url URL
+                                                                --metadata-hash HASH]
+                                                              ( --mainnet
+                                                              | --testnet-magic NATURAL
+                                                              )
+                                                              --out-file FILE
+
+  Create a stake pool registration certificate
+
+Available options:
+  --stake-pool-verification-key STRING
+                           Stake pool verification key (Bech32 or hex-encoded).
+  --cold-verification-key-file FILE
+                           Filepath of the stake pool verification key.
+  --vrf-verification-key STRING
+                           VRF verification key (Bech32 or hex-encoded).
+  --vrf-verification-key-file FILE
+                           Filepath of the VRF verification key.
+  --pool-pledge LOVELACE   The stake pool's pledge.
+  --pool-cost LOVELACE     The stake pool's cost.
+  --pool-margin RATIONAL   The stake pool's margin.
+  --pool-reward-account-verification-key STRING
+                           Reward account stake verification key (Bech32 or
+                           hex-encoded).
+  --pool-reward-account-verification-key-file FILE
+                           Filepath of the reward account stake verification
+                           key.
+  --pool-owner-verification-key STRING
+                           Pool owner stake verification key (Bech32 or
+                           hex-encoded).
+  --pool-owner-stake-verification-key-file FILE
+                           Filepath of the pool owner stake verification key.
+  --pool-relay-ipv4 STRING The stake pool relay's IPv4 address
+  --pool-relay-ipv6 STRING The stake pool relay's IPv6 address
+  --pool-relay-port INT    The stake pool relay's port
+  --single-host-pool-relay STRING
+                           The stake pool relay's DNS name that corresponds to
+                           an A or AAAA DNS record
+  --pool-relay-port INT    The stake pool relay's port
+  --multi-host-pool-relay STRING
+                           The stake pool relay's DNS name that corresponds to
+                           an SRV DNS record
+  --metadata-url URL       Pool metadata URL (maximum length of 64 characters).
+  --metadata-hash HASH     Pool metadata hash.
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley.cli
@@ -6,6 +6,7 @@ Usage: cardano-cli shelley
                              | node
                              | query
                              | stake-address
+                             | stake-pool
                              | text-view
                              | transaction
                              )
@@ -23,5 +24,6 @@ Available commands:
   node                     Era-based node commands
   query                    Era-based query commands
   stake-address            Stake address commands.
+  stake-pool               Era-based text-view commands
   text-view                Era-based text-view commands
   transaction              Era-based transaction commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_stake-pool.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_stake-pool.cli
@@ -1,0 +1,18 @@
+Usage: cardano-cli shelley stake-pool 
+                                        ( registration-certificate
+                                        | deregistration-certificate
+                                        | id
+                                        | metadata-hash
+                                        )
+
+  Era-based text-view commands
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  registration-certificate Create a stake pool registration certificate
+  deregistration-certificate
+                           Create a stake pool deregistration certificate
+  id                       Build pool id from the offline key
+  metadata-hash            Print the hash of pool metadata.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_stake-pool_deregistration-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_stake-pool_deregistration-certificate.cli
@@ -1,0 +1,17 @@
+Usage: cardano-cli shelley stake-pool deregistration-certificate 
+                                                                   ( --stake-pool-verification-key STRING
+                                                                   | --cold-verification-key-file FILE
+                                                                   )
+                                                                   --epoch NATURAL
+                                                                   --out-file FILE
+
+  Create a stake pool deregistration certificate
+
+Available options:
+  --stake-pool-verification-key STRING
+                           Stake pool verification key (Bech32 or hex-encoded).
+  --cold-verification-key-file FILE
+                           Filepath of the stake pool verification key.
+  --epoch NATURAL          The epoch number.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_stake-pool_id.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_stake-pool_id.cli
@@ -1,0 +1,18 @@
+Usage: cardano-cli shelley stake-pool id 
+                                           ( --stake-pool-verification-key STRING
+                                           | --cold-verification-key-file FILE
+                                           )
+                                           [--output-format STRING]
+                                           [--out-file FILE]
+
+  Build pool id from the offline key
+
+Available options:
+  --stake-pool-verification-key STRING
+                           Stake pool verification key (Bech32 or hex-encoded).
+  --cold-verification-key-file FILE
+                           Filepath of the stake pool verification key.
+  --output-format STRING   Optional pool id output format. Accepted output
+                           formats are "hex" and "bech32" (default is "bech32").
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_stake-pool_metadata-hash.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_stake-pool_metadata-hash.cli
@@ -1,0 +1,10 @@
+Usage: cardano-cli shelley stake-pool metadata-hash --pool-metadata-file FILE
+                                                      [--out-file FILE]
+
+  Print the hash of pool metadata.
+
+Available options:
+  --pool-metadata-file FILE
+                           Filepath of the pool metadata.
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_stake-pool_registration-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_stake-pool_registration-certificate.cli
@@ -1,0 +1,73 @@
+Usage: cardano-cli shelley stake-pool registration-certificate 
+                                                                 ( --stake-pool-verification-key STRING
+                                                                 | --cold-verification-key-file FILE
+                                                                 )
+                                                                 ( --vrf-verification-key STRING
+                                                                 | --vrf-verification-key-file FILE
+                                                                 )
+                                                                 --pool-pledge LOVELACE
+                                                                 --pool-cost LOVELACE
+                                                                 --pool-margin RATIONAL
+                                                                 ( --pool-reward-account-verification-key STRING
+                                                                 | --pool-reward-account-verification-key-file FILE
+                                                                 )
+                                                                 ( --pool-owner-verification-key STRING
+                                                                 | --pool-owner-stake-verification-key-file FILE
+                                                                 )
+                                                                 [ [--pool-relay-ipv4 STRING]
+                                                                   [--pool-relay-ipv6 STRING]
+                                                                   --pool-relay-port INT
+                                                                 | --single-host-pool-relay STRING
+                                                                   [--pool-relay-port INT]
+                                                                 | --multi-host-pool-relay STRING
+                                                                 ]
+                                                                 [--metadata-url URL
+                                                                   --metadata-hash HASH]
+                                                                 ( --mainnet
+                                                                 | --testnet-magic NATURAL
+                                                                 )
+                                                                 --out-file FILE
+
+  Create a stake pool registration certificate
+
+Available options:
+  --stake-pool-verification-key STRING
+                           Stake pool verification key (Bech32 or hex-encoded).
+  --cold-verification-key-file FILE
+                           Filepath of the stake pool verification key.
+  --vrf-verification-key STRING
+                           VRF verification key (Bech32 or hex-encoded).
+  --vrf-verification-key-file FILE
+                           Filepath of the VRF verification key.
+  --pool-pledge LOVELACE   The stake pool's pledge.
+  --pool-cost LOVELACE     The stake pool's cost.
+  --pool-margin RATIONAL   The stake pool's margin.
+  --pool-reward-account-verification-key STRING
+                           Reward account stake verification key (Bech32 or
+                           hex-encoded).
+  --pool-reward-account-verification-key-file FILE
+                           Filepath of the reward account stake verification
+                           key.
+  --pool-owner-verification-key STRING
+                           Pool owner stake verification key (Bech32 or
+                           hex-encoded).
+  --pool-owner-stake-verification-key-file FILE
+                           Filepath of the pool owner stake verification key.
+  --pool-relay-ipv4 STRING The stake pool relay's IPv4 address
+  --pool-relay-ipv6 STRING The stake pool relay's IPv6 address
+  --pool-relay-port INT    The stake pool relay's port
+  --single-host-pool-relay STRING
+                           The stake pool relay's DNS name that corresponds to
+                           an A or AAAA DNS record
+  --pool-relay-port INT    The stake pool relay's port
+  --multi-host-pool-relay STRING
+                           The stake pool relay's DNS name that corresponds to
+                           an SRV DNS record
+  --metadata-url URL       Pool metadata URL (maximum length of 64 characters).
+  --metadata-hash HASH     Pool metadata hash.
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILE          The output file.
+  -h,--help                Show this help text


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Era-based `stake-pool` command
# uncomment types applicable to the change:
  type:
  - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
