### PR TITLE
Simplify era handling

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Actions.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Actions.hs
@@ -235,14 +235,10 @@ pIntroducedInBabbagePParams =
 
 -- Not necessary in Conway era onwards
 pProtocolParametersUpdateGenesisKeys :: ShelleyBasedEra era -> Parser [VerificationKeyFile In]
-pProtocolParametersUpdateGenesisKeys sbe =
-  case sbe of
-    ShelleyBasedEraShelley -> many pGenesisVerificationKeyFile
-    ShelleyBasedEraAllegra -> many pGenesisVerificationKeyFile
-    ShelleyBasedEraMary -> many pGenesisVerificationKeyFile
-    ShelleyBasedEraAlonzo -> many pGenesisVerificationKeyFile
-    ShelleyBasedEraBabbage -> many pGenesisVerificationKeyFile
-    ShelleyBasedEraConway -> empty
+pProtocolParametersUpdateGenesisKeys =
+  caseShelleyToBabbageOrConwayEraOnwards
+    (const (many pGenesisVerificationKeyFile))
+    (const empty)
 
 dpGovActionProtocolParametersUpdate
   :: ShelleyBasedEra era -> Parser (EraBasedProtocolParametersUpdate era)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Actions.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Actions.hs
@@ -133,59 +133,26 @@ pGovernanceActionNoConfidenceCmd era = do
 -- | The first argument is the optional prefix.
 pAnyStakeIdentifier :: Maybe String -> Parser AnyStakeIdentifier
 pAnyStakeIdentifier prefix =
-  asum [ AnyStakePoolKey <$> pStakePoolVerificationKeyOrHashOrFile prefix
-       , AnyStakeKey <$> pStakeVerificationKeyOrHashOrFile prefix
-       ]
+  asum
+    [ AnyStakePoolKey <$> pStakePoolVerificationKeyOrHashOrFile prefix
+    , AnyStakeKey <$> pStakeVerificationKeyOrHashOrFile prefix
+    ]
 
-pGovernanceActionProtocolParametersUpdateCmd
-  :: CardanoEra era  -> Maybe (Parser (GovernanceActionCmds era))
-pGovernanceActionProtocolParametersUpdateCmd era =
-   Just $ subParser "create-protocol-parameters-update"
-        $ Opt.info (pCmd era)
-        $ Opt.progDesc "Create a protocol parameters update."
- where
-  pCmd :: CardanoEra era -> Parser (GovernanceActionCmds era)
-  pCmd era' =
-    case cardanoEraStyle era' of
-      LegacyByronEra -> empty
-      ShelleyBasedEra sbe ->
-        case sbe of
-         ShelleyBasedEraShelley ->
-           GovernanceActionProtocolParametersUpdateCmd sbe
-             <$> pEpochNoUpdateProp
-             <*> pProtocolParametersUpdateGenesisKeys sbe
-             <*> dpGovActionProtocolParametersUpdate ShelleyBasedEraShelley
-             <*> pOutputFile
-         ShelleyBasedEraAllegra ->
-           GovernanceActionProtocolParametersUpdateCmd sbe
-             <$> pEpochNoUpdateProp
-             <*> pProtocolParametersUpdateGenesisKeys sbe
-             <*> dpGovActionProtocolParametersUpdate ShelleyBasedEraAllegra
-             <*> pOutputFile
-         ShelleyBasedEraMary ->
-           GovernanceActionProtocolParametersUpdateCmd sbe
-             <$> pEpochNoUpdateProp
-             <*> pProtocolParametersUpdateGenesisKeys sbe
-             <*> dpGovActionProtocolParametersUpdate ShelleyBasedEraMary
-             <*> pOutputFile
-         ShelleyBasedEraAlonzo ->
-           GovernanceActionProtocolParametersUpdateCmd sbe
-             <$> pEpochNoUpdateProp
-             <*> pProtocolParametersUpdateGenesisKeys sbe
-             <*> dpGovActionProtocolParametersUpdate ShelleyBasedEraAlonzo
-             <*> pOutputFile
-         ShelleyBasedEraBabbage ->
-           GovernanceActionProtocolParametersUpdateCmd sbe
-             <$> pEpochNoUpdateProp
-             <*> pProtocolParametersUpdateGenesisKeys sbe
-             <*> dpGovActionProtocolParametersUpdate ShelleyBasedEraBabbage
-             <*> pOutputFile
-         ShelleyBasedEraConway ->
-           GovernanceActionProtocolParametersUpdateCmd sbe
-             <$> pEpochNoUpdateProp
-             <*> pProtocolParametersUpdateGenesisKeys sbe
-             <*> dpGovActionProtocolParametersUpdate ShelleyBasedEraConway
-             <*> pOutputFile
+pGovernanceActionProtocolParametersUpdateCmd :: ()
+  => CardanoEra era
+  -> Maybe (Parser (GovernanceActionCmds era))
+pGovernanceActionProtocolParametersUpdateCmd era = do
+  w <- maybeFeatureInEra era
+  pure
+    $ subParser "create-protocol-parameters-update"
+    $ Opt.info
+        ( GovernanceActionProtocolParametersUpdateCmd w
+            <$> pEpochNoUpdateProp
+            <*> pProtocolParametersUpdateGenesisKeys w
+            <*> dpGovActionProtocolParametersUpdate w
+            <*> pOutputFile
+        )
+    $ Opt.progDesc "Create a protocol parameters update."
 
 convertToLedger :: (a -> b) -> Parser (Maybe a) -> Parser (StrictMaybe b)
 convertToLedger conv = fmap (maybeToStrictMaybe . fmap conv)


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Simplify era handling
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context


# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
