### PR TITLE
Disambiguate 2-n flags in governance new-committee action

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Actions.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Actions.hs
@@ -51,7 +51,7 @@ pGovernanceActionNewInfoCmd era = do
             NewInfoCmd
               <$> pNetwork
               <*> pGovActionDeposit
-              <*> pAnyStakeIdentifier
+              <*> pAnyStakeIdentifier Nothing
               <*> pProposalUrl
               <*> pProposalHashSource
               <*> pFileOutDirection "out-file" "Path to action file to be used later on with build or build-raw "
@@ -71,7 +71,7 @@ pGovernanceActionNewConstitutionCmd era = do
             NewConstitutionCmd
               <$> pNetwork
               <*> pGovActionDeposit
-              <*> pAnyStakeIdentifier
+              <*> pAnyStakeIdentifier Nothing
               <*> pPreviousGovernanceAction
               <*> pProposalUrl
               <*> pProposalHashSource
@@ -99,11 +99,11 @@ pNewCommitteeCmd =
   NewCommitteeCmd
     <$> pNetwork
     <*> pGovActionDeposit
-    <*> pAnyStakeIdentifier
+    <*> pAnyStakeIdentifier Nothing
     <*> pProposalUrl
     <*> pProposalHashSource
-    <*> many pAnyStakeIdentifier
-    <*> many ((,) <$> pAnyStakeIdentifier <*> pEpochNo "Committee member expiry epoch")
+    <*> many (pAnyStakeIdentifier (Just "remove-cc"))
+    <*> many ((,) <$> pAnyStakeIdentifier (Just "add-cc") <*> pEpochNo "Committee member expiry epoch")
     <*> pRational "quorum" "Quorum of the committee that is necessary for a successful vote."
     <*> pPreviousGovernanceAction
     <*> pOutputFile
@@ -121,7 +121,7 @@ pGovernanceActionNoConfidenceCmd era = do
             NoConfidenceCmd
               <$> pNetwork
               <*> pGovActionDeposit
-              <*> pAnyStakeIdentifier
+              <*> pAnyStakeIdentifier Nothing
               <*> pProposalUrl
               <*> pProposalHashSource
               <*> pTxId "governance-action-tx-id" "Previous txid of `NoConfidence` or `NewCommittee` governance action."
@@ -130,10 +130,11 @@ pGovernanceActionNoConfidenceCmd era = do
         )
     $ Opt.progDesc "Create a no confidence proposal."
 
-pAnyStakeIdentifier :: Parser AnyStakeIdentifier
-pAnyStakeIdentifier =
-  asum [ AnyStakePoolKey <$> pStakePoolVerificationKeyOrHashOrFile
-       , AnyStakeKey <$> pStakeVerificationKeyOrHashOrFile
+-- | The first argument is the optional prefix.
+pAnyStakeIdentifier :: Maybe String -> Parser AnyStakeIdentifier
+pAnyStakeIdentifier prefix =
+  asum [ AnyStakePoolKey <$> pStakePoolVerificationKeyOrHashOrFile prefix
+       , AnyStakeKey <$> pStakeVerificationKeyOrHashOrFile prefix
        ]
 
 pGovernanceActionProtocolParametersUpdateCmd
@@ -321,10 +322,10 @@ pGovernanceActionTreasuryWithdrawalCmd era = do
             TreasuryWithdrawalCmd
               <$> pNetwork
               <*> pGovActionDeposit
-              <*> pAnyStakeIdentifier
+              <*> pAnyStakeIdentifier Nothing
               <*> pProposalUrl
               <*> pProposalHashSource
-              <*> many ((,) <$> pAnyStakeIdentifier <*> pTransferAmt)
+              <*> many ((,) <$> pAnyStakeIdentifier Nothing <*> pTransferAmt) -- TODO we should likely pass a prefix here, becaus pAnyStakeIdentiefier is used twice
               <*> pFileOutDirection "out-file" "Output filepath of the treasury withdrawal."
         )
     $ Opt.progDesc "Create a treasury withdrawal."

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Vote.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Vote.hs
@@ -52,5 +52,5 @@ pAnyVote cOnwards =
 pAnyVotingStakeVerificationKeyOrHashOrFile :: Parser AnyVotingStakeVerificationKeyOrHashOrFile
 pAnyVotingStakeVerificationKeyOrHashOrFile =
   asum [ AnyDRepVerificationKeyOrHashOrFile <$> pDRepVerificationKeyOrHashOrFile
-       , AnyStakePoolVerificationKeyOrHashOrFile <$> pStakePoolVerificationKeyOrHashOrFile
+       , AnyStakePoolVerificationKeyOrHashOrFile <$> pStakePoolVerificationKeyOrHashOrFile Nothing
        ]

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Node.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Node.hs
@@ -74,7 +74,7 @@ pKeyHashVRF =
 pNewCounter :: Parser (NodeCmds era)
 pNewCounter =
   NodeNewCounter
