### PR TITLE
Improve pre commit hook: make it block hlint issues

### DIFF
--- a/scripts/githooks/haskell-style-lint
+++ b/scripts/githooks/haskell-style-lint
@@ -7,15 +7,18 @@
 # ln -s $(git-root)/scripts/githooks/haskell-style-lint $(git rev-parse --git-dir)/hooks/pre-commit
 #
 
+hlint_rc="0"
+
 for x in $(git diff --staged --name-only --diff-filter=ACM "*.hs" | tr '\n' ' '); do
   if grep -qE '^#' "$x"; then
     echo "$x contains CPP.  Skipping."
   else
     stylish-haskell -i "$x"
   fi
-  # fail on linting issues
-  hlint "$x"
+  hlint "$x" || hlint_rc="1"
 done
 
 # fail if there are style issues
-git --no-pager diff --exit-code
+git --no-pager diff --exit-code || exit 1
+# if there are no style issue, there could be hlint issues:
+exit $hlint_rc

--- a/scripts/githooks/haskell-style-lint
+++ b/scripts/githooks/haskell-style-lint
@@ -7,16 +7,14 @@
 # ln -s $(git-root)/scripts/githooks/haskell-style-lint $(git rev-parse --git-dir)/hooks/pre-commit
 #
 
-for x in $(git diff --staged --name-only --diff-filter=ACM | tr '\n' ' '); do
-  if [ "${x##*.}" = "hs" ]; then
-    if grep -qE '^#' "$x"; then
-      echo "$x contains CPP.  Skipping."
-    else
-      stylish-haskell -i "$x"
-    fi
-    # fail on linting issues
-    hlint "$x"
+for x in $(git diff --staged --name-only --diff-filter=ACM "*.hs" | tr '\n' ' '); do
+  if grep -qE '^#' "$x"; then
+    echo "$x contains CPP.  Skipping."
+  else
+    stylish-haskell -i "$x"
   fi
+  # fail on linting issues
+  hlint "$x"
 done
 
 # fail if there are style issues


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Update to the pre-commit script, so that it fails on hlint errors
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Fixes https://github.com/input-output-hk/cardano-cli/issues/294

# How to trust this PR

1. Try the procedure described in https://github.com/input-output-hk/cardano-cli/issues/294. 
2. Witness that the `git commit -m "try commit"` step now fails

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] The change log section in the PR description has been filled in
- NA New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- NA The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- NA The changelog section in the PR is updated to describe the change
- [X] Self-reviewed the diff
