### PR TITLE
Update cardano-api to 8.21.0.0

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -14,7 +14,7 @@ repository cardano-haskell-packages
 -- you need to run if you change them
 index-state:
   , hackage.haskell.org 2023-08-08T19:56:09Z
-  , cardano-haskell-packages 2023-09-19T21:43:40Z
+  , cardano-haskell-packages 2023-09-25T12:05:37Z
 
 packages:
   cardano-cli

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -200,7 +200,7 @@ library
                       , binary
                       , bytestring
                       , canonical-json
-                      , cardano-api ^>= 8.20.2
+                      , cardano-api ^>= 8.21.0
                       , cardano-binary
                       , cardano-crypto
                       , cardano-crypto-class ^>= 2.1.2

--- a/cardano-cli/src/Cardano/CLI/Byron/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Parsers.hs
@@ -306,7 +306,7 @@ parseTxOut =
   pLovelaceTxOut l =
     if l > (maxBound :: Word64)
     then error $ show l <> " lovelace exceeds the Word64 upper bound"
-    else TxOutAdaOnly AdaOnlyInByronEra . Lovelace $ toInteger l
+    else TxOutAdaOnly ByronToAllegraEraByron . Lovelace $ toInteger l
 
 readerFromAttoParser :: Atto.Parser a -> Opt.ReadM a
 readerFromAttoParser p =

--- a/cardano-cli/src/Cardano/CLI/Byron/Tx.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Tx.hs
@@ -157,7 +157,7 @@ txSpendGenesisUTxOByronPBFT gc nId sk (ByronAddress bAddr) outs = do
             , txOuts = outs
             , txTotalCollateral = TxTotalCollateralNone
             , txReturnCollateral = TxReturnCollateralNone
