### PR TITLE
Regularise era based command structure

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands.hs
@@ -119,10 +119,7 @@ pCmds envCli era =
     , fmap GenesisCmds      <$> pGenesisCmds envCli
     , fmap GovernanceCmds   <$> pGovernanceCmds envCli era
     , fmap NodeCmds         <$> pNodeCmds
-    , Just
-        $ subParser "query"
-        $ Opt.info (QueryCmds <$> pQueryCmds envCli)
-        $ Opt.progDesc "Era-based query commands"
+    , fmap QueryCmds        <$> pQueryCmds envCli
     , fmap StakeAddressCmds <$> pStakeAddressCmds era envCli
     , Just
         $ subParser "stake-pool"

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands.hs
@@ -122,10 +122,7 @@ pCmds envCli era =
     , fmap QueryCmds        <$> pQueryCmds envCli
     , fmap StakeAddressCmds <$> pStakeAddressCmds era envCli
     , fmap StakePoolCmds    <$> pStakePoolCmds era envCli
-    , Just
-        $ subParser "text-view"
-        $ Opt.info (TextViewCmds <$> pTextViewCmds)
-        $ Opt.progDesc "Era-based text view commands"
+    , fmap TextViewCmds     <$> pTextViewCmds
     , Just
         $ subParser "transaction"
         $ Opt.info (TransactionCmds <$> pTransactionCmds envCli era)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands.hs
@@ -118,10 +118,7 @@ pCmds envCli era =
     , fmap KeyCmds          <$> pKeyCmds
     , fmap GenesisCmds      <$> pGenesisCmds envCli
     , fmap GovernanceCmds   <$> pGovernanceCmds envCli era
-    , Just
-        $ subParser "node"
-        $ Opt.info (NodeCmds <$> pNodeCmds)
-        $ Opt.progDesc "Era-based node commands"
+    , fmap NodeCmds         <$> pNodeCmds
     , Just
         $ subParser "query"
         $ Opt.info (QueryCmds <$> pQueryCmds envCli)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands.hs
@@ -121,10 +121,7 @@ pCmds envCli era =
     , fmap NodeCmds         <$> pNodeCmds
     , fmap QueryCmds        <$> pQueryCmds envCli
     , fmap StakeAddressCmds <$> pStakeAddressCmds era envCli
-    , Just
-        $ subParser "stake-pool"
-        $ Opt.info (StakePoolCmds <$> pStakePoolCmds era envCli)
-        $ Opt.progDesc "Era-based stake pool commands"
+    , fmap StakePoolCmds    <$> pStakePoolCmds era envCli
     , Just
         $ subParser "text-view"
         $ Opt.info (TextViewCmds <$> pTextViewCmds)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands.hs
