### PR TITLE
Remove `--conway-era` flag

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
@@ -35,7 +35,6 @@ import           Data.ByteString (ByteString)
 import qualified Data.ByteString.Base16 as B16
 import qualified Data.ByteString.Char8 as BSC
 import           Data.Foldable
-import           Data.Function
 import           Data.Functor (($>))
 import qualified Data.IP as IP
 import           Data.List.NonEmpty (NonEmpty)
@@ -64,49 +63,6 @@ defaultShelleyBasedEra = AnyShelleyBasedEra ShelleyBasedEraBabbage
 
 defaultShelleyToBabbageEra :: AnyShelleyToBabbageEra
 defaultShelleyToBabbageEra = AnyShelleyToBabbageEra ShelleyToBabbageEraBabbage
-
-pCardanoEra :: EnvCli -> Parser AnyCardanoEra
-pCardanoEra envCli =
-  asum $ mconcat
-    [ [ Opt.flag' (AnyCardanoEra ByronEra) $ mconcat
-        [ Opt.long "byron-era"
-        , Opt.help "Specify the Byron era"
-        ]
-      , Opt.flag' (AnyCardanoEra ShelleyEra) $ mconcat
-        [ Opt.long "shelley-era"
-        , Opt.help "Specify the Shelley era"
-        ]
-      , Opt.flag' (AnyCardanoEra AllegraEra) $ mconcat
-        [ Opt.long "allegra-era"
-        , Opt.help "Specify the Allegra era"
-        ]
-      , Opt.flag' (AnyCardanoEra MaryEra) $ mconcat
-        [ Opt.long "mary-era"
-        , Opt.help "Specify the Mary era"
-        ]
-      , Opt.flag' (AnyCardanoEra AlonzoEra) $ mconcat
-        [ Opt.long "alonzo-era"
-        , Opt.help "Specify the Alonzo era"
-        ]
-      , Opt.flag' (AnyCardanoEra BabbageEra) $ mconcat
-        [ Opt.long "babbage-era"
-        , Opt.help "Specify the Babbage era (default)"
-        ]
-      , Opt.flag' (AnyCardanoEra ConwayEra) $ mconcat
-        [ Opt.long "conway-era"
-        , Opt.help "Specify the Conway era"
-        ]
-
-        -- NEW-ERA-ADD-NEW: When a new era is added, add a new flag here.
-        -- NEW-ERA-SET-DEFAULT: When a new era is working, select a new default above and below.
-      ]
-    , maybeToList $ pure <$> envCliAnyCardanoEra envCli
-    -- TODO is this default needed anymore?
-    , pure $ pure defaultCardanoEra
-  ]
-    where
-      defaultCardanoEra = defaultShelleyBasedEra & \(AnyShelleyBasedEra era) ->
-        AnyCardanoEra (shelleyBasedToCardanoEra era)
 
 command' :: String -> String -> Parser a -> Mod CommandFields a
 command' c descr p =

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Byron/Tx.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Byron/Tx.hs
@@ -28,7 +28,7 @@ hprop_golden_byronTx_legacy = propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir 
   goldenTx <- noteInputFile "test/cardano-cli-golden/files/golden/byron/tx/legacy.tx"
   createdTx <- noteTempFile tempDir "tx"
   void $ execCardanoCLI