-    <$> pColdVerificationKeyOrFile
+    <$> pColdVerificationKeyOrFile Nothing
     <*> pCounterValue
     <*> pOperatorCertIssueCounterFile
 

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Query.hs
@@ -170,7 +170,7 @@ pAllStakePoolsOrOnly = pAll <|> pOnly
           , Opt.help "Query for all stake pools"
           ]
         pOnly :: Parser (AllOrOnly [Hash StakePoolKey])
-        pOnly = Only <$> many pStakePoolVerificationKeyHash
+        pOnly = Only <$> many (pStakePoolVerificationKeyHash Nothing)
 
 pQueryStakeSnapshot :: EnvCli -> Parser (QueryCmds era)
 pQueryStakeSnapshot envCli =
@@ -187,7 +187,7 @@ pQueryPoolState envCli =
     <$> pSocketPath envCli
     <*> pConsensusModeParams
     <*> pNetworkId envCli
-    <*> many pStakePoolVerificationKeyHash
+    <*> many (pStakePoolVerificationKeyHash Nothing)
 
 pQueryTxMempool :: EnvCli -> Parser (QueryCmds era)
 pQueryTxMempool envCli =
@@ -217,7 +217,7 @@ pLeadershipSchedule envCli =
     <*> pConsensusModeParams
     <*> pNetworkId envCli
     <*> pGenesisFile "Shelley genesis filepath"
-    <*> pStakePoolVerificationKeyOrHashOrFile
+    <*> pStakePoolVerificationKeyOrHashOrFile Nothing
     <*> pVrfSigningKeyFile
     <*> pWhichLeadershipSchedule
     <*> pMaybeOutputFile

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/StakeAddress.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/StakeAddress.hs
@@ -60,7 +60,7 @@ pStakeAddressKeyHashCmd era = do
     $ subParser "key-hash"
     $ Opt.info
         ( StakeAddressKeyHashCmd w
-            <$> pStakeVerificationKeyOrFile
+            <$> pStakeVerificationKeyOrFile Nothing
             <*> pMaybeOutputFile
         )
     $ Opt.progDesc "Print the hash of a stake address key"
@@ -121,7 +121,7 @@ pStakeAddressStakeDelegationCertificateCmd era = do
     $ Opt.info
         ( StakeAddressStakeDelegationCertificateCmd w
             <$> pStakeIdentifier
-            <*> pStakePoolVerificationKeyOrHashOrFile
+            <*> pStakePoolVerificationKeyOrHashOrFile Nothing
             <*> pOutputFile
         )
     $ Opt.progDesc
@@ -140,7 +140,7 @@ pStakeAddressStakeAndVoteDelegationCertificateCmd era = do
     $ Opt.info
         ( StakeAddressStakeAndVoteDelegationCertificateCmd w
             <$> pStakeIdentifier
-            <*> pStakePoolVerificationKeyOrHashOrFile
+            <*> pStakePoolVerificationKeyOrHashOrFile Nothing
             <*> pVoteDelegationTarget
             <*> pOutputFile
         )

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/StakePool.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/StakePool.hs
@@ -24,7 +24,7 @@ import qualified Options.Applicative as Opt
 pStakePoolCmds :: CardanoEra era -> EnvCli -> Parser (StakePoolCmds era)
 pStakePoolCmds era envCli =
   asum $ catMaybes
