### PR TITLE
Release 8.9.0.0

### DIFF
--- a/cardano-cli/CHANGELOG.md
+++ b/cardano-cli/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog for cardano-cli
 
+## 8.9.0.0
+
+- Export `Cardano.CLI.Legacy.Options.pLegacyCardanoEra` for cardano-tesnet
+  (compatible)
+  [PR 286](https://github.com/input-output-hk/cardano-cli/pull/286)
+
+- Include fixes from cardano-api 8.20.1.0: https://github.com/input-output-hk/cardano-api/blob/main/cardano-api/CHANGELOG.md#82010
+  (compatible, bugfix)
+  [PR 283](https://github.com/input-output-hk/cardano-cli/pull/283)
+
+- Remove unused governance-related code
+  (improvement)
+  [PR 282](https://github.com/input-output-hk/cardano-cli/pull/282)
+
+- Fix typo in stake-pool help text and clarify drep queries arguments
+  (compatible)
+  [PR 281](https://github.com/input-output-hk/cardano-cli/pull/281)
+
+- Remove `--conway-era` flag
+  (breaking, improvement)
+  [PR 276](https://github.com/input-output-hk/cardano-cli/pull/276)
+
+- Era-based `stake-pool` command
+  (feature, compatible)
+  [PR 275](https://github.com/input-output-hk/cardano-cli/pull/275)
+
+- Fix git revision in `version` command
+  (compatible, bugfix)
+  [PR 274](https://github.com/input-output-hk/cardano-cli/pull/274)
+
+- Add support for `--drep-script-hash` `--always-abstain` `--always-no-confidence` to `vote-delegation-certificate` command
+  (feature, compatible)
+  [PR 272](https://github.com/input-output-hk/cardano-cli/pull/272)
+
 ## 8.8.0.0
 
 - Remove `Shelley` prefix on from errors

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.4
 
 name:                   cardano-cli
-version:                8.8.0.0
+version:                8.9.0.0
 synopsis:               The Cardano command-line interface
 description:            The Cardano command-line interface.
 copyright:              2020-2023 Input Output Global Inc (IOG).


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Release 8.9.0.0
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
   - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Additional context for the PR goes here.

If the PR fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