@@ -117,10 +117,7 @@ pCmds envCli era =
     [ fmap AddressCmds      <$> pAddressCmds era envCli
     , fmap KeyCmds          <$> pKeyCmds
     , fmap GenesisCmds      <$> pGenesisCmds envCli
-    , Just
-        $ subParser "governance"
-        $ Opt.info (GovernanceCmds <$> pGovernanceCmds envCli era)
-        $ Opt.progDesc "Era-based governance commands"
+    , fmap GovernanceCmds   <$> pGovernanceCmds envCli era
     , Just
         $ subParser "node"
         $ Opt.info (NodeCmds <$> pNodeCmds)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands.hs
@@ -115,10 +115,7 @@ pCmds :: EnvCli -> CardanoEra era -> Parser (Cmds era)
 pCmds envCli era =
   asum $ catMaybes
     [ fmap AddressCmds      <$> pAddressCmds era envCli
-    , Just
-        $ subParser "key"
-        $ Opt.info (KeyCmds <$> pKeyCmds)
-        $ Opt.progDesc "Era-based key commands"
+    , fmap KeyCmds          <$> pKeyCmds
     , Just
         $ subParser "genesis"
         $ Opt.info (GenesisCmds <$> pGenesisCmds envCli)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands.hs
@@ -88,40 +88,40 @@ pAnyEraCommand envCli =
     [ -- Note, byron is ommitted because there is already a legacy command group for it.
 
       subParser "shelley"
-        $ Opt.info (AnyEraCommandOf ShelleyBasedEraShelley <$> pCmds envCli ShelleyEra)
+        $ Opt.info (AnyEraCommandOf ShelleyBasedEraShelley <$> pCmds ShelleyEra envCli)
         $ Opt.progDesc "Shelley era commands"
     , subParser "allegra"
-        $ Opt.info (AnyEraCommandOf ShelleyBasedEraAllegra <$> pCmds envCli AllegraEra)
+        $ Opt.info (AnyEraCommandOf ShelleyBasedEraAllegra <$> pCmds AllegraEra envCli)
         $ Opt.progDesc "Allegra era commands"
     , subParser "mary"
-        $ Opt.info (AnyEraCommandOf ShelleyBasedEraMary <$> pCmds envCli MaryEra)
+        $ Opt.info (AnyEraCommandOf ShelleyBasedEraMary <$> pCmds MaryEra envCli)
         $ Opt.progDesc "Mary era commands"
     , subParser "alonzo"
-        $ Opt.info (AnyEraCommandOf ShelleyBasedEraAlonzo <$> pCmds envCli AlonzoEra)
+        $ Opt.info (AnyEraCommandOf ShelleyBasedEraAlonzo <$> pCmds AlonzoEra envCli)
         $ Opt.progDesc "Alonzo era commands"
     , subParser "babbage"
-        $ Opt.info (AnyEraCommandOf ShelleyBasedEraBabbage <$> pCmds envCli BabbageEra)
+        $ Opt.info (AnyEraCommandOf ShelleyBasedEraBabbage <$> pCmds BabbageEra envCli)
         $ Opt.progDesc "Babbage era commands"
     , subParser "conway"
-        $ Opt.info (AnyEraCommandOf ShelleyBasedEraConway <$> pCmds envCli ConwayEra)
+        $ Opt.info (AnyEraCommandOf ShelleyBasedEraConway <$> pCmds ConwayEra envCli)
         $ Opt.progDesc "Conway era commands"
 
     , subParser "latest"
-        $ Opt.info (AnyEraCommandOf ShelleyBasedEraBabbage <$> pCmds envCli BabbageEra)
+        $ Opt.info (AnyEraCommandOf ShelleyBasedEraBabbage <$> pCmds BabbageEra envCli)
         $ Opt.progDesc "Latest era commands (Babbage)"
     ]
 
-pCmds :: EnvCli -> CardanoEra era -> Parser (Cmds era)
-pCmds envCli era =
+pCmds :: CardanoEra era -> EnvCli -> Parser (Cmds era)
+pCmds era envCli =
   asum $ catMaybes
     [ fmap AddressCmds      <$> pAddressCmds era envCli
     , fmap KeyCmds          <$> pKeyCmds
     , fmap GenesisCmds      <$> pGenesisCmds envCli
-    , fmap GovernanceCmds   <$> pGovernanceCmds envCli era
+    , fmap GovernanceCmds   <$> pGovernanceCmds era envCli
     , fmap NodeCmds         <$> pNodeCmds
     , fmap QueryCmds        <$> pQueryCmds envCli
     , fmap StakeAddressCmds <$> pStakeAddressCmds era envCli
     , fmap StakePoolCmds    <$> pStakePoolCmds era envCli
     , fmap TextViewCmds     <$> pTextViewCmds
-    , fmap TransactionCmds  <$> pTransactionCmds envCli era
+    , fmap TransactionCmds  <$> pTransactionCmds era envCli
     ]

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands.hs
@@ -123,8 +123,5 @@ pCmds envCli era =
     , fmap StakeAddressCmds <$> pStakeAddressCmds era envCli
     , fmap StakePoolCmds    <$> pStakePoolCmds era envCli
     , fmap TextViewCmds     <$> pTextViewCmds
-    , Just
-        $ subParser "transaction"
-        $ Opt.info (TransactionCmds <$> pTransactionCmds envCli era)
-        $ Opt.progDesc "Era-based transaction commands"
+    , fmap TransactionCmds  <$> pTransactionCmds envCli era
     ]

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands.hs
@@ -114,10 +114,7 @@ pAnyEraCommand envCli =
 pCmds :: EnvCli -> CardanoEra era -> Parser (Cmds era)
 pCmds envCli era =
   asum $ catMaybes
-    [ Just
-        $ subParser "address"
-        $ Opt.info (AddressCmds <$> pAddressCmds era envCli)
-        $ Opt.progDesc "Era-based address commands"
+    [ fmap AddressCmds      <$> pAddressCmds era envCli
     , Just
         $ subParser "key"
         $ Opt.info (KeyCmds <$> pKeyCmds)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands.hs
@@ -116,10 +116,7 @@ pCmds envCli era =
   asum $ catMaybes
     [ fmap AddressCmds      <$> pAddressCmds era envCli
     , fmap KeyCmds          <$> pKeyCmds
-    , Just
-        $ subParser "genesis"
-        $ Opt.info (GenesisCmds <$> pGenesisCmds envCli)
-        $ Opt.progDesc "Era-based genesis commands"
+    , fmap GenesisCmds      <$> pGenesisCmds envCli
     , Just
         $ subParser "governance"
         $ Opt.info (GovernanceCmds <$> pGovernanceCmds envCli era)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Address.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Address.hs
@@ -24,7 +24,7 @@ pAddressCmds _ envCli =
   subInfoParser "address"
     ( Opt.progDesc
         $ mconcat
-          [ "Address commands."
+          [ "Payment address commands."
           ]
     )
     [ Just

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Address.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Address.hs
@@ -13,14 +13,20 @@ import           Cardano.CLI.Environment (EnvCli (..))
 import           Cardano.CLI.EraBased.Commands.Address
 import           Cardano.CLI.EraBased.Options.Common
 
-import           Data.Foldable
-import           Data.Maybe
 import           Options.Applicative hiding (help, str)
 import qualified Options.Applicative as Opt
 
-pAddressCmds :: CardanoEra era -> EnvCli -> Parser (AddressCmds era)
+pAddressCmds :: ()
+  => CardanoEra era
+  -> EnvCli
+  -> Maybe (Parser (AddressCmds era))
 pAddressCmds _ envCli =
-  asum $ catMaybes
+  subInfoParser "address"
+    ( Opt.progDesc
+        $ mconcat
+          [ "Address commands."
+          ]
+    )
     [ Just
         $ subParser "key-gen"
         $ Opt.info pAddressKeyGen

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Address.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Address.hs
@@ -14,22 +14,27 @@ import           Cardano.CLI.EraBased.Commands.Address
 import           Cardano.CLI.EraBased.Options.Common
 
 import           Data.Foldable
+import           Data.Maybe
 import           Options.Applicative hiding (help, str)
 import qualified Options.Applicative as Opt
 
 pAddressCmds :: CardanoEra era -> EnvCli -> Parser (AddressCmds era)
 pAddressCmds _ envCli =
-  asum
-    [ subParser "key-gen"
+  asum $ catMaybes
+    [ Just
+        $ subParser "key-gen"
         $ Opt.info pAddressKeyGen
         $ Opt.progDesc "Create an address key pair."
-    , subParser "key-hash"
+    , Just
+        $ subParser "key-hash"
         $ Opt.info pAddressKeyHash
         $ Opt.progDesc "Print the hash of an address key."
-    , subParser "build"
+    , Just
+        $ subParser "build"
         $ Opt.info (pAddressBuild envCli)
         $ Opt.progDesc "Build a Shelley payment address, with optional delegation to a stake address."
-    , subParser "info"
+    , Just
+        $ subParser "info"
         $ Opt.info pAddressInfo
         $ Opt.progDesc "Print information about an address."
     ]

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Genesis.hs
@@ -31,7 +31,7 @@ pGenesisCmds envCli =
   subInfoParser "genesis"
     ( Opt.progDesc
         $ mconcat
-          [ "Genesis commands."
+          [ "Genesis block commands."
           ]
     )
     [ Just

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Genesis.hs
@@ -16,7 +16,6 @@ import           Cardano.CLI.EraBased.Options.Common
 import           Cardano.CLI.Parser
 import           Cardano.CLI.Types.Common
 
-import           Data.Foldable
 import           Data.Maybe
 import           Data.Word (Word64)
 import           Options.Applicative hiding (help, str)
@@ -25,9 +24,16 @@ import qualified Options.Applicative as Opt
 {- HLINT ignore "Use <$>" -}
 {- HLINT ignore "Move brackets to avoid $" -}
 
-pGenesisCmds :: EnvCli -> Parser (GenesisCmds era)
+pGenesisCmds :: ()
+  => EnvCli
+  -> Maybe (Parser (GenesisCmds era))
 pGenesisCmds envCli =
-  asum $ catMaybes
+  subInfoParser "genesis"
+    ( Opt.progDesc
+        $ mconcat
+          [ "Genesis commands."
+          ]
+    )
     [ Just
         $ subParser "key-gen-genesis"
         $ Opt.info pGenesisKeyGen

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Genesis.hs
@@ -17,7 +17,7 @@ import           Cardano.CLI.Parser
 import           Cardano.CLI.Types.Common
 
 import           Data.Foldable
-import           Data.Maybe (fromMaybe)
+import           Data.Maybe
 import           Data.Word (Word64)
 import           Options.Applicative hiding (help, str)
 import qualified Options.Applicative as Opt
@@ -27,50 +27,61 @@ import qualified Options.Applicative as Opt
 
 pGenesisCmds :: EnvCli -> Parser (GenesisCmds era)
 pGenesisCmds envCli =
-  asum
-    [ subParser "key-gen-genesis"
+  asum $ catMaybes
+    [ Just
+        $ subParser "key-gen-genesis"
         $ Opt.info pGenesisKeyGen
         $ Opt.progDesc "Create a Shelley genesis key pair"
-    , subParser "key-gen-delegate"
+    , Just
+        $ subParser "key-gen-delegate"
         $ Opt.info pGenesisDelegateKeyGen
         $ Opt.progDesc "Create a Shelley genesis delegate key pair"
-    , subParser "key-gen-utxo"
+    , Just
+        $ subParser "key-gen-utxo"
         $ Opt.info pGenesisUTxOKeyGen
         $ Opt.progDesc "Create a Shelley genesis UTxO key pair"
-    , subParser "key-hash"
+    , Just
+        $ subParser "key-hash"
         $ Opt.info pGenesisKeyHash
         $ Opt.progDesc "Print the identifier (hash) of a public key"
-    , subParser "get-ver-key"
+    , Just
+        $ subParser "get-ver-key"
         $ Opt.info pGenesisVerKey
         $ Opt.progDesc "Derive the verification key from a signing key"
-    , subParser "initial-addr"
+    , Just
+        $ subParser "initial-addr"
         $ Opt.info (pGenesisAddr envCli)
         $ Opt.progDesc "Get the address for an initial UTxO based on the verification key"
-    , subParser "initial-txin"
+    , Just
+        $ subParser "initial-txin"
         $ Opt.info (pGenesisTxIn envCli)
         $ Opt.progDesc "Get the TxIn for an initial UTxO based on the verification key"
-    , subParser "create-cardano"
+    , Just
+        $ subParser "create-cardano"
         $ Opt.info (pGenesisCreateCardano envCli)
         $ Opt.progDesc
         $ mconcat
             [ "Create a Byron and Shelley genesis file from a genesis "
             , "template and genesis/delegation/spending keys."
             ]
-    , subParser "create"
+    , Just
+        $ subParser "create"
         $ Opt.info (pGenesisCreate envCli)
         $ Opt.progDesc
         $ mconcat
             [ "Create a Shelley genesis file from a genesis "
             , "template and genesis/delegation/spending keys."
             ]
-    , subParser "create-staked"
+    , Just
+        $ subParser "create-staked"
         $ Opt.info (pGenesisCreateStaked envCli)
         $ Opt.progDesc
         $ mconcat
             [ "Create a staked Shelley genesis file from a genesis "
             , "template and genesis/delegation/spending keys."
             ]
-    , subParser "hash"
+    , Just
+        $ subParser "hash"
         $ Opt.info pGenesisHash
         $ Opt.progDesc "Compute the hash of a genesis file"
     ]

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance.hs
@@ -20,13 +20,20 @@ import           Cardano.CLI.EraBased.Options.Governance.Vote
 import           Cardano.CLI.Types.Common
 
 import           Data.Foldable
-import           Data.Maybe
 import           Options.Applicative
 import qualified Options.Applicative as Opt
 
-pGovernanceCmds :: EnvCli -> CardanoEra era -> Parser (GovernanceCmds era)
+pGovernanceCmds :: ()
+  => EnvCli
+  -> CardanoEra era
+  -> Maybe (Parser (GovernanceCmds era))
 pGovernanceCmds envCli era =
-  asum $ catMaybes
+  subInfoParser "governance"
+    ( Opt.progDesc
+        $ mconcat
+          [ "Governance commands."
+          ]
+    )
     [ pCreateMirCertificatesCmds era
     , fmap GovernanceQueryCmds        <$> pGovernanceQueryCmds envCli era
     , fmap GovernanceActionCmds       <$> pGovernanceActionCmds era

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance.hs
@@ -24,10 +24,10 @@ import           Options.Applicative
 import qualified Options.Applicative as Opt
 
 pGovernanceCmds :: ()
-  => EnvCli
-  -> CardanoEra era
+  => CardanoEra era
+  -> EnvCli
   -> Maybe (Parser (GovernanceCmds era))
-pGovernanceCmds envCli era =
+pGovernanceCmds era envCli =
   subInfoParser "governance"
     ( Opt.progDesc
         $ mconcat
@@ -35,10 +35,10 @@ pGovernanceCmds envCli era =
           ]
     )
     [ pCreateMirCertificatesCmds era
-    , fmap GovernanceQueryCmds        <$> pGovernanceQueryCmds envCli era
+    , fmap GovernanceQueryCmds        <$> pGovernanceQueryCmds era envCli
     , fmap GovernanceActionCmds       <$> pGovernanceActionCmds era
     , fmap GovernanceCommitteeCmds    <$> pGovernanceCommitteeCmds era
-    , fmap GovernanceDRepCmds         <$> pGovernanceDRepCmds envCli era
+    , fmap GovernanceDRepCmds         <$> pGovernanceDRepCmds era envCli
     , fmap GovernanceVoteCmds         <$> pGovernanceVoteCmds era
     ]
 

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/DRep.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/DRep.hs
@@ -24,10 +24,10 @@ import           Options.Applicative (Parser)
 import qualified Options.Applicative as Opt
 
 pGovernanceDRepCmds :: ()
-  => EnvCli
-  -> CardanoEra era
+  => CardanoEra era
+  -> EnvCli
   -> Maybe (Parser (GovernanceDRepCmds era))
-pGovernanceDRepCmds envCli era =
+pGovernanceDRepCmds era envCli =
   subInfoParser "drep"
     ( Opt.progDesc
         $ mconcat
@@ -36,7 +36,7 @@ pGovernanceDRepCmds envCli era =
     )
     [ pGovernanceDRepKeyGenCmd era
     , pGovernanceDRepKeyIdCmd era
-    , pRegistrationCertificateCmd envCli era
+    , pRegistrationCertificateCmd era envCli
     ]
 
 pGovernanceDRepKeyGenCmd :: ()
@@ -83,10 +83,10 @@ pDRepIdOutputFormat =
 -- Registration Certificate related
 
 pRegistrationCertificateCmd :: ()
-  => EnvCli
-  -> CardanoEra era
+  => CardanoEra era
+  -> EnvCli
   -> Maybe (Parser (GovernanceDRepCmds era))
-pRegistrationCertificateCmd envCli era = do
+pRegistrationCertificateCmd era envCli = do
   w <- maybeFeatureInEra era
   pure
     $ subParser "registration-certificate"

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Query.hs
@@ -14,37 +14,36 @@ import           Cardano.CLI.EraBased.Options.Common
 import           Options.Applicative
 import qualified Options.Applicative as Opt
 
-pGovernanceQueryCmds
-  :: ()
-  => EnvCli
-  -> CardanoEra era
+pGovernanceQueryCmds :: ()
+  => CardanoEra era
+  -> EnvCli
   -> Maybe (Parser (GovernanceQueryCmds era))
-pGovernanceQueryCmds env era =
+pGovernanceQueryCmds era env =
   subInfoParser "query"
     ( Opt.progDesc "Query governance-related information" )
-    [ pGovernanceQueryGetConstitutionCmd env era
-    , pGovernanceQueryGetGovStateCmd env era
-    , pGovernanceQueryDRepStateCmd env era
-    , pGovernanceQueryDRepStakeDistributionCmd env era
-    , pGovernanceQueryGetCommitteeStateCmd env era
+    [ pGovernanceQueryGetConstitutionCmd era env
+    , pGovernanceQueryGetGovStateCmd era env
+    , pGovernanceQueryDRepStateCmd era env
+    , pGovernanceQueryDRepStakeDistributionCmd era env
+    , pGovernanceQueryGetCommitteeStateCmd era env
     ]
 
-pGovernanceQueryGetConstitutionCmd
-  :: EnvCli
-  -> CardanoEra era
+pGovernanceQueryGetConstitutionCmd :: ()
+  => CardanoEra era
+  -> EnvCli
   -> Maybe (Parser (GovernanceQueryCmds era))
-pGovernanceQueryGetConstitutionCmd env era = do
+pGovernanceQueryGetConstitutionCmd era env = do
   cOn <- maybeFeatureInEra era
   pure
     $ subParser "constitution"
     $ Opt.info (GovernanceQueryConstitutionCmd cOn <$> pNoArgQueryCmd env)
     $ Opt.progDesc "Get the constitution"
 
-pGovernanceQueryGetGovStateCmd
-  :: EnvCli
-  -> CardanoEra era
+pGovernanceQueryGetGovStateCmd :: ()
+  => CardanoEra era
+  -> EnvCli
   -> Maybe (Parser (GovernanceQueryCmds era))
-pGovernanceQueryGetGovStateCmd env era = do
+pGovernanceQueryGetGovStateCmd era env = do
   cOn <- maybeFeatureInEra era
   pure
     $ subParser "gov-state"
@@ -56,11 +55,11 @@ pGovernanceQueryGetGovStateCmd env era = do
 -- What about 'DRep c' - this means that only 'KeyHash' constructor is in use here: should also
 -- 'DRepAlwaysAbstain' and 'DRepAlwaysNoConfidence' be supported here?
 
-pGovernanceQueryDRepStateCmd
-  :: EnvCli
-  -> CardanoEra era
+pGovernanceQueryDRepStateCmd :: ()
+  => CardanoEra era
+  -> EnvCli
   -> Maybe (Parser (GovernanceQueryCmds era))
-pGovernanceQueryDRepStateCmd env era = do
+pGovernanceQueryDRepStateCmd era env = do
   cOn <- maybeFeatureInEra era
   pure
     $ subParser "drep-state"
@@ -75,11 +74,11 @@ pGovernanceQueryDRepStateCmd env era = do
       <*> some pDRepVerificationKeyOrHashOrFile
       <*> optional pOutputFile
 
-pGovernanceQueryDRepStakeDistributionCmd
-  :: EnvCli
-  -> CardanoEra era
+pGovernanceQueryDRepStakeDistributionCmd :: ()
+  => CardanoEra era
+  -> EnvCli
   -> Maybe (Parser (GovernanceQueryCmds era))
-pGovernanceQueryDRepStakeDistributionCmd env era = do
+pGovernanceQueryDRepStakeDistributionCmd era env = do
   cOn <- maybeFeatureInEra era
   pure
     $ subParser "drep-stake-distribution"
@@ -94,11 +93,11 @@ pGovernanceQueryDRepStakeDistributionCmd env era = do
       <*> some pDRepVerificationKeyOrHashOrFile
       <*> optional pOutputFile
 
-pGovernanceQueryGetCommitteeStateCmd
-  :: EnvCli
-  -> CardanoEra era
+pGovernanceQueryGetCommitteeStateCmd :: ()
+  => CardanoEra era
+  -> EnvCli
   -> Maybe (Parser (GovernanceQueryCmds era))
-pGovernanceQueryGetCommitteeStateCmd env era = do
+pGovernanceQueryGetCommitteeStateCmd era env = do
   cOn <- maybeFeatureInEra era
   pure
     $ subParser "committee-state"

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Key.hs
@@ -26,7 +26,7 @@ pKeyCmds =
   subInfoParser "key"
     ( Opt.progDesc
         $ mconcat
-          [ "Key commands."
+          [ "Key utility commands."
           ]
     )
     [ Just

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Key.hs
@@ -14,6 +14,7 @@ import           Cardano.CLI.EraBased.Options.Common
 import           Cardano.CLI.Types.Common
 
 import           Data.Foldable
+import           Data.Maybe
 import           Data.Text (Text)
 import           Options.Applicative hiding (help, str)
 import qualified Options.Applicative as Opt
@@ -23,15 +24,17 @@ import qualified Options.Applicative as Opt
 
 pKeyCmds :: Parser (KeyCmds era)
 pKeyCmds =
-  asum
-    [ subParser "verification-key"
+  asum $ catMaybes
+    [ Just
+        $ subParser "verification-key"
         $ Opt.info pKeyGetVerificationKey
         $ Opt.progDesc
         $ mconcat
             [ "Get a verification key from a signing key. This "
             , " supports all key types."
             ]
-    , subParser "non-extended-key"
+    , Just
+        $ subParser "non-extended-key"
         $ Opt.info pKeyNonExtendedKey
         $ Opt.progDesc
         $ mconcat
@@ -39,7 +42,8 @@ pKeyCmds =
             , "extended verification key. This supports all "
             , "extended key types."
             ]
-    , subParser "convert-byron-key"
+    , Just
+        $ subParser "convert-byron-key"
         $ Opt.info pKeyConvertByronKey
         $ Opt.progDesc
         $ mconcat
@@ -47,7 +51,8 @@ pKeyCmds =
             , "delegate key (signing or verification) to a "
             , "corresponding Shelley-format key."
             ]
-    , subParser "convert-byron-genesis-vkey"
+    , Just
+        $ subParser "convert-byron-genesis-vkey"
         $ Opt.info pKeyConvertByronGenesisVKey
         $ Opt.progDesc
         $ mconcat
@@ -55,7 +60,8 @@ pKeyCmds =
             , "verification key to a Shelley genesis "
             , "verification key"
             ]
-    , subParser "convert-itn-key"
+    , Just
+        $ subParser "convert-itn-key"
         $ Opt.info pKeyConvertITNKey
         $ Opt.progDesc
         $ mconcat
@@ -63,7 +69,8 @@ pKeyCmds =
             , "(Ed25519) signing or verification key to a "
             , "corresponding Shelley stake key"
             ]
-    , subParser "convert-itn-extended-key"
+    , Just
+        $ subParser "convert-itn-extended-key"
         $ Opt.info pKeyConvertITNExtendedKey
         $ Opt.progDesc
         $ mconcat
@@ -71,7 +78,8 @@ pKeyCmds =
             , "(Ed25519Extended) signing key to a corresponding "
             , "Shelley stake signing key"
             ]
-    , subParser "convert-itn-bip32-key"
+    , Just
+        $ subParser "convert-itn-bip32-key"
         $ Opt.info pKeyConvertITNBip32Key
         $ Opt.progDesc
         $ mconcat
@@ -79,7 +87,8 @@ pKeyCmds =
             , "(Ed25519Bip32) signing key to a corresponding "
             , "Shelley stake signing key"
             ]
-    , subParser "convert-cardano-address-key"
+    , Just
+        $ subParser "convert-cardano-address-key"
         $ Opt.info pKeyConvertCardanoAddressSigningKey
         $ Opt.progDesc
         $ mconcat

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Key.hs
@@ -14,7 +14,6 @@ import           Cardano.CLI.EraBased.Options.Common
 import           Cardano.CLI.Types.Common
 
 import           Data.Foldable
-import           Data.Maybe
 import           Data.Text (Text)
 import           Options.Applicative hiding (help, str)
 import qualified Options.Applicative as Opt
@@ -22,9 +21,14 @@ import qualified Options.Applicative as Opt
 {- HLINT ignore "Use <$>" -}
 {- HLINT ignore "Move brackets to avoid $" -}
 
-pKeyCmds :: Parser (KeyCmds era)
+pKeyCmds :: Maybe (Parser (KeyCmds era))
 pKeyCmds =
-  asum $ catMaybes
+  subInfoParser "key"
+    ( Opt.progDesc
+        $ mconcat
+          [ "Key commands."
+          ]
+    )
     [ Just
         $ subParser "verification-key"
         $ Opt.info pKeyGetVerificationKey

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Node.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Node.hs
@@ -13,6 +13,7 @@ import           Cardano.CLI.EraBased.Commands.Node
 import           Cardano.CLI.EraBased.Options.Common
 
 import           Data.Foldable
+import           Data.Maybe
 import           Options.Applicative hiding (help, str)
 import qualified Options.Applicative as Opt
 
@@ -21,26 +22,49 @@ import qualified Options.Applicative as Opt
 
 pNodeCmds :: Parser (NodeCmds era)
 pNodeCmds =
-  asum
-    [ subParser "key-gen" . Opt.info pKeyGenOperator . Opt.progDesc $ mconcat
-      [ "Create a key pair for a node operator's offline "
-      , "key and a new certificate issue counter"
-      ]
-    , subParser "key-gen-KES" . Opt.info pKeyGenKES . Opt.progDesc $ mconcat
-      [ "Create a key pair for a node KES operational key"
-      ]
-    , subParser "key-gen-VRF" . Opt.info pKeyGenVRF . Opt.progDesc $ mconcat
-      [ "Create a key pair for a node VRF operational key"
-      ]
-    , subParser "key-hash-VRF". Opt.info pKeyHashVRF . Opt.progDesc $ mconcat
-      [ "Print hash of a node's operational VRF key."
-      ]
-    , subParser "new-counter" . Opt.info pNewCounter . Opt.progDesc $ mconcat
-      [ "Create a new certificate issue counter"
-      ]
-    , subParser "issue-op-cert" . Opt.info pIssueOpCert . Opt.progDesc $ mconcat
-      [ "Issue a node operational certificate"
-      ]
+  asum $ catMaybes
+    [ Just
+        $ subParser "key-gen"
+        $ Opt.info pKeyGenOperator
+        $ Opt.progDesc
+        $ mconcat
+            [ "Create a key pair for a node operator's offline "
+            , "key and a new certificate issue counter"
+            ]
+    , Just
+        $ subParser "key-gen-KES"
+        $ Opt.info pKeyGenKES
+        $ Opt.progDesc
+        $ mconcat
+            [ "Create a key pair for a node KES operational key"
+            ]
+    , Just
+        $ subParser "key-gen-VRF"
+        $ Opt.info pKeyGenVRF
+        $ Opt.progDesc
+        $ mconcat
+            [ "Create a key pair for a node VRF operational key"
+            ]
+    , Just
+        $ subParser "key-hash-VRF". Opt.info pKeyHashVRF
+        $ Opt.progDesc
+        $ mconcat
+            [ "Print hash of a node's operational VRF key."
+            ]
+    , Just
+        $ subParser "new-counter"
+        $ Opt.info pNewCounter
+        $ Opt.progDesc
+        $ mconcat
+            [ "Create a new certificate issue counter"
+            ]
+    , Just
+        $ subParser "issue-op-cert"
+        $ Opt.info pIssueOpCert
+        $ Opt.progDesc
+        $ mconcat
+            [ "Issue a node operational certificate"
+            ]
     ]
 
 pKeyGenOperator :: Parser (NodeCmds era)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Node.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Node.hs
@@ -12,22 +12,24 @@ import           Cardano.Api hiding (QueryInShelleyBasedEra (..))
 import           Cardano.CLI.EraBased.Commands.Node
 import           Cardano.CLI.EraBased.Options.Common
 
-import           Data.Foldable
-import           Data.Maybe
 import           Options.Applicative hiding (help, str)
 import qualified Options.Applicative as Opt
 
 {- HLINT ignore "Use <$>" -}
 {- HLINT ignore "Move brackets to avoid $" -}
 
-pNodeCmds :: Parser (NodeCmds era)
+pNodeCmds :: Maybe (Parser (NodeCmds era))
 pNodeCmds =
-  asum $ catMaybes
+  subInfoParser "node"
+    ( Opt.progDesc
+        $ mconcat
+          [ "Node commands."
+          ]
+    )
     [ Just
         $ subParser "key-gen"
         $ Opt.info pKeyGenOperator
-        $ Opt.progDesc
-        $ mconcat
+        $ Opt.progDesc $ mconcat
             [ "Create a key pair for a node operator's offline "
             , "key and a new certificate issue counter"
             ]

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Node.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Node.hs
@@ -23,7 +23,7 @@ pNodeCmds =
   subInfoParser "node"
     ( Opt.progDesc
         $ mconcat
-          [ "Node commands."
+          [ "Node operation commands."
           ]
     )
     [ Just

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Query.hs
@@ -16,6 +16,7 @@ import           Cardano.CLI.EraBased.Options.Common
 import           Cardano.CLI.Types.Common
 
 import           Data.Foldable
+import           Data.Maybe
 import           Options.Applicative hiding (help, str)
 import qualified Options.Applicative as Opt
 
@@ -24,66 +25,82 @@ import qualified Options.Applicative as Opt
 
 pQueryCmds :: EnvCli -> Parser (QueryCmds era)
 pQueryCmds envCli =
-  asum
-    [ subParser "protocol-parameters"
+  asum $ catMaybes
+    [ Just
+        $ subParser "protocol-parameters"
         $ Opt.info (pQueryProtocolParameters envCli)
         $ Opt.progDesc "Get the node's current protocol parameters"
-    , subParser "constitution-hash"
+    , Just
+        $ subParser "constitution-hash"
         $ Opt.info (pQueryConstitutionHash envCli)
         $ Opt.progDesc "Get the constitution hash"
-    , subParser "tip"
+    , Just
+        $ subParser "tip"
         $ Opt.info (pQueryTip envCli)
         $ Opt.progDesc "Get the node's current tip (slot no, hash, block no)"
-    , subParser "stake-pools"
+    , Just
+        $ subParser "stake-pools"
         $ Opt.info (pQueryStakePools envCli)
         $ Opt.progDesc "Get the node's current set of stake pool ids"
-    , subParser "stake-distribution"
+    , Just
+        $ subParser "stake-distribution"
         $ Opt.info (pQueryStakeDistribution envCli)
         $ Opt.progDesc "Get the node's current aggregated stake distribution"
-    , subParser "stake-address-info"
+    , Just
+        $ subParser "stake-address-info"
         $ Opt.info (pQueryStakeAddressInfo envCli)
         $ Opt.progDesc $ mconcat
             [ "Get the current delegations and reward accounts filtered by stake address."
             ]
-    , subParser "utxo"
+    , Just
+        $ subParser "utxo"
         $ Opt.info (pQueryUTxO envCli)
         $ Opt.progDesc $ mconcat
             [ "Get a portion of the current UTxO: by tx in, by address or the whole."
             ]
-    , subParser "ledger-state"
+    , Just
+        $ subParser "ledger-state"
         $ Opt.info (pQueryLedgerState envCli)
         $ Opt.progDesc $ mconcat
             [ "Dump the current ledger state of the node (Ledger.NewEpochState -- advanced command)"
             ]
-    , subParser "protocol-state"
+    , Just
+        $ subParser "protocol-state"
         $ Opt.info (pQueryProtocolState envCli)
         $ Opt.progDesc $ mconcat
             [ "Dump the current protocol state of the node (Ledger.ChainDepState -- advanced command)"
             ]
-    , subParser "stake-snapshot"
+    , Just
+        $ subParser "stake-snapshot"
         $ Opt.info (pQueryStakeSnapshot envCli)
         $ Opt.progDesc $ mconcat
             [ "Obtain the three stake snapshots for a pool, plus the total active stake (advanced command)"
             ]
-    , hiddenSubParser "pool-params"
+    , Just
+        $ hiddenSubParser "pool-params"
         $ Opt.info (pQueryPoolState envCli)
         $ Opt.progDesc $ mconcat
             [ "DEPRECATED.  Use query pool-state instead.  Dump the pool parameters "
             , "(Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced command)"
             ]
-    , subParser "leadership-schedule"
+    , Just
+        $ subParser "leadership-schedule"
         $ Opt.info (pLeadershipSchedule envCli)
         $ Opt.progDesc "Get the slots the node is expected to mint a block in (advanced command)"
-    , subParser "kes-period-info"
+    , Just
+        $ subParser "kes-period-info"
         $ Opt.info (pKesPeriodInfo envCli)
         $ Opt.progDesc "Get information about the current KES period and your node's operational certificate."
-    , subParser "pool-state"
+    , Just
+        $ subParser "pool-state"
         $ Opt.info (pQueryPoolState envCli)
         $ Opt.progDesc "Dump the pool state"
-    , subParser "tx-mempool"
+    , Just
+        $ subParser "tx-mempool"
         $ Opt.info (pQueryTxMempool envCli)
         $ Opt.progDesc "Local Mempool info"
-    , subParser "slot-number"
+    , Just
+        $ subParser "slot-number"
         $ Opt.info (pQuerySlotNumber envCli)
         $ Opt.progDesc "Query slot number for UTC timestamp"
     ]

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Query.hs
@@ -16,16 +16,22 @@ import           Cardano.CLI.EraBased.Options.Common
 import           Cardano.CLI.Types.Common
 
 import           Data.Foldable
-import           Data.Maybe
 import           Options.Applicative hiding (help, str)
 import qualified Options.Applicative as Opt
 
 {- HLINT ignore "Use <$>" -}
 {- HLINT ignore "Move brackets to avoid $" -}
 
-pQueryCmds :: EnvCli -> Parser (QueryCmds era)
+pQueryCmds :: ()
+  => EnvCli
+  -> Maybe (Parser (QueryCmds era))
 pQueryCmds envCli =
-  asum $ catMaybes
+  subInfoParser "query"
+    ( Opt.progDesc
+        $ mconcat
+          [ "Query commands."
+          ]
+    )
     [ Just
         $ subParser "protocol-parameters"
         $ Opt.info (pQueryProtocolParameters envCli)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Query.hs
@@ -29,7 +29,8 @@ pQueryCmds envCli =
   subInfoParser "query"
     ( Opt.progDesc
         $ mconcat
-          [ "Query commands."
+          [ "Node query commands. Will query the local node whose Unix domain socket is "
+          , "obtained from the CARDANO_NODE_SOCKET_PATH environment variable."
           ]
     )
     [ Just

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/StakePool.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/StakePool.hs
@@ -13,17 +13,23 @@ import           Cardano.CLI.Environment (EnvCli (..))
 import           Cardano.CLI.EraBased.Commands.StakePool
 import           Cardano.CLI.EraBased.Options.Common
 
-import           Data.Foldable
-import           Data.Maybe
 import           Options.Applicative hiding (help, str)
 import qualified Options.Applicative as Opt
 
 {- HLINT ignore "Use <$>" -}
 {- HLINT ignore "Move brackets to avoid $" -}
 
-pStakePoolCmds :: CardanoEra era -> EnvCli -> Parser (StakePoolCmds era)
+pStakePoolCmds :: ()
+  => CardanoEra era
+  -> EnvCli
+  -> Maybe (Parser (StakePoolCmds era))
 pStakePoolCmds era envCli =
-  asum $ catMaybes
+  subInfoParser "stake-pool"
+    ( Opt.progDesc
+        $ mconcat
+          [ "Stake pool commands."
+          ]
+    )
     [ pStakePoolRegistrationCertificateCmd era envCli
     , pStakePoolDeregistrationCertificateCmd era
     , Just

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/TextView.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/TextView.hs
@@ -11,6 +11,7 @@ import           Cardano.CLI.EraBased.Commands.TextView
 import           Cardano.CLI.EraBased.Options.Common
 
 import           Data.Foldable
+import           Data.Maybe
 import           Options.Applicative hiding (help, str)
 import qualified Options.Applicative as Opt
 
@@ -19,8 +20,9 @@ import qualified Options.Applicative as Opt
 
 pTextViewCmds :: Parser (TextViewCmds era)
 pTextViewCmds =
-  asum
-    [ subParser "decode-cbor"
+  asum $ catMaybes
+    [ Just
+        $ subParser "decode-cbor"
         $ Opt.info (TextViewInfo <$> pCBORInFile <*> pMaybeOutputFile)
         $ Opt.progDesc "Print a TextView file as decoded CBOR."
     ]

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/TextView.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/TextView.hs
@@ -10,17 +10,20 @@ module Cardano.CLI.EraBased.Options.TextView
 import           Cardano.CLI.EraBased.Commands.TextView
 import           Cardano.CLI.EraBased.Options.Common
 
-import           Data.Foldable
-import           Data.Maybe
 import           Options.Applicative hiding (help, str)
 import qualified Options.Applicative as Opt
 
 {- HLINT ignore "Use <$>" -}
 {- HLINT ignore "Move brackets to avoid $" -}
 
-pTextViewCmds :: Parser (TextViewCmds era)
+pTextViewCmds :: Maybe (Parser (TextViewCmds era))
 pTextViewCmds =
-  asum $ catMaybes
+  subInfoParser "text-view"
+    ( Opt.progDesc
+        $ mconcat
+          [ "text-view commands."
+          ]
+    )
     [ Just
         $ subParser "decode-cbor"
         $ Opt.info (TextViewInfo <$> pCBORInFile <*> pMaybeOutputFile)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/TextView.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/TextView.hs
@@ -21,7 +21,8 @@ pTextViewCmds =
   subInfoParser "text-view"
     ( Opt.progDesc
         $ mconcat
-          [ "text-view commands."
+          [ "Commands for dealing with Shelley TextView files. Transactions, addresses etc "
+          , "are stored on disk as TextView files."
           ]
     )
     [ Just

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Transaction.hs
@@ -24,8 +24,11 @@ import           Prettyprinter (line, pretty)
 {- HLINT ignore "Use <$>" -}
 {- HLINT ignore "Move brackets to avoid $" -}
 
-pTransactionCmds :: EnvCli -> CardanoEra era -> Maybe (Parser (TransactionCmds era))
-pTransactionCmds envCli era =
+pTransactionCmds :: ()
+  => CardanoEra era
+  -> EnvCli
+  -> Maybe (Parser (TransactionCmds era))
+pTransactionCmds era envCli =
   subInfoParser "transaction"
     ( Opt.progDesc
         $ mconcat
@@ -47,7 +50,7 @@ pTransactionCmds envCli era =
             ]
     , Just
         $ subParser "build"
-        $ Opt.info (pTransactionBuild envCli era)
+        $ Opt.info (pTransactionBuild era envCli)
         $ Opt.progDescDoc
         $ Just $ mconcat
             [ pretty @String "Build a balanced transaction (automatically calculates fees)"
@@ -146,8 +149,8 @@ pScriptValidity = asum
     ]
   ]
 
-pTransactionBuild :: EnvCli -> CardanoEra era -> Parser (TransactionCmds era)
-pTransactionBuild envCli era =
+pTransactionBuild :: CardanoEra era -> EnvCli -> Parser (TransactionCmds era)
+pTransactionBuild era envCli =
   TxBuild era
     <$> pSocketPath envCli
     <*> pConsensusModeParams

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Transaction.hs
@@ -16,7 +16,6 @@ import           Cardano.CLI.EraBased.Options.Common
 import           Cardano.CLI.Types.Common
 
 import           Data.Foldable
-import           Data.Maybe
 import           Options.Applicative hiding (help, str)
 import qualified Options.Applicative as Opt
 import qualified Options.Applicative.Help as H
@@ -25,9 +24,14 @@ import           Prettyprinter (line, pretty)
 {- HLINT ignore "Use <$>" -}
 {- HLINT ignore "Move brackets to avoid $" -}
 
-pTransactionCmds :: EnvCli -> CardanoEra era -> Parser (TransactionCmds era)
+pTransactionCmds :: EnvCli -> CardanoEra era -> Maybe (Parser (TransactionCmds era))
 pTransactionCmds envCli era =
-  asum $ catMaybes
+  subInfoParser "transaction"
+    ( Opt.progDesc
+        $ mconcat
+          [ "Transaction commands."
+          ]
+    )
     [ Just
         $ subParser "build-raw"
         $ Opt.info (pTransactionBuildRaw era)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Transaction.hs
@@ -16,6 +16,7 @@ import           Cardano.CLI.EraBased.Options.Common
 import           Cardano.CLI.Types.Common
 
 import           Data.Foldable
+import           Data.Maybe
 import           Options.Applicative hiding (help, str)
 import qualified Options.Applicative as Opt
 import qualified Options.Applicative.Help as H
@@ -26,8 +27,9 @@ import           Prettyprinter (line, pretty)
 
 pTransactionCmds :: EnvCli -> CardanoEra era -> Parser (TransactionCmds era)
 pTransactionCmds envCli era =
-  asum
-    [ subParser "build-raw"
+  asum $ catMaybes
+    [ Just
+        $ subParser "build-raw"
         $ Opt.info (pTransactionBuildRaw era)
         $ Opt.progDescDoc
         $ Just $ mconcat
@@ -39,7 +41,8 @@ pTransactionCmds envCli era =
                 , "undesired tx body. See nested [] notation above for details."
                 ]
             ]
-    , subParser "build"
+    , Just
+        $ subParser "build"
         $ Opt.info (pTransactionBuild envCli era)
         $ Opt.progDescDoc
         $ Just $ mconcat
@@ -53,40 +56,51 @@ pTransactionCmds envCli era =
                 , "undesired tx body. See nested [] notation above for details."
                 ]
             ]
-    , subParser "sign"
+    , Just
+        $ subParser "sign"
         $ Opt.info (pTransactionSign envCli)
         $ Opt.progDesc "Sign a transaction"
-    , subParser "witness"
+    , Just
+        $ subParser "witness"
         $ Opt.info (pTransactionCreateWitness envCli)
         $ Opt.progDesc "Create a transaction witness"
-    , subParser "assemble"
+    , Just
+        $ subParser "assemble"
         $ Opt.info pTransactionAssembleTxBodyWit
         $ Opt.progDesc "Assemble a tx body and witness(es) to form a transaction"
-    , pSignWitnessBackwardCompatible
-    , subParser "submit"
+    , Just pSignWitnessBackwardCompatible
+    , Just
+        $ subParser "submit"
         $ Opt.info (pTransactionSubmit envCli)
         $ Opt.progDesc
         $ mconcat
             [ "Submit a transaction to the local node whose Unix domain socket "
             , "is obtained from the CARDANO_NODE_SOCKET_PATH environment variable."
             ]
-    , subParser "policyid"
+    , Just
+        $ subParser "policyid"
         $ Opt.info pTransactionPolicyId
         $ Opt.progDesc "Calculate the PolicyId from the monetary policy script."
-    , subParser "calculate-min-fee"
+    , Just
+        $ subParser "calculate-min-fee"
         $ Opt.info (pTransactionCalculateMinFee envCli)
         $ Opt.progDesc "Calculate the minimum fee for a transaction."
-    , subParser "calculate-min-required-utxo"
+    , Just
+        $ subParser "calculate-min-required-utxo"
         $ Opt.info (pTransactionCalculateMinReqUTxO era)
         $ Opt.progDesc "Calculate the minimum required UTxO for a transaction output."
-    , pCalculateMinRequiredUtxoBackwardCompatible era
-    , subParser "hash-script-data"
+    , Just
+        $ pCalculateMinRequiredUtxoBackwardCompatible era
+    , Just
+        $ subParser "hash-script-data"
         $ Opt.info pTxHashScriptData
         $ Opt.progDesc "Calculate the hash of script data."
-    , subParser "txid"
+    , Just
+        $ subParser "txid"
         $ Opt.info pTransactionId
         $ Opt.progDesc "Print a transaction identifier."
-    , subParser "view"
+    , Just
+        $ subParser "view"
         $ Opt.info pTransactionView
         $ Opt.progDesc "Print a transaction."
     ]

--- a/cardano-cli/src/Cardano/CLI/Options.hs
+++ b/cardano-cli/src/Cardano/CLI/Options.hs
@@ -82,7 +82,7 @@ parseLegacy envCli =
 
 _parseTopLevelLatest :: EnvCli -> Parser ClientCommand
 _parseTopLevelLatest envCli =
-  AnyEraCommand . AnyEraCommandOf ShelleyBasedEraBabbage <$> pCmds envCli BabbageEra
+  AnyEraCommand . AnyEraCommandOf ShelleyBasedEraBabbage <$> pCmds BabbageEra envCli
 
 -- | Parse Legacy commands at the top level of the CLI.
 parseTopLevelLegacy :: EnvCli -> Parser ClientCommand

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -451,7 +451,7 @@ Usage: cardano-cli shelley query
                                    | slot-number
                                    )
 
-  Era-based query commands
+  Query commands.
 
 Usage: cardano-cli shelley query protocol-parameters --socket-path SOCKET_PATH
                                                        [ --shelley-mode
@@ -1673,7 +1673,7 @@ Usage: cardano-cli allegra query
                                    | slot-number
                                    )
 
-  Era-based query commands
+  Query commands.
 
 Usage: cardano-cli allegra query protocol-parameters --socket-path SOCKET_PATH
                                                        [ --shelley-mode
@@ -2893,7 +2893,7 @@ Usage: cardano-cli mary query
                                 | slot-number
                                 )
 
-  Era-based query commands
+  Query commands.
 
 Usage: cardano-cli mary query protocol-parameters --socket-path SOCKET_PATH
                                                     [ --shelley-mode
@@ -4094,7 +4094,7 @@ Usage: cardano-cli alonzo query
                                   | slot-number
                                   )
 
-  Era-based query commands
+  Query commands.
 
 Usage: cardano-cli alonzo query protocol-parameters --socket-path SOCKET_PATH
                                                       [ --shelley-mode
@@ -5318,7 +5318,7 @@ Usage: cardano-cli babbage query
                                    | slot-number
                                    )
 
-  Era-based query commands
+  Query commands.
 
 Usage: cardano-cli babbage query protocol-parameters --socket-path SOCKET_PATH
                                                        [ --shelley-mode
@@ -6836,7 +6836,7 @@ Usage: cardano-cli conway query
                                   | slot-number
                                   )
 
-  Era-based query commands
+  Query commands.
 
 Usage: cardano-cli conway query protocol-parameters --socket-path SOCKET_PATH
                                                       [ --shelley-mode
@@ -8100,7 +8100,7 @@ Usage: cardano-cli latest query
                                   | slot-number
                                   )
 
-  Era-based query commands
+  Query commands.
 
 Usage: cardano-cli latest query protocol-parameters --socket-path SOCKET_PATH
                                                       [ --shelley-mode

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -786,7 +786,7 @@ Usage: cardano-cli shelley stake-pool
                                         | metadata-hash
                                         )
 
-  Era-based stake pool commands
+  Stake pool commands.
 
 Usage: cardano-cli shelley stake-pool registration-certificate 
                                                                  ( --stake-pool-verification-key STRING
@@ -2008,7 +2008,7 @@ Usage: cardano-cli allegra stake-pool
                                         | metadata-hash
                                         )
 
-  Era-based stake pool commands
+  Stake pool commands.
 
 Usage: cardano-cli allegra stake-pool registration-certificate 
                                                                  ( --stake-pool-verification-key STRING
@@ -3218,7 +3218,7 @@ Usage: cardano-cli mary stake-pool
                                      | metadata-hash
                                      )
 
-  Era-based stake pool commands
+  Stake pool commands.
 
 Usage: cardano-cli mary stake-pool registration-certificate 
                                                               ( --stake-pool-verification-key STRING
@@ -4429,7 +4429,7 @@ Usage: cardano-cli alonzo stake-pool
                                        | metadata-hash
                                        )
 
-  Era-based stake pool commands
+  Stake pool commands.
 
 Usage: cardano-cli alonzo stake-pool registration-certificate 
                                                                 ( --stake-pool-verification-key STRING
@@ -5653,7 +5653,7 @@ Usage: cardano-cli babbage stake-pool
                                         | metadata-hash
                                         )
 
-  Era-based stake pool commands
+  Stake pool commands.
 
 Usage: cardano-cli babbage stake-pool registration-certificate 
                                                                  ( --stake-pool-verification-key STRING
@@ -7213,7 +7213,7 @@ Usage: cardano-cli conway stake-pool
                                        | metadata-hash
                                        )
 
-  Era-based stake pool commands
+  Stake pool commands.
 
 Usage: cardano-cli conway stake-pool registration-certificate 
                                                                 ( --stake-pool-verification-key STRING
@@ -8435,7 +8435,7 @@ Usage: cardano-cli latest stake-pool
                                        | metadata-hash
                                        )
 
-  Era-based stake pool commands
+  Stake pool commands.
 
 Usage: cardano-cli latest stake-pool registration-certificate 
                                                                 ( --stake-pool-verification-key STRING

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -30,7 +30,7 @@ Usage: cardano-cli shelley
 
 Usage: cardano-cli shelley address (key-gen | key-hash | build | info)
 
-  Address commands.
+  Payment address commands.
 
 Usage: cardano-cli shelley address key-gen [--key-output-format STRING]
                                              [ --normal-key
@@ -80,7 +80,7 @@ Usage: cardano-cli shelley key
                                  | convert-cardano-address-key
                                  )
 
-  Key commands.
+  Key utility commands.
 
 Usage: cardano-cli shelley key verification-key --signing-key-file FILE
                                                   --verification-key-file FILE
@@ -162,7 +162,7 @@ Usage: cardano-cli shelley genesis
                                      | hash
                                      )
 
-  Genesis commands.
+  Genesis block commands.
 
 Usage: cardano-cli shelley genesis key-gen-genesis --verification-key-file FILE
                                                      --signing-key-file FILE
@@ -382,7 +382,7 @@ Usage: cardano-cli shelley node
                                   | issue-op-cert
                                   )
 
-  Node commands.
+  Node operation commands.
 
 Usage: cardano-cli shelley node key-gen [--key-output-format STRING]
                                           --cold-verification-key-file FILE
@@ -451,7 +451,8 @@ Usage: cardano-cli shelley query
                                    | slot-number
                                    )
 
-  Query commands.
+  Node query commands. Will query the local node whose Unix domain socket is
+  obtained from the CARDANO_NODE_SOCKET_PATH environment variable.
 
 Usage: cardano-cli shelley query protocol-parameters --socket-path SOCKET_PATH
                                                        [ --shelley-mode
@@ -845,7 +846,8 @@ Usage: cardano-cli shelley stake-pool metadata-hash --pool-metadata-file FILE
 
 Usage: cardano-cli shelley text-view decode-cbor
 
-  text-view commands.
+  Commands for dealing with Shelley TextView files. Transactions, addresses etc
+  are stored on disk as TextView files.
 
 Usage: cardano-cli shelley text-view decode-cbor --in-file FILE
                                                    [--out-file FILE]
@@ -1252,7 +1254,7 @@ Usage: cardano-cli allegra
 
 Usage: cardano-cli allegra address (key-gen | key-hash | build | info)
 
-  Address commands.
+  Payment address commands.
 
 Usage: cardano-cli allegra address key-gen [--key-output-format STRING]
                                              [ --normal-key
@@ -1302,7 +1304,7 @@ Usage: cardano-cli allegra key
                                  | convert-cardano-address-key
                                  )
 
-  Key commands.
+  Key utility commands.
 
 Usage: cardano-cli allegra key verification-key --signing-key-file FILE
                                                   --verification-key-file FILE
@@ -1384,7 +1386,7 @@ Usage: cardano-cli allegra genesis
                                      | hash
                                      )
 
-  Genesis commands.
+  Genesis block commands.
 
 Usage: cardano-cli allegra genesis key-gen-genesis --verification-key-file FILE
                                                      --signing-key-file FILE
@@ -1604,7 +1606,7 @@ Usage: cardano-cli allegra node
                                   | issue-op-cert
                                   )
 
-  Node commands.
+  Node operation commands.
 
 Usage: cardano-cli allegra node key-gen [--key-output-format STRING]
                                           --cold-verification-key-file FILE
@@ -1673,7 +1675,8 @@ Usage: cardano-cli allegra query
                                    | slot-number
                                    )
 
-  Query commands.
+  Node query commands. Will query the local node whose Unix domain socket is
+  obtained from the CARDANO_NODE_SOCKET_PATH environment variable.
 
 Usage: cardano-cli allegra query protocol-parameters --socket-path SOCKET_PATH
                                                        [ --shelley-mode
@@ -2067,7 +2070,8 @@ Usage: cardano-cli allegra stake-pool metadata-hash --pool-metadata-file FILE
 
 Usage: cardano-cli allegra text-view decode-cbor
 
-  text-view commands.
+  Commands for dealing with Shelley TextView files. Transactions, addresses etc
+  are stored on disk as TextView files.
 
 Usage: cardano-cli allegra text-view decode-cbor --in-file FILE
                                                    [--out-file FILE]
@@ -2474,7 +2478,7 @@ Usage: cardano-cli mary
 
 Usage: cardano-cli mary address (key-gen | key-hash | build | info)
 
-  Address commands.
+  Payment address commands.
 
 Usage: cardano-cli mary address key-gen [--key-output-format STRING]
                                           [ --normal-key
@@ -2524,7 +2528,7 @@ Usage: cardano-cli mary key
                               | convert-cardano-address-key
                               )
 
-  Key commands.
+  Key utility commands.
 
 Usage: cardano-cli mary key verification-key --signing-key-file FILE
                                                --verification-key-file FILE
@@ -2606,7 +2610,7 @@ Usage: cardano-cli mary genesis
                                   | hash
                                   )
 
-  Genesis commands.
+  Genesis block commands.
 
 Usage: cardano-cli mary genesis key-gen-genesis --verification-key-file FILE
                                                   --signing-key-file FILE
@@ -2824,7 +2828,7 @@ Usage: cardano-cli mary node
                                | issue-op-cert
                                )
 
-  Node commands.
+  Node operation commands.
 
 Usage: cardano-cli mary node key-gen [--key-output-format STRING]
                                        --cold-verification-key-file FILE
@@ -2893,7 +2897,8 @@ Usage: cardano-cli mary query
                                 | slot-number
                                 )
 
-  Query commands.
+  Node query commands. Will query the local node whose Unix domain socket is
+  obtained from the CARDANO_NODE_SOCKET_PATH environment variable.
 
 Usage: cardano-cli mary query protocol-parameters --socket-path SOCKET_PATH
                                                     [ --shelley-mode
@@ -3277,7 +3282,8 @@ Usage: cardano-cli mary stake-pool metadata-hash --pool-metadata-file FILE
 
 Usage: cardano-cli mary text-view decode-cbor
 
-  text-view commands.
+  Commands for dealing with Shelley TextView files. Transactions, addresses etc
+  are stored on disk as TextView files.
 
 Usage: cardano-cli mary text-view decode-cbor --in-file FILE [--out-file FILE]
 
@@ -3668,7 +3674,7 @@ Usage: cardano-cli alonzo
 
 Usage: cardano-cli alonzo address (key-gen | key-hash | build | info)
 
-  Address commands.
+  Payment address commands.
 
 Usage: cardano-cli alonzo address key-gen [--key-output-format STRING]
                                             [ --normal-key
@@ -3718,7 +3724,7 @@ Usage: cardano-cli alonzo key
                                 | convert-cardano-address-key
                                 )
 
-  Key commands.
+  Key utility commands.
 
 Usage: cardano-cli alonzo key verification-key --signing-key-file FILE
                                                  --verification-key-file FILE
@@ -3800,7 +3806,7 @@ Usage: cardano-cli alonzo genesis
                                     | hash
                                     )
 
-  Genesis commands.
+  Genesis block commands.
 
 Usage: cardano-cli alonzo genesis key-gen-genesis --verification-key-file FILE
                                                     --signing-key-file FILE
@@ -4025,7 +4031,7 @@ Usage: cardano-cli alonzo node
                                  | issue-op-cert
                                  )
 
-  Node commands.
+  Node operation commands.
 
 Usage: cardano-cli alonzo node key-gen [--key-output-format STRING]
                                          --cold-verification-key-file FILE
@@ -4094,7 +4100,8 @@ Usage: cardano-cli alonzo query
                                   | slot-number
                                   )
 
-  Query commands.
+  Node query commands. Will query the local node whose Unix domain socket is
+  obtained from the CARDANO_NODE_SOCKET_PATH environment variable.
 
 Usage: cardano-cli alonzo query protocol-parameters --socket-path SOCKET_PATH
                                                       [ --shelley-mode
@@ -4488,7 +4495,8 @@ Usage: cardano-cli alonzo stake-pool metadata-hash --pool-metadata-file FILE
 
 Usage: cardano-cli alonzo text-view decode-cbor
 
-  text-view commands.
+  Commands for dealing with Shelley TextView files. Transactions, addresses etc
+  are stored on disk as TextView files.
 
 Usage: cardano-cli alonzo text-view decode-cbor --in-file FILE [--out-file FILE]
 
@@ -4894,7 +4902,7 @@ Usage: cardano-cli babbage
 
 Usage: cardano-cli babbage address (key-gen | key-hash | build | info)
 
-  Address commands.
+  Payment address commands.
 
 Usage: cardano-cli babbage address key-gen [--key-output-format STRING]
                                              [ --normal-key
@@ -4944,7 +4952,7 @@ Usage: cardano-cli babbage key
                                  | convert-cardano-address-key
                                  )
 
-  Key commands.
+  Key utility commands.
 
 Usage: cardano-cli babbage key verification-key --signing-key-file FILE
                                                   --verification-key-file FILE
@@ -5026,7 +5034,7 @@ Usage: cardano-cli babbage genesis
                                      | hash
                                      )
 
-  Genesis commands.
+  Genesis block commands.
 
 Usage: cardano-cli babbage genesis key-gen-genesis --verification-key-file FILE
                                                      --signing-key-file FILE
@@ -5249,7 +5257,7 @@ Usage: cardano-cli babbage node
                                   | issue-op-cert
                                   )
 
-  Node commands.
+  Node operation commands.
 
 Usage: cardano-cli babbage node key-gen [--key-output-format STRING]
                                           --cold-verification-key-file FILE
@@ -5318,7 +5326,8 @@ Usage: cardano-cli babbage query
                                    | slot-number
                                    )
 
-  Query commands.
+  Node query commands. Will query the local node whose Unix domain socket is
+  obtained from the CARDANO_NODE_SOCKET_PATH environment variable.
 
 Usage: cardano-cli babbage query protocol-parameters --socket-path SOCKET_PATH
                                                        [ --shelley-mode
@@ -5712,7 +5721,8 @@ Usage: cardano-cli babbage stake-pool metadata-hash --pool-metadata-file FILE
 
 Usage: cardano-cli babbage text-view decode-cbor
 
-  text-view commands.
+  Commands for dealing with Shelley TextView files. Transactions, addresses etc
+  are stored on disk as TextView files.
 
 Usage: cardano-cli babbage text-view decode-cbor --in-file FILE
                                                    [--out-file FILE]
@@ -6119,7 +6129,7 @@ Usage: cardano-cli conway
 
 Usage: cardano-cli conway address (key-gen | key-hash | build | info)
 
-  Address commands.
+  Payment address commands.
 
 Usage: cardano-cli conway address key-gen [--key-output-format STRING]
                                             [ --normal-key
@@ -6169,7 +6179,7 @@ Usage: cardano-cli conway key
                                 | convert-cardano-address-key
                                 )
 
-  Key commands.
+  Key utility commands.
 
 Usage: cardano-cli conway key verification-key --signing-key-file FILE
                                                  --verification-key-file FILE
@@ -6251,7 +6261,7 @@ Usage: cardano-cli conway genesis
                                     | hash
                                     )
 
-  Genesis commands.
+  Genesis block commands.
 
 Usage: cardano-cli conway genesis key-gen-genesis --verification-key-file FILE
                                                     --signing-key-file FILE
@@ -6767,7 +6777,7 @@ Usage: cardano-cli conway node
                                  | issue-op-cert
                                  )
 
-  Node commands.
+  Node operation commands.
 
 Usage: cardano-cli conway node key-gen [--key-output-format STRING]
                                          --cold-verification-key-file FILE
@@ -6836,7 +6846,8 @@ Usage: cardano-cli conway query
                                   | slot-number
                                   )
 
-  Query commands.
+  Node query commands. Will query the local node whose Unix domain socket is
+  obtained from the CARDANO_NODE_SOCKET_PATH environment variable.
 
 Usage: cardano-cli conway query protocol-parameters --socket-path SOCKET_PATH
                                                       [ --shelley-mode
@@ -7272,7 +7283,8 @@ Usage: cardano-cli conway stake-pool metadata-hash --pool-metadata-file FILE
 
 Usage: cardano-cli conway text-view decode-cbor
 
-  text-view commands.
+  Commands for dealing with Shelley TextView files. Transactions, addresses etc
+  are stored on disk as TextView files.
 
 Usage: cardano-cli conway text-view decode-cbor --in-file FILE [--out-file FILE]
 
@@ -7678,7 +7690,7 @@ Usage: cardano-cli latest
 
 Usage: cardano-cli latest address (key-gen | key-hash | build | info)
 
-  Address commands.
+  Payment address commands.
 
 Usage: cardano-cli latest address key-gen [--key-output-format STRING]
                                             [ --normal-key
@@ -7728,7 +7740,7 @@ Usage: cardano-cli latest key
                                 | convert-cardano-address-key
                                 )
 
-  Key commands.
+  Key utility commands.
 
 Usage: cardano-cli latest key verification-key --signing-key-file FILE
                                                  --verification-key-file FILE
@@ -7810,7 +7822,7 @@ Usage: cardano-cli latest genesis
                                     | hash
                                     )
 
-  Genesis commands.
+  Genesis block commands.
 
 Usage: cardano-cli latest genesis key-gen-genesis --verification-key-file FILE
                                                     --signing-key-file FILE
@@ -8031,7 +8043,7 @@ Usage: cardano-cli latest node
                                  | issue-op-cert
                                  )
 
-  Node commands.
+  Node operation commands.
 
 Usage: cardano-cli latest node key-gen [--key-output-format STRING]
                                          --cold-verification-key-file FILE
@@ -8100,7 +8112,8 @@ Usage: cardano-cli latest query
                                   | slot-number
                                   )
 
-  Query commands.
+  Node query commands. Will query the local node whose Unix domain socket is
+  obtained from the CARDANO_NODE_SOCKET_PATH environment variable.
 
 Usage: cardano-cli latest query protocol-parameters --socket-path SOCKET_PATH
                                                       [ --shelley-mode
@@ -8494,7 +8507,8 @@ Usage: cardano-cli latest stake-pool metadata-hash --pool-metadata-file FILE
 
 Usage: cardano-cli latest text-view decode-cbor
 
-  text-view commands.
+  Commands for dealing with Shelley TextView files. Transactions, addresses etc
+  are stored on disk as TextView files.
 
 Usage: cardano-cli latest text-view decode-cbor --in-file FILE [--out-file FILE]
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -382,7 +382,7 @@ Usage: cardano-cli shelley node
                                   | issue-op-cert
                                   )
 
-  Era-based node commands
+  Node commands.
 
 Usage: cardano-cli shelley node key-gen [--key-output-format STRING]
                                           --cold-verification-key-file FILE
@@ -1604,7 +1604,7 @@ Usage: cardano-cli allegra node
                                   | issue-op-cert
                                   )
 
-  Era-based node commands
+  Node commands.
 
 Usage: cardano-cli allegra node key-gen [--key-output-format STRING]
                                           --cold-verification-key-file FILE
@@ -2824,7 +2824,7 @@ Usage: cardano-cli mary node
                                | issue-op-cert
                                )
 
-  Era-based node commands
+  Node commands.
 
 Usage: cardano-cli mary node key-gen [--key-output-format STRING]
                                        --cold-verification-key-file FILE
@@ -4025,7 +4025,7 @@ Usage: cardano-cli alonzo node
                                  | issue-op-cert
                                  )
 
-  Era-based node commands
+  Node commands.
 
 Usage: cardano-cli alonzo node key-gen [--key-output-format STRING]
                                          --cold-verification-key-file FILE
@@ -5249,7 +5249,7 @@ Usage: cardano-cli babbage node
                                   | issue-op-cert
                                   )
 
-  Era-based node commands
+  Node commands.
 
 Usage: cardano-cli babbage node key-gen [--key-output-format STRING]
                                           --cold-verification-key-file FILE
@@ -6767,7 +6767,7 @@ Usage: cardano-cli conway node
                                  | issue-op-cert
                                  )
 
-  Era-based node commands
+  Node commands.
 
 Usage: cardano-cli conway node key-gen [--key-output-format STRING]
                                          --cold-verification-key-file FILE
@@ -8031,7 +8031,7 @@ Usage: cardano-cli latest node
                                  | issue-op-cert
                                  )
 
-  Era-based node commands
+  Node commands.
 
 Usage: cardano-cli latest node key-gen [--key-output-format STRING]
                                          --cold-verification-key-file FILE

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -162,7 +162,7 @@ Usage: cardano-cli shelley genesis
                                      | hash
                                      )
 