-            , txFee = TxFeeImplicit TxFeesImplicitInByronEra
+            , txFee = TxFeeImplicit ByronEraOnlyByron
             , txValidityRange =
                 ( TxValidityNoLowerBound
                 , TxValidityNoUpperBound ValidityNoUpperBoundInByronEra
@@ -206,7 +206,7 @@ txSpendUTxOByronPBFT nId sk txIns outs = do
           , txOuts = outs
           , txTotalCollateral = TxTotalCollateralNone
           , txReturnCollateral = TxReturnCollateralNone
-          , txFee = TxFeeImplicit TxFeesImplicitInByronEra
+          , txFee = TxFeeImplicit ByronEraOnlyByron
           , txValidityRange =
               ( TxValidityNoLowerBound
               , TxValidityNoUpperBound ValidityNoUpperBoundInByronEra

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/Actions.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/Actions.hs
@@ -54,8 +54,8 @@ data NewCommitteeCmd
     , ebReturnAddress :: AnyStakeIdentifier
     , ebProposalUrl :: ProposalUrl
     , ebProposalHashSource :: ProposalHashSource
-    , ebOldCommittee :: [AnyStakeIdentifier]
-    , ebNewCommittee :: [(AnyStakeIdentifier, EpochNo)]
+    , ebOldCommittee :: [VerificationKeyOrHashOrFile CommitteeColdKey]
+    , ebNewCommittee :: [(VerificationKeyOrHashOrFile CommitteeColdKey, EpochNo)]
     , ebRequiredQuorum :: Rational
     , ebPreviousGovActionId :: Maybe (TxId, Word32)
     , ebFilePath :: File () Out

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance.hs
@@ -44,7 +44,7 @@ pGovernanceCmds era envCli =
 
 pCreateMirCertificatesCmds :: CardanoEra era -> Maybe (Parser (GovernanceCmds era))
 pCreateMirCertificatesCmds era = do
-  w <- maybeFeatureInEra era
+  w <- maybeEonInEra era
   pure
     $ subParser "create-mir-certificate"
     $ Opt.info (pMIRPayStakeAddresses w <|> mirCertParsers w)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Actions.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Actions.hs
@@ -43,7 +43,7 @@ pGovernanceActionNewInfoCmd
   :: CardanoEra era
   -> Maybe (Parser (GovernanceActionCmds era))
 pGovernanceActionNewInfoCmd era = do
-  cOn <- maybeFeatureInEra era
+  cOn <- maybeEonInEra era
   pure
     $ subParser "create-info"
     $ Opt.info
@@ -63,7 +63,7 @@ pGovernanceActionNewConstitutionCmd
   :: CardanoEra era
   -> Maybe (Parser (GovernanceActionCmds era))
 pGovernanceActionNewConstitutionCmd era = do
-  cOn <- maybeFeatureInEra era
+  cOn <- maybeEonInEra era
   pure
     $ subParser "create-constitution"
     $ Opt.info
@@ -85,7 +85,7 @@ pGovernanceActionNewCommitteeCmd
   :: CardanoEra era
   -> Maybe (Parser (GovernanceActionCmds era))
 pGovernanceActionNewCommitteeCmd era = do
-  cOn <- maybeFeatureInEra era
+  cOn <- maybeEonInEra era
   pure
     $ subParser "create-new-committee"
     $ Opt.info
@@ -113,7 +113,7 @@ pGovernanceActionNoConfidenceCmd
   :: CardanoEra era
   -> Maybe (Parser (GovernanceActionCmds era))
 pGovernanceActionNoConfidenceCmd era = do
-  cOn <- maybeFeatureInEra era
+  cOn <- maybeEonInEra era
   pure
     $ subParser "create-no-confidence"
     $ Opt.info
@@ -142,7 +142,7 @@ pGovernanceActionProtocolParametersUpdateCmd :: ()
   => CardanoEra era
   -> Maybe (Parser (GovernanceActionCmds era))
 pGovernanceActionProtocolParametersUpdateCmd era = do
-  w <- maybeFeatureInEra era
+  w <- maybeEonInEra era
   pure
     $ subParser "create-protocol-parameters-update"
     $ Opt.info
@@ -277,7 +277,7 @@ dpGovActionProtocolParametersUpdate = \case
 
 pGovernanceActionTreasuryWithdrawalCmd :: CardanoEra era -> Maybe (Parser (GovernanceActionCmds era))
 pGovernanceActionTreasuryWithdrawalCmd era = do
-  cOn <- maybeFeatureInEra era
+  cOn <- maybeEonInEra era
   pure
     $ subParser "create-treasury-withdrawal"
     $ Opt.info

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Actions.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Actions.hs
@@ -102,8 +102,8 @@ pNewCommitteeCmd =
     <*> pAnyStakeIdentifier Nothing
     <*> pProposalUrl
     <*> pProposalHashSource
-    <*> many (pAnyStakeIdentifier (Just "remove-cc"))
-    <*> many ((,) <$> pAnyStakeIdentifier (Just "add-cc") <*> pEpochNo "Committee member expiry epoch")
+    <*> many (pCommitteeColdVerificationKeyOrHashOrFile {- (Just "remove-cc") -}) -- TODO replug prefix
+    <*> many ((,) <$> pCommitteeColdVerificationKeyOrHashOrFile {- (Just "add-cc") -} <*> pEpochNo "Committee member expiry epoch")
     <*> pRational "quorum" "Quorum of the committee that is necessary for a successful vote."
     <*> pPreviousGovernanceAction
     <*> pOutputFile

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Committee.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Committee.hs
@@ -33,7 +33,7 @@ pGovernanceCommitteeKeyGenColdCmd :: ()
   => CardanoEra era
   -> Maybe (Parser (GovernanceCommitteeCmds era))
 pGovernanceCommitteeKeyGenColdCmd era = do
-  w <- maybeFeatureInEra era
+  w <- maybeEonInEra era
   pure
     $ subParser "key-gen-cold"
     $ Opt.info (pCmd w)
@@ -54,7 +54,7 @@ pGovernanceCommitteeKeyGenHotCmd :: ()
   => CardanoEra era
   -> Maybe (Parser (GovernanceCommitteeCmds era))
 pGovernanceCommitteeKeyGenHotCmd era = do
-  w <- maybeFeatureInEra era
+  w <- maybeEonInEra era
   pure
     $ subParser "key-gen-hot"
     $ Opt.info (pCmd w)
@@ -75,7 +75,7 @@ pGovernanceCommitteeKeyHashCmd :: ()
   => CardanoEra era
   -> Maybe (Parser (GovernanceCommitteeCmds era))
 pGovernanceCommitteeKeyHashCmd era = do
-  w <- maybeFeatureInEra era
+  w <- maybeEonInEra era
   pure
     $ subParser "key-hash"
     $ Opt.info
@@ -91,7 +91,7 @@ pGovernanceCommitteeCreateHotKeyAuthorizationCertificateCmd :: ()
   => CardanoEra era
   -> Maybe (Parser (GovernanceCommitteeCmds era))
 pGovernanceCommitteeCreateHotKeyAuthorizationCertificateCmd era = do
-  w <- maybeFeatureInEra era
+  w <- maybeEonInEra era
   pure
     $ subParser "create-hot-key-authorization-certificate"
     $ Opt.info
@@ -109,7 +109,7 @@ pGovernanceCommitteeCreateColdKeyResignationCertificateCmd :: ()
   => CardanoEra era
   -> Maybe (Parser (GovernanceCommitteeCmds era))
 pGovernanceCommitteeCreateColdKeyResignationCertificateCmd era = do
-  w <- maybeFeatureInEra era
+  w <- maybeEonInEra era
   pure
     $ subParser "create-cold-key-resignation-certificate"
     $ Opt.info

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/DRep.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/DRep.hs
@@ -123,8 +123,8 @@ data AnyEraDecider era where
   AnyEraDeciderShelleyToBabbage :: ShelleyToBabbageEra era -> AnyEraDecider era
   AnyEraDeciderConwayOnwards :: ConwayEraOnwards era -> AnyEraDecider era
 
-instance FeatureInEra AnyEraDecider where
-  featureInEra no yes = \case
+instance Eon AnyEraDecider where
+  inEonForEra no yes = \case
     ByronEra    -> no
     ShelleyEra  -> yes $ AnyEraDeciderShelleyToBabbage ShelleyToBabbageEraShelley
     AllegraEra  -> yes $ AnyEraDeciderShelleyToBabbage ShelleyToBabbageEraAllegra

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/DRep.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/DRep.hs
@@ -43,7 +43,7 @@ pGovernanceDRepKeyGenCmd :: ()
   => CardanoEra era
   -> Maybe (Parser (GovernanceDRepCmds era))
 pGovernanceDRepKeyGenCmd era = do
-  w <- maybeFeatureInEra era
+  w <- maybeEonInEra era
   pure
     $ subParser "key-gen"
     $ Opt.info
@@ -57,7 +57,7 @@ pGovernanceDRepKeyIdCmd :: ()
   => CardanoEra era
   -> Maybe (Parser (GovernanceDRepCmds era))
 pGovernanceDRepKeyIdCmd era = do
-  w <- maybeFeatureInEra era
+  w <- maybeEonInEra era
   pure
     $ subParser "id"
     $ Opt.info
@@ -87,7 +87,7 @@ pRegistrationCertificateCmd :: ()
   -> EnvCli
   -> Maybe (Parser (GovernanceDRepCmds era))
 pRegistrationCertificateCmd era envCli = do
-  w <- maybeFeatureInEra era
+  w <- maybeEonInEra era
   pure
     $ subParser "registration-certificate"
     $ Opt.info (pEraCmd envCli w)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Query.hs
@@ -33,7 +33,7 @@ pGovernanceQueryGetConstitutionCmd :: ()
   -> EnvCli
   -> Maybe (Parser (GovernanceQueryCmds era))
 pGovernanceQueryGetConstitutionCmd era env = do
-  cOn <- maybeFeatureInEra era
+  cOn <- maybeEonInEra era
   pure
     $ subParser "constitution"
     $ Opt.info (GovernanceQueryConstitutionCmd cOn <$> pNoArgQueryCmd env)
@@ -44,7 +44,7 @@ pGovernanceQueryGetGovStateCmd :: ()
   -> EnvCli
   -> Maybe (Parser (GovernanceQueryCmds era))
 pGovernanceQueryGetGovStateCmd era env = do
-  cOn <- maybeFeatureInEra era
+  cOn <- maybeEonInEra era
   pure
     $ subParser "gov-state"
     $ Opt.info (GovernanceQueryGovStateCmd cOn <$> pNoArgQueryCmd env)
@@ -60,7 +60,7 @@ pGovernanceQueryDRepStateCmd :: ()
   -> EnvCli
   -> Maybe (Parser (GovernanceQueryCmds era))
 pGovernanceQueryDRepStateCmd era env = do
-  cOn <- maybeFeatureInEra era
+  cOn <- maybeEonInEra era
   pure
     $ subParser "drep-state"
     $ Opt.info (GovernanceQueryDRepStateCmd cOn <$> pDRepStateQueryCmd)
@@ -79,7 +79,7 @@ pGovernanceQueryDRepStakeDistributionCmd :: ()
   -> EnvCli
   -> Maybe (Parser (GovernanceQueryCmds era))
 pGovernanceQueryDRepStakeDistributionCmd era env = do
-  cOn <- maybeFeatureInEra era
+  cOn <- maybeEonInEra era
   pure
     $ subParser "drep-stake-distribution"
     $ Opt.info (GovernanceQueryDRepStakeDistributionCmd cOn <$> pDRepStakeDistributionQueryCmd)
@@ -98,7 +98,7 @@ pGovernanceQueryGetCommitteeStateCmd :: ()
   -> EnvCli
   -> Maybe (Parser (GovernanceQueryCmds era))
 pGovernanceQueryGetCommitteeStateCmd era env = do
-  cOn <- maybeFeatureInEra era
+  cOn <- maybeEonInEra era
   pure
     $ subParser "committee-state"
     $ Opt.info (GovernanceQueryCommitteeStateCmd cOn <$> pNoArgQueryCmd env)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Vote.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Vote.hs
@@ -32,7 +32,7 @@ pGovernanceVoteCreateCmd :: ()
   => CardanoEra era
   -> Maybe (Parser (GovernanceVoteCmds era))
 pGovernanceVoteCreateCmd era = do
-  w <- maybeFeatureInEra era
+  w <- maybeEonInEra era
   pure
     $ subParser "create"
     $ Opt.info

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/StakeAddress.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/StakeAddress.hs
@@ -39,7 +39,7 @@ pStakeAddressKeyGenCmd :: ()
   => CardanoEra era
   -> Maybe (Parser (StakeAddressCmds era))
 pStakeAddressKeyGenCmd era = do
-  w <- maybeFeatureInEra era
+  w <- maybeEonInEra era
   pure
     $ subParser "key-gen"
     $ Opt.info
@@ -54,7 +54,7 @@ pStakeAddressKeyHashCmd :: ()
   => CardanoEra era
   -> Maybe (Parser (StakeAddressCmds era))
 pStakeAddressKeyHashCmd era = do
-  w <- maybeFeatureInEra era
+  w <- maybeEonInEra era
   pure
     $ subParser "key-hash"
     $ Opt.info
@@ -69,7 +69,7 @@ pStakeAddressBuildCmd :: ()
   -> EnvCli
   -> Maybe (Parser (StakeAddressCmds era))
 pStakeAddressBuildCmd era envCli = do
-  w <- maybeFeatureInEra era
+  w <- maybeEonInEra era
   pure
     $ subParser "build"
     $ Opt.info
@@ -84,7 +84,7 @@ pStakeAddressRegistrationCertificateCmd :: ()
   => CardanoEra era
   -> Maybe (Parser (StakeAddressCmds era))
 pStakeAddressRegistrationCertificateCmd era = do
-  w <- maybeFeatureInEra era
+  w <- maybeEonInEra era
   pure
     $ subParser "registration-certificate"
     $ Opt.info
@@ -99,7 +99,7 @@ pStakeAddressDeregistrationCertificateCmd :: ()
   => CardanoEra era
   -> Maybe (Parser (StakeAddressCmds era))
 pStakeAddressDeregistrationCertificateCmd era = do
-  w <- maybeFeatureInEra era
+  w <- maybeEonInEra era
   pure
     $ subParser "deregistration-certificate"
     $ Opt.info
@@ -114,7 +114,7 @@ pStakeAddressStakeDelegationCertificateCmd :: ()
   => CardanoEra era
   -> Maybe (Parser (StakeAddressCmds era))
 pStakeAddressStakeDelegationCertificateCmd era = do
-  w <- maybeFeatureInEra era
+  w <- maybeEonInEra era
   pure
     $ subParser "stake-delegation-certificate"
     $ Opt.info
@@ -133,7 +133,7 @@ pStakeAddressStakeAndVoteDelegationCertificateCmd :: ()
   => CardanoEra era
   -> Maybe (Parser (StakeAddressCmds era))
 pStakeAddressStakeAndVoteDelegationCertificateCmd era = do
-  w <- maybeFeatureInEra era
+  w <- maybeEonInEra era
   pure
     $ subParser "stake-and-vote-delegation-certificate"
     $ Opt.info
@@ -153,7 +153,7 @@ pStakeAddressVoteDelegationCertificateCmd :: ()
   => CardanoEra era
   -> Maybe (Parser (StakeAddressCmds era))
 pStakeAddressVoteDelegationCertificateCmd era = do
-  w <- maybeFeatureInEra era
+  w <- maybeEonInEra era
   pure
     $ subParser "vote-delegation-certificate"
     $ Opt.info

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/StakePool.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/StakePool.hs
@@ -57,7 +57,7 @@ pStakePoolMetadataHashCmd =
 
 pStakePoolRegistrationCertificateCmd :: CardanoEra era -> EnvCli -> Maybe (Parser (StakePoolCmds era))
 pStakePoolRegistrationCertificateCmd era envCli = do
-  w <- maybeFeatureInEra era
+  w <- maybeEonInEra era
   pure
     $ subParser "registration-certificate"
     $ Opt.info
@@ -78,7 +78,7 @@ pStakePoolRegistrationCertificateCmd era envCli = do
 
 pStakePoolDeregistrationCertificateCmd :: CardanoEra era -> Maybe (Parser (StakePoolCmds era))
 pStakePoolDeregistrationCertificateCmd era = do
-  w <- maybeFeatureInEra era
+  w <- maybeEonInEra era
   pure
     $ subParser "deregistration-certificate"
     $ Opt.info

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Actions.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Actions.hs
@@ -151,8 +151,8 @@ runGovernanceActionCreateNewCommitteeCmd cOn (NewCommitteeCmd network deposit re
         , Ledger.anchorDataHash = proposalHash
         }
 
-  oldCommitteeKeyHashes <- mapM readStakeKeyHash old
-  newCommitteeKeyHashes <- mapM (\(stakeKey, expEpoch) -> (,expEpoch) <$> readStakeKeyHash stakeKey) new
+  oldCommitteeKeyHashes <- mapM readVerificationKeyHash old
+  newCommitteeKeyHashes <- mapM (\(stakeKey, expEpoch) -> (,expEpoch) <$> readVerificationKeyHash stakeKey) new
 
   returnKeyHash <- readStakeKeyHash retAddr
 
@@ -203,6 +203,11 @@ readStakeKeyHash anyStake =
       StakePoolKeyHash t <- firstExceptT GovernanceActionsCmdReadFileError
                               . newExceptT $ readVerificationKeyOrHashOrFile AsStakePoolKey stake
       return $ StakeKeyHash $ coerceKeyRole t
+
+readVerificationKeyHash :: VerificationKeyOrHashOrFile CommitteeColdKey -> ExceptT GovernanceActionsError IO (Hash CommitteeColdKey)
+readVerificationKeyHash keyOrHashOrFile =
+  firstExceptT GovernanceActionsCmdReadFileError
+    . newExceptT $ readVerificationKeyOrHashOrFile AsCommitteeColdKey keyOrHashOrFile
 
 runGovernanceActionTreasuryWithdrawalCmd
   :: ConwayEraOnwards era

--- a/cardano-cli/src/Cardano/CLI/Json/Friendly.hs
+++ b/cardano-cli/src/Cardano/CLI/Json/Friendly.hs
@@ -90,7 +90,7 @@ friendlyTxBody
       , txWithdrawals
       }) =
     [ "auxiliary scripts" .= friendlyAuxScripts txAuxScripts
-    , "certificates" .= inEraFeature era Null (`friendlyCertificates` txCertificates)
+    , "certificates" .= forEraInEon era Null (`friendlyCertificates` txCertificates)
     , "collateral inputs" .= friendlyCollateralInputs txInsCollateral
     , "era" .= era
     , "fee" .= friendlyFee txFee

--- a/cardano-cli/src/Cardano/CLI/Read.hs
+++ b/cardano-cli/src/Cardano/CLI/Read.hs
@@ -796,7 +796,7 @@ readTxGovernanceActions
   -> IO (Either ConstitutionError [Proposal era])
 readTxGovernanceActions _ [] = return $ Right []
 readTxGovernanceActions era files = runExceptT $ do
-  w <- maybeFeatureInEra era
+  w <- maybeEonInEra era
         & hoistMaybe (ConstitutionNotSupportedInEra $ cardanoEraConstraints era $ AnyCardanoEra era)
   newExceptT $ sequence <$> mapM (readProposal w) files
 

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1695160702,
-        "narHash": "sha256-+Mfc6eGA1ZwQ/ZjKzMoMWkHzd+sgR1JbxY0i849HjEU=",
+        "lastModified": 1695701948,
+        "narHash": "sha256-YUrtWWa+DponzzFg46oDCEMMnF2tQG/+WwK+auHeCsE=",
         "owner": "input-output-hk",
         "repo": "cardano-haskell-packages",
-        "rev": "9932690af3713ef034c928850252eb1b88450ee6",
+        "rev": "4c55186c53103fee3e3973d70a9ce8a3a55a8486",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Update cardano-api to 8.21.0.0 + make the `new-committee` use cold CC keys
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

* Follow-up of https://github.com/input-output-hk/cardano-api/pull/262

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff