### PR TITLE
Rename `SomeWitness` to `SomeSigningWitness`.  Rename constructors to avoid name conflicts.

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Key.hs
@@ -23,7 +23,6 @@ module Cardano.CLI.EraBased.Run.Key
 import           Cardano.Api
 import qualified Cardano.Api.Byron as ByronApi
 import           Cardano.Api.Crypto.Ed25519Bip32 (xPrvFromBytes)
-import           Cardano.Api.Shelley
 
 import qualified Cardano.CLI.Byron.Key as Byron
 import           Cardano.CLI.EraBased.Commands.Key
@@ -84,96 +83,6 @@ runGetVerificationKeyCmd skf vkf = do
       let vk = getVerificationKey sk in
       firstExceptT KeyCmdWriteFileError . newExceptT $
         writeLazyByteStringFile vkf $ textEnvelopeToJSON Nothing vk
-
-
-data SomeSigningKey
-  = AByronSigningKey                    (SigningKey ByronKey)
-  | APaymentSigningKey                  (SigningKey PaymentKey)
-  | APaymentExtendedSigningKey          (SigningKey PaymentExtendedKey)
-  | AStakeSigningKey                    (SigningKey StakeKey)
-  | AStakeExtendedSigningKey            (SigningKey StakeExtendedKey)
-  | AStakePoolSigningKey                (SigningKey StakePoolKey)
-  | AGenesisSigningKey                  (SigningKey GenesisKey)
-  | AGenesisExtendedSigningKey          (SigningKey GenesisExtendedKey)
-  | AGenesisDelegateSigningKey          (SigningKey GenesisDelegateKey)
-  | AGenesisDelegateExtendedSigningKey  (SigningKey GenesisDelegateExtendedKey)
-  | AGenesisUTxOSigningKey              (SigningKey GenesisUTxOKey)
-  | AVrfSigningKey                      (SigningKey VrfKey)
-  | AKesSigningKey                      (SigningKey KesKey)
-
-withSomeSigningKey :: ()
-  => SomeSigningKey
-  -> (forall keyrole. (Key keyrole, HasTypeProxy keyrole) => SigningKey keyrole -> a)
-  -> a
-withSomeSigningKey ssk f =
-    case ssk of
-      AByronSigningKey                    sk -> f sk
-      APaymentSigningKey                  sk -> f sk
-      APaymentExtendedSigningKey          sk -> f sk
-      AStakeSigningKey                    sk -> f sk
-      AStakeExtendedSigningKey            sk -> f sk
-      AStakePoolSigningKey                sk -> f sk
-      AGenesisSigningKey                  sk -> f sk
-      AGenesisExtendedSigningKey          sk -> f sk
-      AGenesisDelegateSigningKey          sk -> f sk
-      AGenesisDelegateExtendedSigningKey  sk -> f sk
-      AGenesisUTxOSigningKey              sk -> f sk
-      AVrfSigningKey                      sk -> f sk
-      AKesSigningKey                      sk -> f sk
-
-readSigningKeyFile
-  :: SigningKeyFile In
-  -> ExceptT (FileError InputDecodeError) IO SomeSigningKey
-readSigningKeyFile skFile =
-    newExceptT $
-      readKeyFileAnyOf bech32FileTypes textEnvFileTypes skFile
-  where
-    textEnvFileTypes =
-      [ FromSomeType (AsSigningKey AsByronKey)
-                      AByronSigningKey
-      , FromSomeType (AsSigningKey AsPaymentKey)
-                      APaymentSigningKey
-      , FromSomeType (AsSigningKey AsPaymentExtendedKey)
-                      APaymentExtendedSigningKey
-      , FromSomeType (AsSigningKey AsStakeKey)
-                      AStakeSigningKey
-      , FromSomeType (AsSigningKey AsStakeExtendedKey)
-                      AStakeExtendedSigningKey
-      , FromSomeType (AsSigningKey AsStakePoolKey)
-                      AStakePoolSigningKey
-      , FromSomeType (AsSigningKey AsGenesisKey)
-                      AGenesisSigningKey
-      , FromSomeType (AsSigningKey AsGenesisExtendedKey)
-                      AGenesisExtendedSigningKey
-      , FromSomeType (AsSigningKey AsGenesisDelegateKey)
-                      AGenesisDelegateSigningKey
-      , FromSomeType (AsSigningKey AsGenesisDelegateExtendedKey)
-                      AGenesisDelegateExtendedSigningKey
-      , FromSomeType (AsSigningKey AsGenesisUTxOKey)
-                      AGenesisUTxOSigningKey
-      , FromSomeType (AsSigningKey AsVrfKey)
-                      AVrfSigningKey
-      , FromSomeType (AsSigningKey AsKesKey)
-                      AKesSigningKey
-      ]
-
-    bech32FileTypes =
-      [ FromSomeType (AsSigningKey AsPaymentKey)
-                      APaymentSigningKey
-      , FromSomeType (AsSigningKey AsPaymentExtendedKey)
-                      APaymentExtendedSigningKey
-      , FromSomeType (AsSigningKey AsStakeKey)
-                      AStakeSigningKey
-      , FromSomeType (AsSigningKey AsStakeExtendedKey)
-                      AStakeExtendedSigningKey
-      , FromSomeType (AsSigningKey AsStakePoolKey)
-                      AStakePoolSigningKey
-      , FromSomeType (AsSigningKey AsVrfKey)
-                      AVrfSigningKey
-      , FromSomeType (AsSigningKey AsKesKey)
-                      AKesSigningKey
-      ]
-
 
 runConvertToNonExtendedKeyCmd
   :: VerificationKeyFile In

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Transaction.hs
@@ -888,7 +888,7 @@ runTxSignCmd :: ()
 runTxSignCmd txOrTxBody witSigningData mnw outTxFile = do
   sks <-  mapM (firstExceptT TxCmdReadWitnessSigningDataError . newExceptT . readWitnessSigningData) witSigningData
 
