### PR TITLE
Fix typo in stake-pool help text and clarify drep queries arguments

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands.hs
@@ -142,11 +142,11 @@ pCmds envCli era =
     , Just
         $ subParser "stake-pool"
         $ Opt.info (StakePoolCmds <$> pStakePoolCmds era envCli)
-        $ Opt.progDesc "Era-based text-view commands"
+        $ Opt.progDesc "Era-based stake pool commands"
     , Just
         $ subParser "text-view"
         $ Opt.info (TextViewCmds <$> pTextViewCmds)
-        $ Opt.progDesc "Era-based text-view commands"
+        $ Opt.progDesc "Era-based text view commands"
     , Just
         $ subParser "transaction"
         $ Opt.info (TransactionCmds <$> pTransactionCmds envCli era)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Query.hs
@@ -65,7 +65,7 @@ pGovernanceQueryDRepStateCmd env era = do
   pure
     $ subParser "drep-state"
     $ Opt.info (GovernanceQueryDRepStateCmd cOn <$> pDRepStateQueryCmd)
-    $ Opt.progDesc "Get the DRep state"
+    $ Opt.progDesc "Get the DRep state. If no DRep credentials are provided, return states for all of them."
   where
     pDRepStateQueryCmd :: Parser DRepStateQueryCmd
     pDRepStateQueryCmd = DRepStateQueryCmd
@@ -84,7 +84,7 @@ pGovernanceQueryDRepStakeDistributionCmd env era = do
   pure
     $ subParser "drep-stake-distribution"
     $ Opt.info (GovernanceQueryDRepStakeDistributionCmd cOn <$> pDRepStakeDistributionQueryCmd)
-    $ Opt.progDesc "Get the DRep stake distribution"
+    $ Opt.progDesc "Get the DRep stake distribution. If no DRep credentials are provided, return stake distributions for all of them."
   where
     pDRepStakeDistributionQueryCmd :: Parser DRepStakeDistributionQueryCmd
     pDRepStakeDistributionQueryCmd = DRepStakeDistributionQueryCmd

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -786,7 +786,7 @@ Usage: cardano-cli shelley stake-pool
                                         | metadata-hash
                                         )
 
-  Era-based text-view commands
+  Era-based stake pool commands
 
 Usage: cardano-cli shelley stake-pool registration-certificate 
                                                                  ( --stake-pool-verification-key STRING
@@ -845,7 +845,7 @@ Usage: cardano-cli shelley stake-pool metadata-hash --pool-metadata-file FILE
 
 Usage: cardano-cli shelley text-view decode-cbor
 
-  Era-based text-view commands
+  Era-based text view commands
 
 Usage: cardano-cli shelley text-view decode-cbor --in-file FILE
                                                    [--out-file FILE]
@@ -2008,7 +2008,7 @@ Usage: cardano-cli allegra stake-pool
                                         | metadata-hash
                                         )
 
-  Era-based text-view commands
+  Era-based stake pool commands
 
 Usage: cardano-cli allegra stake-pool registration-certificate 
                                                                  ( --stake-pool-verification-key STRING
@@ -2067,7 +2067,7 @@ Usage: cardano-cli allegra stake-pool metadata-hash --pool-metadata-file FILE
 
 Usage: cardano-cli allegra text-view decode-cbor
 
-  Era-based text-view commands
+  Era-based text view commands
 
 Usage: cardano-cli allegra text-view decode-cbor --in-file FILE
                                                    [--out-file FILE]
@@ -3218,7 +3218,7 @@ Usage: cardano-cli mary stake-pool
                                      | metadata-hash
                                      )
 
-  Era-based text-view commands
+  Era-based stake pool commands
 
 Usage: cardano-cli mary stake-pool registration-certificate 
                                                               ( --stake-pool-verification-key STRING
@@ -3277,7 +3277,7 @@ Usage: cardano-cli mary stake-pool metadata-hash --pool-metadata-file FILE
 
 Usage: cardano-cli mary text-view decode-cbor
 
-  Era-based text-view commands
+  Era-based text view commands
 
 Usage: cardano-cli mary text-view decode-cbor --in-file FILE [--out-file FILE]
 
@@ -4429,7 +4429,7 @@ Usage: cardano-cli alonzo stake-pool
                                        | metadata-hash
                                        )
 