-  Era-based genesis commands
+  Genesis commands.
 
 Usage: cardano-cli shelley genesis key-gen-genesis --verification-key-file FILE
                                                      --signing-key-file FILE
@@ -1384,7 +1384,7 @@ Usage: cardano-cli allegra genesis
                                      | hash
                                      )
 
-  Era-based genesis commands
+  Genesis commands.
 
 Usage: cardano-cli allegra genesis key-gen-genesis --verification-key-file FILE
                                                      --signing-key-file FILE
@@ -2606,7 +2606,7 @@ Usage: cardano-cli mary genesis
                                   | hash
                                   )
 
-  Era-based genesis commands
+  Genesis commands.
 
 Usage: cardano-cli mary genesis key-gen-genesis --verification-key-file FILE
                                                   --signing-key-file FILE
@@ -3800,7 +3800,7 @@ Usage: cardano-cli alonzo genesis
                                     | hash
                                     )
 
-  Era-based genesis commands
+  Genesis commands.
 
 Usage: cardano-cli alonzo genesis key-gen-genesis --verification-key-file FILE
                                                     --signing-key-file FILE
@@ -5026,7 +5026,7 @@ Usage: cardano-cli babbage genesis
                                      | hash
                                      )
 
-  Era-based genesis commands
+  Genesis commands.
 
 Usage: cardano-cli babbage genesis key-gen-genesis --verification-key-file FILE
                                                      --signing-key-file FILE