-    [ "byron","transaction","issue-utxo-expenditure"
+    [ "byron", "transaction", "issue-utxo-expenditure"
     , "--mainnet"
     , "--byron-legacy-formats"
     , "--wallet-key", signingKey
@@ -45,7 +45,7 @@ hprop_golden_byronTx = propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir -> do
   goldenTx <- noteInputFile "test/cardano-cli-golden/files/golden/byron/tx/normal.tx"
   createdTx <- noteTempFile tempDir "tx"
   void $ execCardanoCLI
-    [ "byron","transaction","issue-utxo-expenditure"
+    [ "byron", "transaction", "issue-utxo-expenditure"
     , "--mainnet"
     , "--byron-formats"
     , "--wallet-key", signingKey

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Byron/UpdateProposal.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Byron/UpdateProposal.hs
@@ -23,7 +23,7 @@ hprop_golden_byron_update_proposal = propertyOnce $ H.moduleWorkspace "tmp" $ \t
   signingKey <- noteInputFile "test/cardano-cli-golden/files/golden/byron/keys/byron.skey"
   createdUpdateProposal <- noteTempFile tempDir "byron-update-proposal"
   void $ execCardanoCLI
-    [ "byron","governance","create-update-proposal"
+    [ "byron", "governance", "create-update-proposal"
     , "--mainnet"
     , "--signing-key", signingKey
     , "--protocol-version-major", "1"

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Byron/Vote.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Byron/Vote.hs
@@ -24,7 +24,7 @@ hprop_golden_byron_yes_vote = propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir 
   signingKey <- noteInputFile "test/cardano-cli-golden/files/golden/byron/keys/byron.skey"
   createdYesVote <- noteTempFile tempDir "byron-yes-vote"
   void $ execCardanoCLI
-    [ "byron","governance","create-proposal-vote"
+    [ "byron", "governance", "create-proposal-vote"
     , "--mainnet"
     , "--proposal-filepath", proposal
     , "--signing-key", signingKey
@@ -51,7 +51,7 @@ hprop_golden_byron_no_vote = propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir -
   signingKey <- noteInputFile "test/cardano-cli-golden/files/golden/byron/keys/byron.skey"
   createdNoVote <- noteTempFile tempDir "byron-no-vote"
   void $ execCardanoCLI
-    [ "byron","governance","create-proposal-vote"
+    [ "byron", "governance", "create-proposal-vote"
     , "--mainnet"
     , "--proposal-filepath", proposal
     , "--signing-key", signingKey

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/StakeAddress/DeregistrationCertificate.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/StakeAddress/DeregistrationCertificate.hs
@@ -24,8 +24,7 @@ hprop_golden_shelleyStakeAddressDeregistrationCertificate = propertyOnce . H.mod
   exampleScript <- noteInputFile $ base </> "scripts/plutus/scripts/v1/custom-guess-42-datum-42.plutus"
 
   void $ execCardanoCLI
-    [ "stake-address","deregistration-certificate"
-    , "--babbage-era"
+    [ "babbage", "stake-address","deregistration-certificate"
     , "--staking-verification-key-file", verificationKeyFile
     , "--out-file", deregistrationCertFile
     ]
@@ -33,8 +32,7 @@ hprop_golden_shelleyStakeAddressDeregistrationCertificate = propertyOnce . H.mod
   H.assertFileOccurences 1 "Stake Address Deregistration Certificate" deregistrationCertFile
 
   void $ execCardanoCLI
-    [ "stake-address","deregistration-certificate"
-    , "--babbage-era"
+    [ "babbage", "stake-address","deregistration-certificate"
     , "--stake-script-file", exampleScript
     , "--out-file", scriptDeregistrationCertFile
     ]

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/StakeAddress/RegistrationCertificate.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/StakeAddress/RegistrationCertificate.hs
@@ -24,8 +24,7 @@ hprop_golden_shelleyStakeAddressRegistrationCertificate = propertyOnce . H.modul
   exampleScript <- noteInputFile $ base </> "scripts/plutus/scripts/v1/custom-guess-42-datum-42.plutus"
 
   void $ execCardanoCLI
-    [ "stake-address","registration-certificate"
-    , "--babbage-era"
+    [ "babbage", "stake-address", "registration-certificate"
     , "--staking-verification-key-file", keyGenStakingVerificationKeyFile
     , "--out-file", registrationCertFile
     ]
@@ -33,8 +32,7 @@ hprop_golden_shelleyStakeAddressRegistrationCertificate = propertyOnce . H.modul
   H.assertFileOccurences 1 "Stake Address Registration Certificate" registrationCertFile
 
   void $ execCardanoCLI
-    [ "stake-address","registration-certificate"
-    , "--babbage-era"
+    [ "babbage", "stake-address", "registration-certificate"
     , "--stake-script-file", exampleScript
     , "--out-file", scriptRegistrationCertFile
     ]
@@ -50,8 +48,7 @@ hprop_golden_shelleyStakeAddressRegistrationCertificateWithBuildRaw = propertyOn
   txRawFile <- noteTempFile tempDir "tx.raw"
 
   void $ execCardanoCLI
-    [ "stake-address","registration-certificate"
-    , "--conway-era"
+    [ "conway", "stake-address", "registration-certificate"
     , "--staking-verification-key-file", keyGenStakingVerificationKeyFile
     , "--key-reg-deposit-amt", "2000000"
     , "--out-file", registrationCertFile
@@ -60,8 +57,7 @@ hprop_golden_shelleyStakeAddressRegistrationCertificateWithBuildRaw = propertyOn
   H.assertFileOccurences 1 "Stake Address Registration Certificate" registrationCertFile
 
   void $ execCardanoCLI
-    [ "transaction","build-raw"
-    , "--conway-era"
+    [ "conway", "transaction", "build-raw"
     , "--tx-in", "bdfa7d91a29ffe071c028c0143c5d278c0a7ddb829c1e95f54a1676915fd82c2#0"
     , "--fee", "1"
     , "--certificate-file", registrationCertFile

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/StakePool/RegistrationCertificate.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/StakePool/RegistrationCertificate.hs
@@ -20,8 +20,7 @@ hprop_golden_shelleyStakePoolRegistrationCertificate = propertyOnce . H.moduleWo
   registrationCertFile <- noteTempFile tempDir "registration.cert"
 
   void $ execCardanoCLI
-    [ "stake-pool","registration-certificate"
-    , "--babbage-era"
+    [ "babbage", "stake-pool", "registration-certificate"
     , "--testnet-magic", "42"
     , "--pool-pledge", "0"
     , "--pool-cost", "0"

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Certificates/StakeAddress.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Certificates/StakeAddress.hs
@@ -33,7 +33,7 @@ hprop_golden_shelleyStakeAddressCertificates = propertyOnce . H.moduleWorkspace 
 
   -- Generate stake verification key
   void $ execCardanoCLI
-    [ "stake-address","key-gen"
+    [ "stake-address", "key-gen"
     , "--verification-key-file", verKey
     , "--signing-key-file", signKey
     ]
@@ -42,8 +42,7 @@ hprop_golden_shelleyStakeAddressCertificates = propertyOnce . H.moduleWorkspace 
 
   -- Create stake address registration certificate
   void $ execCardanoCLI
-    [ "stake-address","registration-certificate"
-    , "--babbage-era"
+    [ "babbage", "stake-address", "registration-certificate"
     , "--stake-verification-key-file", verKey
     , "--out-file", registrationCertificate
     ]
@@ -56,8 +55,7 @@ hprop_golden_shelleyStakeAddressCertificates = propertyOnce . H.moduleWorkspace 
 
   -- Create stake address deregistration certificate
   void $ execCardanoCLI
-    [ "stake-address","deregistration-certificate"
-    , "--babbage-era"
+    [ "babbage", "stake-address", "deregistration-certificate"
     , "--stake-verification-key-file", verKey
     , "--out-file", deregistrationCertificate
     ]
@@ -70,7 +68,7 @@ hprop_golden_shelleyStakeAddressCertificates = propertyOnce . H.moduleWorkspace 
 {-
   -- Create stake address delegation certificate
   void $ execCardanoCLI
-    [ "stake-address","delegation-certificate"
+    [ "stake-address", "delegation-certificate"
     , "--stake-verification-key-file", verKey
     , "--cold-verification-key-file", verKey --TODO: Should be stake pool's hash
     , "--out-file", deregistrationCertificate

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Certificates/StakePool.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Certificates/StakePool.hs
@@ -42,7 +42,7 @@ hprop_golden_shelleyStakePoolCertificates = propertyOnce . H.moduleWorkspace "tm
 
   -- Create cold key pair
   void $ execCardanoCLI
-    [ "node","key-gen"
+    [ "node", "key-gen"
     , "--cold-verification-key-file", coldVerKey
     , "--cold-signing-key-file", coldSignKey
     , "--operational-certificate-issue-counter", operationalCertCounter
@@ -52,7 +52,7 @@ hprop_golden_shelleyStakePoolCertificates = propertyOnce . H.moduleWorkspace "tm
 
   -- Generate stake key pair
   void $ execCardanoCLI
-    [ "stake-address","key-gen"
+    [ "stake-address", "key-gen"
     , "--verification-key-file", poolRewardAccountAndOwnerVerKey
     , "--signing-key-file", poolRewardAccountSignKey
     ]
@@ -61,7 +61,7 @@ hprop_golden_shelleyStakePoolCertificates = propertyOnce . H.moduleWorkspace "tm
 
   -- Generate vrf verification key
   void $ execCardanoCLI
-    [ "node","key-gen-VRF"
+    [ "node", "key-gen-VRF"
     , "--verification-key-file", vrfVerKey
     , "--signing-key-file", vrfSignKey
     ]
@@ -71,8 +71,7 @@ hprop_golden_shelleyStakePoolCertificates = propertyOnce . H.moduleWorkspace "tm
 
   -- Create stake pool registration certificate
   void $ execCardanoCLI
-    [ "stake-pool","registration-certificate"
-    , "--babbage-era"
+    [ "babbage", "stake-pool", "registration-certificate"
     , "--cold-verification-key-file", coldVerKey
     , "--vrf-verification-key-file", vrfVerKey
     , "--mainnet"
@@ -94,8 +93,7 @@ hprop_golden_shelleyStakePoolCertificates = propertyOnce . H.moduleWorkspace "tm
 
   -- Create stake pool deregistration certificate
   void $ execCardanoCLI
-    [ "stake-pool", "deregistration-certificate"
-    , "--babbage-era"
+    [ "babbage", "stake-pool", "deregistration-certificate"
     , "--cold-verification-key-file", coldVerKey
     , "--epoch", "42"
     , "--out-file", deregistrationCertificate

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Tx/Tx.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Tx/Tx.hs
@@ -27,8 +27,7 @@ hprop_golden_shelleyTx = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
 
   -- Create transaction body
   void $ execCardanoCLI
-    [ "transaction", "build-raw"
-    , "--alonzo-era"
+    [ "alonzo", "transaction", "build-raw"
     , "--tx-in", "f62cd7bc15d8c6d2c8519fb8d13c57c0157ab6bab50af62bc63706feb966393d#0"
     , "--tx-out", "addr_test1qpmxr8d8jcl25kyz2tz9a9sxv7jxglhddyf475045y8j3zxjcg9vquzkljyfn3rasfwwlkwu7hhm59gzxmsyxf3w9dps8832xh+1199989833223"
     , "--tx-out", "addr_test1vpqgspvmh6m2m5pwangvdg499srfzre2dd96qq57nlnw6yctpasy4+10000000"

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Tx/TxBody.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Tx/TxBody.hs
@@ -23,8 +23,7 @@ hprop_golden_shelleyTxBody = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -
 
   -- Create transaction body
   void $ execCardanoCLI
-    [ "transaction", "build-raw"
-    , "--mary-era"
+    [ "mary", "transaction", "build-raw"
     , "--tx-in", "91999ea21177b33ebe6b8690724a0c026d410a11ad7521caa350abdafa5394c3#0"
     , "--tx-out", "addr1v9wmu83pzajplrtpsq6tsqdgwr98x888trpmah2u0ezznsge7del3+100000000"
     , "--fee", "1000000"

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Transaction/Build.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Transaction/Build.hs
@@ -27,8 +27,7 @@ hprop_golden_shelleyTransactionBuild =
     txBodyOutFile <- noteTempFile tempDir "tx-body-out"
 
     void $ execCardanoCLI
-      [ "transaction","build-raw"
-      , "--mary-era"
+      [ "mary", "transaction", "build-raw"
       , "--tx-in", txIn
       , "--tx-out", txOut
       , "--fee", "12"
@@ -49,8 +48,7 @@ hprop_golden_shelleyTransactionBuild_CertificateScriptWitnessed =
     txBodyOutFile <- noteTempFile tempDir "tx-body-out"
 
     void $ execCardanoCLI
-      [ "transaction","build-raw"
-      , "--mary-era"
+      [ "mary", "transaction", "build-raw"
       , "--tx-in", txIn
       , "--tx-out", txOut
       , "--certificate-file", deregcert, "--certificate-script-file", scriptWit
@@ -81,8 +79,7 @@ hprop_golden_shelleyTransactionBuild_Minting =
     txBodyOutFile <- noteTempFile tempDir "tx-body-out"
 
     void $ execCardanoCLI
-      [ "transaction","build-raw"
-      , "--mary-era"
+      [ "mary", "transaction", "build-raw"
       , "--tx-in", txIn
       , "--tx-out", txOut ++ "+" ++ dummyMA, "--mint-script-file", scriptWit
       , "--mint", dummyMA
@@ -105,8 +102,7 @@ hprop_golden_shelleyTransactionBuild_WithdrawalScriptWitnessed =
         scriptWit = "test/cardano-cli-golden/files/golden/shelley/multisig/scripts/any"
 
     void $ execCardanoCLI
-      [ "transaction","build-raw"
-      , "--mary-era"
+      [ "mary", "transaction", "build-raw"
       , "--tx-in", txIn
       , "--tx-out", txOut
       , "--withdrawal", withdrawal, "--withdrawal-script-file", scriptWit
@@ -126,8 +122,7 @@ hprop_golden_shelleyTransactionBuild_TxInScriptWitnessed =
     txBodyOutFile <- noteTempFile tempDir "tx-body-out"
 
     void $ execCardanoCLI
-      [ "transaction","build-raw"
-      , "--mary-era"
+      [ "mary", "transaction", "build-raw"
       , "--tx-in", txIn, "--txin-script-file", scriptWit
       , "--tx-out", txOut
       , "--fee", "12"

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Transaction/CreateWitness.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Transaction/CreateWitness.hs
@@ -24,8 +24,7 @@ hprop_golden_shelleyTransactionSigningKeyWitness = propertyOnce $ H.moduleWorksp
 
   -- Create tx body file
   void $ execCardanoCLI
-    [ "transaction","build-raw"
-    , "--shelley-era"
+    [ "shelley", "transaction", "build-raw"
     , "--tx-in", txIn
     , "--tx-out", txOut
     , "--invalid-hereafter", "60"

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/TxView.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/TxView.hs
@@ -105,8 +105,7 @@ hprop_golden_view_shelley = let
     -- Create transaction body
     void $
       execCardanoCLI $
-        [ "transaction", "build-raw"
-        , "--shelley-era"
+        [ "shelley", "transaction", "build-raw"
         , "--tx-in"
         ,   "fe5dd07fb576bff960d6e066eade5b26cdb5afebe29f76ea58d0a098bce5d891#29"
         , "--tx-out"
@@ -136,8 +135,7 @@ hprop_golden_view_allegra =
     -- Create transaction body
     void $
       execCardanoCLI
-        [ "transaction", "build-raw"
-        , "--allegra-era"
+        [ "allegra", "transaction", "build-raw"
         , "--tx-in"
         ,   "fe5dd07fb576bff960d6e066eade5b26cdb5afebe29f76ea58d0a098bce5d891#94"
         , "--tx-out"
@@ -167,8 +165,7 @@ hprop_golden_view_mary =
     -- Create transaction body
     void $
       execCardanoCLI
-        [ "transaction", "build-raw"
-        , "--mary-era"
+        [ "mary", "transaction", "build-raw"
         , "--tx-in"
         ,   "fe5dd07fb576bff960d6e066eade5b26cdb5afebe29f76ea58d0a098bce5d891#135"
         , "--tx-out"
@@ -230,8 +227,7 @@ createAlonzoTxBody :: Maybe FilePath -> FilePath -> Integration ()
 createAlonzoTxBody mUpdateProposalFile transactionBodyFile = do
   void $
     execCardanoCLI
-      (   [ "transaction", "build-raw"
-          , "--alonzo-era"
+      (   [ "alonzo", "transaction", "build-raw"
           , "--tx-in"
           ,   "ed7c8f68c194cc763ee65ad22ef0973e26481be058c65005fd39fb93f9c43a20#212"
           , "--tx-in-collateral"

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -9574,7 +9574,6 @@ Usage: cardano-cli legacy transaction build-raw
                                                   | --mary-era
                                                   | --alonzo-era
                                                   | --babbage-era
-                                                  | --conway-era
                                                   ]
                                                   [ --script-valid
                                                   | --script-invalid
@@ -9703,7 +9702,6 @@ Usage: cardano-cli legacy transaction build --socket-path SOCKET_PATH
                                               | --mary-era
                                               | --alonzo-era
                                               | --babbage-era
-                                              | --conway-era
                                               ]
                                               [ --shelley-mode
                                               | --byron-mode
@@ -9900,7 +9898,6 @@ Usage: cardano-cli legacy transaction calculate-min-required-utxo
                                                                     | --mary-era
                                                                     | --alonzo-era
                                                                     | --babbage-era
-                                                                    | --conway-era
                                                                     ]
                                                                     --protocol-params-file FILE
                                                                     --tx-out ADDRESS VALUE
@@ -9926,7 +9923,6 @@ Usage: cardano-cli legacy transaction calculate-min-value
                                                             | --mary-era
                                                             | --alonzo-era
                                                             | --babbage-era
-                                                            | --conway-era
                                                             ]
                                                             --protocol-params-file FILE
                                                             --tx-out ADDRESS VALUE
@@ -10847,7 +10843,6 @@ Usage: cardano-cli transaction build-raw
                                            | --mary-era
                                            | --alonzo-era
                                            | --babbage-era
-                                           | --conway-era
                                            ]
                                            [--script-valid | --script-invalid]
                                            (--tx-in TX-IN
@@ -10973,7 +10968,6 @@ Usage: cardano-cli transaction build --socket-path SOCKET_PATH
                                        | --mary-era
                                        | --alonzo-era
                                        | --babbage-era
-                                       | --conway-era
                                        ]
                                        [ --shelley-mode
                                        | --byron-mode [--epoch-slots SLOTS]
@@ -11152,7 +11146,6 @@ Usage: cardano-cli transaction calculate-min-required-utxo
                                                              | --mary-era
                                                              | --alonzo-era
                                                              | --babbage-era
-                                                             | --conway-era
                                                              ]
                                                              --protocol-params-file FILE
                                                              --tx-out ADDRESS VALUE
@@ -11178,7 +11171,6 @@ Usage: cardano-cli transaction calculate-min-value
                                                      | --mary-era
                                                      | --alonzo-era
                                                      | --babbage-era
-                                                     | --conway-era
                                                      ]
                                                      --protocol-params-file FILE
                                                      --tx-out ADDRESS VALUE

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_transaction_build-raw.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_transaction_build-raw.cli
@@ -5,7 +5,6 @@ Usage: cardano-cli legacy transaction build-raw
                                                   | --mary-era
                                                   | --alonzo-era
                                                   | --babbage-era
-                                                  | --conway-era
                                                   ]
                                                   [ --script-valid
                                                   | --script-invalid
@@ -134,7 +133,6 @@ Available options:
   --mary-era               Specify the Mary era
   --alonzo-era             Specify the Alonzo era
   --babbage-era            Specify the Babbage era (default)
-  --conway-era             Specify the Conway era
   --script-valid           Assertion that the script is valid. (default)
   --script-invalid         Assertion that the script is invalid. If a
                            transaction is submitted with such a script, the

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_transaction_build.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_transaction_build.cli
@@ -5,7 +5,6 @@ Usage: cardano-cli legacy transaction build --socket-path SOCKET_PATH
                                               | --mary-era
                                               | --alonzo-era
                                               | --babbage-era
-                                              | --conway-era
                                               ]
                                               [ --shelley-mode
                                               | --byron-mode
@@ -141,7 +140,6 @@ Available options:
   --mary-era               Specify the Mary era
   --alonzo-era             Specify the Alonzo era
   --babbage-era            Specify the Babbage era (default)
-  --conway-era             Specify the Conway era
   --shelley-mode           For talking to a node running in Shelley-only mode.
   --byron-mode             For talking to a node running in Byron-only mode.
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_transaction_calculate-min-required-utxo.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_transaction_calculate-min-required-utxo.cli
@@ -5,7 +5,6 @@ Usage: cardano-cli legacy transaction calculate-min-required-utxo
                                                                     | --mary-era
                                                                     | --alonzo-era
                                                                     | --babbage-era
-                                                                    | --conway-era
                                                                     ]
                                                                     --protocol-params-file FILE
                                                                     --tx-out ADDRESS VALUE
@@ -31,7 +30,6 @@ Available options:
   --mary-era               Specify the Mary era
   --alonzo-era             Specify the Alonzo era
   --babbage-era            Specify the Babbage era (default)
-  --conway-era             Specify the Conway era
   --protocol-params-file FILE
                            Filepath of the JSON-encoded protocol parameters file
   --tx-out ADDRESS VALUE   The transaction output as ADDRESS VALUE where ADDRESS

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_transaction_calculate-min-value.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_transaction_calculate-min-value.cli
@@ -5,7 +5,6 @@ Usage: cardano-cli legacy transaction calculate-min-value
                                                             | --mary-era
                                                             | --alonzo-era
                                                             | --babbage-era
-                                                            | --conway-era
                                                             ]
                                                             --protocol-params-file FILE
                                                             --tx-out ADDRESS VALUE
@@ -31,7 +30,6 @@ Available options:
   --mary-era               Specify the Mary era
   --alonzo-era             Specify the Alonzo era
   --babbage-era            Specify the Babbage era (default)
-  --conway-era             Specify the Conway era
   --protocol-params-file FILE
                            Filepath of the JSON-encoded protocol parameters file
   --tx-out ADDRESS VALUE   The transaction output as ADDRESS VALUE where ADDRESS

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/transaction_build-raw.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/transaction_build-raw.cli
@@ -5,7 +5,6 @@ Usage: cardano-cli transaction build-raw
                                            | --mary-era
                                            | --alonzo-era
                                            | --babbage-era
-                                           | --conway-era
                                            ]
                                            [--script-valid | --script-invalid]
                                            (--tx-in TX-IN
@@ -131,7 +130,6 @@ Available options:
   --mary-era               Specify the Mary era
   --alonzo-era             Specify the Alonzo era
   --babbage-era            Specify the Babbage era (default)
-  --conway-era             Specify the Conway era
   --script-valid           Assertion that the script is valid. (default)
   --script-invalid         Assertion that the script is invalid. If a
                            transaction is submitted with such a script, the

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/transaction_build.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/transaction_build.cli
@@ -5,7 +5,6 @@ Usage: cardano-cli transaction build --socket-path SOCKET_PATH
                                        | --mary-era
                                        | --alonzo-era
                                        | --babbage-era
-                                       | --conway-era
                                        ]
                                        [ --shelley-mode
                                        | --byron-mode [--epoch-slots SLOTS]
@@ -134,7 +133,6 @@ Available options:
   --mary-era               Specify the Mary era
   --alonzo-era             Specify the Alonzo era
   --babbage-era            Specify the Babbage era (default)
-  --conway-era             Specify the Conway era
   --shelley-mode           For talking to a node running in Shelley-only mode.
   --byron-mode             For talking to a node running in Byron-only mode.
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/transaction_calculate-min-required-utxo.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/transaction_calculate-min-required-utxo.cli
@@ -5,7 +5,6 @@ Usage: cardano-cli transaction calculate-min-required-utxo
                                                              | --mary-era
                                                              | --alonzo-era
                                                              | --babbage-era
-                                                             | --conway-era
                                                              ]
                                                              --protocol-params-file FILE
                                                              --tx-out ADDRESS VALUE
@@ -31,7 +30,6 @@ Available options:
   --mary-era               Specify the Mary era
   --alonzo-era             Specify the Alonzo era
   --babbage-era            Specify the Babbage era (default)
-  --conway-era             Specify the Conway era
   --protocol-params-file FILE
                            Filepath of the JSON-encoded protocol parameters file
   --tx-out ADDRESS VALUE   The transaction output as ADDRESS VALUE where ADDRESS

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/transaction_calculate-min-value.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/transaction_calculate-min-value.cli
@@ -5,7 +5,6 @@ Usage: cardano-cli transaction calculate-min-value
                                                      | --mary-era
                                                      | --alonzo-era
                                                      | --babbage-era
-                                                     | --conway-era
                                                      ]
                                                      --protocol-params-file FILE
                                                      --tx-out ADDRESS VALUE
@@ -31,7 +30,6 @@ Available options:
   --mary-era               Specify the Mary era
   --alonzo-era             Specify the Alonzo era
   --babbage-era            Specify the Babbage era (default)
-  --conway-era             Specify the Conway era
   --protocol-params-file FILE
                            Filepath of the JSON-encoded protocol parameters file
   --tx-out ADDRESS VALUE   The transaction output as ADDRESS VALUE where ADDRESS

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/Pioneers/Exercise4.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/Pioneers/Exercise4.hs
@@ -23,7 +23,7 @@ hprop_createStakeAddressRegistrationCertificate = propertyOnce . H.moduleWorkspa
 
   -- Generate stake verification key
   void $ execCardanoCLI
-    [ "stake-address","key-gen"
+    [ "stake-address", "key-gen"
     , "--verification-key-file", verKey
     , "--signing-key-file", signKey
     ]
@@ -31,8 +31,7 @@ hprop_createStakeAddressRegistrationCertificate = propertyOnce . H.moduleWorkspa
 
   -- Create stake address registration certificate
   void $ execCardanoCLI
-    [ "stake-address","registration-certificate"
-    , "--babbage-era"
+    [ "babbage", "stake-address", "registration-certificate"
     , "--stake-verification-key-file", verKey
     , "--out-file", stakeRegCert
     ]


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Remove `--conway-era` flag
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

From Conway era onwards, era flags will no longer be used.  Era-based command should be used instead.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