-  Era-based text-view commands
+  Era-based stake pool commands
 
 Usage: cardano-cli alonzo stake-pool registration-certificate 
                                                                 ( --stake-pool-verification-key STRING
@@ -4488,7 +4488,7 @@ Usage: cardano-cli alonzo stake-pool metadata-hash --pool-metadata-file FILE
 
 Usage: cardano-cli alonzo text-view decode-cbor
 
-  Era-based text-view commands
+  Era-based text view commands
 
 Usage: cardano-cli alonzo text-view decode-cbor --in-file FILE [--out-file FILE]
 
@@ -5653,7 +5653,7 @@ Usage: cardano-cli babbage stake-pool
                                         | metadata-hash
                                         )
 
-  Era-based text-view commands
+  Era-based stake pool commands
 
 Usage: cardano-cli babbage stake-pool registration-certificate 
                                                                  ( --stake-pool-verification-key STRING
@@ -5712,7 +5712,7 @@ Usage: cardano-cli babbage stake-pool metadata-hash --pool-metadata-file FILE
 
 Usage: cardano-cli babbage text-view decode-cbor
 
-  Era-based text-view commands
+  Era-based text view commands
 
 Usage: cardano-cli babbage text-view decode-cbor --in-file FILE
                                                    [--out-file FILE]
@@ -6408,7 +6408,8 @@ Usage: cardano-cli conway governance query drep-state --socket-path SOCKET_PATH
                                                         )
                                                         [--out-file FILE]
 
-  Get the DRep state
+  Get the DRep state. If no DRep credentials are provided, return states for all
+  of them.
 
 Usage: cardano-cli conway governance query drep-stake-distribution 
                                                                      --socket-path SOCKET_PATH
@@ -6427,7 +6428,8 @@ Usage: cardano-cli conway governance query drep-stake-distribution
                                                                      )
                                                                      [--out-file FILE]
 
-  Get the DRep stake distribution
+  Get the DRep stake distribution. If no DRep credentials are provided, return
+  stake distributions for all of them.
 
 Usage: cardano-cli conway governance query committee-state 
                                                              --socket-path SOCKET_PATH
@@ -7192,7 +7194,7 @@ Usage: cardano-cli conway stake-pool
                                        | metadata-hash
                                        )
 
-  Era-based text-view commands
+  Era-based stake pool commands
 
 Usage: cardano-cli conway stake-pool registration-certificate 
                                                                 ( --stake-pool-verification-key STRING
@@ -7251,7 +7253,7 @@ Usage: cardano-cli conway stake-pool metadata-hash --pool-metadata-file FILE
 
 Usage: cardano-cli conway text-view decode-cbor
 
-  Era-based text-view commands
+  Era-based text view commands
 
 Usage: cardano-cli conway text-view decode-cbor --in-file FILE [--out-file FILE]
 
@@ -8414,7 +8416,7 @@ Usage: cardano-cli latest stake-pool
                                        | metadata-hash
                                        )
 
-  Era-based text-view commands
+  Era-based stake pool commands
 
 Usage: cardano-cli latest stake-pool registration-certificate 
                                                                 ( --stake-pool-verification-key STRING
@@ -8473,7 +8475,7 @@ Usage: cardano-cli latest stake-pool metadata-hash --pool-metadata-file FILE
 
 Usage: cardano-cli latest text-view decode-cbor
 
-  Era-based text-view commands
+  Era-based text view commands
 
 Usage: cardano-cli latest text-view decode-cbor --in-file FILE [--out-file FILE]
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra.cli
@@ -24,6 +24,6 @@ Available commands:
   node                     Era-based node commands
   query                    Era-based query commands
   stake-address            Stake address commands.
-  stake-pool               Era-based text-view commands
-  text-view                Era-based text-view commands
+  stake-pool               Era-based stake pool commands
+  text-view                Era-based text view commands
   transaction              Era-based transaction commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_stake-pool.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_stake-pool.cli
@@ -5,7 +5,7 @@ Usage: cardano-cli allegra stake-pool
                                         | metadata-hash
                                         )
 
-  Era-based text-view commands
+  Era-based stake pool commands
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo.cli
@@ -24,6 +24,6 @@ Available commands:
   node                     Era-based node commands
   query                    Era-based query commands
   stake-address            Stake address commands.
-  stake-pool               Era-based text-view commands
-  text-view                Era-based text-view commands
+  stake-pool               Era-based stake pool commands
+  text-view                Era-based text view commands
   transaction              Era-based transaction commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_stake-pool.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_stake-pool.cli
@@ -5,7 +5,7 @@ Usage: cardano-cli alonzo stake-pool
                                        | metadata-hash
                                        )
 
-  Era-based text-view commands
+  Era-based stake pool commands
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage.cli
@@ -24,6 +24,6 @@ Available commands:
   node                     Era-based node commands
   query                    Era-based query commands
   stake-address            Stake address commands.