-  let (sksByron, sksShelley) = partitionSomeWitnesses $ map categoriseSomeWitness sks
+  let (sksByron, sksShelley) = partitionSomeWitnesses $ map categoriseSomeSigningWitness sks
 
   case txOrTxBody of
     InputTxFile (File inputTxFilePath) -> do
@@ -1191,7 +1191,7 @@ runTxCreateWitnessCmd (File txbodyFilePath) witSignData mbNw oFile = do
      someWit <- firstExceptT TxCmdReadWitnessSigningDataError
                   . newExceptT $ readWitnessSigningData witSignData
      witness <-
-       case categoriseSomeWitness someWit of
+       case categoriseSomeSigningWitness someWit of
          -- Byron witnesses require the network ID. This can either be provided
          -- directly or derived from a provided Byron address.
          AByronWitness bootstrapWitData ->
@@ -1212,7 +1212,7 @@ runTxCreateWitnessCmd (File txbodyFilePath) witSignData mbNw oFile = do
                    . newExceptT $ readWitnessSigningData witSignData
 
       witness <-
-        case categoriseSomeWitness someWit of
+        case categoriseSomeSigningWitness someWit of
           -- Byron witnesses require the network ID. This can either be provided
           -- directly or derived from a provided Byron address.
           AByronWitness bootstrapWitData ->


### PR DESCRIPTION

# Changelog

```yaml
- description: |
    Rename `SomeWitness` to `SomeSigningWitness`.  Rename constructors to avoid name conflicts.  Move to `Key` module.
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

The word "witness" on its own can be ambiguous because we use that word in the context of proving an operation is valid in an era.  To avoid any confusion, rename `SomeWitness` to `SomeSigningWitness`.

Furthermore, the constructor names in `SomeWitness` types conflict with that of `SomeSigningKey`.  Rename those constructors to end with `SigningWitness` instead of `SigningKey` to deconflict.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
