### PR TITLE
new-committee: use committee cold key

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/Actions.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/Actions.hs
@@ -54,8 +54,8 @@ data NewCommitteeCmd
     , ebReturnAddress :: AnyStakeIdentifier
     , ebProposalUrl :: ProposalUrl
     , ebProposalHashSource :: ProposalHashSource
-    , ebOldCommittee :: [AnyStakeIdentifier]
-    , ebNewCommittee :: [(AnyStakeIdentifier, EpochNo)]
+    , ebOldCommittee :: [VerificationKeyOrHashOrFile CommitteeColdKey]
+    , ebNewCommittee :: [(VerificationKeyOrHashOrFile CommitteeColdKey, EpochNo)]
     , ebRequiredQuorum :: Rational
     , ebPreviousGovActionId :: Maybe (TxId, Word32)
     , ebFilePath :: File () Out

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Actions.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Actions.hs
@@ -102,8 +102,8 @@ pNewCommitteeCmd =
     <*> pAnyStakeIdentifier Nothing
     <*> pProposalUrl
     <*> pProposalHashSource
-    <*> many (pAnyStakeIdentifier (Just "remove-cc"))
-    <*> many ((,) <$> pAnyStakeIdentifier (Just "add-cc") <*> pEpochNo "Committee member expiry epoch")
+    <*> many (pCommitteeColdVerificationKeyOrHashOrFile {- (Just "remove-cc") -}) -- TODO replug prefix
+    <*> many ((,) <$> pCommitteeColdVerificationKeyOrHashOrFile {- (Just "add-cc") -} <*> pEpochNo "Committee member expiry epoch")
     <*> pRational "quorum" "Quorum of the committee that is necessary for a successful vote."
     <*> pPreviousGovernanceAction
     <*> pOutputFile

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Actions.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Actions.hs
@@ -151,8 +151,8 @@ runGovernanceActionCreateNewCommitteeCmd cOn (NewCommitteeCmd network deposit re
         , Ledger.anchorDataHash = proposalHash
         }
 
-  oldCommitteeKeyHashes <- mapM readStakeKeyHash old
-  newCommitteeKeyHashes <- mapM (\(stakeKey, expEpoch) -> (,expEpoch) <$> readStakeKeyHash stakeKey) new
+  oldCommitteeKeyHashes <- mapM readVerificationKeyHash old
+  newCommitteeKeyHashes <- mapM (\(stakeKey, expEpoch) -> (,expEpoch) <$> readVerificationKeyHash stakeKey) new
 
   returnKeyHash <- readStakeKeyHash retAddr
 
@@ -203,6 +203,11 @@ readStakeKeyHash anyStake =
       StakePoolKeyHash t <- firstExceptT GovernanceActionsCmdReadFileError
                               . newExceptT $ readVerificationKeyOrHashOrFile AsStakePoolKey stake
       return $ StakeKeyHash $ coerceKeyRole t
+
+readVerificationKeyHash :: VerificationKeyOrHashOrFile CommitteeColdKey -> ExceptT GovernanceActionsError IO (Hash CommitteeColdKey)
+readVerificationKeyHash keyOrHashOrFile =
+  firstExceptT GovernanceActionsCmdReadFileError
+    . newExceptT $ readVerificationKeyOrHashOrFile AsCommitteeColdKey keyOrHashOrFile
 
 runGovernanceActionTreasuryWithdrawalCmd
   :: ConwayEraOnwards era


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Make the `new-committee` command reach its final API (see [here](https://github.com/input-output-hk/cardano-cli/issues/300#issuecomment-1731004496))
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

:warning: Depends on these PRs to be merged first :construction: 

- [X] https://github.com/input-output-hk/cardano-api/pull/264
- [x] https://github.com/input-output-hk/cardano-haskell-packages/pull/510
- [ ] [Other PR to update to cardano-api 8.21.0.0](https://github.com/input-output-hk/cardano-cli/pull/307) (or possibly 307 will replace this one altogether)

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] The change log section in the PR description has been filled in
- NA New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [X] The changelog section in the PR is updated to describe the change
- [X] Self-reviewed the diff