-  stake-pool               Era-based text-view commands
-  text-view                Era-based text-view commands
+  stake-pool               Era-based stake pool commands
+  text-view                Era-based text view commands
   transaction              Era-based transaction commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_stake-pool.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_stake-pool.cli
@@ -5,7 +5,7 @@ Usage: cardano-cli babbage stake-pool
                                         | metadata-hash
                                         )
 
-  Era-based text-view commands
+  Era-based stake pool commands
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway.cli
@@ -24,6 +24,6 @@ Available commands:
   node                     Era-based node commands
   query                    Era-based query commands
   stake-address            Stake address commands.
-  stake-pool               Era-based text-view commands
-  text-view                Era-based text-view commands
+  stake-pool               Era-based stake pool commands
+  text-view                Era-based text view commands
   transaction              Era-based transaction commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_query.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_query.cli
@@ -14,6 +14,9 @@ Available options:
 Available commands:
   constitution             Get the constitution
   gov-state                Get the governance state
-  drep-state               Get the DRep state
-  drep-stake-distribution  Get the DRep stake distribution
+  drep-state               Get the DRep state. If no DRep credentials are
+                           provided, return states for all of them.
+  drep-stake-distribution  Get the DRep stake distribution. If no DRep
+                           credentials are provided, return stake distributions
+                           for all of them.
   committee-state          Get the committee state

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_query_drep-stake-distribution.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_query_drep-stake-distribution.cli
@@ -15,7 +15,8 @@ Usage: cardano-cli conway governance query drep-stake-distribution
                                                                      )
                                                                      [--out-file FILE]
 
-  Get the DRep stake distribution
+  Get the DRep stake distribution. If no DRep credentials are provided, return
+  stake distributions for all of them.
 
 Available options:
   --socket-path SOCKET_PATH

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_query_drep-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_query_drep-state.cli
@@ -14,7 +14,8 @@ Usage: cardano-cli conway governance query drep-state --socket-path SOCKET_PATH
                                                         )
                                                         [--out-file FILE]
 
-  Get the DRep state
+  Get the DRep state. If no DRep credentials are provided, return states for all
+  of them.
 
 Available options:
   --socket-path SOCKET_PATH

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_stake-pool.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_stake-pool.cli
@@ -5,7 +5,7 @@ Usage: cardano-cli conway stake-pool
                                        | metadata-hash
                                        )
 
-  Era-based text-view commands
+  Era-based stake pool commands
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest.cli
@@ -24,6 +24,6 @@ Available commands:
   node                     Era-based node commands
   query                    Era-based query commands
   stake-address            Stake address commands.
-  stake-pool               Era-based text-view commands
-  text-view                Era-based text-view commands
+  stake-pool               Era-based stake pool commands
+  text-view                Era-based text view commands
   transaction              Era-based transaction commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_stake-pool.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_stake-pool.cli
@@ -5,7 +5,7 @@ Usage: cardano-cli latest stake-pool
                                        | metadata-hash
                                        )
 
-  Era-based text-view commands
+  Era-based stake pool commands
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary.cli
@@ -24,6 +24,6 @@ Available commands:
   node                     Era-based node commands
   query                    Era-based query commands
   stake-address            Stake address commands.
-  stake-pool               Era-based text-view commands
-  text-view                Era-based text-view commands
+  stake-pool               Era-based stake pool commands
+  text-view                Era-based text view commands
   transaction              Era-based transaction commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_stake-pool.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_stake-pool.cli
@@ -5,7 +5,7 @@ Usage: cardano-cli mary stake-pool
                                      | metadata-hash
                                      )
 
-  Era-based text-view commands
+  Era-based stake pool commands
 
 Available options:
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley.cli
@@ -24,6 +24,6 @@ Available commands:
   node                     Era-based node commands
   query                    Era-based query commands
   stake-address            Stake address commands.
-  stake-pool               Era-based text-view commands
-  text-view                Era-based text-view commands
+  stake-pool               Era-based stake pool commands
+  text-view                Era-based text view commands
   transaction              Era-based transaction commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_stake-pool.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_stake-pool.cli
@@ -5,7 +5,7 @@ Usage: cardano-cli shelley stake-pool
                                         | metadata-hash
                                         )
 
-  Era-based text-view commands
+  Era-based stake pool commands
 
 Available options:
   -h,--help                Show this help text


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Fix typo in stake-pool help text and clarify drep queries arguments
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
   - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Additional context for the PR goes here.

If the PR fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