-    [ pStakePoolRegistrationCertificiateCmd era envCli
+    [ pStakePoolRegistrationCertificateCmd era envCli
     , pStakePoolDeregistrationCertificateCmd era
     , Just
         $ subParser "id"
@@ -39,7 +39,7 @@ pStakePoolCmds era envCli =
 pStakePoolId :: Parser (StakePoolCmds era)
 pStakePoolId =
   StakePoolIdCmd
-    <$> pStakePoolVerificationKeyOrFile
+    <$> pStakePoolVerificationKeyOrFile Nothing
     <*> pPoolIdOutputFormat
     <*> pMaybeOutputFile
 
@@ -49,14 +49,14 @@ pStakePoolMetadataHashCmd =
     <$> pPoolMetadataFile
     <*> pMaybeOutputFile
 
-pStakePoolRegistrationCertificiateCmd :: CardanoEra era -> EnvCli -> Maybe (Parser (StakePoolCmds era))
-pStakePoolRegistrationCertificiateCmd era envCli = do
+pStakePoolRegistrationCertificateCmd :: CardanoEra era -> EnvCli -> Maybe (Parser (StakePoolCmds era))
+pStakePoolRegistrationCertificateCmd era envCli = do
   w <- maybeFeatureInEra era
   pure
     $ subParser "registration-certificate"
     $ Opt.info
         ( StakePoolRegistrationCertificateCmd w
-            <$> pStakePoolVerificationKeyOrFile
+            <$> pStakePoolVerificationKeyOrFile Nothing
             <*> pVrfVerificationKeyOrFile
             <*> pPoolPledge
             <*> pPoolCost
@@ -77,7 +77,7 @@ pStakePoolDeregistrationCertificateCmd era = do
     $ subParser "deregistration-certificate"
     $ Opt.info
         ( StakePoolDeregistrationCertificateCmd w
-            <$> pStakePoolVerificationKeyOrFile
+            <$> pStakePoolVerificationKeyOrFile Nothing
             <*> pEpochNo "The epoch number."
             <*> pOutputFile
         )

--- a/cardano-cli/src/Cardano/CLI/Legacy/Options.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Options.hs
@@ -179,7 +179,7 @@ pStakeAddressCmds envCli =
     pStakeAddressKeyHashCmd :: Parser LegacyStakeAddressCmds
     pStakeAddressKeyHashCmd =
       StakeAddressKeyHashCmd
-        <$> pStakeVerificationKeyOrFile
+        <$> pStakeVerificationKeyOrFile Nothing
         <*> pMaybeOutputFile
 
     pStakeAddressBuildCmd :: Parser LegacyStakeAddressCmds
@@ -210,7 +210,7 @@ pStakeAddressCmds envCli =
       StakeAddressDelegationCertificateCmd
         <$> pAnyShelleyBasedEra envCli
         <*> pStakeIdentifier
-        <*> pStakePoolVerificationKeyOrHashOrFile
+        <*> pStakePoolVerificationKeyOrHashOrFile Nothing
         <*> pOutputFile
 
 pKeyCmds :: Parser LegacyKeyCmds
@@ -725,7 +725,7 @@ pNodeCmds =
     pNewCounter :: Parser LegacyNodeCmds
     pNewCounter =
       NodeNewCounter
-        <$> pColdVerificationKeyOrFile
+        <$> pColdVerificationKeyOrFile Nothing
         <*> pCounterValue
         <*> pOperatorCertIssueCounterFile
 
@@ -766,7 +766,7 @@ pStakePoolCmds  envCli =
     pStakePoolId :: Parser LegacyStakePoolCmds
     pStakePoolId =
       StakePoolIdCmd
-        <$> pStakePoolVerificationKeyOrFile
+        <$> pStakePoolVerificationKeyOrFile Nothing
         <*> pPoolIdOutputFormat
         <*> pMaybeOutputFile
 
@@ -924,7 +924,7 @@ pQueryCmds envCli =
               , Opt.help "Query for all stake pools"
               ]
             pOnly :: Parser (AllOrOnly [Hash StakePoolKey])
-            pOnly = Only <$> many pStakePoolVerificationKeyHash
+            pOnly = Only <$> many (pStakePoolVerificationKeyHash Nothing)
 
     pQueryStakeSnapshot :: Parser LegacyQueryCmds
     pQueryStakeSnapshot =
@@ -941,7 +941,7 @@ pQueryCmds envCli =
         <$> pSocketPath envCli
         <*> pConsensusModeParams
         <*> pNetworkId envCli
-        <*> many pStakePoolVerificationKeyHash
+        <*> many (pStakePoolVerificationKeyHash Nothing)
 
     pQueryTxMempool :: Parser LegacyQueryCmds
     pQueryTxMempool =
@@ -971,7 +971,7 @@ pQueryCmds envCli =
         <*> pConsensusModeParams
         <*> pNetworkId envCli
         <*> pGenesisFile "Shelley genesis filepath"
-        <*> pStakePoolVerificationKeyOrHashOrFile
+        <*> pStakePoolVerificationKeyOrHashOrFile Nothing
         <*> pVrfSigningKeyFile
         <*> pWhichLeadershipSchedule
         <*> pMaybeOutputFile
@@ -1395,7 +1395,7 @@ pStakePoolRegistrationCertificiateCmd :: EnvCli -> Parser LegacyStakePoolCmds
 pStakePoolRegistrationCertificiateCmd envCli =
   StakePoolRegistrationCertificateCmd
     <$> pAnyShelleyBasedEra envCli
-    <*> pStakePoolVerificationKeyOrFile
+    <*> pStakePoolVerificationKeyOrFile Nothing
     <*> pVrfVerificationKeyOrFile
     <*> pPoolPledge
     <*> pPoolCost
@@ -1411,7 +1411,7 @@ pStakePoolDeregistrationCertificateCmd :: EnvCli -> Parser LegacyStakePoolCmds
 pStakePoolDeregistrationCertificateCmd envCli =
   StakePoolDeregistrationCertificateCmd
     <$> pAnyShelleyBasedEra envCli
-    <*> pStakePoolVerificationKeyOrFile
+    <*> pStakePoolVerificationKeyOrFile Nothing
     <*> pEpochNo "The epoch number."
     <*> pOutputFile
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -6502,20 +6502,20 @@ Usage: cardano-cli conway governance action create-new-committee
                                                                    | --proposal-file FILE
                                                                    | --proposal-hash HASH
                                                                    )
-                                                                   [ --stake-pool-verification-key STRING
-                                                                   | --cold-verification-key-file FILE
-                                                                   | --stake-pool-id STAKE_POOL_ID
-                                                                   | --stake-verification-key STRING
-                                                                   | --stake-verification-key-file FILE
-                                                                   | --stake-key-hash HASH
+                                                                   [ --remove-cc-stake-pool-verification-key STRING
+                                                                   | --remove-cc-cold-verification-key-file FILE
+                                                                   | --remove-cc-stake-pool-id STAKE_POOL_ID
+                                                                   | --remove-cc-stake-verification-key STRING
+                                                                   | --remove-cc-stake-verification-key-file FILE
+                                                                   | --remove-cc-stake-key-hash HASH
                                                                    ]
                                                                    [
-                                                                     ( --stake-pool-verification-key STRING
-                                                                     | --cold-verification-key-file FILE
-                                                                     | --stake-pool-id STAKE_POOL_ID
-                                                                     | --stake-verification-key STRING
-                                                                     | --stake-verification-key-file FILE
-                                                                     | --stake-key-hash HASH
+                                                                     ( --add-cc-stake-pool-verification-key STRING
+                                                                     | --add-cc-cold-verification-key-file FILE
+                                                                     | --add-cc-stake-pool-id STAKE_POOL_ID
+                                                                     | --add-cc-stake-verification-key STRING
+                                                                     | --add-cc-stake-verification-key-file FILE
+                                                                     | --add-cc-stake-key-hash HASH
                                                                      )
                                                                      --epoch NATURAL]
                                                                    --quorum RATIONAL

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_create-new-committee.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_create-new-committee.cli
@@ -15,20 +15,20 @@ Usage: cardano-cli conway governance action create-new-committee
                                                                    | --proposal-file FILE
                                                                    | --proposal-hash HASH
                                                                    )
-                                                                   [ --stake-pool-verification-key STRING
-                                                                   | --cold-verification-key-file FILE
-                                                                   | --stake-pool-id STAKE_POOL_ID
-                                                                   | --stake-verification-key STRING
-                                                                   | --stake-verification-key-file FILE
-                                                                   | --stake-key-hash HASH
+                                                                   [ --remove-cc-stake-pool-verification-key STRING
+                                                                   | --remove-cc-cold-verification-key-file FILE
+                                                                   | --remove-cc-stake-pool-id STAKE_POOL_ID
+                                                                   | --remove-cc-stake-verification-key STRING
+                                                                   | --remove-cc-stake-verification-key-file FILE
+                                                                   | --remove-cc-stake-key-hash HASH
                                                                    ]
                                                                    [
-                                                                     ( --stake-pool-verification-key STRING
-                                                                     | --cold-verification-key-file FILE
-                                                                     | --stake-pool-id STAKE_POOL_ID
-                                                                     | --stake-verification-key STRING
-                                                                     | --stake-verification-key-file FILE
-                                                                     | --stake-key-hash HASH
+                                                                     ( --add-cc-stake-pool-verification-key STRING
+                                                                     | --add-cc-cold-verification-key-file FILE
+                                                                     | --add-cc-stake-pool-id STAKE_POOL_ID
+                                                                     | --add-cc-stake-verification-key STRING
+                                                                     | --add-cc-stake-verification-key-file FILE
+                                                                     | --add-cc-stake-key-hash HASH
                                                                      )
                                                                      --epoch NATURAL]
                                                                    --quorum RATIONAL
@@ -60,32 +60,34 @@ Available options:
   --proposal-text TEXT     Input proposal as UTF-8 encoded text.
   --proposal-file FILE     Input proposal as a text file.
   --proposal-hash HASH     Proposal anchor data hash.
-  --stake-pool-verification-key STRING
+  --remove-cc-stake-pool-verification-key STRING
                            Stake pool verification key (Bech32 or hex-encoded).
-  --cold-verification-key-file FILE
+  --remove-cc-cold-verification-key-file FILE
                            Filepath of the stake pool verification key.
-  --stake-pool-id STAKE_POOL_ID
+  --remove-cc-stake-pool-id STAKE_POOL_ID
                            Stake pool ID/verification key hash (either
                            Bech32-encoded or hex-encoded). Zero or more
                            occurences of this option is allowed.
-  --stake-verification-key STRING
+  --remove-cc-stake-verification-key STRING
                            Stake verification key (Bech32 or hex-encoded).
-  --stake-verification-key-file FILE
+  --remove-cc-stake-verification-key-file FILE
                            Filepath of the staking verification key.
-  --stake-key-hash HASH    Stake verification key hash (hex-encoded).
-  --stake-pool-verification-key STRING
+  --remove-cc-stake-key-hash HASH
+                           Stake verification key hash (hex-encoded).
+  --add-cc-stake-pool-verification-key STRING
                            Stake pool verification key (Bech32 or hex-encoded).
-  --cold-verification-key-file FILE
+  --add-cc-cold-verification-key-file FILE
                            Filepath of the stake pool verification key.
-  --stake-pool-id STAKE_POOL_ID
+  --add-cc-stake-pool-id STAKE_POOL_ID
                            Stake pool ID/verification key hash (either
                            Bech32-encoded or hex-encoded). Zero or more
                            occurences of this option is allowed.
-  --stake-verification-key STRING
+  --add-cc-stake-verification-key STRING
                            Stake verification key (Bech32 or hex-encoded).
-  --stake-verification-key-file FILE
+  --add-cc-stake-verification-key-file FILE
                            Filepath of the staking verification key.
-  --stake-key-hash HASH    Stake verification key hash (hex-encoded).
+  --add-cc-stake-key-hash HASH
+                           Stake verification key hash (hex-encoded).
   --epoch NATURAL          Committee member expiry epoch
   --quorum RATIONAL        Quorum of the committee that is necessary for a
                            successful vote.


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    A number of flags appeared in the parameters of new-committee multiple times, with the same long flag, making the parser break. This PR disambiguates the repeated occurences.
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way <- Clément: I believe right?
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Contributes to fixing https://github.com/input-output-hk/cardano-cli/issues/300

# How to trust this PR

This PR is mostly boilerplate, but there is one thing to make sure of:

When a `prefix` argument is introduced in a parser, it is used _in all branches_ of the parser. For example in this snippet:

```hs
asum [ AnyStakePoolKey <$> pStakePoolVerificationKeyOrHashOrFile prefix
       , AnyStakeKey <$> pStakeVerificationKeyOrHashOrFile prefix
       ]
```

It is important to pass `prefix` to every branch of the `asum`. Otherwise we could create inconsistent parsers. I have made sure this was correct.

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- NA The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [X] The changelog section in the PR is updated to describe the change
- [X] Self-reviewed the diff