@@ -6251,7 +6251,7 @@ Usage: cardano-cli conway genesis
                                     | hash
                                     )
 
-  Era-based genesis commands
+  Genesis commands.
 
 Usage: cardano-cli conway genesis key-gen-genesis --verification-key-file FILE
                                                     --signing-key-file FILE
@@ -7810,7 +7810,7 @@ Usage: cardano-cli latest genesis
                                     | hash
                                     )
 
-  Era-based genesis commands
+  Genesis commands.
 
 Usage: cardano-cli latest genesis key-gen-genesis --verification-key-file FILE
                                                     --signing-key-file FILE

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -845,7 +845,7 @@ Usage: cardano-cli shelley stake-pool metadata-hash --pool-metadata-file FILE
 
 Usage: cardano-cli shelley text-view decode-cbor
 
-  Era-based text view commands
+  text-view commands.
 
 Usage: cardano-cli shelley text-view decode-cbor --in-file FILE
                                                    [--out-file FILE]
@@ -2067,7 +2067,7 @@ Usage: cardano-cli allegra stake-pool metadata-hash --pool-metadata-file FILE
 
 Usage: cardano-cli allegra text-view decode-cbor
 
-  Era-based text view commands
+  text-view commands.
 
 Usage: cardano-cli allegra text-view decode-cbor --in-file FILE
                                                    [--out-file FILE]
@@ -3277,7 +3277,7 @@ Usage: cardano-cli mary stake-pool metadata-hash --pool-metadata-file FILE
 
 Usage: cardano-cli mary text-view decode-cbor
 
-  Era-based text view commands
+  text-view commands.
 
 Usage: cardano-cli mary text-view decode-cbor --in-file FILE [--out-file FILE]
 
@@ -4488,7 +4488,7 @@ Usage: cardano-cli alonzo stake-pool metadata-hash --pool-metadata-file FILE
 
 Usage: cardano-cli alonzo text-view decode-cbor
 
-  Era-based text view commands
+  text-view commands.
 
 Usage: cardano-cli alonzo text-view decode-cbor --in-file FILE [--out-file FILE]
 
@@ -5712,7 +5712,7 @@ Usage: cardano-cli babbage stake-pool metadata-hash --pool-metadata-file FILE
 
 Usage: cardano-cli babbage text-view decode-cbor
 
-  Era-based text view commands
+  text-view commands.
 
 Usage: cardano-cli babbage text-view decode-cbor --in-file FILE
                                                    [--out-file FILE]
@@ -7272,7 +7272,7 @@ Usage: cardano-cli conway stake-pool metadata-hash --pool-metadata-file FILE
 
 Usage: cardano-cli conway text-view decode-cbor
 
-  Era-based text view commands
+  text-view commands.
 
 Usage: cardano-cli conway text-view decode-cbor --in-file FILE [--out-file FILE]
 
@@ -8494,7 +8494,7 @@ Usage: cardano-cli latest stake-pool metadata-hash --pool-metadata-file FILE
 
 Usage: cardano-cli latest text-view decode-cbor
 
-  Era-based text view commands
+  text-view commands.
 
 Usage: cardano-cli latest text-view decode-cbor --in-file FILE [--out-file FILE]
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -867,7 +867,7 @@ Usage: cardano-cli shelley transaction
                                          | view
                                          )
 
-  Era-based transaction commands
+  Transaction commands.
 
 Usage: cardano-cli shelley transaction build-raw 
                                                    [ --script-valid
@@ -2089,7 +2089,7 @@ Usage: cardano-cli allegra transaction
                                          | view
                                          )
 
-  Era-based transaction commands
+  Transaction commands.
 
 Usage: cardano-cli allegra transaction build-raw 
                                                    [ --script-valid
@@ -3298,7 +3298,7 @@ Usage: cardano-cli mary transaction
                                       | view
                                       )
 
-  Era-based transaction commands
+  Transaction commands.
 
 Usage: cardano-cli mary transaction build-raw 
                                                 [ --script-valid
@@ -4509,7 +4509,7 @@ Usage: cardano-cli alonzo transaction
                                         | view
                                         )
 
-  Era-based transaction commands
+  Transaction commands.
 
 Usage: cardano-cli alonzo transaction build-raw 
                                                   [ --script-valid
@@ -5734,7 +5734,7 @@ Usage: cardano-cli babbage transaction
                                          | view
                                          )
 
-  Era-based transaction commands
+  Transaction commands.
 
 Usage: cardano-cli babbage transaction build-raw 
                                                    [ --script-valid
@@ -7293,7 +7293,7 @@ Usage: cardano-cli conway transaction
                                         | view
                                         )
 
-  Era-based transaction commands
+  Transaction commands.
 
 Usage: cardano-cli conway transaction build-raw 
                                                   [ --script-valid
@@ -8515,7 +8515,7 @@ Usage: cardano-cli latest transaction
                                         | view
                                         )
 
-  Era-based transaction commands
+  Transaction commands.
 
 Usage: cardano-cli latest transaction build-raw 
                                                   [ --script-valid

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -80,7 +80,7 @@ Usage: cardano-cli shelley key
                                  | convert-cardano-address-key
                                  )
 
-  Era-based key commands
+  Key commands.
 
 Usage: cardano-cli shelley key verification-key --signing-key-file FILE
                                                   --verification-key-file FILE
@@ -1302,7 +1302,7 @@ Usage: cardano-cli allegra key
                                  | convert-cardano-address-key
                                  )
 
-  Era-based key commands
+  Key commands.
 
 Usage: cardano-cli allegra key verification-key --signing-key-file FILE
                                                   --verification-key-file FILE
@@ -2524,7 +2524,7 @@ Usage: cardano-cli mary key
                               | convert-cardano-address-key
                               )
 
-  Era-based key commands
+  Key commands.
 
 Usage: cardano-cli mary key verification-key --signing-key-file FILE
                                                --verification-key-file FILE
@@ -3718,7 +3718,7 @@ Usage: cardano-cli alonzo key
                                 | convert-cardano-address-key
                                 )
 
-  Era-based key commands
+  Key commands.
 
 Usage: cardano-cli alonzo key verification-key --signing-key-file FILE
                                                  --verification-key-file FILE
@@ -4944,7 +4944,7 @@ Usage: cardano-cli babbage key
                                  | convert-cardano-address-key
                                  )
 
-  Era-based key commands
+  Key commands.
 
 Usage: cardano-cli babbage key verification-key --signing-key-file FILE
                                                   --verification-key-file FILE
@@ -6169,7 +6169,7 @@ Usage: cardano-cli conway key
                                 | convert-cardano-address-key
                                 )
 
-  Era-based key commands
+  Key commands.
 
 Usage: cardano-cli conway key verification-key --signing-key-file FILE
                                                  --verification-key-file FILE
@@ -7728,7 +7728,7 @@ Usage: cardano-cli latest key
                                 | convert-cardano-address-key
                                 )
 
-  Era-based key commands
+  Key commands.
 
 Usage: cardano-cli latest key verification-key --signing-key-file FILE
                                                  --verification-key-file FILE

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -264,7 +264,7 @@ Usage: cardano-cli shelley genesis hash --genesis FILE
 
 Usage: cardano-cli shelley governance (create-mir-certificate | action | drep)
 
-  Era-based governance commands
+  Governance commands.
 
 Usage: cardano-cli shelley governance create-mir-certificate 
                                                                ( ( --reserves
@@ -1486,7 +1486,7 @@ Usage: cardano-cli allegra genesis hash --genesis FILE
 
 Usage: cardano-cli allegra governance (create-mir-certificate | action | drep)
 
-  Era-based governance commands
+  Governance commands.
 
 Usage: cardano-cli allegra governance create-mir-certificate 
                                                                ( ( --reserves
@@ -2706,7 +2706,7 @@ Usage: cardano-cli mary genesis hash --genesis FILE
 
 Usage: cardano-cli mary governance (create-mir-certificate | action | drep)
 
-  Era-based governance commands
+  Governance commands.
 
 Usage: cardano-cli mary governance create-mir-certificate 
                                                             ( ( --reserves
@@ -3900,7 +3900,7 @@ Usage: cardano-cli alonzo genesis hash --genesis FILE
 
 Usage: cardano-cli alonzo governance (create-mir-certificate | action | drep)
 
-  Era-based governance commands
+  Governance commands.
 
 Usage: cardano-cli alonzo governance create-mir-certificate 
                                                               ( ( --reserves
@@ -5128,7 +5128,7 @@ Usage: cardano-cli babbage genesis hash --genesis FILE
 
 Usage: cardano-cli babbage governance (create-mir-certificate | action | drep)
 
-  Era-based governance commands
+  Governance commands.
 
 Usage: cardano-cli babbage governance create-mir-certificate 
                                                                ( ( --reserves
@@ -6351,7 +6351,7 @@ Usage: cardano-cli conway genesis hash --genesis FILE
 
 Usage: cardano-cli conway governance (query | action | committee | drep | vote)
 
-  Era-based governance commands
+  Governance commands.
 
 Usage: cardano-cli conway governance query 
                                              ( constitution
@@ -7910,7 +7910,7 @@ Usage: cardano-cli latest genesis hash --genesis FILE
 
 Usage: cardano-cli latest governance (create-mir-certificate | action | drep)
 
-  Era-based governance commands
+  Governance commands.
 
 Usage: cardano-cli latest governance create-mir-certificate 
                                                               ( ( --reserves

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -30,7 +30,7 @@ Usage: cardano-cli shelley
 
 Usage: cardano-cli shelley address (key-gen | key-hash | build | info)
 
-  Era-based address commands
+  Address commands.
 
 Usage: cardano-cli shelley address key-gen [--key-output-format STRING]
                                              [ --normal-key
@@ -1252,7 +1252,7 @@ Usage: cardano-cli allegra
 
 Usage: cardano-cli allegra address (key-gen | key-hash | build | info)
 
-  Era-based address commands
+  Address commands.
 
 Usage: cardano-cli allegra address key-gen [--key-output-format STRING]
                                              [ --normal-key
@@ -2474,7 +2474,7 @@ Usage: cardano-cli mary
 
 Usage: cardano-cli mary address (key-gen | key-hash | build | info)
 
-  Era-based address commands
+  Address commands.
 
 Usage: cardano-cli mary address key-gen [--key-output-format STRING]
                                           [ --normal-key
@@ -3668,7 +3668,7 @@ Usage: cardano-cli alonzo
 
 Usage: cardano-cli alonzo address (key-gen | key-hash | build | info)
 
-  Era-based address commands
+  Address commands.
 
 Usage: cardano-cli alonzo address key-gen [--key-output-format STRING]
                                             [ --normal-key
@@ -4894,7 +4894,7 @@ Usage: cardano-cli babbage
 
 Usage: cardano-cli babbage address (key-gen | key-hash | build | info)
 
-  Era-based address commands
+  Address commands.
 
 Usage: cardano-cli babbage address key-gen [--key-output-format STRING]
                                              [ --normal-key
@@ -6119,7 +6119,7 @@ Usage: cardano-cli conway
 
 Usage: cardano-cli conway address (key-gen | key-hash | build | info)
 
-  Era-based address commands
+  Address commands.
 
 Usage: cardano-cli conway address key-gen [--key-output-format STRING]
                                             [ --normal-key
@@ -7678,7 +7678,7 @@ Usage: cardano-cli latest
 
 Usage: cardano-cli latest address (key-gen | key-hash | build | info)
 
-  Era-based address commands
+  Address commands.
 
 Usage: cardano-cli latest address key-gen [--key-output-format STRING]
                                             [ --normal-key

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra.cli
@@ -25,5 +25,5 @@ Available commands:
   query                    Query commands.
   stake-address            Stake address commands.
   stake-pool               Stake pool commands.
-  text-view                Era-based text view commands
+  text-view                text-view commands.
   transaction              Era-based transaction commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra.cli
@@ -24,6 +24,6 @@ Available commands:
   node                     Node commands.
   query                    Query commands.
   stake-address            Stake address commands.
-  stake-pool               Era-based stake pool commands
+  stake-pool               Stake pool commands.
   text-view                Era-based text view commands
   transaction              Era-based transaction commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra.cli
@@ -20,7 +20,7 @@ Available commands:
   address                  Address commands.
   key                      Key commands.
   genesis                  Genesis commands.
-  governance               Era-based governance commands
+  governance               Governance commands.
   node                     Era-based node commands
   query                    Era-based query commands
   stake-address            Stake address commands.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra.cli
@@ -17,13 +17,17 @@ Available options:
   -h,--help                Show this help text
 
 Available commands:
-  address                  Address commands.
-  key                      Key commands.
-  genesis                  Genesis commands.
+  address                  Payment address commands.
+  key                      Key utility commands.
+  genesis                  Genesis block commands.
   governance               Governance commands.
-  node                     Node commands.
-  query                    Query commands.
+  node                     Node operation commands.
+  query                    Node query commands. Will query the local node whose
+                           Unix domain socket is obtained from the
+                           CARDANO_NODE_SOCKET_PATH environment variable.
   stake-address            Stake address commands.
   stake-pool               Stake pool commands.
-  text-view                text-view commands.
+  text-view                Commands for dealing with Shelley TextView files.
+                           Transactions, addresses etc are stored on disk as
+                           TextView files.
   transaction              Transaction commands.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra.cli
@@ -22,7 +22,7 @@ Available commands:
   genesis                  Genesis commands.
   governance               Governance commands.
   node                     Node commands.
-  query                    Era-based query commands
+  query                    Query commands.
   stake-address            Stake address commands.
   stake-pool               Era-based stake pool commands
   text-view                Era-based text view commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra.cli
@@ -26,4 +26,4 @@ Available commands:
   stake-address            Stake address commands.
   stake-pool               Stake pool commands.
   text-view                text-view commands.
-  transaction              Era-based transaction commands
+  transaction              Transaction commands.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra.cli
@@ -18,7 +18,7 @@ Available options:
 
 Available commands:
   address                  Address commands.
-  key                      Era-based key commands
+  key                      Key commands.
   genesis                  Era-based genesis commands
   governance               Era-based governance commands
   node                     Era-based node commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra.cli
@@ -21,7 +21,7 @@ Available commands:
   key                      Key commands.
   genesis                  Genesis commands.
   governance               Governance commands.
-  node                     Era-based node commands
+  node                     Node commands.
   query                    Era-based query commands
   stake-address            Stake address commands.
   stake-pool               Era-based stake pool commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra.cli
@@ -19,7 +19,7 @@ Available options:
 Available commands:
   address                  Address commands.
   key                      Key commands.
-  genesis                  Era-based genesis commands
+  genesis                  Genesis commands.
   governance               Era-based governance commands
   node                     Era-based node commands
   query                    Era-based query commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra.cli
@@ -17,7 +17,7 @@ Available options:
   -h,--help                Show this help text
 
 Available commands:
-  address                  Era-based address commands
+  address                  Address commands.
   key                      Era-based key commands
   genesis                  Era-based genesis commands
   governance               Era-based governance commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_address.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_address.cli
@@ -1,6 +1,6 @@
 Usage: cardano-cli allegra address (key-gen | key-hash | build | info)
 
-  Address commands.
+  Payment address commands.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_address.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_address.cli
@@ -1,6 +1,6 @@
 Usage: cardano-cli allegra address (key-gen | key-hash | build | info)
 
-  Era-based address commands
+  Address commands.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_genesis.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_genesis.cli
@@ -12,7 +12,7 @@ Usage: cardano-cli allegra genesis
                                      | hash
                                      )
 
-  Genesis commands.
+  Genesis block commands.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_genesis.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_genesis.cli
@@ -12,7 +12,7 @@ Usage: cardano-cli allegra genesis
                                      | hash
                                      )
 
-  Era-based genesis commands
+  Genesis commands.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_governance.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_governance.cli
@@ -1,6 +1,6 @@
 Usage: cardano-cli allegra governance (create-mir-certificate | action | drep)
 
-  Era-based governance commands
+  Governance commands.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_key.cli
@@ -9,7 +9,7 @@ Usage: cardano-cli allegra key
                                  | convert-cardano-address-key
                                  )
 
-  Era-based key commands
+  Key commands.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_key.cli
@@ -9,7 +9,7 @@ Usage: cardano-cli allegra key
                                  | convert-cardano-address-key
                                  )
 
-  Key commands.
+  Key utility commands.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_node.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_node.cli
@@ -7,7 +7,7 @@ Usage: cardano-cli allegra node
                                   | issue-op-cert
                                   )
 
-  Era-based node commands
+  Node commands.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_node.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_node.cli
@@ -7,7 +7,7 @@ Usage: cardano-cli allegra node
                                   | issue-op-cert
                                   )
 
-  Node commands.
+  Node operation commands.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query.cli
@@ -16,7 +16,7 @@ Usage: cardano-cli allegra query
                                    | slot-number
                                    )
 
-  Era-based query commands
+  Query commands.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query.cli
@@ -16,7 +16,8 @@ Usage: cardano-cli allegra query
                                    | slot-number
                                    )
 
-  Query commands.
+  Node query commands. Will query the local node whose Unix domain socket is
+  obtained from the CARDANO_NODE_SOCKET_PATH environment variable.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_stake-pool.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_stake-pool.cli
@@ -5,7 +5,7 @@ Usage: cardano-cli allegra stake-pool
                                         | metadata-hash
                                         )
 
-  Era-based stake pool commands
+  Stake pool commands.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_transaction.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_transaction.cli
@@ -13,7 +13,7 @@ Usage: cardano-cli allegra transaction
                                          | view
                                          )
 
-  Era-based transaction commands
+  Transaction commands.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo.cli
@@ -25,5 +25,5 @@ Available commands:
   query                    Query commands.
   stake-address            Stake address commands.
   stake-pool               Stake pool commands.
-  text-view                Era-based text view commands
+  text-view                text-view commands.
   transaction              Era-based transaction commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo.cli
@@ -24,6 +24,6 @@ Available commands:
   node                     Node commands.
   query                    Query commands.
   stake-address            Stake address commands.
-  stake-pool               Era-based stake pool commands
+  stake-pool               Stake pool commands.
   text-view                Era-based text view commands
   transaction              Era-based transaction commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo.cli
@@ -20,7 +20,7 @@ Available commands:
   address                  Address commands.
   key                      Key commands.
   genesis                  Genesis commands.
-  governance               Era-based governance commands
+  governance               Governance commands.
   node                     Era-based node commands
   query                    Era-based query commands
   stake-address            Stake address commands.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo.cli
@@ -17,13 +17,17 @@ Available options:
   -h,--help                Show this help text
 
 Available commands:
-  address                  Address commands.
-  key                      Key commands.
-  genesis                  Genesis commands.
+  address                  Payment address commands.
+  key                      Key utility commands.
+  genesis                  Genesis block commands.
   governance               Governance commands.
-  node                     Node commands.
-  query                    Query commands.
+  node                     Node operation commands.
+  query                    Node query commands. Will query the local node whose
+                           Unix domain socket is obtained from the
+                           CARDANO_NODE_SOCKET_PATH environment variable.
   stake-address            Stake address commands.
   stake-pool               Stake pool commands.
-  text-view                text-view commands.
+  text-view                Commands for dealing with Shelley TextView files.
+                           Transactions, addresses etc are stored on disk as
+                           TextView files.
   transaction              Transaction commands.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo.cli
@@ -22,7 +22,7 @@ Available commands:
   genesis                  Genesis commands.
   governance               Governance commands.
   node                     Node commands.
-  query                    Era-based query commands
+  query                    Query commands.
   stake-address            Stake address commands.
   stake-pool               Era-based stake pool commands
   text-view                Era-based text view commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo.cli
@@ -26,4 +26,4 @@ Available commands:
   stake-address            Stake address commands.
   stake-pool               Stake pool commands.
   text-view                text-view commands.
-  transaction              Era-based transaction commands
+  transaction              Transaction commands.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo.cli
@@ -18,7 +18,7 @@ Available options:
 
 Available commands:
   address                  Address commands.
-  key                      Era-based key commands
+  key                      Key commands.
   genesis                  Era-based genesis commands
   governance               Era-based governance commands
   node                     Era-based node commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo.cli
@@ -21,7 +21,7 @@ Available commands:
   key                      Key commands.
   genesis                  Genesis commands.
   governance               Governance commands.
-  node                     Era-based node commands
+  node                     Node commands.
   query                    Era-based query commands
   stake-address            Stake address commands.
   stake-pool               Era-based stake pool commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo.cli
@@ -19,7 +19,7 @@ Available options:
 Available commands:
   address                  Address commands.
   key                      Key commands.
-  genesis                  Era-based genesis commands
+  genesis                  Genesis commands.
   governance               Era-based governance commands
   node                     Era-based node commands
   query                    Era-based query commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo.cli
@@ -17,7 +17,7 @@ Available options:
   -h,--help                Show this help text
 
 Available commands:
-  address                  Era-based address commands
+  address                  Address commands.
   key                      Era-based key commands
   genesis                  Era-based genesis commands
   governance               Era-based governance commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_address.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_address.cli
@@ -1,6 +1,6 @@
 Usage: cardano-cli alonzo address (key-gen | key-hash | build | info)
 
-  Address commands.
+  Payment address commands.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_address.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_address.cli
@@ -1,6 +1,6 @@
 Usage: cardano-cli alonzo address (key-gen | key-hash | build | info)
 
-  Era-based address commands
+  Address commands.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_genesis.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_genesis.cli
@@ -12,7 +12,7 @@ Usage: cardano-cli alonzo genesis
                                     | hash
                                     )
 
-  Genesis commands.
+  Genesis block commands.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_genesis.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_genesis.cli
@@ -12,7 +12,7 @@ Usage: cardano-cli alonzo genesis
                                     | hash
                                     )
 
-  Era-based genesis commands
+  Genesis commands.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_governance.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_governance.cli
@@ -1,6 +1,6 @@
 Usage: cardano-cli alonzo governance (create-mir-certificate | action | drep)
 
-  Era-based governance commands
+  Governance commands.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_key.cli
@@ -9,7 +9,7 @@ Usage: cardano-cli alonzo key
                                 | convert-cardano-address-key
                                 )
 
-  Key commands.
+  Key utility commands.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_key.cli
@@ -9,7 +9,7 @@ Usage: cardano-cli alonzo key
                                 | convert-cardano-address-key
                                 )
 
-  Era-based key commands
+  Key commands.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_node.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_node.cli
@@ -7,7 +7,7 @@ Usage: cardano-cli alonzo node
                                  | issue-op-cert
                                  )
 
-  Node commands.
+  Node operation commands.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_node.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_node.cli
@@ -7,7 +7,7 @@ Usage: cardano-cli alonzo node
                                  | issue-op-cert
                                  )
 
-  Era-based node commands
+  Node commands.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query.cli
@@ -16,7 +16,8 @@ Usage: cardano-cli alonzo query
                                   | slot-number
                                   )
 
-  Query commands.
+  Node query commands. Will query the local node whose Unix domain socket is
+  obtained from the CARDANO_NODE_SOCKET_PATH environment variable.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query.cli
@@ -16,7 +16,7 @@ Usage: cardano-cli alonzo query
                                   | slot-number
                                   )
 
-  Era-based query commands
+  Query commands.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_stake-pool.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_stake-pool.cli
@@ -5,7 +5,7 @@ Usage: cardano-cli alonzo stake-pool
                                        | metadata-hash
                                        )
 
-  Era-based stake pool commands
+  Stake pool commands.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_transaction.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_transaction.cli
@@ -13,7 +13,7 @@ Usage: cardano-cli alonzo transaction
                                         | view
                                         )
 
-  Era-based transaction commands
+  Transaction commands.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage.cli
@@ -25,5 +25,5 @@ Available commands:
   query                    Query commands.
   stake-address            Stake address commands.
   stake-pool               Stake pool commands.
-  text-view                Era-based text view commands
+  text-view                text-view commands.
   transaction              Era-based transaction commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage.cli
@@ -24,6 +24,6 @@ Available commands:
   node                     Node commands.
   query                    Query commands.
   stake-address            Stake address commands.
-  stake-pool               Era-based stake pool commands
+  stake-pool               Stake pool commands.
   text-view                Era-based text view commands
   transaction              Era-based transaction commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage.cli
@@ -20,7 +20,7 @@ Available commands:
   address                  Address commands.
   key                      Key commands.
   genesis                  Genesis commands.
-  governance               Era-based governance commands
+  governance               Governance commands.
   node                     Era-based node commands
   query                    Era-based query commands
   stake-address            Stake address commands.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage.cli
@@ -17,13 +17,17 @@ Available options:
   -h,--help                Show this help text
 
 Available commands:
-  address                  Address commands.
-  key                      Key commands.
-  genesis                  Genesis commands.
+  address                  Payment address commands.
+  key                      Key utility commands.
+  genesis                  Genesis block commands.
   governance               Governance commands.
-  node                     Node commands.
-  query                    Query commands.
+  node                     Node operation commands.
+  query                    Node query commands. Will query the local node whose
+                           Unix domain socket is obtained from the
+                           CARDANO_NODE_SOCKET_PATH environment variable.
   stake-address            Stake address commands.
   stake-pool               Stake pool commands.
-  text-view                text-view commands.
+  text-view                Commands for dealing with Shelley TextView files.
+                           Transactions, addresses etc are stored on disk as
+                           TextView files.
   transaction              Transaction commands.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage.cli
@@ -22,7 +22,7 @@ Available commands:
   genesis                  Genesis commands.
   governance               Governance commands.
   node                     Node commands.
-  query                    Era-based query commands
+  query                    Query commands.
   stake-address            Stake address commands.
   stake-pool               Era-based stake pool commands
   text-view                Era-based text view commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage.cli
@@ -26,4 +26,4 @@ Available commands:
   stake-address            Stake address commands.
   stake-pool               Stake pool commands.
   text-view                text-view commands.
-  transaction              Era-based transaction commands
+  transaction              Transaction commands.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage.cli
@@ -18,7 +18,7 @@ Available options:
 
 Available commands:
   address                  Address commands.
-  key                      Era-based key commands
+  key                      Key commands.
   genesis                  Era-based genesis commands
   governance               Era-based governance commands
   node                     Era-based node commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage.cli
@@ -21,7 +21,7 @@ Available commands:
   key                      Key commands.
   genesis                  Genesis commands.
   governance               Governance commands.
-  node                     Era-based node commands
+  node                     Node commands.
   query                    Era-based query commands
   stake-address            Stake address commands.
   stake-pool               Era-based stake pool commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage.cli
@@ -19,7 +19,7 @@ Available options:
 Available commands:
   address                  Address commands.
   key                      Key commands.
-  genesis                  Era-based genesis commands
+  genesis                  Genesis commands.
   governance               Era-based governance commands
   node                     Era-based node commands
   query                    Era-based query commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage.cli
@@ -17,7 +17,7 @@ Available options:
   -h,--help                Show this help text
 
 Available commands:
-  address                  Era-based address commands
+  address                  Address commands.
   key                      Era-based key commands
   genesis                  Era-based genesis commands
   governance               Era-based governance commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_address.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_address.cli
@@ -1,6 +1,6 @@
 Usage: cardano-cli babbage address (key-gen | key-hash | build | info)
 
-  Era-based address commands
+  Address commands.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_address.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_address.cli
@@ -1,6 +1,6 @@
 Usage: cardano-cli babbage address (key-gen | key-hash | build | info)
 
-  Address commands.
+  Payment address commands.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_genesis.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_genesis.cli
@@ -12,7 +12,7 @@ Usage: cardano-cli babbage genesis
                                      | hash
                                      )
 
-  Era-based genesis commands
+  Genesis commands.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_genesis.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_genesis.cli
@@ -12,7 +12,7 @@ Usage: cardano-cli babbage genesis
                                      | hash
                                      )
 
-  Genesis commands.
+  Genesis block commands.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_governance.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_governance.cli
@@ -1,6 +1,6 @@
 Usage: cardano-cli babbage governance (create-mir-certificate | action | drep)
 
-  Era-based governance commands
+  Governance commands.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_key.cli
@@ -9,7 +9,7 @@ Usage: cardano-cli babbage key
                                  | convert-cardano-address-key
                                  )
 
-  Era-based key commands
+  Key commands.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_key.cli
@@ -9,7 +9,7 @@ Usage: cardano-cli babbage key
                                  | convert-cardano-address-key
                                  )
 
-  Key commands.
+  Key utility commands.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_node.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_node.cli
@@ -7,7 +7,7 @@ Usage: cardano-cli babbage node
                                   | issue-op-cert
                                   )
 
-  Node commands.
+  Node operation commands.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_node.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_node.cli
@@ -7,7 +7,7 @@ Usage: cardano-cli babbage node
                                   | issue-op-cert
                                   )
 
-  Era-based node commands
+  Node commands.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query.cli
@@ -16,7 +16,7 @@ Usage: cardano-cli babbage query
                                    | slot-number
                                    )
 
-  Era-based query commands
+  Query commands.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query.cli
@@ -16,7 +16,8 @@ Usage: cardano-cli babbage query
                                    | slot-number
                                    )
 
-  Query commands.
+  Node query commands. Will query the local node whose Unix domain socket is
+  obtained from the CARDANO_NODE_SOCKET_PATH environment variable.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_stake-pool.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_stake-pool.cli
@@ -5,7 +5,7 @@ Usage: cardano-cli babbage stake-pool
                                         | metadata-hash
                                         )
 
-  Era-based stake pool commands
+  Stake pool commands.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_transaction.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_transaction.cli
@@ -13,7 +13,7 @@ Usage: cardano-cli babbage transaction
                                          | view
                                          )
 
-  Era-based transaction commands
+  Transaction commands.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway.cli
@@ -25,5 +25,5 @@ Available commands:
   query                    Query commands.
   stake-address            Stake address commands.
   stake-pool               Stake pool commands.
-  text-view                Era-based text view commands
+  text-view                text-view commands.
   transaction              Era-based transaction commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway.cli
@@ -24,6 +24,6 @@ Available commands:
   node                     Node commands.
   query                    Query commands.
   stake-address            Stake address commands.
-  stake-pool               Era-based stake pool commands
+  stake-pool               Stake pool commands.
   text-view                Era-based text view commands
   transaction              Era-based transaction commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway.cli
@@ -20,7 +20,7 @@ Available commands:
   address                  Address commands.
   key                      Key commands.
   genesis                  Genesis commands.
-  governance               Era-based governance commands
+  governance               Governance commands.
   node                     Era-based node commands
   query                    Era-based query commands
   stake-address            Stake address commands.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway.cli
@@ -17,13 +17,17 @@ Available options:
   -h,--help                Show this help text
 
 Available commands:
-  address                  Address commands.
-  key                      Key commands.
-  genesis                  Genesis commands.
+  address                  Payment address commands.
+  key                      Key utility commands.
+  genesis                  Genesis block commands.
   governance               Governance commands.
-  node                     Node commands.
-  query                    Query commands.
+  node                     Node operation commands.
+  query                    Node query commands. Will query the local node whose
+                           Unix domain socket is obtained from the
+                           CARDANO_NODE_SOCKET_PATH environment variable.
   stake-address            Stake address commands.
   stake-pool               Stake pool commands.
-  text-view                text-view commands.
+  text-view                Commands for dealing with Shelley TextView files.
+                           Transactions, addresses etc are stored on disk as
+                           TextView files.
   transaction              Transaction commands.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway.cli
@@ -22,7 +22,7 @@ Available commands:
   genesis                  Genesis commands.
   governance               Governance commands.
   node                     Node commands.
-  query                    Era-based query commands
+  query                    Query commands.
   stake-address            Stake address commands.
   stake-pool               Era-based stake pool commands
   text-view                Era-based text view commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway.cli
@@ -26,4 +26,4 @@ Available commands:
   stake-address            Stake address commands.
   stake-pool               Stake pool commands.
   text-view                text-view commands.
-  transaction              Era-based transaction commands
+  transaction              Transaction commands.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway.cli
@@ -18,7 +18,7 @@ Available options:
 
 Available commands:
   address                  Address commands.
-  key                      Era-based key commands
+  key                      Key commands.
   genesis                  Era-based genesis commands
   governance               Era-based governance commands
   node                     Era-based node commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway.cli
@@ -21,7 +21,7 @@ Available commands:
   key                      Key commands.
   genesis                  Genesis commands.
   governance               Governance commands.
-  node                     Era-based node commands
+  node                     Node commands.
   query                    Era-based query commands
   stake-address            Stake address commands.
   stake-pool               Era-based stake pool commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway.cli
@@ -19,7 +19,7 @@ Available options:
 Available commands:
   address                  Address commands.
   key                      Key commands.
-  genesis                  Era-based genesis commands
+  genesis                  Genesis commands.
   governance               Era-based governance commands
   node                     Era-based node commands
   query                    Era-based query commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway.cli
@@ -17,7 +17,7 @@ Available options:
   -h,--help                Show this help text
 
 Available commands:
-  address                  Era-based address commands
+  address                  Address commands.
   key                      Era-based key commands
   genesis                  Era-based genesis commands
   governance               Era-based governance commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_address.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_address.cli
@@ -1,6 +1,6 @@
 Usage: cardano-cli conway address (key-gen | key-hash | build | info)
 
-  Address commands.
+  Payment address commands.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_address.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_address.cli
@@ -1,6 +1,6 @@
 Usage: cardano-cli conway address (key-gen | key-hash | build | info)
 
-  Era-based address commands
+  Address commands.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_genesis.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_genesis.cli
@@ -12,7 +12,7 @@ Usage: cardano-cli conway genesis
                                     | hash
                                     )
 
-  Era-based genesis commands
+  Genesis commands.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_genesis.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_genesis.cli
@@ -12,7 +12,7 @@ Usage: cardano-cli conway genesis
                                     | hash
                                     )
 
-  Genesis commands.
+  Genesis block commands.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance.cli
@@ -1,6 +1,6 @@
 Usage: cardano-cli conway governance (query | action | committee | drep | vote)
 
-  Era-based governance commands
+  Governance commands.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_key.cli
@@ -9,7 +9,7 @@ Usage: cardano-cli conway key
                                 | convert-cardano-address-key
                                 )
 
-  Era-based key commands
+  Key commands.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_key.cli
@@ -9,7 +9,7 @@ Usage: cardano-cli conway key
                                 | convert-cardano-address-key
                                 )
 
-  Key commands.
+  Key utility commands.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_node.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_node.cli
@@ -7,7 +7,7 @@ Usage: cardano-cli conway node
                                  | issue-op-cert
                                  )
 
-  Node commands.
+  Node operation commands.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_node.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_node.cli
@@ -7,7 +7,7 @@ Usage: cardano-cli conway node
                                  | issue-op-cert
                                  )
 
-  Era-based node commands
+  Node commands.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query.cli
@@ -16,7 +16,7 @@ Usage: cardano-cli conway query
                                   | slot-number
                                   )
 
-  Era-based query commands
+  Query commands.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query.cli
@@ -16,7 +16,8 @@ Usage: cardano-cli conway query
                                   | slot-number
                                   )
 
-  Query commands.
+  Node query commands. Will query the local node whose Unix domain socket is
+  obtained from the CARDANO_NODE_SOCKET_PATH environment variable.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_stake-pool.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_stake-pool.cli
@@ -5,7 +5,7 @@ Usage: cardano-cli conway stake-pool
                                        | metadata-hash
                                        )
 
-  Era-based stake pool commands
+  Stake pool commands.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction.cli
@@ -13,7 +13,7 @@ Usage: cardano-cli conway transaction
                                         | view
                                         )
 
-  Era-based transaction commands
+  Transaction commands.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest.cli
@@ -25,5 +25,5 @@ Available commands:
   query                    Query commands.
   stake-address            Stake address commands.
   stake-pool               Stake pool commands.
-  text-view                Era-based text view commands
+  text-view                text-view commands.
   transaction              Era-based transaction commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest.cli
@@ -24,6 +24,6 @@ Available commands:
   node                     Node commands.
   query                    Query commands.
   stake-address            Stake address commands.
-  stake-pool               Era-based stake pool commands
+  stake-pool               Stake pool commands.
   text-view                Era-based text view commands
   transaction              Era-based transaction commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest.cli
@@ -20,7 +20,7 @@ Available commands:
   address                  Address commands.
   key                      Key commands.
   genesis                  Genesis commands.
-  governance               Era-based governance commands
+  governance               Governance commands.
   node                     Era-based node commands
   query                    Era-based query commands
   stake-address            Stake address commands.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest.cli
@@ -17,13 +17,17 @@ Available options:
   -h,--help                Show this help text
 
 Available commands:
-  address                  Address commands.
-  key                      Key commands.
-  genesis                  Genesis commands.
+  address                  Payment address commands.
+  key                      Key utility commands.
+  genesis                  Genesis block commands.
   governance               Governance commands.
-  node                     Node commands.
-  query                    Query commands.
+  node                     Node operation commands.
+  query                    Node query commands. Will query the local node whose
+                           Unix domain socket is obtained from the
+                           CARDANO_NODE_SOCKET_PATH environment variable.
   stake-address            Stake address commands.
   stake-pool               Stake pool commands.
-  text-view                text-view commands.
+  text-view                Commands for dealing with Shelley TextView files.
+                           Transactions, addresses etc are stored on disk as
+                           TextView files.
   transaction              Transaction commands.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest.cli
@@ -22,7 +22,7 @@ Available commands:
   genesis                  Genesis commands.
   governance               Governance commands.
   node                     Node commands.
-  query                    Era-based query commands
+  query                    Query commands.
   stake-address            Stake address commands.
   stake-pool               Era-based stake pool commands
   text-view                Era-based text view commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest.cli
@@ -26,4 +26,4 @@ Available commands:
   stake-address            Stake address commands.
   stake-pool               Stake pool commands.
   text-view                text-view commands.
-  transaction              Era-based transaction commands
+  transaction              Transaction commands.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest.cli
@@ -18,7 +18,7 @@ Available options:
 
 Available commands:
   address                  Address commands.
-  key                      Era-based key commands
+  key                      Key commands.
   genesis                  Era-based genesis commands
   governance               Era-based governance commands
   node                     Era-based node commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest.cli
@@ -21,7 +21,7 @@ Available commands:
   key                      Key commands.
   genesis                  Genesis commands.
   governance               Governance commands.
-  node                     Era-based node commands
+  node                     Node commands.
   query                    Era-based query commands
   stake-address            Stake address commands.
   stake-pool               Era-based stake pool commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest.cli
@@ -19,7 +19,7 @@ Available options:
 Available commands:
   address                  Address commands.
   key                      Key commands.
-  genesis                  Era-based genesis commands
+  genesis                  Genesis commands.
   governance               Era-based governance commands
   node                     Era-based node commands
   query                    Era-based query commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest.cli
@@ -17,7 +17,7 @@ Available options:
   -h,--help                Show this help text
 
 Available commands:
-  address                  Era-based address commands
+  address                  Address commands.
   key                      Era-based key commands
   genesis                  Era-based genesis commands
   governance               Era-based governance commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_address.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_address.cli
@@ -1,6 +1,6 @@
 Usage: cardano-cli latest address (key-gen | key-hash | build | info)
 
-  Address commands.
+  Payment address commands.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_address.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_address.cli
@@ -1,6 +1,6 @@
 Usage: cardano-cli latest address (key-gen | key-hash | build | info)
 
-  Era-based address commands
+  Address commands.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_genesis.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_genesis.cli
@@ -12,7 +12,7 @@ Usage: cardano-cli latest genesis
                                     | hash
                                     )
 
-  Genesis commands.
+  Genesis block commands.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_genesis.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_genesis.cli
@@ -12,7 +12,7 @@ Usage: cardano-cli latest genesis
                                     | hash
                                     )
 
-  Era-based genesis commands
+  Genesis commands.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_governance.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_governance.cli
@@ -1,6 +1,6 @@
 Usage: cardano-cli latest governance (create-mir-certificate | action | drep)
 
-  Era-based governance commands
+  Governance commands.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_key.cli
@@ -9,7 +9,7 @@ Usage: cardano-cli latest key
                                 | convert-cardano-address-key
                                 )
 
-  Era-based key commands
+  Key commands.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_key.cli
@@ -9,7 +9,7 @@ Usage: cardano-cli latest key
                                 | convert-cardano-address-key
                                 )
 
-  Key commands.
+  Key utility commands.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_node.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_node.cli
@@ -7,7 +7,7 @@ Usage: cardano-cli latest node
                                  | issue-op-cert
                                  )
 
-  Node commands.
+  Node operation commands.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_node.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_node.cli
@@ -7,7 +7,7 @@ Usage: cardano-cli latest node
                                  | issue-op-cert
                                  )
 
-  Era-based node commands
+  Node commands.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query.cli
@@ -16,7 +16,7 @@ Usage: cardano-cli latest query
                                   | slot-number
                                   )
 
-  Era-based query commands
+  Query commands.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query.cli
@@ -16,7 +16,8 @@ Usage: cardano-cli latest query
                                   | slot-number
                                   )
 
-  Query commands.
+  Node query commands. Will query the local node whose Unix domain socket is
+  obtained from the CARDANO_NODE_SOCKET_PATH environment variable.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_stake-pool.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_stake-pool.cli
@@ -5,7 +5,7 @@ Usage: cardano-cli latest stake-pool
                                        | metadata-hash
                                        )
 
-  Era-based stake pool commands
+  Stake pool commands.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_transaction.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_transaction.cli
@@ -13,7 +13,7 @@ Usage: cardano-cli latest transaction
                                         | view
                                         )
 
-  Era-based transaction commands
+  Transaction commands.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary.cli
@@ -25,5 +25,5 @@ Available commands:
   query                    Query commands.
   stake-address            Stake address commands.
   stake-pool               Stake pool commands.
-  text-view                Era-based text view commands
+  text-view                text-view commands.
   transaction              Era-based transaction commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary.cli
@@ -24,6 +24,6 @@ Available commands:
   node                     Node commands.
   query                    Query commands.
   stake-address            Stake address commands.
-  stake-pool               Era-based stake pool commands
+  stake-pool               Stake pool commands.
   text-view                Era-based text view commands
   transaction              Era-based transaction commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary.cli
@@ -20,7 +20,7 @@ Available commands:
   address                  Address commands.
   key                      Key commands.
   genesis                  Genesis commands.
-  governance               Era-based governance commands
+  governance               Governance commands.
   node                     Era-based node commands
   query                    Era-based query commands
   stake-address            Stake address commands.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary.cli
@@ -17,13 +17,17 @@ Available options:
   -h,--help                Show this help text
 
 Available commands:
-  address                  Address commands.
-  key                      Key commands.
-  genesis                  Genesis commands.
+  address                  Payment address commands.
+  key                      Key utility commands.
+  genesis                  Genesis block commands.
   governance               Governance commands.
-  node                     Node commands.
-  query                    Query commands.
+  node                     Node operation commands.
+  query                    Node query commands. Will query the local node whose
+                           Unix domain socket is obtained from the
+                           CARDANO_NODE_SOCKET_PATH environment variable.
   stake-address            Stake address commands.
   stake-pool               Stake pool commands.
-  text-view                text-view commands.
+  text-view                Commands for dealing with Shelley TextView files.
+                           Transactions, addresses etc are stored on disk as
+                           TextView files.
   transaction              Transaction commands.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary.cli
@@ -22,7 +22,7 @@ Available commands:
   genesis                  Genesis commands.
   governance               Governance commands.
   node                     Node commands.
-  query                    Era-based query commands
+  query                    Query commands.
   stake-address            Stake address commands.
   stake-pool               Era-based stake pool commands
   text-view                Era-based text view commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary.cli
@@ -26,4 +26,4 @@ Available commands:
   stake-address            Stake address commands.
   stake-pool               Stake pool commands.
   text-view                text-view commands.
-  transaction              Era-based transaction commands
+  transaction              Transaction commands.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary.cli
@@ -18,7 +18,7 @@ Available options:
 
 Available commands:
   address                  Address commands.
-  key                      Era-based key commands
+  key                      Key commands.
   genesis                  Era-based genesis commands
   governance               Era-based governance commands
   node                     Era-based node commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary.cli
@@ -21,7 +21,7 @@ Available commands:
   key                      Key commands.
   genesis                  Genesis commands.
   governance               Governance commands.
-  node                     Era-based node commands
+  node                     Node commands.
   query                    Era-based query commands
   stake-address            Stake address commands.
   stake-pool               Era-based stake pool commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary.cli
@@ -19,7 +19,7 @@ Available options:
 Available commands:
   address                  Address commands.
   key                      Key commands.
-  genesis                  Era-based genesis commands
+  genesis                  Genesis commands.
   governance               Era-based governance commands
   node                     Era-based node commands
   query                    Era-based query commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary.cli
@@ -17,7 +17,7 @@ Available options:
   -h,--help                Show this help text
 
 Available commands:
-  address                  Era-based address commands
+  address                  Address commands.
   key                      Era-based key commands
   genesis                  Era-based genesis commands
   governance               Era-based governance commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_address.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_address.cli
@@ -1,6 +1,6 @@
 Usage: cardano-cli mary address (key-gen | key-hash | build | info)
 
-  Address commands.
+  Payment address commands.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_address.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_address.cli
@@ -1,6 +1,6 @@
 Usage: cardano-cli mary address (key-gen | key-hash | build | info)
 
-  Era-based address commands
+  Address commands.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_genesis.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_genesis.cli
@@ -12,7 +12,7 @@ Usage: cardano-cli mary genesis
                                   | hash
                                   )
 
-  Genesis commands.
+  Genesis block commands.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_genesis.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_genesis.cli
@@ -12,7 +12,7 @@ Usage: cardano-cli mary genesis
                                   | hash
                                   )
 
-  Era-based genesis commands
+  Genesis commands.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_governance.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_governance.cli
@@ -1,6 +1,6 @@
 Usage: cardano-cli mary governance (create-mir-certificate | action | drep)
 
-  Era-based governance commands
+  Governance commands.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_key.cli
@@ -9,7 +9,7 @@ Usage: cardano-cli mary key
                               | convert-cardano-address-key
                               )
 
-  Era-based key commands
+  Key commands.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_key.cli
@@ -9,7 +9,7 @@ Usage: cardano-cli mary key
                               | convert-cardano-address-key
                               )
 
-  Key commands.
+  Key utility commands.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_node.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_node.cli
@@ -7,7 +7,7 @@ Usage: cardano-cli mary node
                                | issue-op-cert
                                )
 
-  Era-based node commands
+  Node commands.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_node.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_node.cli
@@ -7,7 +7,7 @@ Usage: cardano-cli mary node
                                | issue-op-cert
                                )
 
-  Node commands.
+  Node operation commands.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query.cli
@@ -16,7 +16,7 @@ Usage: cardano-cli mary query
                                 | slot-number
                                 )
 
-  Era-based query commands
+  Query commands.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query.cli
@@ -16,7 +16,8 @@ Usage: cardano-cli mary query
                                 | slot-number
                                 )
 
-  Query commands.
+  Node query commands. Will query the local node whose Unix domain socket is
+  obtained from the CARDANO_NODE_SOCKET_PATH environment variable.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_stake-pool.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_stake-pool.cli
@@ -5,7 +5,7 @@ Usage: cardano-cli mary stake-pool
                                      | metadata-hash
                                      )
 
-  Era-based stake pool commands
+  Stake pool commands.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_transaction.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_transaction.cli
@@ -13,7 +13,7 @@ Usage: cardano-cli mary transaction
                                       | view
                                       )
 
-  Era-based transaction commands
+  Transaction commands.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley.cli
@@ -25,5 +25,5 @@ Available commands:
   query                    Query commands.
   stake-address            Stake address commands.
   stake-pool               Stake pool commands.
-  text-view                Era-based text view commands
+  text-view                text-view commands.
   transaction              Era-based transaction commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley.cli
@@ -24,6 +24,6 @@ Available commands:
   node                     Node commands.
   query                    Query commands.
   stake-address            Stake address commands.
-  stake-pool               Era-based stake pool commands
+  stake-pool               Stake pool commands.
   text-view                Era-based text view commands
   transaction              Era-based transaction commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley.cli
@@ -20,7 +20,7 @@ Available commands:
   address                  Address commands.
   key                      Key commands.
   genesis                  Genesis commands.
-  governance               Era-based governance commands
+  governance               Governance commands.
   node                     Era-based node commands
   query                    Era-based query commands
   stake-address            Stake address commands.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley.cli
@@ -17,13 +17,17 @@ Available options:
   -h,--help                Show this help text
 
 Available commands:
-  address                  Address commands.
-  key                      Key commands.
-  genesis                  Genesis commands.
+  address                  Payment address commands.
+  key                      Key utility commands.
+  genesis                  Genesis block commands.
   governance               Governance commands.
-  node                     Node commands.
-  query                    Query commands.
+  node                     Node operation commands.
+  query                    Node query commands. Will query the local node whose
+                           Unix domain socket is obtained from the
+                           CARDANO_NODE_SOCKET_PATH environment variable.
   stake-address            Stake address commands.
   stake-pool               Stake pool commands.
-  text-view                text-view commands.
+  text-view                Commands for dealing with Shelley TextView files.
+                           Transactions, addresses etc are stored on disk as
+                           TextView files.
   transaction              Transaction commands.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley.cli
@@ -22,7 +22,7 @@ Available commands:
   genesis                  Genesis commands.
   governance               Governance commands.
   node                     Node commands.
-  query                    Era-based query commands
+  query                    Query commands.
   stake-address            Stake address commands.
   stake-pool               Era-based stake pool commands
   text-view                Era-based text view commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley.cli
@@ -26,4 +26,4 @@ Available commands:
   stake-address            Stake address commands.
   stake-pool               Stake pool commands.
   text-view                text-view commands.
-  transaction              Era-based transaction commands
+  transaction              Transaction commands.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley.cli
@@ -18,7 +18,7 @@ Available options:
 
 Available commands:
   address                  Address commands.
-  key                      Era-based key commands
+  key                      Key commands.
   genesis                  Era-based genesis commands
   governance               Era-based governance commands
   node                     Era-based node commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley.cli
@@ -21,7 +21,7 @@ Available commands:
   key                      Key commands.
   genesis                  Genesis commands.
   governance               Governance commands.
-  node                     Era-based node commands
+  node                     Node commands.
   query                    Era-based query commands
   stake-address            Stake address commands.
   stake-pool               Era-based stake pool commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley.cli
@@ -19,7 +19,7 @@ Available options:
 Available commands:
   address                  Address commands.
   key                      Key commands.
-  genesis                  Era-based genesis commands
+  genesis                  Genesis commands.
   governance               Era-based governance commands
   node                     Era-based node commands
   query                    Era-based query commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley.cli
@@ -17,7 +17,7 @@ Available options:
   -h,--help                Show this help text
 
 Available commands:
-  address                  Era-based address commands
+  address                  Address commands.
   key                      Era-based key commands
   genesis                  Era-based genesis commands
   governance               Era-based governance commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_address.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_address.cli
@@ -1,6 +1,6 @@
 Usage: cardano-cli shelley address (key-gen | key-hash | build | info)
 
-  Era-based address commands
+  Address commands.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_address.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_address.cli
@@ -1,6 +1,6 @@
 Usage: cardano-cli shelley address (key-gen | key-hash | build | info)
 
-  Address commands.
+  Payment address commands.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_genesis.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_genesis.cli
@@ -12,7 +12,7 @@ Usage: cardano-cli shelley genesis
                                      | hash
                                      )
 
-  Genesis commands.
+  Genesis block commands.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_genesis.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_genesis.cli
@@ -12,7 +12,7 @@ Usage: cardano-cli shelley genesis
                                      | hash
                                      )
 
-  Era-based genesis commands
+  Genesis commands.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_governance.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_governance.cli
@@ -1,6 +1,6 @@
 Usage: cardano-cli shelley governance (create-mir-certificate | action | drep)
 
-  Era-based governance commands
+  Governance commands.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_key.cli
@@ -9,7 +9,7 @@ Usage: cardano-cli shelley key
                                  | convert-cardano-address-key
                                  )
 
-  Key commands.
+  Key utility commands.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_key.cli
@@ -9,7 +9,7 @@ Usage: cardano-cli shelley key
                                  | convert-cardano-address-key
                                  )
 
-  Era-based key commands
+  Key commands.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_node.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_node.cli
@@ -7,7 +7,7 @@ Usage: cardano-cli shelley node
                                   | issue-op-cert
                                   )
 
-  Era-based node commands
+  Node commands.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_node.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_node.cli
@@ -7,7 +7,7 @@ Usage: cardano-cli shelley node
                                   | issue-op-cert
                                   )
 
-  Node commands.
+  Node operation commands.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query.cli
@@ -16,7 +16,8 @@ Usage: cardano-cli shelley query
                                    | slot-number
                                    )
 
-  Query commands.
+  Node query commands. Will query the local node whose Unix domain socket is
+  obtained from the CARDANO_NODE_SOCKET_PATH environment variable.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query.cli
@@ -16,7 +16,7 @@ Usage: cardano-cli shelley query
                                    | slot-number
                                    )
 
-  Era-based query commands
+  Query commands.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_stake-pool.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_stake-pool.cli
@@ -5,7 +5,7 @@ Usage: cardano-cli shelley stake-pool
                                         | metadata-hash
                                         )
 
-  Era-based stake pool commands
+  Stake pool commands.
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_transaction.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_transaction.cli
@@ -13,7 +13,7 @@ Usage: cardano-cli shelley transaction
                                          | view
                                          )
 
-  Era-based transaction commands
+  Transaction commands.
 
 Available options:
   -h,--help                Show this help text


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Regularise era based command structure
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

The main change in this PR is to change command parsers to return `Maybe (Parser a)` instead of `Parser a`.

This is based on the principle that commands themselves should determined whether they exist in a given era.  This principle is used in the new Conway commands and will see more use in the future.

Requiring that all command groups accept `Maybe (Parser a)` will mean that any new or existing commands can become era-sensitive without inducing refactoring.  As it is at the moment if a command needs to become era-sensitive, the parent command group will need to be refactored to accomodate it if it doesn't already which is the case for a number top-level commands groups.

The PR also contains a small number of help text fixes.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
