### PR TITLE
Fourmolu formatting / nixified pre-commit hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,6 @@ cardano-tracer/cardano-tracer-test
 
 # IntellIJ project folder
 .idea/
+
+# pre-commit-hooks config file, which is generated from the flake
+.pre-commit-config.yaml

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -22,7 +22,7 @@ Flag unexpected_thunks
 common project-config
   default-language:     Haskell2010
 
-  default-extensions:   OverloadedStrings
+  default-extensions:   OverloadedStrings, ImportQualifiedPost
   build-depends:        base >= 4.14 && < 4.19
 
   ghc-options:          -Wall

--- a/cardano-cli/src/Cardano/CLI/Byron/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Commands.hs
@@ -10,111 +10,101 @@ module Cardano.CLI.Byron.Commands
   , NewCertificateFile (..)
   ) where
 
-import           Cardano.Api hiding (GenesisParameters)
-import           Cardano.Api.Byron hiding (GenesisParameters)
+import Cardano.Api hiding (GenesisParameters)
+import Cardano.Api.Byron hiding (GenesisParameters)
 
-import           Cardano.Chain.Update (InstallerHash (..), ProtocolVersion (..),
-                   SoftwareVersion (..), SystemTag (..))
-import           Cardano.CLI.Byron.Genesis
-import           Cardano.CLI.Byron.Key
-import           Cardano.CLI.Byron.Tx
-import           Cardano.CLI.Types.Common
+import Cardano.CLI.Byron.Genesis
+import Cardano.CLI.Byron.Key
+import Cardano.CLI.Byron.Tx
+import Cardano.CLI.Types.Common
+import Cardano.Chain.Update
+  ( InstallerHash (..)
+  , ProtocolVersion (..)
+  , SoftwareVersion (..)
+  , SystemTag (..)
+  )
 
-import           Data.String (IsString)
+import Data.String (IsString)
 
-data ByronCommand =
-
-  --- Node Related Commands ---
+data ByronCommand
+  = --- Node Related Commands ---
     NodeCmds
-        NodeCmds
-
-  --- Genesis Related Commands ---
-  | Genesis
-        NewDirectory
-        GenesisParameters
-
+      NodeCmds
+  | --- Genesis Related Commands ---
+    Genesis
+      NewDirectory
+      GenesisParameters
   | PrintGenesisHash
-        GenesisFile
-
-  --- Key Related Commands ---
-  | Keygen
-        NewSigningKeyFile
-
+      GenesisFile
+  | --- Key Related Commands ---
+    Keygen
+      NewSigningKeyFile
   | ToVerification
-        ByronKeyFormat
-        (SigningKeyFile In)
-        NewVerificationKeyFile
-
+      ByronKeyFormat
+      (SigningKeyFile In)
+      NewVerificationKeyFile
   | PrettySigningKeyPublic
-        ByronKeyFormat
-        (SigningKeyFile In)
-
+      ByronKeyFormat
+      (SigningKeyFile In)
   | MigrateDelegateKeyFrom
-        (SigningKeyFile In)
-        -- ^ Old key
-        NewSigningKeyFile
-        -- ^ New Key
-
+      (SigningKeyFile In)
+      -- ^ Old key
+      NewSigningKeyFile
+      -- ^ New Key
   | PrintSigningKeyAddress
-        ByronKeyFormat
-        NetworkId
-        (SigningKeyFile In)
-
-  | GetLocalNodeTip
-        SocketPath
-        NetworkId
-
-    -----------------------------------
-
-  | SubmitTx
-        SocketPath
-        NetworkId
-        (TxFile In)
-        -- ^ Filepath of transaction to submit.
-
-  | SpendGenesisUTxO
-        GenesisFile
-        NetworkId
-        ByronKeyFormat
-        NewTxFile
-        -- ^ Filepath of the newly created transaction.
-        (SigningKeyFile In)
-        -- ^ Signing key of genesis UTxO owner.
-        (Address ByronAddr)
-        -- ^ Genesis UTxO address.
-        [TxOut CtxTx ByronEra]
-        -- ^ Tx output.
-  | SpendUTxO
-        NetworkId
-        ByronKeyFormat
-        NewTxFile
-        -- ^ Filepath of the newly created transaction.
-        (SigningKeyFile In)
-        -- ^ Signing key of Tx underwriter.
-        [TxIn]
-        -- ^ Inputs available for spending to the Tx underwriter's key.
-        [TxOut CtxTx ByronEra]
-        -- ^ Genesis UTxO output Address.
-
-  | GetTxId (TxFile In)
-
-    --- Misc Commands ---
-
-  | ValidateCBOR
-        CBORObject
-        -- ^ Type of the CBOR object
-        FilePath
-
-  | PrettyPrintCBOR
-        FilePath
-  deriving Show
-
-
-data NodeCmds =
-    CreateVote
+      ByronKeyFormat
       NetworkId
       (SigningKeyFile In)
-      FilePath -- ^ filepath to update proposal
+  | GetLocalNodeTip
+      SocketPath
+      NetworkId
+  | -----------------------------------
+
+    -- | Filepath of transaction to submit.
+    SubmitTx
+      SocketPath
+      NetworkId
+      (TxFile In)
+  | SpendGenesisUTxO
+      GenesisFile
+      NetworkId
+      ByronKeyFormat
+      NewTxFile
+      -- ^ Filepath of the newly created transaction.
+      (SigningKeyFile In)
+      -- ^ Signing key of genesis UTxO owner.
+      (Address ByronAddr)
+      -- ^ Genesis UTxO address.
+      [TxOut CtxTx ByronEra]
+      -- ^ Tx output.
+  | SpendUTxO
+      NetworkId
+      ByronKeyFormat
+      NewTxFile
+      -- ^ Filepath of the newly created transaction.
+      (SigningKeyFile In)
+      -- ^ Signing key of Tx underwriter.
+      [TxIn]
+      -- ^ Inputs available for spending to the Tx underwriter's key.
+      [TxOut CtxTx ByronEra]
+      -- ^ Genesis UTxO output Address.
+  | GetTxId (TxFile In)
+  | --- Misc Commands ---
+
+    ValidateCBOR
+      CBORObject
+      -- ^ Type of the CBOR object
+      FilePath
+  | PrettyPrintCBOR
+      FilePath
+  deriving (Show)
+
+data NodeCmds
+  = CreateVote
+      NetworkId
+      (SigningKeyFile In)
+      FilePath
+      -- ^ filepath to update proposal
       Bool
       FilePath
   | UpdateProposal
@@ -126,16 +116,17 @@ data NodeCmds =
       InstallerHash
       FilePath
       ByronProtocolParametersUpdate
-  | SubmitUpdateProposal
+  | -- | Update proposal filepath.
+    SubmitUpdateProposal
       SocketPath
       NetworkId
-      FilePath -- ^ Update proposal filepath.
-  | SubmitVote
+      FilePath
+  | -- | Vote filepath.
+    SubmitVote
       SocketPath
       NetworkId
-      FilePath -- ^ Vote filepath.
-  deriving Show
+      FilePath
+  deriving (Show)
 
-newtype NewCertificateFile
-  = NewCertificateFile { nFp :: FilePath }
+newtype NewCertificateFile = NewCertificateFile {nFp :: FilePath}
   deriving (Eq, Show, IsString)

--- a/cardano-cli/src/Cardano/CLI/Byron/Delegation.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Delegation.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Cardano.CLI.Byron.Delegation
-  ( ByronDelegationError(..)
+  ( ByronDelegationError (..)
   , checkByronGenesisDelegation
   , issueByronGenesisDelegation
   , renderByronDelegationError
@@ -12,34 +12,34 @@ module Cardano.CLI.Byron.Delegation
   )
 where
 
-import           Cardano.Api.Byron
+import Cardano.Api.Byron
 
+import Cardano.CLI.Byron.Key (ByronKeyFailure, renderByronKeyFailure)
+import Cardano.CLI.Types.Common (CertificateFile (..))
 import qualified Cardano.Chain.Delegation as Dlg
-import           Cardano.Chain.Slotting (EpochNumber)
-import           Cardano.CLI.Byron.Key (ByronKeyFailure, renderByronKeyFailure)
-import           Cardano.CLI.Types.Common (CertificateFile (..))
-import           Cardano.Crypto (ProtocolMagicId)
+import Cardano.Chain.Slotting (EpochNumber)
+import Cardano.Crypto (ProtocolMagicId)
 import qualified Cardano.Crypto as Crypto
-import           Cardano.Ledger.Binary (Annotated (..), byronProtVer, serialize')
-import           Cardano.Prelude (canonicalDecodePretty, canonicalEncodePretty)
+import Cardano.Ledger.Binary (Annotated (..), byronProtVer, serialize')
+import Cardano.Prelude (canonicalDecodePretty, canonicalEncodePretty)
 
-import           Prelude hiding ((.))
+import Prelude hiding ((.))
 
-import           Control.Category
-import           Control.Monad (unless)
-import           Control.Monad.IO.Class (MonadIO (..))
-import           Control.Monad.Trans.Except (ExceptT)
-import           Control.Monad.Trans.Except.Extra (left)
-import           Data.ByteString (ByteString)
+import Control.Category
+import Control.Monad (unless)
+import Control.Monad.IO.Class (MonadIO (..))
+import Control.Monad.Trans.Except (ExceptT)
+import Control.Monad.Trans.Except.Extra (left)
+import Data.ByteString (ByteString)
 import qualified Data.ByteString.Lazy as LB
-import           Data.Text (Text)
-import           Formatting (Format, sformat)
+import Data.Text (Text)
+import Formatting (Format, sformat)
 
 data ByronDelegationError
   = CertificateValidationErrors !FilePath ![Text]
   | DlgCertificateDeserialisationFailed !FilePath !Text
   | ByronDelegationKeyError !ByronKeyFailure
-  deriving Show
+  deriving (Show)
 
 renderByronDelegationError :: ByronDelegationError -> Text
 renderByronDelegationError err =
@@ -51,6 +51,7 @@ renderByronDelegationError err =
     ByronDelegationKeyError kerr -> renderByronKeyFailure kerr
 
 -- TODO:  we need to support password-protected secrets.
+
 -- | Issue a certificate for genesis delegation to a delegate key, signed by the
 --   issuer key, for a given protocol magic and coming into effect at given epoch.
 issueByronGenesisDelegation
@@ -61,7 +62,7 @@ issueByronGenesisDelegation
   -> Dlg.Certificate
 issueByronGenesisDelegation magic epoch issuerSK delegateVK =
   Dlg.signCertificate magic delegateVK epoch $
-  Crypto.noPassSafeSigner issuerSK
+    Crypto.noPassSafeSigner issuerSK
 
 -- | Verify that a certificate signifies genesis delegation by assumed genesis key
 --   to a delegate key, for a given protocol magic.
@@ -79,44 +80,54 @@ checkByronGenesisDelegation (CertificateFile certF) magic issuer delegate = do
     Right (cert :: Dlg.Certificate) -> do
       let issues = checkDlgCert cert magic issuer delegate
       unless (null issues) $
-        left $ CertificateValidationErrors certF issues
+        left $
+          CertificateValidationErrors certF issues
 
 checkDlgCert
   :: Dlg.ACertificate a
   -> ProtocolMagicId
   -> Crypto.VerificationKey
-  -> Crypto.VerificationKey -> [Text]
+  -> Crypto.VerificationKey
+  -> [Text]
 checkDlgCert cert magic issuerVK' delegateVK' =
   mconcat
-  [ [ sformat "Certificate does not have a valid signature."
+    [ [ sformat "Certificate does not have a valid signature."
       | not (Dlg.isValid magic' cert')
-    ]
-  , [ sformat ("Certificate issuer ".vkF." doesn't match expected: ".vkF)
-      ( Dlg.issuerVK cert) issuerVK'
+      ]
+    , [ sformat
+        ("Certificate issuer " . vkF . " doesn't match expected: " . vkF)
+        (Dlg.issuerVK cert)
+        issuerVK'
       | Dlg.issuerVK cert /= issuerVK'
-    ]
-  , [ sformat ("Certificate delegate ".vkF." doesn't match expected: ".vkF)
-      ( Dlg.delegateVK cert) delegateVK'
+      ]
+    , [ sformat
+        ("Certificate delegate " . vkF . " doesn't match expected: " . vkF)
+        (Dlg.delegateVK cert)
+        delegateVK'
       | Dlg.delegateVK cert /= delegateVK'
+      ]
     ]
-  ]
-  where
-    magic' :: Annotated ProtocolMagicId ByteString
-    magic' = Annotated magic (serialize' byronProtVer magic)
+ where
+  magic' :: Annotated ProtocolMagicId ByteString
+  magic' = Annotated magic (serialize' byronProtVer magic)
 
-    epoch :: EpochNumber
-    epoch = unAnnotated $ Dlg.aEpoch cert
+  epoch :: EpochNumber
+  epoch = unAnnotated $ Dlg.aEpoch cert
 
-    cert' :: Dlg.ACertificate ByteString
-    cert' =
-      let unannotated = cert { Dlg.aEpoch = Annotated epoch ()
-                             , Dlg.annotation = () }
-      in unannotated { Dlg.annotation = serialize' byronProtVer unannotated
-                     , Dlg.aEpoch = Annotated epoch (serialize' byronProtVer epoch) }
+  cert' :: Dlg.ACertificate ByteString
+  cert' =
+    let unannotated =
+          cert
+            { Dlg.aEpoch = Annotated epoch ()
+            , Dlg.annotation = ()
+            }
+     in unannotated
+          { Dlg.annotation = serialize' byronProtVer unannotated
+          , Dlg.aEpoch = Annotated epoch (serialize' byronProtVer epoch)
+          }
 
-    vkF :: forall r. Format r (Crypto.VerificationKey -> r)
-    vkF = Crypto.fullVerificationKeyF
-
+  vkF :: forall r. Format r (Crypto.VerificationKey -> r)
+  vkF = Crypto.fullVerificationKeyF
 
 serialiseDelegationCert :: Dlg.Certificate -> ByteString
 serialiseDelegationCert = LB.toStrict . canonicalEncodePretty
@@ -126,4 +137,3 @@ serialiseByronWitness sk =
   case sk of
     AByronSigningKeyLegacy bSkey -> serialiseToRawBytes bSkey
     AByronSigningKey legBKey -> serialiseToRawBytes legBKey
-

--- a/cardano-cli/src/Cardano/CLI/Byron/Delegation.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Delegation.hs
@@ -16,10 +16,10 @@ import Cardano.Api.Byron
 
 import Cardano.CLI.Byron.Key (ByronKeyFailure, renderByronKeyFailure)
 import Cardano.CLI.Types.Common (CertificateFile (..))
-import qualified Cardano.Chain.Delegation as Dlg
+import Cardano.Chain.Delegation qualified as Dlg
 import Cardano.Chain.Slotting (EpochNumber)
 import Cardano.Crypto (ProtocolMagicId)
-import qualified Cardano.Crypto as Crypto
+import Cardano.Crypto qualified as Crypto
 import Cardano.Ledger.Binary (Annotated (..), byronProtVer, serialize')
 import Cardano.Prelude (canonicalDecodePretty, canonicalEncodePretty)
 
@@ -31,7 +31,7 @@ import Control.Monad.IO.Class (MonadIO (..))
 import Control.Monad.Trans.Except (ExceptT)
 import Control.Monad.Trans.Except.Extra (left)
 import Data.ByteString (ByteString)
-import qualified Data.ByteString.Lazy as LB
+import Data.ByteString.Lazy qualified as LB
 import Data.Text (Text)
 import Formatting (Format, sformat)
 

--- a/cardano-cli/src/Cardano/CLI/Byron/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Genesis.hs
@@ -22,12 +22,12 @@ import Cardano.Api.Byron
 import Cardano.CLI.Byron.Delegation
 import Cardano.CLI.Byron.Key
 import Cardano.CLI.Types.Common (GenesisFile (..))
-import qualified Cardano.Chain.Common as Common
+import Cardano.Chain.Common qualified as Common
 import Cardano.Chain.Delegation hiding (Map, epoch)
 import Cardano.Chain.Genesis (GeneratedSecrets (..))
-import qualified Cardano.Chain.Genesis as Genesis
-import qualified Cardano.Chain.UTxO as UTxO
-import qualified Cardano.Crypto as Crypto
+import Cardano.Chain.Genesis qualified as Genesis
+import Cardano.Chain.UTxO qualified as UTxO
+import Cardano.Crypto qualified as Crypto
 import Cardano.Prelude (canonicalDecodePretty, canonicalEncodePretty)
 
 import Control.Monad.IO.Class (MonadIO (..))
@@ -35,13 +35,13 @@ import Control.Monad.Trans (MonadTrans (..))
 import Control.Monad.Trans.Except (ExceptT (..), withExceptT)
 import Control.Monad.Trans.Except.Extra (firstExceptT, left, right)
 import Data.ByteString (ByteString)
-import qualified Data.ByteString.Lazy as LB
-import qualified Data.List as List
+import Data.ByteString.Lazy qualified as LB
+import Data.List qualified as List
 import Data.Map.Strict (Map)
-import qualified Data.Map.Strict as Map
+import Data.Map.Strict qualified as Map
 import Data.String (IsString)
 import Data.Text (Text)
-import qualified Data.Text.Encoding as Text
+import Data.Text.Encoding qualified as Text
 import Data.Text.Lazy (toStrict)
 import Data.Text.Lazy.Builder (toLazyText)
 import Data.Time (UTCTime)

--- a/cardano-cli/src/Cardano/CLI/Byron/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Key.hs
@@ -3,9 +3,9 @@
 
 module Cardano.CLI.Byron.Key
   ( -- * Keys
-    ByronKeyFailure(..)
-  , NewSigningKeyFile(..)
-  , NewVerificationKeyFile(..)
+    ByronKeyFailure (..)
+  , NewSigningKeyFile (..)
+  , NewVerificationKeyFile (..)
   , VerificationKeyFile
   , prettyPublicKey
   , readByronSigningKey
@@ -15,23 +15,27 @@ module Cardano.CLI.Byron.Key
   )
 where
 
-import           Cardano.Api.Byron
+import Cardano.Api.Byron
 
+import Cardano.CLI.Types.Common
 import qualified Cardano.Chain.Common as Common
-import           Cardano.CLI.Types.Common
 import qualified Cardano.Crypto.Signing as Crypto
 
-import           Control.Exception (Exception (..))
-import           Control.Monad.Trans.Except (ExceptT)
-import           Control.Monad.Trans.Except.Extra (firstExceptT, handleIOExceptT, hoistEither, left,
-                   right)
+import Control.Exception (Exception (..))
+import Control.Monad.Trans.Except (ExceptT)
+import Control.Monad.Trans.Except.Extra
+  ( firstExceptT
+  , handleIOExceptT
+  , hoistEither
+  , left
+  , right
+  )
 import qualified Data.ByteString as SB
 import qualified Data.ByteString.UTF8 as UTF8
-import           Data.String (IsString, fromString)
-import           Data.Text (Text)
+import Data.String (IsString, fromString)
+import Data.Text (Text)
 import qualified Data.Text as T
-import           Formatting (build, sformat, (%))
-
+import Formatting (build, sformat, (%))
 
 data ByronKeyFailure
   = ReadSigningKeyFailure !FilePath !Text
@@ -40,7 +44,7 @@ data ByronKeyFailure
   | SigningKeyDeserialisationFailed !FilePath
   | VerificationKeyDeserialisationFailed !FilePath !Text
   | CannotMigrateFromNonLegacySigningKey !FilePath
-  deriving Show
+  deriving (Show)
 
 renderByronKeyFailure :: ByronKeyFailure -> Text
 renderByronKeyFailure err =
@@ -53,35 +57,44 @@ renderByronKeyFailure err =
       "Error reading verification key at: " <> textShow vKeyFp <> " Error: " <> textShow readErr
     LegacySigningKeyDeserialisationFailed fp ->
       "Error attempting to deserialise a legacy signing key at: " <> textShow fp
-    SigningKeyDeserialisationFailed sKeyFp  ->
+    SigningKeyDeserialisationFailed sKeyFp ->
       "Error deserialising signing key at: " <> textShow sKeyFp
     VerificationKeyDeserialisationFailed vKeyFp deSerError ->
       "Error deserialising verification key at: " <> textShow vKeyFp <> " Error: " <> textShow deSerError
 
-newtype NewSigningKeyFile =
-  NewSigningKeyFile FilePath
+newtype NewSigningKeyFile
+  = NewSigningKeyFile FilePath
   deriving (Eq, Ord, Show, IsString)
 
-newtype NewVerificationKeyFile =
-  NewVerificationKeyFile FilePath
-   deriving (Eq, Ord, Show, IsString)
+newtype NewVerificationKeyFile
+  = NewVerificationKeyFile FilePath
+  deriving (Eq, Ord, Show, IsString)
 
 -- | Print some invariant properties of a public key:
 --   its hash and formatted view.
-prettyPublicKey :: VerificationKey ByronKey-> Text
+prettyPublicKey :: VerificationKey ByronKey -> Text
 prettyPublicKey (ByronVerificationKey vk) =
-  sformat (  "    public key hash: " % build %
-           "\npublic key (base64): " % Crypto.fullVerificationKeyF %
-           "\n   public key (hex): " % Crypto.fullVerificationKeyHexF)
-    (Common.addressHash vk) vk vk
+  sformat
+    ( "    public key hash: "
+        % build
+        % "\npublic key (base64): "
+        % Crypto.fullVerificationKeyF
+        % "\n   public key (hex): "
+        % Crypto.fullVerificationKeyHexF
+    )
+    (Common.addressHash vk)
+    vk
+    vk
 
 byronWitnessToVerKey :: SomeByronSigningKey -> VerificationKey ByronKey
 byronWitnessToVerKey (AByronSigningKeyLegacy sKeyLeg) = castVerificationKey $ getVerificationKey sKeyLeg
 byronWitnessToVerKey (AByronSigningKey sKeyNonLeg) = getVerificationKey sKeyNonLeg
 
 -- TODO:  we need to support password-protected secrets.
+
 -- | Read signing key from a file.
-readByronSigningKey :: ByronKeyFormat -> SigningKeyFile In -> ExceptT ByronKeyFailure IO SomeByronSigningKey
+readByronSigningKey
+  :: ByronKeyFormat -> SigningKeyFile In -> ExceptT ByronKeyFailure IO SomeByronSigningKey
 readByronSigningKey bKeyFormat (File fp) = do
   sK <- handleIOExceptT (ReadSigningKeyFailure fp . T.pack . displayException) $ SB.readFile fp
   case bKeyFormat of
@@ -96,11 +109,11 @@ readByronSigningKey bKeyFormat (File fp) = do
 
 -- | Read verification key from a file.  Throw an error if the file can't be read
 -- or the key fails to deserialise.
-readPaymentVerificationKey :: VerificationKeyFile In -> ExceptT ByronKeyFailure IO Crypto.VerificationKey
+readPaymentVerificationKey
+  :: VerificationKeyFile In -> ExceptT ByronKeyFailure IO Crypto.VerificationKey
 readPaymentVerificationKey (File fp) = do
   vkB <- handleIOExceptT (ReadVerificationKeyFailure fp . T.pack . displayException) (SB.readFile fp)
   -- Verification Key
   let eVk = hoistEither . Crypto.parseFullVerificationKey . fromString $ UTF8.toString vkB
   -- Convert error to 'CliError'
   firstExceptT (VerificationKeyDeserialisationFailed fp . T.pack . show) eVk
-

--- a/cardano-cli/src/Cardano/CLI/Byron/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Key.hs
@@ -18,8 +18,8 @@ where
 import Cardano.Api.Byron
 
 import Cardano.CLI.Types.Common
-import qualified Cardano.Chain.Common as Common
-import qualified Cardano.Crypto.Signing as Crypto
+import Cardano.Chain.Common qualified as Common
+import Cardano.Crypto.Signing qualified as Crypto
 
 import Control.Exception (Exception (..))
 import Control.Monad.Trans.Except (ExceptT)
@@ -30,11 +30,11 @@ import Control.Monad.Trans.Except.Extra
   , left
   , right
   )
-import qualified Data.ByteString as SB
-import qualified Data.ByteString.UTF8 as UTF8
+import Data.ByteString qualified as SB
+import Data.ByteString.UTF8 qualified as UTF8
 import Data.String (IsString, fromString)
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import Formatting (build, sformat, (%))
 
 data ByronKeyFailure

--- a/cardano-cli/src/Cardano/CLI/Byron/Legacy.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Legacy.hs
@@ -3,23 +3,22 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-module Cardano.CLI.Byron.Legacy (
-      LegacyDelegateKey(..)
-    , encodeLegacyDelegateKey
-    , decodeLegacyDelegateKey
-    ) where
+module Cardano.CLI.Byron.Legacy
+  ( LegacyDelegateKey (..)
+  , encodeLegacyDelegateKey
+  , decodeLegacyDelegateKey
+  ) where
 
-import           Cardano.Api (textShow)
+import Cardano.Api (textShow)
 
-import           Cardano.Crypto.Signing (SigningKey (..))
+import Cardano.Crypto.Signing (SigningKey (..))
 import qualified Cardano.Crypto.Wallet as Wallet
 
 import qualified Codec.CBOR.Decoding as D
 import qualified Codec.CBOR.Encoding as E
-import           Control.Monad (when)
-import           Data.Text (Text)
-import           Formatting (build, formatToString)
-
+import Control.Monad (when)
+import Data.Text (Text)
+import Formatting (build, formatToString)
 
 -- | LegacyDelegateKey is a subset of the UserSecret's from the legacy codebase:
 -- 1. the VSS keypair must be present
@@ -27,7 +26,7 @@ import           Formatting (build, formatToString)
 -- 3. the rest must be absent (Nothing)
 --
 -- Legacy reference: https://github.com/input-output-hk/cardano-sl/blob/release/3.0.1/lib/src/Pos/Util/UserSecret.hs#L189
-newtype LegacyDelegateKey =  LegacyDelegateKey { lrkSigningKey :: SigningKey}
+newtype LegacyDelegateKey = LegacyDelegateKey {lrkSigningKey :: SigningKey}
 
 encodeXPrv :: Wallet.XPrv -> E.Encoding
 encodeXPrv a = E.encodeBytes $ Wallet.unXPrv a
@@ -37,42 +36,55 @@ decodeXPrv =
   either (fail . formatToString build) pure . Wallet.xprv =<< D.decodeBytesCanonical
 
 -- Stolen from: cardano-sl/binary/src/Pos/Binary/Class/Core.hs
+
 -- | Enforces that the input size is the same as the decoded one, failing in
 -- case it's not.
 enforceSize :: Text -> Int -> D.Decoder s ()
 enforceSize lbl requestedSize = D.decodeListLenCanonical >>= matchSize requestedSize lbl
 
 -- Stolen from: cardano-sl/binary/src/Pos/Binary/Class/Core.hs
+
 -- | Compare two sizes, failing if they are not equal.
 matchSize :: Int -> Text -> Int -> D.Decoder s ()
 matchSize requestedSize lbl actualSize =
   when (actualSize /= requestedSize) $
-    fail $ formatToString build (lbl <> " failed the size check. Expected " <> textShow requestedSize <> ", found " <> textShow actualSize)
+    fail $
+      formatToString
+        build
+        ( lbl
+            <> " failed the size check. Expected "
+            <> textShow requestedSize
+            <> ", found "
+            <> textShow actualSize
+        )
 
 -- | Encoder for a Byron/Classic signing key.
 --   Lifted from cardano-sl legacy codebase.
 encodeLegacyDelegateKey :: LegacyDelegateKey -> E.Encoding
-encodeLegacyDelegateKey (LegacyDelegateKey (SigningKey sk))
-  =  E.encodeListLen 4
-  <> E.encodeListLen 1 <> E.encodeBytes "vss deprecated"
-  <> E.encodeListLen 1 <> encodeXPrv sk
-  <> E.encodeListLenIndef <> E.encodeBreak
-  <> E.encodeListLen 0
+encodeLegacyDelegateKey (LegacyDelegateKey (SigningKey sk)) =
+  E.encodeListLen 4
+    <> E.encodeListLen 1
+    <> E.encodeBytes "vss deprecated"
+    <> E.encodeListLen 1
+    <> encodeXPrv sk
+    <> E.encodeListLenIndef
+    <> E.encodeBreak
+    <> E.encodeListLen 0
 
 -- | Decoder for a Byron/Classic signing key.
 --   Lifted from cardano-sl legacy codebase.
 decodeLegacyDelegateKey :: D.Decoder s LegacyDelegateKey
 decodeLegacyDelegateKey = do
-    enforceSize "UserSecret" 4
-    _    <- do
-      enforceSize "vss" 1
-      D.decodeBytes
-    pkey <- do
-      enforceSize "pkey" 1
-      SigningKey <$> decodeXPrv
-    _    <- do
-      D.decodeListLenIndef
-      D.decodeSequenceLenIndef (flip (:)) [] reverse D.decodeNull
-    _    <- do
-      enforceSize "wallet" 0
-    pure $ LegacyDelegateKey pkey
+  enforceSize "UserSecret" 4
+  _ <- do
+    enforceSize "vss" 1
+    D.decodeBytes
+  pkey <- do
+    enforceSize "pkey" 1
+    SigningKey <$> decodeXPrv
+  _ <- do
+    D.decodeListLenIndef
+    D.decodeSequenceLenIndef (flip (:)) [] reverse D.decodeNull
+  _ <- do
+    enforceSize "wallet" 0
+  pure $ LegacyDelegateKey pkey

--- a/cardano-cli/src/Cardano/CLI/Byron/Legacy.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Legacy.hs
@@ -12,10 +12,10 @@ module Cardano.CLI.Byron.Legacy
 import Cardano.Api (textShow)
 
 import Cardano.Crypto.Signing (SigningKey (..))
-import qualified Cardano.Crypto.Wallet as Wallet
+import Cardano.Crypto.Wallet qualified as Wallet
 
-import qualified Codec.CBOR.Decoding as D
-import qualified Codec.CBOR.Encoding as E
+import Codec.CBOR.Decoding qualified as D
+import Codec.CBOR.Encoding qualified as E
 import Control.Monad (when)
 import Data.Text (Text)
 import Formatting (build, formatToString)

--- a/cardano-cli/src/Cardano/CLI/Byron/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Parsers.hs
@@ -1,8 +1,8 @@
 {-# LANGUAGE DataKinds #-}
 
 module Cardano.CLI.Byron.Parsers
-  ( ByronCommand(..)
-  , NodeCmds(..)
+  ( ByronCommand (..)
+  , NodeCmds (..)
   , backwardsCompatibilityCommands
   , parseByronCommands
   , parseHeavyDelThd
@@ -23,208 +23,246 @@ module Cardano.CLI.Byron.Parsers
   , parseUpdateVoteThd
   ) where
 
+import Cardano.Api hiding (GenesisParameters, UpdateProposal)
+import Cardano.Api.Byron
+  ( Address (..)
+  , ByronProtocolParametersUpdate (..)
+  , toByronLovelace
+  )
+import Cardano.Api.Shelley (ReferenceScript (ReferenceScriptNone))
 
-import           Cardano.Api hiding (GenesisParameters, UpdateProposal)
-import           Cardano.Api.Byron (Address (..), ByronProtocolParametersUpdate (..),
-                   toByronLovelace)
-import           Cardano.Api.Shelley (ReferenceScript (ReferenceScriptNone))
-
-import           Cardano.Chain.Common (BlockCount (..), TxFeePolicy (..), TxSizeLinear (..),
-                   decodeAddressBase58, rationalToLovelacePortion)
+import Cardano.CLI.Byron.Commands
+import Cardano.CLI.Byron.Genesis
+import Cardano.CLI.Byron.Key
+import Cardano.CLI.Byron.Tx
+import Cardano.CLI.Environment (EnvCli (..))
+import Cardano.CLI.EraBased.Options.Common hiding (parseLovelace, parseTxIn)
+import Cardano.CLI.Run (ClientCommand (ByronCommand))
+import Cardano.CLI.Types.Common
+import Cardano.Chain.Common
+  ( BlockCount (..)
+  , TxFeePolicy (..)
+  , TxSizeLinear (..)
+  , decodeAddressBase58
+  , rationalToLovelacePortion
+  )
 import qualified Cardano.Chain.Common as Byron
-import           Cardano.Chain.Genesis (FakeAvvmOptions (..), TestnetBalanceOptions (..))
-import           Cardano.Chain.Slotting (EpochNumber (..), SlotNumber (..))
-import           Cardano.Chain.Update (ApplicationName (..), InstallerHash (..), NumSoftwareVersion,
-                   ProtocolVersion (..), SoftforkRule (..), SoftwareVersion (..), SystemTag (..),
-                   checkApplicationName, checkSystemTag)
-import           Cardano.CLI.Byron.Commands
-import           Cardano.CLI.Byron.Genesis
-import           Cardano.CLI.Byron.Key
-import           Cardano.CLI.Byron.Tx
-import           Cardano.CLI.Environment (EnvCli (..))
-import           Cardano.CLI.EraBased.Options.Common hiding (parseLovelace, parseTxIn)
-import           Cardano.CLI.Run (ClientCommand (ByronCommand))
-import           Cardano.CLI.Types.Common
-import           Cardano.Crypto (RequiresNetworkMagic (..))
-import           Cardano.Crypto.Hashing (hashRaw)
-import           Cardano.Crypto.ProtocolMagic (AProtocolMagic (..), ProtocolMagic,
-                   ProtocolMagicId (..))
-import           Cardano.Ledger.Binary (Annotated (..))
+import Cardano.Chain.Genesis (FakeAvvmOptions (..), TestnetBalanceOptions (..))
+import Cardano.Chain.Slotting (EpochNumber (..), SlotNumber (..))
+import Cardano.Chain.Update
+  ( ApplicationName (..)
+  , InstallerHash (..)
+  , NumSoftwareVersion
+  , ProtocolVersion (..)
+  , SoftforkRule (..)
+  , SoftwareVersion (..)
+  , SystemTag (..)
+  , checkApplicationName
+  , checkSystemTag
+  )
+import Cardano.Crypto (RequiresNetworkMagic (..))
+import Cardano.Crypto.Hashing (hashRaw)
+import Cardano.Crypto.ProtocolMagic
+  ( AProtocolMagic (..)
+  , ProtocolMagic
+  , ProtocolMagicId (..)
+  )
+import Cardano.Ledger.Binary (Annotated (..))
 
-import           Control.Monad (when)
+import Control.Monad (when)
 import qualified Data.Attoparsec.ByteString.Char8 as Atto
-import           Data.Attoparsec.Combinator ((<?>))
+import Data.Attoparsec.Combinator ((<?>))
 import qualified Data.ByteString.Char8 as BSC
 import qualified Data.ByteString.Lazy.Char8 as C8
 import qualified Data.Char as Char
-import           Data.Foldable
-import           Data.Text (Text)
+import Data.Foldable
+import Data.Text (Text)
 import qualified Data.Text as Text
-import           Data.Time (UTCTime)
-import           Data.Time.Clock.POSIX (posixSecondsToUTCTime)
-import           Data.Word (Word16, Word64)
-import           Formatting (build, sformat)
-import           GHC.Natural (Natural)
-import           GHC.Word (Word8)
-import           Options.Applicative
+import Data.Time (UTCTime)
+import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
+import Data.Word (Word16, Word64)
+import Formatting (build, sformat)
+import GHC.Natural (Natural)
+import GHC.Word (Word8)
+import Options.Applicative
 import qualified Options.Applicative as Opt
 
 backwardsCompatibilityCommands :: EnvCli -> Parser ClientCommand
 backwardsCompatibilityCommands envCli =
   asum hiddenCmds
+ where
+  convertToByronCommand :: Mod CommandFields ByronCommand -> Parser ClientCommand
+  convertToByronCommand p = ByronCommand <$> Opt.subparser (p <> Opt.internal)
 
-  where
-    convertToByronCommand :: Mod CommandFields ByronCommand -> Parser ClientCommand
-    convertToByronCommand p = ByronCommand <$> Opt.subparser (p <> Opt.internal)
-
-    hiddenCmds :: [Parser ClientCommand]
-    hiddenCmds =
-     concatMap (fmap convertToByronCommand)
-          [ parseGenesisRelatedValues
-          , parseKeyRelatedValues envCli
-          , parseTxRelatedValues envCli
-          , return (parseLocalNodeQueryValues envCli)
-          , parseMiscellaneous
-          ]
+  hiddenCmds :: [Parser ClientCommand]
+  hiddenCmds =
+    concatMap
+      (fmap convertToByronCommand)
+      [ parseGenesisRelatedValues
+      , parseKeyRelatedValues envCli
+      , parseTxRelatedValues envCli
+      , return (parseLocalNodeQueryValues envCli)
+      , parseMiscellaneous
+      ]
 
 -- Implemented with asum so all commands don't get hidden when trying to hide
 -- the 'pNodeCmdBackwardCompatible' parser.
 parseByronCommands :: EnvCli -> Parser ByronCommand
-parseByronCommands envCli = asum
-  [ subParser' "key" (Opt.info (asum $ map Opt.subparser (parseKeyRelatedValues envCli))
-      $ Opt.progDesc "Byron key utility commands")
-  , subParser' "transaction" (Opt.info (asum $ map Opt.subparser (parseTxRelatedValues envCli))
-      $ Opt.progDesc "Byron transaction commands")
-  , subParser' "query" (Opt.info (Opt.subparser (parseLocalNodeQueryValues envCli))
-      $ Opt.progDesc "Byron node query commands.")
-  , subParser' "genesis" (Opt.info (asum $ map Opt.subparser parseGenesisRelatedValues)
-      $ Opt.progDesc "Byron genesis block commands")
-  , subParser' "governance" (Opt.info (NodeCmds <$> Opt.subparser (pNodeCmds envCli))
-      $ Opt.progDesc "Byron governance commands")
-  , subParser' "miscellaneous" (Opt.info (asum $ map Opt.subparser parseMiscellaneous)
-      $ Opt.progDesc "Byron miscellaneous commands")
-  , NodeCmds <$> pNodeCmdBackwardCompatible envCli
-  ]
+parseByronCommands envCli =
+  asum
+    [ subParser'
+        "key"
+        ( Opt.info (asum $ map Opt.subparser (parseKeyRelatedValues envCli)) $
+            Opt.progDesc "Byron key utility commands"
+        )
+    , subParser'
+        "transaction"
+        ( Opt.info (asum $ map Opt.subparser (parseTxRelatedValues envCli)) $
+            Opt.progDesc "Byron transaction commands"
+        )
+    , subParser'
+        "query"
+        ( Opt.info (Opt.subparser (parseLocalNodeQueryValues envCli)) $
+            Opt.progDesc "Byron node query commands."
+        )
+    , subParser'
+        "genesis"
+        ( Opt.info (asum $ map Opt.subparser parseGenesisRelatedValues) $
+            Opt.progDesc "Byron genesis block commands"
+        )
+    , subParser'
+        "governance"
+        ( Opt.info (NodeCmds <$> Opt.subparser (pNodeCmds envCli)) $
+            Opt.progDesc "Byron governance commands"
+        )
+    , subParser'
+        "miscellaneous"
+        ( Opt.info (asum $ map Opt.subparser parseMiscellaneous) $
+            Opt.progDesc "Byron miscellaneous commands"
+        )
+    , NodeCmds <$> pNodeCmdBackwardCompatible envCli
+    ]
  where
-   subParser' :: String -> ParserInfo ByronCommand -> Parser ByronCommand
-   subParser' name pInfo = Opt.subparser $ Opt.command name pInfo <> Opt.metavar name
+  subParser' :: String -> ParserInfo ByronCommand -> Parser ByronCommand
+  subParser' name pInfo = Opt.subparser $ Opt.command name pInfo <> Opt.metavar name
 
 pNodeCmdBackwardCompatible :: EnvCli -> Parser NodeCmds
 pNodeCmdBackwardCompatible envCli = Opt.subparser $ pNodeCmds envCli <> Opt.internal
 
 parseCBORObject :: Parser CBORObject
-parseCBORObject = asum
-  [ CBORBlockByron <$> Opt.option auto
-      (  long "byron-block"
-      <> help
-          (   "The CBOR file is a byron era block."
-          <>  " Enter the number of slots in an epoch. The default value is 21600")
-      <> metavar "INT"
-      <> value (EpochSlots 21600)
-      )
-
-  , flag' CBORDelegationCertificateByron $
+parseCBORObject =
+  asum
+    [ CBORBlockByron
+        <$> Opt.option
+          auto
+          ( long "byron-block"
+              <> help
+                ( "The CBOR file is a byron era block."
+                    <> " Enter the number of slots in an epoch. The default value is 21600"
+                )
+              <> metavar "INT"
+              <> value (EpochSlots 21600)
+          )
+    , flag' CBORDelegationCertificateByron $
         long "byron-delegation-certificate"
-     <> help "The CBOR file is a byron era delegation certificate"
-
-  , flag' CBORTxByron $
+          <> help "The CBOR file is a byron era delegation certificate"
+    , flag' CBORTxByron $
         long "byron-tx"
-     <> help "The CBOR file is a byron era tx"
-
-  , flag' CBORUpdateProposalByron $
+          <> help "The CBOR file is a byron era tx"
+    , flag' CBORUpdateProposalByron $
         long "byron-update-proposal"
-     <> help "The CBOR file is a byron era update proposal"
-  , flag' CBORVoteByron $
+          <> help "The CBOR file is a byron era update proposal"
+    , flag' CBORVoteByron $
         long "byron-vote"
-     <> help "The CBOR file is a byron era vote"
-  ]
+          <> help "The CBOR file is a byron era vote"
+    ]
 
 -- | Values required to create genesis.
 parseGenesisParameters :: Parser GenesisParameters
 parseGenesisParameters =
   GenesisParameters
     <$> parseUTCTime
-          "start-time"
-          "Start time of the new cluster to be enshrined in the new genesis."
+      "start-time"
+      "Start time of the new cluster to be enshrined in the new genesis."
     <*> parseFilePath
-          "protocol-parameters-file"
-          "JSON file with protocol parameters."
+      "protocol-parameters-file"
+      "JSON file with protocol parameters."
     <*> parseK
     <*> parseProtocolMagic
     <*> parseTestnetBalanceOptions
     <*> parseFakeAvvmOptions
-    <*> (rationalToLovelacePortion <$>
-         parseFractionWithDefault
-          "avvm-balance-factor"
-          "AVVM balances will be multiplied by this factor (defaults to 1)."
-          1)
-    <*> optional
-        ( parseIntegral
-            "secret-seed"
-            "Optionally specify the seed of generation."
+    <*> ( rationalToLovelacePortion
+            <$> parseFractionWithDefault
+              "avvm-balance-factor"
+              "AVVM balances will be multiplied by this factor (defaults to 1)."
+              1
         )
+    <*> optional
+      ( parseIntegral
+          "secret-seed"
+          "Optionally specify the seed of generation."
+      )
 
 parseGenesisRelatedValues :: [Mod CommandFields ByronCommand]
 parseGenesisRelatedValues =
-    [ command' "genesis" "Create genesis."
-      $ Genesis
-          <$> parseNewDirectory
-              "genesis-output-dir"
-              "Non-existent directory where genesis JSON file and secrets shall be placed."
-          <*> parseGenesisParameters
-    , command' "print-genesis-hash" "Compute hash of a genesis file."
-        $ PrintGenesisHash
-            <$> parseGenesisFile "genesis-json"
-    ]
+  [ command' "genesis" "Create genesis." $
+      Genesis
+        <$> parseNewDirectory
+          "genesis-output-dir"
+          "Non-existent directory where genesis JSON file and secrets shall be placed."
+        <*> parseGenesisParameters
+  , command' "print-genesis-hash" "Compute hash of a genesis file." $
+      PrintGenesisHash
+        <$> parseGenesisFile "genesis-json"
+  ]
 
 -- | Values required to create keys and perform
 -- transformation on keys.
 parseKeyRelatedValues :: EnvCli -> [Mod CommandFields ByronCommand]
 parseKeyRelatedValues envCli =
-    [ command' "keygen" "Generate a signing key."
-        $ Keygen
-            <$> parseNewSigningKeyFile "secret"
-    , command'
-        "to-verification"
-        "Extract a verification key in its base64 form."
-        $ ToVerification
-            <$> parseByronKeyFormat
-            <*> parseSigningKeyFile
-                  "secret"
-                  "Signing key file to extract the verification part from."
-            <*> parseNewVerificationKeyFile "to"
-    , command'
-        "signing-key-public"
-        "Pretty-print a signing key's verification key (not a secret)."
-        $ PrettySigningKeyPublic
-            <$> parseByronKeyFormat
-            <*> parseSigningKeyFile
-                  "secret"
-                  "Signing key to pretty-print."
-    , command'
-        "signing-key-address"
-        "Print address of a signing key."
-        $ PrintSigningKeyAddress
-            <$> parseByronKeyFormat
-            <*> pNetworkId envCli
-            <*> parseSigningKeyFile
-                  "secret"
-                  "Signing key, whose address is to be printed."
-    , command'
-        "migrate-delegate-key-from"
-        "Migrate a delegate key from an older version."
-        $ MigrateDelegateKeyFrom
-            <$> parseSigningKeyFile "from" "Legacy signing key file to migrate."
-            <*> parseNewSigningKeyFile "to"
-    ]
+  [ command' "keygen" "Generate a signing key." $
+      Keygen
+        <$> parseNewSigningKeyFile "secret"
+  , command'
+      "to-verification"
+      "Extract a verification key in its base64 form."
+      $ ToVerification
+        <$> parseByronKeyFormat
+        <*> parseSigningKeyFile
+          "secret"
+          "Signing key file to extract the verification part from."
+        <*> parseNewVerificationKeyFile "to"
+  , command'
+      "signing-key-public"
+      "Pretty-print a signing key's verification key (not a secret)."
+      $ PrettySigningKeyPublic
+        <$> parseByronKeyFormat
+        <*> parseSigningKeyFile
+          "secret"
+          "Signing key to pretty-print."
+  , command'
+      "signing-key-address"
+      "Print address of a signing key."
+      $ PrintSigningKeyAddress
+        <$> parseByronKeyFormat
+        <*> pNetworkId envCli
+        <*> parseSigningKeyFile
+          "secret"
+          "Signing key, whose address is to be printed."
+  , command'
+      "migrate-delegate-key-from"
+      "Migrate a delegate key from an older version."
+      $ MigrateDelegateKeyFrom
+        <$> parseSigningKeyFile "from" "Legacy signing key file to migrate."
+        <*> parseNewSigningKeyFile "to"
+  ]
 
 parseLocalNodeQueryValues :: EnvCli -> Mod CommandFields ByronCommand
 parseLocalNodeQueryValues envCli =
-  command' "get-tip" "Get the tip of your local node's blockchain"
-    $ GetLocalNodeTip
-        <$> pSocketPath envCli
-        <*> pNetworkId envCli
-
+  command' "get-tip" "Get the tip of your local node's blockchain" $
+    GetLocalNodeTip
+      <$> pSocketPath envCli
+      <*> pNetworkId envCli
 
 parseMiscellaneous :: [Mod CommandFields ByronCommand]
 parseMiscellaneous =
@@ -232,46 +270,44 @@ parseMiscellaneous =
       "validate-cbor"
       "Validate a CBOR blockchain object."
       $ ValidateCBOR
-          <$> parseCBORObject
-          <*> parseFilePath "filepath" "Filepath of CBOR file."
+        <$> parseCBORObject
+        <*> parseFilePath "filepath" "Filepath of CBOR file."
   , command'
       "pretty-print-cbor"
       "Pretty print a CBOR file."
       $ PrettyPrintCBOR
-          <$> parseFilePath "filepath" "Filepath of CBOR file."
+        <$> parseFilePath "filepath" "Filepath of CBOR file."
   ]
-
-
 
 parseTestnetBalanceOptions :: Parser TestnetBalanceOptions
 parseTestnetBalanceOptions =
   TestnetBalanceOptions
     <$> parseIntegral
-          "n-poor-addresses"
-          "Number of poor nodes (with small balance)."
+      "n-poor-addresses"
+      "Number of poor nodes (with small balance)."
     <*> parseIntegral
-          "n-delegate-addresses"
-          "Number of delegate nodes (with huge balance)."
+      "n-delegate-addresses"
+      "Number of delegate nodes (with huge balance)."
     <*> parseLovelace
-          "total-balance"
-          "Total balance owned by these nodes."
+      "total-balance"
+      "Total balance owned by these nodes."
     <*> parseFraction
-          "delegate-share"
-          "Portion of stake owned by all delegates together."
+      "delegate-share"
+      "Portion of stake owned by all delegates together."
 
 parseTxIn :: Parser TxIn
 parseTxIn =
   Opt.option
-  (readerFromAttoParser parseTxInAtto)
-  $ long "txin"
-    <> metavar "(TXID,INDEX)"
-    <> help "Transaction input is a pair of an UTxO TxId and a zero-based output index."
+    (readerFromAttoParser parseTxInAtto)
+    $ long "txin"
+      <> metavar "(TXID,INDEX)"
+      <> help "Transaction input is a pair of an UTxO TxId and a zero-based output index."
 
 parseTxInAtto :: Atto.Parser TxIn
 parseTxInAtto =
-  TxIn <$> (Atto.char '(' *> parseTxIdAtto <* Atto.char ',')
-       <*> (parseTxIxAtto <* Atto.char ')')
-
+  TxIn
+    <$> (Atto.char '(' *> parseTxIdAtto <* Atto.char ',')
+    <*> (parseTxIxAtto <* Atto.char ')')
 
 parseTxIdAtto :: Atto.Parser TxId
 parseTxIdAtto = (<?> "Transaction ID (hexadecimal)") $ do
@@ -286,11 +322,14 @@ parseTxIxAtto = toEnum <$> Atto.decimal
 parseTxOut :: Parser (TxOut CtxTx ByronEra)
 parseTxOut =
   Opt.option
-    ( (\(addr, lovelace) -> TxOut (pAddressInEra addr)
-                                  (pLovelaceTxOut lovelace)
-                                  TxOutDatumNone
-                                  ReferenceScriptNone)
-      <$> auto
+    ( ( \(addr, lovelace) ->
+          TxOut
+            (pAddressInEra addr)
+            (pLovelaceTxOut lovelace)
+            TxOutDatumNone
+            ReferenceScriptNone
+      )
+        <$> auto
     )
     $ long "txout"
       <> metavar "'(\"ADDR\", LOVELACE)'"
@@ -314,60 +353,62 @@ readerFromAttoParser p =
 
 parseTxRelatedValues :: EnvCli -> [Mod CommandFields ByronCommand]
 parseTxRelatedValues envCli =
-    [ command'
-        "submit-tx"
-        "Submit a raw, signed transaction, in its on-wire representation."
-        $ SubmitTx
-            <$> pSocketPath envCli
-            <*> pNetworkId envCli
-            <*> parseTxFile "tx"
-    , command'
-        "issue-genesis-utxo-expenditure"
-        "Write a file with a signed transaction, spending genesis UTxO."
-        $ SpendGenesisUTxO
-            <$> parseGenesisFile "genesis-json"
-            <*> pNetworkId envCli
-            <*> parseByronKeyFormat
-            <*> parseNewTxFile "tx"
-            <*> parseSigningKeyFile
-                  "wallet-key"
-                  "Key that has access to all mentioned genesis UTxO inputs."
-            <*> parseAddress
-                  "rich-addr-from"
-                  "Tx source: genesis UTxO richman address (non-HD)."
-            <*> some parseTxOut
-
-    , command'
-        "issue-utxo-expenditure"
-        "Write a file with a signed transaction, spending normal UTxO."
-        $ SpendUTxO
-            <$> pNetworkId envCli
-            <*> parseByronKeyFormat
-            <*> parseNewTxFile "tx"
-            <*> parseSigningKeyFile
-                  "wallet-key"
-                  "Key that has access to all mentioned genesis UTxO inputs."
-            <*> some parseTxIn
-            <*> some parseTxOut
-
-    , command'
-        "txid"
-        "Print the txid of a raw, signed transaction."
-        $ GetTxId
-            <$> parseTxFile "tx"
-    ]
+  [ command'
+      "submit-tx"
+      "Submit a raw, signed transaction, in its on-wire representation."
+      $ SubmitTx
+        <$> pSocketPath envCli
+        <*> pNetworkId envCli
+        <*> parseTxFile "tx"
+  , command'
+      "issue-genesis-utxo-expenditure"
+      "Write a file with a signed transaction, spending genesis UTxO."
+      $ SpendGenesisUTxO
+        <$> parseGenesisFile "genesis-json"
+        <*> pNetworkId envCli
+        <*> parseByronKeyFormat
+        <*> parseNewTxFile "tx"
+        <*> parseSigningKeyFile
+          "wallet-key"
+          "Key that has access to all mentioned genesis UTxO inputs."
+        <*> parseAddress
+          "rich-addr-from"
+          "Tx source: genesis UTxO richman address (non-HD)."
+        <*> some parseTxOut
+  , command'
+      "issue-utxo-expenditure"
+      "Write a file with a signed transaction, spending normal UTxO."
+      $ SpendUTxO
+        <$> pNetworkId envCli
+        <*> parseByronKeyFormat
+        <*> parseNewTxFile "tx"
+        <*> parseSigningKeyFile
+          "wallet-key"
+          "Key that has access to all mentioned genesis UTxO inputs."
+        <*> some parseTxIn
+        <*> some parseTxOut
+  , command'
+      "txid"
+      "Print the txid of a raw, signed transaction."
+      $ GetTxId
+        <$> parseTxFile "tx"
+  ]
 
 pNodeCmds :: EnvCli -> Mod CommandFields NodeCmds
 pNodeCmds envCli =
   mconcat
     [ Opt.command "create-update-proposal" $
-        Opt.info (parseByronUpdateProposal envCli) $ Opt.progDesc  "Create an update proposal."
+        Opt.info (parseByronUpdateProposal envCli) $
+          Opt.progDesc "Create an update proposal."
     , Opt.command "create-proposal-vote" $
-        Opt.info (parseByronVote envCli) $ Opt.progDesc "Create an update proposal vote."
+        Opt.info (parseByronVote envCli) $
+          Opt.progDesc "Create an update proposal vote."
     , Opt.command "submit-update-proposal" $
-        Opt.info (parseByronUpdateProposalSubmission envCli) $ Opt.progDesc "Submit an update proposal."
+        Opt.info (parseByronUpdateProposalSubmission envCli) $
+          Opt.progDesc "Submit an update proposal."
     , Opt.command "submit-proposal-vote" $
-        Opt.info (parseByronVoteSubmission envCli) $ Opt.progDesc "Submit a proposal vote."
+        Opt.info (parseByronVoteSubmission envCli) $
+          Opt.progDesc "Submit a proposal vote."
     ]
 
 parseByronUpdateProposal :: EnvCli -> Parser NodeCmds
@@ -388,7 +429,6 @@ parseByronVoteSubmission envCli = do
     <$> pSocketPath envCli
     <*> pNetworkId envCli
     <*> parseFilePath "filepath" "Filepath of Byron update proposal vote."
-
 
 pByronProtocolParametersUpdate :: Parser ByronProtocolParametersUpdate
 pByronProtocolParametersUpdate =
@@ -430,72 +470,81 @@ parseByronVote envCli =
 
 parseScriptVersion :: Parser Word16
 parseScriptVersion =
-  Opt.option auto
+  Opt.option
+    auto
     ( long "script-version"
-    <> metavar "WORD16"
-    <> help "Proposed script version."
+        <> metavar "WORD16"
+        <> help "Proposed script version."
     )
 
 parseSlotDuration :: Parser Natural
 parseSlotDuration =
-  Opt.option auto
+  Opt.option
+    auto
     ( long "slot-duration"
-    <> metavar "NATURAL"
-    <> help "Proposed slot duration."
+        <> metavar "NATURAL"
+        <> help "Proposed slot duration."
     )
 
 parseSystemTag :: Parser SystemTag
-parseSystemTag = Opt.option (eitherReader checkSysTag)
-                   ( long "system-tag"
-                   <> metavar "STRING"
-                   <> help "Identify which system (linux, win64, etc) the update proposal is for."
-                   )
+parseSystemTag =
+  Opt.option
+    (eitherReader checkSysTag)
+    ( long "system-tag"
+        <> metavar "STRING"
+        <> help "Identify which system (linux, win64, etc) the update proposal is for."
+    )
  where
   checkSysTag :: String -> Either String SystemTag
   checkSysTag name =
     let tag = SystemTag $ Text.pack name
-    in case checkSystemTag tag of
-         Left err -> Left . Text.unpack $ sformat build err
-         Right () -> Right tag
+     in case checkSystemTag tag of
+          Left err -> Left . Text.unpack $ sformat build err
+          Right () -> Right tag
 
 parseInstallerHash :: Parser InstallerHash
 parseInstallerHash =
-  InstallerHash .  hashRaw . C8.pack
-    <$> strOption ( long "installer-hash"
-                  <> metavar "HASH"
-                  <> help "Software hash."
-                  )
+  InstallerHash . hashRaw . C8.pack
+    <$> strOption
+      ( long "installer-hash"
+          <> metavar "HASH"
+          <> help "Software hash."
+      )
 
 parseMaxBlockSize :: Parser Natural
 parseMaxBlockSize =
-  Opt.option auto
+  Opt.option
+    auto
     ( long "max-block-size"
-    <> metavar "NATURAL"
-    <> help "Proposed max block size."
+        <> metavar "NATURAL"
+        <> help "Proposed max block size."
     )
 
 parseMaxHeaderSize :: Parser Natural
 parseMaxHeaderSize =
-  Opt.option auto
+  Opt.option
+    auto
     ( long "max-header-size"
-    <> metavar "NATURAL"
-    <> help "Proposed max block header size."
+        <> metavar "NATURAL"
+        <> help "Proposed max block header size."
     )
 
 parseMaxTxSize :: Parser Natural
 parseMaxTxSize =
-  Opt.option auto
+  Opt.option
+    auto
     ( long "max-tx-size"
-    <> metavar "NATURAL"
-    <> help "Proposed max transaction size."
+        <> metavar "NATURAL"
+        <> help "Proposed max transaction size."
     )
 
-parseMaxProposalSize :: Parser  Natural
+parseMaxProposalSize :: Parser Natural
 parseMaxProposalSize =
-  Opt.option auto
+  Opt.option
+    auto
     ( long "max-proposal-size"
-    <> metavar "NATURAL"
-    <> help "Proposed max update proposal size."
+        <> metavar "NATURAL"
+        <> help "Proposed max update proposal size."
     )
 
 parseMpcThd :: Parser Byron.LovelacePortion
@@ -505,9 +554,10 @@ parseMpcThd =
 
 parseProtocolVersion :: Parser ProtocolVersion
 parseProtocolVersion =
-  ProtocolVersion <$> (parseWord "protocol-version-major" "Protocol version major." "WORD16" :: Parser Word16)
-                  <*> (parseWord "protocol-version-minor" "Protocol version minor." "WORD16" :: Parser Word16)
-                  <*> (parseWord "protocol-version-alt" "Protocol version alt." "WORD8" :: Parser Word8)
+  ProtocolVersion
+    <$> (parseWord "protocol-version-major" "Protocol version major." "WORD16" :: Parser Word16)
+    <*> (parseWord "protocol-version-minor" "Protocol version minor." "WORD16" :: Parser Word16)
+    <*> (parseWord "protocol-version-alt" "Protocol version alt." "WORD8" :: Parser Word8)
 
 parseHeavyDelThd :: Parser Byron.LovelacePortion
 parseHeavyDelThd =
@@ -527,37 +577,47 @@ parseUpdateProposalThd =
 parseUpdateProposalTTL :: Parser SlotNumber
 parseUpdateProposalTTL =
   SlotNumber
-    <$> Opt.option auto
-          ( long "time-to-live"
+    <$> Opt.option
+      auto
+      ( long "time-to-live"
           <> metavar "WORD64"
           <> help "Proposed time for an update proposal to live."
-          )
+      )
 
 parseSoftforkRule :: Parser SoftforkRule
 parseSoftforkRule =
   SoftforkRule
-    <$> (rationalToLovelacePortion <$> parseFraction "softfork-init-thd" "Propose initial threshold (right after proposal is confirmed).")
-    <*> (rationalToLovelacePortion <$> parseFraction "softfork-min-thd" "Propose minimum threshold (threshold can't be less than this).")
-    <*> (rationalToLovelacePortion <$> parseFraction "softfork-thd-dec" "Propose threshold decrement (threshold will decrease by this amount after each epoch).")
-
+    <$> ( rationalToLovelacePortion
+            <$> parseFraction "softfork-init-thd" "Propose initial threshold (right after proposal is confirmed)."
+        )
+    <*> ( rationalToLovelacePortion
+            <$> parseFraction "softfork-min-thd" "Propose minimum threshold (threshold can't be less than this)."
+        )
+    <*> ( rationalToLovelacePortion
+            <$> parseFraction
+              "softfork-thd-dec"
+              "Propose threshold decrement (threshold will decrease by this amount after each epoch)."
+        )
 
 parseSoftwareVersion :: Parser SoftwareVersion
 parseSoftwareVersion =
   SoftwareVersion <$> parseApplicationName <*> parseNumSoftwareVersion
 
 parseApplicationName :: Parser ApplicationName
-parseApplicationName = Opt.option (eitherReader checkAppNameLength)
-       (  long "application-name"
-       <> metavar "STRING"
-       <> help "The name of the application."
-       )
+parseApplicationName =
+  Opt.option
+    (eitherReader checkAppNameLength)
+    ( long "application-name"
+        <> metavar "STRING"
+        <> help "The name of the application."
+    )
  where
   checkAppNameLength :: String -> Either String ApplicationName
   checkAppNameLength name =
     let appName = ApplicationName $ Text.pack name
-    in case checkApplicationName appName of
-         Left err -> Left . Text.unpack $ sformat build err
-         Right () -> Right appName
+     in case checkApplicationName appName of
+          Left err -> Left . Text.unpack $ sformat build err
+          Right () -> Right appName
 
 parseNumSoftwareVersion :: Parser NumSoftwareVersion
 parseNumSoftwareVersion =
@@ -569,53 +629,51 @@ parseNumSoftwareVersion =
 parseTxFeePolicy :: Parser TxFeePolicy
 parseTxFeePolicy =
   TxFeePolicyTxSizeLinear
-    <$> ( TxSizeLinear <$> parseLovelace "tx-fee-a-constant" "Propose the constant a for txfee = a + b*s where s is the size."
-                       <*> parseFraction "tx-fee-b-constant" "Propose the constant b for txfee = a + b*s where s is the size."
+    <$> ( TxSizeLinear
+            <$> parseLovelace "tx-fee-a-constant" "Propose the constant a for txfee = a + b*s where s is the size."
+            <*> parseFraction "tx-fee-b-constant" "Propose the constant b for txfee = a + b*s where s is the size."
         )
 
 parseVoteBool :: Parser Bool
-parseVoteBool = flag' True (long "vote-yes" <> help "Vote yes with respect to an update proposal.")
-            <|> flag' False (long "vote-no" <> help "Vote no with respect to an update proposal.")
+parseVoteBool =
+  flag' True (long "vote-yes" <> help "Vote yes with respect to an update proposal.")
+    <|> flag' False (long "vote-no" <> help "Vote no with respect to an update proposal.")
 
 parseUnlockStakeEpoch :: Parser EpochNumber
 parseUnlockStakeEpoch =
   EpochNumber
-    <$> Opt.option auto
+    <$> Opt.option
+      auto
       ( long "unlock-stake-epoch"
-      <> metavar "WORD64"
-      <> help "Proposed epoch to unlock all stake."
+          <> metavar "WORD64"
+          <> help "Proposed epoch to unlock all stake."
       )
 
-
-parseWord :: Integral a => String -> String -> String -> Parser a
-parseWord optname desc metvar = Opt.option (fromInteger <$> auto)
-  $ long optname <> metavar metvar <> help desc
-
-
+parseWord :: (Integral a) => String -> String -> String -> Parser a
+parseWord optname desc metvar =
+  Opt.option (fromInteger <$> auto) $
+    long optname <> metavar metvar <> help desc
 
 parseAddress :: String -> String -> Parser (Address ByronAddr)
 parseAddress opt desc =
-  Opt.option (cliParseBase58Address <$> str)
-    $ long opt <> metavar "ADDR" <> help desc
+  Opt.option (cliParseBase58Address <$> str) $
+    long opt <> metavar "ADDR" <> help desc
 
 parseByronKeyFormat :: Parser ByronKeyFormat
-parseByronKeyFormat = asum
-  [ flag' LegacyByronKeyFormat $
+parseByronKeyFormat =
+  asum
+    [ flag' LegacyByronKeyFormat $
         long "byron-legacy-formats"
-     <> help "Byron/cardano-sl formats and compatibility"
-
-  , flag' NonLegacyByronKeyFormat $
+          <> help "Byron/cardano-sl formats and compatibility"
+    , flag' NonLegacyByronKeyFormat $
         long "byron-formats"
-     <> help "Byron era formats and compatibility"
-
-    -- And hidden compatibility flag aliases that should be deprecated:
-  , flag' LegacyByronKeyFormat $ hidden <> long "byron-legacy"
-  , flag' NonLegacyByronKeyFormat $ hidden <> long "real-pbft"
-
-  -- Default Byron key format
-  , pure NonLegacyByronKeyFormat
-  ]
-
+          <> help "Byron era formats and compatibility"
+    , -- And hidden compatibility flag aliases that should be deprecated:
+      flag' LegacyByronKeyFormat $ hidden <> long "byron-legacy"
+    , flag' NonLegacyByronKeyFormat $ hidden <> long "real-pbft"
+    , -- Default Byron key format
+      pure NonLegacyByronKeyFormat
+    ]
 
 parseFakeAvvmOptions :: Parser FakeAvvmOptions
 parseFakeAvvmOptions =
@@ -637,12 +695,14 @@ parseFractionWithDefault
   -> Double
   -> Parser Rational
 parseFractionWithDefault optname desc w =
-  toRational <$> Opt.option readDouble
-    ( long optname
-    <> metavar "DOUBLE"
-    <> help desc
-    <> value w
-    )
+  toRational
+    <$> Opt.option
+      readDouble
+      ( long optname
+          <> metavar "DOUBLE"
+          <> help desc
+          <> value w
+      )
 
 parseNewSigningKeyFile :: String -> Parser NewSigningKeyFile
 parseNewSigningKeyFile opt =
@@ -676,8 +736,8 @@ parseTxFile opt =
 
 parseUTCTime :: String -> String -> Parser UTCTime
 parseUTCTime optname desc =
-  Opt.option (posixSecondsToUTCTime . fromInteger <$> auto)
-    $ long optname <> metavar "POSIXSECONDS" <> help desc
+  Opt.option (posixSecondsToUTCTime . fromInteger <$> auto) $
+    long optname <> metavar "POSIXSECONDS" <> help desc
 
 cliParseBase58Address :: Text -> Address ByronAddr
 cliParseBase58Address t =
@@ -688,30 +748,32 @@ cliParseBase58Address t =
 parseFraction :: String -> String -> Parser Rational
 parseFraction optname desc =
   Opt.option (toRational <$> readDouble) $
-      long optname
-   <> metavar "DOUBLE"
-   <> help desc
+    long optname
+      <> metavar "DOUBLE"
+      <> help desc
 
-parseIntegral :: Integral a => String -> String -> Parser a
-parseIntegral optname desc = Opt.option (fromInteger <$> auto)
-  $ long optname <> metavar "INT" <> help desc
+parseIntegral :: (Integral a) => String -> String -> Parser a
+parseIntegral optname desc =
+  Opt.option (fromInteger <$> auto) $
+    long optname <> metavar "INT" <> help desc
 
 parseLovelace :: String -> String -> Parser Byron.Lovelace
 parseLovelace optname desc =
-  Opt.option (readerFromAttoParser parseLovelaceAtto)
-    (  long optname
-    <> metavar "INT"
-    <> help desc
+  Opt.option
+    (readerFromAttoParser parseLovelaceAtto)
+    ( long optname
+        <> metavar "INT"
+        <> help desc
     )
  where
   parseLovelaceAtto :: Atto.Parser Byron.Lovelace
   parseLovelaceAtto = do
     i <- Atto.decimal
     if i > toInteger (maxBound :: Word64)
-    then fail $ show i <> " lovelace exceeds the Word64 upper bound"
-    else case toByronLovelace (Lovelace i) of
-           Just byronLovelace -> return byronLovelace
-           Nothing -> error $ "Error converting lovelace: " <> show i
+      then fail $ show i <> " lovelace exceeds the Word64 upper bound"
+      else case toByronLovelace (Lovelace i) of
+        Just byronLovelace -> return byronLovelace
+        Nothing -> error $ "Error converting lovelace: " <> show i
 
 readDouble :: ReadM Double
 readDouble = do
@@ -723,8 +785,6 @@ readDouble = do
 parseSigningKeyFile :: String -> String -> Parser (SigningKeyFile In)
 parseSigningKeyFile opt desc = File <$> parseFilePath opt desc
 
-
 parseGenesisFile :: String -> Parser GenesisFile
 parseGenesisFile opt =
   GenesisFile <$> parseFilePath opt "Genesis JSON file."
-

--- a/cardano-cli/src/Cardano/CLI/Byron/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Parsers.hs
@@ -46,7 +46,7 @@ import Cardano.Chain.Common
   , decodeAddressBase58
   , rationalToLovelacePortion
   )
-import qualified Cardano.Chain.Common as Byron
+import Cardano.Chain.Common qualified as Byron
 import Cardano.Chain.Genesis (FakeAvvmOptions (..), TestnetBalanceOptions (..))
 import Cardano.Chain.Slotting (EpochNumber (..), SlotNumber (..))
 import Cardano.Chain.Update
@@ -70,14 +70,14 @@ import Cardano.Crypto.ProtocolMagic
 import Cardano.Ledger.Binary (Annotated (..))
 
 import Control.Monad (when)
-import qualified Data.Attoparsec.ByteString.Char8 as Atto
+import Data.Attoparsec.ByteString.Char8 qualified as Atto
 import Data.Attoparsec.Combinator ((<?>))
-import qualified Data.ByteString.Char8 as BSC
-import qualified Data.ByteString.Lazy.Char8 as C8
-import qualified Data.Char as Char
+import Data.ByteString.Char8 qualified as BSC
+import Data.ByteString.Lazy.Char8 qualified as C8
+import Data.Char qualified as Char
 import Data.Foldable
 import Data.Text (Text)
-import qualified Data.Text as Text
+import Data.Text qualified as Text
 import Data.Time (UTCTime)
 import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
 import Data.Word (Word16, Word64)
@@ -85,7 +85,7 @@ import Formatting (build, sformat)
 import GHC.Natural (Natural)
 import GHC.Word (Word8)
 import Options.Applicative
-import qualified Options.Applicative as Opt
+import Options.Applicative qualified as Opt
 
 backwardsCompatibilityCommands :: EnvCli -> Parser ClientCommand
 backwardsCompatibilityCommands envCli =

--- a/cardano-cli/src/Cardano/CLI/Byron/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Query.hs
@@ -10,9 +10,9 @@ module Cardano.CLI.Byron.Query
 import Cardano.Api
 
 import Data.Aeson.Encode.Pretty (encodePretty)
-import qualified Data.ByteString.Lazy as LB
-import qualified Data.Text.Encoding as Text
-import qualified Data.Text.IO as Text
+import Data.ByteString.Lazy qualified as LB
+import Data.Text.Encoding qualified as Text
+import Data.Text.IO qualified as Text
 
 {- HLINT ignore "Reduce duplication" -}
 

--- a/cardano-cli/src/Cardano/CLI/Byron/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Query.hs
@@ -7,13 +7,12 @@ module Cardano.CLI.Byron.Query
   ( runGetLocalNodeTip
   ) where
 
-import           Cardano.Api
+import Cardano.Api
 
-import           Data.Aeson.Encode.Pretty (encodePretty)
+import Data.Aeson.Encode.Pretty (encodePretty)
 import qualified Data.ByteString.Lazy as LB
 import qualified Data.Text.Encoding as Text
 import qualified Data.Text.IO as Text
-
 
 {- HLINT ignore "Reduce duplication" -}
 
@@ -35,5 +34,3 @@ runGetLocalNodeTip socketPath networkId = do
 
   tip <- getLocalChainTip connctInfo
   Text.putStrLn . Text.decodeUtf8 . LB.toStrict $ encodePretty tip
-
-

--- a/cardano-cli/src/Cardano/CLI/Byron/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Run.hs
@@ -20,9 +20,9 @@ import Cardano.CLI.Byron.UpdateProposal
 import Cardano.CLI.Byron.Vote
 import Cardano.CLI.Helpers
 import Cardano.CLI.Types.Common
-import qualified Cardano.Chain.Genesis as Genesis
-import qualified Cardano.Crypto.Hashing as Crypto
-import qualified Cardano.Crypto.Signing as Crypto
+import Cardano.Chain.Genesis qualified as Genesis
+import Cardano.Crypto.Hashing qualified as Crypto
+import Cardano.Crypto.Signing qualified as Crypto
 import Ouroboros.Consensus.Byron.Ledger (ByronBlock)
 import Ouroboros.Consensus.Ledger.SupportsMempool (ApplyTxErr)
 
@@ -30,13 +30,13 @@ import Control.Monad.IO.Class (MonadIO (liftIO))
 import Control.Monad.Trans.Except (ExceptT)
 import Control.Monad.Trans.Except.Extra (firstExceptT, hoistEither, left)
 import Data.Bifunctor (Bifunctor (..))
-import qualified Data.ByteString.Char8 as BS
+import Data.ByteString.Char8 qualified as BS
 import Data.Text (Text)
-import qualified Data.Text as Text
-import qualified Data.Text.IO as Text
-import qualified Data.Text.Lazy.Builder as Builder
-import qualified Data.Text.Lazy.IO as TL
-import qualified Formatting as F
+import Data.Text qualified as Text
+import Data.Text.IO qualified as Text
+import Data.Text.Lazy.Builder qualified as Builder
+import Data.Text.Lazy.IO qualified as TL
+import Formatting qualified as F
 
 -- | Data type that encompasses all the possible errors of the
 -- Byron client.

--- a/cardano-cli/src/Cardano/CLI/Byron/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Run.hs
@@ -7,31 +7,31 @@ module Cardano.CLI.Byron.Run
   , runByronClientCommand
   ) where
 
-import           Cardano.Api hiding (GenesisParameters, UpdateProposal)
-import           Cardano.Api.Byron (SomeByronSigningKey (..), Tx (..))
+import Cardano.Api hiding (GenesisParameters, UpdateProposal)
+import Cardano.Api.Byron (SomeByronSigningKey (..), Tx (..))
 
+import Cardano.CLI.Byron.Commands
+import Cardano.CLI.Byron.Delegation
+import Cardano.CLI.Byron.Genesis
+import Cardano.CLI.Byron.Key
+import Cardano.CLI.Byron.Query
+import Cardano.CLI.Byron.Tx
+import Cardano.CLI.Byron.UpdateProposal
+import Cardano.CLI.Byron.Vote
+import Cardano.CLI.Helpers
+import Cardano.CLI.Types.Common
 import qualified Cardano.Chain.Genesis as Genesis
-import           Cardano.CLI.Byron.Commands
-import           Cardano.CLI.Byron.Delegation
-import           Cardano.CLI.Byron.Genesis
-import           Cardano.CLI.Byron.Key
-import           Cardano.CLI.Byron.Query
-import           Cardano.CLI.Byron.Tx
-import           Cardano.CLI.Byron.UpdateProposal
-import           Cardano.CLI.Byron.Vote
-import           Cardano.CLI.Helpers
-import           Cardano.CLI.Types.Common
 import qualified Cardano.Crypto.Hashing as Crypto
 import qualified Cardano.Crypto.Signing as Crypto
-import           Ouroboros.Consensus.Byron.Ledger (ByronBlock)
-import           Ouroboros.Consensus.Ledger.SupportsMempool (ApplyTxErr)
+import Ouroboros.Consensus.Byron.Ledger (ByronBlock)
+import Ouroboros.Consensus.Ledger.SupportsMempool (ApplyTxErr)
 
-import           Control.Monad.IO.Class (MonadIO (liftIO))
-import           Control.Monad.Trans.Except (ExceptT)
-import           Control.Monad.Trans.Except.Extra (firstExceptT, hoistEither, left)
-import           Data.Bifunctor (Bifunctor (..))
+import Control.Monad.IO.Class (MonadIO (liftIO))
+import Control.Monad.Trans.Except (ExceptT)
+import Control.Monad.Trans.Except.Extra (firstExceptT, hoistEither, left)
+import Data.Bifunctor (Bifunctor (..))
 import qualified Data.ByteString.Char8 as BS
-import           Data.Text (Text)
+import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
 import qualified Data.Text.Lazy.Builder as Builder
@@ -49,7 +49,7 @@ data ByronClientCmdError
   | ByronCmdTxSubmitError !(ApplyTxErr ByronBlock)
   | ByronCmdUpdateProposalError !ByronUpdateProposalError
   | ByronCmdVoteError !ByronVoteError
-  deriving Show
+  deriving (Show)
 
 renderByronClientCmdError :: ByronClientCmdError -> Text
 renderByronClientCmdError err =
@@ -74,7 +74,7 @@ runByronClientCommand c =
     PrettyPrintCBOR fp -> runPrettyPrintCBOR fp
     PrettySigningKeyPublic bKeyFormat skF -> runPrettySigningKeyPublic bKeyFormat skF
     MigrateDelegateKeyFrom oldKey nskf ->
-       runMigrateDelegateKeyFrom oldKey nskf
+      runMigrateDelegateKeyFrom oldKey nskf
     PrintGenesisHash genFp -> runPrintGenesisHash genFp
     PrintSigningKeyAddress bKeyFormat networkid skF -> runPrintSigningKeyAddress bKeyFormat networkid skF
     Keygen nskf -> runKeygen nskf
@@ -86,21 +86,17 @@ runByronClientCommand c =
     SpendUTxO nw era nftx ctKey ins outs ->
       runSpendUTxO nw era nftx ctKey ins outs
 
-
 runNodeCmds :: NodeCmds -> ExceptT ByronClientCmdError IO ()
 runNodeCmds (CreateVote nw sKey upPropFp voteBool outputFp) =
   firstExceptT ByronCmdVoteError $ runVoteCreation nw sKey upPropFp voteBool outputFp
-
 runNodeCmds (SubmitUpdateProposal nodeSocketPath network proposalFp) = do
-  firstExceptT ByronCmdUpdateProposalError
-    $ submitByronUpdateProposal nodeSocketPath network proposalFp
-
+  firstExceptT ByronCmdUpdateProposalError $
+    submitByronUpdateProposal nodeSocketPath network proposalFp
 runNodeCmds (SubmitVote nodeSocketPath network voteFp) = do
   firstExceptT ByronCmdVoteError $ submitByronVote nodeSocketPath network voteFp
-
 runNodeCmds (UpdateProposal nw sKey pVer sVer sysTag insHash outputFp params) =
-  firstExceptT ByronCmdUpdateProposalError
-    $ runProposalCreation nw sKey pVer sVer sysTag insHash outputFp params
+  firstExceptT ByronCmdUpdateProposalError $
+    runProposalCreation nw sKey pVer sVer sysTag insHash outputFp params
 
 runGenesisCommand :: NewDirectory -> GenesisParameters -> ExceptT ByronClientCmdError IO ()
 runGenesisCommand outDir params = do
@@ -118,7 +114,8 @@ runPrettyPrintCBOR fp = do
   bs <- firstExceptT ByronCmdHelpersError $ readCBOR fp
   firstExceptT ByronCmdHelpersError $ pPrintCBOR bs
 
-runPrettySigningKeyPublic :: ByronKeyFormat -> SigningKeyFile In -> ExceptT ByronClientCmdError IO ()
+runPrettySigningKeyPublic
+  :: ByronKeyFormat -> SigningKeyFile In -> ExceptT ByronClientCmdError IO ()
 runPrettySigningKeyPublic bKeyFormat skF = do
   sK <- firstExceptT ByronCmdKeyFailure $ readByronSigningKey bKeyFormat skF
   liftIO . Text.putStrLn . prettyPublicKey $ byronWitnessToVerKey sK
@@ -131,27 +128,29 @@ runMigrateDelegateKeyFrom
 runMigrateDelegateKeyFrom oldKey@(File fp) (NewSigningKeyFile newKey) = do
   sk <- firstExceptT ByronCmdKeyFailure $ readByronSigningKey LegacyByronKeyFormat oldKey
   migratedWitness <- case sk of
-                       AByronSigningKeyLegacy (ByronSigningKeyLegacy sKey) ->
-                         return . AByronSigningKey $ ByronSigningKey sKey
-                       AByronSigningKey _ ->
-                         left . ByronCmdKeyFailure $ CannotMigrateFromNonLegacySigningKey fp
+    AByronSigningKeyLegacy (ByronSigningKeyLegacy sKey) ->
+      return . AByronSigningKey $ ByronSigningKey sKey
+    AByronSigningKey _ ->
+      left . ByronCmdKeyFailure $ CannotMigrateFromNonLegacySigningKey fp
   firstExceptT ByronCmdHelpersError . ensureNewFileLBS newKey $ serialiseByronWitness migratedWitness
 
 runPrintGenesisHash :: GenesisFile -> ExceptT ByronClientCmdError IO ()
 runPrintGenesisHash genFp = do
-    genesis <- firstExceptT ByronCmdGenesisError $
-                 readGenesis genFp dummyNetwork
-    liftIO . Text.putStrLn $ formatter genesis
-  where
-    -- For this purpose of getting the hash, it does not matter what network
-    -- value we use here.
-    dummyNetwork :: NetworkId
-    dummyNetwork = Mainnet
+  genesis <-
+    firstExceptT ByronCmdGenesisError $
+      readGenesis genFp dummyNetwork
+  liftIO . Text.putStrLn $ formatter genesis
+ where
+  -- For this purpose of getting the hash, it does not matter what network
+  -- value we use here.
+  dummyNetwork :: NetworkId
+  dummyNetwork = Mainnet
 
-    formatter :: Genesis.Config -> Text
-    formatter = F.sformat Crypto.hashHexF
-              . Genesis.unGenesisHash
-              . Genesis.configGenesisHash
+  formatter :: Genesis.Config -> Text
+  formatter =
+    F.sformat Crypto.hashHexF
+      . Genesis.unGenesisHash
+      . Genesis.configGenesisHash
 
 runPrintSigningKeyAddress
   :: ByronKeyFormat
@@ -164,18 +163,19 @@ runPrintSigningKeyAddress bKeyFormat networkid skF = do
   liftIO $ Text.putStrLn sKeyAddr
 
 runKeygen :: NewSigningKeyFile -> ExceptT ByronClientCmdError IO ()
-runKeygen (NewSigningKeyFile skF)  = do
+runKeygen (NewSigningKeyFile skF) = do
   sK <- liftIO $ generateSigningKey AsByronKey
   firstExceptT ByronCmdHelpersError . ensureNewFileLBS skF $ serialiseToRawBytes sK
 
-runToVerification :: ByronKeyFormat -> SigningKeyFile In -> NewVerificationKeyFile -> ExceptT ByronClientCmdError IO ()
+runToVerification
+  :: ByronKeyFormat -> SigningKeyFile In -> NewVerificationKeyFile -> ExceptT ByronClientCmdError IO ()
 runToVerification bKeyFormat skFp (NewVerificationKeyFile vkFp) = do
   sk <- firstExceptT ByronCmdKeyFailure $ readByronSigningKey bKeyFormat skFp
   let ByronVerificationKey vK = byronWitnessToVerKey sk
   let vKey = Builder.toLazyText $ Crypto.formatFullVerificationKey vK
   firstExceptT ByronCmdHelpersError $ ensureNewFile TL.writeFile vkFp vKey
 
-runSubmitTx ::SocketPath -> NetworkId -> TxFile In -> ExceptT ByronClientCmdError IO ()
+runSubmitTx :: SocketPath -> NetworkId -> TxFile In -> ExceptT ByronClientCmdError IO ()
 runSubmitTx nodeSocketPath network fp = do
   tx <- firstExceptT ByronCmdTxError $ readByronTx fp
 
@@ -184,10 +184,10 @@ runSubmitTx nodeSocketPath network fp = do
 
 runGetTxId :: TxFile In -> ExceptT ByronClientCmdError IO ()
 runGetTxId fp = firstExceptT ByronCmdTxError $ do
-    tx <- readByronTx fp
-    let txbody = getTxBody (ByronTx tx)
-        txid   = getTxId txbody
-    liftIO $ BS.putStrLn $ serialiseToRawBytesHex txid
+  tx <- readByronTx fp
+  let txbody = getTxBody (ByronTx tx)
+      txid = getTxId txbody
+  liftIO $ BS.putStrLn $ serialiseToRawBytesHex txid
 
 runSpendGenesisUTxO
   :: GenesisFile
@@ -199,11 +199,11 @@ runSpendGenesisUTxO
   -> [TxOut CtxTx ByronEra]
   -> ExceptT ByronClientCmdError IO ()
 runSpendGenesisUTxO genesisFile nw bKeyFormat (NewTxFile ctTx) ctKey genRichAddr outs = do
-    genesis <- firstExceptT ByronCmdGenesisError $ readGenesis genesisFile nw
-    sk <- firstExceptT ByronCmdKeyFailure $ readByronSigningKey bKeyFormat ctKey
+  genesis <- firstExceptT ByronCmdGenesisError $ readGenesis genesisFile nw
+  sk <- firstExceptT ByronCmdKeyFailure $ readByronSigningKey bKeyFormat ctKey
 
-    let tx = txSpendGenesisUTxOByronPBFT genesis nw sk genRichAddr outs
-    firstExceptT ByronCmdHelpersError . ensureNewFileLBS ctTx $ serialiseToCBOR tx
+  let tx = txSpendGenesisUTxOByronPBFT genesis nw sk genRichAddr outs
+  firstExceptT ByronCmdHelpersError . ensureNewFileLBS ctTx $ serialiseToCBOR tx
 
 runSpendUTxO
   :: NetworkId
@@ -214,7 +214,7 @@ runSpendUTxO
   -> [TxOut CtxTx ByronEra]
   -> ExceptT ByronClientCmdError IO ()
 runSpendUTxO nw bKeyFormat (NewTxFile ctTx) ctKey ins outs = do
-    sk <- firstExceptT ByronCmdKeyFailure $ readByronSigningKey bKeyFormat ctKey
+  sk <- firstExceptT ByronCmdKeyFailure $ readByronSigningKey bKeyFormat ctKey
 
-    let gTx = txSpendUTxOByronPBFT nw sk ins outs
-    firstExceptT ByronCmdHelpersError . ensureNewFileLBS ctTx $ serialiseToCBOR gTx
+  let gTx = txSpendUTxOByronPBFT nw sk ins outs
+  firstExceptT ByronCmdHelpersError . ensureNewFileLBS ctTx $ serialiseToCBOR gTx

--- a/cardano-cli/src/Cardano/CLI/Byron/Tx.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Tx.hs
@@ -25,34 +25,34 @@ where
 import Cardano.Api
 import Cardano.Api.Byron
 
-import qualified Cardano.Binary as Binary
+import Cardano.Binary qualified as Binary
 import Cardano.CLI.Byron.Key (byronWitnessToVerKey)
 import Cardano.CLI.Types.Common (TxFile)
-import qualified Cardano.Chain.Common as Common
+import Cardano.Chain.Common qualified as Common
 import Cardano.Chain.Genesis as Genesis
-import qualified Cardano.Chain.UTxO as UTxO
-import qualified Cardano.Crypto.Signing as Crypto
-import qualified Cardano.Ledger.Binary.Decoding as LedgerBinary
+import Cardano.Chain.UTxO qualified as UTxO
+import Cardano.Crypto.Signing qualified as Crypto
+import Cardano.Ledger.Binary.Decoding qualified as LedgerBinary
 import Ouroboros.Consensus.Byron.Ledger (ByronBlock, GenTx (..))
-import qualified Ouroboros.Consensus.Byron.Ledger as Byron
+import Ouroboros.Consensus.Byron.Ledger qualified as Byron
 import Ouroboros.Consensus.Cardano.Block (EraMismatch (..))
-import qualified Ouroboros.Network.Protocol.LocalTxSubmission.Client as Net.Tx
+import Ouroboros.Network.Protocol.LocalTxSubmission.Client qualified as Net.Tx
 
 import Control.Monad.IO.Class (MonadIO (..))
 import Control.Monad.Trans.Except (ExceptT)
 import Control.Monad.Trans.Except.Extra (left)
 import Data.Bifunctor (Bifunctor (..))
 import Data.ByteString (ByteString)
-import qualified Data.ByteString as B
-import qualified Data.ByteString.Lazy as LB
-import qualified Data.List as List
+import Data.ByteString qualified as B
+import Data.ByteString.Lazy qualified as LB
+import Data.List qualified as List
 import Data.Map.Strict (Map)
-import qualified Data.Map.Strict as Map
+import Data.Map.Strict qualified as Map
 import Data.Maybe (fromMaybe, mapMaybe)
 import Data.String (IsString)
 import Data.Text (Text)
-import qualified Data.Text as Text
-import qualified Data.Text.IO as Text
+import Data.Text qualified as Text
+import Data.Text.IO qualified as Text
 import Formatting (sformat, (%))
 
 data ByronTxError

--- a/cardano-cli/src/Cardano/CLI/Byron/UpdateProposal.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/UpdateProposal.hs
@@ -37,9 +37,9 @@ import Control.Monad.Trans.Except (ExceptT)
 import Control.Monad.Trans.Except.Extra (firstExceptT, handleIOExceptT, hoistEither)
 import Control.Tracer (stdoutTracer, traceWith)
 import Data.Bifunctor (Bifunctor (..))
-import qualified Data.ByteString as BS
+import Data.ByteString qualified as BS
 import Data.Text (Text)
-import qualified Data.Text as Text
+import Data.Text qualified as Text
 
 data ByronUpdateProposalError
   = ByronReadUpdateProposalFileFailure !FilePath !Text

--- a/cardano-cli/src/Cardano/CLI/Byron/Vote.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Vote.hs
@@ -11,7 +11,7 @@ module Cardano.CLI.Byron.Vote
 
 import Cardano.Api.Byron
 
-import qualified Cardano.Binary as Binary
+import Cardano.Binary qualified as Binary
 import Cardano.CLI.Byron.Genesis (ByronGenesisError)
 import Cardano.CLI.Byron.Key (ByronKeyFailure, readByronSigningKey)
 import Cardano.CLI.Byron.Tx (ByronTxError, nodeSubmitTx)
@@ -29,9 +29,9 @@ import Control.Monad.Trans.Except (ExceptT)
 import Control.Monad.Trans.Except.Extra (firstExceptT, hoistEither)
 import Control.Tracer (stdoutTracer, traceWith)
 import Data.Bifunctor (first)
-import qualified Data.ByteString as BS
+import Data.ByteString qualified as BS
 import Data.Text (Text)
-import qualified Data.Text as Text
+import Data.Text qualified as Text
 
 data ByronVoteError
   = ByronVoteDecodingError !FilePath

--- a/cardano-cli/src/Cardano/CLI/Byron/Vote.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Vote.hs
@@ -2,35 +2,36 @@
 {-# LANGUAGE GADTs #-}
 
 module Cardano.CLI.Byron.Vote
-  ( ByronVoteError(..)
+  ( ByronVoteError (..)
   , readByronVote
   , renderByronVoteError
   , runVoteCreation
   , submitByronVote
   ) where
 
-import           Cardano.Api.Byron
+import Cardano.Api.Byron
 
 import qualified Cardano.Binary as Binary
-import           Cardano.CLI.Byron.Genesis (ByronGenesisError)
-import           Cardano.CLI.Byron.Key (ByronKeyFailure, readByronSigningKey)
-import           Cardano.CLI.Byron.Tx (ByronTxError, nodeSubmitTx)
-import           Cardano.CLI.Byron.UpdateProposal (ByronUpdateProposalError,
-                   readByronUpdateProposal)
-import           Cardano.CLI.Helpers (HelpersError, ensureNewFileLBS)
-import           Cardano.CLI.Types.Common
-import           Ouroboros.Consensus.Ledger.SupportsMempool (txId)
-import           Ouroboros.Consensus.Util.Condense (condense)
+import Cardano.CLI.Byron.Genesis (ByronGenesisError)
+import Cardano.CLI.Byron.Key (ByronKeyFailure, readByronSigningKey)
+import Cardano.CLI.Byron.Tx (ByronTxError, nodeSubmitTx)
+import Cardano.CLI.Byron.UpdateProposal
+  ( ByronUpdateProposalError
+  , readByronUpdateProposal
+  )
+import Cardano.CLI.Helpers (HelpersError, ensureNewFileLBS)
+import Cardano.CLI.Types.Common
+import Ouroboros.Consensus.Ledger.SupportsMempool (txId)
+import Ouroboros.Consensus.Util.Condense (condense)
 
-import           Control.Monad.IO.Class (MonadIO (..))
-import           Control.Monad.Trans.Except (ExceptT)
-import           Control.Monad.Trans.Except.Extra (firstExceptT, hoistEither)
-import           Control.Tracer (stdoutTracer, traceWith)
-import           Data.Bifunctor (first)
+import Control.Monad.IO.Class (MonadIO (..))
+import Control.Monad.Trans.Except (ExceptT)
+import Control.Monad.Trans.Except.Extra (firstExceptT, hoistEither)
+import Control.Tracer (stdoutTracer, traceWith)
+import Data.Bifunctor (first)
 import qualified Data.ByteString as BS
-import           Data.Text (Text)
+import Data.Text (Text)
 import qualified Data.Text as Text
-
 
 data ByronVoteError
   = ByronVoteDecodingError !FilePath
@@ -41,20 +42,19 @@ data ByronVoteError
   | ByronVoteUpdateProposalFailure !ByronUpdateProposalError
   | ByronVoteUpdateProposalDecodingError !Binary.DecoderError
   | ByronVoteUpdateHelperError !HelpersError
-  deriving Show
+  deriving (Show)
 
 renderByronVoteError :: ByronVoteError -> Text
 renderByronVoteError bVerr =
   case bVerr of
-    ByronVoteDecodingError fp -> "Error decoding Byron vote at " <>  Text.pack fp
+    ByronVoteDecodingError fp -> "Error decoding Byron vote at " <> Text.pack fp
     ByronVoteGenesisReadError genErr -> "Error reading the genesis file:" <> Text.pack (show genErr)
     ByronVoteReadFileFailure fp err -> "Error reading Byron vote at " <> Text.pack fp <> " Error: " <> err
     ByronVoteTxSubmissionError txErr -> "Error submitting the transaction: " <> Text.pack (show txErr)
     ByronVoteUpdateProposalDecodingError err -> "Error decoding Byron update proposal: " <> Text.pack (show err)
     ByronVoteUpdateProposalFailure err -> "Error reading the update proposal: " <> Text.pack (show err)
-    ByronVoteUpdateHelperError err ->"Error creating the vote: " <> Text.pack (show err)
+    ByronVoteUpdateHelperError err -> "Error creating the vote: " <> Text.pack (show err)
     ByronVoteKeyReadFailure err -> "Error reading the signing key: " <> Text.pack (show err)
-
 
 runVoteCreation
   :: NetworkId
@@ -67,8 +67,8 @@ runVoteCreation nw sKey upPropFp voteBool outputFp = do
   sK <- firstExceptT ByronVoteKeyReadFailure $ readByronSigningKey NonLegacyByronKeyFormat sKey
   proposal <- firstExceptT ByronVoteUpdateProposalFailure $ readByronUpdateProposal upPropFp
   let vote = makeByronVote nw sK proposal voteBool
-  firstExceptT ByronVoteUpdateHelperError . ensureNewFileLBS outputFp
-    $ serialiseToRawBytes vote
+  firstExceptT ByronVoteUpdateHelperError . ensureNewFileLBS outputFp $
+    serialiseToRawBytes vote
 
 submitByronVote
   :: SocketPath

--- a/cardano-cli/src/Cardano/CLI/Environment.hs
+++ b/cardano-cli/src/Cardano/CLI/Environment.hs
@@ -23,8 +23,8 @@ import Cardano.Api
   )
 
 import Data.Word (Word32)
-import qualified System.Environment as IO
-import qualified System.IO as IO
+import System.Environment qualified as IO
+import System.IO qualified as IO
 import Text.Read (readMaybe)
 
 data EnvCli = EnvCli

--- a/cardano-cli/src/Cardano/CLI/Environment.hs
+++ b/cardano-cli/src/Cardano/CLI/Environment.hs
@@ -3,7 +3,7 @@
 
 -- | This module defines constants derived from the environment.
 module Cardano.CLI.Environment
-  ( EnvCli(..)
+  ( EnvCli (..)
   , envCliAnyShelleyBasedEra
   , envCliAnyShelleyToBabbageEra
   , getEnvCli
@@ -11,14 +11,21 @@ module Cardano.CLI.Environment
   , getEnvSocketPath
   ) where
 
-import           Cardano.Api (AnyCardanoEra (..), AnyShelleyBasedEra (..),
-                   AnyShelleyToBabbageEra (..), CardanoEra (..), NetworkId (..), NetworkMagic (..),
-                   ShelleyBasedEra (..), ShelleyToBabbageEra (..))
+import Cardano.Api
+  ( AnyCardanoEra (..)
+  , AnyShelleyBasedEra (..)
+  , AnyShelleyToBabbageEra (..)
+  , CardanoEra (..)
+  , NetworkId (..)
+  , NetworkMagic (..)
+  , ShelleyBasedEra (..)
+  , ShelleyToBabbageEra (..)
+  )
 
-import           Data.Word (Word32)
+import Data.Word (Word32)
 import qualified System.Environment as IO
 import qualified System.IO as IO
-import           Text.Read (readMaybe)
+import Text.Read (readMaybe)
 
 data EnvCli = EnvCli
   { envCliNetworkId :: Maybe NetworkId
@@ -32,11 +39,12 @@ getEnvCli = do
   mSocketPath <- getEnvSocketPath
   mCardanoEra <- getCardanoEra
 
-  pure EnvCli
-    { envCliNetworkId = mNetworkId
-    , envCliSocketPath = mSocketPath
-    , envCliAnyCardanoEra = mCardanoEra
-    }
+  pure
+    EnvCli
+      { envCliNetworkId = mNetworkId
+      , envCliSocketPath = mSocketPath
+      , envCliAnyCardanoEra = mCardanoEra
+      }
 
 envCliAnyShelleyBasedEra :: EnvCli -> Maybe AnyShelleyBasedEra
 envCliAnyShelleyBasedEra envCli = do
@@ -79,10 +87,11 @@ getEnvNetworkId = do
           case readMaybe @Word32 networkIdString of
             Just networkId -> pure $ Just $ Testnet $ NetworkMagic networkId
             Nothing -> do
-              IO.hPutStrLn IO.stderr $ mconcat
-                [ "The network id specified in CARDANO_NODE_NETWORK_ID invalid: " <> networkIdString
-                , " It should be either 'mainnet' or a number."
-                ]
+              IO.hPutStrLn IO.stderr $
+                mconcat
+                  [ "The network id specified in CARDANO_NODE_NETWORK_ID invalid: " <> networkIdString
+                  , " It should be either 'mainnet' or a number."
+                  ]
               pure Nothing
 
 -- | If the environment variable @CARDANO_NODE_SOCKET_PATH@ is set, then return the set value.
@@ -107,5 +116,4 @@ getCardanoEra = do
         "babbage" -> pure $ Just $ AnyCardanoEra BabbageEra
         "conway" -> pure $ Just $ AnyCardanoEra ConwayEra
         unknown -> error $ "Unknown era: " <> unknown -- TODO improve error handling
-
     Nothing -> pure Nothing

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands.hs
@@ -10,34 +10,34 @@ module Cardano.CLI.EraBased.Commands
   , pCmds
   ) where
 
-import           Cardano.Api (CardanoEra (..), ShelleyBasedEra (..))
+import Cardano.Api (CardanoEra (..), ShelleyBasedEra (..))
 
-import           Cardano.CLI.Environment
-import           Cardano.CLI.EraBased.Commands.Address
-import           Cardano.CLI.EraBased.Commands.Genesis
-import           Cardano.CLI.EraBased.Commands.Key
-import           Cardano.CLI.EraBased.Commands.Node
-import           Cardano.CLI.EraBased.Commands.Query
-import           Cardano.CLI.EraBased.Commands.StakeAddress
-import           Cardano.CLI.EraBased.Commands.StakePool
-import           Cardano.CLI.EraBased.Commands.TextView
-import           Cardano.CLI.EraBased.Commands.Transaction
-import           Cardano.CLI.EraBased.Options.Address
-import           Cardano.CLI.EraBased.Options.Common
-import           Cardano.CLI.EraBased.Options.Genesis
-import           Cardano.CLI.EraBased.Options.Governance
-import           Cardano.CLI.EraBased.Options.Key
-import           Cardano.CLI.EraBased.Options.Node
-import           Cardano.CLI.EraBased.Options.Query
-import           Cardano.CLI.EraBased.Options.StakeAddress
-import           Cardano.CLI.EraBased.Options.StakePool
-import           Cardano.CLI.EraBased.Options.TextView
-import           Cardano.CLI.EraBased.Options.Transaction
+import Cardano.CLI.Environment
+import Cardano.CLI.EraBased.Commands.Address
+import Cardano.CLI.EraBased.Commands.Genesis
+import Cardano.CLI.EraBased.Commands.Key
+import Cardano.CLI.EraBased.Commands.Node
+import Cardano.CLI.EraBased.Commands.Query
+import Cardano.CLI.EraBased.Commands.StakeAddress
+import Cardano.CLI.EraBased.Commands.StakePool
+import Cardano.CLI.EraBased.Commands.TextView
+import Cardano.CLI.EraBased.Commands.Transaction
+import Cardano.CLI.EraBased.Options.Address
+import Cardano.CLI.EraBased.Options.Common
+import Cardano.CLI.EraBased.Options.Genesis
+import Cardano.CLI.EraBased.Options.Governance
+import Cardano.CLI.EraBased.Options.Key
+import Cardano.CLI.EraBased.Options.Node
+import Cardano.CLI.EraBased.Options.Query
+import Cardano.CLI.EraBased.Options.StakeAddress
+import Cardano.CLI.EraBased.Options.StakePool
+import Cardano.CLI.EraBased.Options.TextView
+import Cardano.CLI.EraBased.Options.Transaction
 
-import           Data.Foldable
-import           Data.Maybe
-import           Data.Text (Text)
-import           Options.Applicative (Parser)
+import Data.Foldable
+import Data.Maybe
+import Data.Text (Text)
+import Options.Applicative (Parser)
 import qualified Options.Applicative as Opt
 
 data AnyEraCommand where
@@ -48,16 +48,16 @@ renderAnyEraCommand = \case
   AnyEraCommandOf _ cmd -> renderCmds cmd
 
 data Cmds era
-  = AddressCmds         (AddressCmds era)
-  | KeyCmds             (KeyCmds era)
-  | GenesisCmds         (GenesisCmds era)
-  | GovernanceCmds      (GovernanceCmds era)
-  | NodeCmds            (NodeCmds era)
-  | QueryCmds           (QueryCmds era)
-  | StakeAddressCmds    (StakeAddressCmds era)
-  | StakePoolCmds       (StakePoolCmds era)
-  | TextViewCmds        (TextViewCmds era)
-  | TransactionCmds     (TransactionCmds era)
+  = AddressCmds (AddressCmds era)
+  | KeyCmds (KeyCmds era)
+  | GenesisCmds (GenesisCmds era)
+  | GovernanceCmds (GovernanceCmds era)
+  | NodeCmds (NodeCmds era)
+  | QueryCmds (QueryCmds era)
+  | StakeAddressCmds (StakeAddressCmds era)
+  | StakePoolCmds (StakePoolCmds era)
+  | TextViewCmds (TextViewCmds era)
+  | TransactionCmds (TransactionCmds era)
 
 renderCmds :: Cmds era -> Text
 renderCmds = \case
@@ -87,41 +87,41 @@ pAnyEraCommand envCli =
   asum
     [ -- Note, byron is ommitted because there is already a legacy command group for it.
 
-      subParser "shelley"
-        $ Opt.info (AnyEraCommandOf ShelleyBasedEraShelley <$> pCmds ShelleyEra envCli)
-        $ Opt.progDesc "Shelley era commands"
-    , subParser "allegra"
-        $ Opt.info (AnyEraCommandOf ShelleyBasedEraAllegra <$> pCmds AllegraEra envCli)
-        $ Opt.progDesc "Allegra era commands"
-    , subParser "mary"
-        $ Opt.info (AnyEraCommandOf ShelleyBasedEraMary <$> pCmds MaryEra envCli)
-        $ Opt.progDesc "Mary era commands"
-    , subParser "alonzo"
-        $ Opt.info (AnyEraCommandOf ShelleyBasedEraAlonzo <$> pCmds AlonzoEra envCli)
-        $ Opt.progDesc "Alonzo era commands"
-    , subParser "babbage"
-        $ Opt.info (AnyEraCommandOf ShelleyBasedEraBabbage <$> pCmds BabbageEra envCli)
-        $ Opt.progDesc "Babbage era commands"
-    , subParser "conway"
-        $ Opt.info (AnyEraCommandOf ShelleyBasedEraConway <$> pCmds ConwayEra envCli)
-        $ Opt.progDesc "Conway era commands"
-
-    , subParser "latest"
-        $ Opt.info (AnyEraCommandOf ShelleyBasedEraBabbage <$> pCmds BabbageEra envCli)
-        $ Opt.progDesc "Latest era commands (Babbage)"
+      subParser "shelley" $
+        Opt.info (AnyEraCommandOf ShelleyBasedEraShelley <$> pCmds ShelleyEra envCli) $
+          Opt.progDesc "Shelley era commands"
+    , subParser "allegra" $
+        Opt.info (AnyEraCommandOf ShelleyBasedEraAllegra <$> pCmds AllegraEra envCli) $
+          Opt.progDesc "Allegra era commands"
+    , subParser "mary" $
+        Opt.info (AnyEraCommandOf ShelleyBasedEraMary <$> pCmds MaryEra envCli) $
+          Opt.progDesc "Mary era commands"
+    , subParser "alonzo" $
+        Opt.info (AnyEraCommandOf ShelleyBasedEraAlonzo <$> pCmds AlonzoEra envCli) $
+          Opt.progDesc "Alonzo era commands"
+    , subParser "babbage" $
+        Opt.info (AnyEraCommandOf ShelleyBasedEraBabbage <$> pCmds BabbageEra envCli) $
+          Opt.progDesc "Babbage era commands"
+    , subParser "conway" $
+        Opt.info (AnyEraCommandOf ShelleyBasedEraConway <$> pCmds ConwayEra envCli) $
+          Opt.progDesc "Conway era commands"
+    , subParser "latest" $
+        Opt.info (AnyEraCommandOf ShelleyBasedEraBabbage <$> pCmds BabbageEra envCli) $
+          Opt.progDesc "Latest era commands (Babbage)"
     ]
 
 pCmds :: CardanoEra era -> EnvCli -> Parser (Cmds era)
 pCmds era envCli =
-  asum $ catMaybes
-    [ fmap AddressCmds      <$> pAddressCmds era envCli
-    , fmap KeyCmds          <$> pKeyCmds
-    , fmap GenesisCmds      <$> pGenesisCmds envCli
-    , fmap GovernanceCmds   <$> pGovernanceCmds era envCli
-    , fmap NodeCmds         <$> pNodeCmds
-    , fmap QueryCmds        <$> pQueryCmds envCli
-    , fmap StakeAddressCmds <$> pStakeAddressCmds era envCli
-    , fmap StakePoolCmds    <$> pStakePoolCmds era envCli
-    , fmap TextViewCmds     <$> pTextViewCmds
-    , fmap TransactionCmds  <$> pTransactionCmds era envCli
-    ]
+  asum $
+    catMaybes
+      [ fmap AddressCmds <$> pAddressCmds era envCli
+      , fmap KeyCmds <$> pKeyCmds
+      , fmap GenesisCmds <$> pGenesisCmds envCli
+      , fmap GovernanceCmds <$> pGovernanceCmds era envCli
+      , fmap NodeCmds <$> pNodeCmds
+      , fmap QueryCmds <$> pQueryCmds envCli
+      , fmap StakeAddressCmds <$> pStakeAddressCmds era envCli
+      , fmap StakePoolCmds <$> pStakePoolCmds era envCli
+      , fmap TextViewCmds <$> pTextViewCmds
+      , fmap TransactionCmds <$> pTransactionCmds era envCli
+      ]

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands.hs
@@ -38,7 +38,7 @@ import Data.Foldable
 import Data.Maybe
 import Data.Text (Text)
 import Options.Applicative (Parser)
-import qualified Options.Applicative as Opt
+import Options.Applicative qualified as Opt
 
 data AnyEraCommand where
   AnyEraCommandOf :: ShelleyBasedEra era -> Cmds era -> AnyEraCommand

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Address.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Address.hs
@@ -6,14 +6,14 @@ module Cardano.CLI.EraBased.Commands.Address
   , renderAddressCmds
   ) where
 
-import           Cardano.Api.Shelley hiding (QueryInShelleyBasedEra (..))
+import Cardano.Api.Shelley hiding (QueryInShelleyBasedEra (..))
 
-import           Cardano.CLI.Types.Common
-import           Cardano.CLI.Types.Key
+import Cardano.CLI.Types.Common
+import Cardano.CLI.Types.Key
 
-import           Prelude
+import Prelude
 
-import           Data.Text (Text)
+import Data.Text (Text)
 
 data AddressCmds era
   = AddressKeyGen
@@ -32,7 +32,7 @@ data AddressCmds era
   | AddressInfo
       Text
       (Maybe (File () Out))
-  deriving Show
+  deriving (Show)
 
 renderAddressCmds :: AddressCmds era -> Text
 renderAddressCmds = \case

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Genesis.hs
@@ -6,12 +6,12 @@ module Cardano.CLI.EraBased.Commands.Genesis
   , renderGenesisCmds
   ) where
 
-import           Cardano.Api.Shelley
+import Cardano.Api.Shelley
 
-import           Cardano.Chain.Common (BlockCount)
-import           Cardano.CLI.Types.Common
+import Cardano.CLI.Types.Common
+import Cardano.Chain.Common (BlockCount)
 
-import           Data.Text (Text)
+import Data.Text (Text)
 
 data GenesisCmds era
   = GenesisCreate
@@ -37,7 +37,8 @@ data GenesisCmds era
       FilePath
       FilePath
       (Maybe FilePath)
-  | GenesisCreateStaked
+  | -- | Relay specification filepath
+    GenesisCreateStaked
       KeyOutputFormat
       GenesisDir
       Word
@@ -51,7 +52,7 @@ data GenesisCmds era
       Word
       Word
       Word
-      (Maybe FilePath) -- ^ Relay specification filepath
+      (Maybe FilePath)
   | GenesisKeyGenGenesis
       (VerificationKeyFile Out)
       (SigningKeyFile Out)
@@ -77,7 +78,7 @@ data GenesisCmds era
       (Maybe (File () Out))
   | GenesisHashFile
       GenesisFile
-  deriving Show
+  deriving (Show)
 
 renderGenesisCmds :: GenesisCmds era -> Text
 renderGenesisCmds = \case

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance.hs
@@ -3,20 +3,20 @@
 {-# LANGUAGE LambdaCase #-}
 
 module Cardano.CLI.EraBased.Commands.Governance
-  ( GovernanceCmds(..)
+  ( GovernanceCmds (..)
   , renderGovernanceCmds
   ) where
 
-import           Cardano.Api
+import Cardano.Api
 
-import           Cardano.CLI.EraBased.Commands.Governance.Actions
-import           Cardano.CLI.EraBased.Commands.Governance.Committee
-import           Cardano.CLI.EraBased.Commands.Governance.DRep
-import           Cardano.CLI.EraBased.Commands.Governance.Query
-import           Cardano.CLI.EraBased.Commands.Governance.Vote
-import           Cardano.CLI.Types.Common
+import Cardano.CLI.EraBased.Commands.Governance.Actions
+import Cardano.CLI.EraBased.Commands.Governance.Committee
+import Cardano.CLI.EraBased.Commands.Governance.DRep
+import Cardano.CLI.EraBased.Commands.Governance.Query
+import Cardano.CLI.EraBased.Commands.Governance.Vote
+import Cardano.CLI.Types.Common
 
-import           Data.Text (Text)
+import Data.Text (Text)
 
 data GovernanceCmds era
   = GovernanceMIRPayStakeAddressesCertificate

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/Actions.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/Actions.hs
@@ -14,7 +14,7 @@ module Cardano.CLI.EraBased.Commands.Governance.Actions
   ) where
 
 import Cardano.Api
-import qualified Cardano.Api.Ledger as Ledger
+import Cardano.Api.Ledger qualified as Ledger
 import Cardano.Api.Shelley
 
 import Cardano.CLI.Types.Common

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/Actions.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/Actions.hs
@@ -3,25 +3,25 @@
 {-# LANGUAGE LambdaCase #-}
 
 module Cardano.CLI.EraBased.Commands.Governance.Actions
-  ( AnyStakeIdentifier(..)
-  , GovernanceActionCmds(..)
-  , NewCommitteeCmd(..)
-  , NewConstitutionCmd(..)
-  , NewInfoCmd(..)
-  , NoConfidenceCmd(..)
-  , TreasuryWithdrawalCmd(..)
+  ( AnyStakeIdentifier (..)
+  , GovernanceActionCmds (..)
+  , NewCommitteeCmd (..)
+  , NewConstitutionCmd (..)
+  , NewInfoCmd (..)
+  , NoConfidenceCmd (..)
+  , TreasuryWithdrawalCmd (..)
   , renderGovernanceActionCmds
   ) where
 
-import           Cardano.Api
+import Cardano.Api
 import qualified Cardano.Api.Ledger as Ledger
-import           Cardano.Api.Shelley
+import Cardano.Api.Shelley
 
-import           Cardano.CLI.Types.Common
-import           Cardano.CLI.Types.Key
+import Cardano.CLI.Types.Common
+import Cardano.CLI.Types.Key
 
-import           Data.Text (Text)
-import           Data.Word
+import Data.Text (Text)
+import Data.Word
 
 data GovernanceActionCmds era
   = GovernanceActionCreateConstitutionCmd
@@ -45,90 +45,88 @@ data GovernanceActionCmds era
   | GovernanceActionInfoCmd
       (ConwayEraOnwards era)
       NewInfoCmd
-  deriving Show
+  deriving (Show)
 
-data NewCommitteeCmd
-  = NewCommitteeCmd
-    { ebNetwork :: Ledger.Network
-    , ebDeposit :: Lovelace
-    , ebReturnAddress :: AnyStakeIdentifier
-    , ebProposalUrl :: ProposalUrl
-    , ebProposalHashSource :: ProposalHashSource
-    , ebOldCommittee :: [VerificationKeyOrHashOrFile CommitteeColdKey]
-    , ebNewCommittee :: [(VerificationKeyOrHashOrFile CommitteeColdKey, EpochNo)]
-    , ebRequiredQuorum :: Rational
-    , ebPreviousGovActionId :: Maybe (TxId, Word32)
-    , ebFilePath :: File () Out
-    } deriving Show
+data NewCommitteeCmd = NewCommitteeCmd
+  { ebNetwork :: Ledger.Network
+  , ebDeposit :: Lovelace
+  , ebReturnAddress :: AnyStakeIdentifier
+  , ebProposalUrl :: ProposalUrl
+  , ebProposalHashSource :: ProposalHashSource
+  , ebOldCommittee :: [VerificationKeyOrHashOrFile CommitteeColdKey]
+  , ebNewCommittee :: [(VerificationKeyOrHashOrFile CommitteeColdKey, EpochNo)]
+  , ebRequiredQuorum :: Rational
+  , ebPreviousGovActionId :: Maybe (TxId, Word32)
+  , ebFilePath :: File () Out
+  }
+  deriving (Show)
 
-data NewConstitutionCmd
-  = NewConstitutionCmd
-      { encNetwork :: Ledger.Network
-      , encDeposit :: Lovelace
-      , encStakeCredential :: AnyStakeIdentifier
-      , encPrevGovActId :: Maybe (TxId, Word32)
-      , encProposalUrl :: ProposalUrl
-      , encProposalHashSource :: ProposalHashSource
-      , encConstitutionUrl :: ConstitutionUrl
-      , encConstitutionHashSource :: ConstitutionHashSource
-      , encFilePath :: File () Out
-      } deriving Show
+data NewConstitutionCmd = NewConstitutionCmd
+  { encNetwork :: Ledger.Network
+  , encDeposit :: Lovelace
+  , encStakeCredential :: AnyStakeIdentifier
+  , encPrevGovActId :: Maybe (TxId, Word32)
+  , encProposalUrl :: ProposalUrl
+  , encProposalHashSource :: ProposalHashSource
+  , encConstitutionUrl :: ConstitutionUrl
+  , encConstitutionHashSource :: ConstitutionHashSource
+  , encFilePath :: File () Out
+  }
+  deriving (Show)
 
 -- | Datatype to carry data for the create-info governance action
-data NewInfoCmd
-   = NewInfoCmd
-      { niNetwork :: Ledger.Network
-      , niDeposit :: Lovelace
-      , niStakeCredential :: AnyStakeIdentifier
-      , niProposalUrl :: ProposalUrl
-      , niProposalHashSource :: ProposalHashSource
-      , niOutputFilePath :: File () Out
-      } deriving Show
+data NewInfoCmd = NewInfoCmd
+  { niNetwork :: Ledger.Network
+  , niDeposit :: Lovelace
+  , niStakeCredential :: AnyStakeIdentifier
+  , niProposalUrl :: ProposalUrl
+  , niProposalHashSource :: ProposalHashSource
+  , niOutputFilePath :: File () Out
+  }
+  deriving (Show)
 
-data NoConfidenceCmd
-  = NoConfidenceCmd
-      { ncNetwork :: Ledger.Network
-      , ncDeposit :: Lovelace
-      , ncStakeCredential :: AnyStakeIdentifier
-      , ncProposalUrl :: ProposalUrl
-      , ncProposalHashSource :: ProposalHashSource
-      , ncGovAct :: TxId
-      , ncGovActIndex :: Word32
-      , ncFilePath :: File () Out
-      } deriving Show
+data NoConfidenceCmd = NoConfidenceCmd
+  { ncNetwork :: Ledger.Network
+  , ncDeposit :: Lovelace
+  , ncStakeCredential :: AnyStakeIdentifier
+  , ncProposalUrl :: ProposalUrl
+  , ncProposalHashSource :: ProposalHashSource
+  , ncGovAct :: TxId
+  , ncGovActIndex :: Word32
+  , ncFilePath :: File () Out
+  }
+  deriving (Show)
 
-data TreasuryWithdrawalCmd
-  = TreasuryWithdrawalCmd
-    { twNetwork :: Ledger.Network
-    , twDeposit :: Lovelace -- ^ Deposit
-    , twReturnAddr :: AnyStakeIdentifier -- ^ Return address
-    , twProposalUrl :: ProposalUrl
-    , twProposalHashSource :: ProposalHashSource
-    , twTreasuryWithdrawal :: [(AnyStakeIdentifier, Lovelace)]
-    , twFilePath :: File () Out
-    } deriving Show
+data TreasuryWithdrawalCmd = TreasuryWithdrawalCmd
+  { twNetwork :: Ledger.Network
+  , twDeposit :: Lovelace
+  -- ^ Deposit
+  , twReturnAddr :: AnyStakeIdentifier
+  -- ^ Return address
+  , twProposalUrl :: ProposalUrl
+  , twProposalHashSource :: ProposalHashSource
+  , twTreasuryWithdrawal :: [(AnyStakeIdentifier, Lovelace)]
+  , twFilePath :: File () Out
+  }
+  deriving (Show)
 
 renderGovernanceActionCmds :: GovernanceActionCmds era -> Text
-renderGovernanceActionCmds = ("governance action " <>) . \case
-  GovernanceActionCreateConstitutionCmd {} ->
-    "create-constitution"
-
-  GovernanceActionProtocolParametersUpdateCmd {} ->
-    "create-protocol-parameters-update"
-
-  GovernanceActionTreasuryWithdrawalCmd {} ->
-    "create-treasury-withdrawal"
-
-  GoveranceActionCreateNewCommitteeCmd {} ->
-    "create-new-committee"
-
-  GovernanceActionCreateNoConfidenceCmd {} ->
-    "create-no-confidence"
-
-  GovernanceActionInfoCmd {} ->
-    "create-info"
+renderGovernanceActionCmds =
+  ("governance action " <>) . \case
+    GovernanceActionCreateConstitutionCmd {} ->
+      "create-constitution"
+    GovernanceActionProtocolParametersUpdateCmd {} ->
+      "create-protocol-parameters-update"
+    GovernanceActionTreasuryWithdrawalCmd {} ->
+      "create-treasury-withdrawal"
+    GoveranceActionCreateNewCommitteeCmd {} ->
+      "create-new-committee"
+    GovernanceActionCreateNoConfidenceCmd {} ->
+      "create-no-confidence"
+    GovernanceActionInfoCmd {} ->
+      "create-info"
 
 data AnyStakeIdentifier
   = AnyStakeKey (VerificationKeyOrHashOrFile StakeKey)
   | AnyStakePoolKey (VerificationKeyOrHashOrFile StakePoolKey)
-  deriving Show
+  deriving (Show)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/Committee.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/Committee.hs
@@ -2,16 +2,16 @@
 {-# LANGUAGE LambdaCase #-}
 
 module Cardano.CLI.EraBased.Commands.Governance.Committee
-  ( GovernanceCommitteeCmds(..)
+  ( GovernanceCommitteeCmds (..)
   , renderGovernanceCommitteeCmds
   ) where
 
-import           Cardano.Api
+import Cardano.Api
 
-import           Cardano.CLI.Types.Key
-import           Cardano.CLI.Types.Key.VerificationKey
+import Cardano.CLI.Types.Key
+import Cardano.CLI.Types.Key.VerificationKey
 
-import           Data.Text (Text)
+import Data.Text (Text)
 
 data GovernanceCommitteeCmds era
   = GovernanceCommitteeKeyGenColdCmd
@@ -34,7 +34,7 @@ data GovernanceCommitteeCmds era
       (ConwayEraOnwards era)
       (VerificationKeyOrHashOrFile CommitteeColdKey)
       (File () Out)
-  deriving Show
+  deriving (Show)
 
 renderGovernanceCommitteeCmds :: GovernanceCommitteeCmds era -> Text
 renderGovernanceCommitteeCmds = \case

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/DRep.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/DRep.hs
@@ -2,16 +2,16 @@
 {-# LANGUAGE LambdaCase #-}
 
 module Cardano.CLI.EraBased.Commands.Governance.DRep
-  ( GovernanceDRepCmds(..)
+  ( GovernanceDRepCmds (..)
   , renderGovernanceDRepCmds
   ) where
 
-import           Cardano.Api
+import Cardano.Api
 
-import           Cardano.CLI.Types.Common
-import           Cardano.CLI.Types.Key
+import Cardano.CLI.Types.Common
+import Cardano.CLI.Types.Key
 
-import           Data.Text (Text)
+import Data.Text (Text)
 
 data GovernanceDRepCmds era
   = GovernanceDRepGenerateKeyCmd
@@ -27,11 +27,12 @@ data GovernanceDRepCmds era
       AnyRegistrationTarget
       (File () Out)
 
-renderGovernanceDRepCmds :: ()
+renderGovernanceDRepCmds
+  :: ()
   => GovernanceDRepCmds era
   -> Text
 renderGovernanceDRepCmds = \case
-  GovernanceDRepGenerateKeyCmd{} ->
+  GovernanceDRepGenerateKeyCmd {} ->
     "governance drep key-gen"
   GovernanceDRepIdCmd {} ->
     "governance drep id"

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/Query.hs
@@ -3,18 +3,18 @@
 {-# LANGUAGE LambdaCase #-}
 
 module Cardano.CLI.EraBased.Commands.Governance.Query
-  ( GovernanceQueryCmds(..)
-  , NoArgQueryCmd(..)
-  , DRepStateQueryCmd(..)
-  , DRepStakeDistributionQueryCmd(..)
+  ( GovernanceQueryCmds (..)
+  , NoArgQueryCmd (..)
+  , DRepStateQueryCmd (..)
+  , DRepStakeDistributionQueryCmd (..)
   , renderGovernanceQueryCmds
   ) where
 
-import           Cardano.Api
+import Cardano.Api
 
-import           Cardano.CLI.Types.Key
+import Cardano.CLI.Types.Key
 
-import           Data.Text (Text)
+import Data.Text (Text)
 
 data GovernanceQueryCmds era
   = GovernanceQueryConstitutionCmd
@@ -32,35 +32,39 @@ data GovernanceQueryCmds era
   | GovernanceQueryCommitteeStateCmd
       (ConwayEraOnwards era)
       NoArgQueryCmd
-  deriving Show
+  deriving (Show)
 
 data NoArgQueryCmd = NoArgQueryCmd
-  { naSocketPath          :: !SocketPath
+  { naSocketPath :: !SocketPath
   , naConsensusModeParams :: !AnyConsensusModeParams
-  , naNetworkId           :: !NetworkId
-  , naOutputFile          :: !(Maybe (File () Out))
-  } deriving Show
+  , naNetworkId :: !NetworkId
+  , naOutputFile :: !(Maybe (File () Out))
+  }
+  deriving (Show)
 
 data DRepStateQueryCmd = DRepStateQueryCmd
-  { dsSocketPath          :: !SocketPath
+  { dsSocketPath :: !SocketPath
   , dsConsensusModeParams :: !AnyConsensusModeParams
-  , dsNetworkId           :: !NetworkId
-  , dsDRepKeys            :: ![VerificationKeyOrHashOrFile DRepKey]
-  , dsOutputFile          :: !(Maybe (File () Out))
-  } deriving Show
+  , dsNetworkId :: !NetworkId
+  , dsDRepKeys :: ![VerificationKeyOrHashOrFile DRepKey]
+  , dsOutputFile :: !(Maybe (File () Out))
+  }
+  deriving (Show)
 
 data DRepStakeDistributionQueryCmd = DRepStakeDistributionQueryCmd
-  { dsdSocketPath          :: !SocketPath
+  { dsdSocketPath :: !SocketPath
   , dsdConsensusModeParams :: !AnyConsensusModeParams
-  , dsdNetworkId           :: !NetworkId
-  , dsdDRepKeys            :: ![VerificationKeyOrHashOrFile DRepKey]
-  , dsdOutputFile          :: !(Maybe (File () Out))
-  } deriving Show
+  , dsdNetworkId :: !NetworkId
+  , dsdDRepKeys :: ![VerificationKeyOrHashOrFile DRepKey]
+  , dsdOutputFile :: !(Maybe (File () Out))
+  }
+  deriving (Show)
 
 renderGovernanceQueryCmds :: GovernanceQueryCmds era -> Text
-renderGovernanceQueryCmds = ("governance query " <>) . \case
-  GovernanceQueryConstitutionCmd{}          -> "constitution"
-  GovernanceQueryGovStateCmd{}              -> "gov-state"
-  GovernanceQueryDRepStateCmd{}             -> "drep-state"
-  GovernanceQueryDRepStakeDistributionCmd{} -> "drep-stake-distribution"
-  GovernanceQueryCommitteeStateCmd{}        -> "committee-state"
+renderGovernanceQueryCmds =
+  ("governance query " <>) . \case
+    GovernanceQueryConstitutionCmd {} -> "constitution"
+    GovernanceQueryGovStateCmd {} -> "gov-state"
+    GovernanceQueryDRepStateCmd {} -> "drep-state"
+    GovernanceQueryDRepStakeDistributionCmd {} -> "drep-stake-distribution"
+    GovernanceQueryCommitteeStateCmd {} -> "committee-state"

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/Vote.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/Vote.hs
@@ -2,20 +2,20 @@
 {-# LANGUAGE LambdaCase #-}
 
 module Cardano.CLI.EraBased.Commands.Governance.Vote
-  ( GovernanceVoteCmds(..)
+  ( GovernanceVoteCmds (..)
   , renderGovernanceVoteCmds
   ) where
 
+import Cardano.CLI.Types.Governance
 
-import           Cardano.CLI.Types.Governance
-
-import           Data.Text (Text)
+import Data.Text (Text)
 
 newtype GovernanceVoteCmds era
   = GovernanceVoteCreateCmd
       AnyVote
 
-renderGovernanceVoteCmds :: ()
+renderGovernanceVoteCmds
+  :: ()
   => GovernanceVoteCmds era
   -> Text
 renderGovernanceVoteCmds = \case

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Key.hs
@@ -6,11 +6,11 @@ module Cardano.CLI.EraBased.Commands.Key
   , renderKeyCmds
   ) where
 
-import           Cardano.Api.Shelley
+import Cardano.Api.Shelley
 
-import           Cardano.CLI.Types.Common
+import Cardano.CLI.Types.Common
 
-import           Data.Text (Text)
+import Data.Text (Text)
 
 data KeyCmds era
   = KeyGetVerificationKey
@@ -40,7 +40,7 @@ data KeyCmds era
       CardanoAddressKeyType
       (SigningKeyFile In)
       (File () Out)
-  deriving Show
+  deriving (Show)
 
 renderKeyCmds :: KeyCmds era -> Text
 renderKeyCmds = \case

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Node.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Node.hs
@@ -6,12 +6,12 @@ module Cardano.CLI.EraBased.Commands.Node
   , renderNodeCmds
   ) where
 
-import           Cardano.Api.Shelley
+import Cardano.Api.Shelley
 
-import           Cardano.CLI.Types.Common
-import           Cardano.CLI.Types.Key
+import Cardano.CLI.Types.Common
+import Cardano.CLI.Types.Key
 
-import           Data.Text (Text)
+import Data.Text (Text)
 
 data NodeCmds era
   = NodeKeyGenCold
@@ -38,8 +38,9 @@ data NodeCmds era
       (VerificationKeyOrFile KesKey)
       (SigningKeyFile In)
       (OpCertCounterFile InOut)
-      KESPeriod (File () Out)
-  deriving Show
+      KESPeriod
+      (File () Out)
+  deriving (Show)
 
 renderNodeCmds :: NodeCmds era -> Text
 renderNodeCmds = \case
@@ -53,5 +54,5 @@ renderNodeCmds = \case
     "node key-hash-VRF"
   NodeNewCounter {} ->
     "node new-counter"
-  NodeIssueOpCert{} ->
+  NodeIssueOpCert {} ->
     "node issue-op-cert"

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Query.hs
@@ -6,16 +6,16 @@ module Cardano.CLI.EraBased.Commands.Query
   , renderQueryCmds
   ) where
 
-import           Cardano.Api.Shelley hiding (QueryInShelleyBasedEra (..))
+import Cardano.Api.Shelley hiding (QueryInShelleyBasedEra (..))
 
-import           Cardano.CLI.Types.Common
-import           Cardano.CLI.Types.Key
+import Cardano.CLI.Types.Common
+import Cardano.CLI.Types.Key
 
-import           Data.Text (Text)
-import           Data.Time.Clock
+import Data.Text (Text)
+import Data.Time.Clock
 
-data QueryCmds era =
-    QueryLeadershipSchedule
+data QueryCmds era
+  = QueryLeadershipSchedule
       SocketPath
       AnyConsensusModeParams
       NetworkId
@@ -100,7 +100,7 @@ data QueryCmds era =
       AnyConsensusModeParams
       NetworkId
       UTCTime
-  deriving Show
+  deriving (Show)
 
 renderQueryCmds :: QueryCmds era -> Text
 renderQueryCmds = \case

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/StakeAddress.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/StakeAddress.hs
@@ -6,15 +6,15 @@ module Cardano.CLI.EraBased.Commands.StakeAddress
   , renderStakeAddressCmds
   ) where
 
-import           Cardano.Api.Shelley
+import Cardano.Api.Shelley
 
-import           Cardano.CLI.Types.Common
-import           Cardano.CLI.Types.Governance
-import           Cardano.CLI.Types.Key
+import Cardano.CLI.Types.Common
+import Cardano.CLI.Types.Governance
+import Cardano.CLI.Types.Key
 
-import           Prelude
+import Prelude
 
-import           Data.Text (Text)
+import Data.Text (Text)
 
 data StakeAddressCmds era
   = StakeAddressKeyGenCmd
@@ -57,15 +57,15 @@ data StakeAddressCmds era
       StakeIdentifier
       (Maybe Lovelace)
       (File () Out)
-  deriving Show
+  deriving (Show)
 
 renderStakeAddressCmds :: StakeAddressCmds era -> Text
 renderStakeAddressCmds = \case
-  StakeAddressBuildCmd                              {} -> "stake-address build"
-  StakeAddressDeregistrationCertificateCmd          {} -> "stake-address deregistration-certificate"
-  StakeAddressKeyGenCmd                             {} -> "stake-address key-gen"
-  StakeAddressKeyHashCmd                            {} -> "stake-address key-hash"
-  StakeAddressRegistrationCertificateCmd            {} -> "stake-address registration-certificate"
-  StakeAddressStakeAndVoteDelegationCertificateCmd  {} -> "stake-address stake-and-vote-delegation-certificate"
-  StakeAddressStakeDelegationCertificateCmd         {} -> "stake-address stake-delegation-certificate"
-  StakeAddressVoteDelegationCertificateCmd          {} -> "stake-address vote-delegation-certificate"
+  StakeAddressBuildCmd {} -> "stake-address build"
+  StakeAddressDeregistrationCertificateCmd {} -> "stake-address deregistration-certificate"
+  StakeAddressKeyGenCmd {} -> "stake-address key-gen"
+  StakeAddressKeyHashCmd {} -> "stake-address key-hash"
+  StakeAddressRegistrationCertificateCmd {} -> "stake-address registration-certificate"
+  StakeAddressStakeAndVoteDelegationCertificateCmd {} -> "stake-address stake-and-vote-delegation-certificate"
+  StakeAddressStakeDelegationCertificateCmd {} -> "stake-address stake-delegation-certificate"
+  StakeAddressVoteDelegationCertificateCmd {} -> "stake-address vote-delegation-certificate"

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/StakePool.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/StakePool.hs
@@ -6,14 +6,14 @@ module Cardano.CLI.EraBased.Commands.StakePool
   , renderStakePoolCmds
   ) where
 
-import           Cardano.Api.Shelley hiding (QueryInShelleyBasedEra (..))
+import Cardano.Api.Shelley hiding (QueryInShelleyBasedEra (..))
 
-import           Cardano.CLI.Types.Common
-import           Cardano.CLI.Types.Key
+import Cardano.CLI.Types.Common
+import Cardano.CLI.Types.Key
 
-import           Prelude
+import Prelude
 
-import           Data.Text (Text)
+import Data.Text (Text)
 
 data StakePoolCmds era
   = StakePoolDeregistrationCertificateCmd
@@ -54,7 +54,7 @@ data StakePoolCmds era
       -- ^ Stake pool metadata.
       NetworkId
       (File () Out)
-  deriving Show
+  deriving (Show)
 
 renderStakePoolCmds :: StakePoolCmds era -> Text
 renderStakePoolCmds = \case

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/TextView.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/TextView.hs
@@ -6,15 +6,15 @@ module Cardano.CLI.EraBased.Commands.TextView
   , renderTextViewCmds
   ) where
 
-import           Cardano.Api.Shelley
+import Cardano.Api.Shelley
 
-import           Data.Text (Text)
+import Data.Text (Text)
 
 data TextViewCmds era
   = TextViewInfo
       !FilePath
       (Maybe (File () Out))
-  deriving Show
+  deriving (Show)
 
 renderTextViewCmds :: TextViewCmds era -> Text
 renderTextViewCmds = \case

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Transaction.hs
@@ -6,12 +6,12 @@ module Cardano.CLI.EraBased.Commands.Transaction
   , renderTransactionCmds
   ) where
 
-import           Cardano.Api.Shelley
+import Cardano.Api.Shelley
 
-import           Cardano.CLI.Types.Common
-import           Cardano.CLI.Types.Governance
+import Cardano.CLI.Types.Common
+import Cardano.CLI.Types.Governance
 
-import           Data.Text (Text)
+import Data.Text (Text)
 
 data TransactionCmds era
   = TxBuildRaw
@@ -49,14 +49,14 @@ data TransactionCmds era
       (Maybe ProtocolParamsFile)
       (Maybe UpdateProposalFile)
       (TxBodyFile Out)
-
-    -- | Like 'TxBuildRaw' but without the fee, and with a change output.
-  | TxBuild
+  | -- | Like 'TxBuildRaw' but without the fee, and with a change output.
+    TxBuild
       (CardanoEra era)
       SocketPath
       AnyConsensusModeParams
       NetworkId
-      (Maybe ScriptValidity) -- ^ Mark script as expected to pass or fail validation
+      (Maybe ScriptValidity)
+      -- ^ Mark script as expected to pass or fail validation
       (Maybe Word)
       -- ^ Override the required number of tx witnesses
       [(TxIn, Maybe (ScriptWitnessFiles WitCtxTxIn))]

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Address.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Address.hs
@@ -7,42 +7,44 @@ module Cardano.CLI.EraBased.Options.Address
   ( pAddressCmds
   ) where
 
-import           Cardano.Api
+import Cardano.Api
 
-import           Cardano.CLI.Environment (EnvCli (..))
-import           Cardano.CLI.EraBased.Commands.Address
-import           Cardano.CLI.EraBased.Options.Common
+import Cardano.CLI.Environment (EnvCli (..))
+import Cardano.CLI.EraBased.Commands.Address
+import Cardano.CLI.EraBased.Options.Common
 
-import           Options.Applicative hiding (help, str)
+import Options.Applicative hiding (help, str)
 import qualified Options.Applicative as Opt
 
-pAddressCmds :: ()
+pAddressCmds
+  :: ()
   => CardanoEra era
   -> EnvCli
   -> Maybe (Parser (AddressCmds era))
 pAddressCmds _ envCli =
-  subInfoParser "address"
-    ( Opt.progDesc
-        $ mconcat
+  subInfoParser
+    "address"
+    ( Opt.progDesc $
+        mconcat
           [ "Payment address commands."
           ]
     )
-    [ Just
-        $ subParser "key-gen"
-        $ Opt.info pAddressKeyGen
-        $ Opt.progDesc "Create an address key pair."
-    , Just
-        $ subParser "key-hash"
-        $ Opt.info pAddressKeyHash
-        $ Opt.progDesc "Print the hash of an address key."
-    , Just
-        $ subParser "build"
-        $ Opt.info (pAddressBuild envCli)
-        $ Opt.progDesc "Build a Shelley payment address, with optional delegation to a stake address."
-    , Just
-        $ subParser "info"
-        $ Opt.info pAddressInfo
-        $ Opt.progDesc "Print information about an address."
+    [ Just $
+        subParser "key-gen" $
+          Opt.info pAddressKeyGen $
+            Opt.progDesc "Create an address key pair."
+    , Just $
+        subParser "key-hash" $
+          Opt.info pAddressKeyHash $
+            Opt.progDesc "Print the hash of an address key."
+    , Just $
+        subParser "build" $
+          Opt.info (pAddressBuild envCli) $
+            Opt.progDesc "Build a Shelley payment address, with optional delegation to a stake address."
+    , Just $
+        subParser "info" $
+          Opt.info pAddressInfo $
+            Opt.progDesc "Print information about an address."
     ]
 
 pAddressKeyGen :: Parser (AddressCmds era)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Address.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Address.hs
@@ -14,7 +14,7 @@ import Cardano.CLI.EraBased.Commands.Address
 import Cardano.CLI.EraBased.Options.Common
 
 import Options.Applicative hiding (help, str)
-import qualified Options.Applicative as Opt
+import Options.Applicative qualified as Opt
 
 pAddressCmds
   :: ()

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
@@ -12,7 +12,7 @@
 module Cardano.CLI.EraBased.Options.Common where
 
 import Cardano.Api
-import qualified Cardano.Api.Ledger as Ledger
+import Cardano.Api.Ledger qualified as Ledger
 import Cardano.Api.Shelley
 
 import Cardano.CLI.Environment
@@ -26,39 +26,39 @@ import Cardano.CLI.Types.Common
 import Cardano.CLI.Types.Governance
 import Cardano.CLI.Types.Key
 import Cardano.CLI.Types.Key.VerificationKey
-import qualified Cardano.Ledger.BaseTypes as L
-import qualified Cardano.Ledger.Crypto as Crypto
-import qualified Cardano.Ledger.SafeHash as L
-import qualified Cardano.Ledger.Shelley.TxBody as Shelley
+import Cardano.Ledger.BaseTypes qualified as L
+import Cardano.Ledger.Crypto qualified as Crypto
+import Cardano.Ledger.SafeHash qualified as L
+import Cardano.Ledger.Shelley.TxBody qualified as Shelley
 
 import Control.Monad (mfilter)
-import qualified Data.Aeson as Aeson
+import Data.Aeson qualified as Aeson
 import Data.Bifunctor
 import Data.ByteString (ByteString)
-import qualified Data.ByteString.Base16 as B16
-import qualified Data.ByteString.Char8 as BSC
+import Data.ByteString.Base16 qualified as B16
+import Data.ByteString.Char8 qualified as BSC
 import Data.Foldable
 import Data.Functor (($>))
-import qualified Data.IP as IP
+import Data.IP qualified as IP
 import Data.List.NonEmpty (NonEmpty)
-import qualified Data.List.NonEmpty as NE
+import Data.List.NonEmpty qualified as NE
 import Data.Maybe
-import qualified Data.Set as Set
+import Data.Set qualified as Set
 import Data.Text (Text)
-import qualified Data.Text as Text
+import Data.Text qualified as Text
 import Data.Time.Clock (UTCTime)
 import Data.Time.Format (defaultTimeLocale, parseTimeOrError)
 import Data.Word
 import GHC.Natural (Natural)
 import Network.Socket (PortNumber)
 import Options.Applicative hiding (help, str)
-import qualified Options.Applicative as Opt
+import Options.Applicative qualified as Opt
 import Text.Parsec ((<?>))
-import qualified Text.Parsec as Parsec
-import qualified Text.Parsec.Error as Parsec
-import qualified Text.Parsec.Language as Parsec
-import qualified Text.Parsec.String as Parsec
-import qualified Text.Parsec.Token as Parsec
+import Text.Parsec qualified as Parsec
+import Text.Parsec.Error qualified as Parsec
+import Text.Parsec.Language qualified as Parsec
+import Text.Parsec.String qualified as Parsec
+import Text.Parsec.Token qualified as Parsec
 import Text.Read (readEither, readMaybe)
 
 defaultShelleyBasedEra :: AnyShelleyBasedEra

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
@@ -11,52 +11,55 @@
 
 module Cardano.CLI.EraBased.Options.Common where
 
-import           Cardano.Api
+import Cardano.Api
 import qualified Cardano.Api.Ledger as Ledger
-import           Cardano.Api.Shelley
+import Cardano.Api.Shelley
 
-import           Cardano.CLI.Environment (EnvCli (..), envCliAnyShelleyBasedEra,
-                   envCliAnyShelleyToBabbageEra)
-import           Cardano.CLI.Parser
-import           Cardano.CLI.Read
-import           Cardano.CLI.Types.Common
-import           Cardano.CLI.Types.Governance
-import           Cardano.CLI.Types.Key
-import           Cardano.CLI.Types.Key.VerificationKey
+import Cardano.CLI.Environment
+  ( EnvCli (..)
+  , envCliAnyShelleyBasedEra
+  , envCliAnyShelleyToBabbageEra
+  )
+import Cardano.CLI.Parser
+import Cardano.CLI.Read
+import Cardano.CLI.Types.Common
+import Cardano.CLI.Types.Governance
+import Cardano.CLI.Types.Key
+import Cardano.CLI.Types.Key.VerificationKey
 import qualified Cardano.Ledger.BaseTypes as L
 import qualified Cardano.Ledger.Crypto as Crypto
 import qualified Cardano.Ledger.SafeHash as L
 import qualified Cardano.Ledger.Shelley.TxBody as Shelley
 
-import           Control.Monad (mfilter)
+import Control.Monad (mfilter)
 import qualified Data.Aeson as Aeson
-import           Data.Bifunctor
-import           Data.ByteString (ByteString)
+import Data.Bifunctor
+import Data.ByteString (ByteString)
 import qualified Data.ByteString.Base16 as B16
 import qualified Data.ByteString.Char8 as BSC
-import           Data.Foldable
-import           Data.Functor (($>))
+import Data.Foldable
+import Data.Functor (($>))
 import qualified Data.IP as IP
-import           Data.List.NonEmpty (NonEmpty)
+import Data.List.NonEmpty (NonEmpty)
 import qualified Data.List.NonEmpty as NE
-import           Data.Maybe
+import Data.Maybe
 import qualified Data.Set as Set
-import           Data.Text (Text)
+import Data.Text (Text)
 import qualified Data.Text as Text
-import           Data.Time.Clock (UTCTime)
-import           Data.Time.Format (defaultTimeLocale, parseTimeOrError)
-import           Data.Word
-import           GHC.Natural (Natural)
-import           Network.Socket (PortNumber)
-import           Options.Applicative hiding (help, str)
+import Data.Time.Clock (UTCTime)
+import Data.Time.Format (defaultTimeLocale, parseTimeOrError)
+import Data.Word
+import GHC.Natural (Natural)
+import Network.Socket (PortNumber)
+import Options.Applicative hiding (help, str)
 import qualified Options.Applicative as Opt
+import Text.Parsec ((<?>))
 import qualified Text.Parsec as Parsec
-import           Text.Parsec ((<?>))
 import qualified Text.Parsec.Error as Parsec
 import qualified Text.Parsec.Language as Parsec
 import qualified Text.Parsec.String as Parsec
 import qualified Text.Parsec.Token as Parsec
-import           Text.Read (readEither, readMaybe)
+import Text.Read (readEither, readMaybe)
 
 defaultShelleyBasedEra :: AnyShelleyBasedEra
 defaultShelleyBasedEra = AnyShelleyBasedEra ShelleyBasedEraBabbage
@@ -67,7 +70,7 @@ defaultShelleyToBabbageEra = AnyShelleyToBabbageEra ShelleyToBabbageEraBabbage
 command' :: String -> String -> Parser a -> Mod CommandFields a
 command' c descr p =
   mconcat
-    [ command c (info (p <**> helper) $ mconcat [ progDesc descr ])
+    [ command c (info (p <**> helper) $ mconcat [progDesc descr])
     , metavar c
     ]
 
@@ -80,108 +83,131 @@ prefixFlag prefix longFlag =
     Just prefix' -> prefix' <> "-" <> longFlag
 
 pNetworkId :: EnvCli -> Parser NetworkId
-pNetworkId envCli = asum $ mconcat
-  [ [ Opt.flag' Mainnet $ mconcat
-      [ Opt.long "mainnet"
-      , Opt.help $ mconcat
-        [ "Use the mainnet magic id. This overrides the CARDANO_NODE_NETWORK_ID "
-        , "environment variable"
+pNetworkId envCli =
+  asum $
+    mconcat
+      [
+        [ Opt.flag' Mainnet $
+            mconcat
+              [ Opt.long "mainnet"
+              , Opt.help $
+                  mconcat
+                    [ "Use the mainnet magic id. This overrides the CARDANO_NODE_NETWORK_ID "
+                    , "environment variable"
+                    ]
+              ]
+        , fmap (Testnet . NetworkMagic) $
+            Opt.option (bounded "TESTNET_MAGIC") $
+              mconcat
+                [ Opt.long "testnet-magic"
+                , Opt.metavar "NATURAL"
+                , Opt.help $
+                    mconcat
+                      [ "Specify a testnet magic id. This overrides the CARDANO_NODE_NETWORK_ID "
+                      , "environment variable"
+                      ]
+                ]
         ]
+      , -- Default to the network id specified by the environment variable if it is available.
+        pure <$> maybeToList (envCliNetworkId envCli)
       ]
-    , fmap (Testnet . NetworkMagic) $ Opt.option (bounded "TESTNET_MAGIC") $ mconcat
-      [ Opt.long "testnet-magic"
-      , Opt.metavar "NATURAL"
-      , Opt.help $ mconcat
-        [ "Specify a testnet magic id. This overrides the CARDANO_NODE_NETWORK_ID "
-        , "environment variable"
-        ]
-      ]
-    ]
-  , -- Default to the network id specified by the environment variable if it is available.
-    pure <$> maybeToList (envCliNetworkId envCli)
-  ]
 
 pConsensusModeParams :: Parser AnyConsensusModeParams
-pConsensusModeParams = asum
-  [ pShelleyMode *> pShelleyConsensusMode
-  , pByronMode *> pByronConsensusMode
-  , pCardanoMode *> pCardanoConsensusMode
-  , pDefaultConsensusMode
-  ]
-  where
-    pShelleyMode :: Parser ()
-    pShelleyMode =
-      Opt.flag' () $ mconcat
+pConsensusModeParams =
+  asum
+    [ pShelleyMode *> pShelleyConsensusMode
+    , pByronMode *> pByronConsensusMode
+    , pCardanoMode *> pCardanoConsensusMode
+    , pDefaultConsensusMode
+    ]
+ where
+  pShelleyMode :: Parser ()
+  pShelleyMode =
+    Opt.flag' () $
+      mconcat
         [ Opt.long "shelley-mode"
         , Opt.help "For talking to a node running in Shelley-only mode."
         ]
 
-    pByronMode :: Parser ()
-    pByronMode =
-      Opt.flag' () $ mconcat
+  pByronMode :: Parser ()
+  pByronMode =
+    Opt.flag' () $
+      mconcat
         [ Opt.long "byron-mode"
         , Opt.help "For talking to a node running in Byron-only mode."
         ]
 
-    pCardanoMode :: Parser ()
-    pCardanoMode =
-      Opt.flag' () $ mconcat
+  pCardanoMode :: Parser ()
+  pCardanoMode =
+    Opt.flag' () $
+      mconcat
         [ Opt.long "cardano-mode"
         , Opt.help "For talking to a node running in full Cardano mode (default)."
         ]
 
-    pCardanoConsensusMode :: Parser AnyConsensusModeParams
-    pCardanoConsensusMode = AnyConsensusModeParams . CardanoModeParams <$> pEpochSlots
+  pCardanoConsensusMode :: Parser AnyConsensusModeParams
+  pCardanoConsensusMode = AnyConsensusModeParams . CardanoModeParams <$> pEpochSlots
 
-    pByronConsensusMode :: Parser AnyConsensusModeParams
-    pByronConsensusMode = AnyConsensusModeParams . ByronModeParams <$> pEpochSlots
+  pByronConsensusMode :: Parser AnyConsensusModeParams
+  pByronConsensusMode = AnyConsensusModeParams . ByronModeParams <$> pEpochSlots
 
-    pShelleyConsensusMode :: Parser AnyConsensusModeParams
-    pShelleyConsensusMode = pure (AnyConsensusModeParams ShelleyModeParams)
+  pShelleyConsensusMode :: Parser AnyConsensusModeParams
+  pShelleyConsensusMode = pure (AnyConsensusModeParams ShelleyModeParams)
 
-    pDefaultConsensusMode :: Parser AnyConsensusModeParams
-    pDefaultConsensusMode =
-      pure . AnyConsensusModeParams . CardanoModeParams $ EpochSlots defaultByronEpochSlots
+  pDefaultConsensusMode :: Parser AnyConsensusModeParams
+  pDefaultConsensusMode =
+    pure . AnyConsensusModeParams . CardanoModeParams $ EpochSlots defaultByronEpochSlots
 
 defaultByronEpochSlots :: Word64
 defaultByronEpochSlots = 21600
 
 pEpochSlots :: Parser EpochSlots
 pEpochSlots =
-  fmap EpochSlots $ Opt.option (bounded "SLOTS") $ mconcat
-    [ Opt.long "epoch-slots"
-    , Opt.metavar "SLOTS"
-    , Opt.help "The number of slots per epoch for the Byron era."
-    , Opt.value defaultByronEpochSlots -- Default to the mainnet value.
-    , Opt.showDefault
-    ]
+  fmap EpochSlots $
+    Opt.option (bounded "SLOTS") $
+      mconcat
+        [ Opt.long "epoch-slots"
+        , Opt.metavar "SLOTS"
+        , Opt.help "The number of slots per epoch for the Byron era."
+        , Opt.value defaultByronEpochSlots -- Default to the mainnet value.
+        , Opt.showDefault
+        ]
 
 pSocketPath :: EnvCli -> Parser SocketPath
 pSocketPath envCli =
-  asum $ mconcat
-    [ [ fmap File $ Opt.strOption $ mconcat
-        [ Opt.long "socket-path"
-        , Opt.metavar "SOCKET_PATH"
-        , Opt.help $ mconcat
-          [ "Path to the node socket.  This overrides the CARDANO_NODE_SOCKET_PATH "
-          , "environment variable.  The argument is optional if CARDANO_NODE_SOCKET_PATH "
-          , "is defined and mandatory otherwise."
-          ]
-        , Opt.completer (Opt.bashCompleter "file")
+  asum $
+    mconcat
+      [
+        [ fmap File $
+            Opt.strOption $
+              mconcat
+                [ Opt.long "socket-path"
+                , Opt.metavar "SOCKET_PATH"
+                , Opt.help $
+                    mconcat
+                      [ "Path to the node socket.  This overrides the CARDANO_NODE_SOCKET_PATH "
+                      , "environment variable.  The argument is optional if CARDANO_NODE_SOCKET_PATH "
+                      , "is defined and mandatory otherwise."
+                      ]
+                , Opt.completer (Opt.bashCompleter "file")
+                ]
         ]
+      , -- Default to the socket path specified by the environment variable if it is available.
+        pure . File <$> maybeToList (envCliSocketPath envCli)
       ]
-    , -- Default to the socket path specified by the environment variable if it is available.
-      pure . File <$> maybeToList (envCliSocketPath envCli)
-    ]
 
 readerFromParsecParser :: Parsec.Parser a -> Opt.ReadM a
 readerFromParsecParser p =
-    Opt.eitherReader (first formatError . Parsec.parse (p <* Parsec.eof) "")
-  where
-    formatError err =
-      Parsec.showErrorMessages "or" "unknown parse error"
-                               "expecting" "unexpected" "end of input"
-                               (Parsec.errorMessages err)
+  Opt.eitherReader (first formatError . Parsec.parse (p <* Parsec.eof) "")
+ where
+  formatError err =
+    Parsec.showErrorMessages
+      "or"
+      "unknown parse error"
+      "expecting"
+      "unexpected"
+      "end of input"
+      (Parsec.errorMessages err)
 
 parseTxIn :: Parsec.Parser TxIn
 parseTxIn = TxIn <$> parseTxId <*> (Parsec.char '#' *> parseTxIx)
@@ -197,100 +223,111 @@ parseTxIx :: Parsec.Parser TxIx
 parseTxIx = TxIx . fromIntegral <$> decimal
 
 decimal :: Parsec.Parser Integer
-Parsec.TokenParser { Parsec.decimal = decimal } = Parsec.haskell
-
+Parsec.TokenParser {Parsec.decimal = decimal} = Parsec.haskell
 
 pStakeIdentifier :: Parser StakeIdentifier
-pStakeIdentifier = asum
-  [ StakeIdentifierVerifier <$> pStakeVerifier
-  , StakeIdentifierAddress <$> pStakeAddress
-  ]
+pStakeIdentifier =
+  asum
+    [ StakeIdentifierVerifier <$> pStakeVerifier
+    , StakeIdentifierAddress <$> pStakeAddress
+    ]
 
 pStakeVerifier :: Parser StakeVerifier
-pStakeVerifier = asum
-  [ StakeVerifierKey <$> pStakeVerificationKeyOrFile Nothing
-  , StakeVerifierScriptFile <$> pScriptFor "stake-script-file" Nothing "Filepath of the staking script."
-  ]
+pStakeVerifier =
+  asum
+    [ StakeVerifierKey <$> pStakeVerificationKeyOrFile Nothing
+    , StakeVerifierScriptFile <$> pScriptFor "stake-script-file" Nothing "Filepath of the staking script."
+    ]
 
 pStakeAddress :: Parser StakeAddress
 pStakeAddress =
-  Opt.option (readerFromParsecParser parseStakeAddress) $ mconcat
-    [ Opt.long "stake-address"
-    , Opt.metavar "ADDRESS"
-    , Opt.help "Target stake address (bech32 format)."
-    ]
+  Opt.option (readerFromParsecParser parseStakeAddress) $
+    mconcat
+      [ Opt.long "stake-address"
+      , Opt.metavar "ADDRESS"
+      , Opt.help "Target stake address (bech32 format)."
+      ]
 
 parseStakeAddress :: Parsec.Parser StakeAddress
 parseStakeAddress = do
   str' <- lexPlausibleAddressString
   case deserialiseAddress AsStakeAddress str' of
-    Nothing   -> fail $ "invalid address: " <> Text.unpack str'
+    Nothing -> fail $ "invalid address: " <> Text.unpack str'
     Just addr -> pure addr
 
 -- | First argument is the optional prefix
 pStakeVerificationKeyOrFile :: Maybe String -> Parser (VerificationKeyOrFile StakeKey)
 pStakeVerificationKeyOrFile prefix =
-  VerificationKeyValue <$> pStakeVerificationKey prefix
-    <|> VerificationKeyFilePath <$> pStakeVerificationKeyFile prefix
+  VerificationKeyValue
+    <$> pStakeVerificationKey prefix
+      <|> VerificationKeyFilePath
+    <$> pStakeVerificationKeyFile prefix
 
 pScriptFor :: String -> Maybe String -> String -> Parser ScriptFile
 pScriptFor name Nothing help' =
-  fmap ScriptFile $ Opt.strOption $ mconcat
-    [ Opt.long name
-    , Opt.metavar "FILE"
-    , Opt.help help'
-    , Opt.completer (Opt.bashCompleter "file")
-    ]
-
+  fmap ScriptFile $
+    Opt.strOption $
+      mconcat
+        [ Opt.long name
+        , Opt.metavar "FILE"
+        , Opt.help help'
+        , Opt.completer (Opt.bashCompleter "file")
+        ]
 pScriptFor name (Just deprecated) help' =
-      pScriptFor name Nothing help'
-  <|> ScriptFile <$> Opt.strOption
-        (  Opt.long deprecated
-        <> Opt.internal
-        )
+  pScriptFor name Nothing help'
+    <|> ScriptFile
+    <$> Opt.strOption
+      ( Opt.long deprecated
+          <> Opt.internal
+      )
 
 -- | The first argument is the optional prefix.
 pStakeVerificationKey :: Maybe String -> Parser (VerificationKey StakeKey)
 pStakeVerificationKey prefix =
-  Opt.option (readVerificationKey AsStakeKey) $ mconcat
-    [ Opt.long $ prefixFlag prefix "stake-verification-key"
-    , Opt.metavar "STRING"
-    , Opt.help "Stake verification key (Bech32 or hex-encoded)."
-    ]
+  Opt.option (readVerificationKey AsStakeKey) $
+    mconcat
+      [ Opt.long $ prefixFlag prefix "stake-verification-key"
+      , Opt.metavar "STRING"
+      , Opt.help "Stake verification key (Bech32 or hex-encoded)."
+      ]
 
 -- | Read a Bech32 or hex-encoded verification key.
 readVerificationKey
-  :: forall keyrole. SerialiseAsBech32 (VerificationKey keyrole)
+  :: forall keyrole
+   . (SerialiseAsBech32 (VerificationKey keyrole))
   => AsType keyrole
   -> Opt.ReadM (VerificationKey keyrole)
 readVerificationKey asType =
-    Opt.eitherReader deserialiseFromBech32OrHex
-  where
-    keyFormats :: NonEmpty (InputFormat (VerificationKey keyrole))
-    keyFormats = NE.fromList [InputFormatBech32, InputFormatHex]
+  Opt.eitherReader deserialiseFromBech32OrHex
+ where
+  keyFormats :: NonEmpty (InputFormat (VerificationKey keyrole))
+  keyFormats = NE.fromList [InputFormatBech32, InputFormatHex]
 
-    deserialiseFromBech32OrHex
-      :: String
-      -> Either String (VerificationKey keyrole)
-    deserialiseFromBech32OrHex str' =
-      first (Text.unpack . renderInputDecodeError) $
-        deserialiseInput (AsVerificationKey asType) keyFormats (BSC.pack str')
+  deserialiseFromBech32OrHex
+    :: String
+    -> Either String (VerificationKey keyrole)
+  deserialiseFromBech32OrHex str' =
+    first (Text.unpack . renderInputDecodeError) $
+      deserialiseInput (AsVerificationKey asType) keyFormats (BSC.pack str')
 
 -- | The first argument is the optional prefix.
 pStakeVerificationKeyFile :: Maybe String -> Parser (VerificationKeyFile In)
 pStakeVerificationKeyFile prefix =
-  File <$> asum
-    [ Opt.strOption $ mconcat
-      [ Opt.long $ prefixFlag prefix "stake-verification-key-file"
-      , Opt.metavar "FILE"
-      , Opt.help "Filepath of the staking verification key."
-      , Opt.completer (Opt.bashCompleter "file")
+  File
+    <$> asum
+      [ Opt.strOption $
+          mconcat
+            [ Opt.long $ prefixFlag prefix "stake-verification-key-file"
+            , Opt.metavar "FILE"
+            , Opt.help "Filepath of the staking verification key."
+            , Opt.completer (Opt.bashCompleter "file")
+            ]
+      , Opt.strOption $
+          mconcat
+            [ Opt.long $ prefixFlag prefix "staking-verification-key-file"
+            , Opt.internal
+            ]
       ]
-    , Opt.strOption $ mconcat
-      [ Opt.long $ prefixFlag prefix "staking-verification-key-file"
-      , Opt.internal
-      ]
-    ]
 
 subParser :: String -> ParserInfo a -> Parser a
 subParser availableCommand pInfo =
@@ -303,131 +340,149 @@ subInfoParser name i mps = case catMaybes mps of
 
 pAnyShelleyBasedEra :: EnvCli -> Parser AnyShelleyBasedEra
 pAnyShelleyBasedEra envCli =
-  asum $ mconcat
-    [ [ Opt.flag' (AnyShelleyBasedEra ShelleyBasedEraShelley)
-        $ mconcat [Opt.long "shelley-era", Opt.help "Specify the Shelley era"]
-      , Opt.flag' (AnyShelleyBasedEra ShelleyBasedEraAllegra)
-        $ mconcat [Opt.long "allegra-era", Opt.help "Specify the Allegra era"]
-      , Opt.flag' (AnyShelleyBasedEra ShelleyBasedEraMary)
-        $ mconcat [Opt.long "mary-era", Opt.help "Specify the Mary era"]
-      , Opt.flag' (AnyShelleyBasedEra ShelleyBasedEraAlonzo)
-        $ mconcat [Opt.long "alonzo-era", Opt.help "Specify the Alonzo era"]
-      , Opt.flag' (AnyShelleyBasedEra ShelleyBasedEraBabbage)
-        $ mconcat [Opt.long "babbage-era", Opt.help "Specify the Babbage era (default)"]
-      , Opt.flag' (AnyShelleyBasedEra ShelleyBasedEraConway)
-        $ mconcat [Opt.long "conway-era", Opt.help "Specify the Conway era"]
+  asum $
+    mconcat
+      [
+        [ Opt.flag' (AnyShelleyBasedEra ShelleyBasedEraShelley) $
+            mconcat [Opt.long "shelley-era", Opt.help "Specify the Shelley era"]
+        , Opt.flag' (AnyShelleyBasedEra ShelleyBasedEraAllegra) $
+            mconcat [Opt.long "allegra-era", Opt.help "Specify the Allegra era"]
+        , Opt.flag' (AnyShelleyBasedEra ShelleyBasedEraMary) $
+            mconcat [Opt.long "mary-era", Opt.help "Specify the Mary era"]
+        , Opt.flag' (AnyShelleyBasedEra ShelleyBasedEraAlonzo) $
+            mconcat [Opt.long "alonzo-era", Opt.help "Specify the Alonzo era"]
+        , Opt.flag' (AnyShelleyBasedEra ShelleyBasedEraBabbage) $
+            mconcat [Opt.long "babbage-era", Opt.help "Specify the Babbage era (default)"]
+        , Opt.flag' (AnyShelleyBasedEra ShelleyBasedEraConway) $
+            mconcat [Opt.long "conway-era", Opt.help "Specify the Conway era"]
+        ]
+      , maybeToList $ pure <$> envCliAnyShelleyBasedEra envCli
+      , pure $ pure defaultShelleyBasedEra
       ]
-    , maybeToList $ pure <$> envCliAnyShelleyBasedEra envCli
-    , pure $ pure defaultShelleyBasedEra
-  ]
 
 pAnyShelleyToBabbageEra :: EnvCli -> Parser AnyShelleyToBabbageEra
 pAnyShelleyToBabbageEra envCli =
-  asum $ mconcat
-    [ [ Opt.flag' (AnyShelleyToBabbageEra ShelleyToBabbageEraShelley)
-        $ mconcat [Opt.long "shelley-era", Opt.help "Specify the Shelley era"]
-      , Opt.flag' (AnyShelleyToBabbageEra ShelleyToBabbageEraAllegra)
-        $ mconcat [Opt.long "allegra-era", Opt.help "Specify the Allegra era"]
-      , Opt.flag' (AnyShelleyToBabbageEra ShelleyToBabbageEraMary)
-        $ mconcat [Opt.long "mary-era", Opt.help "Specify the Mary era"]
-      , Opt.flag' (AnyShelleyToBabbageEra ShelleyToBabbageEraAlonzo)
-        $ mconcat [Opt.long "alonzo-era", Opt.help "Specify the Alonzo era"]
-      , Opt.flag' (AnyShelleyToBabbageEra ShelleyToBabbageEraBabbage)
-        $ mconcat [Opt.long "babbage-era", Opt.help "Specify the Babbage era (default)"]
+  asum $
+    mconcat
+      [
+        [ Opt.flag' (AnyShelleyToBabbageEra ShelleyToBabbageEraShelley) $
+            mconcat [Opt.long "shelley-era", Opt.help "Specify the Shelley era"]
+        , Opt.flag' (AnyShelleyToBabbageEra ShelleyToBabbageEraAllegra) $
+            mconcat [Opt.long "allegra-era", Opt.help "Specify the Allegra era"]
+        , Opt.flag' (AnyShelleyToBabbageEra ShelleyToBabbageEraMary) $
+            mconcat [Opt.long "mary-era", Opt.help "Specify the Mary era"]
+        , Opt.flag' (AnyShelleyToBabbageEra ShelleyToBabbageEraAlonzo) $
+            mconcat [Opt.long "alonzo-era", Opt.help "Specify the Alonzo era"]
+        , Opt.flag' (AnyShelleyToBabbageEra ShelleyToBabbageEraBabbage) $
+            mconcat [Opt.long "babbage-era", Opt.help "Specify the Babbage era (default)"]
+        ]
+      , maybeToList $ pure <$> envCliAnyShelleyToBabbageEra envCli
+      , pure $ pure defaultShelleyToBabbageEra
       ]
-    , maybeToList $ pure <$> envCliAnyShelleyToBabbageEra envCli
-    , pure $ pure defaultShelleyToBabbageEra
-  ]
 
 pShelleyBasedShelley :: EnvCli -> Parser AnyShelleyBasedEra
 pShelleyBasedShelley envCli =
-  asum $ mconcat
-    [ [ Opt.flag' (AnyShelleyBasedEra ShelleyBasedEraShelley)
-          $ mconcat [Opt.long "shelley-era", Opt.help "Specify the Shelley era"]
+  asum $
+    mconcat
+      [
+        [ Opt.flag' (AnyShelleyBasedEra ShelleyBasedEraShelley) $
+            mconcat [Opt.long "shelley-era", Opt.help "Specify the Shelley era"]
+        ]
+      , maybeToList $
+          fmap pure $
+            mfilter (== AnyShelleyBasedEra ShelleyBasedEraShelley) $
+              envCliAnyShelleyBasedEra envCli
       ]
-    , maybeToList
-        $ fmap pure
-        $ mfilter (== AnyShelleyBasedEra ShelleyBasedEraShelley)
-        $ envCliAnyShelleyBasedEra envCli
-    ]
 
 pShelleyBasedAllegra :: EnvCli -> Parser AnyShelleyBasedEra
 pShelleyBasedAllegra envCli =
-  asum $ mconcat
-    [ [ Opt.flag' (AnyShelleyBasedEra ShelleyBasedEraAllegra)
-          $ mconcat [Opt.long "allegra-era", Opt.help "Specify the Allegra era"]
+  asum $
+    mconcat
+      [
+        [ Opt.flag' (AnyShelleyBasedEra ShelleyBasedEraAllegra) $
+            mconcat [Opt.long "allegra-era", Opt.help "Specify the Allegra era"]
+        ]
+      , maybeToList $
+          fmap pure $
+            mfilter (== AnyShelleyBasedEra ShelleyBasedEraAllegra) $
+              envCliAnyShelleyBasedEra envCli
       ]
-    , maybeToList
-        $ fmap pure
-        $ mfilter (== AnyShelleyBasedEra ShelleyBasedEraAllegra)
-        $ envCliAnyShelleyBasedEra envCli
-    ]
 
 pShelleyBasedMary :: EnvCli -> Parser AnyShelleyBasedEra
 pShelleyBasedMary envCli =
-  asum $ mconcat
-    [ [ Opt.flag' (AnyShelleyBasedEra ShelleyBasedEraMary)
-          $ mconcat [Opt.long "mary-era", Opt.help "Specify the Mary era"]
+  asum $
+    mconcat
+      [
+        [ Opt.flag' (AnyShelleyBasedEra ShelleyBasedEraMary) $
+            mconcat [Opt.long "mary-era", Opt.help "Specify the Mary era"]
+        ]
+      , maybeToList $
+          fmap pure $
+            mfilter (== AnyShelleyBasedEra ShelleyBasedEraMary) $
+              envCliAnyShelleyBasedEra envCli
       ]
-    , maybeToList
-        $ fmap pure
-        $ mfilter (== AnyShelleyBasedEra ShelleyBasedEraMary)
-        $ envCliAnyShelleyBasedEra envCli
-    ]
 
 pShelleyBasedAlonzo :: EnvCli -> Parser AnyShelleyBasedEra
 pShelleyBasedAlonzo envCli =
-  asum $ mconcat
-    [ [ Opt.flag' (AnyShelleyBasedEra ShelleyBasedEraAlonzo)
-          $ mconcat [Opt.long "alonzo-era", Opt.help "Specify the Alonzo era"]
+  asum $
+    mconcat
+      [
+        [ Opt.flag' (AnyShelleyBasedEra ShelleyBasedEraAlonzo) $
+            mconcat [Opt.long "alonzo-era", Opt.help "Specify the Alonzo era"]
+        ]
+      , maybeToList $
+          fmap pure $
+            mfilter (== AnyShelleyBasedEra ShelleyBasedEraAlonzo) $
+              envCliAnyShelleyBasedEra envCli
       ]
-    , maybeToList
-        $ fmap pure
-        $ mfilter (== AnyShelleyBasedEra ShelleyBasedEraAlonzo)
-        $ envCliAnyShelleyBasedEra envCli
-    ]
 
 pShelleyBasedBabbage :: EnvCli -> Parser AnyShelleyBasedEra
 pShelleyBasedBabbage envCli =
-  asum $ mconcat
-    [ [ Opt.flag' (AnyShelleyBasedEra ShelleyBasedEraBabbage)
-          $ mconcat [Opt.long "babbage-era", Opt.help "Specify the Babbage era (default)"]
+  asum $
+    mconcat
+      [
+        [ Opt.flag' (AnyShelleyBasedEra ShelleyBasedEraBabbage) $
+            mconcat [Opt.long "babbage-era", Opt.help "Specify the Babbage era (default)"]
+        ]
+      , maybeToList $
+          fmap pure $
+            mfilter (== AnyShelleyBasedEra ShelleyBasedEraBabbage) $
+              envCliAnyShelleyBasedEra envCli
       ]
-    , maybeToList
-        $ fmap pure
-        $ mfilter (== AnyShelleyBasedEra ShelleyBasedEraBabbage)
-        $ envCliAnyShelleyBasedEra envCli
-    ]
 
 pShelleyBasedConway :: EnvCli -> Parser AnyShelleyBasedEra
 pShelleyBasedConway envCli =
-  asum $ mconcat
-    [ [ Opt.flag' (AnyShelleyBasedEra ShelleyBasedEraConway)
-          $ mconcat [Opt.long "conway-era", Opt.help "Specify the Conway era"]
+  asum $
+    mconcat
+      [
+        [ Opt.flag' (AnyShelleyBasedEra ShelleyBasedEraConway) $
+            mconcat [Opt.long "conway-era", Opt.help "Specify the Conway era"]
+        ]
+      , maybeToList $
+          fmap pure $
+            mfilter (== AnyShelleyBasedEra ShelleyBasedEraConway) $
+              envCliAnyShelleyBasedEra envCli
       ]
-    , maybeToList
-        $ fmap pure
-        $ mfilter (== AnyShelleyBasedEra ShelleyBasedEraConway)
-        $ envCliAnyShelleyBasedEra envCli
-    ]
 
 pFileOutDirection :: String -> String -> Parser (File a Out)
 pFileOutDirection l h =
-  Opt.strOption $ mconcat
-    [ Opt.long l
-    , Opt.metavar "FILE"
-    , Opt.help h
-    , Opt.completer (Opt.bashCompleter "file")
-    ]
+  Opt.strOption $
+    mconcat
+      [ Opt.long l
+      , Opt.metavar "FILE"
+      , Opt.help h
+      , Opt.completer (Opt.bashCompleter "file")
+      ]
 
 pFileInDirection :: String -> String -> Parser (File a In)
 pFileInDirection l h =
-  Opt.strOption $ mconcat
-    [ Opt.long l
-    , Opt.metavar "FILE"
-    , Opt.help h
-    , Opt.completer (Opt.bashCompleter "file")
-    ]
+  Opt.strOption $
+    mconcat
+      [ Opt.long l
+      , Opt.metavar "FILE"
+      , Opt.help h
+      , Opt.completer (Opt.bashCompleter "file")
+      ]
 
 parseLovelace :: Parsec.Parser Lovelace
 parseLovelace = do
@@ -447,97 +502,108 @@ pStakePoolVerificationKeyOrFile prefix =
 -- | The first argument is the optional prefix.
 pStakePoolVerificationKey :: Maybe String -> Parser (VerificationKey StakePoolKey)
 pStakePoolVerificationKey prefix =
-  Opt.option (readVerificationKey AsStakePoolKey) $ mconcat
-    [ Opt.long $ prefixFlag prefix "stake-pool-verification-key"
-    , Opt.metavar "STRING"
-    , Opt.help "Stake pool verification key (Bech32 or hex-encoded)."
-    ]
+  Opt.option (readVerificationKey AsStakePoolKey) $
+    mconcat
+      [ Opt.long $ prefixFlag prefix "stake-pool-verification-key"
+      , Opt.metavar "STRING"
+      , Opt.help "Stake pool verification key (Bech32 or hex-encoded)."
+      ]
 
 -- | The first argument is the optional prefix.
 pStakePoolVerificationKeyFile :: Maybe String -> Parser (VerificationKeyFile In)
 pStakePoolVerificationKeyFile prefix =
-  File <$> asum
-    [ Opt.strOption $ mconcat
-      [ Opt.long $ prefixFlag prefix "cold-verification-key-file"
-      , Opt.metavar "FILE"
-      , Opt.help "Filepath of the stake pool verification key."
-      , Opt.completer (Opt.bashCompleter "file")
+  File
+    <$> asum
+      [ Opt.strOption $
+          mconcat
+            [ Opt.long $ prefixFlag prefix "cold-verification-key-file"
+            , Opt.metavar "FILE"
+            , Opt.help "Filepath of the stake pool verification key."
+            , Opt.completer (Opt.bashCompleter "file")
+            ]
+      , Opt.strOption $
+          mconcat
+            [ Opt.long $ prefixFlag prefix "stake-pool-verification-key-file"
+            , Opt.internal
+            ]
       ]
-    , Opt.strOption $ mconcat
-      [ Opt.long $ prefixFlag prefix "stake-pool-verification-key-file"
-      , Opt.internal
-      ]
-    ]
 
 pOutputFile :: Parser (File content Out)
 pOutputFile =
-  fmap File $ Opt.strOption $ mconcat
-    [ Opt.long "out-file"
-    , Opt.metavar "FILE"
-    , Opt.help "The output file."
-    , Opt.completer (Opt.bashCompleter "file")
-    ]
+  fmap File $
+    Opt.strOption $
+      mconcat
+        [ Opt.long "out-file"
+        , Opt.metavar "FILE"
+        , Opt.help "The output file."
+        , Opt.completer (Opt.bashCompleter "file")
+        ]
 
 pMIRPot :: Parser Shelley.MIRPot
 pMIRPot =
   asum
-    [ Opt.flag' Shelley.ReservesMIR $ mconcat
-        [ Opt.long "reserves"
-        , Opt.help "Use the reserves pot."
-        ]
-    , Opt.flag' Shelley.TreasuryMIR $ mconcat
-        [ Opt.long "treasury"
-        , Opt.help "Use the treasury pot."
-        ]
+    [ Opt.flag' Shelley.ReservesMIR $
+        mconcat
+          [ Opt.long "reserves"
+          , Opt.help "Use the reserves pot."
+          ]
+    , Opt.flag' Shelley.TreasuryMIR $
+        mconcat
+          [ Opt.long "treasury"
+          , Opt.help "Use the treasury pot."
+          ]
     ]
 
 pRewardAmt :: Parser Lovelace
 pRewardAmt =
-  Opt.option (readerFromParsecParser parseLovelace) $ mconcat
-    [ Opt.long "reward"
-    , Opt.metavar "LOVELACE"
-    , Opt.help "The reward for the relevant reward account."
-    ]
+  Opt.option (readerFromParsecParser parseLovelace) $
+    mconcat
+      [ Opt.long "reward"
+      , Opt.metavar "LOVELACE"
+      , Opt.help "The reward for the relevant reward account."
+      ]
 
 pTransferAmt :: Parser Lovelace
 pTransferAmt =
-  Opt.option (readerFromParsecParser parseLovelace) $ mconcat
-    [ Opt.long "transfer"
-    , Opt.metavar "LOVELACE"
-    , Opt.help "The amount to transfer."
-    ]
+  Opt.option (readerFromParsecParser parseLovelace) $
+    mconcat
+      [ Opt.long "transfer"
+      , Opt.metavar "LOVELACE"
+      , Opt.help "The amount to transfer."
+      ]
 
 pHexHash
-  :: SerialiseAsRawBytes (Hash a) => AsType a -> ReadM (Hash a)
+  :: (SerialiseAsRawBytes (Hash a)) => AsType a -> ReadM (Hash a)
 pHexHash a =
   Opt.eitherReader $
     first displayError
       . deserialiseFromRawBytesHex (AsHash a)
       . BSC.pack
 
-pBech32KeyHash :: SerialiseAsBech32 (Hash a) => AsType a -> ReadM (Hash a)
+pBech32KeyHash :: (SerialiseAsBech32 (Hash a)) => AsType a -> ReadM (Hash a)
 pBech32KeyHash a =
   Opt.eitherReader $
     first displayError
-    . deserialiseFromBech32 (AsHash a)
-    . Text.pack
+      . deserialiseFromBech32 (AsHash a)
+      . Text.pack
 
 pGenesisDelegateVerificationKey :: Parser (VerificationKey GenesisDelegateKey)
 pGenesisDelegateVerificationKey =
-  Opt.option (Opt.eitherReader deserialiseFromHex) $ mconcat
-    [ Opt.long "genesis-delegate-verification-key"
-    , Opt.metavar "STRING"
-    , Opt.help "Genesis delegate verification key (hex-encoded)."
-    ]
-  where
-    deserialiseFromHex
-      :: String
-      -> Either String (VerificationKey GenesisDelegateKey)
-    deserialiseFromHex =
-      first
-        (\e -> "Invalid genesis delegate verification key: " ++ displayError e)
-        . deserialiseFromRawBytesHex (AsVerificationKey AsGenesisDelegateKey)
-        . BSC.pack
+  Opt.option (Opt.eitherReader deserialiseFromHex) $
+    mconcat
+      [ Opt.long "genesis-delegate-verification-key"
+      , Opt.metavar "STRING"
+      , Opt.help "Genesis delegate verification key (hex-encoded)."
+      ]
+ where
+  deserialiseFromHex
+    :: String
+    -> Either String (VerificationKey GenesisDelegateKey)
+  deserialiseFromHex =
+    first
+      (\e -> "Invalid genesis delegate verification key: " ++ displayError e)
+      . deserialiseFromRawBytesHex (AsVerificationKey AsGenesisDelegateKey)
+      . BSC.pack
 
 -- | The first argument is the optional prefix.
 pColdVerificationKeyOrFile :: Maybe String -> Parser ColdVerificationKeyOrFile
@@ -550,72 +616,86 @@ pColdVerificationKeyOrFile prefix =
 
 pColdVerificationKeyFile :: Parser (VerificationKeyFile direction)
 pColdVerificationKeyFile =
-  fmap File $ asum
-    [ Opt.strOption $ mconcat
-      [ Opt.long "cold-verification-key-file"
-      , Opt.metavar "FILE"
-      , Opt.help "Filepath of the cold verification key."
-      , Opt.completer (Opt.bashCompleter "file")
+  fmap File $
+    asum
+      [ Opt.strOption $
+          mconcat
+            [ Opt.long "cold-verification-key-file"
+            , Opt.metavar "FILE"
+            , Opt.help "Filepath of the cold verification key."
+            , Opt.completer (Opt.bashCompleter "file")
+            ]
+      , Opt.strOption $
+          mconcat
+            [ Opt.long "verification-key-file"
+            , Opt.internal
+            ]
       ]
-    , Opt.strOption $ mconcat
-      [ Opt.long "verification-key-file"
-      , Opt.internal
-      ]
-    ]
 
 -- TODO CIP-1694 parameterise this by signing key role
 pColdSigningKeyFile :: Parser (File (SigningKey keyrole) direction)
 pColdSigningKeyFile =
-  fmap File $ asum
-    [ Opt.strOption $ mconcat
-      [ Opt.long "cold-signing-key-file"
-      , Opt.metavar "FILE"
-      , Opt.help "Filepath of the cold signing key."
-      , Opt.completer (Opt.bashCompleter "file")
+  fmap File $
+    asum
+      [ Opt.strOption $
+          mconcat
+            [ Opt.long "cold-signing-key-file"
+            , Opt.metavar "FILE"
+            , Opt.help "Filepath of the cold signing key."
+            , Opt.completer (Opt.bashCompleter "file")
+            ]
+      , Opt.strOption $
+          mconcat
+            [ Opt.long "signing-key-file"
+            , Opt.internal
+            ]
       ]
-    , Opt.strOption $ mconcat
-      [ Opt.long "signing-key-file"
-      , Opt.internal
-      ]
-    ]
 
 -- TODO CIP-1694 parameterise this by verification key role
 pVerificationKeyFileOut :: Parser (File (VerificationKey keyrole) Out)
 pVerificationKeyFileOut =
-  fmap File $ Opt.strOption $ mconcat
-    [ Opt.long "verification-key-file"
-    , Opt.metavar "FILE"
-    , Opt.help "Output filepath of the verification key."
-    , Opt.completer (Opt.bashCompleter "file")
-    ]
+  fmap File $
+    Opt.strOption $
+      mconcat
+        [ Opt.long "verification-key-file"
+        , Opt.metavar "FILE"
+        , Opt.help "Output filepath of the verification key."
+        , Opt.completer (Opt.bashCompleter "file")
+        ]
 
 pSigningKeyFileOut :: Parser (File (SigningKey keyrole) Out)
 pSigningKeyFileOut =
-  fmap File $ Opt.strOption $ mconcat
-    [ Opt.long "signing-key-file"
-    , Opt.metavar "FILE"
-    , Opt.help "Output filepath of the signing key."
-    , Opt.completer (Opt.bashCompleter "file")
-    ]
+  fmap File $
+    Opt.strOption $
+      mconcat
+        [ Opt.long "signing-key-file"
+        , Opt.metavar "FILE"
+        , Opt.help "Output filepath of the signing key."
+        , Opt.completer (Opt.bashCompleter "file")
+        ]
 
 pOperatorCertIssueCounterFile :: Parser (File OpCertCounter direction)
 pOperatorCertIssueCounterFile =
-  fmap File $ asum
-    [ Opt.strOption $ mconcat
-      [ Opt.long "operational-certificate-issue-counter-file"
-      , Opt.metavar "FILE"
-      , Opt.help "The file with the issue counter for the operational certificate."
-      , Opt.completer (Opt.bashCompleter "file")
+  fmap File $
+    asum
+      [ Opt.strOption $
+          mconcat
+            [ Opt.long "operational-certificate-issue-counter-file"
+            , Opt.metavar "FILE"
+            , Opt.help "The file with the issue counter for the operational certificate."
+            , Opt.completer (Opt.bashCompleter "file")
+            ]
+      , Opt.strOption $
+          mconcat
+            [ Opt.long "operational-certificate-issue-counter"
+            , Opt.internal
+            ]
       ]
-    , Opt.strOption $ mconcat
-      [ Opt.long "operational-certificate-issue-counter"
-      , Opt.internal
-      ]
-    ]
 
 ---
 
-pAddCommitteeColdVerificationKeyOrHashOrFile :: Parser (VerificationKeyOrHashOrFile CommitteeColdKey)
+pAddCommitteeColdVerificationKeyOrHashOrFile
+  :: Parser (VerificationKeyOrHashOrFile CommitteeColdKey)
 pAddCommitteeColdVerificationKeyOrHashOrFile =
   asum
     [ VerificationKeyOrFile <$> pAddCommitteeColdVerificationKeyOrFile
@@ -624,17 +704,18 @@ pAddCommitteeColdVerificationKeyOrHashOrFile =
 
 pAddCommitteeColdVerificationKeyHash :: Parser (Hash CommitteeColdKey)
 pAddCommitteeColdVerificationKeyHash =
-  Opt.option (Opt.eitherReader deserialiseFromHex) $ mconcat
-    [ Opt.long "add-cc-cold-verification-key-hash"
-    , Opt.metavar "STRING"
-    , Opt.help "Constitutional Committee key hash (hex-encoded)."
-    ]
-  where
-    deserialiseFromHex :: String -> Either String (Hash CommitteeColdKey)
-    deserialiseFromHex =
-      first (\e -> "Invalid Consitutional Committee cold key hash: " ++ displayError e)
-        . deserialiseFromRawBytesHex (AsHash AsCommitteeColdKey)
-        . BSC.pack
+  Opt.option (Opt.eitherReader deserialiseFromHex) $
+    mconcat
+      [ Opt.long "add-cc-cold-verification-key-hash"
+      , Opt.metavar "STRING"
+      , Opt.help "Constitutional Committee key hash (hex-encoded)."
+      ]
+ where
+  deserialiseFromHex :: String -> Either String (Hash CommitteeColdKey)
+  deserialiseFromHex =
+    first (\e -> "Invalid Consitutional Committee cold key hash: " ++ displayError e)
+      . deserialiseFromRawBytesHex (AsHash AsCommitteeColdKey)
+      . BSC.pack
 
 pAddCommitteeColdVerificationKeyOrFile :: Parser (VerificationKeyOrFile CommitteeColdKey)
 pAddCommitteeColdVerificationKeyOrFile =
@@ -645,29 +726,33 @@ pAddCommitteeColdVerificationKeyOrFile =
 
 pAddCommitteeColdVerificationKey :: Parser (VerificationKey CommitteeColdKey)
 pAddCommitteeColdVerificationKey =
-  Opt.option (Opt.eitherReader deserialiseFromHex) $ mconcat
-    [ Opt.long "add-cc-cold-verification-key"
-    , Opt.metavar "STRING"
-    , Opt.help "Constitutional Committee cold key (hex-encoded)."
-    ]
-  where
-    deserialiseFromHex :: String -> Either String (VerificationKey CommitteeColdKey)
-    deserialiseFromHex =
-      first (\e -> "Invalid Constitutional Committee cold key: " ++ displayError e)
-        . deserialiseFromRawBytesHex (AsVerificationKey AsCommitteeColdKey)
-        . BSC.pack
+  Opt.option (Opt.eitherReader deserialiseFromHex) $
+    mconcat
+      [ Opt.long "add-cc-cold-verification-key"
+      , Opt.metavar "STRING"
+      , Opt.help "Constitutional Committee cold key (hex-encoded)."
+      ]
+ where
+  deserialiseFromHex :: String -> Either String (VerificationKey CommitteeColdKey)
+  deserialiseFromHex =
+    first (\e -> "Invalid Constitutional Committee cold key: " ++ displayError e)
+      . deserialiseFromRawBytesHex (AsVerificationKey AsCommitteeColdKey)
+      . BSC.pack
 
 pAddCommitteeColdVerificationKeyFile :: Parser (File (VerificationKey keyrole) In)
 pAddCommitteeColdVerificationKeyFile =
-  fmap File $ Opt.strOption $ mconcat
-    [ Opt.long "add-cc-cold-verification-key-file"
-    , Opt.metavar "FILE"
-    , Opt.help "Filepath of the Consitutional Committee cold key."
-    , Opt.completer (Opt.bashCompleter "file")
-    ]
+  fmap File $
+    Opt.strOption $
+      mconcat
+        [ Opt.long "add-cc-cold-verification-key-file"
+        , Opt.metavar "FILE"
+        , Opt.help "Filepath of the Consitutional Committee cold key."
+        , Opt.completer (Opt.bashCompleter "file")
+        ]
 
 ---
-pRemoveCommitteeColdVerificationKeyOrHashOrFile :: Parser (VerificationKeyOrHashOrFile CommitteeColdKey)
+pRemoveCommitteeColdVerificationKeyOrHashOrFile
+  :: Parser (VerificationKeyOrHashOrFile CommitteeColdKey)
 pRemoveCommitteeColdVerificationKeyOrHashOrFile =
   asum
     [ VerificationKeyOrFile <$> pRemoveCommitteeColdVerificationKeyOrFile
@@ -676,17 +761,18 @@ pRemoveCommitteeColdVerificationKeyOrHashOrFile =
 
 pRemoveCommitteeColdVerificationKeyHash :: Parser (Hash CommitteeColdKey)
 pRemoveCommitteeColdVerificationKeyHash =
-  Opt.option (Opt.eitherReader deserialiseFromHex) $ mconcat
-    [ Opt.long "remove-cc-cold-verification-key-hash"
-    , Opt.metavar "STRING"
-    , Opt.help "Constitutional Committee key hash (hex-encoded)."
-    ]
-  where
-    deserialiseFromHex :: String -> Either String (Hash CommitteeColdKey)
-    deserialiseFromHex =
-      first (\e -> "Invalid Consitutional Committee cold key hash: " ++ displayError e)
-        . deserialiseFromRawBytesHex (AsHash AsCommitteeColdKey)
-        . BSC.pack
+  Opt.option (Opt.eitherReader deserialiseFromHex) $
+    mconcat
+      [ Opt.long "remove-cc-cold-verification-key-hash"
+      , Opt.metavar "STRING"
+      , Opt.help "Constitutional Committee key hash (hex-encoded)."
+      ]
+ where
+  deserialiseFromHex :: String -> Either String (Hash CommitteeColdKey)
+  deserialiseFromHex =
+    first (\e -> "Invalid Consitutional Committee cold key hash: " ++ displayError e)
+      . deserialiseFromRawBytesHex (AsHash AsCommitteeColdKey)
+      . BSC.pack
 
 pRemoveCommitteeColdVerificationKeyOrFile :: Parser (VerificationKeyOrFile CommitteeColdKey)
 pRemoveCommitteeColdVerificationKeyOrFile =
@@ -697,26 +783,29 @@ pRemoveCommitteeColdVerificationKeyOrFile =
 
 pRemoveCommitteeColdVerificationKey :: Parser (VerificationKey CommitteeColdKey)
 pRemoveCommitteeColdVerificationKey =
-  Opt.option (Opt.eitherReader deserialiseFromHex) $ mconcat
-    [ Opt.long "remove-cc-cold-verification-key"
-    , Opt.metavar "STRING"
-    , Opt.help "Constitutional Committee cold key (hex-encoded)."
-    ]
-  where
-    deserialiseFromHex :: String -> Either String (VerificationKey CommitteeColdKey)
-    deserialiseFromHex =
-      first (\e -> "Invalid Constitutional Committee cold key: " ++ displayError e)
-        . deserialiseFromRawBytesHex (AsVerificationKey AsCommitteeColdKey)
-        . BSC.pack
+  Opt.option (Opt.eitherReader deserialiseFromHex) $
+    mconcat
+      [ Opt.long "remove-cc-cold-verification-key"
+      , Opt.metavar "STRING"
+      , Opt.help "Constitutional Committee cold key (hex-encoded)."
+      ]
+ where
+  deserialiseFromHex :: String -> Either String (VerificationKey CommitteeColdKey)
+  deserialiseFromHex =
+    first (\e -> "Invalid Constitutional Committee cold key: " ++ displayError e)
+      . deserialiseFromRawBytesHex (AsVerificationKey AsCommitteeColdKey)
+      . BSC.pack
 
 pRemoveCommitteeColdVerificationKeyFile :: Parser (File (VerificationKey keyrole) In)
 pRemoveCommitteeColdVerificationKeyFile =
-  fmap File $ Opt.strOption $ mconcat
-    [ Opt.long "remove-cc-cold-verification-key-file"
-    , Opt.metavar "FILE"
-    , Opt.help "Filepath of the Consitutional Committee cold key."
-    , Opt.completer (Opt.bashCompleter "file")
-    ]
+  fmap File $
+    Opt.strOption $
+      mconcat
+        [ Opt.long "remove-cc-cold-verification-key-file"
+        , Opt.metavar "FILE"
+        , Opt.help "Filepath of the Consitutional Committee cold key."
+        , Opt.completer (Opt.bashCompleter "file")
+        ]
 
 ---
 
@@ -736,66 +825,76 @@ pCommitteeColdVerificationKeyOrFile =
 
 pCommitteeColdVerificationKey :: Parser (VerificationKey CommitteeColdKey)
 pCommitteeColdVerificationKey =
-  Opt.option (Opt.eitherReader deserialiseFromHex) $ mconcat
-    [ Opt.long "cold-verification-key"
-    , Opt.metavar "STRING"
-    , Opt.help "Constitutional Committee cold key (hex-encoded)."
-    ]
-  where
-    deserialiseFromHex :: String -> Either String (VerificationKey CommitteeColdKey)
-    deserialiseFromHex =
-      first (\e -> "Invalid Constitutional Committee cold key: " ++ displayError e)
-        . deserialiseFromRawBytesHex (AsVerificationKey AsCommitteeColdKey)
-        . BSC.pack
+  Opt.option (Opt.eitherReader deserialiseFromHex) $
+    mconcat
+      [ Opt.long "cold-verification-key"
+      , Opt.metavar "STRING"
+      , Opt.help "Constitutional Committee cold key (hex-encoded)."
+      ]
+ where
+  deserialiseFromHex :: String -> Either String (VerificationKey CommitteeColdKey)
+  deserialiseFromHex =
+    first (\e -> "Invalid Constitutional Committee cold key: " ++ displayError e)
+      . deserialiseFromRawBytesHex (AsVerificationKey AsCommitteeColdKey)
+      . BSC.pack
 
 pCommitteeColdVerificationKeyHash :: Parser (Hash CommitteeColdKey)
 pCommitteeColdVerificationKeyHash =
-  Opt.option (Opt.eitherReader deserialiseFromHex) $ mconcat
-    [ Opt.long "cold-verification-key-hash"
-    , Opt.metavar "STRING"
-    , Opt.help "Constitutional Committee key hash (hex-encoded)."
-    ]
-  where
-    deserialiseFromHex :: String -> Either String (Hash CommitteeColdKey)
-    deserialiseFromHex =
-      first (\e -> "Invalid Consitutional Committee cold key hash: " ++ displayError e)
-        . deserialiseFromRawBytesHex (AsHash AsCommitteeColdKey)
-        . BSC.pack
+  Opt.option (Opt.eitherReader deserialiseFromHex) $
+    mconcat
+      [ Opt.long "cold-verification-key-hash"
+      , Opt.metavar "STRING"
+      , Opt.help "Constitutional Committee key hash (hex-encoded)."
+      ]
+ where
+  deserialiseFromHex :: String -> Either String (Hash CommitteeColdKey)
+  deserialiseFromHex =
+    first (\e -> "Invalid Consitutional Committee cold key hash: " ++ displayError e)
+      . deserialiseFromRawBytesHex (AsHash AsCommitteeColdKey)
+      . BSC.pack
 
 pCommitteeColdVerificationKeyFile :: Parser (File (VerificationKey keyrole) In)
 pCommitteeColdVerificationKeyFile =
-  fmap File $ Opt.strOption $ mconcat
-    [ Opt.long "cold-verification-key-file"
-    , Opt.metavar "FILE"
-    , Opt.help "Filepath of the Consitutional Committee cold key."
-    , Opt.completer (Opt.bashCompleter "file")
-    ]
+  fmap File $
+    Opt.strOption $
+      mconcat
+        [ Opt.long "cold-verification-key-file"
+        , Opt.metavar "FILE"
+        , Opt.help "Filepath of the Consitutional Committee cold key."
+        , Opt.completer (Opt.bashCompleter "file")
+        ]
 
 pVerificationKeyFileIn :: Parser (VerificationKeyFile In)
 pVerificationKeyFileIn =
-  fmap File $ Opt.strOption $ mconcat
-    [ Opt.long "verification-key-file"
-    , Opt.metavar "FILE"
-    , Opt.help "Input filepath of the verification key."
-    , Opt.completer (Opt.bashCompleter "file")
-    ]
+  fmap File $
+    Opt.strOption $
+      mconcat
+        [ Opt.long "verification-key-file"
+        , Opt.metavar "FILE"
+        , Opt.help "Input filepath of the verification key."
+        , Opt.completer (Opt.bashCompleter "file")
+        ]
 
 pAnyVerificationKeyFileIn :: String -> Parser (VerificationKeyFile In)
 pAnyVerificationKeyFileIn helpText =
-  fmap File $ Opt.strOption $ mconcat
-    [ Opt.long "verification-key-file"
-    , Opt.metavar "FILE"
-    , Opt.help $ "Input filepath of the " <> helpText <> "."
-    , Opt.completer (Opt.bashCompleter "file")
-    ]
+  fmap File $
+    Opt.strOption $
+      mconcat
+        [ Opt.long "verification-key-file"
+        , Opt.metavar "FILE"
+        , Opt.help $ "Input filepath of the " <> helpText <> "."
+        , Opt.completer (Opt.bashCompleter "file")
+        ]
 
 pAnyVerificationKeyText :: String -> Parser AnyVerificationKeyText
 pAnyVerificationKeyText helpText =
-  fmap (AnyVerificationKeyText . Text.pack) $ Opt.strOption $ mconcat
-    [ Opt.long "verification-key"
-    , Opt.metavar "STRING"
-    , Opt.help $ helpText <> " (Bech32-encoded)"
-    ]
+  fmap (AnyVerificationKeyText . Text.pack) $
+    Opt.strOption $
+      mconcat
+        [ Opt.long "verification-key"
+        , Opt.metavar "STRING"
+        , Opt.help $ helpText <> " (Bech32-encoded)"
+        ]
 
 pAnyVerificationKeySource :: String -> Parser AnyVerificationKeySource
 pAnyVerificationKeySource helpText =
@@ -806,40 +905,44 @@ pAnyVerificationKeySource helpText =
 
 pCommitteeHotKey :: Parser (VerificationKey CommitteeHotKey)
 pCommitteeHotKey =
-  Opt.option (Opt.eitherReader deserialiseFromHex) $ mconcat
-    [ Opt.long "hot-key"
-    , Opt.metavar "STRING"
-    , Opt.help "Constitutional Committee hot key (hex-encoded)."
-    ]
-  where
-    deserialiseFromHex :: String -> Either String (VerificationKey CommitteeHotKey)
-    deserialiseFromHex =
-      first (\e -> "Invalid Constitutional Committee hot key: " ++ displayError e)
-        . deserialiseFromRawBytesHex (AsVerificationKey AsCommitteeHotKey)
-        . BSC.pack
+  Opt.option (Opt.eitherReader deserialiseFromHex) $
+    mconcat
+      [ Opt.long "hot-key"
+      , Opt.metavar "STRING"
+      , Opt.help "Constitutional Committee hot key (hex-encoded)."
+      ]
+ where
+  deserialiseFromHex :: String -> Either String (VerificationKey CommitteeHotKey)
+  deserialiseFromHex =
+    first (\e -> "Invalid Constitutional Committee hot key: " ++ displayError e)
+      . deserialiseFromRawBytesHex (AsVerificationKey AsCommitteeHotKey)
+      . BSC.pack
 
 pCommitteeHotKeyFile :: Parser (VerificationKeyFile In)
 pCommitteeHotKeyFile =
-  fmap File $ Opt.strOption $ mconcat
-    [ Opt.long "hot-key-file"
-    , Opt.metavar "FILE"
-    , Opt.help "Filepath of the Consitutional Committee hot key."
-    , Opt.completer (Opt.bashCompleter "file")
-    ]
+  fmap File $
+    Opt.strOption $
+      mconcat
+        [ Opt.long "hot-key-file"
+        , Opt.metavar "FILE"
+        , Opt.help "Filepath of the Consitutional Committee hot key."
+        , Opt.completer (Opt.bashCompleter "file")
+        ]
 
 pCommitteeHotKeyHash :: Parser (Hash CommitteeHotKey)
 pCommitteeHotKeyHash =
-  Opt.option (Opt.eitherReader deserialiseFromHex) $ mconcat
-    [ Opt.long "hot-key-hash"
-    , Opt.metavar "STRING"
-    , Opt.help "Constitutional Committee key hash (hex-encoded)."
-    ]
-  where
-    deserialiseFromHex :: String -> Either String (Hash CommitteeHotKey)
-    deserialiseFromHex =
-      first (\e -> "Invalid Consitutional Committee hot key hash: " ++ displayError e)
-        . deserialiseFromRawBytesHex (AsHash AsCommitteeHotKey)
-        . BSC.pack
+  Opt.option (Opt.eitherReader deserialiseFromHex) $
+    mconcat
+      [ Opt.long "hot-key-hash"
+      , Opt.metavar "STRING"
+      , Opt.help "Constitutional Committee key hash (hex-encoded)."
+      ]
+ where
+  deserialiseFromHex :: String -> Either String (Hash CommitteeHotKey)
+  deserialiseFromHex =
+    first (\e -> "Invalid Consitutional Committee hot key hash: " ++ displayError e)
+      . deserialiseFromRawBytesHex (AsHash AsCommitteeHotKey)
+      . BSC.pack
 
 pCommitteeHotKeyOrFile :: Parser (VerificationKeyOrFile CommitteeHotKey)
 pCommitteeHotKeyOrFile =
@@ -870,12 +973,12 @@ pConstitutionHashSource =
   asum
     [ ConstitutionHashSourceText
         <$> Opt.strOption
-            ( mconcat
-                [ Opt.long "constitution-text"
-                , Opt.metavar "TEXT"
-                , Opt.help "Input constitution as UTF-8 encoded text."
-                ]
-            )
+          ( mconcat
+              [ Opt.long "constitution-text"
+              , Opt.metavar "TEXT"
+              , Opt.help "Input constitution as UTF-8 encoded text."
+              ]
+          )
     , ConstitutionHashSourceFile
         <$> pFileInDirection "constitution-file" "Input constitution as a text file."
     , ConstitutionHashSourceHash
@@ -884,46 +987,51 @@ pConstitutionHashSource =
 
 pConstitutionHash :: Parser (L.SafeHash Crypto.StandardCrypto L.AnchorData)
 pConstitutionHash =
-  Opt.option readSafeHash $ mconcat
-    [ Opt.long "constitution-hash"
-    , Opt.metavar "HASH"
-    , Opt.help "Constitution anchor data hash."
-    ]
+  Opt.option readSafeHash $
+    mconcat
+      [ Opt.long "constitution-hash"
+      , Opt.metavar "HASH"
+      , Opt.help "Constitution anchor data hash."
+      ]
 
 pUrl :: String -> String -> Parser Ledger.Url
-pUrl l h = fromMaybe (error "Url longer than 64 bytes")
-         . Ledger.textToUrl <$>
-             Opt.strOption (mconcat
-                            [ Opt.long l
-                            , Opt.metavar "TEXT"
-                            , Opt.help h
-                            ])
+pUrl l h =
+  fromMaybe (error "Url longer than 64 bytes")
+    . Ledger.textToUrl
+    <$> Opt.strOption
+      ( mconcat
+          [ Opt.long l
+          , Opt.metavar "TEXT"
+          , Opt.help h
+          ]
+      )
 
 pGovActionDeposit :: Parser Lovelace
 pGovActionDeposit =
-  Opt.option (readerFromParsecParser parseLovelace) $ mconcat
-    [ Opt.long "governance-action-deposit"
-    , Opt.metavar "NATURAL"
-    , Opt.help "Deposit required to submit a governance action."
-    ]
-
+  Opt.option (readerFromParsecParser parseLovelace) $
+    mconcat
+      [ Opt.long "governance-action-deposit"
+      , Opt.metavar "NATURAL"
+      , Opt.help "Deposit required to submit a governance action."
+      ]
 
 -- | First argument is the optional prefix
 pStakeVerificationKeyOrHashOrFile :: Maybe String -> Parser (VerificationKeyOrHashOrFile StakeKey)
-pStakeVerificationKeyOrHashOrFile prefix = asum
-  [ VerificationKeyOrFile <$> pStakeVerificationKeyOrFile prefix
-  , VerificationKeyHash <$> pStakeVerificationKeyHash prefix
-  ]
+pStakeVerificationKeyOrHashOrFile prefix =
+  asum
+    [ VerificationKeyOrFile <$> pStakeVerificationKeyOrFile prefix
+    , VerificationKeyHash <$> pStakeVerificationKeyHash prefix
+    ]
 
 -- | First argument is the optional prefix
 pStakeVerificationKeyHash :: Maybe String -> Parser (Hash StakeKey)
 pStakeVerificationKeyHash prefix =
-   Opt.option (pHexHash AsStakeKey) $ mconcat
+  Opt.option (pHexHash AsStakeKey) $
+    mconcat
       [ Opt.long $ prefixFlag prefix "stake-key-hash"
       , Opt.metavar "HASH"
       , Opt.help "Stake verification key hash (hex-encoded)."
       ]
-
 
 -- | The first argument is the optional prefix.
 pStakePoolVerificationKeyOrHashOrFile
@@ -951,170 +1059,199 @@ pCombinedStakePoolVerificationKeyOrFile =
 
 pCombinedStakePoolVerificationKeyHash :: Parser (Hash StakePoolKey)
 pCombinedStakePoolVerificationKeyHash =
-    Opt.option (pBech32KeyHash AsStakePoolKey <|> pHexHash AsStakePoolKey) $ mconcat
+  Opt.option (pBech32KeyHash AsStakePoolKey <|> pHexHash AsStakePoolKey) $
+    mconcat
       [ Opt.long "combined-stake-pool-id"
       , Opt.metavar "STAKE_POOL_ID"
-      , Opt.help $ mconcat
-          [ "Stake pool ID/verification key hash (either Bech32-encoded or hex-encoded).  "
-          , "Zero or more occurences of this option is allowed."
-          ]
+      , Opt.help $
+          mconcat
+            [ "Stake pool ID/verification key hash (either Bech32-encoded or hex-encoded).  "
+            , "Zero or more occurences of this option is allowed."
+            ]
       ]
 
 pCombinedStakePoolVerificationKey :: Parser (VerificationKey StakePoolKey)
 pCombinedStakePoolVerificationKey =
-  Opt.option (readVerificationKey AsStakePoolKey) $ mconcat
-    [ Opt.long "combined-stake-pool-verification-key"
-    , Opt.metavar "STRING"
-    , Opt.help "Stake pool verification key (Bech32 or hex-encoded)."
-    ]
+  Opt.option (readVerificationKey AsStakePoolKey) $
+    mconcat
+      [ Opt.long "combined-stake-pool-verification-key"
+      , Opt.metavar "STRING"
+      , Opt.help "Stake pool verification key (Bech32 or hex-encoded)."
+      ]
 
 pCombinedStakePoolVerificationKeyFile :: Parser (VerificationKeyFile In)
 pCombinedStakePoolVerificationKeyFile =
-  File <$> asum
-    [ Opt.strOption $ mconcat
-      [ Opt.long "combined-cold-verification-key-file"
-      , Opt.metavar "FILE"
-      , Opt.help "Filepath of the stake pool verification key."
-      , Opt.completer (Opt.bashCompleter "file")
+  File
+    <$> asum
+      [ Opt.strOption $
+          mconcat
+            [ Opt.long "combined-cold-verification-key-file"
+            , Opt.metavar "FILE"
+            , Opt.help "Filepath of the stake pool verification key."
+            , Opt.completer (Opt.bashCompleter "file")
+            ]
+      , Opt.strOption $
+          mconcat
+            [ Opt.long "stake-pool-verification-key-file"
+            , Opt.internal
+            ]
       ]
-    , Opt.strOption $ mconcat
-      [ Opt.long "stake-pool-verification-key-file"
-      , Opt.internal
-      ]
-    ]
 
 --------------------------------------------------------------------------------
 
 pCBORInFile :: Parser FilePath
 pCBORInFile =
   asum
-    [ Opt.strOption $ mconcat
-        [ Opt.long "in-file"
-        , Opt.metavar "FILE"
-        , Opt.help "CBOR input file."
-        , Opt.completer (Opt.bashCompleter "file")
-        ]
-    , Opt.strOption $ mconcat
-        [ Opt.long "file"
-        , Opt.internal
-        ]
+    [ Opt.strOption $
+        mconcat
+          [ Opt.long "in-file"
+          , Opt.metavar "FILE"
+          , Opt.help "CBOR input file."
+          , Opt.completer (Opt.bashCompleter "file")
+          ]
+    , Opt.strOption $
+        mconcat
+          [ Opt.long "file"
+          , Opt.internal
+          ]
     ]
 
 --------------------------------------------------------------------------------
 
 pPollQuestion :: Parser Text
 pPollQuestion =
-  Opt.strOption $ mconcat
-    [ Opt.long "question"
-    , Opt.metavar "STRING"
-    , Opt.help "The question for the poll."
-    ]
+  Opt.strOption $
+    mconcat
+      [ Opt.long "question"
+      , Opt.metavar "STRING"
+      , Opt.help "The question for the poll."
+      ]
 
 pPollAnswer :: Parser Text
 pPollAnswer =
-  Opt.strOption $ mconcat
-    [ Opt.long "answer"
-    , Opt.metavar "STRING"
-    , Opt.help "A possible choice for the poll. The option is repeatable."
-    ]
+  Opt.strOption $
+    mconcat
+      [ Opt.long "answer"
+      , Opt.metavar "STRING"
+      , Opt.help "A possible choice for the poll. The option is repeatable."
+      ]
 
 pPollAnswerIndex :: Parser Word
 pPollAnswerIndex =
-  Opt.option auto $ mconcat
-    [ Opt.long "answer"
-    , Opt.metavar "INT"
-    , Opt.help "The index of the chosen answer in the poll. Optional. Asked interactively if omitted."
-    ]
+  Opt.option auto $
+    mconcat
+      [ Opt.long "answer"
+      , Opt.metavar "INT"
+      , Opt.help "The index of the chosen answer in the poll. Optional. Asked interactively if omitted."
+      ]
 
 pPollFile :: Parser (File GovernancePoll In)
 pPollFile =
-  Opt.strOption $ mconcat
-    [ Opt.long "poll-file"
-    , Opt.metavar "FILE"
-    , Opt.help "Filepath to the ongoing poll."
-    , Opt.completer (Opt.bashCompleter "file")
-    ]
+  Opt.strOption $
+    mconcat
+      [ Opt.long "poll-file"
+      , Opt.metavar "FILE"
+      , Opt.help "Filepath to the ongoing poll."
+      , Opt.completer (Opt.bashCompleter "file")
+      ]
 
 pPollTxFile :: Parser (TxFile In)
 pPollTxFile =
-  fmap File $ Opt.strOption $ mconcat
-    [ Opt.long "tx-file"
-    , Opt.metavar "FILE"
-    , Opt.help "Filepath to the JSON TxBody or JSON Tx carrying a valid poll answer."
-    , Opt.completer (Opt.bashCompleter "file")
-    ]
+  fmap File $
+    Opt.strOption $
+      mconcat
+        [ Opt.long "tx-file"
+        , Opt.metavar "FILE"
+        , Opt.help "Filepath to the JSON TxBody or JSON Tx carrying a valid poll answer."
+        , Opt.completer (Opt.bashCompleter "file")
+        ]
 
 pPollNonce :: Parser Word
 pPollNonce =
-  Opt.option auto $ mconcat
-    [ Opt.long "nonce"
-    , Opt.metavar "UINT"
-    , Opt.help "An (optional) nonce for non-replayability."
-    ]
+  Opt.option auto $
+    mconcat
+      [ Opt.long "nonce"
+      , Opt.metavar "UINT"
+      , Opt.help "An (optional) nonce for non-replayability."
+      ]
 
 --------------------------------------------------------------------------------
 
-pScriptWitnessFiles :: forall witctx.
-                       WitCtx witctx
-                    -> BalanceTxExecUnits -- ^ Use the @execution-units@ flag.
-                    -> String -- ^ Script flag prefix
-                    -> Maybe String
-                    -> String
-                    -> Parser (ScriptWitnessFiles witctx)
+pScriptWitnessFiles
+  :: forall witctx
+   . WitCtx witctx
+  -> BalanceTxExecUnits
+  -- ^ Use the @execution-units@ flag.
+  -> String
+  -- ^ Script flag prefix
+  -> Maybe String
+  -> String
+  -> Parser (ScriptWitnessFiles witctx)
 pScriptWitnessFiles witctx autoBalanceExecUnits scriptFlagPrefix scriptFlagPrefixDeprecated help =
-    toScriptWitnessFiles
-      <$> pScriptFor (scriptFlagPrefix ++ "-script-file")
-                     ((++ "-script-file") <$> scriptFlagPrefixDeprecated)
-                     ("The file containing the script to witness " ++ help)
-      <*> optional ((,,) <$> pScriptDatumOrFile scriptFlagPrefix witctx
-                         <*> pScriptRedeemerOrFile scriptFlagPrefix
-                         <*> (case autoBalanceExecUnits of
-                               AutoBalance -> pure (ExecutionUnits 0 0)
-                               ManualBalance -> pExecutionUnits scriptFlagPrefix)
-                   )
-  where
-    toScriptWitnessFiles :: ScriptFile
-                         -> Maybe (ScriptDatumOrFile witctx,
-                                   ScriptRedeemerOrFile,
-                                   ExecutionUnits)
-                         -> ScriptWitnessFiles witctx
-    toScriptWitnessFiles sf Nothing        = SimpleScriptWitnessFile  sf
-    toScriptWitnessFiles sf (Just (d,r, e)) = PlutusScriptWitnessFiles sf d r e
-
+  toScriptWitnessFiles
+    <$> pScriptFor
+      (scriptFlagPrefix ++ "-script-file")
+      ((++ "-script-file") <$> scriptFlagPrefixDeprecated)
+      ("The file containing the script to witness " ++ help)
+    <*> optional
+      ( (,,)
+          <$> pScriptDatumOrFile scriptFlagPrefix witctx
+          <*> pScriptRedeemerOrFile scriptFlagPrefix
+          <*> ( case autoBalanceExecUnits of
+                  AutoBalance -> pure (ExecutionUnits 0 0)
+                  ManualBalance -> pExecutionUnits scriptFlagPrefix
+              )
+      )
+ where
+  toScriptWitnessFiles
+    :: ScriptFile
+    -> Maybe
+        ( ScriptDatumOrFile witctx
+        , ScriptRedeemerOrFile
+        , ExecutionUnits
+        )
+    -> ScriptWitnessFiles witctx
+  toScriptWitnessFiles sf Nothing = SimpleScriptWitnessFile sf
+  toScriptWitnessFiles sf (Just (d, r, e)) = PlutusScriptWitnessFiles sf d r e
 
 pExecutionUnits :: String -> Parser ExecutionUnits
 pExecutionUnits scriptFlagPrefix =
-  fmap (uncurry ExecutionUnits) $ Opt.option Opt.auto $ mconcat
-    [ Opt.long (scriptFlagPrefix ++ "-execution-units")
-    , Opt.metavar "(INT, INT)"
-    , Opt.help "The time and space units needed by the script."
-    ]
+  fmap (uncurry ExecutionUnits) $
+    Opt.option Opt.auto $
+      mconcat
+        [ Opt.long (scriptFlagPrefix ++ "-execution-units")
+        , Opt.metavar "(INT, INT)"
+        , Opt.help "The time and space units needed by the script."
+        ]
 
 pScriptRedeemerOrFile :: String -> Parser ScriptDataOrFile
 pScriptRedeemerOrFile scriptFlagPrefix =
-  pScriptDataOrFile (scriptFlagPrefix ++ "-redeemer")
+  pScriptDataOrFile
+    (scriptFlagPrefix ++ "-redeemer")
     "The script redeemer, in JSON syntax."
     "The script redeemer, in the given JSON file."
-
 
 pScriptDatumOrFile :: String -> WitCtx witctx -> Parser (ScriptDatumOrFile witctx)
 pScriptDatumOrFile scriptFlagPrefix witctx =
   case witctx of
-    WitCtxTxIn  -> (ScriptDatumOrFileForTxIn <$>
-                     pScriptDataOrFile
-                       (scriptFlagPrefix ++ "-datum")
-                       "The script datum, in JSON syntax."
-                       "The script datum, in the given JSON file.") <|>
-                    pInlineDatumPresent
-    WitCtxMint  -> pure NoScriptDatumOrFileForMint
+    WitCtxTxIn ->
+      ( ScriptDatumOrFileForTxIn
+          <$> pScriptDataOrFile
+            (scriptFlagPrefix ++ "-datum")
+            "The script datum, in JSON syntax."
+            "The script datum, in the given JSON file."
+      )
+        <|> pInlineDatumPresent
+    WitCtxMint -> pure NoScriptDatumOrFileForMint
     WitCtxStake -> pure NoScriptDatumOrFileForStake
  where
   pInlineDatumPresent :: Parser (ScriptDatumOrFile WitCtxTxIn)
-  pInlineDatumPresent  =
-    flag' InlineDatumPresentAtTxIn $ mconcat
-      [ long (scriptFlagPrefix ++ "-inline-datum-present")
-      , Opt.help "Inline datum present at transaction input."
-      ]
+  pInlineDatumPresent =
+    flag' InlineDatumPresentAtTxIn $
+      mconcat
+        [ long (scriptFlagPrefix ++ "-inline-datum-present")
+        , Opt.help "Inline datum present at transaction input."
+        ]
 
 pScriptDataOrFile :: String -> String -> String -> Parser ScriptDataOrFile
 pScriptDataOrFile dataFlagPrefix helpTextForValue helpTextForFile =
@@ -1123,44 +1260,53 @@ pScriptDataOrFile dataFlagPrefix helpTextForValue helpTextForFile =
     , pScriptDataFile
     , pScriptDataValue
     ]
-  where
-    pScriptDataCborFile = fmap ScriptDataCborFile . Opt.strOption $ mconcat
-      [ Opt.long (dataFlagPrefix ++ "-cbor-file")
-      , Opt.metavar "CBOR FILE"
-      , Opt.help $ mconcat
-        [ helpTextForFile
-        , " The file must follow the special JSON schema for script data."
+ where
+  pScriptDataCborFile =
+    fmap ScriptDataCborFile . Opt.strOption $
+      mconcat
+        [ Opt.long (dataFlagPrefix ++ "-cbor-file")
+        , Opt.metavar "CBOR FILE"
+        , Opt.help $
+            mconcat
+              [ helpTextForFile
+              , " The file must follow the special JSON schema for script data."
+              ]
         ]
-      ]
 
-    pScriptDataFile = fmap ScriptDataJsonFile . Opt.strOption $ mconcat
-      [ Opt.long (dataFlagPrefix ++ "-file")
-      , Opt.metavar "JSON FILE"
-      , Opt.help $ mconcat
-        [ helpTextForFile ++ " The file must follow the special "
-        , "JSON schema for script data."
+  pScriptDataFile =
+    fmap ScriptDataJsonFile . Opt.strOption $
+      mconcat
+        [ Opt.long (dataFlagPrefix ++ "-file")
+        , Opt.metavar "JSON FILE"
+        , Opt.help $
+            mconcat
+              [ helpTextForFile ++ " The file must follow the special "
+              , "JSON schema for script data."
+              ]
         ]
-      ]
 
-    pScriptDataValue = fmap ScriptDataValue . Opt.option readerScriptData $ mconcat
-      [ Opt.long (dataFlagPrefix ++ "-value")
-      , Opt.metavar "JSON VALUE"
-      , Opt.help $ mconcat
-        [ helpTextForValue
-        , " There is no schema: (almost) any JSON value is supported, including "
-        , "top-level strings and numbers."
+  pScriptDataValue =
+    fmap ScriptDataValue . Opt.option readerScriptData $
+      mconcat
+        [ Opt.long (dataFlagPrefix ++ "-value")
+        , Opt.metavar "JSON VALUE"
+        , Opt.help $
+            mconcat
+              [ helpTextForValue
+              , " There is no schema: (almost) any JSON value is supported, including "
+              , "top-level strings and numbers."
+              ]
         ]
-      ]
 
-    readerScriptData :: ReadM HashableScriptData
-    readerScriptData = do
-      v <- Opt.str
-      case Aeson.eitherDecode v of
-        Left e -> fail $ "readerScriptData: " <> e
-        Right sDataValue ->
-          case scriptDataJsonToHashable ScriptDataJsonNoSchema sDataValue of
-            Left err -> fail (displayError err)
-            Right sd -> return sd
+  readerScriptData :: ReadM HashableScriptData
+  readerScriptData = do
+    v <- Opt.str
+    case Aeson.eitherDecode v of
+      Left e -> fail $ "readerScriptData: " <> e
+      Right sDataValue ->
+        case scriptDataJsonToHashable ScriptDataJsonNoSchema sDataValue of
+          Left err -> fail (displayError err)
+          Right sd -> return sd
 
 --------------------------------------------------------------------------------
 
@@ -1168,10 +1314,9 @@ pPaymentVerifier :: Parser PaymentVerifier
 pPaymentVerifier =
   asum
     [ PaymentVerifierKey <$> pPaymentVerificationKeyTextOrFile
-    , PaymentVerifierScriptFile <$>
-        pScriptFor "payment-script-file" Nothing "Filepath of the payment script."
+    , PaymentVerifierScriptFile
+        <$> pScriptFor "payment-script-file" Nothing "Filepath of the payment script."
     ]
-
 
 pPaymentVerificationKeyTextOrFile :: Parser VerificationKeyTextOrFile
 pPaymentVerificationKeyTextOrFile =
@@ -1182,104 +1327,121 @@ pPaymentVerificationKeyTextOrFile =
 
 pPaymentVerificationKeyText :: Parser Text
 pPaymentVerificationKeyText =
-  fmap Text.pack $ Opt.strOption $ mconcat
-    [ Opt.long "payment-verification-key"
-    , Opt.metavar "STRING"
-    , Opt.help "Payment verification key (Bech32-encoded)"
-    ]
+  fmap Text.pack $
+    Opt.strOption $
+      mconcat
+        [ Opt.long "payment-verification-key"
+        , Opt.metavar "STRING"
+        , Opt.help "Payment verification key (Bech32-encoded)"
+        ]
 
 pPaymentVerificationKeyFile :: Parser (VerificationKeyFile In)
 pPaymentVerificationKeyFile =
-  fmap File $ asum
-    [ Opt.strOption $ mconcat
-      [ Opt.long "payment-verification-key-file"
-      , Opt.metavar "FILE"
-      , Opt.help "Filepath of the payment verification key."
-      , Opt.completer (Opt.bashCompleter "file")
+  fmap File $
+    asum
+      [ Opt.strOption $
+          mconcat
+            [ Opt.long "payment-verification-key-file"
+            , Opt.metavar "FILE"
+            , Opt.help "Filepath of the payment verification key."
+            , Opt.completer (Opt.bashCompleter "file")
+            ]
+      , Opt.strOption $
+          mconcat
+            [ Opt.long "verification-key-file"
+            , Opt.internal
+            ]
       ]
-    , Opt.strOption $ mconcat
-      [ Opt.long "verification-key-file"
-      , Opt.internal
-      ]
-    ]
 
 pScript :: Parser ScriptFile
 pScript = pScriptFor "script-file" Nothing "Filepath of the script."
 
 pReferenceTxIn :: String -> String -> Parser TxIn
 pReferenceTxIn prefix scriptType =
-  Opt.option (readerFromParsecParser parseTxIn) $ mconcat
-    [ Opt.long (prefix ++ "tx-in-reference")
-    , Opt.metavar "TX-IN"
-    , Opt.help $ mconcat
-      [ "TxId#TxIx - Specify a reference input. The reference input must have"
-      , " a " <> scriptType <> " reference script attached."
+  Opt.option (readerFromParsecParser parseTxIn) $
+    mconcat
+      [ Opt.long (prefix ++ "tx-in-reference")
+      , Opt.metavar "TX-IN"
+      , Opt.help $
+          mconcat
+            [ "TxId#TxIx - Specify a reference input. The reference input must have"
+            , " a " <> scriptType <> " reference script attached."
+            ]
       ]
-    ]
 
 pReadOnlyReferenceTxIn :: Parser TxIn
 pReadOnlyReferenceTxIn =
-  Opt.option (readerFromParsecParser parseTxIn) $ mconcat
-    [ Opt.long "read-only-tx-in-reference"
-    , Opt.metavar "TX-IN"
-    , Opt.help $ mconcat
-      [ "Specify a read only reference input. This reference input is not witnessing anything "
-      , "it is simply provided in the plutus script context."
+  Opt.option (readerFromParsecParser parseTxIn) $
+    mconcat
+      [ Opt.long "read-only-tx-in-reference"
+      , Opt.metavar "TX-IN"
+      , Opt.help $
+          mconcat
+            [ "Specify a read only reference input. This reference input is not witnessing anything "
+            , "it is simply provided in the plutus script context."
+            ]
       ]
-    ]
 
 --------------------------------------------------------------------------------
 
 pAddressKeyType :: Parser AddressKeyType
 pAddressKeyType =
   asum
-    [ Opt.flag' AddressKeyShelley $ mconcat
-        [ Opt.long "normal-key"
-        , Opt.help "Use a normal Shelley-era key (default)."
-        ]
-    , Opt.flag' AddressKeyShelleyExtended $ mconcat
-        [ Opt.long "extended-key"
-        , Opt.help "Use an extended ed25519 Shelley-era key."
-        ]
-    , Opt.flag' AddressKeyByron $ mconcat
-        [ Opt.long "byron-key"
-        , Opt.help "Use a Byron-era key."
-        ]
+    [ Opt.flag' AddressKeyShelley $
+        mconcat
+          [ Opt.long "normal-key"
+          , Opt.help "Use a normal Shelley-era key (default)."
+          ]
+    , Opt.flag' AddressKeyShelleyExtended $
+        mconcat
+          [ Opt.long "extended-key"
+          , Opt.help "Use an extended ed25519 Shelley-era key."
+          ]
+    , Opt.flag' AddressKeyByron $
+        mconcat
+          [ Opt.long "byron-key"
+          , Opt.help "Use a Byron-era key."
+          ]
     , pure AddressKeyShelley
     ]
 
 pProtocolParamsFile :: Parser ProtocolParamsFile
 pProtocolParamsFile =
-  fmap ProtocolParamsFile $ Opt.strOption $ mconcat
-    [ Opt.long "protocol-params-file"
-    , Opt.metavar "FILE"
-    , Opt.help "Filepath of the JSON-encoded protocol parameters file"
-    , Opt.completer (Opt.bashCompleter "file")
-    ]
+  fmap ProtocolParamsFile $
+    Opt.strOption $
+      mconcat
+        [ Opt.long "protocol-params-file"
+        , Opt.metavar "FILE"
+        , Opt.help "Filepath of the JSON-encoded protocol parameters file"
+        , Opt.completer (Opt.bashCompleter "file")
+        ]
 
 pCalculatePlutusScriptCost :: Parser TxBuildOutputOptions
 pCalculatePlutusScriptCost =
-  OutputScriptCostOnly <$> Opt.strOption
-   ( Opt.long "calculate-plutus-script-cost" <>
-     Opt.metavar "FILE" <>
-     Opt.help "(File () Out) filepath of the script cost information." <>
-     Opt.completer (Opt.bashCompleter "file")
-   )
+  OutputScriptCostOnly
+    <$> Opt.strOption
+      ( Opt.long "calculate-plutus-script-cost"
+          <> Opt.metavar "FILE"
+          <> Opt.help "(File () Out) filepath of the script cost information."
+          <> Opt.completer (Opt.bashCompleter "file")
+      )
 
 pCertificateFile
   :: BalanceTxExecUnits
   -> Parser (CertificateFile, Maybe (ScriptWitnessFiles WitCtxStake))
 pCertificateFile balanceExecUnits =
   (,)
-    <$> ( fmap CertificateFile $ asum
-            [ Opt.strOption $ mconcat
-                [ Opt.long "certificate-file"
-                , Opt.metavar "CERTIFICATEFILE"
-                , Opt.help helpText
-                , Opt.completer (Opt.bashCompleter "file")
-                ]
-            , Opt.strOption (Opt.long "certificate" <> Opt.internal)
-            ]
+    <$> ( fmap CertificateFile $
+            asum
+              [ Opt.strOption $
+                  mconcat
+                    [ Opt.long "certificate-file"
+                    , Opt.metavar "CERTIFICATEFILE"
+                    , Opt.help helpText
+                    , Opt.completer (Opt.bashCompleter "file")
+                    ]
+              , Opt.strOption (Opt.long "certificate" <> Opt.internal)
+              ]
         )
     <*> optional (pCertifyingScriptOrReferenceScriptWit balanceExecUnits)
  where
@@ -1287,38 +1449,44 @@ pCertificateFile balanceExecUnits =
     :: BalanceTxExecUnits -> Parser (ScriptWitnessFiles WitCtxStake)
   pCertifyingScriptOrReferenceScriptWit bExecUnits =
     pScriptWitnessFiles
-     WitCtxStake
-     balanceExecUnits
-     "certificate" Nothing
-     "the use of the certificate." <|>
-    pPlutusStakeReferenceScriptWitnessFiles "certificate-" bExecUnits
+      WitCtxStake
+      balanceExecUnits
+      "certificate"
+      Nothing
+      "the use of the certificate."
+      <|> pPlutusStakeReferenceScriptWitnessFiles "certificate-" bExecUnits
 
-  helpText = mconcat
-    [ "Filepath of the certificate. This encompasses all "
-    , "types of certificates (stake pool certificates, "
-    , "stake key certificates etc). Optionally specify a script witness."
-    ]
+  helpText =
+    mconcat
+      [ "Filepath of the certificate. This encompasses all "
+      , "types of certificates (stake pool certificates, "
+      , "stake key certificates etc). Optionally specify a script witness."
+      ]
 
 pPoolMetadataFile :: Parser (StakePoolMetadataFile In)
 pPoolMetadataFile =
-  fmap File $ Opt.strOption $ mconcat
-    [ Opt.long "pool-metadata-file"
-    , Opt.metavar "FILE"
-    , Opt.help "Filepath of the pool metadata."
-    , Opt.completer (Opt.bashCompleter "file")
-    ]
+  fmap File $
+    Opt.strOption $
+      mconcat
+        [ Opt.long "pool-metadata-file"
+        , Opt.metavar "FILE"
+        , Opt.help "Filepath of the pool metadata."
+        , Opt.completer (Opt.bashCompleter "file")
+        ]
 
 pTxMetadataJsonSchema :: Parser TxMetadataJsonSchema
 pTxMetadataJsonSchema =
   asum
-    [ Opt.flag' ()
-        (  Opt.long "json-metadata-no-schema"
-        <> Opt.help "Use the \"no schema\" conversion from JSON to tx metadata."
+    [ Opt.flag'
+        ()
+        ( Opt.long "json-metadata-no-schema"
+            <> Opt.help "Use the \"no schema\" conversion from JSON to tx metadata."
         )
         $> TxMetadataJsonNoSchema
-    , Opt.flag' ()
-        (  Opt.long "json-metadata-detailed-schema"
-        <> Opt.help "Use the \"detailed schema\" conversion from JSON to tx metadata."
+    , Opt.flag'
+        ()
+        ( Opt.long "json-metadata-detailed-schema"
+            <> Opt.help "Use the \"detailed schema\" conversion from JSON to tx metadata."
         )
         $> TxMetadataJsonDetailedSchema
     , -- Default to the no-schema conversion.
@@ -1332,56 +1500,65 @@ convertTime =
 pMetadataFile :: Parser MetadataFile
 pMetadataFile =
   asum
-    [ fmap MetadataFileJSON
-        $ asum
-            [ Opt.strOption $ mconcat
+    [ fmap MetadataFileJSON $
+        asum
+          [ Opt.strOption $
+              mconcat
                 [ Opt.long "metadata-json-file"
                 , Opt.metavar "FILE"
                 , Opt.help "Filepath of the metadata file, in JSON format."
                 , Opt.completer (Opt.bashCompleter "file")
                 ]
-            , Opt.strOption $ mconcat
+          , Opt.strOption $
+              mconcat
                 [ Opt.long "metadata-file" -- backward compat name
                 , Opt.internal
                 ]
+          ]
+    , fmap MetadataFileCBOR $
+        Opt.strOption $
+          mconcat
+            [ Opt.long "metadata-cbor-file"
+            , Opt.metavar "FILE"
+            , Opt.help "Filepath of the metadata, in raw CBOR format."
+            , Opt.completer (Opt.bashCompleter "file")
             ]
-    , fmap MetadataFileCBOR $ Opt.strOption $ mconcat
-        [ Opt.long "metadata-cbor-file"
-        , Opt.metavar "FILE"
-        , Opt.help "Filepath of the metadata, in raw CBOR format."
-        , Opt.completer (Opt.bashCompleter "file")
-        ]
     ]
 
 pWithdrawal
   :: BalanceTxExecUnits
-  -> Parser (StakeAddress,
-            Lovelace,
-            Maybe (ScriptWitnessFiles WitCtxStake))
+  -> Parser
+      ( StakeAddress
+      , Lovelace
+      , Maybe (ScriptWitnessFiles WitCtxStake)
+      )
 pWithdrawal balance =
-    (\(stakeAddr,lovelace) maybeScriptFp -> (stakeAddr, lovelace, maybeScriptFp))
-      <$> Opt.option (readerFromParsecParser parseWithdrawal)
-            (  Opt.long "withdrawal"
-            <> Opt.metavar "WITHDRAWAL"
-            <> Opt.help helpText
-            )
-      <*> optional pWithdrawalScriptOrReferenceScriptWit
+  (\(stakeAddr, lovelace) maybeScriptFp -> (stakeAddr, lovelace, maybeScriptFp))
+    <$> Opt.option
+      (readerFromParsecParser parseWithdrawal)
+      ( Opt.long "withdrawal"
+          <> Opt.metavar "WITHDRAWAL"
+          <> Opt.help helpText
+      )
+    <*> optional pWithdrawalScriptOrReferenceScriptWit
  where
   pWithdrawalScriptOrReferenceScriptWit :: Parser (ScriptWitnessFiles WitCtxStake)
   pWithdrawalScriptOrReferenceScriptWit =
-   pScriptWitnessFiles
-     WitCtxStake
-     balance
-     "withdrawal" Nothing
-     "the withdrawal of rewards." <|>
-   pPlutusStakeReferenceScriptWitnessFiles "withdrawal-" balance
+    pScriptWitnessFiles
+      WitCtxStake
+      balance
+      "withdrawal"
+      Nothing
+      "the withdrawal of rewards."
+      <|> pPlutusStakeReferenceScriptWitnessFiles "withdrawal-" balance
 
-  helpText = mconcat
-    [ "The reward withdrawal as StakeAddress+Lovelace where "
-    , "StakeAddress is the Bech32-encoded stake address "
-    , "followed by the amount in Lovelace. Optionally specify "
-    , "a script witness."
-    ]
+  helpText =
+    mconcat
+      [ "The reward withdrawal as StakeAddress+Lovelace where "
+      , "StakeAddress is the Bech32-encoded stake address "
+      , "followed by the amount in Lovelace. Optionally specify "
+      , "a script witness."
+      ]
 
   parseWithdrawal :: Parsec.Parser (StakeAddress, Lovelace)
   parseWithdrawal =
@@ -1389,7 +1566,8 @@ pWithdrawal balance =
 
 pPlutusStakeReferenceScriptWitnessFiles
   :: String
-  -> BalanceTxExecUnits -- ^ Use the @execution-units@ flag.
+  -> BalanceTxExecUnits
+  -- ^ Use the @execution-units@ flag.
   -> Parser (ScriptWitnessFiles WitCtxStake)
 pPlutusStakeReferenceScriptWitnessFiles prefix autoBalanceExecUnits =
   PlutusReferenceScriptWitnessFiles
@@ -1397,82 +1575,98 @@ pPlutusStakeReferenceScriptWitnessFiles prefix autoBalanceExecUnits =
     <*> pPlutusScriptLanguage prefix
     <*> pure NoScriptDatumOrFileForStake
     <*> pScriptRedeemerOrFile (prefix ++ "reference-tx-in")
-    <*> (case autoBalanceExecUnits of
-          AutoBalance -> pure (ExecutionUnits 0 0)
-          ManualBalance -> pExecutionUnits $ prefix ++ "reference-tx-in")
+    <*> ( case autoBalanceExecUnits of
+            AutoBalance -> pure (ExecutionUnits 0 0)
+            ManualBalance -> pExecutionUnits $ prefix ++ "reference-tx-in"
+        )
     <*> pure Nothing
 
 pPlutusScriptLanguage :: String -> Parser AnyScriptLanguage
 pPlutusScriptLanguage prefix =
-  Opt.flag' (AnyScriptLanguage $ PlutusScriptLanguage PlutusScriptV2)
-    (  Opt.long (prefix ++ "plutus-script-v2")
-    <> Opt.help "Specify a plutus script v2 reference script."
+  Opt.flag'
+    (AnyScriptLanguage $ PlutusScriptLanguage PlutusScriptV2)
+    ( Opt.long (prefix ++ "plutus-script-v2")
+        <> Opt.help "Specify a plutus script v2 reference script."
     )
 
 pUpdateProposalFile :: Parser UpdateProposalFile
 pUpdateProposalFile =
-  fmap UpdateProposalFile
-    $ asum
-        [ Opt.strOption $ mconcat
-          [ Opt.long "update-proposal-file"
-          , Opt.metavar "FILE"
-          , Opt.help "Filepath of the update proposal."
-          , Opt.completer (Opt.bashCompleter "file")
-          ]
-        , Opt.strOption $ mconcat
-          [ Opt.long "update-proposal"
-          , Opt.internal
-          ]
-        ]
+  fmap UpdateProposalFile $
+    asum
+      [ Opt.strOption $
+          mconcat
+            [ Opt.long "update-proposal-file"
+            , Opt.metavar "FILE"
+            , Opt.help "Filepath of the update proposal."
+            , Opt.completer (Opt.bashCompleter "file")
+            ]
+      , Opt.strOption $
+          mconcat
+            [ Opt.long "update-proposal"
+            , Opt.internal
+            ]
+      ]
 
 pRequiredSigner :: Parser RequiredSigner
 pRequiredSigner =
-      RequiredSignerSkeyFile <$> sKeyFile
-  <|> RequiredSignerHash <$> sPayKeyHash
+  RequiredSignerSkeyFile
+    <$> sKeyFile
+      <|> RequiredSignerHash
+    <$> sPayKeyHash
  where
   sKeyFile :: Parser (SigningKeyFile In)
-  sKeyFile = fmap File $ Opt.strOption $ mconcat
-    [ Opt.long "required-signer"
-    , Opt.metavar "FILE"
-    , Opt.help $ mconcat
-      [ "Input filepath of the signing key (zero or more) whose "
-      , "signature is required."
-      ]
-    , Opt.completer (Opt.bashCompleter "file")
-    ]
+  sKeyFile =
+    fmap File $
+      Opt.strOption $
+        mconcat
+          [ Opt.long "required-signer"
+          , Opt.metavar "FILE"
+          , Opt.help $
+              mconcat
+                [ "Input filepath of the signing key (zero or more) whose "
+                , "signature is required."
+                ]
+          , Opt.completer (Opt.bashCompleter "file")
+          ]
   sPayKeyHash :: Parser (Hash PaymentKey)
   sPayKeyHash =
-    Opt.option (readerFromParsecParser $ parseHash (AsHash AsPaymentKey)) $ mconcat
-      [ Opt.long "required-signer-hash"
-      , Opt.metavar "HASH"
-      , Opt.help $ mconcat
-        [ "Hash of the verification key (zero or more) whose "
-        , "signature is required."
+    Opt.option (readerFromParsecParser $ parseHash (AsHash AsPaymentKey)) $
+      mconcat
+        [ Opt.long "required-signer-hash"
+        , Opt.metavar "HASH"
+        , Opt.help $
+            mconcat
+              [ "Hash of the verification key (zero or more) whose "
+              , "signature is required."
+              ]
         ]
-      ]
 
 pVrfSigningKeyFile :: Parser (SigningKeyFile In)
 pVrfSigningKeyFile =
-  fmap File $ Opt.strOption $ mconcat
-    [ Opt.long "vrf-signing-key-file"
-    , Opt.metavar "FILE"
-    , Opt.help "Input filepath of the VRF signing key."
-    , Opt.completer (Opt.bashCompleter "file")
-    ]
+  fmap File $
+    Opt.strOption $
+      mconcat
+        [ Opt.long "vrf-signing-key-file"
+        , Opt.metavar "FILE"
+        , Opt.help "Input filepath of the VRF signing key."
+        , Opt.completer (Opt.bashCompleter "file")
+        ]
 
 pWhichLeadershipSchedule :: Parser EpochLeadershipSchedule
 pWhichLeadershipSchedule = pCurrent <|> pNext
-  where
-    pCurrent :: Parser EpochLeadershipSchedule
-    pCurrent =
-      Opt.flag' CurrentEpoch $ mconcat
+ where
+  pCurrent :: Parser EpochLeadershipSchedule
+  pCurrent =
+    Opt.flag' CurrentEpoch $
+      mconcat
         [ Opt.long "current"
         , Opt.help "Get the leadership schedule for the current epoch."
         ]
 
-    pNext :: Parser EpochLeadershipSchedule
-    pNext =
-      Opt.flag' NextEpoch $ mconcat
+  pNext :: Parser EpochLeadershipSchedule
+  pNext =
+    Opt.flag' NextEpoch $
+      mconcat
         [ Opt.long "next"
         , Opt.help "Get the leadership schedule for the following epoch."
         ]
@@ -1480,108 +1674,127 @@ pWhichLeadershipSchedule = pCurrent <|> pNext
 pWitnessSigningData :: Parser WitnessSigningData
 pWitnessSigningData =
   KeyWitnessSigningData
-    <$> ( fmap File $ Opt.strOption $ mconcat
-          [ Opt.long "signing-key-file"
-          , Opt.metavar "FILE"
-          , Opt.help "Input filepath of the signing key (one or more)."
-          , Opt.completer (Opt.bashCompleter "file")
-          ]
+    <$> ( fmap File $
+            Opt.strOption $
+              mconcat
+                [ Opt.long "signing-key-file"
+                , Opt.metavar "FILE"
+                , Opt.help "Input filepath of the signing key (one or more)."
+                , Opt.completer (Opt.bashCompleter "file")
+                ]
         )
     <*> optional pByronAddress
 
 pSigningKeyFileIn :: Parser (SigningKeyFile In)
 pSigningKeyFileIn =
-  fmap File $ Opt.strOption $ mconcat
-    [ Opt.long "signing-key-file"
-    , Opt.metavar "FILE"
-    , Opt.help "Input filepath of the signing key."
-    , Opt.completer (Opt.bashCompleter "file")
-    ]
+  fmap File $
+    Opt.strOption $
+      mconcat
+        [ Opt.long "signing-key-file"
+        , Opt.metavar "FILE"
+        , Opt.help "Input filepath of the signing key."
+        , Opt.completer (Opt.bashCompleter "file")
+        ]
 
 pKesPeriod :: Parser KESPeriod
 pKesPeriod =
-  fmap KESPeriod $ Opt.option (bounded "KES_PERIOD") $ mconcat
-    [ Opt.long "kes-period"
-    , Opt.metavar "NATURAL"
-    , Opt.help "The start of the KES key validity period."
-    ]
+  fmap KESPeriod $
+    Opt.option (bounded "KES_PERIOD") $
+      mconcat
+        [ Opt.long "kes-period"
+        , Opt.metavar "NATURAL"
+        , Opt.help "The start of the KES key validity period."
+        ]
 
 pEpochNo :: String -> Parser EpochNo
 pEpochNo h =
-  fmap EpochNo $ Opt.option (bounded "EPOCH") $ mconcat
-    [ Opt.long "epoch"
-    , Opt.metavar "NATURAL"
-    , Opt.help h
-    ]
-
+  fmap EpochNo $
+    Opt.option (bounded "EPOCH") $
+      mconcat
+        [ Opt.long "epoch"
+        , Opt.metavar "NATURAL"
+        , Opt.help h
+        ]
 
 pEpochNoUpdateProp :: Parser EpochNo
 pEpochNoUpdateProp = pEpochNo "The epoch number in which the update proposal is valid."
 
 pGenesisFile :: String -> Parser GenesisFile
 pGenesisFile desc =
-  fmap GenesisFile $ Opt.strOption $ mconcat
-    [ Opt.long "genesis"
-    , Opt.metavar "FILE"
-    , Opt.help desc
-    , Opt.completer (Opt.bashCompleter "file")
-    ]
+  fmap GenesisFile $
+    Opt.strOption $
+      mconcat
+        [ Opt.long "genesis"
+        , Opt.metavar "FILE"
+        , Opt.help desc
+        , Opt.completer (Opt.bashCompleter "file")
+        ]
 
 pOperationalCertificateFile :: Parser (File () direction)
 pOperationalCertificateFile =
-  Opt.strOption $ mconcat
-    [ Opt.long "op-cert-file"
-    , Opt.metavar "FILE"
-    , Opt.help "Filepath of the node's operational certificate."
-    , Opt.completer (Opt.bashCompleter "file")
-    ]
+  Opt.strOption $
+    mconcat
+      [ Opt.long "op-cert-file"
+      , Opt.metavar "FILE"
+      , Opt.help "Filepath of the node's operational certificate."
+      , Opt.completer (Opt.bashCompleter "file")
+      ]
 
 pKeyOutputFormat :: Parser KeyOutputFormat
 pKeyOutputFormat =
-  Opt.option readKeyOutputFormat $ mconcat
-    [ Opt.long "key-output-format"
-    , Opt.metavar "STRING"
-    , Opt.help $ mconcat
-      [ "Optional key output format. Accepted output formats are \"text-envelope\" "
-      , "and \"bech32\" (default is \"bech32\")."
+  Opt.option readKeyOutputFormat $
+    mconcat
+      [ Opt.long "key-output-format"
+      , Opt.metavar "STRING"
+      , Opt.help $
+          mconcat
+            [ "Optional key output format. Accepted output formats are \"text-envelope\" "
+            , "and \"bech32\" (default is \"bech32\")."
+            ]
+      , Opt.value KeyOutputFormatTextEnvelope
       ]
-    , Opt.value KeyOutputFormatTextEnvelope
-    ]
 
 pPoolIdOutputFormat :: Parser IdOutputFormat
 pPoolIdOutputFormat =
-  Opt.option readIdOutputFormat $ mconcat
-    [ Opt.long "output-format"
-    , Opt.metavar "STRING"
-    , Opt.help $ mconcat
-      [ "Optional pool id output format. Accepted output formats are \"hex\" "
-      , "and \"bech32\" (default is \"bech32\")."
+  Opt.option readIdOutputFormat $
+    mconcat
+      [ Opt.long "output-format"
+      , Opt.metavar "STRING"
+      , Opt.help $
+          mconcat
+            [ "Optional pool id output format. Accepted output formats are \"hex\" "
+            , "and \"bech32\" (default is \"bech32\")."
+            ]
+      , Opt.value IdOutputFormatBech32
       ]
-    , Opt.value IdOutputFormatBech32
-    ]
 
 pMaybeOutputFile :: Parser (Maybe (File content Out))
 pMaybeOutputFile =
-  optional $ fmap File $ Opt.strOption $ mconcat
-    [ Opt.long "out-file"
-    , Opt.metavar "FILE"
-    , Opt.help "Optional output file. Default is to write to stdout."
-    , Opt.completer (Opt.bashCompleter "file")
-    ]
+  optional $
+    fmap File $
+      Opt.strOption $
+        mconcat
+          [ Opt.long "out-file"
+          , Opt.metavar "FILE"
+          , Opt.help "Optional output file. Default is to write to stdout."
+          , Opt.completer (Opt.bashCompleter "file")
+          ]
 
 pVerificationKey
-  :: forall keyrole. SerialiseAsBech32 (VerificationKey keyrole)
+  :: forall keyrole
+   . (SerialiseAsBech32 (VerificationKey keyrole))
   => AsType keyrole
   -> Parser (VerificationKey keyrole)
 pVerificationKey asType =
-  Opt.option (readVerificationKey asType) $ mconcat
-    [ Opt.long "verification-key"
-    , Opt.metavar "STRING"
-    , Opt.help "Verification key (Bech32 or hex-encoded)."
-    ]
+  Opt.option (readVerificationKey asType) $
+    mconcat
+      [ Opt.long "verification-key"
+      , Opt.metavar "STRING"
+      , Opt.help "Verification key (Bech32 or hex-encoded)."
+      ]
 
 pVerificationKeyOrFileIn
-  :: SerialiseAsBech32 (VerificationKey keyrole)
+  :: (SerialiseAsBech32 (VerificationKey keyrole))
   => AsType keyrole
   -> Parser (VerificationKeyOrFile keyrole)
 pVerificationKeyOrFileIn asType =
@@ -1592,49 +1805,55 @@ pVerificationKeyOrFileIn asType =
 
 pExtendedVerificationKeyFileIn :: Parser (VerificationKeyFile In)
 pExtendedVerificationKeyFileIn =
-  fmap File $ Opt.strOption $ mconcat
-    [ Opt.long "extended-verification-key-file"
-    , Opt.metavar "FILE"
-    , Opt.help "Input filepath of the ed25519-bip32 verification key."
-    , Opt.completer (Opt.bashCompleter "file")
-    ]
+  fmap File $
+    Opt.strOption $
+      mconcat
+        [ Opt.long "extended-verification-key-file"
+        , Opt.metavar "FILE"
+        , Opt.help "Input filepath of the ed25519-bip32 verification key."
+        , Opt.completer (Opt.bashCompleter "file")
+        ]
 
 pGenesisVerificationKeyFile :: Parser (VerificationKeyFile In)
 pGenesisVerificationKeyFile =
-  fmap File $ Opt.strOption $ mconcat
-    [ Opt.long "genesis-verification-key-file"
-    , Opt.metavar "FILE"
-    , Opt.help "Filepath of the genesis verification key."
-    , Opt.completer (Opt.bashCompleter "file")
-    ]
+  fmap File $
+    Opt.strOption $
+      mconcat
+        [ Opt.long "genesis-verification-key-file"
+        , Opt.metavar "FILE"
+        , Opt.help "Filepath of the genesis verification key."
+        , Opt.completer (Opt.bashCompleter "file")
+        ]
 
 pGenesisVerificationKeyHash :: Parser (Hash GenesisKey)
 pGenesisVerificationKeyHash =
-  Opt.option (Opt.eitherReader deserialiseFromHex) $ mconcat
-    [ Opt.long "genesis-verification-key-hash"
-    , Opt.metavar "STRING"
-    , Opt.help "Genesis verification key hash (hex-encoded)."
-    ]
-  where
-    deserialiseFromHex :: String -> Either String (Hash GenesisKey)
-    deserialiseFromHex =
-      first (\e -> "Invalid genesis verification key hash: " ++ displayError e)
-        . deserialiseFromRawBytesHex (AsHash AsGenesisKey)
-        . BSC.pack
+  Opt.option (Opt.eitherReader deserialiseFromHex) $
+    mconcat
+      [ Opt.long "genesis-verification-key-hash"
+      , Opt.metavar "STRING"
+      , Opt.help "Genesis verification key hash (hex-encoded)."
+      ]
+ where
+  deserialiseFromHex :: String -> Either String (Hash GenesisKey)
+  deserialiseFromHex =
+    first (\e -> "Invalid genesis verification key hash: " ++ displayError e)
+      . deserialiseFromRawBytesHex (AsHash AsGenesisKey)
+      . BSC.pack
 
 pGenesisVerificationKey :: Parser (VerificationKey GenesisKey)
 pGenesisVerificationKey =
-  Opt.option (Opt.eitherReader deserialiseFromHex) $ mconcat
-    [ Opt.long "genesis-verification-key"
-    , Opt.metavar "STRING"
-    , Opt.help "Genesis verification key (hex-encoded)."
-    ]
-  where
-    deserialiseFromHex :: String -> Either String (VerificationKey GenesisKey)
-    deserialiseFromHex =
-      first (\e -> "Invalid genesis verification key: " ++ displayError e)
-        . deserialiseFromRawBytesHex (AsVerificationKey AsGenesisKey)
-        . BSC.pack
+  Opt.option (Opt.eitherReader deserialiseFromHex) $
+    mconcat
+      [ Opt.long "genesis-verification-key"
+      , Opt.metavar "STRING"
+      , Opt.help "Genesis verification key (hex-encoded)."
+      ]
+ where
+  deserialiseFromHex :: String -> Either String (VerificationKey GenesisKey)
+  deserialiseFromHex =
+    first (\e -> "Invalid genesis verification key: " ++ displayError e)
+      . deserialiseFromRawBytesHex (AsVerificationKey AsGenesisKey)
+      . BSC.pack
 
 pGenesisVerificationKeyOrFile :: Parser (VerificationKeyOrFile GenesisKey)
 pGenesisVerificationKeyOrFile =
@@ -1652,28 +1871,32 @@ pGenesisVerificationKeyOrHashOrFile =
 
 pGenesisDelegateVerificationKeyFile :: Parser (VerificationKeyFile In)
 pGenesisDelegateVerificationKeyFile =
-  fmap File $ Opt.strOption $ mconcat
-    [ Opt.long "genesis-delegate-verification-key-file"
-    , Opt.metavar "FILE"
-    , Opt.help "Filepath of the genesis delegate verification key."
-    , Opt.completer (Opt.bashCompleter "file")
-    ]
+  fmap File $
+    Opt.strOption $
+      mconcat
+        [ Opt.long "genesis-delegate-verification-key-file"
+        , Opt.metavar "FILE"
+        , Opt.help "Filepath of the genesis delegate verification key."
+        , Opt.completer (Opt.bashCompleter "file")
+        ]
 
 pGenesisDelegateVerificationKeyHash :: Parser (Hash GenesisDelegateKey)
 pGenesisDelegateVerificationKeyHash =
-  Opt.option (Opt.eitherReader deserialiseFromHex) $ mconcat
-    [ Opt.long "genesis-delegate-verification-key-hash"
-    , Opt.metavar "STRING"
-    , Opt.help "Genesis delegate verification key hash (hex-encoded)."
-    ]
-  where
-    deserialiseFromHex :: String -> Either String (Hash GenesisDelegateKey)
-    deserialiseFromHex =
-      first
-        (\e ->
-          "Invalid genesis delegate verification key hash: " ++ displayError e)
-        . deserialiseFromRawBytesHex (AsHash AsGenesisDelegateKey)
-        . BSC.pack
+  Opt.option (Opt.eitherReader deserialiseFromHex) $
+    mconcat
+      [ Opt.long "genesis-delegate-verification-key-hash"
+      , Opt.metavar "STRING"
+      , Opt.help "Genesis delegate verification key hash (hex-encoded)."
+      ]
+ where
+  deserialiseFromHex :: String -> Either String (Hash GenesisDelegateKey)
+  deserialiseFromHex =
+    first
+      ( \e ->
+          "Invalid genesis delegate verification key hash: " ++ displayError e
+      )
+      . deserialiseFromRawBytesHex (AsHash AsGenesisDelegateKey)
+      . BSC.pack
 
 pGenesisDelegateVerificationKeyOrFile
   :: Parser (VerificationKeyOrFile GenesisDelegateKey)
@@ -1700,68 +1923,75 @@ pKesVerificationKeyOrFile =
 
 pKesVerificationKey :: Parser (VerificationKey KesKey)
 pKesVerificationKey =
-  Opt.option (Opt.eitherReader deserialiseVerKey) $ mconcat
-    [ Opt.long "kes-verification-key"
-    , Opt.metavar "STRING"
-    , Opt.help "A Bech32 or hex-encoded hot KES verification key."
-    ]
-  where
-    asType :: AsType (VerificationKey KesKey)
-    asType = AsVerificationKey AsKesKey
+  Opt.option (Opt.eitherReader deserialiseVerKey) $
+    mconcat
+      [ Opt.long "kes-verification-key"
+      , Opt.metavar "STRING"
+      , Opt.help "A Bech32 or hex-encoded hot KES verification key."
+      ]
+ where
+  asType :: AsType (VerificationKey KesKey)
+  asType = AsVerificationKey AsKesKey
 
-    deserialiseVerKey :: String -> Either String (VerificationKey KesKey)
-    deserialiseVerKey str =
-      case deserialiseFromBech32 asType (Text.pack str) of
-        Right res -> Right res
-
-        -- The input was valid Bech32, but some other error occurred.
-        Left err@(Bech32UnexpectedPrefix _ _) -> Left (displayError err)
-        Left err@(Bech32DataPartToBytesError _) -> Left (displayError err)
-        Left err@(Bech32DeserialiseFromBytesError _) -> Left (displayError err)
-        Left err@(Bech32WrongPrefix _ _) -> Left (displayError err)
-
-        -- The input was not valid Bech32. Attempt to deserialise it as hex.
-        Left (Bech32DecodingError _) ->
-          first
-            (\e -> "Invalid stake pool verification key: " ++ displayError e) $
-          deserialiseFromRawBytesHex asType (BSC.pack str)
+  deserialiseVerKey :: String -> Either String (VerificationKey KesKey)
+  deserialiseVerKey str =
+    case deserialiseFromBech32 asType (Text.pack str) of
+      Right res -> Right res
+      -- The input was valid Bech32, but some other error occurred.
+      Left err@(Bech32UnexpectedPrefix _ _) -> Left (displayError err)
+      Left err@(Bech32DataPartToBytesError _) -> Left (displayError err)
+      Left err@(Bech32DeserialiseFromBytesError _) -> Left (displayError err)
+      Left err@(Bech32WrongPrefix _ _) -> Left (displayError err)
+      -- The input was not valid Bech32. Attempt to deserialise it as hex.
+      Left (Bech32DecodingError _) ->
+        first
+          (\e -> "Invalid stake pool verification key: " ++ displayError e)
+          $ deserialiseFromRawBytesHex asType (BSC.pack str)
 
 pKesVerificationKeyFile :: Parser (VerificationKeyFile In)
 pKesVerificationKeyFile =
-  fmap File $ asum
-    [ Opt.strOption $ mconcat
-      [ Opt.long "kes-verification-key-file"
-      , Opt.metavar "FILE"
-      , Opt.help "Filepath of the hot KES verification key."
-      , Opt.completer (Opt.bashCompleter "file")
+  fmap File $
+    asum
+      [ Opt.strOption $
+          mconcat
+            [ Opt.long "kes-verification-key-file"
+            , Opt.metavar "FILE"
+            , Opt.help "Filepath of the hot KES verification key."
+            , Opt.completer (Opt.bashCompleter "file")
+            ]
+      , Opt.strOption $
+          mconcat
+            [ Opt.long "hot-kes-verification-key-file"
+            , Opt.internal
+            ]
       ]
-    , Opt.strOption $ mconcat
-      [ Opt.long "hot-kes-verification-key-file"
-      , Opt.internal
-      ]
-    ]
 
 pTxSubmitFile :: Parser FilePath
 pTxSubmitFile =
-  Opt.strOption $ mconcat
-    [ Opt.long "tx-file"
-    , Opt.metavar "FILE"
-    , Opt.help "Filepath of the transaction you intend to submit."
-    , Opt.completer (Opt.bashCompleter "file")
-    ]
+  Opt.strOption $
+    mconcat
+      [ Opt.long "tx-file"
+      , Opt.metavar "FILE"
+      , Opt.help "Filepath of the transaction you intend to submit."
+      , Opt.completer (Opt.bashCompleter "file")
+      ]
 
-pTxIn :: BalanceTxExecUnits
-      -> Parser (TxIn, Maybe (ScriptWitnessFiles WitCtxTxIn))
+pTxIn
+  :: BalanceTxExecUnits
+  -> Parser (TxIn, Maybe (ScriptWitnessFiles WitCtxTxIn))
 pTxIn balance =
-     (,) <$> Opt.option (readerFromParsecParser parseTxIn)
-               (  Opt.long "tx-in"
-                <> Opt.metavar "TX-IN"
-               <> Opt.help "TxId#TxIx"
-               )
-         <*> optional (pPlutusReferenceScriptWitness balance <|>
-                       pSimpleReferenceSpendingScriptWitess <|>
-                       pEmbeddedPlutusScriptWitness
-                       )
+  (,)
+    <$> Opt.option
+      (readerFromParsecParser parseTxIn)
+      ( Opt.long "tx-in"
+          <> Opt.metavar "TX-IN"
+          <> Opt.help "TxId#TxIx"
+      )
+    <*> optional
+      ( pPlutusReferenceScriptWitness balance
+          <|> pSimpleReferenceSpendingScriptWitess
+          <|> pEmbeddedPlutusScriptWitness
+      )
  where
   pSimpleReferenceSpendingScriptWitess :: Parser (ScriptWitnessFiles WitCtxTxIn)
   pSimpleReferenceSpendingScriptWitess =
@@ -1771,9 +2001,9 @@ pTxIn balance =
     createSimpleReferenceScriptWitnessFiles
       :: TxIn
       -> ScriptWitnessFiles WitCtxTxIn
-    createSimpleReferenceScriptWitnessFiles refTxIn  =
+    createSimpleReferenceScriptWitnessFiles refTxIn =
       let simpleLang = AnyScriptLanguage SimpleScriptLanguage
-      in SimpleReferenceScriptWitnessFiles refTxIn simpleLang Nothing
+       in SimpleReferenceScriptWitnessFiles refTxIn simpleLang Nothing
 
   pPlutusReferenceScriptWitness :: BalanceTxExecUnits -> Parser (ScriptWitnessFiles WitCtxTxIn)
   pPlutusReferenceScriptWitness autoBalanceExecUnits =
@@ -1782,9 +2012,10 @@ pTxIn balance =
       <*> pPlutusScriptLanguage "spending-"
       <*> pScriptDatumOrFile "spending-reference-tx-in" WitCtxTxIn
       <*> pScriptRedeemerOrFile "spending-reference-tx-in"
-      <*> (case autoBalanceExecUnits of
+      <*> ( case autoBalanceExecUnits of
               AutoBalance -> pure (ExecutionUnits 0 0)
-              ManualBalance -> pExecutionUnits "spending-reference-tx-in")
+              ManualBalance -> pExecutionUnits "spending-reference-tx-in"
+          )
    where
     createPlutusReferenceScriptWitnessFiles
       :: TxIn
@@ -1801,164 +2032,180 @@ pTxIn balance =
     pScriptWitnessFiles
       WitCtxTxIn
       balance
-      "tx-in" (Just "txin")
+      "tx-in"
+      (Just "txin")
       "the spending of the transaction input."
 
 pTxInCollateral :: Parser TxIn
 pTxInCollateral =
-    Opt.option (readerFromParsecParser parseTxIn)
-      (  Opt.long "tx-in-collateral"
-      <> Opt.metavar "TX-IN"
-      <> Opt.help "TxId#TxIx"
-      )
+  Opt.option
+    (readerFromParsecParser parseTxIn)
+    ( Opt.long "tx-in-collateral"
+        <> Opt.metavar "TX-IN"
+        <> Opt.help "TxId#TxIx"
+    )
 
 pReturnCollateral :: Parser TxOutAnyEra
 pReturnCollateral =
-  Opt.option (readerFromParsecParser parseTxOutAnyEra)
-          ( mconcat
-            [ Opt.long "tx-out-return-collateral"
-            , Opt.metavar "ADDRESS VALUE"
-            -- TODO alonzo: Update the help text to describe the new syntax as well.
-            , Opt.help ( "The transaction output as ADDRESS VALUE where ADDRESS is " <>
-                        "the Bech32-encoded address followed by the value in " <>
-                        "Lovelace. In the situation where your collateral txin " <>
-                        "over collateralizes the transaction, you can optionally " <>
-                        "specify a tx out of your choosing to return the excess Lovelace."
+  Opt.option
+    (readerFromParsecParser parseTxOutAnyEra)
+    ( mconcat
+        [ Opt.long "tx-out-return-collateral"
+        , Opt.metavar "ADDRESS VALUE"
+        , -- TODO alonzo: Update the help text to describe the new syntax as well.
+          Opt.help
+            ( "The transaction output as ADDRESS VALUE where ADDRESS is "
+                <> "the Bech32-encoded address followed by the value in "
+                <> "Lovelace. In the situation where your collateral txin "
+                <> "over collateralizes the transaction, you can optionally "
+                <> "specify a tx out of your choosing to return the excess Lovelace."
             )
-            ]
-          )
+        ]
+    )
     <*> pure TxOutDatumByNone -- TODO: Babbage era - we should be able to return these
     <*> pure ReferenceScriptAnyEraNone -- TODO: Babbage era - we should be able to return these
 
 pTotalCollateral :: Parser Lovelace
 pTotalCollateral =
-  Opt.option (Lovelace <$> readerFromParsecParser decimal) $ mconcat
-  [ Opt.long "tx-total-collateral"
-  , Opt.metavar "INTEGER"
-  , Opt.help $ mconcat
-    [ "The total amount of collateral that will be collected "
-    , "as fees in the event of a Plutus script failure. Must be used "
-    , "in conjuction with \"--tx-out-return-collateral\"."
-    ]
-  ]
+  Opt.option (Lovelace <$> readerFromParsecParser decimal) $
+    mconcat
+      [ Opt.long "tx-total-collateral"
+      , Opt.metavar "INTEGER"
+      , Opt.help $
+          mconcat
+            [ "The total amount of collateral that will be collected "
+            , "as fees in the event of a Plutus script failure. Must be used "
+            , "in conjuction with \"--tx-out-return-collateral\"."
+            ]
+      ]
 
 pWitnessOverride :: Parser Word
-pWitnessOverride = Opt.option Opt.auto $ mconcat
-  [ Opt.long "witness-override"
-  , Opt.metavar "WORD"
-  , Opt.help "Specify and override the number of witnesses the transaction requires."
-  ]
-
+pWitnessOverride =
+  Opt.option Opt.auto $
+    mconcat
+      [ Opt.long "witness-override"
+      , Opt.metavar "WORD"
+      , Opt.help "Specify and override the number of witnesses the transaction requires."
+      ]
 
 pTxOut :: Parser TxOutAnyEra
 pTxOut =
-        Opt.option (readerFromParsecParser parseTxOutAnyEra)
-          (  Opt.long "tx-out"
-          <> Opt.metavar "ADDRESS VALUE"
-          -- TODO alonzo: Update the help text to describe the new syntax as well.
-          <> Opt.help "The transaction output as ADDRESS VALUE where ADDRESS is \
-                      \the Bech32-encoded address followed by the value in \
-                      \the multi-asset syntax (including simply Lovelace)."
-          )
+  Opt.option
+    (readerFromParsecParser parseTxOutAnyEra)
+    ( Opt.long "tx-out"
+        <> Opt.metavar "ADDRESS VALUE"
+        -- TODO alonzo: Update the help text to describe the new syntax as well.
+        <> Opt.help
+          "The transaction output as ADDRESS VALUE where ADDRESS is \
+          \the Bech32-encoded address followed by the value in \
+          \the multi-asset syntax (including simply Lovelace)."
+    )
     <*> pTxOutDatum
     <*> pRefScriptFp
 
 pTxOutDatum :: Parser TxOutDatumAnyEra
 pTxOutDatum =
-      pTxOutDatumByHashOnly
-  <|> pTxOutDatumByHashOf
-  <|> pTxOutDatumByValue
-  <|> pTxOutInlineDatumByValue
-  <|> pure TxOutDatumByNone
-  where
-    pTxOutDatumByHashOnly =
-      fmap TxOutDatumByHashOnly
-      $ Opt.option (readerFromParsecParser $ parseHash (AsHash AsScriptData))
-      $ mconcat
-        [ Opt.long "tx-out-datum-hash"
-        , Opt.metavar "HASH"
-        , Opt.help $ mconcat
-          [ "The script datum hash for this tx output, as "
-          , "the raw datum hash (in hex)."
+  pTxOutDatumByHashOnly
+    <|> pTxOutDatumByHashOf
+    <|> pTxOutDatumByValue
+    <|> pTxOutInlineDatumByValue
+    <|> pure TxOutDatumByNone
+ where
+  pTxOutDatumByHashOnly =
+    fmap TxOutDatumByHashOnly $
+      Opt.option (readerFromParsecParser $ parseHash (AsHash AsScriptData)) $
+        mconcat
+          [ Opt.long "tx-out-datum-hash"
+          , Opt.metavar "HASH"
+          , Opt.help $
+              mconcat
+                [ "The script datum hash for this tx output, as "
+                , "the raw datum hash (in hex)."
+                ]
           ]
-        ]
 
-    pTxOutDatumByHashOf = TxOutDatumByHashOf <$>
-        pScriptDataOrFile
-          "tx-out-datum-hash"
-          ( mconcat
+  pTxOutDatumByHashOf =
+    TxOutDatumByHashOf
+      <$> pScriptDataOrFile
+        "tx-out-datum-hash"
+        ( mconcat
             [ "The script datum hash for this tx output, by hashing the "
             , "script datum given here in JSON syntax."
             ]
-          )
-          ( mconcat
+        )
+        ( mconcat
             [ "The script datum hash for this tx output, by hashing the "
             , "script datum in the given JSON file."
             ]
-          )
+        )
 
-    pTxOutDatumByValue =
-      TxOutDatumByValue <$>
-        pScriptDataOrFile
-          "tx-out-datum-embed"
-          ( mconcat
+  pTxOutDatumByValue =
+    TxOutDatumByValue
+      <$> pScriptDataOrFile
+        "tx-out-datum-embed"
+        ( mconcat
             [ "The script datum to embed in the tx for this output, "
             , "given here in JSON syntax."
             ]
-          )
-          ( mconcat
+        )
+        ( mconcat
             [ "The script datum to embed in the tx for this output, "
             , "in the given JSON file."
             ]
-          )
+        )
 
-    pTxOutInlineDatumByValue =
-      TxOutInlineDatumByValue <$>
-        pScriptDataOrFile
-          "tx-out-inline-datum"
-          ( mconcat
+  pTxOutInlineDatumByValue =
+    TxOutInlineDatumByValue
+      <$> pScriptDataOrFile
+        "tx-out-inline-datum"
+        ( mconcat
             [ "The script datum to embed in the tx output as an inline datum, "
             , "given here in JSON syntax."
             ]
-          )
-          ( mconcat
+        )
+        ( mconcat
             [ "The script datum to embed in the tx output as an inline datum, "
             , "in the given JSON file."
             ]
-          )
+        )
 
 pRefScriptFp :: Parser ReferenceScriptAnyEra
 pRefScriptFp =
-  ReferenceScriptAnyEra <$> Opt.strOption
-    (  Opt.long "tx-out-reference-script-file"
-    <> Opt.metavar "FILE"
-    <> Opt.help "Reference script input file."
-    <> Opt.completer (Opt.bashCompleter "file")
-    ) <|> pure ReferenceScriptAnyEraNone
+  ReferenceScriptAnyEra
+    <$> Opt.strOption
+      ( Opt.long "tx-out-reference-script-file"
+          <> Opt.metavar "FILE"
+          <> Opt.help "Reference script input file."
+          <> Opt.completer (Opt.bashCompleter "file")
+      )
+      <|> pure ReferenceScriptAnyEraNone
 
 pMintMultiAsset
   :: BalanceTxExecUnits
   -> Parser (Value, [ScriptWitnessFiles WitCtxMint])
 pMintMultiAsset balanceExecUnits =
-  (,) <$> Opt.option
-            (readerFromParsecParser parseValue)
-              (  Opt.long "mint"
-              <> Opt.metavar "VALUE"
-              <> Opt.help helpText
-              )
-      <*> some (pMintingScriptOrReferenceScriptWit balanceExecUnits <|>
-                pSimpleReferenceMintingScriptWitness <|>
-                pPlutusMintReferenceScriptWitnessFiles balanceExecUnits
-               )
+  (,)
+    <$> Opt.option
+      (readerFromParsecParser parseValue)
+      ( Opt.long "mint"
+          <> Opt.metavar "VALUE"
+          <> Opt.help helpText
+      )
+    <*> some
+      ( pMintingScriptOrReferenceScriptWit balanceExecUnits
+          <|> pSimpleReferenceMintingScriptWitness
+          <|> pPlutusMintReferenceScriptWitnessFiles balanceExecUnits
+      )
  where
   pMintingScriptOrReferenceScriptWit
     :: BalanceTxExecUnits -> Parser (ScriptWitnessFiles WitCtxMint)
   pMintingScriptOrReferenceScriptWit bExecUnits =
-   pScriptWitnessFiles
-     WitCtxMint
-     bExecUnits
-     "mint" (Just "minting")
-     "the minting of assets for a particular policy Id."
+    pScriptWitnessFiles
+      WitCtxMint
+      bExecUnits
+      "mint"
+      (Just "minting")
+      "the minting of assets for a particular policy Id."
 
   pSimpleReferenceMintingScriptWitness :: Parser (ScriptWitnessFiles WitCtxMint)
   pSimpleReferenceMintingScriptWitness =
@@ -1972,142 +2219,168 @@ pMintMultiAsset balanceExecUnits =
       -> ScriptWitnessFiles WitCtxMint
     createSimpleMintingReferenceScriptWitnessFiles refTxIn pid =
       let simpleLang = AnyScriptLanguage SimpleScriptLanguage
-      in SimpleReferenceScriptWitnessFiles refTxIn simpleLang (Just pid)
+       in SimpleReferenceScriptWitnessFiles refTxIn simpleLang (Just pid)
 
   pPlutusMintReferenceScriptWitnessFiles
-    :: BalanceTxExecUnits ->  Parser (ScriptWitnessFiles WitCtxMint)
+    :: BalanceTxExecUnits -> Parser (ScriptWitnessFiles WitCtxMint)
   pPlutusMintReferenceScriptWitnessFiles autoBalanceExecUnits =
-   PlutusReferenceScriptWitnessFiles
-     <$> pReferenceTxIn "mint-" "plutus"
-     <*> pPlutusScriptLanguage "mint-"
-     <*> pure NoScriptDatumOrFileForMint
-     <*> pScriptRedeemerOrFile "mint-reference-tx-in"
-     <*> (case autoBalanceExecUnits of
-           AutoBalance -> pure (ExecutionUnits 0 0)
-           ManualBalance -> pExecutionUnits "mint-reference-tx-in")
-     <*> (Just <$> pPolicyId)
+    PlutusReferenceScriptWitnessFiles
+      <$> pReferenceTxIn "mint-" "plutus"
+      <*> pPlutusScriptLanguage "mint-"
+      <*> pure NoScriptDatumOrFileForMint
+      <*> pScriptRedeemerOrFile "mint-reference-tx-in"
+      <*> ( case autoBalanceExecUnits of
+              AutoBalance -> pure (ExecutionUnits 0 0)
+              ManualBalance -> pExecutionUnits "mint-reference-tx-in"
+          )
+      <*> (Just <$> pPolicyId)
 
-  helpText = mconcat
-    [ "Mint multi-asset value(s) with the multi-asset cli syntax. "
-    , "You must specify a script witness."
-    ]
+  helpText =
+    mconcat
+      [ "Mint multi-asset value(s) with the multi-asset cli syntax. "
+      , "You must specify a script witness."
+      ]
 
 pPolicyId :: Parser PolicyId
 pPolicyId =
-  Opt.option (readerFromParsecParser policyId) $ mconcat
-    [ Opt.long "policy-id"
-    , Opt.metavar "HASH"
-    , Opt.help "Policy id of minting script."
-    ]
-
+  Opt.option (readerFromParsecParser policyId) $
+    mconcat
+      [ Opt.long "policy-id"
+      , Opt.metavar "HASH"
+      , Opt.help "Policy id of minting script."
+      ]
 
 pInvalidBefore :: Parser SlotNo
-pInvalidBefore = fmap SlotNo $ asum
-  [ Opt.option (bounded "SLOT") $ mconcat
-    [ Opt.long "invalid-before"
-    , Opt.metavar "SLOT"
-    , Opt.help "Time that transaction is valid from (in slots)."
-    ]
-  , Opt.option (bounded "SLOT") $ mconcat
-    [ Opt.long "lower-bound"
-    , Opt.metavar "SLOT"
-    , Opt.help $ mconcat
-      [ "Time that transaction is valid from (in slots) "
-      , "(deprecated; use --invalid-before instead)."
+pInvalidBefore =
+  fmap SlotNo $
+    asum
+      [ Opt.option (bounded "SLOT") $
+          mconcat
+            [ Opt.long "invalid-before"
+            , Opt.metavar "SLOT"
+            , Opt.help "Time that transaction is valid from (in slots)."
+            ]
+      , Opt.option (bounded "SLOT") $
+          mconcat
+            [ Opt.long "lower-bound"
+            , Opt.metavar "SLOT"
+            , Opt.help $
+                mconcat
+                  [ "Time that transaction is valid from (in slots) "
+                  , "(deprecated; use --invalid-before instead)."
+                  ]
+            , Opt.internal
+            ]
       ]
-    , Opt.internal
-    ]
-  ]
 
 pInvalidHereafter :: Parser SlotNo
 pInvalidHereafter =
-  fmap SlotNo $ asum
-  [ Opt.option (bounded "SLOT") $ mconcat
-    [ Opt.long "invalid-hereafter"
-    , Opt.metavar "SLOT"
-    , Opt.help "Time that transaction is valid until (in slots)."
-    ]
-  , Opt.option (bounded "SLOT") $ mconcat
-    [ Opt.long "upper-bound"
-    , Opt.metavar "SLOT"
-    , Opt.help $ mconcat
-      [ "Time that transaction is valid until (in slots) "
-      , "(deprecated; use --invalid-hereafter instead)."
+  fmap SlotNo $
+    asum
+      [ Opt.option (bounded "SLOT") $
+          mconcat
+            [ Opt.long "invalid-hereafter"
+            , Opt.metavar "SLOT"
+            , Opt.help "Time that transaction is valid until (in slots)."
+            ]
+      , Opt.option (bounded "SLOT") $
+          mconcat
+            [ Opt.long "upper-bound"
+            , Opt.metavar "SLOT"
+            , Opt.help $
+                mconcat
+                  [ "Time that transaction is valid until (in slots) "
+                  , "(deprecated; use --invalid-hereafter instead)."
+                  ]
+            , Opt.internal
+            ]
+      , Opt.option (bounded "SLOT") $
+          mconcat
+            [ Opt.long "ttl"
+            , Opt.metavar "SLOT"
+            , Opt.help "Time to live (in slots) (deprecated; use --invalid-hereafter instead)."
+            , Opt.internal
+            ]
       ]
-    , Opt.internal
-    ]
-  , Opt.option (bounded "SLOT") $ mconcat
-    [ Opt.long "ttl"
-    , Opt.metavar "SLOT"
-    , Opt.help "Time to live (in slots) (deprecated; use --invalid-hereafter instead)."
-    , Opt.internal
-    ]
-  ]
 
 pTxFee :: Parser Lovelace
 pTxFee =
-  fmap (Lovelace . (fromIntegral :: Natural -> Integer)) $ Opt.option Opt.auto $ mconcat
-    [ Opt.long "fee"
-    , Opt.metavar "LOVELACE"
-    , Opt.help "The fee amount in Lovelace."
-    ]
+  fmap (Lovelace . (fromIntegral :: Natural -> Integer)) $
+    Opt.option Opt.auto $
+      mconcat
+        [ Opt.long "fee"
+        , Opt.metavar "LOVELACE"
+        , Opt.help "The fee amount in Lovelace."
+        ]
 
 pWitnessFile :: Parser WitnessFile
 pWitnessFile =
-  fmap WitnessFile $ Opt.strOption $ mconcat
-    [ Opt.long "witness-file"
-    , Opt.metavar "FILE"
-    , Opt.help "Filepath of the witness"
-    , Opt.completer (Opt.bashCompleter "file")
-    ]
+  fmap WitnessFile $
+    Opt.strOption $
+      mconcat
+        [ Opt.long "witness-file"
+        , Opt.metavar "FILE"
+        , Opt.help "Filepath of the witness"
+        , Opt.completer (Opt.bashCompleter "file")
+        ]
 
 pTxBodyFileIn :: Parser (TxBodyFile In)
 pTxBodyFileIn =
-  fmap File $ Opt.strOption $ mconcat
-    [ Opt.long "tx-body-file"
-    , Opt.metavar "FILE"
-    , Opt.help "Input filepath of the JSON TxBody."
-    , Opt.completer (Opt.bashCompleter "file")
-    ]
+  fmap File $
+    Opt.strOption $
+      mconcat
+        [ Opt.long "tx-body-file"
+        , Opt.metavar "FILE"
+        , Opt.help "Input filepath of the JSON TxBody."
+        , Opt.completer (Opt.bashCompleter "file")
+        ]
 
 pTxBodyFileOut :: Parser (TxBodyFile Out)
 pTxBodyFileOut =
-  fmap File $ asum
-    [ Opt.strOption $ mconcat
-      [ Opt.long "out-file"
-      , Opt.metavar "FILE"
-      , Opt.help "Output filepath of the JSON TxBody."
-      , Opt.completer (Opt.bashCompleter "file")
+  fmap File $
+    asum
+      [ Opt.strOption $
+          mconcat
+            [ Opt.long "out-file"
+            , Opt.metavar "FILE"
+            , Opt.help "Output filepath of the JSON TxBody."
+            , Opt.completer (Opt.bashCompleter "file")
+            ]
+      , Opt.strOption $
+          mconcat
+            [ Opt.long "tx-body-file"
+            , Opt.internal
+            ]
       ]
-    , Opt.strOption $ mconcat
-      [ Opt.long "tx-body-file"
-      , Opt.internal
-      ]
-    ]
 
 pTxFileIn :: Parser (TxFile In)
 pTxFileIn =
-  fmap File $ Opt.strOption $ mconcat
-    [ Opt.long "tx-file"
-    , Opt.metavar "FILE"
-    , Opt.help "Input filepath of the JSON Tx."
-    , Opt.completer (Opt.bashCompleter "file")
-    ]
+  fmap File $
+    Opt.strOption $
+      mconcat
+        [ Opt.long "tx-file"
+        , Opt.metavar "FILE"
+        , Opt.help "Input filepath of the JSON Tx."
+        , Opt.completer (Opt.bashCompleter "file")
+        ]
 
 pTxFileOut :: Parser (TxFile Out)
 pTxFileOut =
-  fmap File $ asum
-    [ Opt.strOption $ mconcat
-      [ Opt.long "out-file"
-      , Opt.metavar "FILE"
-      , Opt.help "Output filepath of the JSON Tx."
-      , Opt.completer (Opt.bashCompleter "file")
+  fmap File $
+    asum
+      [ Opt.strOption $
+          mconcat
+            [ Opt.long "out-file"
+            , Opt.metavar "FILE"
+            , Opt.help "Output filepath of the JSON Tx."
+            , Opt.completer (Opt.bashCompleter "file")
+            ]
+      , Opt.strOption $
+          mconcat
+            [ Opt.long "tx-file"
+            , Opt.internal
+            ]
       ]
-    , Opt.strOption $ mconcat
-      [ Opt.long "tx-file"
-      , Opt.internal
-      ]
-    ]
 
 pInputTxOrTxBodyFile :: Parser InputTxBodyOrTxFile
 pInputTxOrTxBodyFile =
@@ -2118,36 +2391,44 @@ pInputTxOrTxBodyFile =
 
 pTxInCount :: Parser TxInCount
 pTxInCount =
-  fmap TxInCount $ Opt.option Opt.auto $ mconcat
-    [ Opt.long "tx-in-count"
-    , Opt.metavar "NATURAL"
-    , Opt.help "The number of transaction inputs."
-    ]
+  fmap TxInCount $
+    Opt.option Opt.auto $
+      mconcat
+        [ Opt.long "tx-in-count"
+        , Opt.metavar "NATURAL"
+        , Opt.help "The number of transaction inputs."
+        ]
 
 pTxOutCount :: Parser TxOutCount
 pTxOutCount =
-  fmap TxOutCount $ Opt.option Opt.auto $ mconcat
-    [ Opt.long "tx-out-count"
-    , Opt.metavar "NATURAL"
-    , Opt.help "The number of transaction outputs."
-    ]
+  fmap TxOutCount $
+    Opt.option Opt.auto $
+      mconcat
+        [ Opt.long "tx-out-count"
+        , Opt.metavar "NATURAL"
+        , Opt.help "The number of transaction outputs."
+        ]
 
 pTxShelleyWitnessCount :: Parser TxShelleyWitnessCount
 pTxShelleyWitnessCount =
-  fmap TxShelleyWitnessCount $ Opt.option Opt.auto $ mconcat
-    [ Opt.long "witness-count"
-    , Opt.metavar "NATURAL"
-    , Opt.help "The number of Shelley key witnesses."
-    ]
+  fmap TxShelleyWitnessCount $
+    Opt.option Opt.auto $
+      mconcat
+        [ Opt.long "witness-count"
+        , Opt.metavar "NATURAL"
+        , Opt.help "The number of Shelley key witnesses."
+        ]
 
 pTxByronWitnessCount :: Parser TxByronWitnessCount
 pTxByronWitnessCount =
-  fmap TxByronWitnessCount $ Opt.option Opt.auto $ mconcat
-    [ Opt.long "byron-witness-count"
-    , Opt.metavar "NATURAL"
-    , Opt.help "The number of Byron key witnesses (default is 0)."
-    , Opt.value 0
-    ]
+  fmap TxByronWitnessCount $
+    Opt.option Opt.auto $
+      mconcat
+        [ Opt.long "byron-witness-count"
+        , Opt.metavar "NATURAL"
+        , Opt.help "The number of Byron key witnesses (default is 0)."
+        , Opt.value 0
+        ]
 
 pQueryUTxOFilter :: Parser QueryUTxOFilter
 pQueryUTxOFilter =
@@ -2156,30 +2437,33 @@ pQueryUTxOFilter =
     , pQueryUTxOByAddress
     , pQueryUTxOByTxIn
     ]
-  where
-    pQueryUTxOWhole =
-      Opt.flag' QueryUTxOWhole $ mconcat
+ where
+  pQueryUTxOWhole =
+    Opt.flag' QueryUTxOWhole $
+      mconcat
         [ Opt.long "whole-utxo"
         , Opt.help "Return the whole UTxO (only appropriate on small testnets)."
         ]
 
-    pQueryUTxOByAddress :: Parser QueryUTxOFilter
-    pQueryUTxOByAddress = QueryUTxOByAddress . Set.fromList <$> some pByAddress
+  pQueryUTxOByAddress :: Parser QueryUTxOFilter
+  pQueryUTxOByAddress = QueryUTxOByAddress . Set.fromList <$> some pByAddress
 
-    pByAddress :: Parser AddressAny
-    pByAddress =
-      Opt.option (readerFromParsecParser parseAddressAny) $ mconcat
+  pByAddress :: Parser AddressAny
+  pByAddress =
+    Opt.option (readerFromParsecParser parseAddressAny) $
+      mconcat
         [ Opt.long "address"
         , Opt.metavar "ADDRESS"
         , Opt.help "Filter by Cardano address(es) (Bech32-encoded)."
         ]
 
-    pQueryUTxOByTxIn :: Parser QueryUTxOFilter
-    pQueryUTxOByTxIn = QueryUTxOByTxIn . Set.fromList <$> some pByTxIn
+  pQueryUTxOByTxIn :: Parser QueryUTxOFilter
+  pQueryUTxOByTxIn = QueryUTxOByTxIn . Set.fromList <$> some pByTxIn
 
-    pByTxIn :: Parser TxIn
-    pByTxIn =
-      Opt.option (readerFromParsecParser parseTxIn) $ mconcat
+  pByTxIn :: Parser TxIn
+  pByTxIn =
+    Opt.option (readerFromParsecParser parseTxIn) $
+      mconcat
         [ Opt.long "tx-in"
         , Opt.metavar "TX-IN"
         , Opt.help "Filter by transaction input (TxId#TxIx)."
@@ -2187,7 +2471,8 @@ pQueryUTxOFilter =
 
 pFilterByStakeAddress :: Parser StakeAddress
 pFilterByStakeAddress =
-    Opt.option (readerFromParsecParser parseStakeAddress) $ mconcat
+  Opt.option (readerFromParsecParser parseStakeAddress) $
+    mconcat
       [ Opt.long "address"
       , Opt.metavar "ADDRESS"
       , Opt.help "Filter by Cardano stake address (Bech32-encoded)."
@@ -2195,68 +2480,77 @@ pFilterByStakeAddress =
 
 pByronAddress :: Parser (Address ByronAddr)
 pByronAddress =
-  Opt.option (Opt.eitherReader deserialise) $ mconcat
-    [ Opt.long "address"
-    , Opt.metavar "STRING"
-    , Opt.help "Byron address (Base58-encoded)."
-    ]
-  where
-    deserialise :: String -> Either String (Address ByronAddr)
-    deserialise =
-      maybe (Left "Invalid Byron address.") Right
-        . deserialiseAddress AsByronAddress
-        . Text.pack
+  Opt.option (Opt.eitherReader deserialise) $
+    mconcat
+      [ Opt.long "address"
+      , Opt.metavar "STRING"
+      , Opt.help "Byron address (Base58-encoded)."
+      ]
+ where
+  deserialise :: String -> Either String (Address ByronAddr)
+  deserialise =
+    maybe (Left "Invalid Byron address.") Right
+      . deserialiseAddress AsByronAddress
+      . Text.pack
 
 pAddress :: Parser Text
 pAddress =
-  fmap Text.pack $ Opt.strOption $ mconcat
-    [ Opt.long "address"
-    , Opt.metavar "ADDRESS"
-    , Opt.help "A Cardano address"
-    ]
+  fmap Text.pack $
+    Opt.strOption $
+      mconcat
+        [ Opt.long "address"
+        , Opt.metavar "ADDRESS"
+        , Opt.help "A Cardano address"
+        ]
 
 -- | First argument is the prefix to use
 pStakePoolVerificationKeyHash :: Maybe String -> Parser (Hash StakePoolKey)
 pStakePoolVerificationKeyHash prefix =
-    Opt.option (pBech32KeyHash AsStakePoolKey <|> pHexHash AsStakePoolKey) $ mconcat
+  Opt.option (pBech32KeyHash AsStakePoolKey <|> pHexHash AsStakePoolKey) $
+    mconcat
       [ Opt.long $ prefixFlag prefix "stake-pool-id"
       , Opt.metavar "STAKE_POOL_ID"
-      , Opt.help $ mconcat
-          [ "Stake pool ID/verification key hash (either Bech32-encoded or hex-encoded).  "
-          , "Zero or more occurences of this option is allowed."
-          ]
+      , Opt.help $
+          mconcat
+            [ "Stake pool ID/verification key hash (either Bech32-encoded or hex-encoded).  "
+            , "Zero or more occurences of this option is allowed."
+            ]
       ]
 
 pVrfVerificationKeyFile :: Parser (VerificationKeyFile In)
 pVrfVerificationKeyFile =
-  fmap File $ Opt.strOption $ mconcat
-    [ Opt.long "vrf-verification-key-file"
-    , Opt.metavar "FILE"
-    , Opt.help "Filepath of the VRF verification key."
-    , Opt.completer (Opt.bashCompleter "file")
-    ]
+  fmap File $
+    Opt.strOption $
+      mconcat
+        [ Opt.long "vrf-verification-key-file"
+        , Opt.metavar "FILE"
+        , Opt.help "Filepath of the VRF verification key."
+        , Opt.completer (Opt.bashCompleter "file")
+        ]
 
 pVrfVerificationKeyHash :: Parser (Hash VrfKey)
 pVrfVerificationKeyHash =
-  Opt.option (Opt.eitherReader deserialiseFromHex) $ mconcat
-    [ Opt.long "vrf-verification-key-hash"
-    , Opt.metavar "STRING"
-    , Opt.help "VRF verification key hash (hex-encoded)."
-    ]
-  where
-    deserialiseFromHex :: String -> Either String (Hash VrfKey)
-    deserialiseFromHex =
-      first (\e -> "Invalid VRF verification key hash: " ++ displayError e)
-        . deserialiseFromRawBytesHex (AsHash AsVrfKey)
-        . BSC.pack
+  Opt.option (Opt.eitherReader deserialiseFromHex) $
+    mconcat
+      [ Opt.long "vrf-verification-key-hash"
+      , Opt.metavar "STRING"
+      , Opt.help "VRF verification key hash (hex-encoded)."
+      ]
+ where
+  deserialiseFromHex :: String -> Either String (Hash VrfKey)
+  deserialiseFromHex =
+    first (\e -> "Invalid VRF verification key hash: " ++ displayError e)
+      . deserialiseFromRawBytesHex (AsHash AsVrfKey)
+      . BSC.pack
 
 pVrfVerificationKey :: Parser (VerificationKey VrfKey)
 pVrfVerificationKey =
-  Opt.option (readVerificationKey AsVrfKey) $ mconcat
-    [ Opt.long "vrf-verification-key"
-    , Opt.metavar "STRING"
-    , Opt.help "VRF verification key (Bech32 or hex-encoded)."
-    ]
+  Opt.option (readVerificationKey AsVrfKey) $
+    mconcat
+      [ Opt.long "vrf-verification-key"
+      , Opt.metavar "STRING"
+      , Opt.help "VRF verification key (Bech32 or hex-encoded)."
+      ]
 
 pVrfVerificationKeyOrFile :: Parser (VerificationKeyOrFile VrfKey)
 pVrfVerificationKeyOrFile =
@@ -2272,29 +2566,32 @@ pVrfVerificationKeyOrHashOrFile =
     , VerificationKeyHash <$> pVrfVerificationKeyHash
     ]
 
-
 pRewardAcctVerificationKeyFile :: Parser (VerificationKeyFile In)
 pRewardAcctVerificationKeyFile =
-  fmap File $ asum
-    [ Opt.strOption $ mconcat
-      [ Opt.long "pool-reward-account-verification-key-file"
-      , Opt.metavar "FILE"
-      , Opt.help "Filepath of the reward account stake verification key."
-      , Opt.completer (Opt.bashCompleter "file")
+  fmap File $
+    asum
+      [ Opt.strOption $
+          mconcat
+            [ Opt.long "pool-reward-account-verification-key-file"
+            , Opt.metavar "FILE"
+            , Opt.help "Filepath of the reward account stake verification key."
+            , Opt.completer (Opt.bashCompleter "file")
+            ]
+      , Opt.strOption $
+          mconcat
+            [ Opt.long "reward-account-verification-key-file"
+            , Opt.internal
+            ]
       ]
-    , Opt.strOption $ mconcat
-      [ Opt.long "reward-account-verification-key-file"
-      , Opt.internal
-      ]
-    ]
 
 pRewardAcctVerificationKey :: Parser (VerificationKey StakeKey)
 pRewardAcctVerificationKey =
-  Opt.option (readVerificationKey AsStakeKey) $ mconcat
-    [ Opt.long "pool-reward-account-verification-key"
-    , Opt.metavar "STRING"
-    , Opt.help "Reward account stake verification key (Bech32 or hex-encoded)."
-    ]
+  Opt.option (readVerificationKey AsStakeKey) $
+    mconcat
+      [ Opt.long "pool-reward-account-verification-key"
+      , Opt.metavar "STRING"
+      , Opt.help "Reward account stake verification key (Bech32 or hex-encoded)."
+      ]
 
 pRewardAcctVerificationKeyOrFile :: Parser (VerificationKeyOrFile StakeKey)
 pRewardAcctVerificationKeyOrFile =
@@ -2305,26 +2602,30 @@ pRewardAcctVerificationKeyOrFile =
 
 pPoolOwnerVerificationKeyFile :: Parser (VerificationKeyFile In)
 pPoolOwnerVerificationKeyFile =
-  fmap File $ asum
-    [ Opt.strOption $ mconcat
-      [ Opt.long "pool-owner-stake-verification-key-file"
-      , Opt.metavar "FILE"
-      , Opt.help "Filepath of the pool owner stake verification key."
-      , Opt.completer (Opt.bashCompleter "file")
+  fmap File $
+    asum
+      [ Opt.strOption $
+          mconcat
+            [ Opt.long "pool-owner-stake-verification-key-file"
+            , Opt.metavar "FILE"
+            , Opt.help "Filepath of the pool owner stake verification key."
+            , Opt.completer (Opt.bashCompleter "file")
+            ]
+      , Opt.strOption $
+          mconcat
+            [ Opt.long "pool-owner-staking-verification-key"
+            , Opt.internal
+            ]
       ]
-    , Opt.strOption $ mconcat
-      [ Opt.long "pool-owner-staking-verification-key"
-      , Opt.internal
-      ]
-    ]
 
 pPoolOwnerVerificationKey :: Parser (VerificationKey StakeKey)
 pPoolOwnerVerificationKey =
-  Opt.option (readVerificationKey AsStakeKey) $ mconcat
-    [ Opt.long "pool-owner-verification-key"
-    , Opt.metavar "STRING"
-    , Opt.help "Pool owner stake verification key (Bech32 or hex-encoded)."
-    ]
+  Opt.option (readVerificationKey AsStakeKey) $
+    mconcat
+      [ Opt.long "pool-owner-verification-key"
+      , Opt.metavar "STRING"
+      , Opt.help "Pool owner stake verification key (Bech32 or hex-encoded)."
+      ]
 
 pPoolOwnerVerificationKeyOrFile :: Parser (VerificationKeyOrFile StakeKey)
 pPoolOwnerVerificationKeyOrFile =
@@ -2335,31 +2636,33 @@ pPoolOwnerVerificationKeyOrFile =
 
 pPoolPledge :: Parser Lovelace
 pPoolPledge =
-  Opt.option (readerFromParsecParser parseLovelace) $ mconcat
-    [ Opt.long "pool-pledge"
-    , Opt.metavar "LOVELACE"
-    , Opt.help "The stake pool's pledge."
-    ]
+  Opt.option (readerFromParsecParser parseLovelace) $
+    mconcat
+      [ Opt.long "pool-pledge"
+      , Opt.metavar "LOVELACE"
+      , Opt.help "The stake pool's pledge."
+      ]
 
 pPoolCost :: Parser Lovelace
 pPoolCost =
-  Opt.option (readerFromParsecParser parseLovelace) $ mconcat
-    [ Opt.long "pool-cost"
-    , Opt.metavar "LOVELACE"
-    , Opt.help "The stake pool's cost."
-    ]
+  Opt.option (readerFromParsecParser parseLovelace) $
+    mconcat
+      [ Opt.long "pool-cost"
+      , Opt.metavar "LOVELACE"
+      , Opt.help "The stake pool's cost."
+      ]
 
 pRational :: String -> String -> Parser Rational
 pRational opt h =
-  Opt.option readRationalUnitInterval $ mconcat
-    [ Opt.long opt
-    , Opt.metavar "RATIONAL"
-    , Opt.help h
-    ]
+  Opt.option readRationalUnitInterval $
+    mconcat
+      [ Opt.long opt
+      , Opt.metavar "RATIONAL"
+      , Opt.help h
+      ]
 
 pPoolMargin :: Parser Rational
 pPoolMargin = pRational "pool-margin" "The stake pool's margin."
-
 
 pPoolRelay :: Parser StakePoolRelay
 pPoolRelay =
@@ -2372,10 +2675,11 @@ pPoolRelay =
 pMultiHostName :: Parser StakePoolRelay
 pMultiHostName =
   StakePoolRelayDnsSrvRecord <$> pDNSName
-  where
-    pDNSName :: Parser ByteString
-    pDNSName =
-      Opt.option (Opt.eitherReader eDNSName) $ mconcat
+ where
+  pDNSName :: Parser ByteString
+  pDNSName =
+    Opt.option (Opt.eitherReader eDNSName) $
+      mconcat
         [ Opt.long "multi-host-pool-relay"
         , Opt.metavar "STRING"
         , Opt.help "The stake pool relay's DNS name that corresponds to an SRV DNS record"
@@ -2384,16 +2688,19 @@ pMultiHostName =
 pSingleHostName :: Parser StakePoolRelay
 pSingleHostName =
   StakePoolRelayDnsARecord <$> pDNSName <*> optional pPort
-  where
-    pDNSName :: Parser ByteString
-    pDNSName = Opt.option (Opt.eitherReader eDNSName) $ mconcat
-      [ Opt.long "single-host-pool-relay"
-      , Opt.metavar "STRING"
-      , Opt.help $ mconcat
-        [ "The stake pool relay's DNS name that corresponds to an"
-        , " A or AAAA DNS record"
+ where
+  pDNSName :: Parser ByteString
+  pDNSName =
+    Opt.option (Opt.eitherReader eDNSName) $
+      mconcat
+        [ Opt.long "single-host-pool-relay"
+        , Opt.metavar "STRING"
+        , Opt.help $
+            mconcat
+              [ "The stake pool relay's DNS name that corresponds to an"
+              , " A or AAAA DNS record"
+              ]
         ]
-      ]
 
 pSingleHostAddress :: Parser StakePoolRelay
 pSingleHostAddress =
@@ -2401,42 +2708,45 @@ pSingleHostAddress =
     <$> optional pIpV4
     <*> optional pIpV6
     <*> pPort
-  where
-    singleHostAddress :: Maybe IP.IPv4 -> Maybe IP.IPv6 -> PortNumber -> StakePoolRelay
-    singleHostAddress ipv4 ipv6 port =
-      case (ipv4, ipv6) of
-        (Nothing, Nothing) ->
-          error "Please enter either an IPv4 or IPv6 address for the pool relay"
-        (Just i4, Nothing) ->
-          StakePoolRelayIp (Just i4) Nothing (Just port)
-        (Nothing, Just i6) ->
-          StakePoolRelayIp Nothing (Just i6) (Just port)
-        (Just i4, Just i6) ->
-          StakePoolRelayIp (Just i4) (Just i6) (Just port)
+ where
+  singleHostAddress :: Maybe IP.IPv4 -> Maybe IP.IPv6 -> PortNumber -> StakePoolRelay
+  singleHostAddress ipv4 ipv6 port =
+    case (ipv4, ipv6) of
+      (Nothing, Nothing) ->
+        error "Please enter either an IPv4 or IPv6 address for the pool relay"
+      (Just i4, Nothing) ->
+        StakePoolRelayIp (Just i4) Nothing (Just port)
+      (Nothing, Just i6) ->
+        StakePoolRelayIp Nothing (Just i6) (Just port)
+      (Just i4, Just i6) ->
+        StakePoolRelayIp (Just i4) (Just i6) (Just port)
 
 pIpV4 :: Parser IP.IPv4
 pIpV4 =
-  Opt.option (Opt.maybeReader readMaybe :: Opt.ReadM IP.IPv4) $ mconcat
-    [ Opt.long "pool-relay-ipv4"
-    , Opt.metavar "STRING"
-    , Opt.help "The stake pool relay's IPv4 address"
-    ]
+  Opt.option (Opt.maybeReader readMaybe :: Opt.ReadM IP.IPv4) $
+    mconcat
+      [ Opt.long "pool-relay-ipv4"
+      , Opt.metavar "STRING"
+      , Opt.help "The stake pool relay's IPv4 address"
+      ]
 
 pIpV6 :: Parser IP.IPv6
 pIpV6 =
-  Opt.option (Opt.maybeReader readMaybe :: Opt.ReadM IP.IPv6) $ mconcat
-    [ Opt.long "pool-relay-ipv6"
-    , Opt.metavar "STRING"
-    , Opt.help "The stake pool relay's IPv6 address"
-    ]
+  Opt.option (Opt.maybeReader readMaybe :: Opt.ReadM IP.IPv6) $
+    mconcat
+      [ Opt.long "pool-relay-ipv6"
+      , Opt.metavar "STRING"
+      , Opt.help "The stake pool relay's IPv6 address"
+      ]
 
 pPort :: Parser PortNumber
 pPort =
-  Opt.option (fromInteger <$> Opt.eitherReader readEither) $ mconcat
-    [ Opt.long "pool-relay-port"
-    , Opt.metavar "INT"
-    , Opt.help "The stake pool relay's port"
-    ]
+  Opt.option (fromInteger <$> Opt.eitherReader readEither) $
+    mconcat
+      [ Opt.long "pool-relay-port"
+      , Opt.metavar "INT"
+      , Opt.help "The stake pool relay's port"
+      ]
 
 pStakePoolMetadataReference :: Parser (Maybe StakePoolMetadataReference)
 pStakePoolMetadataReference =
@@ -2447,25 +2757,27 @@ pStakePoolMetadataReference =
 
 pStakePoolMetadataUrl :: Parser Text
 pStakePoolMetadataUrl =
-  Opt.option (readURIOfMaxLength 64) $ mconcat
-    [ Opt.long "metadata-url"
-    , Opt.metavar "URL"
-    , Opt.help "Pool metadata URL (maximum length of 64 characters)."
-    ]
+  Opt.option (readURIOfMaxLength 64) $
+    mconcat
+      [ Opt.long "metadata-url"
+      , Opt.metavar "URL"
+      , Opt.help "Pool metadata URL (maximum length of 64 characters)."
+      ]
 
 pStakePoolMetadataHash :: Parser (Hash StakePoolMetadata)
 pStakePoolMetadataHash =
-  Opt.option (Opt.eitherReader metadataHash) $ mconcat
-    [ Opt.long "metadata-hash"
-    , Opt.metavar "HASH"
-    , Opt.help "Pool metadata hash."
-    ]
-  where
-    metadataHash :: String -> Either String (Hash StakePoolMetadata)
-    metadataHash =
-      first displayError
-        . deserialiseFromRawBytesHex (AsHash AsStakePoolMetadata)
-        . BSC.pack
+  Opt.option (Opt.eitherReader metadataHash) $
+    mconcat
+      [ Opt.long "metadata-hash"
+      , Opt.metavar "HASH"
+      , Opt.help "Pool metadata hash."
+      ]
+ where
+  metadataHash :: String -> Either String (Hash StakePoolMetadata)
+  metadataHash =
+    first displayError
+      . deserialiseFromRawBytesHex (AsHash AsStakePoolMetadata)
+      . BSC.pack
 
 pStakePoolRegistrationParserRequirements
   :: EnvCli -> Parser StakePoolRegistrationParserRequirements
@@ -2514,273 +2826,314 @@ pProtocolParametersUpdate =
 
 pCostModels :: Parser FilePath
 pCostModels =
-  Opt.strOption $ mconcat
-    [ Opt.long "cost-model-file"
-    , Opt.metavar "FILE"
-    , Opt.help "Filepath of the JSON formatted cost model"
-    , Opt.completer (Opt.bashCompleter "file")
-    ]
+  Opt.strOption $
+    mconcat
+      [ Opt.long "cost-model-file"
+      , Opt.metavar "FILE"
+      , Opt.help "Filepath of the JSON formatted cost model"
+      , Opt.completer (Opt.bashCompleter "file")
+      ]
 
 pMinFeePerByteFactor :: Parser Lovelace
 pMinFeePerByteFactor =
-  Opt.option (readerFromParsecParser parseLovelace) $ mconcat
-    [ Opt.long "min-fee-linear"
-    , Opt.metavar "LOVELACE"
-    , Opt.help "The linear factor per byte for the minimum fee calculation."
-    ]
+  Opt.option (readerFromParsecParser parseLovelace) $
+    mconcat
+      [ Opt.long "min-fee-linear"
+      , Opt.metavar "LOVELACE"
+      , Opt.help "The linear factor per byte for the minimum fee calculation."
+      ]
 
 pMinFeeConstantFactor :: Parser Lovelace
 pMinFeeConstantFactor =
-  Opt.option (readerFromParsecParser parseLovelace) $ mconcat
-    [ Opt.long "min-fee-constant"
-    , Opt.metavar "LOVELACE"
-    , Opt.help "The constant factor for the minimum fee calculation."
-    ]
+  Opt.option (readerFromParsecParser parseLovelace) $
+    mconcat
+      [ Opt.long "min-fee-constant"
+      , Opt.metavar "LOVELACE"
+      , Opt.help "The constant factor for the minimum fee calculation."
+      ]
 
 pMinUTxOValue :: Parser Lovelace
 pMinUTxOValue =
-  Opt.option (readerFromParsecParser parseLovelace) $ mconcat
-    [ Opt.long "min-utxo-value"
-    , Opt.metavar "NATURAL"
-    , Opt.help "The minimum allowed UTxO value (Shelley to Mary eras)."
-    ]
+  Opt.option (readerFromParsecParser parseLovelace) $
+    mconcat
+      [ Opt.long "min-utxo-value"
+      , Opt.metavar "NATURAL"
+      , Opt.help "The minimum allowed UTxO value (Shelley to Mary eras)."
+      ]
 
 pMinPoolCost :: Parser Lovelace
 pMinPoolCost =
-  Opt.option (readerFromParsecParser parseLovelace) $ mconcat
-    [ Opt.long "min-pool-cost"
-    , Opt.metavar "NATURAL"
-    , Opt.help "The minimum allowed cost parameter for stake pools."
-    ]
+  Opt.option (readerFromParsecParser parseLovelace) $
+    mconcat
+      [ Opt.long "min-pool-cost"
+      , Opt.metavar "NATURAL"
+      , Opt.help "The minimum allowed cost parameter for stake pools."
+      ]
 
 pMaxBodySize :: Parser Natural
 pMaxBodySize =
-  Opt.option Opt.auto $ mconcat
-    [ Opt.long "max-block-body-size"
-    , Opt.metavar "NATURAL"
-    , Opt.help "Maximal block body size."
-    ]
+  Opt.option Opt.auto $
+    mconcat
+      [ Opt.long "max-block-body-size"
+      , Opt.metavar "NATURAL"
+      , Opt.help "Maximal block body size."
+      ]
 
 pMaxTransactionSize :: Parser Natural
 pMaxTransactionSize =
-  Opt.option Opt.auto $ mconcat
-    [ Opt.long "max-tx-size"
-    , Opt.metavar "NATURAL"
-    , Opt.help "Maximum transaction size."
-    ]
+  Opt.option Opt.auto $
+    mconcat
+      [ Opt.long "max-tx-size"
+      , Opt.metavar "NATURAL"
+      , Opt.help "Maximum transaction size."
+      ]
 
 pMaxBlockHeaderSize :: Parser Natural
 pMaxBlockHeaderSize =
-  Opt.option Opt.auto $ mconcat
-   [ Opt.long "max-block-header-size"
-   , Opt.metavar "NATURAL"
-   , Opt.help "Maximum block header size."
-   ]
+  Opt.option Opt.auto $
+    mconcat
+      [ Opt.long "max-block-header-size"
+      , Opt.metavar "NATURAL"
+      , Opt.help "Maximum block header size."
+      ]
 
 pKeyRegistDeposit :: Parser Lovelace
 pKeyRegistDeposit =
-  Opt.option (readerFromParsecParser parseLovelace) $ mconcat
-   [ Opt.long "key-reg-deposit-amt"
-   , Opt.metavar "NATURAL"
-   , Opt.help "Key registration deposit amount."
-   ]
+  Opt.option (readerFromParsecParser parseLovelace) $
+    mconcat
+      [ Opt.long "key-reg-deposit-amt"
+      , Opt.metavar "NATURAL"
+      , Opt.help "Key registration deposit amount."
+      ]
 
 pPoolDeposit :: Parser Lovelace
 pPoolDeposit =
-  Opt.option (readerFromParsecParser parseLovelace) $ mconcat
-   [ Opt.long "pool-reg-deposit"
-   , Opt.metavar "NATURAL"
-   , Opt.help "The amount of a pool registration deposit."
-   ]
+  Opt.option (readerFromParsecParser parseLovelace) $
+    mconcat
+      [ Opt.long "pool-reg-deposit"
+      , Opt.metavar "NATURAL"
+      , Opt.help "The amount of a pool registration deposit."
+      ]
 
 pEpochBoundRetirement :: Parser EpochNo
 pEpochBoundRetirement =
-  fmap EpochNo $ Opt.option (bounded "EPOCH_BOUNDARY") $ mconcat
-    [ Opt.long "pool-retirement-epoch-boundary"
-    , Opt.metavar "EPOCH_BOUNDARY"
-    , Opt.help "Epoch bound on pool retirement."
-    ]
+  fmap EpochNo $
+    Opt.option (bounded "EPOCH_BOUNDARY") $
+      mconcat
+        [ Opt.long "pool-retirement-epoch-boundary"
+        , Opt.metavar "EPOCH_BOUNDARY"
+        , Opt.help "Epoch bound on pool retirement."
+        ]
 
 pNumberOfPools :: Parser Natural
 pNumberOfPools =
-  Opt.option Opt.auto $ mconcat
-   [ Opt.long "number-of-pools"
-   , Opt.metavar "NATURAL"
-   , Opt.help "Desired number of pools."
-   ]
+  Opt.option Opt.auto $
+    mconcat
+      [ Opt.long "number-of-pools"
+      , Opt.metavar "NATURAL"
+      , Opt.help "Desired number of pools."
+      ]
 
 pPoolInfluence :: Parser Rational
 pPoolInfluence =
-  Opt.option readRational $ mconcat
-    [ Opt.long "pool-influence"
-    , Opt.metavar "RATIONAL"
-    , Opt.help "Pool influence."
-    ]
+  Opt.option readRational $
+    mconcat
+      [ Opt.long "pool-influence"
+      , Opt.metavar "RATIONAL"
+      , Opt.help "Pool influence."
+      ]
 
 pTreasuryExpansion :: Parser Rational
 pTreasuryExpansion =
-  Opt.option readRationalUnitInterval $ mconcat
-    [ Opt.long "treasury-expansion"
-    , Opt.metavar "RATIONAL"
-    , Opt.help "Treasury expansion."
-    ]
+  Opt.option readRationalUnitInterval $
+    mconcat
+      [ Opt.long "treasury-expansion"
+      , Opt.metavar "RATIONAL"
+      , Opt.help "Treasury expansion."
+      ]
 
 pMonetaryExpansion :: Parser Rational
 pMonetaryExpansion =
-  Opt.option readRationalUnitInterval $ mconcat
-    [ Opt.long "monetary-expansion"
-    , Opt.metavar "RATIONAL"
-    , Opt.help "Monetary expansion."
-    ]
+  Opt.option readRationalUnitInterval $
+    mconcat
+      [ Opt.long "monetary-expansion"
+      , Opt.metavar "RATIONAL"
+      , Opt.help "Monetary expansion."
+      ]
 
 pDecentralParam :: Parser Rational
 pDecentralParam =
-  Opt.option readRationalUnitInterval $ mconcat
-    [ Opt.long "decentralization-parameter"
-    , Opt.metavar "RATIONAL"
-    , Opt.help "Decentralization parameter."
-    ]
+  Opt.option readRationalUnitInterval $
+    mconcat
+      [ Opt.long "decentralization-parameter"
+      , Opt.metavar "RATIONAL"
+      , Opt.help "Decentralization parameter."
+      ]
 
 pExtraEntropy :: Parser (Maybe PraosNonce)
 pExtraEntropy =
   asum
-    [ Opt.option (Just <$> readerFromParsecParser parsePraosNonce) $ mconcat
-        [ Opt.long "extra-entropy"
-        , Opt.metavar "HEX"
-        , Opt.help "Praos extra entropy seed, as a hex byte string."
-        ]
-    , Opt.flag' Nothing $ mconcat
-        [  Opt.long "reset-extra-entropy"
-        , Opt.help "Reset the Praos extra entropy to none."
-        ]
+    [ Opt.option (Just <$> readerFromParsecParser parsePraosNonce) $
+        mconcat
+          [ Opt.long "extra-entropy"
+          , Opt.metavar "HEX"
+          , Opt.help "Praos extra entropy seed, as a hex byte string."
+          ]
+    , Opt.flag' Nothing $
+        mconcat
+          [ Opt.long "reset-extra-entropy"
+          , Opt.help "Reset the Praos extra entropy to none."
+          ]
     ]
-  where
-    parsePraosNonce :: Parsec.Parser PraosNonce
-    parsePraosNonce = makePraosNonce <$> parseEntropyBytes
+ where
+  parsePraosNonce :: Parsec.Parser PraosNonce
+  parsePraosNonce = makePraosNonce <$> parseEntropyBytes
 
-    parseEntropyBytes :: Parsec.Parser ByteString
-    parseEntropyBytes = either fail return
-                      . B16.decode . BSC.pack
-                    =<< some Parsec.hexDigit
+  parseEntropyBytes :: Parsec.Parser ByteString
+  parseEntropyBytes =
+    either fail return
+      . B16.decode
+      . BSC.pack
+      =<< some Parsec.hexDigit
 
 pUTxOCostPerWord :: Parser Lovelace
 pUTxOCostPerWord =
-  Opt.option (readerFromParsecParser parseLovelace) $ mconcat
-    [ Opt.long "utxo-cost-per-word"
-    , Opt.metavar "LOVELACE"
-    , Opt.help "Cost in lovelace per unit of UTxO storage (from Alonzo era)."
-    ]
+  Opt.option (readerFromParsecParser parseLovelace) $
+    mconcat
+      [ Opt.long "utxo-cost-per-word"
+      , Opt.metavar "LOVELACE"
+      , Opt.help "Cost in lovelace per unit of UTxO storage (from Alonzo era)."
+      ]
 
 pUTxOCostPerByte :: Parser Lovelace
 pUTxOCostPerByte =
-  Opt.option (readerFromParsecParser parseLovelace) $ mconcat
-    [ Opt.long "utxo-cost-per-byte"
-    , Opt.metavar "LOVELACE"
-    , Opt.help "Cost in lovelace per unit of UTxO storage (from Babbage era)."
-    ]
+  Opt.option (readerFromParsecParser parseLovelace) $
+    mconcat
+      [ Opt.long "utxo-cost-per-byte"
+      , Opt.metavar "LOVELACE"
+      , Opt.help "Cost in lovelace per unit of UTxO storage (from Babbage era)."
+      ]
 
 pExecutionUnitPrices :: Parser ExecutionUnitPrices
-pExecutionUnitPrices = ExecutionUnitPrices
-  <$> Opt.option readRational
+pExecutionUnitPrices =
+  ExecutionUnitPrices
+    <$> Opt.option
+      readRational
       ( mconcat
-        [ Opt.long "price-execution-steps"
-        , Opt.metavar "RATIONAL"
-        , Opt.help $ mconcat
-          [ "Step price of execution units for script languages that use "
-          , "them (from Alonzo era).  (Examples: '1.1', '11/10')"
+          [ Opt.long "price-execution-steps"
+          , Opt.metavar "RATIONAL"
+          , Opt.help $
+              mconcat
+                [ "Step price of execution units for script languages that use "
+                , "them (from Alonzo era).  (Examples: '1.1', '11/10')"
+                ]
           ]
-        ]
       )
-  <*> Opt.option readRational
+    <*> Opt.option
+      readRational
       ( mconcat
-        [ Opt.long "price-execution-memory"
-        , Opt.metavar "RATIONAL"
-        , Opt.help $ mconcat
-          [ "Memory price of execution units for script languages that "
-          , "use them (from Alonzo era).  (Examples: '1.1', '11/10')"
+          [ Opt.long "price-execution-memory"
+          , Opt.metavar "RATIONAL"
+          , Opt.help $
+              mconcat
+                [ "Memory price of execution units for script languages that "
+                , "use them (from Alonzo era).  (Examples: '1.1', '11/10')"
+                ]
           ]
-        ]
       )
 
 pMaxTxExecutionUnits :: Parser ExecutionUnits
 pMaxTxExecutionUnits =
-  uncurry ExecutionUnits <$>
-  Opt.option Opt.auto
+  uncurry ExecutionUnits
+    <$> Opt.option
+      Opt.auto
       ( mconcat
-        [ Opt.long "max-tx-execution-units"
-        , Opt.metavar "(INT, INT)"
-        , Opt.help $ mconcat
-          [ "Max total script execution resources units allowed per tx "
-          , "(from Alonzo era). They are denominated as follows (steps, memory)."
+          [ Opt.long "max-tx-execution-units"
+          , Opt.metavar "(INT, INT)"
+          , Opt.help $
+              mconcat
+                [ "Max total script execution resources units allowed per tx "
+                , "(from Alonzo era). They are denominated as follows (steps, memory)."
+                ]
           ]
-        ]
       )
 
 pMaxBlockExecutionUnits :: Parser ExecutionUnits
 pMaxBlockExecutionUnits =
-  uncurry ExecutionUnits <$>
-  Opt.option Opt.auto
+  uncurry ExecutionUnits
+    <$> Opt.option
+      Opt.auto
       ( mconcat
-        [ Opt.long "max-block-execution-units"
-        , Opt.metavar "(INT, INT)"
-        , Opt.help $ mconcat
-          [ "Max total script execution resources units allowed per block "
-          , "(from Alonzo era). They are denominated as follows (steps, memory)."
+          [ Opt.long "max-block-execution-units"
+          , Opt.metavar "(INT, INT)"
+          , Opt.help $
+              mconcat
+                [ "Max total script execution resources units allowed per block "
+                , "(from Alonzo era). They are denominated as follows (steps, memory)."
+                ]
           ]
-        ]
       )
 
 pMaxValueSize :: Parser Natural
 pMaxValueSize =
-  Opt.option Opt.auto $ mconcat
-  [ Opt.long "max-value-size"
-  , Opt.metavar "INT"
-  , Opt.help $ mconcat
-    [ "Max size of a multi-asset value in a tx output (from Alonzo era)."
-    ]
-  ]
+  Opt.option Opt.auto $
+    mconcat
+      [ Opt.long "max-value-size"
+      , Opt.metavar "INT"
+      , Opt.help $
+          mconcat
+            [ "Max size of a multi-asset value in a tx output (from Alonzo era)."
+            ]
+      ]
 
 pCollateralPercent :: Parser Natural
 pCollateralPercent =
-  Opt.option Opt.auto $ mconcat
-  [ Opt.long "collateral-percent"
-  , Opt.metavar "INT"
-  , Opt.help $ mconcat
-    [ "The percentage of the script contribution to the txfee that "
-    , "must be provided as collateral inputs when including Plutus "
-    , "scripts (from Alonzo era)."
-    ]
-  ]
+  Opt.option Opt.auto $
+    mconcat
+      [ Opt.long "collateral-percent"
+      , Opt.metavar "INT"
+      , Opt.help $
+          mconcat
+            [ "The percentage of the script contribution to the txfee that "
+            , "must be provided as collateral inputs when including Plutus "
+            , "scripts (from Alonzo era)."
+            ]
+      ]
 
 pMaxCollateralInputs :: Parser Natural
 pMaxCollateralInputs =
-  Opt.option Opt.auto $ mconcat
-  [ Opt.long "max-collateral-inputs"
-  , Opt.metavar "INT"
-  , Opt.help $ mconcat
-    [ "The maximum number of collateral inputs allowed in a "
-    , "transaction (from Alonzo era)."
-    ]
-  ]
+  Opt.option Opt.auto $
+    mconcat
+      [ Opt.long "max-collateral-inputs"
+      , Opt.metavar "INT"
+      , Opt.help $
+          mconcat
+            [ "The maximum number of collateral inputs allowed in a "
+            , "transaction (from Alonzo era)."
+            ]
+      ]
 
 pProtocolVersion :: Parser (Natural, Natural)
 pProtocolVersion =
-    (,) <$> pProtocolMajorVersion <*> pProtocolMinorVersion
-  where
-    pProtocolMajorVersion =
-      Opt.option Opt.auto $ mconcat
+  (,) <$> pProtocolMajorVersion <*> pProtocolMinorVersion
+ where
+  pProtocolMajorVersion =
+    Opt.option Opt.auto $
+      mconcat
         [ Opt.long "protocol-major-version"
         , Opt.metavar "NATURAL"
         , Opt.help "Major protocol version. An increase indicates a hard fork."
         ]
-    pProtocolMinorVersion =
-      Opt.option Opt.auto $ mconcat
+  pProtocolMinorVersion =
+    Opt.option Opt.auto $
+      mconcat
         [ Opt.long "protocol-minor-version"
         , Opt.metavar "NATURAL"
-        , Opt.help $ mconcat
-          [ "Minor protocol version. An increase indicates a soft fork"
-          , " (old software canvalidate but not produce new blocks)."
-          ]
+        , Opt.help $
+            mconcat
+              [ "Minor protocol version. An increase indicates a soft fork"
+              , " (old software canvalidate but not produce new blocks)."
+              ]
         ]
 
 --------------------------------------------------------------------------------
@@ -2788,31 +3141,32 @@ pProtocolVersion =
 parseTxOutAnyEra
   :: Parsec.Parser (TxOutDatumAnyEra -> ReferenceScriptAnyEra -> TxOutAnyEra)
 parseTxOutAnyEra = do
-    addr <- parseAddressAny
-    Parsec.spaces
-    -- Accept the old style of separating the address and value in a
-    -- transaction output:
-    Parsec.option () (Parsec.char '+' >> Parsec.spaces)
-    val <- parseValue
-    return (TxOutAnyEra addr val)
+  addr <- parseAddressAny
+  Parsec.spaces
+  -- Accept the old style of separating the address and value in a
+  -- transaction output:
+  Parsec.option () (Parsec.char '+' >> Parsec.spaces)
+  val <- parseValue
+  return (TxOutAnyEra addr val)
 
 --------------------------------------------------------------------------------
 
 pVoteChoice :: Parser Vote
 pVoteChoice =
   asum
-   [  flag' Yes $ long "yes"
-   ,  flag' No $ long "no"
-   ,  flag' Abstain $ long "abstain"
-   ]
+    [ flag' Yes $ long "yes"
+    , flag' No $ long "no"
+    , flag' Abstain $ long "abstain"
+    ]
 
 pVoterType :: Parser VType
 pVoterType =
   asum
-   [  flag' VCC $ mconcat [long "constitutional-committee-member", Opt.help "Member of the constiutional committee"]
-   ,  flag' VDR $ mconcat [long "drep", Opt.help "Delegate representative"]
-   ,  flag' VSP $ mconcat [long "spo", Opt.help "Stake pool operator"]
-   ]
+    [ flag' VCC $
+        mconcat [long "constitutional-committee-member", Opt.help "Member of the constiutional committee"]
+    , flag' VDR $ mconcat [long "drep", Opt.help "Delegate representative"]
+    , flag' VSP $ mconcat [long "spo", Opt.help "Stake pool operator"]
+    ]
 
 -- TODO: Conway era include "normal" stake keys
 pVotingCredential :: Parser (VerificationKeyOrFile StakePoolKey)
@@ -2828,17 +3182,19 @@ pVoteDelegationTarget =
 
 pAlwaysAbstain :: Parser ()
 pAlwaysAbstain =
-  Opt.flag' () $ mconcat
-    [ Opt.long "always-abstain"
-    , Opt.help "Abstain from voting on all proposals."
-    ]
+  Opt.flag' () $
+    mconcat
+      [ Opt.long "always-abstain"
+      , Opt.help "Abstain from voting on all proposals."
+      ]
 
 pAlwaysNoConfidence :: Parser ()
 pAlwaysNoConfidence =
-  Opt.flag' () $ mconcat
-    [ Opt.long "always-no-confidence"
-    , Opt.help "Always vote no confidence"
-    ]
+  Opt.flag' () $
+    mconcat
+      [ Opt.long "always-no-confidence"
+      , Opt.help "Always vote no confidence"
+      ]
 
 pDRepHashSource :: Parser DRepHashSource
 pDRepHashSource =
@@ -2849,13 +3205,15 @@ pDRepHashSource =
 
 pDRepScriptHash :: Parser ScriptHash
 pDRepScriptHash =
-  Opt.option scriptHashReader $ mconcat
-    [ Opt.long "drep-script-hash"
-    , Opt.metavar "HASH"
-    , Opt.help $ mconcat
-        [ "DRep script hash (hex-encoded)."
-        ]
-    ]
+  Opt.option scriptHashReader $
+    mconcat
+      [ Opt.long "drep-script-hash"
+      , Opt.metavar "HASH"
+      , Opt.help $
+          mconcat
+            [ "DRep script hash (hex-encoded)."
+            ]
+      ]
 
 pDRepVerificationKeyOrHashOrFile
   :: Parser (VerificationKeyOrHashOrFile DRepKey)
@@ -2875,22 +3233,25 @@ pCombinedDRepVerificationKeyOrHashOrFile =
 
 pCombinedDRepVerificationKeyHash :: Parser (Hash DRepKey)
 pCombinedDRepVerificationKeyHash =
-    Opt.option (pBech32KeyHash AsDRepKey <|> pHexHash AsDRepKey) $ mconcat
+  Opt.option (pBech32KeyHash AsDRepKey <|> pHexHash AsDRepKey) $
+    mconcat
       [ Opt.long "combined-drep-key-hash"
       , Opt.metavar "HASH"
-      , Opt.help $ mconcat
-          [ "DRep verification key hash (either Bech32-encoded or hex-encoded).  "
-          , "Zero or more occurences of this option is allowed."
-          ]
+      , Opt.help $
+          mconcat
+            [ "DRep verification key hash (either Bech32-encoded or hex-encoded).  "
+            , "Zero or more occurences of this option is allowed."
+            ]
       ]
 
 pCombinedDRepVerificationKey :: Parser (VerificationKey DRepKey)
 pCombinedDRepVerificationKey =
-  Opt.option (readVerificationKey AsDRepKey) $ mconcat
-    [ Opt.long "combined-drep-verification-key"
-    , Opt.metavar "STRING"
-    , Opt.help "DRep verification key (Bech32 or hex-encoded)."
-    ]
+  Opt.option (readVerificationKey AsDRepKey) $
+    mconcat
+      [ Opt.long "combined-drep-verification-key"
+      , Opt.metavar "STRING"
+      , Opt.help "DRep verification key (Bech32 or hex-encoded)."
+      ]
 
 pCombinedDRepVerificationKeyOrFile :: Parser (VerificationKeyOrFile DRepKey)
 pCombinedDRepVerificationKeyOrFile =
@@ -2901,31 +3262,35 @@ pCombinedDRepVerificationKeyOrFile =
 
 pCombinedDRepVerificationKeyFile :: Parser (VerificationKeyFile In)
 pCombinedDRepVerificationKeyFile =
-  fmap File . Opt.strOption $ mconcat
-    [ Opt.long "combined-drep-verification-key-file"
-    , Opt.metavar "FILE"
-    , Opt.help "Filepath of the DRep verification key."
-    , Opt.completer (Opt.bashCompleter "file")
-    ]
+  fmap File . Opt.strOption $
+    mconcat
+      [ Opt.long "combined-drep-verification-key-file"
+      , Opt.metavar "FILE"
+      , Opt.help "Filepath of the DRep verification key."
+      , Opt.completer (Opt.bashCompleter "file")
+      ]
 
 pDRepVerificationKeyHash :: Parser (Hash DRepKey)
 pDRepVerificationKeyHash =
-    Opt.option (pBech32KeyHash AsDRepKey <|> pHexHash AsDRepKey) $ mconcat
+  Opt.option (pBech32KeyHash AsDRepKey <|> pHexHash AsDRepKey) $
+    mconcat
       [ Opt.long "drep-key-hash"
       , Opt.metavar "HASH"
-      , Opt.help $ mconcat
-          [ "DRep verification key hash (either Bech32-encoded or hex-encoded).  "
-          , "Zero or more occurences of this option is allowed."
-          ]
+      , Opt.help $
+          mconcat
+            [ "DRep verification key hash (either Bech32-encoded or hex-encoded).  "
+            , "Zero or more occurences of this option is allowed."
+            ]
       ]
 
 pDRepVerificationKey :: Parser (VerificationKey DRepKey)
 pDRepVerificationKey =
-  Opt.option (readVerificationKey AsDRepKey) $ mconcat
-    [ Opt.long "drep-verification-key"
-    , Opt.metavar "STRING"
-    , Opt.help "DRep verification key (Bech32 or hex-encoded)."
-    ]
+  Opt.option (readVerificationKey AsDRepKey) $
+    mconcat
+      [ Opt.long "drep-verification-key"
+      , Opt.metavar "STRING"
+      , Opt.help "DRep verification key (Bech32 or hex-encoded)."
+      ]
 
 pDRepVerificationKeyOrFile :: Parser (VerificationKeyOrFile DRepKey)
 pDRepVerificationKeyOrFile =
@@ -2936,12 +3301,13 @@ pDRepVerificationKeyOrFile =
 
 pDRepVerificationKeyFile :: Parser (VerificationKeyFile In)
 pDRepVerificationKeyFile =
-  fmap File . Opt.strOption $ mconcat
-    [ Opt.long "drep-verification-key-file"
-    , Opt.metavar "FILE"
-    , Opt.help "Filepath of the DRep verification key."
-    , Opt.completer (Opt.bashCompleter "file")
-    ]
+  fmap File . Opt.strOption $
+    mconcat
+      [ Opt.long "drep-verification-key-file"
+      , Opt.metavar "FILE"
+      , Opt.help "Filepath of the DRep verification key."
+      , Opt.completer (Opt.bashCompleter "file")
+      ]
 
 pProposalUrl :: Parser ProposalUrl
 pProposalUrl =
@@ -2953,12 +3319,12 @@ pProposalHashSource =
   asum
     [ ProposalHashSourceText
         <$> Opt.strOption
-            ( mconcat
-                [ Opt.long "proposal-text"
-                , Opt.metavar "TEXT"
-                , Opt.help "Input proposal as UTF-8 encoded text."
-                ]
-            )
+          ( mconcat
+              [ Opt.long "proposal-text"
+              , Opt.metavar "TEXT"
+              , Opt.help "Input proposal as UTF-8 encoded text."
+              ]
+          )
     , ProposalHashSourceFile
         <$> pFileInDirection "proposal-file" "Input proposal as a text file."
     , ProposalHashSourceHash
@@ -2967,38 +3333,43 @@ pProposalHashSource =
 
 pProposalHash :: Parser (L.SafeHash Crypto.StandardCrypto L.AnchorData)
 pProposalHash =
-  Opt.option readSafeHash $ mconcat
-    [ Opt.long "proposal-hash"
-    , Opt.metavar "HASH"
-    , Opt.help "Proposal anchor data hash."
-    ]
+  Opt.option readSafeHash $
+    mconcat
+      [ Opt.long "proposal-hash"
+      , Opt.metavar "HASH"
+      , Opt.help "Proposal anchor data hash."
+      ]
 
 pPreviousGovernanceAction :: Parser (Maybe (TxId, Word32))
-pPreviousGovernanceAction = optional $
-  (,) <$> pTxId "governance-action-tx-id" "Previous txid of the governance action."
+pPreviousGovernanceAction =
+  optional $
+    (,)
+      <$> pTxId "governance-action-tx-id" "Previous txid of the governance action."
       <*> pWord32 "governance-action-index" "Previous tx's governance action index."
 
 pGovernanceActionId :: Parser (TxId, Word32)
 pGovernanceActionId =
-  (,) <$> pTxId "governance-action-tx-id" "Txid of the governance action."
-      <*> pWord32 "governance-action-index" "Tx's governance action index."
+  (,)
+    <$> pTxId "governance-action-tx-id" "Txid of the governance action."
+    <*> pWord32 "governance-action-index" "Tx's governance action index."
 
 pWord32 :: String -> String -> Parser Word32
 pWord32 l h =
-  Opt.option auto $ mconcat
-    [ Opt.long l
-    , Opt.metavar "WORD32"
-    , Opt.help h
-    ]
+  Opt.option auto $
+    mconcat
+      [ Opt.long l
+      , Opt.metavar "WORD32"
+      , Opt.help h
+      ]
 
 pTxId :: String -> String -> Parser TxId
 pTxId l h =
-  Opt.option (readerFromParsecParser parseTxId) $ mconcat
-    [ Opt.long l
-    , Opt.metavar "TXID"
-    , Opt.help h
-    ]
-
+  Opt.option (readerFromParsecParser parseTxId) $
+    mconcat
+      [ Opt.long l
+      , Opt.metavar "TXID"
+      , Opt.help h
+      ]
 
 --------------------------------------------------------------------------------
 -- Helpers

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Genesis.hs
@@ -19,7 +19,7 @@ import Cardano.Chain.Common (BlockCount (BlockCount))
 import Data.Maybe
 import Data.Word (Word64)
 import Options.Applicative hiding (help, str)
-import qualified Options.Applicative as Opt
+import Options.Applicative qualified as Opt
 
 {- HLINT ignore "Use <$>" -}
 {- HLINT ignore "Move brackets to avoid $" -}

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Genesis.hs
@@ -7,89 +7,91 @@ module Cardano.CLI.EraBased.Options.Genesis
   ( pGenesisCmds
   ) where
 
-import           Cardano.Api hiding (QueryInShelleyBasedEra (..))
+import Cardano.Api hiding (QueryInShelleyBasedEra (..))
 
-import           Cardano.Chain.Common (BlockCount (BlockCount))
-import           Cardano.CLI.Environment (EnvCli (..))
-import           Cardano.CLI.EraBased.Commands.Genesis
-import           Cardano.CLI.EraBased.Options.Common
-import           Cardano.CLI.Parser
-import           Cardano.CLI.Types.Common
+import Cardano.CLI.Environment (EnvCli (..))
+import Cardano.CLI.EraBased.Commands.Genesis
+import Cardano.CLI.EraBased.Options.Common
+import Cardano.CLI.Parser
+import Cardano.CLI.Types.Common
+import Cardano.Chain.Common (BlockCount (BlockCount))
 
-import           Data.Maybe
-import           Data.Word (Word64)
-import           Options.Applicative hiding (help, str)
+import Data.Maybe
+import Data.Word (Word64)
+import Options.Applicative hiding (help, str)
 import qualified Options.Applicative as Opt
 
 {- HLINT ignore "Use <$>" -}
 {- HLINT ignore "Move brackets to avoid $" -}
 
-pGenesisCmds :: ()
+pGenesisCmds
+  :: ()
   => EnvCli
   -> Maybe (Parser (GenesisCmds era))
 pGenesisCmds envCli =
-  subInfoParser "genesis"
-    ( Opt.progDesc
-        $ mconcat
+  subInfoParser
+    "genesis"
+    ( Opt.progDesc $
+        mconcat
           [ "Genesis block commands."
           ]
     )
-    [ Just
-        $ subParser "key-gen-genesis"
-        $ Opt.info pGenesisKeyGen
-        $ Opt.progDesc "Create a Shelley genesis key pair"
-    , Just
-        $ subParser "key-gen-delegate"
-        $ Opt.info pGenesisDelegateKeyGen
-        $ Opt.progDesc "Create a Shelley genesis delegate key pair"
-    , Just
-        $ subParser "key-gen-utxo"
-        $ Opt.info pGenesisUTxOKeyGen
-        $ Opt.progDesc "Create a Shelley genesis UTxO key pair"
-    , Just
-        $ subParser "key-hash"
-        $ Opt.info pGenesisKeyHash
-        $ Opt.progDesc "Print the identifier (hash) of a public key"
-    , Just
-        $ subParser "get-ver-key"
-        $ Opt.info pGenesisVerKey
-        $ Opt.progDesc "Derive the verification key from a signing key"
-    , Just
-        $ subParser "initial-addr"
-        $ Opt.info (pGenesisAddr envCli)
-        $ Opt.progDesc "Get the address for an initial UTxO based on the verification key"
-    , Just
-        $ subParser "initial-txin"
-        $ Opt.info (pGenesisTxIn envCli)
-        $ Opt.progDesc "Get the TxIn for an initial UTxO based on the verification key"
-    , Just
-        $ subParser "create-cardano"
-        $ Opt.info (pGenesisCreateCardano envCli)
-        $ Opt.progDesc
-        $ mconcat
-            [ "Create a Byron and Shelley genesis file from a genesis "
-            , "template and genesis/delegation/spending keys."
-            ]
-    , Just
-        $ subParser "create"
-        $ Opt.info (pGenesisCreate envCli)
-        $ Opt.progDesc
-        $ mconcat
-            [ "Create a Shelley genesis file from a genesis "
-            , "template and genesis/delegation/spending keys."
-            ]
-    , Just
-        $ subParser "create-staked"
-        $ Opt.info (pGenesisCreateStaked envCli)
-        $ Opt.progDesc
-        $ mconcat
-            [ "Create a staked Shelley genesis file from a genesis "
-            , "template and genesis/delegation/spending keys."
-            ]
-    , Just
-        $ subParser "hash"
-        $ Opt.info pGenesisHash
-        $ Opt.progDesc "Compute the hash of a genesis file"
+    [ Just $
+        subParser "key-gen-genesis" $
+          Opt.info pGenesisKeyGen $
+            Opt.progDesc "Create a Shelley genesis key pair"
+    , Just $
+        subParser "key-gen-delegate" $
+          Opt.info pGenesisDelegateKeyGen $
+            Opt.progDesc "Create a Shelley genesis delegate key pair"
+    , Just $
+        subParser "key-gen-utxo" $
+          Opt.info pGenesisUTxOKeyGen $
+            Opt.progDesc "Create a Shelley genesis UTxO key pair"
+    , Just $
+        subParser "key-hash" $
+          Opt.info pGenesisKeyHash $
+            Opt.progDesc "Print the identifier (hash) of a public key"
+    , Just $
+        subParser "get-ver-key" $
+          Opt.info pGenesisVerKey $
+            Opt.progDesc "Derive the verification key from a signing key"
+    , Just $
+        subParser "initial-addr" $
+          Opt.info (pGenesisAddr envCli) $
+            Opt.progDesc "Get the address for an initial UTxO based on the verification key"
+    , Just $
+        subParser "initial-txin" $
+          Opt.info (pGenesisTxIn envCli) $
+            Opt.progDesc "Get the TxIn for an initial UTxO based on the verification key"
+    , Just $
+        subParser "create-cardano" $
+          Opt.info (pGenesisCreateCardano envCli) $
+            Opt.progDesc $
+              mconcat
+                [ "Create a Byron and Shelley genesis file from a genesis "
+                , "template and genesis/delegation/spending keys."
+                ]
+    , Just $
+        subParser "create" $
+          Opt.info (pGenesisCreate envCli) $
+            Opt.progDesc $
+              mconcat
+                [ "Create a Shelley genesis file from a genesis "
+                , "template and genesis/delegation/spending keys."
+                ]
+    , Just $
+        subParser "create-staked" $
+          Opt.info (pGenesisCreateStaked envCli) $
+            Opt.progDesc $
+              mconcat
+                [ "Create a staked Shelley genesis file from a genesis "
+                , "template and genesis/delegation/spending keys."
+                ]
+    , Just $
+        subParser "hash" $
+          Opt.info pGenesisHash $
+            Opt.progDesc "Compute the hash of a genesis file"
     ]
 
 pGenesisKeyGen :: Parser (GenesisCmds era)
@@ -149,17 +151,17 @@ pGenesisCreateCardano envCli =
     <*> pSlotCoefficient
     <*> pNetworkId envCli
     <*> parseFilePath
-          "byron-template"
-          "JSON file with genesis defaults for each byron."
+      "byron-template"
+      "JSON file with genesis defaults for each byron."
     <*> parseFilePath
-          "shelley-template"
-          "JSON file with genesis defaults for each shelley."
+      "shelley-template"
+      "JSON file with genesis defaults for each shelley."
     <*> parseFilePath
-          "alonzo-template"
-          "JSON file with genesis defaults for alonzo."
+      "alonzo-template"
+      "JSON file with genesis defaults for alonzo."
     <*> parseFilePath
-          "conway-template"
-          "JSON file with genesis defaults for conway."
+      "conway-template"
+      "JSON file with genesis defaults for conway."
     <*> pNodeConfigTemplate
 
 pGenesisCreate :: EnvCli -> Parser (GenesisCmds era)
@@ -197,136 +199,161 @@ pGenesisHash =
 
 pGenesisDir :: Parser GenesisDir
 pGenesisDir =
-  fmap GenesisDir $ Opt.strOption $ mconcat
-    [ Opt.long "genesis-dir"
-    , Opt.metavar "DIR"
-    , Opt.help "The genesis directory containing the genesis template and required genesis/delegation/spending keys."
-    ]
+  fmap GenesisDir $
+    Opt.strOption $
+      mconcat
+        [ Opt.long "genesis-dir"
+        , Opt.metavar "DIR"
+        , Opt.help
+            "The genesis directory containing the genesis template and required genesis/delegation/spending keys."
+        ]
 
 pMaybeSystemStart :: Parser (Maybe SystemStart)
 pMaybeSystemStart =
-  Opt.optional $ fmap (SystemStart . convertTime) $ Opt.strOption $ mconcat
-    [ Opt.long "start-time"
-    , Opt.metavar "UTC-TIME"
-    , Opt.help "The genesis start time in YYYY-MM-DDThh:mm:ssZ format. If unspecified, will be the current time +30 seconds."
-    ]
+  Opt.optional $
+    fmap (SystemStart . convertTime) $
+      Opt.strOption $
+        mconcat
+          [ Opt.long "start-time"
+          , Opt.metavar "UTC-TIME"
+          , Opt.help
+              "The genesis start time in YYYY-MM-DDThh:mm:ssZ format. If unspecified, will be the current time +30 seconds."
+          ]
 
 pGenesisNumGenesisKeys :: Parser Word
 pGenesisNumGenesisKeys =
-  Opt.option Opt.auto $ mconcat
-    [ Opt.long "gen-genesis-keys"
-    , Opt.metavar "INT"
-    , Opt.help "The number of genesis keys to make [default is 3]."
-    , Opt.value 3
-    ]
+  Opt.option Opt.auto $
+    mconcat
+      [ Opt.long "gen-genesis-keys"
+      , Opt.metavar "INT"
+      , Opt.help "The number of genesis keys to make [default is 3]."
+      , Opt.value 3
+      ]
 
 pNodeConfigTemplate :: Parser (Maybe FilePath)
 pNodeConfigTemplate = optional $ parseFilePath "node-config-template" "the node config template"
 
 pGenesisNumUTxOKeys :: Parser Word
 pGenesisNumUTxOKeys =
-  Opt.option Opt.auto $ mconcat
-    [ Opt.long "gen-utxo-keys"
-    , Opt.metavar "INT"
-    , Opt.help "The number of UTxO keys to make [default is 0]."
-    , Opt.value 0
-    ]
+  Opt.option Opt.auto $
+    mconcat
+      [ Opt.long "gen-utxo-keys"
+      , Opt.metavar "INT"
+      , Opt.help "The number of UTxO keys to make [default is 0]."
+      , Opt.value 0
+      ]
 
 pGenesisNumPools :: Parser Word
 pGenesisNumPools =
-  Opt.option Opt.auto $ mconcat
-    [ Opt.long "gen-pools"
-    , Opt.metavar "INT"
-    , Opt.help "The number of stake pool credential sets to make [default is 0]."
-    , Opt.value 0
-    ]
+  Opt.option Opt.auto $
+    mconcat
+      [ Opt.long "gen-pools"
+      , Opt.metavar "INT"
+      , Opt.help "The number of stake pool credential sets to make [default is 0]."
+      , Opt.value 0
+      ]
 
 pGenesisNumStDelegs :: Parser Word
 pGenesisNumStDelegs =
-  Opt.option Opt.auto $ mconcat
-    [ Opt.long "gen-stake-delegs"
-    , Opt.metavar "INT"
-    , Opt.help "The number of stake delegator credential sets to make [default is 0]."
-    , Opt.value 0
-    ]
+  Opt.option Opt.auto $
+    mconcat
+      [ Opt.long "gen-stake-delegs"
+      , Opt.metavar "INT"
+      , Opt.help "The number of stake delegator credential sets to make [default is 0]."
+      , Opt.value 0
+      ]
 
 pStuffedUtxoCount :: Parser Word
 pStuffedUtxoCount =
-  Opt.option Opt.auto $ mconcat
-    [ Opt.long "num-stuffed-utxo"
-    , Opt.metavar "INT"
-    , Opt.help "The number of fake UTxO entries to generate [default is 0]."
-    , Opt.value 0
-    ]
+  Opt.option Opt.auto $
+    mconcat
+      [ Opt.long "num-stuffed-utxo"
+      , Opt.metavar "INT"
+      , Opt.help "The number of fake UTxO entries to generate [default is 0]."
+      , Opt.value 0
+      ]
 
 pRelayJsonFp :: Parser FilePath
 pRelayJsonFp =
-  Opt.strOption $ mconcat
-    [ Opt.long "relay-specification-file"
-    , Opt.metavar "FILE"
-    , Opt.help "JSON file specified the relays of each stake pool."
-    , Opt.completer (Opt.bashCompleter "file")
-    ]
+  Opt.strOption $
+    mconcat
+      [ Opt.long "relay-specification-file"
+      , Opt.metavar "FILE"
+      , Opt.help "JSON file specified the relays of each stake pool."
+      , Opt.completer (Opt.bashCompleter "file")
+      ]
 
 pInitialSupplyNonDelegated :: Parser (Maybe Lovelace)
 pInitialSupplyNonDelegated =
-  Opt.optional $ fmap Lovelace $ Opt.option Opt.auto $ mconcat
-    [ Opt.long "supply"
-    , Opt.metavar "LOVELACE"
-    , Opt.help "The initial coin supply in Lovelace which will be evenly distributed across initial, non-delegating stake holders."
-    ]
+  Opt.optional $
+    fmap Lovelace $
+      Opt.option Opt.auto $
+        mconcat
+          [ Opt.long "supply"
+          , Opt.metavar "LOVELACE"
+          , Opt.help
+              "The initial coin supply in Lovelace which will be evenly distributed across initial, non-delegating stake holders."
+          ]
 
 pInitialSupplyDelegated :: Parser Lovelace
 pInitialSupplyDelegated =
-  fmap (Lovelace . fromMaybe 0) $ Opt.optional $ Opt.option Opt.auto $ mconcat
-    [ Opt.long "supply-delegated"
-    , Opt.metavar "LOVELACE"
-    , Opt.help "The initial coin supply in Lovelace which will be evenly distributed across initial, delegating stake holders."
-    , Opt.value 0
-    ]
+  fmap (Lovelace . fromMaybe 0) $
+    Opt.optional $
+      Opt.option Opt.auto $
+        mconcat
+          [ Opt.long "supply-delegated"
+          , Opt.metavar "LOVELACE"
+          , Opt.help
+              "The initial coin supply in Lovelace which will be evenly distributed across initial, delegating stake holders."
+          , Opt.value 0
+          ]
 
 pSecurityParam :: Parser Word64
 pSecurityParam =
-  Opt.option Opt.auto $ mconcat
-    [ Opt.long "security-param"
-    , Opt.metavar "INT"
-    , Opt.help "Security parameter for genesis file [default is 108]."
-    , Opt.value 108
-    ]
+  Opt.option Opt.auto $
+    mconcat
+      [ Opt.long "security-param"
+      , Opt.metavar "INT"
+      , Opt.help "Security parameter for genesis file [default is 108]."
+      , Opt.value 108
+      ]
 
 pSlotLength :: Parser Word
 pSlotLength =
-  Opt.option Opt.auto $ mconcat
-    [ Opt.long "slot-length"
-    , Opt.metavar "INT"
-    , Opt.help "slot length (ms) parameter for genesis file [default is 1000]."
-    , Opt.value 1000
-    ]
-
+  Opt.option Opt.auto $
+    mconcat
+      [ Opt.long "slot-length"
+      , Opt.metavar "INT"
+      , Opt.help "slot length (ms) parameter for genesis file [default is 1000]."
+      , Opt.value 1000
+      ]
 
 pSlotCoefficient :: Parser Rational
 pSlotCoefficient =
-  Opt.option readRationalUnitInterval $ mconcat
-    [ Opt.long "slot-coefficient"
-    , Opt.metavar "RATIONAL"
-    , Opt.help "Slot Coefficient for genesis file [default is .05]."
-    , Opt.value 0.05
-    ]
+  Opt.option readRationalUnitInterval $
+    mconcat
+      [ Opt.long "slot-coefficient"
+      , Opt.metavar "RATIONAL"
+      , Opt.help "Slot Coefficient for genesis file [default is .05]."
+      , Opt.value 0.05
+      ]
 
 pBulkPoolCredFiles :: Parser Word
 pBulkPoolCredFiles =
-  Opt.option Opt.auto $ mconcat
-    [ Opt.long "bulk-pool-cred-files"
-    , Opt.metavar "INT"
-    , Opt.help "Generate bulk pool credential files [default is 0]."
-    , Opt.value 0
-    ]
+  Opt.option Opt.auto $
+    mconcat
+      [ Opt.long "bulk-pool-cred-files"
+      , Opt.metavar "INT"
+      , Opt.help "Generate bulk pool credential files [default is 0]."
+      , Opt.value 0
+      ]
 
 pBulkPoolsPerFile :: Parser Word
 pBulkPoolsPerFile =
-  Opt.option Opt.auto $ mconcat
-    [ Opt.long "bulk-pools-per-file"
-    , Opt.metavar "INT"
-    , Opt.help "Each bulk pool to contain this many pool credential sets [default is 0]."
-    , Opt.value 0
-    ]
+  Opt.option Opt.auto $
+    mconcat
+      [ Opt.long "bulk-pools-per-file"
+      , Opt.metavar "INT"
+      , Opt.help "Each bulk pool to contain this many pool credential sets [default is 0]."
+      , Opt.value 0
+      ]

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance.hs
@@ -2,71 +2,75 @@
 {-# LANGUAGE GADTs #-}
 
 module Cardano.CLI.EraBased.Options.Governance
-  ( GovernanceCmds(..)
+  ( GovernanceCmds (..)
   , renderGovernanceCmds
   , pGovernanceCmds
   ) where
 
-import           Cardano.Api
+import Cardano.Api
 
-import           Cardano.CLI.Environment
-import           Cardano.CLI.EraBased.Commands.Governance
-import           Cardano.CLI.EraBased.Options.Common
-import           Cardano.CLI.EraBased.Options.Governance.Actions
-import           Cardano.CLI.EraBased.Options.Governance.Committee
-import           Cardano.CLI.EraBased.Options.Governance.DRep
-import           Cardano.CLI.EraBased.Options.Governance.Query
-import           Cardano.CLI.EraBased.Options.Governance.Vote
-import           Cardano.CLI.Types.Common
+import Cardano.CLI.Environment
+import Cardano.CLI.EraBased.Commands.Governance
+import Cardano.CLI.EraBased.Options.Common
+import Cardano.CLI.EraBased.Options.Governance.Actions
+import Cardano.CLI.EraBased.Options.Governance.Committee
+import Cardano.CLI.EraBased.Options.Governance.DRep
+import Cardano.CLI.EraBased.Options.Governance.Query
+import Cardano.CLI.EraBased.Options.Governance.Vote
+import Cardano.CLI.Types.Common
 
-import           Data.Foldable
-import           Options.Applicative
+import Data.Foldable
+import Options.Applicative
 import qualified Options.Applicative as Opt
 
-pGovernanceCmds :: ()
+pGovernanceCmds
+  :: ()
   => CardanoEra era
   -> EnvCli
   -> Maybe (Parser (GovernanceCmds era))
 pGovernanceCmds era envCli =
-  subInfoParser "governance"
-    ( Opt.progDesc
-        $ mconcat
+  subInfoParser
+    "governance"
+    ( Opt.progDesc $
+        mconcat
           [ "Governance commands."
           ]
     )
     [ pCreateMirCertificatesCmds era
-    , fmap GovernanceQueryCmds        <$> pGovernanceQueryCmds era envCli
-    , fmap GovernanceActionCmds       <$> pGovernanceActionCmds era
-    , fmap GovernanceCommitteeCmds    <$> pGovernanceCommitteeCmds era
-    , fmap GovernanceDRepCmds         <$> pGovernanceDRepCmds era envCli
-    , fmap GovernanceVoteCmds         <$> pGovernanceVoteCmds era
+    , fmap GovernanceQueryCmds <$> pGovernanceQueryCmds era envCli
+    , fmap GovernanceActionCmds <$> pGovernanceActionCmds era
+    , fmap GovernanceCommitteeCmds <$> pGovernanceCommitteeCmds era
+    , fmap GovernanceDRepCmds <$> pGovernanceDRepCmds era envCli
+    , fmap GovernanceVoteCmds <$> pGovernanceVoteCmds era
     ]
 
 pCreateMirCertificatesCmds :: CardanoEra era -> Maybe (Parser (GovernanceCmds era))
 pCreateMirCertificatesCmds era = do
   w <- maybeEonInEra era
-  pure
-    $ subParser "create-mir-certificate"
-    $ Opt.info (pMIRPayStakeAddresses w <|> mirCertParsers w)
-    $ Opt.progDesc "Create an MIR (Move Instantaneous Rewards) certificate"
+  pure $
+    subParser "create-mir-certificate" $
+      Opt.info (pMIRPayStakeAddresses w <|> mirCertParsers w) $
+        Opt.progDesc "Create an MIR (Move Instantaneous Rewards) certificate"
 
-mirCertParsers :: ()
+mirCertParsers
+  :: ()
   => ShelleyToBabbageEra era
   -> Parser (GovernanceCmds era)
 mirCertParsers w =
   asum
-    [ subParser "stake-addresses"
-      $ Opt.info (pMIRPayStakeAddresses w)
-      $ Opt.progDesc "Create an MIR certificate to pay stake addresses"
-    , subParser "transfer-to-treasury"
-      $ Opt.info (pMIRTransferToTreasury w)
-      $ Opt.progDesc "Create an MIR certificate to transfer from the reserves pot to the treasury pot"
-    , subParser "transfer-to-rewards"
-      $ Opt.info (pMIRTransferToReserves w)
-      $ Opt.progDesc "Create an MIR certificate to transfer from the treasury pot to the reserves pot"
+    [ subParser "stake-addresses" $
+        Opt.info (pMIRPayStakeAddresses w) $
+          Opt.progDesc "Create an MIR certificate to pay stake addresses"
+    , subParser "transfer-to-treasury" $
+        Opt.info (pMIRTransferToTreasury w) $
+          Opt.progDesc "Create an MIR certificate to transfer from the reserves pot to the treasury pot"
+    , subParser "transfer-to-rewards" $
+        Opt.info (pMIRTransferToReserves w) $
+          Opt.progDesc "Create an MIR certificate to transfer from the treasury pot to the reserves pot"
     ]
 
-pMIRPayStakeAddresses :: ()
+pMIRPayStakeAddresses
+  :: ()
   => ShelleyToBabbageEra era
   -> Parser (GovernanceCmds era)
 pMIRPayStakeAddresses w =
@@ -76,7 +80,8 @@ pMIRPayStakeAddresses w =
     <*> some pRewardAmt
     <*> pOutputFile
 
-pMIRTransferToTreasury :: ()
+pMIRTransferToTreasury
+  :: ()
   => ShelleyToBabbageEra era
   -> Parser (GovernanceCmds era)
 pMIRTransferToTreasury w =
@@ -85,7 +90,8 @@ pMIRTransferToTreasury w =
     <*> pOutputFile
     <*> pure TransferToTreasury
 
-pMIRTransferToReserves :: ()
+pMIRTransferToReserves
+  :: ()
   => ShelleyToBabbageEra era
   -> Parser (GovernanceCmds era)
 pMIRTransferToReserves w =

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance.hs
@@ -21,7 +21,7 @@ import Cardano.CLI.Types.Common
 
 import Data.Foldable
 import Options.Applicative
-import qualified Options.Applicative as Opt
+import Options.Applicative qualified as Opt
 
 pGovernanceCmds
   :: ()

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Actions.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Actions.hs
@@ -14,12 +14,12 @@ import Cardano.CLI.EraBased.Commands.Governance.Actions
 import Cardano.CLI.EraBased.Options.Common
 import Cardano.CLI.Types.Common
 import Cardano.Ledger.BaseTypes (NonNegativeInterval)
-import qualified Cardano.Ledger.BaseTypes as Ledger
+import Cardano.Ledger.BaseTypes qualified as Ledger
 
 import Data.Foldable
 import GHC.Natural (Natural)
 import Options.Applicative
-import qualified Options.Applicative as Opt
+import Options.Applicative qualified as Opt
 
 pGovernanceActionCmds
   :: ()

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Actions.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Actions.hs
@@ -6,28 +6,30 @@ module Cardano.CLI.EraBased.Options.Governance.Actions
   ( pGovernanceActionCmds
   ) where
 
-import           Cardano.Api
-import           Cardano.Api.Ledger
-import           Cardano.Api.Shelley
+import Cardano.Api
+import Cardano.Api.Ledger
+import Cardano.Api.Shelley
 
-import           Cardano.CLI.EraBased.Commands.Governance.Actions
-import           Cardano.CLI.EraBased.Options.Common
-import           Cardano.CLI.Types.Common
-import           Cardano.Ledger.BaseTypes (NonNegativeInterval)
+import Cardano.CLI.EraBased.Commands.Governance.Actions
+import Cardano.CLI.EraBased.Options.Common
+import Cardano.CLI.Types.Common
+import Cardano.Ledger.BaseTypes (NonNegativeInterval)
 import qualified Cardano.Ledger.BaseTypes as Ledger
 
-import           Data.Foldable
-import           GHC.Natural (Natural)
-import           Options.Applicative
+import Data.Foldable
+import GHC.Natural (Natural)
+import Options.Applicative
 import qualified Options.Applicative as Opt
 
-pGovernanceActionCmds :: ()
+pGovernanceActionCmds
+  :: ()
   => CardanoEra era
   -> Maybe (Parser (GovernanceActionCmds era))
 pGovernanceActionCmds era =
-  subInfoParser "action"
-    ( Opt.progDesc
-        $ mconcat
+  subInfoParser
+    "action"
+    ( Opt.progDesc $
+        mconcat
           [ "Governance action commands."
           ]
     )
@@ -47,17 +49,16 @@ pGovernanceActionNewInfoCmd era = do
   pure
     $ subParser "create-info"
     $ Opt.info
-        ( fmap (GovernanceActionInfoCmd cOn) $
-            NewInfoCmd
-              <$> pNetwork
-              <*> pGovActionDeposit
-              <*> pAnyStakeIdentifier Nothing
-              <*> pProposalUrl
-              <*> pProposalHashSource
-              <*> pFileOutDirection "out-file" "Path to action file to be used later on with build or build-raw "
-        )
+      ( fmap (GovernanceActionInfoCmd cOn) $
+          NewInfoCmd
+            <$> pNetwork
+            <*> pGovActionDeposit
+            <*> pAnyStakeIdentifier Nothing
+            <*> pProposalUrl
+            <*> pProposalHashSource
+            <*> pFileOutDirection "out-file" "Path to action file to be used later on with build or build-raw "
+      )
     $ Opt.progDesc "Create an info action."
-
 
 pGovernanceActionNewConstitutionCmd
   :: CardanoEra era
@@ -67,18 +68,18 @@ pGovernanceActionNewConstitutionCmd era = do
   pure
     $ subParser "create-constitution"
     $ Opt.info
-        ( fmap (GovernanceActionCreateConstitutionCmd cOn) $
-            NewConstitutionCmd
-              <$> pNetwork
-              <*> pGovActionDeposit
-              <*> pAnyStakeIdentifier Nothing
-              <*> pPreviousGovernanceAction
-              <*> pProposalUrl
-              <*> pProposalHashSource
-              <*> pConstitutionUrl
-              <*> pConstitutionHashSource
-              <*> pFileOutDirection "out-file" "Output filepath of the constitution."
-        )
+      ( fmap (GovernanceActionCreateConstitutionCmd cOn) $
+          NewConstitutionCmd
+            <$> pNetwork
+            <*> pGovActionDeposit
+            <*> pAnyStakeIdentifier Nothing
+            <*> pPreviousGovernanceAction
+            <*> pProposalUrl
+            <*> pProposalHashSource
+            <*> pConstitutionUrl
+            <*> pConstitutionHashSource
+            <*> pFileOutDirection "out-file" "Output filepath of the constitution."
+      )
     $ Opt.progDesc "Create a constitution."
 
 pGovernanceActionNewCommitteeCmd
@@ -104,13 +105,13 @@ pNewCommitteeCmd =
     <*> pProposalHashSource
     <*> many pRemoveCommitteeColdVerificationKeyOrHashOrFile
     <*> many
-          ( (,)
-              <$> pAddCommitteeColdVerificationKeyOrHashOrFile
-              <*> pEpochNo "Committee member expiry epoch")
+      ( (,)
+          <$> pAddCommitteeColdVerificationKeyOrHashOrFile
+          <*> pEpochNo "Committee member expiry epoch"
+      )
     <*> pRational "quorum" "Quorum of the committee that is necessary for a successful vote."
     <*> pPreviousGovernanceAction
     <*> pOutputFile
-
 
 pGovernanceActionNoConfidenceCmd
   :: CardanoEra era
@@ -120,17 +121,21 @@ pGovernanceActionNoConfidenceCmd era = do
   pure
     $ subParser "create-no-confidence"
     $ Opt.info
-        ( fmap (GovernanceActionCreateNoConfidenceCmd cOn) $
-            NoConfidenceCmd
-              <$> pNetwork
-              <*> pGovActionDeposit
-              <*> pAnyStakeIdentifier Nothing
-              <*> pProposalUrl
-              <*> pProposalHashSource
-              <*> pTxId "governance-action-tx-id" "Previous txid of `NoConfidence` or `NewCommittee` governance action."
-              <*> pWord32 "governance-action-index" "Previous tx's governance action index of `NoConfidence` or `NewCommittee` governance action."
-              <*> pFileOutDirection "out-file" "Output filepath of the no confidence proposal."
-        )
+      ( fmap (GovernanceActionCreateNoConfidenceCmd cOn) $
+          NoConfidenceCmd
+            <$> pNetwork
+            <*> pGovActionDeposit
+            <*> pAnyStakeIdentifier Nothing
+            <*> pProposalUrl
+            <*> pProposalHashSource
+            <*> pTxId
+              "governance-action-tx-id"
+              "Previous txid of `NoConfidence` or `NewCommittee` governance action."
+            <*> pWord32
+              "governance-action-index"
+              "Previous tx's governance action index of `NoConfidence` or `NewCommittee` governance action."
+            <*> pFileOutDirection "out-file" "Output filepath of the no confidence proposal."
+      )
     $ Opt.progDesc "Create a no confidence proposal."
 
 -- | The first argument is the optional prefix.
@@ -141,7 +146,8 @@ pAnyStakeIdentifier prefix =
     , AnyStakeKey <$> pStakeVerificationKeyOrHashOrFile prefix
     ]
 
-pGovernanceActionProtocolParametersUpdateCmd :: ()
+pGovernanceActionProtocolParametersUpdateCmd
+  :: ()
   => CardanoEra era
   -> Maybe (Parser (GovernanceActionCmds era))
 pGovernanceActionProtocolParametersUpdateCmd era = do
@@ -149,12 +155,12 @@ pGovernanceActionProtocolParametersUpdateCmd era = do
   pure
     $ subParser "create-protocol-parameters-update"
     $ Opt.info
-        ( GovernanceActionProtocolParametersUpdateCmd w
-            <$> pEpochNoUpdateProp
-            <*> pProtocolParametersUpdateGenesisKeys w
-            <*> dpGovActionProtocolParametersUpdate w
-            <*> pOutputFile
-        )
+      ( GovernanceActionProtocolParametersUpdateCmd w
+          <$> pEpochNoUpdateProp
+          <*> pProtocolParametersUpdateGenesisKeys w
+          <*> dpGovActionProtocolParametersUpdate w
+          <*> pOutputFile
+      )
     $ Opt.progDesc "Create a protocol parameters update."
 
 convertToLedger :: (a -> b) -> Parser (Maybe a) -> Parser (StrictMaybe b)
@@ -162,19 +168,23 @@ convertToLedger conv = fmap (maybeToStrictMaybe . fmap conv)
 
 toNonNegativeIntervalOrErr :: Rational -> NonNegativeInterval
 toNonNegativeIntervalOrErr r = case Ledger.boundRational r of
-                         Nothing ->
-                           error $ mconcat [ "toNonNegativeIntervalOrErr: "
-                                           , "rational out of bounds " <> show r
-                                           ]
-                         Just n -> n
+  Nothing ->
+    error $
+      mconcat
+        [ "toNonNegativeIntervalOrErr: "
+        , "rational out of bounds " <> show r
+        ]
+  Just n -> n
 
 toUnitIntervalOrErr :: Rational -> Ledger.UnitInterval
 toUnitIntervalOrErr r = case Ledger.boundRational r of
-                         Nothing ->
-                           error $ mconcat [ "toUnitIntervalOrErr: "
-                                           , "rational out of bounds " <> show r
-                                           ]
-                         Just n -> n
+  Nothing ->
+    error $
+      mconcat
+        [ "toUnitIntervalOrErr: "
+        , "rational out of bounds " <> show r
+        ]
+  Just n -> n
 
 mkProtocolVersionOrErr :: (Natural, Natural) -> Ledger.ProtVer
 mkProtocolVersionOrErr (majorProtVer, minorProtVer) =
@@ -201,7 +211,6 @@ pCommonProtocolParameters =
     <*> convertToLedger mkProtocolVersionOrErr (optional pProtocolVersion)
     <*> convertToLedger toShelleyLovelace (optional pMinPoolCost)
 
-
 pDeprecatedAfterMaryPParams :: Parser (DeprecatedAfterMaryPParams ledgerera)
 pDeprecatedAfterMaryPParams =
   DeprecatedAfterMaryPParams
@@ -218,18 +227,17 @@ pShelleyToAlonzoPParams =
   ShelleyToAlonzoPParams
     <$> convertToLedger (CoinPerWord . toShelleyLovelace) (optional pUTxOCostPerWord)
 
-
 pAlonzoOnwardsPParams :: Parser (AlonzoOnwardsPParams ledgerera)
 pAlonzoOnwardsPParams =
   AlonzoOnwardsPParams SNothing -- TODO: Conway era cost model
-    <$> convertToLedger (either (\e -> error $ "pAlonzoOnwardsPParams: " <> show e) id . toAlonzoPrices)
-                        (optional pExecutionUnitPrices)
+    <$> convertToLedger
+      (either (\e -> error $ "pAlonzoOnwardsPParams: " <> show e) id . toAlonzoPrices)
+      (optional pExecutionUnitPrices)
     <*> convertToLedger toAlonzoExUnits (optional pMaxTxExecutionUnits)
     <*> convertToLedger toAlonzoExUnits (optional pMaxBlockExecutionUnits)
     <*> convertToLedger id (optional pMaxValueSize)
     <*> convertToLedger id (optional pCollateralPercent)
     <*> convertToLedger id (optional pMaxCollateralInputs)
-
 
 pIntroducedInBabbagePParams :: Parser (IntroducedInBabbagePParams ledgerera)
 pIntroducedInBabbagePParams =
@@ -278,33 +286,39 @@ dpGovActionProtocolParametersUpdate = \case
       <*> pAlonzoOnwardsPParams
       <*> pIntroducedInBabbagePParams
 
-pGovernanceActionTreasuryWithdrawalCmd :: CardanoEra era -> Maybe (Parser (GovernanceActionCmds era))
+pGovernanceActionTreasuryWithdrawalCmd
+  :: CardanoEra era -> Maybe (Parser (GovernanceActionCmds era))
 pGovernanceActionTreasuryWithdrawalCmd era = do
   cOn <- maybeEonInEra era
   pure
     $ subParser "create-treasury-withdrawal"
     $ Opt.info
-        ( fmap (GovernanceActionTreasuryWithdrawalCmd cOn) $
-            TreasuryWithdrawalCmd
-              <$> pNetwork
-              <*> pGovActionDeposit
-              <*> pAnyStakeIdentifier Nothing
-              <*> pProposalUrl
-              <*> pProposalHashSource
-              <*> many ((,) <$> pAnyStakeIdentifier Nothing <*> pTransferAmt) -- TODO we should likely pass a prefix here, becaus pAnyStakeIdentiefier is used twice
-              <*> pFileOutDirection "out-file" "Output filepath of the treasury withdrawal."
-        )
+      ( fmap (GovernanceActionTreasuryWithdrawalCmd cOn) $
+          TreasuryWithdrawalCmd
+            <$> pNetwork
+            <*> pGovActionDeposit
+            <*> pAnyStakeIdentifier Nothing
+            <*> pProposalUrl
+            <*> pProposalHashSource
+            <*> many ((,) <$> pAnyStakeIdentifier Nothing <*> pTransferAmt) -- TODO we should likely pass a prefix here, becaus pAnyStakeIdentiefier is used twice
+            <*> pFileOutDirection "out-file" "Output filepath of the treasury withdrawal."
+      )
     $ Opt.progDesc "Create a treasury withdrawal."
 
 pNetwork :: Parser Ledger.Network
-pNetwork  = asum $ mconcat
-  [ [ Opt.flag' Ledger.Mainnet $ mconcat
-      [ Opt.long "mainnet"
-      , Opt.help "Use the mainnet magic id."
+pNetwork =
+  asum $
+    mconcat
+      [
+        [ Opt.flag' Ledger.Mainnet $
+            mconcat
+              [ Opt.long "mainnet"
+              , Opt.help "Use the mainnet magic id."
+              ]
+        , Opt.flag' Ledger.Testnet $
+            mconcat
+              [ Opt.long "testnet"
+              , Opt.help "Use the testnet magic id."
+              ]
+        ]
       ]
-    , Opt.flag' Ledger.Testnet $ mconcat
-      [ Opt.long "testnet"
-      , Opt.help "Use the testnet magic id."
-      ]
-    ]
-  ]

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Committee.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Committee.hs
@@ -4,21 +4,23 @@ module Cardano.CLI.EraBased.Options.Governance.Committee
   ( pGovernanceCommitteeCmds
   ) where
 
-import           Cardano.Api
+import Cardano.Api
 
-import           Cardano.CLI.EraBased.Commands.Governance.Committee
-import           Cardano.CLI.EraBased.Options.Common
+import Cardano.CLI.EraBased.Commands.Governance.Committee
+import Cardano.CLI.EraBased.Options.Common
 
-import           Options.Applicative (Parser)
+import Options.Applicative (Parser)
 import qualified Options.Applicative as Opt
 
-pGovernanceCommitteeCmds :: ()
+pGovernanceCommitteeCmds
+  :: ()
   => CardanoEra era
   -> Maybe (Parser (GovernanceCommitteeCmds era))
 pGovernanceCommitteeCmds era =
-  subInfoParser "committee"
-    ( Opt.progDesc
-        $ mconcat
+  subInfoParser
+    "committee"
+    ( Opt.progDesc $
+        mconcat
           [ "Committee member commands."
           ]
     )
@@ -29,49 +31,54 @@ pGovernanceCommitteeCmds era =
     , pGovernanceCommitteeCreateColdKeyResignationCertificateCmd era
     ]
 
-pGovernanceCommitteeKeyGenColdCmd :: ()
+pGovernanceCommitteeKeyGenColdCmd
+  :: ()
   => CardanoEra era
   -> Maybe (Parser (GovernanceCommitteeCmds era))
 pGovernanceCommitteeKeyGenColdCmd era = do
   w <- maybeEonInEra era
-  pure
-    $ subParser "key-gen-cold"
-    $ Opt.info (pCmd w)
-    $ Opt.progDesc
-    $ mconcat
-        [ "Create a cold key pair for a Constitutional Committee Member"
-        ]
-  where
-    pCmd :: ()
-      => ConwayEraOnwards era
-      -> Parser (GovernanceCommitteeCmds era)
-    pCmd w =
-      GovernanceCommitteeKeyGenColdCmd w
-        <$> pColdVerificationKeyFile
-        <*> pColdSigningKeyFile
+  pure $
+    subParser "key-gen-cold" $
+      Opt.info (pCmd w) $
+        Opt.progDesc $
+          mconcat
+            [ "Create a cold key pair for a Constitutional Committee Member"
+            ]
+ where
+  pCmd
+    :: ()
+    => ConwayEraOnwards era
+    -> Parser (GovernanceCommitteeCmds era)
+  pCmd w =
+    GovernanceCommitteeKeyGenColdCmd w
+      <$> pColdVerificationKeyFile
+      <*> pColdSigningKeyFile
 
-pGovernanceCommitteeKeyGenHotCmd :: ()
+pGovernanceCommitteeKeyGenHotCmd
+  :: ()
   => CardanoEra era
   -> Maybe (Parser (GovernanceCommitteeCmds era))
 pGovernanceCommitteeKeyGenHotCmd era = do
   w <- maybeEonInEra era
-  pure
-    $ subParser "key-gen-hot"
-    $ Opt.info (pCmd w)
-    $ Opt.progDesc
-    $ mconcat
-        [ "Create a cold key pair for a Constitutional Committee Member"
-        ]
-  where
-    pCmd :: ()
-      => ConwayEraOnwards era
-      -> Parser (GovernanceCommitteeCmds era)
-    pCmd w =
-      GovernanceCommitteeKeyGenHotCmd w
-        <$> pVerificationKeyFileOut
-        <*> pSigningKeyFileOut
+  pure $
+    subParser "key-gen-hot" $
+      Opt.info (pCmd w) $
+        Opt.progDesc $
+          mconcat
+            [ "Create a cold key pair for a Constitutional Committee Member"
+            ]
+ where
+  pCmd
+    :: ()
+    => ConwayEraOnwards era
+    -> Parser (GovernanceCommitteeCmds era)
+  pCmd w =
+    GovernanceCommitteeKeyGenHotCmd w
+      <$> pVerificationKeyFileOut
+      <*> pSigningKeyFileOut
 
-pGovernanceCommitteeKeyHashCmd :: ()
+pGovernanceCommitteeKeyHashCmd
+  :: ()
   => CardanoEra era
   -> Maybe (Parser (GovernanceCommitteeCmds era))
 pGovernanceCommitteeKeyHashCmd era = do
@@ -79,15 +86,16 @@ pGovernanceCommitteeKeyHashCmd era = do
   pure
     $ subParser "key-hash"
     $ Opt.info
-        ( GovernanceCommitteeKeyHashCmd w
-            <$> pAnyVerificationKeySource "Constitutional Committee Member key (hot or cold)"
-        )
+      ( GovernanceCommitteeKeyHashCmd w
+          <$> pAnyVerificationKeySource "Constitutional Committee Member key (hot or cold)"
+      )
     $ Opt.progDesc
     $ mconcat
-        [ "Print the identifier (hash) of a public key"
-        ]
+      [ "Print the identifier (hash) of a public key"
+      ]
 
-pGovernanceCommitteeCreateHotKeyAuthorizationCertificateCmd :: ()
+pGovernanceCommitteeCreateHotKeyAuthorizationCertificateCmd
+  :: ()
   => CardanoEra era
   -> Maybe (Parser (GovernanceCommitteeCmds era))
 pGovernanceCommitteeCreateHotKeyAuthorizationCertificateCmd era = do
@@ -95,17 +103,18 @@ pGovernanceCommitteeCreateHotKeyAuthorizationCertificateCmd era = do
   pure
     $ subParser "create-hot-key-authorization-certificate"
     $ Opt.info
-        ( GovernanceCommitteeCreateHotKeyAuthorizationCertificateCmd w
-            <$> pCommitteeColdVerificationKeyOrHashOrFile
-            <*> pCommitteeHotKeyOrHashOrFile
-            <*> pOutputFile
-        )
+      ( GovernanceCommitteeCreateHotKeyAuthorizationCertificateCmd w
+          <$> pCommitteeColdVerificationKeyOrHashOrFile
+          <*> pCommitteeHotKeyOrHashOrFile
+          <*> pOutputFile
+      )
     $ Opt.progDesc
     $ mconcat
-        [ "Create hot key authorization certificate for a Constitutional Committee Member"
-        ]
+      [ "Create hot key authorization certificate for a Constitutional Committee Member"
+      ]
 
-pGovernanceCommitteeCreateColdKeyResignationCertificateCmd :: ()
+pGovernanceCommitteeCreateColdKeyResignationCertificateCmd
+  :: ()
   => CardanoEra era
   -> Maybe (Parser (GovernanceCommitteeCmds era))
 pGovernanceCommitteeCreateColdKeyResignationCertificateCmd era = do
@@ -113,11 +122,11 @@ pGovernanceCommitteeCreateColdKeyResignationCertificateCmd era = do
   pure
     $ subParser "create-cold-key-resignation-certificate"
     $ Opt.info
-        ( GovernanceCommitteeCreateColdKeyResignationCertificateCmd w
-            <$> pCommitteeColdVerificationKeyOrHashOrFile
-            <*> pOutputFile
-        )
+      ( GovernanceCommitteeCreateColdKeyResignationCertificateCmd w
+          <$> pCommitteeColdVerificationKeyOrHashOrFile
+          <*> pOutputFile
+      )
     $ Opt.progDesc
     $ mconcat
-        [ "Create cold key resignation certificate for a Constitutional Committee Member"
-        ]
+      [ "Create cold key resignation certificate for a Constitutional Committee Member"
+      ]

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Committee.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Committee.hs
@@ -10,7 +10,7 @@ import Cardano.CLI.EraBased.Commands.Governance.Committee
 import Cardano.CLI.EraBased.Options.Common
 
 import Options.Applicative (Parser)
-import qualified Options.Applicative as Opt
+import Options.Applicative qualified as Opt
 
 pGovernanceCommitteeCmds
   :: ()

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/DRep.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/DRep.hs
@@ -1,36 +1,37 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
-
 {-# OPTIONS_GHC -Wno-unused-imports #-}
 
 module Cardano.CLI.EraBased.Options.Governance.DRep
   ( pGovernanceDRepCmds
   ) where
 
-import           Cardano.Api
+import Cardano.Api
 
-import           Cardano.CLI.Environment
-import           Cardano.CLI.EraBased.Commands.Governance.DRep
-import           Cardano.CLI.EraBased.Options.Common
-import           Cardano.CLI.Parser
-import           Cardano.CLI.Types.Common
-import           Cardano.CLI.Types.Key
+import Cardano.CLI.Environment
+import Cardano.CLI.EraBased.Commands.Governance.DRep
+import Cardano.CLI.EraBased.Options.Common
+import Cardano.CLI.Parser
+import Cardano.CLI.Types.Common
+import Cardano.CLI.Types.Key
 
-import           Control.Applicative
-import           Data.Foldable
-import           Data.String
-import           Options.Applicative (Parser)
+import Control.Applicative
+import Data.Foldable
+import Data.String
+import Options.Applicative (Parser)
 import qualified Options.Applicative as Opt
 
-pGovernanceDRepCmds :: ()
+pGovernanceDRepCmds
+  :: ()
   => CardanoEra era
   -> EnvCli
   -> Maybe (Parser (GovernanceDRepCmds era))
 pGovernanceDRepCmds era envCli =
-  subInfoParser "drep"
-    ( Opt.progDesc
-        $ mconcat
+  subInfoParser
+    "drep"
+    ( Opt.progDesc $
+        mconcat
           [ "DRep member commands."
           ]
     )
@@ -39,7 +40,8 @@ pGovernanceDRepCmds era envCli =
     , pRegistrationCertificateCmd era envCli
     ]
 
-pGovernanceDRepKeyGenCmd :: ()
+pGovernanceDRepKeyGenCmd
+  :: ()
   => CardanoEra era
   -> Maybe (Parser (GovernanceDRepCmds era))
 pGovernanceDRepKeyGenCmd era = do
@@ -47,13 +49,14 @@ pGovernanceDRepKeyGenCmd era = do
   pure
     $ subParser "key-gen"
     $ Opt.info
-        ( GovernanceDRepGenerateKeyCmd w
-            <$> pVerificationKeyFileOut
-            <*> pSigningKeyFileOut
-        )
+      ( GovernanceDRepGenerateKeyCmd w
+          <$> pVerificationKeyFileOut
+          <*> pSigningKeyFileOut
+      )
     $ Opt.progDesc "Generate Delegate Representative verification and signing keys."
 
-pGovernanceDRepKeyIdCmd :: ()
+pGovernanceDRepKeyIdCmd
+  :: ()
   => CardanoEra era
   -> Maybe (Parser (GovernanceDRepCmds era))
 pGovernanceDRepKeyIdCmd era = do
@@ -61,60 +64,64 @@ pGovernanceDRepKeyIdCmd era = do
   pure
     $ subParser "id"
     $ Opt.info
-        ( GovernanceDRepIdCmd w
-            <$> pDRepVerificationKeyOrFile
-            <*> pDRepIdOutputFormat
-            <*> optional pOutputFile
-        )
+      ( GovernanceDRepIdCmd w
+          <$> pDRepVerificationKeyOrFile
+          <*> pDRepIdOutputFormat
+          <*> optional pOutputFile
+      )
     $ Opt.progDesc "Generate a drep id."
 
 pDRepIdOutputFormat :: Parser IdOutputFormat
 pDRepIdOutputFormat =
-  Opt.option readIdOutputFormat $ mconcat
-    [ Opt.long "output-format"
-    , Opt.metavar "STRING"
-    , Opt.help $ mconcat
-      [ "Optional drep id output format. Accepted output formats are \"hex\" "
-      , "and \"bech32\" (default is \"bech32\")."
+  Opt.option readIdOutputFormat $
+    mconcat
+      [ Opt.long "output-format"
+      , Opt.metavar "STRING"
+      , Opt.help $
+          mconcat
+            [ "Optional drep id output format. Accepted output formats are \"hex\" "
+            , "and \"bech32\" (default is \"bech32\")."
+            ]
+      , Opt.value IdOutputFormatBech32
       ]
-    , Opt.value IdOutputFormatBech32
-    ]
 
 -- Registration Certificate related
 
-pRegistrationCertificateCmd :: ()
+pRegistrationCertificateCmd
+  :: ()
   => CardanoEra era
   -> EnvCli
   -> Maybe (Parser (GovernanceDRepCmds era))
 pRegistrationCertificateCmd era envCli = do
   w <- maybeEonInEra era
-  pure
-    $ subParser "registration-certificate"
-    $ Opt.info (pEraCmd envCli w)
-    $ Opt.progDesc "Create a registration certificate."
+  pure $
+    subParser "registration-certificate" $
+      Opt.info (pEraCmd envCli w) $
+        Opt.progDesc "Create a registration certificate."
  where
   pEraCmd :: EnvCli -> AnyEraDecider era -> Parser (GovernanceDRepCmds era)
   pEraCmd envCli' = \case
     AnyEraDeciderShelleyToBabbage sToB ->
       GovernanceDRepRegistrationCertificateCmd
-        <$> asum [ ShelleyToBabbageStakePoolRegTarget sToB
-                     <$> pStakePoolRegistrationParserRequirements envCli'
-                 , ShelleyToBabbageStakeKeyRegTarget sToB
-                     <$> pStakeIdentifier
-                 ]
+        <$> asum
+          [ ShelleyToBabbageStakePoolRegTarget sToB
+              <$> pStakePoolRegistrationParserRequirements envCli'
+          , ShelleyToBabbageStakeKeyRegTarget sToB
+              <$> pStakeIdentifier
+          ]
         <*> pOutputFile
-
     AnyEraDeciderConwayOnwards cOn ->
       GovernanceDRepRegistrationCertificateCmd . ConwayOnwardRegTarget cOn
-        <$> asum [ RegisterStakePool cOn
-                     <$> pStakePoolRegistrationParserRequirements envCli'
-                 , RegisterStakeKey cOn
-                     <$> pStakeIdentifier
-                     <*> pKeyRegistDeposit
-                 , RegisterDRep cOn
-                     <$> pDRepVerificationKeyOrHashOrFile
-                     <*> pKeyRegistDeposit
-                 ]
+        <$> asum
+          [ RegisterStakePool cOn
+              <$> pStakePoolRegistrationParserRequirements envCli'
+          , RegisterStakeKey cOn
+              <$> pStakeIdentifier
+              <*> pKeyRegistDeposit
+          , RegisterDRep cOn
+              <$> pDRepVerificationKeyOrHashOrFile
+              <*> pKeyRegistDeposit
+          ]
         <*> pOutputFile
 
 --------------------------------------------------------------------------------
@@ -125,10 +132,10 @@ data AnyEraDecider era where
 
 instance Eon AnyEraDecider where
   inEonForEra no yes = \case
-    ByronEra    -> no
-    ShelleyEra  -> yes $ AnyEraDeciderShelleyToBabbage ShelleyToBabbageEraShelley
-    AllegraEra  -> yes $ AnyEraDeciderShelleyToBabbage ShelleyToBabbageEraAllegra
-    MaryEra     -> yes $ AnyEraDeciderShelleyToBabbage ShelleyToBabbageEraMary
-    AlonzoEra   -> yes $ AnyEraDeciderShelleyToBabbage ShelleyToBabbageEraAlonzo
-    BabbageEra  -> yes $ AnyEraDeciderShelleyToBabbage ShelleyToBabbageEraBabbage
-    ConwayEra   -> yes $ AnyEraDeciderConwayOnwards ConwayEraOnwardsConway
+    ByronEra -> no
+    ShelleyEra -> yes $ AnyEraDeciderShelleyToBabbage ShelleyToBabbageEraShelley
+    AllegraEra -> yes $ AnyEraDeciderShelleyToBabbage ShelleyToBabbageEraAllegra
+    MaryEra -> yes $ AnyEraDeciderShelleyToBabbage ShelleyToBabbageEraMary
+    AlonzoEra -> yes $ AnyEraDeciderShelleyToBabbage ShelleyToBabbageEraAlonzo
+    BabbageEra -> yes $ AnyEraDeciderShelleyToBabbage ShelleyToBabbageEraBabbage
+    ConwayEra -> yes $ AnyEraDeciderConwayOnwards ConwayEraOnwardsConway

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/DRep.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/DRep.hs
@@ -20,7 +20,7 @@ import Control.Applicative
 import Data.Foldable
 import Data.String
 import Options.Applicative (Parser)
-import qualified Options.Applicative as Opt
+import Options.Applicative qualified as Opt
 
 pGovernanceDRepCmds
   :: ()

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Query.hs
@@ -12,7 +12,7 @@ import Cardano.CLI.EraBased.Commands.Governance.Query
 import Cardano.CLI.EraBased.Options.Common
 
 import Options.Applicative
-import qualified Options.Applicative as Opt
+import Options.Applicative qualified as Opt
 
 pGovernanceQueryCmds
   :: ()

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Query.hs
@@ -5,22 +5,24 @@ module Cardano.CLI.EraBased.Options.Governance.Query
   ( pGovernanceQueryCmds
   ) where
 
-import           Cardano.Api
+import Cardano.Api
 
-import           Cardano.CLI.Environment
-import           Cardano.CLI.EraBased.Commands.Governance.Query
-import           Cardano.CLI.EraBased.Options.Common
+import Cardano.CLI.Environment
+import Cardano.CLI.EraBased.Commands.Governance.Query
+import Cardano.CLI.EraBased.Options.Common
 
-import           Options.Applicative
+import Options.Applicative
 import qualified Options.Applicative as Opt
 
-pGovernanceQueryCmds :: ()
+pGovernanceQueryCmds
+  :: ()
   => CardanoEra era
   -> EnvCli
   -> Maybe (Parser (GovernanceQueryCmds era))
 pGovernanceQueryCmds era env =
-  subInfoParser "query"
-    ( Opt.progDesc "Query governance-related information" )
+  subInfoParser
+    "query"
+    (Opt.progDesc "Query governance-related information")
     [ pGovernanceQueryGetConstitutionCmd era env
     , pGovernanceQueryGetGovStateCmd era env
     , pGovernanceQueryDRepStateCmd era env
@@ -28,81 +30,90 @@ pGovernanceQueryCmds era env =
     , pGovernanceQueryGetCommitteeStateCmd era env
     ]
 
-pGovernanceQueryGetConstitutionCmd :: ()
+pGovernanceQueryGetConstitutionCmd
+  :: ()
   => CardanoEra era
   -> EnvCli
   -> Maybe (Parser (GovernanceQueryCmds era))
 pGovernanceQueryGetConstitutionCmd era env = do
   cOn <- maybeEonInEra era
-  pure
-    $ subParser "constitution"
-    $ Opt.info (GovernanceQueryConstitutionCmd cOn <$> pNoArgQueryCmd env)
-    $ Opt.progDesc "Get the constitution"
+  pure $
+    subParser "constitution" $
+      Opt.info (GovernanceQueryConstitutionCmd cOn <$> pNoArgQueryCmd env) $
+        Opt.progDesc "Get the constitution"
 
-pGovernanceQueryGetGovStateCmd :: ()
+pGovernanceQueryGetGovStateCmd
+  :: ()
   => CardanoEra era
   -> EnvCli
   -> Maybe (Parser (GovernanceQueryCmds era))
 pGovernanceQueryGetGovStateCmd era env = do
   cOn <- maybeEonInEra era
-  pure
-    $ subParser "gov-state"
-    $ Opt.info (GovernanceQueryGovStateCmd cOn <$> pNoArgQueryCmd env)
-    $ Opt.progDesc "Get the governance state"
+  pure $
+    subParser "gov-state" $
+      Opt.info (GovernanceQueryGovStateCmd cOn <$> pNoArgQueryCmd env) $
+        Opt.progDesc "Get the governance state"
 
 -- TODO Conway: DRep State and DRep Stake Distribution parsers use DRep keys to obtain DRep credentials. This only
 -- makes use of 'KeyHashObj' constructor of 'Credential kr c'. Should we also support here 'ScriptHashObj'?
 -- What about 'DRep c' - this means that only 'KeyHash' constructor is in use here: should also
 -- 'DRepAlwaysAbstain' and 'DRepAlwaysNoConfidence' be supported here?
 
-pGovernanceQueryDRepStateCmd :: ()
+pGovernanceQueryDRepStateCmd
+  :: ()
   => CardanoEra era
   -> EnvCli
   -> Maybe (Parser (GovernanceQueryCmds era))
 pGovernanceQueryDRepStateCmd era env = do
   cOn <- maybeEonInEra era
-  pure
-    $ subParser "drep-state"
-    $ Opt.info (GovernanceQueryDRepStateCmd cOn <$> pDRepStateQueryCmd)
-    $ Opt.progDesc "Get the DRep state. If no DRep credentials are provided, return states for all of them."
-  where
-    pDRepStateQueryCmd :: Parser DRepStateQueryCmd
-    pDRepStateQueryCmd = DRepStateQueryCmd
+  pure $
+    subParser "drep-state" $
+      Opt.info (GovernanceQueryDRepStateCmd cOn <$> pDRepStateQueryCmd) $
+        Opt.progDesc
+          "Get the DRep state. If no DRep credentials are provided, return states for all of them."
+ where
+  pDRepStateQueryCmd :: Parser DRepStateQueryCmd
+  pDRepStateQueryCmd =
+    DRepStateQueryCmd
       <$> pSocketPath env
       <*> pConsensusModeParams
       <*> pNetworkId env
       <*> some pDRepVerificationKeyOrHashOrFile
       <*> optional pOutputFile
 
-pGovernanceQueryDRepStakeDistributionCmd :: ()
+pGovernanceQueryDRepStakeDistributionCmd
+  :: ()
   => CardanoEra era
   -> EnvCli
   -> Maybe (Parser (GovernanceQueryCmds era))
 pGovernanceQueryDRepStakeDistributionCmd era env = do
   cOn <- maybeEonInEra era
-  pure
-    $ subParser "drep-stake-distribution"
-    $ Opt.info (GovernanceQueryDRepStakeDistributionCmd cOn <$> pDRepStakeDistributionQueryCmd)
-    $ Opt.progDesc "Get the DRep stake distribution. If no DRep credentials are provided, return stake distributions for all of them."
-  where
-    pDRepStakeDistributionQueryCmd :: Parser DRepStakeDistributionQueryCmd
-    pDRepStakeDistributionQueryCmd = DRepStakeDistributionQueryCmd
+  pure $
+    subParser "drep-stake-distribution" $
+      Opt.info (GovernanceQueryDRepStakeDistributionCmd cOn <$> pDRepStakeDistributionQueryCmd) $
+        Opt.progDesc
+          "Get the DRep stake distribution. If no DRep credentials are provided, return stake distributions for all of them."
+ where
+  pDRepStakeDistributionQueryCmd :: Parser DRepStakeDistributionQueryCmd
+  pDRepStakeDistributionQueryCmd =
+    DRepStakeDistributionQueryCmd
       <$> pSocketPath env
       <*> pConsensusModeParams
       <*> pNetworkId env
       <*> some pDRepVerificationKeyOrHashOrFile
       <*> optional pOutputFile
 
-pGovernanceQueryGetCommitteeStateCmd :: ()
+pGovernanceQueryGetCommitteeStateCmd
+  :: ()
   => CardanoEra era
   -> EnvCli
   -> Maybe (Parser (GovernanceQueryCmds era))
 pGovernanceQueryGetCommitteeStateCmd era env = do
   cOn <- maybeEonInEra era
-  pure
-    $ subParser "committee-state"
-    $ Opt.info (GovernanceQueryCommitteeStateCmd cOn <$> pNoArgQueryCmd env)
-    $ Opt.progDesc "Get the committee state"
+  pure $
+    subParser "committee-state" $
+      Opt.info (GovernanceQueryCommitteeStateCmd cOn <$> pNoArgQueryCmd env) $
+        Opt.progDesc "Get the committee state"
 
 pNoArgQueryCmd :: EnvCli -> Parser NoArgQueryCmd
 pNoArgQueryCmd env =

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Vote.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Vote.hs
@@ -5,30 +5,33 @@ module Cardano.CLI.EraBased.Options.Governance.Vote
   ( pGovernanceVoteCmds
   ) where
 
-import           Cardano.Api
+import Cardano.Api
 
-import           Cardano.CLI.EraBased.Commands.Governance.Vote
-import           Cardano.CLI.EraBased.Options.Common
-import           Cardano.CLI.Types.Governance
+import Cardano.CLI.EraBased.Commands.Governance.Vote
+import Cardano.CLI.EraBased.Options.Common
+import Cardano.CLI.Types.Governance
 
-import           Data.Foldable
-import           Options.Applicative (Parser)
+import Data.Foldable
+import Options.Applicative (Parser)
 import qualified Options.Applicative as Opt
 
-pGovernanceVoteCmds :: ()
+pGovernanceVoteCmds
+  :: ()
   => CardanoEra era
   -> Maybe (Parser (GovernanceVoteCmds era))
 pGovernanceVoteCmds era =
-  subInfoParser "vote"
-    ( Opt.progDesc
-        $ mconcat
+  subInfoParser
+    "vote"
+    ( Opt.progDesc $
+        mconcat
           [ "Vote commands."
           ]
     )
     [ pGovernanceVoteCreateCmd era
     ]
 
-pGovernanceVoteCreateCmd :: ()
+pGovernanceVoteCreateCmd
+  :: ()
   => CardanoEra era
   -> Maybe (Parser (GovernanceVoteCmds era))
 pGovernanceVoteCreateCmd era = do
@@ -36,21 +39,22 @@ pGovernanceVoteCreateCmd era = do
   pure
     $ subParser "create"
     $ Opt.info
-        ( GovernanceVoteCreateCmd
-            <$> pAnyVote w
-        )
+      ( GovernanceVoteCreateCmd
+          <$> pAnyVote w
+      )
     $ Opt.progDesc "Vote creation."
 
 pAnyVote :: ConwayEraOnwards era -> Parser AnyVote
 pAnyVote cOnwards =
   ConwayOnwardsVote cOnwards
-      <$> pVoteChoice
-      <*> pGovernanceActionId
-      <*> pAnyVotingStakeVerificationKeyOrHashOrFile
-      <*> pFileOutDirection "out-file" "Output filepath of the vote."
+    <$> pVoteChoice
+    <*> pGovernanceActionId
+    <*> pAnyVotingStakeVerificationKeyOrHashOrFile
+    <*> pFileOutDirection "out-file" "Output filepath of the vote."
 
 pAnyVotingStakeVerificationKeyOrHashOrFile :: Parser AnyVotingStakeVerificationKeyOrHashOrFile
 pAnyVotingStakeVerificationKeyOrHashOrFile =
-  asum [ AnyDRepVerificationKeyOrHashOrFile <$> pDRepVerificationKeyOrHashOrFile
-       , AnyStakePoolVerificationKeyOrHashOrFile <$> pStakePoolVerificationKeyOrHashOrFile Nothing
-       ]
+  asum
+    [ AnyDRepVerificationKeyOrHashOrFile <$> pDRepVerificationKeyOrHashOrFile
+    , AnyStakePoolVerificationKeyOrHashOrFile <$> pStakePoolVerificationKeyOrHashOrFile Nothing
+    ]

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Vote.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Vote.hs
@@ -13,7 +13,7 @@ import Cardano.CLI.Types.Governance
 
 import Data.Foldable
 import Options.Applicative (Parser)
-import qualified Options.Applicative as Opt
+import Options.Applicative qualified as Opt
 
 pGovernanceVoteCmds
   :: ()

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Key.hs
@@ -16,7 +16,7 @@ import Cardano.CLI.Types.Common
 import Data.Foldable
 import Data.Text (Text)
 import Options.Applicative hiding (help, str)
-import qualified Options.Applicative as Opt
+import Options.Applicative qualified as Opt
 
 {- HLINT ignore "Use <$>" -}
 {- HLINT ignore "Move brackets to avoid $" -}

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Key.hs
@@ -7,15 +7,15 @@ module Cardano.CLI.EraBased.Options.Key
   ( pKeyCmds
   ) where
 
-import           Cardano.Api hiding (QueryInShelleyBasedEra (..))
+import Cardano.Api hiding (QueryInShelleyBasedEra (..))
 
-import           Cardano.CLI.EraBased.Commands.Key
-import           Cardano.CLI.EraBased.Options.Common
-import           Cardano.CLI.Types.Common
+import Cardano.CLI.EraBased.Commands.Key
+import Cardano.CLI.EraBased.Options.Common
+import Cardano.CLI.Types.Common
 
-import           Data.Foldable
-import           Data.Text (Text)
-import           Options.Applicative hiding (help, str)
+import Data.Foldable
+import Data.Text (Text)
+import Options.Applicative hiding (help, str)
 import qualified Options.Applicative as Opt
 
 {- HLINT ignore "Use <$>" -}
@@ -23,82 +23,83 @@ import qualified Options.Applicative as Opt
 
 pKeyCmds :: Maybe (Parser (KeyCmds era))
 pKeyCmds =
-  subInfoParser "key"
-    ( Opt.progDesc
-        $ mconcat
+  subInfoParser
+    "key"
+    ( Opt.progDesc $
+        mconcat
           [ "Key utility commands."
           ]
     )
-    [ Just
-        $ subParser "verification-key"
-        $ Opt.info pKeyGetVerificationKey
-        $ Opt.progDesc
-        $ mconcat
-            [ "Get a verification key from a signing key. This "
-            , " supports all key types."
-            ]
-    , Just
-        $ subParser "non-extended-key"
-        $ Opt.info pKeyNonExtendedKey
-        $ Opt.progDesc
-        $ mconcat
-            [ "Get a non-extended verification key from an "
-            , "extended verification key. This supports all "
-            , "extended key types."
-            ]
-    , Just
-        $ subParser "convert-byron-key"
-        $ Opt.info pKeyConvertByronKey
-        $ Opt.progDesc
-        $ mconcat
-            [ "Convert a Byron payment, genesis or genesis "
-            , "delegate key (signing or verification) to a "
-            , "corresponding Shelley-format key."
-            ]
-    , Just
-        $ subParser "convert-byron-genesis-vkey"
-        $ Opt.info pKeyConvertByronGenesisVKey
-        $ Opt.progDesc
-        $ mconcat
-            [ "Convert a Base64-encoded Byron genesis "
-            , "verification key to a Shelley genesis "
-            , "verification key"
-            ]
-    , Just
-        $ subParser "convert-itn-key"
-        $ Opt.info pKeyConvertITNKey
-        $ Opt.progDesc
-        $ mconcat
-            [ "Convert an Incentivized Testnet (ITN) non-extended "
-            , "(Ed25519) signing or verification key to a "
-            , "corresponding Shelley stake key"
-            ]
-    , Just
-        $ subParser "convert-itn-extended-key"
-        $ Opt.info pKeyConvertITNExtendedKey
-        $ Opt.progDesc
-        $ mconcat
-            [ "Convert an Incentivized Testnet (ITN) extended "
-            , "(Ed25519Extended) signing key to a corresponding "
-            , "Shelley stake signing key"
-            ]
-    , Just
-        $ subParser "convert-itn-bip32-key"
-        $ Opt.info pKeyConvertITNBip32Key
-        $ Opt.progDesc
-        $ mconcat
-            [ "Convert an Incentivized Testnet (ITN) BIP32 "
-            , "(Ed25519Bip32) signing key to a corresponding "
-            , "Shelley stake signing key"
-            ]
-    , Just
-        $ subParser "convert-cardano-address-key"
-        $ Opt.info pKeyConvertCardanoAddressSigningKey
-        $ Opt.progDesc
-        $ mconcat
-            [ "Convert a cardano-address extended signing key "
-            , "to a corresponding Shelley-format key."
-            ]
+    [ Just $
+        subParser "verification-key" $
+          Opt.info pKeyGetVerificationKey $
+            Opt.progDesc $
+              mconcat
+                [ "Get a verification key from a signing key. This "
+                , " supports all key types."
+                ]
+    , Just $
+        subParser "non-extended-key" $
+          Opt.info pKeyNonExtendedKey $
+            Opt.progDesc $
+              mconcat
+                [ "Get a non-extended verification key from an "
+                , "extended verification key. This supports all "
+                , "extended key types."
+                ]
+    , Just $
+        subParser "convert-byron-key" $
+          Opt.info pKeyConvertByronKey $
+            Opt.progDesc $
+              mconcat
+                [ "Convert a Byron payment, genesis or genesis "
+                , "delegate key (signing or verification) to a "
+                , "corresponding Shelley-format key."
+                ]
+    , Just $
+        subParser "convert-byron-genesis-vkey" $
+          Opt.info pKeyConvertByronGenesisVKey $
+            Opt.progDesc $
+              mconcat
+                [ "Convert a Base64-encoded Byron genesis "
+                , "verification key to a Shelley genesis "
+                , "verification key"
+                ]
+    , Just $
+        subParser "convert-itn-key" $
+          Opt.info pKeyConvertITNKey $
+            Opt.progDesc $
+              mconcat
+                [ "Convert an Incentivized Testnet (ITN) non-extended "
+                , "(Ed25519) signing or verification key to a "
+                , "corresponding Shelley stake key"
+                ]
+    , Just $
+        subParser "convert-itn-extended-key" $
+          Opt.info pKeyConvertITNExtendedKey $
+            Opt.progDesc $
+              mconcat
+                [ "Convert an Incentivized Testnet (ITN) extended "
+                , "(Ed25519Extended) signing key to a corresponding "
+                , "Shelley stake signing key"
+                ]
+    , Just $
+        subParser "convert-itn-bip32-key" $
+          Opt.info pKeyConvertITNBip32Key $
+            Opt.progDesc $
+              mconcat
+                [ "Convert an Incentivized Testnet (ITN) BIP32 "
+                , "(Ed25519Bip32) signing key to a corresponding "
+                , "Shelley stake signing key"
+                ]
+    , Just $
+        subParser "convert-cardano-address-key" $
+          Opt.info pKeyConvertCardanoAddressSigningKey $
+            Opt.progDesc $
+              mconcat
+                [ "Convert a cardano-address extended signing key "
+                , "to a corresponding Shelley-format key."
+                ]
     ]
 
 pKeyGetVerificationKey :: Parser (KeyCmds era)
@@ -123,65 +124,76 @@ pKeyConvertByronKey =
 
 pPassword :: Parser Text
 pPassword =
-  Opt.strOption $ mconcat
-    [ Opt.long "password"
-    , Opt.metavar "TEXT"
-    , Opt.help "Password for signing key (if applicable)."
-    ]
+  Opt.strOption $
+    mconcat
+      [ Opt.long "password"
+      , Opt.metavar "TEXT"
+      , Opt.help "Password for signing key (if applicable)."
+      ]
 
 pByronKeyType :: Parser ByronKeyType
 pByronKeyType =
   asum
-    [ Opt.flag' (ByronPaymentKey NonLegacyByronKeyFormat) $ mconcat
-        [ Opt.long "byron-payment-key-type"
-        , Opt.help "Use a Byron-era payment key."
-        ]
-    , Opt.flag' (ByronPaymentKey LegacyByronKeyFormat) $ mconcat
-        [ Opt.long "legacy-byron-payment-key-type"
-        , Opt.help "Use a Byron-era payment key, in legacy SL format."
-        ]
-    , Opt.flag' (ByronGenesisKey NonLegacyByronKeyFormat) $ mconcat
-        [ Opt.long "byron-genesis-key-type"
-        , Opt.help "Use a Byron-era genesis key."
-        ]
-    , Opt.flag' (ByronGenesisKey LegacyByronKeyFormat) $ mconcat
-        [ Opt.long "legacy-byron-genesis-key-type"
-        , Opt.help "Use a Byron-era genesis key, in legacy SL format."
-        ]
-    , Opt.flag' (ByronDelegateKey NonLegacyByronKeyFormat) $ mconcat
-        [ Opt.long "byron-genesis-delegate-key-type"
-        , Opt.help "Use a Byron-era genesis delegate key."
-        ]
-    , Opt.flag' (ByronDelegateKey LegacyByronKeyFormat) $ mconcat
-        [ Opt.long "legacy-byron-genesis-delegate-key-type"
-        , Opt.help "Use a Byron-era genesis delegate key, in legacy SL format."
-        ]
+    [ Opt.flag' (ByronPaymentKey NonLegacyByronKeyFormat) $
+        mconcat
+          [ Opt.long "byron-payment-key-type"
+          , Opt.help "Use a Byron-era payment key."
+          ]
+    , Opt.flag' (ByronPaymentKey LegacyByronKeyFormat) $
+        mconcat
+          [ Opt.long "legacy-byron-payment-key-type"
+          , Opt.help "Use a Byron-era payment key, in legacy SL format."
+          ]
+    , Opt.flag' (ByronGenesisKey NonLegacyByronKeyFormat) $
+        mconcat
+          [ Opt.long "byron-genesis-key-type"
+          , Opt.help "Use a Byron-era genesis key."
+          ]
+    , Opt.flag' (ByronGenesisKey LegacyByronKeyFormat) $
+        mconcat
+          [ Opt.long "legacy-byron-genesis-key-type"
+          , Opt.help "Use a Byron-era genesis key, in legacy SL format."
+          ]
+    , Opt.flag' (ByronDelegateKey NonLegacyByronKeyFormat) $
+        mconcat
+          [ Opt.long "byron-genesis-delegate-key-type"
+          , Opt.help "Use a Byron-era genesis delegate key."
+          ]
+    , Opt.flag' (ByronDelegateKey LegacyByronKeyFormat) $
+        mconcat
+          [ Opt.long "legacy-byron-genesis-delegate-key-type"
+          , Opt.help "Use a Byron-era genesis delegate key, in legacy SL format."
+          ]
     ]
 
 pByronKeyFile :: Parser (SomeKeyFile In)
 pByronKeyFile =
   asum
-    [ ASigningKeyFile      <$> pByronSigningKeyFile
+    [ ASigningKeyFile <$> pByronSigningKeyFile
     , AVerificationKeyFile <$> pByronVerificationKeyFile
     ]
 
 pByronSigningKeyFile :: Parser (SigningKeyFile In)
 pByronSigningKeyFile =
-  fmap File $ Opt.strOption $ mconcat
-    [ Opt.long "byron-signing-key-file"
-    , Opt.metavar "FILE"
-    , Opt.help "Input filepath of the Byron-format signing key."
-    , Opt.completer (Opt.bashCompleter "file")
-    ]
+  fmap File $
+    Opt.strOption $
+      mconcat
+        [ Opt.long "byron-signing-key-file"
+        , Opt.metavar "FILE"
+        , Opt.help "Input filepath of the Byron-format signing key."
+        , Opt.completer (Opt.bashCompleter "file")
+        ]
 
 pByronVerificationKeyFile :: Parser (VerificationKeyFile In)
 pByronVerificationKeyFile =
-  fmap File $ Opt.strOption $ mconcat
-    [ Opt.long "byron-verification-key-file"
-    , Opt.metavar "FILE"
-    , Opt.help "Input filepath of the Byron-format verification key."
-    , Opt.completer (Opt.bashCompleter "file")
-    ]
+  fmap File $
+    Opt.strOption $
+      mconcat
+        [ Opt.long "byron-verification-key-file"
+        , Opt.metavar "FILE"
+        , Opt.help "Input filepath of the Byron-format verification key."
+        , Opt.completer (Opt.bashCompleter "file")
+        ]
 
 pKeyConvertByronGenesisVKey :: Parser (KeyCmds era)
 pKeyConvertByronGenesisVKey =
@@ -191,11 +203,13 @@ pKeyConvertByronGenesisVKey =
 
 pByronGenesisVKeyBase64 :: Parser VerificationKeyBase64
 pByronGenesisVKeyBase64 =
-  fmap VerificationKeyBase64 $ Opt.strOption $ mconcat
-    [ Opt.long "byron-genesis-verification-key"
-    , Opt.metavar "BASE64"
-    , Opt.help "Base64 string for the Byron genesis verification key."
-    ]
+  fmap VerificationKeyBase64 $
+    Opt.strOption $
+      mconcat
+        [ Opt.long "byron-genesis-verification-key"
+        , Opt.metavar "BASE64"
+        , Opt.help "Base64 string for the Byron genesis verification key."
+        ]
 
 pKeyConvertITNKey :: Parser (KeyCmds era)
 pKeyConvertITNKey =
@@ -224,21 +238,25 @@ pITNKeyFIle =
 
 pITNSigningKeyFile :: Parser (SomeKeyFile direction)
 pITNSigningKeyFile =
-  fmap (ASigningKeyFile . File) $ Opt.strOption $ mconcat
-    [ Opt.long "itn-signing-key-file"
-    , Opt.metavar "FILE"
-    , Opt.help "Filepath of the ITN signing key."
-    , Opt.completer (Opt.bashCompleter "file")
-    ]
+  fmap (ASigningKeyFile . File) $
+    Opt.strOption $
+      mconcat
+        [ Opt.long "itn-signing-key-file"
+        , Opt.metavar "FILE"
+        , Opt.help "Filepath of the ITN signing key."
+        , Opt.completer (Opt.bashCompleter "file")
+        ]
 
 pITNVerificationKeyFile :: Parser (SomeKeyFile direction)
 pITNVerificationKeyFile =
-  fmap (AVerificationKeyFile . File) $ Opt.strOption $ mconcat
-    [ Opt.long "itn-verification-key-file"
-    , Opt.metavar "FILE"
-    , Opt.help "Filepath of the ITN verification key."
-    , Opt.completer (Opt.bashCompleter "file")
-    ]
+  fmap (AVerificationKeyFile . File) $
+    Opt.strOption $
+      mconcat
+        [ Opt.long "itn-verification-key-file"
+        , Opt.metavar "FILE"
+        , Opt.help "Filepath of the ITN verification key."
+        , Opt.completer (Opt.bashCompleter "file")
+        ]
 
 pKeyConvertCardanoAddressSigningKey :: Parser (KeyCmds era)
 pKeyConvertCardanoAddressSigningKey =
@@ -250,20 +268,24 @@ pKeyConvertCardanoAddressSigningKey =
 pCardanoAddressKeyType :: Parser CardanoAddressKeyType
 pCardanoAddressKeyType =
   asum
-    [ Opt.flag' CardanoAddressShelleyPaymentKey $ mconcat
-        [ Opt.long "shelley-payment-key"
-        , Opt.help "Use a Shelley-era extended payment key."
-        ]
-    , Opt.flag' CardanoAddressShelleyStakeKey $ mconcat
-        [ Opt.long "shelley-stake-key"
-        , Opt.help "Use a Shelley-era extended stake key."
-        ]
-    , Opt.flag' CardanoAddressIcarusPaymentKey $ mconcat
-        [ Opt.long "icarus-payment-key"
-        , Opt.help "Use a Byron-era extended payment key formatted in the Icarus style."
-        ]
-    , Opt.flag' CardanoAddressByronPaymentKey $ mconcat
-        [ Opt.long "byron-payment-key"
-        , Opt.help "Use a Byron-era extended payment key formatted in the deprecated Byron style."
-        ]
+    [ Opt.flag' CardanoAddressShelleyPaymentKey $
+        mconcat
+          [ Opt.long "shelley-payment-key"
+          , Opt.help "Use a Shelley-era extended payment key."
+          ]
+    , Opt.flag' CardanoAddressShelleyStakeKey $
+        mconcat
+          [ Opt.long "shelley-stake-key"
+          , Opt.help "Use a Shelley-era extended stake key."
+          ]
+    , Opt.flag' CardanoAddressIcarusPaymentKey $
+        mconcat
+          [ Opt.long "icarus-payment-key"
+          , Opt.help "Use a Byron-era extended payment key formatted in the Icarus style."
+          ]
+    , Opt.flag' CardanoAddressByronPaymentKey $
+        mconcat
+          [ Opt.long "byron-payment-key"
+          , Opt.help "Use a Byron-era extended payment key formatted in the deprecated Byron style."
+          ]
     ]

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Node.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Node.hs
@@ -13,7 +13,7 @@ import Cardano.CLI.EraBased.Commands.Node
 import Cardano.CLI.EraBased.Options.Common
 
 import Options.Applicative hiding (help, str)
-import qualified Options.Applicative as Opt
+import Options.Applicative qualified as Opt
 
 {- HLINT ignore "Use <$>" -}
 {- HLINT ignore "Move brackets to avoid $" -}

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Node.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Node.hs
@@ -7,12 +7,12 @@ module Cardano.CLI.EraBased.Options.Node
   ( pNodeCmds
   ) where
 
-import           Cardano.Api hiding (QueryInShelleyBasedEra (..))
+import Cardano.Api hiding (QueryInShelleyBasedEra (..))
 
-import           Cardano.CLI.EraBased.Commands.Node
-import           Cardano.CLI.EraBased.Options.Common
+import Cardano.CLI.EraBased.Commands.Node
+import Cardano.CLI.EraBased.Options.Common
 
-import           Options.Applicative hiding (help, str)
+import Options.Applicative hiding (help, str)
 import qualified Options.Applicative as Opt
 
 {- HLINT ignore "Use <$>" -}
@@ -20,53 +20,55 @@ import qualified Options.Applicative as Opt
 
 pNodeCmds :: Maybe (Parser (NodeCmds era))
 pNodeCmds =
-  subInfoParser "node"
-    ( Opt.progDesc
-        $ mconcat
+  subInfoParser
+    "node"
+    ( Opt.progDesc $
+        mconcat
           [ "Node operation commands."
           ]
     )
-    [ Just
-        $ subParser "key-gen"
-        $ Opt.info pKeyGenOperator
-        $ Opt.progDesc $ mconcat
-            [ "Create a key pair for a node operator's offline "
-            , "key and a new certificate issue counter"
-            ]
-    , Just
-        $ subParser "key-gen-KES"
-        $ Opt.info pKeyGenKES
-        $ Opt.progDesc
-        $ mconcat
-            [ "Create a key pair for a node KES operational key"
-            ]
-    , Just
-        $ subParser "key-gen-VRF"
-        $ Opt.info pKeyGenVRF
-        $ Opt.progDesc
-        $ mconcat
-            [ "Create a key pair for a node VRF operational key"
-            ]
-    , Just
-        $ subParser "key-hash-VRF". Opt.info pKeyHashVRF
-        $ Opt.progDesc
-        $ mconcat
-            [ "Print hash of a node's operational VRF key."
-            ]
-    , Just
-        $ subParser "new-counter"
-        $ Opt.info pNewCounter
-        $ Opt.progDesc
-        $ mconcat
-            [ "Create a new certificate issue counter"
-            ]
-    , Just
-        $ subParser "issue-op-cert"
-        $ Opt.info pIssueOpCert
-        $ Opt.progDesc
-        $ mconcat
-            [ "Issue a node operational certificate"
-            ]
+    [ Just $
+        subParser "key-gen" $
+          Opt.info pKeyGenOperator $
+            Opt.progDesc $
+              mconcat
+                [ "Create a key pair for a node operator's offline "
+                , "key and a new certificate issue counter"
+                ]
+    , Just $
+        subParser "key-gen-KES" $
+          Opt.info pKeyGenKES $
+            Opt.progDesc $
+              mconcat
+                [ "Create a key pair for a node KES operational key"
+                ]
+    , Just $
+        subParser "key-gen-VRF" $
+          Opt.info pKeyGenVRF $
+            Opt.progDesc $
+              mconcat
+                [ "Create a key pair for a node VRF operational key"
+                ]
+    , Just $
+        subParser "key-hash-VRF" . Opt.info pKeyHashVRF $
+          Opt.progDesc $
+            mconcat
+              [ "Print hash of a node's operational VRF key."
+              ]
+    , Just $
+        subParser "new-counter" $
+          Opt.info pNewCounter $
+            Opt.progDesc $
+              mconcat
+                [ "Create a new certificate issue counter"
+                ]
+    , Just $
+        subParser "issue-op-cert" $
+          Opt.info pIssueOpCert $
+            Opt.progDesc $
+              mconcat
+                [ "Issue a node operational certificate"
+                ]
     ]
 
 pKeyGenOperator :: Parser (NodeCmds era)
@@ -106,11 +108,12 @@ pNewCounter =
 
 pCounterValue :: Parser Word
 pCounterValue =
-  Opt.option Opt.auto $ mconcat
-    [ Opt.long "counter-value"
-    , Opt.metavar "INT"
-    , Opt.help "The next certificate issue counter value to use."
-    ]
+  Opt.option Opt.auto $
+    mconcat
+      [ Opt.long "counter-value"
+      , Opt.metavar "INT"
+      , Opt.help "The next certificate issue counter value to use."
+      ]
 
 pIssueOpCert :: Parser (NodeCmds era)
 pIssueOpCert =

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Query.hs
@@ -7,109 +7,117 @@ module Cardano.CLI.EraBased.Options.Query
   ( pQueryCmds
   ) where
 
-import           Cardano.Api hiding (QueryInShelleyBasedEra (..))
-import           Cardano.Api.Shelley hiding (QueryInShelleyBasedEra (..))
+import Cardano.Api hiding (QueryInShelleyBasedEra (..))
+import Cardano.Api.Shelley hiding (QueryInShelleyBasedEra (..))
 
-import           Cardano.CLI.Environment (EnvCli (..))
-import           Cardano.CLI.EraBased.Commands.Query
-import           Cardano.CLI.EraBased.Options.Common
-import           Cardano.CLI.Types.Common
+import Cardano.CLI.Environment (EnvCli (..))
+import Cardano.CLI.EraBased.Commands.Query
+import Cardano.CLI.EraBased.Options.Common
+import Cardano.CLI.Types.Common
 
-import           Data.Foldable
-import           Options.Applicative hiding (help, str)
+import Data.Foldable
+import Options.Applicative hiding (help, str)
 import qualified Options.Applicative as Opt
 
 {- HLINT ignore "Use <$>" -}
 {- HLINT ignore "Move brackets to avoid $" -}
 
-pQueryCmds :: ()
+pQueryCmds
+  :: ()
   => EnvCli
   -> Maybe (Parser (QueryCmds era))
 pQueryCmds envCli =
-  subInfoParser "query"
-    ( Opt.progDesc
-        $ mconcat
+  subInfoParser
+    "query"
+    ( Opt.progDesc $
+        mconcat
           [ "Node query commands. Will query the local node whose Unix domain socket is "
           , "obtained from the CARDANO_NODE_SOCKET_PATH environment variable."
           ]
     )
-    [ Just
-        $ subParser "protocol-parameters"
-        $ Opt.info (pQueryProtocolParameters envCli)
-        $ Opt.progDesc "Get the node's current protocol parameters"
-    , Just
-        $ subParser "constitution-hash"
-        $ Opt.info (pQueryConstitutionHash envCli)
-        $ Opt.progDesc "Get the constitution hash"
-    , Just
-        $ subParser "tip"
-        $ Opt.info (pQueryTip envCli)
-        $ Opt.progDesc "Get the node's current tip (slot no, hash, block no)"
-    , Just
-        $ subParser "stake-pools"
-        $ Opt.info (pQueryStakePools envCli)
-        $ Opt.progDesc "Get the node's current set of stake pool ids"
-    , Just
-        $ subParser "stake-distribution"
-        $ Opt.info (pQueryStakeDistribution envCli)
-        $ Opt.progDesc "Get the node's current aggregated stake distribution"
-    , Just
-        $ subParser "stake-address-info"
-        $ Opt.info (pQueryStakeAddressInfo envCli)
-        $ Opt.progDesc $ mconcat
-            [ "Get the current delegations and reward accounts filtered by stake address."
-            ]
-    , Just
-        $ subParser "utxo"
-        $ Opt.info (pQueryUTxO envCli)
-        $ Opt.progDesc $ mconcat
-            [ "Get a portion of the current UTxO: by tx in, by address or the whole."
-            ]
-    , Just
-        $ subParser "ledger-state"
-        $ Opt.info (pQueryLedgerState envCli)
-        $ Opt.progDesc $ mconcat
-            [ "Dump the current ledger state of the node (Ledger.NewEpochState -- advanced command)"
-            ]
-    , Just
-        $ subParser "protocol-state"
-        $ Opt.info (pQueryProtocolState envCli)
-        $ Opt.progDesc $ mconcat
-            [ "Dump the current protocol state of the node (Ledger.ChainDepState -- advanced command)"
-            ]
-    , Just
-        $ subParser "stake-snapshot"
-        $ Opt.info (pQueryStakeSnapshot envCli)
-        $ Opt.progDesc $ mconcat
-            [ "Obtain the three stake snapshots for a pool, plus the total active stake (advanced command)"
-            ]
-    , Just
-        $ hiddenSubParser "pool-params"
-        $ Opt.info (pQueryPoolState envCli)
-        $ Opt.progDesc $ mconcat
-            [ "DEPRECATED.  Use query pool-state instead.  Dump the pool parameters "
-            , "(Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced command)"
-            ]
-    , Just
-        $ subParser "leadership-schedule"
-        $ Opt.info (pLeadershipSchedule envCli)
-        $ Opt.progDesc "Get the slots the node is expected to mint a block in (advanced command)"
-    , Just
-        $ subParser "kes-period-info"
-        $ Opt.info (pKesPeriodInfo envCli)
-        $ Opt.progDesc "Get information about the current KES period and your node's operational certificate."
-    , Just
-        $ subParser "pool-state"
-        $ Opt.info (pQueryPoolState envCli)
-        $ Opt.progDesc "Dump the pool state"
-    , Just
-        $ subParser "tx-mempool"
-        $ Opt.info (pQueryTxMempool envCli)
-        $ Opt.progDesc "Local Mempool info"
-    , Just
-        $ subParser "slot-number"
-        $ Opt.info (pQuerySlotNumber envCli)
-        $ Opt.progDesc "Query slot number for UTC timestamp"
+    [ Just $
+        subParser "protocol-parameters" $
+          Opt.info (pQueryProtocolParameters envCli) $
+            Opt.progDesc "Get the node's current protocol parameters"
+    , Just $
+        subParser "constitution-hash" $
+          Opt.info (pQueryConstitutionHash envCli) $
+            Opt.progDesc "Get the constitution hash"
+    , Just $
+        subParser "tip" $
+          Opt.info (pQueryTip envCli) $
+            Opt.progDesc "Get the node's current tip (slot no, hash, block no)"
+    , Just $
+        subParser "stake-pools" $
+          Opt.info (pQueryStakePools envCli) $
+            Opt.progDesc "Get the node's current set of stake pool ids"
+    , Just $
+        subParser "stake-distribution" $
+          Opt.info (pQueryStakeDistribution envCli) $
+            Opt.progDesc "Get the node's current aggregated stake distribution"
+    , Just $
+        subParser "stake-address-info" $
+          Opt.info (pQueryStakeAddressInfo envCli) $
+            Opt.progDesc $
+              mconcat
+                [ "Get the current delegations and reward accounts filtered by stake address."
+                ]
+    , Just $
+        subParser "utxo" $
+          Opt.info (pQueryUTxO envCli) $
+            Opt.progDesc $
+              mconcat
+                [ "Get a portion of the current UTxO: by tx in, by address or the whole."
+                ]
+    , Just $
+        subParser "ledger-state" $
+          Opt.info (pQueryLedgerState envCli) $
+            Opt.progDesc $
+              mconcat
+                [ "Dump the current ledger state of the node (Ledger.NewEpochState -- advanced command)"
+                ]
+    , Just $
+        subParser "protocol-state" $
+          Opt.info (pQueryProtocolState envCli) $
+            Opt.progDesc $
+              mconcat
+                [ "Dump the current protocol state of the node (Ledger.ChainDepState -- advanced command)"
+                ]
+    , Just $
+        subParser "stake-snapshot" $
+          Opt.info (pQueryStakeSnapshot envCli) $
+            Opt.progDesc $
+              mconcat
+                [ "Obtain the three stake snapshots for a pool, plus the total active stake (advanced command)"
+                ]
+    , Just $
+        hiddenSubParser "pool-params" $
+          Opt.info (pQueryPoolState envCli) $
+            Opt.progDesc $
+              mconcat
+                [ "DEPRECATED.  Use query pool-state instead.  Dump the pool parameters "
+                , "(Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced command)"
+                ]
+    , Just $
+        subParser "leadership-schedule" $
+          Opt.info (pLeadershipSchedule envCli) $
+            Opt.progDesc "Get the slots the node is expected to mint a block in (advanced command)"
+    , Just $
+        subParser "kes-period-info" $
+          Opt.info (pKesPeriodInfo envCli) $
+            Opt.progDesc "Get information about the current KES period and your node's operational certificate."
+    , Just $
+        subParser "pool-state" $
+          Opt.info (pQueryPoolState envCli) $
+            Opt.progDesc "Dump the pool state"
+    , Just $
+        subParser "tx-mempool" $
+          Opt.info (pQueryTxMempool envCli) $
+            Opt.progDesc "Local Mempool info"
+    , Just $
+        subParser "slot-number" $
+          Opt.info (pQuerySlotNumber envCli) $
+            Opt.progDesc "Query slot number for UTC timestamp"
     ]
 
 pQueryProtocolParameters :: EnvCli -> Parser (QueryCmds era)
@@ -188,13 +196,16 @@ pQueryProtocolState envCli =
 
 pAllStakePoolsOrOnly :: Parser (AllOrOnly [Hash StakePoolKey])
 pAllStakePoolsOrOnly = pAll <|> pOnly
-  where pAll :: Parser (AllOrOnly [Hash StakePoolKey])
-        pAll = Opt.flag' All $ mconcat
-          [ Opt.long "all-stake-pools"
-          , Opt.help "Query for all stake pools"
-          ]
-        pOnly :: Parser (AllOrOnly [Hash StakePoolKey])
-        pOnly = Only <$> many (pStakePoolVerificationKeyHash Nothing)
+ where
+  pAll :: Parser (AllOrOnly [Hash StakePoolKey])
+  pAll =
+    Opt.flag' All $
+      mconcat
+        [ Opt.long "all-stake-pools"
+        , Opt.help "Query for all stake pools"
+        ]
+  pOnly :: Parser (AllOrOnly [Hash StakePoolKey])
+  pOnly = Only <$> many (pStakePoolVerificationKeyHash Nothing)
 
 pQueryStakeSnapshot :: EnvCli -> Parser (QueryCmds era)
 pQueryStakeSnapshot envCli =
@@ -221,18 +232,19 @@ pQueryTxMempool envCli =
     <*> pNetworkId envCli
     <*> pTxMempoolQuery
     <*> pMaybeOutputFile
-  where
-    pTxMempoolQuery :: Parser TxMempoolQuery
-    pTxMempoolQuery = asum
-      [ subParser "info"
-          $ Opt.info (pure TxMempoolQueryInfo)
-          $ Opt.progDesc "Ask the node about the current mempool's capacity and sizes"
-      , subParser "next-tx"
-          $ Opt.info (pure TxMempoolQueryNextTx)
-          $ Opt.progDesc "Requests the next transaction from the mempool's current list"
-      , subParser "tx-exists"
-          $ Opt.info (TxMempoolQueryTxExists <$> argument Opt.str (metavar "TX_ID"))
-          $ Opt.progDesc "Query if a particular transaction exists in the mempool"
+ where
+  pTxMempoolQuery :: Parser TxMempoolQuery
+  pTxMempoolQuery =
+    asum
+      [ subParser "info" $
+          Opt.info (pure TxMempoolQueryInfo) $
+            Opt.progDesc "Ask the node about the current mempool's capacity and sizes"
+      , subParser "next-tx" $
+          Opt.info (pure TxMempoolQueryNextTx) $
+            Opt.progDesc "Requests the next transaction from the mempool's current list"
+      , subParser "tx-exists" $
+          Opt.info (TxMempoolQueryTxExists <$> argument Opt.str (metavar "TX_ID")) $
+            Opt.progDesc "Query if a particular transaction exists in the mempool"
       ]
 pLeadershipSchedule :: EnvCli -> Parser (QueryCmds era)
 pLeadershipSchedule envCli =
@@ -262,9 +274,10 @@ pQuerySlotNumber envCli =
     <*> pConsensusModeParams
     <*> pNetworkId envCli
     <*> pUtcTimestamp
-      where
-        pUtcTimestamp =
-          convertTime <$> (Opt.strArgument . mconcat)
-            [ Opt.metavar "TIMESTAMP"
-            , Opt.help "UTC timestamp in YYYY-MM-DDThh:mm:ssZ format"
-            ]
+ where
+  pUtcTimestamp =
+    convertTime
+      <$> (Opt.strArgument . mconcat)
+        [ Opt.metavar "TIMESTAMP"
+        , Opt.help "UTC timestamp in YYYY-MM-DDThh:mm:ssZ format"
+        ]

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Query.hs
@@ -17,7 +17,7 @@ import Cardano.CLI.Types.Common
 
 import Data.Foldable
 import Options.Applicative hiding (help, str)
-import qualified Options.Applicative as Opt
+import Options.Applicative qualified as Opt
 
 {- HLINT ignore "Use <$>" -}
 {- HLINT ignore "Move brackets to avoid $" -}

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/StakeAddress.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/StakeAddress.hs
@@ -5,23 +5,25 @@ module Cardano.CLI.EraBased.Options.StakeAddress
   ( pStakeAddressCmds
   ) where
 
-import           Cardano.Api
+import Cardano.Api
 
-import           Cardano.CLI.Environment
-import           Cardano.CLI.EraBased.Commands.StakeAddress
-import           Cardano.CLI.EraBased.Options.Common
+import Cardano.CLI.Environment
+import Cardano.CLI.EraBased.Commands.StakeAddress
+import Cardano.CLI.EraBased.Options.Common
 
-import           Options.Applicative
+import Options.Applicative
 import qualified Options.Applicative as Opt
 
-pStakeAddressCmds :: ()
+pStakeAddressCmds
+  :: ()
   => CardanoEra era
   -> EnvCli
   -> Maybe (Parser (StakeAddressCmds era))
 pStakeAddressCmds era envCli =
-  subInfoParser "stake-address"
-    ( Opt.progDesc
-        $ mconcat
+  subInfoParser
+    "stake-address"
+    ( Opt.progDesc $
+        mconcat
           [ "Stake address commands."
           ]
     )
@@ -35,7 +37,8 @@ pStakeAddressCmds era envCli =
     , pStakeAddressVoteDelegationCertificateCmd era
     ]
 
-pStakeAddressKeyGenCmd :: ()
+pStakeAddressKeyGenCmd
+  :: ()
   => CardanoEra era
   -> Maybe (Parser (StakeAddressCmds era))
 pStakeAddressKeyGenCmd era = do
@@ -43,14 +46,15 @@ pStakeAddressKeyGenCmd era = do
   pure
     $ subParser "key-gen"
     $ Opt.info
-        ( StakeAddressKeyGenCmd w
-            <$> pKeyOutputFormat
-            <*> pVerificationKeyFileOut
-            <*> pSigningKeyFileOut
-        )
+      ( StakeAddressKeyGenCmd w
+          <$> pKeyOutputFormat
+          <*> pVerificationKeyFileOut
+          <*> pSigningKeyFileOut
+      )
     $ Opt.progDesc "Create a stake address key pair"
 
-pStakeAddressKeyHashCmd :: ()
+pStakeAddressKeyHashCmd
+  :: ()
   => CardanoEra era
   -> Maybe (Parser (StakeAddressCmds era))
 pStakeAddressKeyHashCmd era = do
@@ -58,13 +62,14 @@ pStakeAddressKeyHashCmd era = do
   pure
     $ subParser "key-hash"
     $ Opt.info
-        ( StakeAddressKeyHashCmd w
-            <$> pStakeVerificationKeyOrFile Nothing
-            <*> pMaybeOutputFile
-        )
+      ( StakeAddressKeyHashCmd w
+          <$> pStakeVerificationKeyOrFile Nothing
+          <*> pMaybeOutputFile
+      )
     $ Opt.progDesc "Print the hash of a stake address key"
 
-pStakeAddressBuildCmd :: ()
+pStakeAddressBuildCmd
+  :: ()
   => CardanoEra era
   -> EnvCli
   -> Maybe (Parser (StakeAddressCmds era))
@@ -73,14 +78,15 @@ pStakeAddressBuildCmd era envCli = do
   pure
     $ subParser "build"
     $ Opt.info
-        ( StakeAddressBuildCmd w
-            <$> pStakeVerifier
-            <*> pNetworkId envCli
-            <*> pMaybeOutputFile
-        )
+      ( StakeAddressBuildCmd w
+          <$> pStakeVerifier
+          <*> pNetworkId envCli
+          <*> pMaybeOutputFile
+      )
     $ Opt.progDesc "Build a stake address"
 
-pStakeAddressRegistrationCertificateCmd :: ()
+pStakeAddressRegistrationCertificateCmd
+  :: ()
   => CardanoEra era
   -> Maybe (Parser (StakeAddressCmds era))
 pStakeAddressRegistrationCertificateCmd era = do
@@ -88,14 +94,15 @@ pStakeAddressRegistrationCertificateCmd era = do
   pure
     $ subParser "registration-certificate"
     $ Opt.info
-        ( StakeAddressRegistrationCertificateCmd w
-            <$> pStakeIdentifier
-            <*> optional pKeyRegistDeposit
-            <*> pOutputFile
-        )
+      ( StakeAddressRegistrationCertificateCmd w
+          <$> pStakeIdentifier
+          <*> optional pKeyRegistDeposit
+          <*> pOutputFile
+      )
     $ Opt.progDesc "Create a stake address registration certificate"
 
-pStakeAddressDeregistrationCertificateCmd :: ()
+pStakeAddressDeregistrationCertificateCmd
+  :: ()
   => CardanoEra era
   -> Maybe (Parser (StakeAddressCmds era))
 pStakeAddressDeregistrationCertificateCmd era = do
@@ -103,14 +110,15 @@ pStakeAddressDeregistrationCertificateCmd era = do
   pure
     $ subParser "deregistration-certificate"
     $ Opt.info
-        ( StakeAddressDeregistrationCertificateCmd w
-            <$> pStakeIdentifier
-            <*> optional pKeyRegistDeposit
-            <*> pOutputFile
-        )
+      ( StakeAddressDeregistrationCertificateCmd w
+          <$> pStakeIdentifier
+          <*> optional pKeyRegistDeposit
+          <*> pOutputFile
+      )
     $ Opt.progDesc "Create a stake address deregistration certificate"
 
-pStakeAddressStakeDelegationCertificateCmd :: ()
+pStakeAddressStakeDelegationCertificateCmd
+  :: ()
   => CardanoEra era
   -> Maybe (Parser (StakeAddressCmds era))
 pStakeAddressStakeDelegationCertificateCmd era = do
@@ -118,18 +126,19 @@ pStakeAddressStakeDelegationCertificateCmd era = do
   pure
     $ subParser "stake-delegation-certificate"
     $ Opt.info
-        ( StakeAddressStakeDelegationCertificateCmd w
-            <$> pStakeIdentifier
-            <*> pStakePoolVerificationKeyOrHashOrFile Nothing
-            <*> pOutputFile
-        )
+      ( StakeAddressStakeDelegationCertificateCmd w
+          <$> pStakeIdentifier
+          <*> pStakePoolVerificationKeyOrHashOrFile Nothing
+          <*> pOutputFile
+      )
     $ Opt.progDesc
     $ mconcat
-        [ "Create a stake address stake delegation certificate, which when submitted in a transaction "
-        , "delegates stake to a stake pool."
-        ]
+      [ "Create a stake address stake delegation certificate, which when submitted in a transaction "
+      , "delegates stake to a stake pool."
+      ]
 
-pStakeAddressStakeAndVoteDelegationCertificateCmd :: ()
+pStakeAddressStakeAndVoteDelegationCertificateCmd
+  :: ()
   => CardanoEra era
   -> Maybe (Parser (StakeAddressCmds era))
 pStakeAddressStakeAndVoteDelegationCertificateCmd era = do
@@ -137,19 +146,20 @@ pStakeAddressStakeAndVoteDelegationCertificateCmd era = do
   pure
     $ subParser "stake-and-vote-delegation-certificate"
     $ Opt.info
-        ( StakeAddressStakeAndVoteDelegationCertificateCmd w
-            <$> pStakeIdentifier
-            <*> pStakePoolVerificationKeyOrHashOrFile Nothing
-            <*> pVoteDelegationTarget
-            <*> pOutputFile
-        )
+      ( StakeAddressStakeAndVoteDelegationCertificateCmd w
+          <$> pStakeIdentifier
+          <*> pStakePoolVerificationKeyOrHashOrFile Nothing
+          <*> pVoteDelegationTarget
+          <*> pOutputFile
+      )
     $ Opt.progDesc
     $ mconcat
-        [ "Create a stake address stake and vote delegation certificate, which when submitted in a transaction "
-        , "delegates stake to a stake pool and a DRep."
-        ]
+      [ "Create a stake address stake and vote delegation certificate, which when submitted in a transaction "
+      , "delegates stake to a stake pool and a DRep."
+      ]
 
-pStakeAddressVoteDelegationCertificateCmd :: ()
+pStakeAddressVoteDelegationCertificateCmd
+  :: ()
   => CardanoEra era
   -> Maybe (Parser (StakeAddressCmds era))
 pStakeAddressVoteDelegationCertificateCmd era = do
@@ -157,13 +167,13 @@ pStakeAddressVoteDelegationCertificateCmd era = do
   pure
     $ subParser "vote-delegation-certificate"
     $ Opt.info
-        ( StakeAddressVoteDelegationCertificateCmd w
-            <$> pStakeIdentifier
-            <*> pVoteDelegationTarget
-            <*> pOutputFile
-        )
+      ( StakeAddressVoteDelegationCertificateCmd w
+          <$> pStakeIdentifier
+          <*> pVoteDelegationTarget
+          <*> pOutputFile
+      )
     $ Opt.progDesc
     $ mconcat
-        [ "Create a stake address vote delegation certificate, which when submitted in a transaction "
-        , "delegates stake to a stake pool and a DRep."
-        ]
+      [ "Create a stake address vote delegation certificate, which when submitted in a transaction "
+      , "delegates stake to a stake pool and a DRep."
+      ]

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/StakeAddress.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/StakeAddress.hs
@@ -12,7 +12,7 @@ import Cardano.CLI.EraBased.Commands.StakeAddress
 import Cardano.CLI.EraBased.Options.Common
 
 import Options.Applicative
-import qualified Options.Applicative as Opt
+import Options.Applicative qualified as Opt
 
 pStakeAddressCmds
   :: ()

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/StakePool.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/StakePool.hs
@@ -14,7 +14,7 @@ import Cardano.CLI.EraBased.Commands.StakePool
 import Cardano.CLI.EraBased.Options.Common
 
 import Options.Applicative hiding (help, str)
-import qualified Options.Applicative as Opt
+import Options.Applicative qualified as Opt
 
 {- HLINT ignore "Use <$>" -}
 {- HLINT ignore "Move brackets to avoid $" -}

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/StakePool.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/StakePool.hs
@@ -7,39 +7,41 @@ module Cardano.CLI.EraBased.Options.StakePool
   ( pStakePoolCmds
   ) where
 
-import           Cardano.Api
+import Cardano.Api
 
-import           Cardano.CLI.Environment (EnvCli (..))
-import           Cardano.CLI.EraBased.Commands.StakePool
-import           Cardano.CLI.EraBased.Options.Common
+import Cardano.CLI.Environment (EnvCli (..))
+import Cardano.CLI.EraBased.Commands.StakePool
+import Cardano.CLI.EraBased.Options.Common
 
-import           Options.Applicative hiding (help, str)
+import Options.Applicative hiding (help, str)
 import qualified Options.Applicative as Opt
 
 {- HLINT ignore "Use <$>" -}
 {- HLINT ignore "Move brackets to avoid $" -}
 
-pStakePoolCmds :: ()
+pStakePoolCmds
+  :: ()
   => CardanoEra era
   -> EnvCli
   -> Maybe (Parser (StakePoolCmds era))
 pStakePoolCmds era envCli =
-  subInfoParser "stake-pool"
-    ( Opt.progDesc
-        $ mconcat
+  subInfoParser
+    "stake-pool"
+    ( Opt.progDesc $
+        mconcat
           [ "Stake pool commands."
           ]
     )
     [ pStakePoolRegistrationCertificateCmd era envCli
     , pStakePoolDeregistrationCertificateCmd era
-    , Just
-        $ subParser "id"
-        $ Opt.info pStakePoolId
-        $ Opt.progDesc "Build pool id from the offline key"
-    , Just
-        $ subParser "metadata-hash"
-        $ Opt.info pStakePoolMetadataHashCmd
-        $ Opt.progDesc "Print the hash of pool metadata."
+    , Just $
+        subParser "id" $
+          Opt.info pStakePoolId $
+            Opt.progDesc "Build pool id from the offline key"
+    , Just $
+        subParser "metadata-hash" $
+          Opt.info pStakePoolMetadataHashCmd $
+            Opt.progDesc "Print the hash of pool metadata."
     ]
 
 pStakePoolId :: Parser (StakePoolCmds era)
@@ -55,25 +57,26 @@ pStakePoolMetadataHashCmd =
     <$> pPoolMetadataFile
     <*> pMaybeOutputFile
 
-pStakePoolRegistrationCertificateCmd :: CardanoEra era -> EnvCli -> Maybe (Parser (StakePoolCmds era))
+pStakePoolRegistrationCertificateCmd
+  :: CardanoEra era -> EnvCli -> Maybe (Parser (StakePoolCmds era))
 pStakePoolRegistrationCertificateCmd era envCli = do
   w <- maybeEonInEra era
   pure
     $ subParser "registration-certificate"
     $ Opt.info
-        ( StakePoolRegistrationCertificateCmd w
-            <$> pStakePoolVerificationKeyOrFile Nothing
-            <*> pVrfVerificationKeyOrFile
-            <*> pPoolPledge
-            <*> pPoolCost
-            <*> pPoolMargin
-            <*> pRewardAcctVerificationKeyOrFile
-            <*> some pPoolOwnerVerificationKeyOrFile
-            <*> many pPoolRelay
-            <*> pStakePoolMetadataReference
-            <*> pNetworkId envCli
-            <*> pOutputFile
-        )
+      ( StakePoolRegistrationCertificateCmd w
+          <$> pStakePoolVerificationKeyOrFile Nothing
+          <*> pVrfVerificationKeyOrFile
+          <*> pPoolPledge
+          <*> pPoolCost
+          <*> pPoolMargin
+          <*> pRewardAcctVerificationKeyOrFile
+          <*> some pPoolOwnerVerificationKeyOrFile
+          <*> many pPoolRelay
+          <*> pStakePoolMetadataReference
+          <*> pNetworkId envCli
+          <*> pOutputFile
+      )
     $ Opt.progDesc "Create a stake pool registration certificate"
 
 pStakePoolDeregistrationCertificateCmd :: CardanoEra era -> Maybe (Parser (StakePoolCmds era))
@@ -82,9 +85,9 @@ pStakePoolDeregistrationCertificateCmd era = do
   pure
     $ subParser "deregistration-certificate"
     $ Opt.info
-        ( StakePoolDeregistrationCertificateCmd w
-            <$> pStakePoolVerificationKeyOrFile Nothing
-            <*> pEpochNo "The epoch number."
-            <*> pOutputFile
-        )
+      ( StakePoolDeregistrationCertificateCmd w
+          <$> pStakePoolVerificationKeyOrFile Nothing
+          <*> pEpochNo "The epoch number."
+          <*> pOutputFile
+      )
     $ Opt.progDesc "Create a stake pool deregistration certificate"

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/TextView.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/TextView.hs
@@ -7,10 +7,10 @@ module Cardano.CLI.EraBased.Options.TextView
   ( pTextViewCmds
   ) where
 
-import           Cardano.CLI.EraBased.Commands.TextView
-import           Cardano.CLI.EraBased.Options.Common
+import Cardano.CLI.EraBased.Commands.TextView
+import Cardano.CLI.EraBased.Options.Common
 
-import           Options.Applicative hiding (help, str)
+import Options.Applicative hiding (help, str)
 import qualified Options.Applicative as Opt
 
 {- HLINT ignore "Use <$>" -}
@@ -18,15 +18,16 @@ import qualified Options.Applicative as Opt
 
 pTextViewCmds :: Maybe (Parser (TextViewCmds era))
 pTextViewCmds =
-  subInfoParser "text-view"
-    ( Opt.progDesc
-        $ mconcat
+  subInfoParser
+    "text-view"
+    ( Opt.progDesc $
+        mconcat
           [ "Commands for dealing with Shelley TextView files. Transactions, addresses etc "
           , "are stored on disk as TextView files."
           ]
     )
-    [ Just
-        $ subParser "decode-cbor"
-        $ Opt.info (TextViewInfo <$> pCBORInFile <*> pMaybeOutputFile)
-        $ Opt.progDesc "Print a TextView file as decoded CBOR."
+    [ Just $
+        subParser "decode-cbor" $
+          Opt.info (TextViewInfo <$> pCBORInFile <*> pMaybeOutputFile) $
+            Opt.progDesc "Print a TextView file as decoded CBOR."
     ]

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/TextView.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/TextView.hs
@@ -11,7 +11,7 @@ import Cardano.CLI.EraBased.Commands.TextView
 import Cardano.CLI.EraBased.Options.Common
 
 import Options.Applicative hiding (help, str)
-import qualified Options.Applicative as Opt
+import Options.Applicative qualified as Opt
 
 {- HLINT ignore "Use <$>" -}
 {- HLINT ignore "Move brackets to avoid $" -}

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Transaction.hs
@@ -17,8 +17,8 @@ import Cardano.CLI.Types.Common
 
 import Data.Foldable
 import Options.Applicative hiding (help, str)
-import qualified Options.Applicative as Opt
-import qualified Options.Applicative.Help as H
+import Options.Applicative qualified as Opt
+import Options.Applicative.Help qualified as H
 import Prettyprinter (line, pretty)
 
 {- HLINT ignore "Use <$>" -}

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Transaction.hs
@@ -8,146 +8,156 @@ module Cardano.CLI.EraBased.Options.Transaction
   ( pTransactionCmds
   ) where
 
-import           Cardano.Api hiding (QueryInShelleyBasedEra (..))
+import Cardano.Api hiding (QueryInShelleyBasedEra (..))
 
-import           Cardano.CLI.Environment (EnvCli (..))
-import           Cardano.CLI.EraBased.Commands.Transaction
-import           Cardano.CLI.EraBased.Options.Common
-import           Cardano.CLI.Types.Common
+import Cardano.CLI.Environment (EnvCli (..))
+import Cardano.CLI.EraBased.Commands.Transaction
+import Cardano.CLI.EraBased.Options.Common
+import Cardano.CLI.Types.Common
 
-import           Data.Foldable
-import           Options.Applicative hiding (help, str)
+import Data.Foldable
+import Options.Applicative hiding (help, str)
 import qualified Options.Applicative as Opt
 import qualified Options.Applicative.Help as H
-import           Prettyprinter (line, pretty)
+import Prettyprinter (line, pretty)
 
 {- HLINT ignore "Use <$>" -}
 {- HLINT ignore "Move brackets to avoid $" -}
 
-pTransactionCmds :: ()
+pTransactionCmds
+  :: ()
   => CardanoEra era
   -> EnvCli
   -> Maybe (Parser (TransactionCmds era))
 pTransactionCmds era envCli =
-  subInfoParser "transaction"
-    ( Opt.progDesc
-        $ mconcat
+  subInfoParser
+    "transaction"
+    ( Opt.progDesc $
+        mconcat
           [ "Transaction commands."
           ]
     )
-    [ Just
-        $ subParser "build-raw"
-        $ Opt.info (pTransactionBuildRaw era)
-        $ Opt.progDescDoc
-        $ Just $ mconcat
-            [ pretty @String "Build a transaction (low-level, inconvenient)"
-            , line
-            , line
-            , H.yellow $ mconcat
-                [ "Please note the order of some cmd options is crucial. If used incorrectly may produce "
-                , "undesired tx body. See nested [] notation above for details."
-                ]
-            ]
-    , Just
-        $ subParser "build"
-        $ Opt.info (pTransactionBuild era envCli)
-        $ Opt.progDescDoc
-        $ Just $ mconcat
-            [ pretty @String "Build a balanced transaction (automatically calculates fees)"
-            , line
-            , line
-            , H.yellow $ mconcat
-                [ "Please note "
-                , H.underline "the order"
-                , " of some cmd options is crucial. If used incorrectly may produce "
-                , "undesired tx body. See nested [] notation above for details."
-                ]
-            ]
-    , Just
-        $ subParser "sign"
-        $ Opt.info (pTransactionSign envCli)
-        $ Opt.progDesc "Sign a transaction"
-    , Just
-        $ subParser "witness"
-        $ Opt.info (pTransactionCreateWitness envCli)
-        $ Opt.progDesc "Create a transaction witness"
-    , Just
-        $ subParser "assemble"
-        $ Opt.info pTransactionAssembleTxBodyWit
-        $ Opt.progDesc "Assemble a tx body and witness(es) to form a transaction"
+    [ Just $
+        subParser "build-raw" $
+          Opt.info (pTransactionBuildRaw era) $
+            Opt.progDescDoc $
+              Just $
+                mconcat
+                  [ pretty @String "Build a transaction (low-level, inconvenient)"
+                  , line
+                  , line
+                  , H.yellow $
+                      mconcat
+                        [ "Please note the order of some cmd options is crucial. If used incorrectly may produce "
+                        , "undesired tx body. See nested [] notation above for details."
+                        ]
+                  ]
+    , Just $
+        subParser "build" $
+          Opt.info (pTransactionBuild era envCli) $
+            Opt.progDescDoc $
+              Just $
+                mconcat
+                  [ pretty @String "Build a balanced transaction (automatically calculates fees)"
+                  , line
+                  , line
+                  , H.yellow $
+                      mconcat
+                        [ "Please note "
+                        , H.underline "the order"
+                        , " of some cmd options is crucial. If used incorrectly may produce "
+                        , "undesired tx body. See nested [] notation above for details."
+                        ]
+                  ]
+    , Just $
+        subParser "sign" $
+          Opt.info (pTransactionSign envCli) $
+            Opt.progDesc "Sign a transaction"
+    , Just $
+        subParser "witness" $
+          Opt.info (pTransactionCreateWitness envCli) $
+            Opt.progDesc "Create a transaction witness"
+    , Just $
+        subParser "assemble" $
+          Opt.info pTransactionAssembleTxBodyWit $
+            Opt.progDesc "Assemble a tx body and witness(es) to form a transaction"
     , Just pSignWitnessBackwardCompatible
-    , Just
-        $ subParser "submit"
-        $ Opt.info (pTransactionSubmit envCli)
-        $ Opt.progDesc
-        $ mconcat
-            [ "Submit a transaction to the local node whose Unix domain socket "
-            , "is obtained from the CARDANO_NODE_SOCKET_PATH environment variable."
-            ]
-    , Just
-        $ subParser "policyid"
-        $ Opt.info pTransactionPolicyId
-        $ Opt.progDesc "Calculate the PolicyId from the monetary policy script."
-    , Just
-        $ subParser "calculate-min-fee"
-        $ Opt.info (pTransactionCalculateMinFee envCli)
-        $ Opt.progDesc "Calculate the minimum fee for a transaction."
-    , Just
-        $ subParser "calculate-min-required-utxo"
-        $ Opt.info (pTransactionCalculateMinReqUTxO era)
-        $ Opt.progDesc "Calculate the minimum required UTxO for a transaction output."
-    , Just
-        $ pCalculateMinRequiredUtxoBackwardCompatible era
-    , Just
-        $ subParser "hash-script-data"
-        $ Opt.info pTxHashScriptData
-        $ Opt.progDesc "Calculate the hash of script data."
-    , Just
-        $ subParser "txid"
-        $ Opt.info pTransactionId
-        $ Opt.progDesc "Print a transaction identifier."
-    , Just
-        $ subParser "view"
-        $ Opt.info pTransactionView
-        $ Opt.progDesc "Print a transaction."
+    , Just $
+        subParser "submit" $
+          Opt.info (pTransactionSubmit envCli) $
+            Opt.progDesc $
+              mconcat
+                [ "Submit a transaction to the local node whose Unix domain socket "
+                , "is obtained from the CARDANO_NODE_SOCKET_PATH environment variable."
+                ]
+    , Just $
+        subParser "policyid" $
+          Opt.info pTransactionPolicyId $
+            Opt.progDesc "Calculate the PolicyId from the monetary policy script."
+    , Just $
+        subParser "calculate-min-fee" $
+          Opt.info (pTransactionCalculateMinFee envCli) $
+            Opt.progDesc "Calculate the minimum fee for a transaction."
+    , Just $
+        subParser "calculate-min-required-utxo" $
+          Opt.info (pTransactionCalculateMinReqUTxO era) $
+            Opt.progDesc "Calculate the minimum required UTxO for a transaction output."
+    , Just $
+        pCalculateMinRequiredUtxoBackwardCompatible era
+    , Just $
+        subParser "hash-script-data" $
+          Opt.info pTxHashScriptData $
+            Opt.progDesc "Calculate the hash of script data."
+    , Just $
+        subParser "txid" $
+          Opt.info pTransactionId $
+            Opt.progDesc "Print a transaction identifier."
+    , Just $
+        subParser "view" $
+          Opt.info pTransactionView $
+            Opt.progDesc "Print a transaction."
     ]
 
 -- Backwards compatible parsers
 calcMinValueInfo :: CardanoEra era -> ParserInfo (TransactionCmds era)
 calcMinValueInfo era =
-  Opt.info (pTransactionCalculateMinReqUTxO era)
-    $ Opt.progDesc "DEPRECATED: Use 'calculate-min-required-utxo' instead."
+  Opt.info (pTransactionCalculateMinReqUTxO era) $
+    Opt.progDesc "DEPRECATED: Use 'calculate-min-required-utxo' instead."
 
 pCalculateMinRequiredUtxoBackwardCompatible :: CardanoEra era -> Parser (TransactionCmds era)
 pCalculateMinRequiredUtxoBackwardCompatible era =
-  Opt.subparser
-    $ Opt.command "calculate-min-value" (calcMinValueInfo era) <> Opt.internal
+  Opt.subparser $
+    Opt.command "calculate-min-value" (calcMinValueInfo era) <> Opt.internal
 
 assembleInfo :: ParserInfo (TransactionCmds era)
 assembleInfo =
-  Opt.info pTransactionAssembleTxBodyWit
-    $ Opt.progDesc "Assemble a tx body and witness(es) to form a transaction"
+  Opt.info pTransactionAssembleTxBodyWit $
+    Opt.progDesc "Assemble a tx body and witness(es) to form a transaction"
 
 pSignWitnessBackwardCompatible :: Parser (TransactionCmds era)
 pSignWitnessBackwardCompatible =
-  Opt.subparser
-    $ Opt.command "sign-witness" assembleInfo <> Opt.internal
+  Opt.subparser $
+    Opt.command "sign-witness" assembleInfo <> Opt.internal
 
 pScriptValidity :: Parser ScriptValidity
-pScriptValidity = asum
-  [ Opt.flag' ScriptValid $ mconcat
-    [ Opt.long "script-valid"
-    , Opt.help "Assertion that the script is valid. (default)"
+pScriptValidity =
+  asum
+    [ Opt.flag' ScriptValid $
+        mconcat
+          [ Opt.long "script-valid"
+          , Opt.help "Assertion that the script is valid. (default)"
+          ]
+    , Opt.flag' ScriptInvalid $
+        mconcat
+          [ Opt.long "script-invalid"
+          , Opt.help $
+              mconcat
+                [ "Assertion that the script is invalid.  "
+                , "If a transaction is submitted with such a script, "
+                , "the script will fail and the collateral will be taken."
+                ]
+          ]
     ]
-  , Opt.flag' ScriptInvalid $ mconcat
-    [ Opt.long "script-invalid"
-    , Opt.help $ mconcat
-      [ "Assertion that the script is invalid.  "
-      , "If a transaction is submitted with such a script, "
-      , "the script will fail and the collateral will be taken."
-      ]
-    ]
-  ]
 
 pTransactionBuild :: CardanoEra era -> EnvCli -> Parser (TransactionCmds era)
 pTransactionBuild era envCli =
@@ -171,10 +181,12 @@ pTransactionBuild era envCli =
     <*> many (pCertificateFile AutoBalance)
     <*> many (pWithdrawal AutoBalance)
     <*> pTxMetadataJsonSchema
-    <*> many (pScriptFor
-                "auxiliary-script-file"
-                Nothing
-                "Filepath of auxiliary script(s)")
+    <*> many
+      ( pScriptFor
+          "auxiliary-script-file"
+          Nothing
+          "Filepath of auxiliary script(s)"
+      )
     <*> many pMetadataFile
     <*> optional pUpdateProposalFile
     <*> many (pFileInDirection "vote-file" "Filepath of the vote.")
@@ -183,11 +195,13 @@ pTransactionBuild era envCli =
 
 pChangeAddress :: Parser TxOutChangeAddress
 pChangeAddress =
-  fmap TxOutChangeAddress $ Opt.option (readerFromParsecParser parseAddressAny) $ mconcat
-    [ Opt.long "change-address"
-    , Opt.metavar "ADDRESS"
-    , Opt.help "Address where ADA in excess of the tx fee will go to."
-    ]
+  fmap TxOutChangeAddress $
+    Opt.option (readerFromParsecParser parseAddressAny) $
+      mconcat
+        [ Opt.long "change-address"
+        , Opt.metavar "ADDRESS"
+        , Opt.help "Address where ADA in excess of the tx fee will go to."
+        ]
 
 pTransactionBuildRaw :: CardanoEra era -> Parser (TransactionCmds era)
 pTransactionBuildRaw era =
@@ -204,7 +218,7 @@ pTransactionBuildRaw era =
     <*> optional pInvalidBefore
     <*> optional pInvalidHereafter
     <*> optional pTxFee
-    <*> many (pCertificateFile ManualBalance )
+    <*> many (pCertificateFile ManualBalance)
     <*> many (pWithdrawal ManualBalance)
     <*> pTxMetadataJsonSchema
     <*> many (pScriptFor "auxiliary-script-file" Nothing "Filepath of auxiliary script(s)")
@@ -213,7 +227,7 @@ pTransactionBuildRaw era =
     <*> optional pUpdateProposalFile
     <*> pTxBodyFileOut
 
-pTransactionSign  :: EnvCli -> Parser (TransactionCmds era)
+pTransactionSign :: EnvCli -> Parser (TransactionCmds era)
 pTransactionSign envCli =
   TxSign
     <$> pInputTxOrTxBodyFile
@@ -248,7 +262,7 @@ pTransactionPolicyId :: Parser (TransactionCmds era)
 pTransactionPolicyId = TxMintedPolicyId <$> pScript
 
 pTransactionCalculateMinFee :: EnvCli -> Parser (TransactionCmds era)
-pTransactionCalculateMinFee envCli  =
+pTransactionCalculateMinFee envCli =
   TxCalculateMinFee
     <$> pTxBodyFileIn
     <*> pNetworkId envCli
@@ -266,13 +280,13 @@ pTransactionCalculateMinReqUTxO era =
 
 pTxHashScriptData :: Parser (TransactionCmds era)
 pTxHashScriptData =
-  fmap TxHashScriptData
-    $ pScriptDataOrFile
-        "script-data"
-        "The script data, in JSON syntax."
-        "The script data, in the given JSON file."
+  fmap TxHashScriptData $
+    pScriptDataOrFile
+      "script-data"
+      "The script data, in JSON syntax."
+      "The script data, in the given JSON file."
 
-pTransactionId  :: Parser (TransactionCmds era)
+pTransactionId :: Parser (TransactionCmds era)
 pTransactionId = TxGetTxId <$> pInputTxOrTxBodyFile
 
 pTransactionView :: Parser (TransactionCmds era)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run.hs
@@ -7,39 +7,41 @@ module Cardano.CLI.EraBased.Run
   , runGovernanceCmds
   ) where
 
-import           Cardano.Api
+import Cardano.Api
 
-import           Cardano.CLI.EraBased.Commands
-import           Cardano.CLI.EraBased.Options.Governance
-import           Cardano.CLI.EraBased.Run.Address
-import           Cardano.CLI.EraBased.Run.Genesis
-import           Cardano.CLI.EraBased.Run.Governance
-import           Cardano.CLI.EraBased.Run.Governance.Actions
-import           Cardano.CLI.EraBased.Run.Governance.Committee
-import           Cardano.CLI.EraBased.Run.Governance.DRep
-import           Cardano.CLI.EraBased.Run.Governance.Query
-import           Cardano.CLI.EraBased.Run.Governance.Vote
-import           Cardano.CLI.EraBased.Run.Key
-import           Cardano.CLI.EraBased.Run.Node
-import           Cardano.CLI.EraBased.Run.Query
-import           Cardano.CLI.EraBased.Run.StakeAddress
-import           Cardano.CLI.EraBased.Run.StakePool
-import           Cardano.CLI.EraBased.Run.TextView
-import           Cardano.CLI.EraBased.Run.Transaction
-import           Cardano.CLI.Types.Errors.CmdError
+import Cardano.CLI.EraBased.Commands
+import Cardano.CLI.EraBased.Options.Governance
+import Cardano.CLI.EraBased.Run.Address
+import Cardano.CLI.EraBased.Run.Genesis
+import Cardano.CLI.EraBased.Run.Governance
+import Cardano.CLI.EraBased.Run.Governance.Actions
+import Cardano.CLI.EraBased.Run.Governance.Committee
+import Cardano.CLI.EraBased.Run.Governance.DRep
+import Cardano.CLI.EraBased.Run.Governance.Query
+import Cardano.CLI.EraBased.Run.Governance.Vote
+import Cardano.CLI.EraBased.Run.Key
+import Cardano.CLI.EraBased.Run.Node
+import Cardano.CLI.EraBased.Run.Query
+import Cardano.CLI.EraBased.Run.StakeAddress
+import Cardano.CLI.EraBased.Run.StakePool
+import Cardano.CLI.EraBased.Run.TextView
+import Cardano.CLI.EraBased.Run.Transaction
+import Cardano.CLI.Types.Errors.CmdError
 
-import           Control.Monad.Trans.Except
-import           Control.Monad.Trans.Except.Extra (firstExceptT)
-import           Data.Function ((&))
+import Control.Monad.Trans.Except
+import Control.Monad.Trans.Except.Extra (firstExceptT)
+import Data.Function ((&))
 
-runAnyEraCommand :: ()
+runAnyEraCommand
+  :: ()
   => AnyEraCommand
   -> ExceptT CmdError IO ()
 runAnyEraCommand = \case
   AnyEraCommandOf sbe cmd ->
     shelleyBasedEraConstraints sbe $ runCmds cmd
 
-runCmds :: ()
+runCmds
+  :: ()
   => Cmds era
   -> ExceptT CmdError IO ()
 runCmds = \case
@@ -72,31 +74,26 @@ runCmds = \case
     runTransactionCmds cmd
       & firstExceptT CmdTransactionError
 
-runGovernanceCmds :: ()
+runGovernanceCmds
+  :: ()
   => GovernanceCmds era
   -> ExceptT CmdError IO ()
 runGovernanceCmds = \case
   GovernanceMIRPayStakeAddressesCertificate w mirpot vKeys rewards out ->
     runGovernanceMIRCertificatePayStakeAddrs w mirpot vKeys rewards out
       & firstExceptT CmdGovernanceCmdError
-
   GovernanceMIRTransfer w ll oFp direction ->
     runGovernanceMIRCertificateTransfer w ll oFp direction
       & firstExceptT CmdGovernanceCmdError
-
   GovernanceCommitteeCmds cmds ->
     runGovernanceCommitteeCmds cmds
       & firstExceptT CmdGovernanceCommitteeError
-
   GovernanceActionCmds cmds ->
     runGovernanceActionCmds cmds
       & firstExceptT CmdGovernanceActionError
-
   GovernanceDRepCmds cmds ->
     runGovernanceDRepCmds cmds
-
   GovernanceVoteCmds cmds ->
     runGovernanceVoteCmds cmds
-
   GovernanceQueryCmds cmds ->
     runGovernanceQueryCmds cmds

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Address.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Address.hs
@@ -33,9 +33,9 @@ import Cardano.CLI.Types.Key
 import Control.Monad.IO.Class (MonadIO (..))
 import Control.Monad.Trans.Except (ExceptT)
 import Control.Monad.Trans.Except.Extra (firstExceptT, left, newExceptT)
-import qualified Data.ByteString.Char8 as BS
+import Data.ByteString.Char8 qualified as BS
 import Data.Function
-import qualified Data.Text.IO as Text
+import Data.Text.IO qualified as Text
 
 runAddressCmds
   :: ()

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Address/Info.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Address/Info.hs
@@ -14,7 +14,7 @@ import Control.Monad.Trans.Except (ExceptT)
 import Control.Monad.Trans.Except.Extra (left)
 import Data.Aeson (ToJSON (..), object, (.=))
 import Data.Aeson.Encode.Pretty (encodePretty)
-import qualified Data.ByteString.Lazy.Char8 as LBS
+import Data.ByteString.Lazy.Char8 qualified as LBS
 import Data.Text (Text)
 import Options.Applicative (Alternative (..))
 

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Address/Info.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Address/Info.hs
@@ -5,18 +5,18 @@ module Cardano.CLI.EraBased.Run.Address.Info
   ( runAddressInfoCmd
   ) where
 
-import           Cardano.Api
+import Cardano.Api
 
-import           Cardano.CLI.Types.Errors.AddressInfoError
+import Cardano.CLI.Types.Errors.AddressInfoError
 
-import           Control.Monad.IO.Class (MonadIO (..))
-import           Control.Monad.Trans.Except (ExceptT)
-import           Control.Monad.Trans.Except.Extra (left)
-import           Data.Aeson (ToJSON (..), object, (.=))
-import           Data.Aeson.Encode.Pretty (encodePretty)
+import Control.Monad.IO.Class (MonadIO (..))
+import Control.Monad.Trans.Except (ExceptT)
+import Control.Monad.Trans.Except.Extra (left)
+import Data.Aeson (ToJSON (..), object, (.=))
+import Data.Aeson.Encode.Pretty (encodePretty)
 import qualified Data.ByteString.Lazy.Char8 as LBS
-import           Data.Text (Text)
-import           Options.Applicative (Alternative (..))
+import Data.Text (Text)
+import Options.Applicative (Alternative (..))
 
 data AddressInfo = AddressInfo
   { aiType :: !Text
@@ -38,32 +38,31 @@ instance ToJSON AddressInfo where
 
 runAddressInfoCmd :: Text -> Maybe (File () Out) -> ExceptT AddressInfoError IO ()
 runAddressInfoCmd addrTxt mOutputFp = do
-    addrInfo <- case (Left  <$> deserialiseAddress AsAddressAny addrTxt)
-                 <|> (Right <$> deserialiseAddress AsStakeAddress addrTxt) of
-
-      Nothing ->
-        left $ ShelleyAddressInvalid addrTxt
-
-      Just (Left (AddressByron payaddr)) ->
-            pure $ AddressInfo
-              { aiType = "payment"
-              , aiEra = "byron"
-              , aiEncoding = "base58"
-              , aiAddress = addrTxt
-              , aiBase16 = serialiseToRawBytesHexText payaddr
-              }
-
-      Just (Left (AddressShelley payaddr)) ->
-            pure $ AddressInfo
-              { aiType = "payment"
-              , aiEra = "shelley"
-              , aiEncoding = "bech32"
-              , aiAddress = addrTxt
-              , aiBase16 = serialiseToRawBytesHexText payaddr
-              }
-
-      Just (Right addr) ->
-        pure $ AddressInfo
+  addrInfo <- case (Left <$> deserialiseAddress AsAddressAny addrTxt)
+    <|> (Right <$> deserialiseAddress AsStakeAddress addrTxt) of
+    Nothing ->
+      left $ ShelleyAddressInvalid addrTxt
+    Just (Left (AddressByron payaddr)) ->
+      pure $
+        AddressInfo
+          { aiType = "payment"
+          , aiEra = "byron"
+          , aiEncoding = "base58"
+          , aiAddress = addrTxt
+          , aiBase16 = serialiseToRawBytesHexText payaddr
+          }
+    Just (Left (AddressShelley payaddr)) ->
+      pure $
+        AddressInfo
+          { aiType = "payment"
+          , aiEra = "shelley"
+          , aiEncoding = "bech32"
+          , aiAddress = addrTxt
+          , aiBase16 = serialiseToRawBytesHexText payaddr
+          }
+    Just (Right addr) ->
+      pure $
+        AddressInfo
           { aiType = "stake"
           , aiEra = "shelley"
           , aiEncoding = "bech32"
@@ -71,7 +70,6 @@ runAddressInfoCmd addrTxt mOutputFp = do
           , aiBase16 = serialiseToRawBytesHexText addr
           }
 
-    case mOutputFp of
-      Just (File fpath) -> liftIO $ LBS.writeFile fpath $ encodePretty addrInfo
-      Nothing -> liftIO $ LBS.putStrLn $ encodePretty addrInfo
-
+  case mOutputFp of
+    Just (File fpath) -> liftIO $ LBS.writeFile fpath $ encodePretty addrInfo
+    Nothing -> liftIO $ LBS.putStrLn $ encodePretty addrInfo

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Genesis.hs
@@ -5,13 +5,12 @@
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeApplications #-}
-
-{-# OPTIONS_GHC -Wno-unticked-promoted-constructors #-}
 {-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
-{-# LANGUAGE LambdaCase #-}
+{-# OPTIONS_GHC -Wno-unticked-promoted-constructors #-}
 
 {- HLINT ignore "Reduce duplication" -}
 {- HLINT ignore "Redundant <$>" -}
@@ -19,7 +18,6 @@
 
 module Cardano.CLI.EraBased.Run.Genesis
   ( runGenesisCmds
-
   , runGenesisAddrCmd
   , runGenesisCreateCardanoCmd
   , runGenesisCreateCmd
@@ -31,113 +29,130 @@ module Cardano.CLI.EraBased.Run.Genesis
   , runGenesisKeyHashCmd
   , runGenesisTxInCmd
   , runGenesisVerKeyCmd
-
   , readAndDecodeShelleyGenesis
 
-  -- * Protocol Parameters
+    -- * Protocol Parameters
   , readProtocolParameters
   ) where
 
-import           Cardano.Api
-import           Cardano.Api.Byron (toByronLovelace, toByronProtocolMagicId,
-                   toByronRequiresNetworkMagic)
-import           Cardano.Api.Shelley
+import Cardano.Api
+import Cardano.Api.Byron
+  ( toByronLovelace
+  , toByronProtocolMagicId
+  , toByronRequiresNetworkMagic
+  )
+import Cardano.Api.Shelley
 
-import           Cardano.Chain.Common (BlockCount (unBlockCount))
-import qualified Cardano.Chain.Common as Byron (KeyHash, mkKnownLovelace, rationalToLovelacePortion)
-import           Cardano.Chain.Delegation (delegateVK)
-import qualified Cardano.Chain.Delegation as Dlg
-import           Cardano.Chain.Genesis (FakeAvvmOptions (..), TestnetBalanceOptions (..),
-                   gdProtocolParameters, gsDlgIssuersSecrets, gsPoorSecrets, gsRichSecrets)
-import qualified Cardano.Chain.Genesis as Genesis
-import           Cardano.Chain.Update hiding (ProtocolParameters)
-import           Cardano.CLI.Byron.Delegation
-import           Cardano.CLI.Byron.Genesis as Byron
+import Cardano.CLI.Byron.Delegation
+import Cardano.CLI.Byron.Genesis as Byron
 import qualified Cardano.CLI.Byron.Key as Byron
-import           Cardano.CLI.EraBased.Commands.Genesis
-import           Cardano.CLI.EraBased.Run.Node (runNodeIssueOpCertCmd, runNodeKeyGenColdCmd,
-                   runNodeKeyGenKesCmd, runNodeKeyGenVrfCmd)
-import           Cardano.CLI.EraBased.Run.StakeAddress (runStakeAddressKeyGenCmd)
+import Cardano.CLI.EraBased.Commands.Genesis
+import Cardano.CLI.EraBased.Run.Node
+  ( runNodeIssueOpCertCmd
+  , runNodeKeyGenColdCmd
+  , runNodeKeyGenKesCmd
+  , runNodeKeyGenVrfCmd
+  )
+import Cardano.CLI.EraBased.Run.StakeAddress (runStakeAddressKeyGenCmd)
 import qualified Cardano.CLI.IO.Lazy as Lazy
-import           Cardano.CLI.Types.Common
-import           Cardano.CLI.Types.Errors.GenesisCmdError
-import           Cardano.CLI.Types.Errors.NodeCmdError
-import           Cardano.CLI.Types.Errors.ProtocolParamsError
-import           Cardano.CLI.Types.Errors.StakePoolCmdError
-import           Cardano.CLI.Types.Key
+import Cardano.CLI.Types.Common
+import Cardano.CLI.Types.Errors.GenesisCmdError
+import Cardano.CLI.Types.Errors.NodeCmdError
+import Cardano.CLI.Types.Errors.ProtocolParamsError
+import Cardano.CLI.Types.Errors.StakePoolCmdError
+import Cardano.CLI.Types.Key
+import Cardano.Chain.Common (BlockCount (unBlockCount))
+import qualified Cardano.Chain.Common as Byron (KeyHash, mkKnownLovelace, rationalToLovelacePortion)
+import Cardano.Chain.Delegation (delegateVK)
+import qualified Cardano.Chain.Delegation as Dlg
+import Cardano.Chain.Genesis
+  ( FakeAvvmOptions (..)
+  , TestnetBalanceOptions (..)
+  , gdProtocolParameters
+  , gsDlgIssuersSecrets
+  , gsPoorSecrets
+  , gsRichSecrets
+  )
+import qualified Cardano.Chain.Genesis as Genesis
+import Cardano.Chain.Update hiding (ProtocolParameters)
 import qualified Cardano.Crypto as CC
-import           Cardano.Crypto.Hash (HashAlgorithm)
+import Cardano.Crypto.Hash (HashAlgorithm)
 import qualified Cardano.Crypto.Hash as Crypto
 import qualified Cardano.Crypto.Hash as Hash
 import qualified Cardano.Crypto.Random as Crypto
 import qualified Cardano.Crypto.Signing as Byron
 import qualified Cardano.Ledger.Alonzo.Genesis as Alonzo
 import qualified Cardano.Ledger.BaseTypes as Ledger
-import           Cardano.Ledger.Binary (Annotated (Annotated), ToCBOR (..))
-import           Cardano.Ledger.Coin (Coin (..))
+import Cardano.Ledger.Binary (Annotated (Annotated), ToCBOR (..))
+import Cardano.Ledger.Coin (Coin (..))
 import qualified Cardano.Ledger.Conway.Genesis as Conway
-import           Cardano.Ledger.Core (ppMinUTxOValueL)
-import           Cardano.Ledger.Crypto (ADDRHASH, Crypto, StandardCrypto)
-import           Cardano.Ledger.Era ()
+import Cardano.Ledger.Core (ppMinUTxOValueL)
+import Cardano.Ledger.Crypto (ADDRHASH, Crypto, StandardCrypto)
+import Cardano.Ledger.Era ()
 import qualified Cardano.Ledger.Keys as Ledger
 import qualified Cardano.Ledger.Shelley.API as Ledger
-import           Cardano.Ledger.Shelley.Genesis (secondsToNominalDiffTimeMicro)
-import           Cardano.Prelude (canonicalEncodePretty)
-import           Cardano.Slotting.Slot (EpochSize (EpochSize))
-import           Ouroboros.Consensus.Shelley.Node (ShelleyGenesisStaking (..))
+import Cardano.Ledger.Shelley.Genesis (secondsToNominalDiffTimeMicro)
+import Cardano.Prelude (canonicalEncodePretty)
+import Cardano.Slotting.Slot (EpochSize (EpochSize))
+import Ouroboros.Consensus.Shelley.Node (ShelleyGenesisStaking (..))
 
-import           Control.DeepSeq (NFData, force)
-import           Control.Monad (forM, forM_, unless, when)
-import           Control.Monad.Except (MonadError (..), runExceptT)
-import           Control.Monad.IO.Class (MonadIO (..))
-import           Control.Monad.Trans.Except (ExceptT, throwE, withExceptT)
-import           Control.Monad.Trans.Except.Extra (firstExceptT, handleIOExceptT, hoistEither, left,
-                   newExceptT)
-import           Data.Aeson hiding (Key)
+import Control.DeepSeq (NFData, force)
+import Control.Monad (forM, forM_, unless, when)
+import Control.Monad.Except (MonadError (..), runExceptT)
+import Control.Monad.IO.Class (MonadIO (..))
+import Control.Monad.Trans.Except (ExceptT, throwE, withExceptT)
+import Control.Monad.Trans.Except.Extra
+  ( firstExceptT
+  , handleIOExceptT
+  , hoistEither
+  , left
+  , newExceptT
+  )
+import Data.Aeson hiding (Key)
 import qualified Data.Aeson as Aeson
-import           Data.Aeson.Encode.Pretty (encodePretty)
+import Data.Aeson.Encode.Pretty (encodePretty)
 import qualified Data.Aeson.KeyMap as Aeson
-import           Data.Bifunctor (Bifunctor (..))
+import Data.Bifunctor (Bifunctor (..))
 import qualified Data.Binary.Get as Bin
-import           Data.ByteString (ByteString)
+import Data.ByteString (ByteString)
 import qualified Data.ByteString.Char8 as BS
 import qualified Data.ByteString.Lazy.Char8 as LBS
-import           Data.Char (isDigit)
-import           Data.Coerce (coerce)
-import           Data.Data (Proxy (..))
-import           Data.Either (fromRight)
-import           Data.Fixed (Fixed (MkFixed))
-import           Data.Function (on)
-import           Data.Functor (void)
-import           Data.Functor.Identity
+import Data.Char (isDigit)
+import Data.Coerce (coerce)
+import Data.Data (Proxy (..))
+import Data.Either (fromRight)
+import Data.Fixed (Fixed (MkFixed))
+import Data.Function (on)
+import Data.Functor (void)
+import Data.Functor.Identity
 import qualified Data.List as List
 import qualified Data.List.Split as List
-import           Data.ListMap (ListMap (..))
+import Data.ListMap (ListMap (..))
 import qualified Data.ListMap as ListMap
-import           Data.Map.Strict (Map)
+import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import           Data.Maybe (fromMaybe)
+import Data.Maybe (fromMaybe)
 import qualified Data.Sequence.Strict as Seq
-import           Data.String (fromString)
-import           Data.Text (Text)
+import Data.String (fromString)
+import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
-import           Data.Time.Clock (NominalDiffTime, UTCTime, addUTCTime, getCurrentTime)
-import           Data.Word (Word64)
+import Data.Time.Clock (NominalDiffTime, UTCTime, addUTCTime, getCurrentTime)
+import Data.Word (Word64)
 import qualified Data.Yaml as Yaml
-import           GHC.Generics (Generic)
-import           Lens.Micro ((^.))
-import           System.Directory (createDirectoryIfMissing, listDirectory)
-import           System.FilePath (takeExtension, takeExtensions, (</>))
+import GHC.Generics (Generic)
+import Lens.Micro ((^.))
+import System.Directory (createDirectoryIfMissing, listDirectory)
+import System.FilePath (takeExtension, takeExtensions, (</>))
 import qualified System.IO as IO
-import           System.IO.Error (isDoesNotExistError)
+import System.IO.Error (isDoesNotExistError)
+import System.Random (StdGen)
 import qualified System.Random as Random
-import           System.Random (StdGen)
+import Text.JSON.Canonical (parseCanonicalJSON, renderCanonicalJSON)
 import qualified Text.JSON.Canonical (ToJSON)
-import           Text.JSON.Canonical (parseCanonicalJSON, renderCanonicalJSON)
-import           Text.Read (readMaybe)
+import Text.Read (readMaybe)
 
-import           Crypto.Random as Crypto
+import Crypto.Random as Crypto
 
 runGenesisCmds :: GenesisCmds era -> ExceptT GenesisCmdError IO ()
 runGenesisCmds = \case
@@ -164,190 +179,197 @@ runGenesisCmds = \case
   GenesisHashFile gf ->
     runGenesisHashFileCmd gf
 
-runGenesisKeyGenGenesisCmd ::
-     VerificationKeyFile Out
+runGenesisKeyGenGenesisCmd
+  :: VerificationKeyFile Out
   -> SigningKeyFile Out
   -> ExceptT GenesisCmdError IO ()
 runGenesisKeyGenGenesisCmd vkeyPath skeyPath = do
-    skey <- liftIO $ generateSigningKey AsGenesisKey
-    let vkey = getVerificationKey skey
-    firstExceptT GenesisCmdGenesisFileError
-      . newExceptT
-      $ writeLazyByteStringFile skeyPath
-      $ textEnvelopeToJSON (Just skeyDesc) skey
-    firstExceptT GenesisCmdGenesisFileError
-      . newExceptT
-      $ writeLazyByteStringFile vkeyPath
-      $ textEnvelopeToJSON (Just vkeyDesc) vkey
-  where
-    skeyDesc, vkeyDesc :: TextEnvelopeDescr
-    skeyDesc = "Genesis Signing Key"
-    vkeyDesc = "Genesis Verification Key"
+  skey <- liftIO $ generateSigningKey AsGenesisKey
+  let vkey = getVerificationKey skey
+  firstExceptT GenesisCmdGenesisFileError
+    . newExceptT
+    $ writeLazyByteStringFile skeyPath
+    $ textEnvelopeToJSON (Just skeyDesc) skey
+  firstExceptT GenesisCmdGenesisFileError
+    . newExceptT
+    $ writeLazyByteStringFile vkeyPath
+    $ textEnvelopeToJSON (Just vkeyDesc) vkey
+ where
+  skeyDesc, vkeyDesc :: TextEnvelopeDescr
+  skeyDesc = "Genesis Signing Key"
+  vkeyDesc = "Genesis Verification Key"
 
-
-runGenesisKeyGenDelegateCmd ::
-     VerificationKeyFile Out
+runGenesisKeyGenDelegateCmd
+  :: VerificationKeyFile Out
   -> SigningKeyFile Out
   -> OpCertCounterFile Out
   -> ExceptT GenesisCmdError IO ()
 runGenesisKeyGenDelegateCmd vkeyPath skeyPath ocertCtrPath = do
-    skey <- liftIO $ generateSigningKey AsGenesisDelegateKey
-    let vkey = getVerificationKey skey
-    firstExceptT GenesisCmdGenesisFileError
-      . newExceptT
-      $ writeLazyByteStringFile skeyPath
-      $ textEnvelopeToJSON (Just skeyDesc) skey
-    firstExceptT GenesisCmdGenesisFileError
-      . newExceptT
-      $ writeLazyByteStringFile vkeyPath
-      $ textEnvelopeToJSON (Just vkeyDesc) vkey
-    firstExceptT GenesisCmdGenesisFileError
-      . newExceptT
-      $ writeLazyByteStringFile ocertCtrPath
-      $ textEnvelopeToJSON (Just certCtrDesc)
-      $ OperationalCertificateIssueCounter
-          initialCounter
-          (castVerificationKey vkey)  -- Cast to a 'StakePoolKey'
-  where
-    skeyDesc, vkeyDesc, certCtrDesc :: TextEnvelopeDescr
-    skeyDesc = "Genesis delegate operator key"
-    vkeyDesc = "Genesis delegate operator key"
-    certCtrDesc = "Next certificate issue number: "
-               <> fromString (show initialCounter)
+  skey <- liftIO $ generateSigningKey AsGenesisDelegateKey
+  let vkey = getVerificationKey skey
+  firstExceptT GenesisCmdGenesisFileError
+    . newExceptT
+    $ writeLazyByteStringFile skeyPath
+    $ textEnvelopeToJSON (Just skeyDesc) skey
+  firstExceptT GenesisCmdGenesisFileError
+    . newExceptT
+    $ writeLazyByteStringFile vkeyPath
+    $ textEnvelopeToJSON (Just vkeyDesc) vkey
+  firstExceptT GenesisCmdGenesisFileError
+    . newExceptT
+    $ writeLazyByteStringFile ocertCtrPath
+    $ textEnvelopeToJSON (Just certCtrDesc)
+    $ OperationalCertificateIssueCounter
+      initialCounter
+      (castVerificationKey vkey) -- Cast to a 'StakePoolKey'
+ where
+  skeyDesc, vkeyDesc, certCtrDesc :: TextEnvelopeDescr
+  skeyDesc = "Genesis delegate operator key"
+  vkeyDesc = "Genesis delegate operator key"
+  certCtrDesc =
+    "Next certificate issue number: "
+      <> fromString (show initialCounter)
 
-    initialCounter :: Word64
-    initialCounter = 0
+  initialCounter :: Word64
+  initialCounter = 0
 
-
-runGenesisKeyGenDelegateVRF ::
-     VerificationKeyFile Out
+runGenesisKeyGenDelegateVRF
+  :: VerificationKeyFile Out
   -> SigningKeyFile Out
   -> ExceptT GenesisCmdError IO ()
 runGenesisKeyGenDelegateVRF vkeyPath skeyPath = do
-    skey <- liftIO $ generateSigningKey AsVrfKey
-    let vkey = getVerificationKey skey
-    firstExceptT GenesisCmdGenesisFileError
-      . newExceptT
-      $ writeLazyByteStringFile skeyPath
-      $ textEnvelopeToJSON (Just skeyDesc) skey
-    firstExceptT GenesisCmdGenesisFileError
-      . newExceptT
-      $ writeLazyByteStringFile vkeyPath
-      $ textEnvelopeToJSON (Just vkeyDesc) vkey
-  where
-    skeyDesc, vkeyDesc :: TextEnvelopeDescr
-    skeyDesc = "VRF Signing Key"
-    vkeyDesc = "VRF Verification Key"
+  skey <- liftIO $ generateSigningKey AsVrfKey
+  let vkey = getVerificationKey skey
+  firstExceptT GenesisCmdGenesisFileError
+    . newExceptT
+    $ writeLazyByteStringFile skeyPath
+    $ textEnvelopeToJSON (Just skeyDesc) skey
+  firstExceptT GenesisCmdGenesisFileError
+    . newExceptT
+    $ writeLazyByteStringFile vkeyPath
+    $ textEnvelopeToJSON (Just vkeyDesc) vkey
+ where
+  skeyDesc, vkeyDesc :: TextEnvelopeDescr
+  skeyDesc = "VRF Signing Key"
+  vkeyDesc = "VRF Verification Key"
 
-
-runGenesisKeyGenUTxOCmd ::
-     VerificationKeyFile Out
+runGenesisKeyGenUTxOCmd
+  :: VerificationKeyFile Out
   -> SigningKeyFile Out
   -> ExceptT GenesisCmdError IO ()
 runGenesisKeyGenUTxOCmd vkeyPath skeyPath = do
-    skey <- liftIO $ generateSigningKey AsGenesisUTxOKey
-    let vkey = getVerificationKey skey
-    firstExceptT GenesisCmdGenesisFileError
-      . newExceptT
-      $ writeLazyByteStringFile skeyPath
-      $ textEnvelopeToJSON (Just skeyDesc) skey
-    firstExceptT GenesisCmdGenesisFileError
-      . newExceptT
-      $ writeLazyByteStringFile vkeyPath
-      $ textEnvelopeToJSON (Just vkeyDesc) vkey
-  where
-    skeyDesc, vkeyDesc :: TextEnvelopeDescr
-    skeyDesc = "Genesis Initial UTxO Signing Key"
-    vkeyDesc = "Genesis Initial UTxO Verification Key"
-
+  skey <- liftIO $ generateSigningKey AsGenesisUTxOKey
+  let vkey = getVerificationKey skey
+  firstExceptT GenesisCmdGenesisFileError
+    . newExceptT
+    $ writeLazyByteStringFile skeyPath
+    $ textEnvelopeToJSON (Just skeyDesc) skey
+  firstExceptT GenesisCmdGenesisFileError
+    . newExceptT
+    $ writeLazyByteStringFile vkeyPath
+    $ textEnvelopeToJSON (Just vkeyDesc) vkey
+ where
+  skeyDesc, vkeyDesc :: TextEnvelopeDescr
+  skeyDesc = "Genesis Initial UTxO Signing Key"
+  vkeyDesc = "Genesis Initial UTxO Verification Key"
 
 runGenesisKeyHashCmd :: VerificationKeyFile In -> ExceptT GenesisCmdError IO ()
 runGenesisKeyHashCmd vkeyPath = do
-    vkey <- firstExceptT GenesisCmdTextEnvReadFileError . newExceptT $
-            readFileTextEnvelopeAnyOf
-              [ FromSomeType (AsVerificationKey AsGenesisKey)
-                             AGenesisKey
-              , FromSomeType (AsVerificationKey AsGenesisDelegateKey)
-                             AGenesisDelegateKey
-              , FromSomeType (AsVerificationKey AsGenesisUTxOKey)
-                             AGenesisUTxOKey
-              ]
-              vkeyPath
-    liftIO $ BS.putStrLn (renderKeyHash vkey)
-  where
-    renderKeyHash :: SomeGenesisKey VerificationKey -> ByteString
-    renderKeyHash (AGenesisKey         vk) = renderVerificationKeyHash vk
-    renderKeyHash (AGenesisDelegateKey vk) = renderVerificationKeyHash vk
-    renderKeyHash (AGenesisUTxOKey     vk) = renderVerificationKeyHash vk
+  vkey <-
+    firstExceptT GenesisCmdTextEnvReadFileError . newExceptT $
+      readFileTextEnvelopeAnyOf
+        [ FromSomeType
+            (AsVerificationKey AsGenesisKey)
+            AGenesisKey
+        , FromSomeType
+            (AsVerificationKey AsGenesisDelegateKey)
+            AGenesisDelegateKey
+        , FromSomeType
+            (AsVerificationKey AsGenesisUTxOKey)
+            AGenesisUTxOKey
+        ]
+        vkeyPath
+  liftIO $ BS.putStrLn (renderKeyHash vkey)
+ where
+  renderKeyHash :: SomeGenesisKey VerificationKey -> ByteString
+  renderKeyHash (AGenesisKey vk) = renderVerificationKeyHash vk
+  renderKeyHash (AGenesisDelegateKey vk) = renderVerificationKeyHash vk
+  renderKeyHash (AGenesisUTxOKey vk) = renderVerificationKeyHash vk
 
-    renderVerificationKeyHash :: Key keyrole => VerificationKey keyrole -> ByteString
-    renderVerificationKeyHash = serialiseToRawBytesHex
-                              . verificationKeyHash
+  renderVerificationKeyHash :: (Key keyrole) => VerificationKey keyrole -> ByteString
+  renderVerificationKeyHash =
+    serialiseToRawBytesHex
+      . verificationKeyHash
 
-
-runGenesisVerKeyCmd ::
-     VerificationKeyFile Out
+runGenesisVerKeyCmd
+  :: VerificationKeyFile Out
   -> SigningKeyFile In
   -> ExceptT GenesisCmdError IO ()
 runGenesisVerKeyCmd vkeyPath skeyPath = do
-    skey <- firstExceptT GenesisCmdTextEnvReadFileError . newExceptT $
-            readFileTextEnvelopeAnyOf
-              [ FromSomeType (AsSigningKey AsGenesisKey)
-                             AGenesisKey
-              , FromSomeType (AsSigningKey AsGenesisDelegateKey)
-                             AGenesisDelegateKey
-              , FromSomeType (AsSigningKey AsGenesisUTxOKey)
-                             AGenesisUTxOKey
-              ]
-              skeyPath
+  skey <-
+    firstExceptT GenesisCmdTextEnvReadFileError . newExceptT $
+      readFileTextEnvelopeAnyOf
+        [ FromSomeType
+            (AsSigningKey AsGenesisKey)
+            AGenesisKey
+        , FromSomeType
+            (AsSigningKey AsGenesisDelegateKey)
+            AGenesisDelegateKey
+        , FromSomeType
+            (AsSigningKey AsGenesisUTxOKey)
+            AGenesisUTxOKey
+        ]
+        skeyPath
 
-    let vkey :: SomeGenesisKey VerificationKey
-        vkey = case skey of
-          AGenesisKey         sk -> AGenesisKey         (getVerificationKey sk)
-          AGenesisDelegateKey sk -> AGenesisDelegateKey (getVerificationKey sk)
-          AGenesisUTxOKey     sk -> AGenesisUTxOKey     (getVerificationKey sk)
+  let vkey :: SomeGenesisKey VerificationKey
+      vkey = case skey of
+        AGenesisKey sk -> AGenesisKey (getVerificationKey sk)
+        AGenesisDelegateKey sk -> AGenesisDelegateKey (getVerificationKey sk)
+        AGenesisUTxOKey sk -> AGenesisUTxOKey (getVerificationKey sk)
 
-    firstExceptT GenesisCmdGenesisFileError . newExceptT . liftIO $
-      case vkey of
-        AGenesisKey         vk -> writeLazyByteStringFile vkeyPath $ textEnvelopeToJSON Nothing vk
-        AGenesisDelegateKey vk -> writeLazyByteStringFile vkeyPath $ textEnvelopeToJSON Nothing vk
-        AGenesisUTxOKey     vk -> writeLazyByteStringFile vkeyPath $ textEnvelopeToJSON Nothing vk
+  firstExceptT GenesisCmdGenesisFileError . newExceptT . liftIO $
+    case vkey of
+      AGenesisKey vk -> writeLazyByteStringFile vkeyPath $ textEnvelopeToJSON Nothing vk
+      AGenesisDelegateKey vk -> writeLazyByteStringFile vkeyPath $ textEnvelopeToJSON Nothing vk
+      AGenesisUTxOKey vk -> writeLazyByteStringFile vkeyPath $ textEnvelopeToJSON Nothing vk
 
 data SomeGenesisKey f
-     = AGenesisKey         (f GenesisKey)
-     | AGenesisDelegateKey (f GenesisDelegateKey)
-     | AGenesisUTxOKey     (f GenesisUTxOKey)
+  = AGenesisKey (f GenesisKey)
+  | AGenesisDelegateKey (f GenesisDelegateKey)
+  | AGenesisUTxOKey (f GenesisUTxOKey)
 
-
-runGenesisTxInCmd ::
-     VerificationKeyFile In
+runGenesisTxInCmd
+  :: VerificationKeyFile In
   -> NetworkId
   -> Maybe (File () Out)
   -> ExceptT GenesisCmdError IO ()
 runGenesisTxInCmd vkeyPath network mOutFile = do
-    vkey <- firstExceptT GenesisCmdTextEnvReadFileError . newExceptT $
-            readFileTextEnvelope (AsVerificationKey AsGenesisUTxOKey) vkeyPath
-    let txin = genesisUTxOPseudoTxIn network (verificationKeyHash vkey)
-    liftIO $ writeOutput mOutFile (renderTxIn txin)
+  vkey <-
+    firstExceptT GenesisCmdTextEnvReadFileError . newExceptT $
+      readFileTextEnvelope (AsVerificationKey AsGenesisUTxOKey) vkeyPath
+  let txin = genesisUTxOPseudoTxIn network (verificationKeyHash vkey)
+  liftIO $ writeOutput mOutFile (renderTxIn txin)
 
-
-runGenesisAddrCmd ::
-     VerificationKeyFile In
+runGenesisAddrCmd
+  :: VerificationKeyFile In
   -> NetworkId
   -> Maybe (File () Out)
   -> ExceptT GenesisCmdError IO ()
 runGenesisAddrCmd vkeyPath network mOutFile = do
-    vkey <- firstExceptT GenesisCmdTextEnvReadFileError . newExceptT $
-            readFileTextEnvelope (AsVerificationKey AsGenesisUTxOKey) vkeyPath
-    let vkh  = verificationKeyHash (castVerificationKey vkey)
-        addr = makeShelleyAddress network (PaymentCredentialByKey vkh)
-                                  NoStakeAddress
-    liftIO $ writeOutput mOutFile (serialiseAddress addr)
+  vkey <-
+    firstExceptT GenesisCmdTextEnvReadFileError . newExceptT $
+      readFileTextEnvelope (AsVerificationKey AsGenesisUTxOKey) vkeyPath
+  let vkh = verificationKeyHash (castVerificationKey vkey)
+      addr =
+        makeShelleyAddress
+          network
+          (PaymentCredentialByKey vkh)
+          NoStakeAddress
+  liftIO $ writeOutput mOutFile (serialiseAddress addr)
 
 writeOutput :: Maybe (File () Out) -> Text -> IO ()
 writeOutput (Just (File fpath)) = Text.writeFile fpath
-writeOutput Nothing                   = Text.putStrLn
-
+writeOutput Nothing = Text.putStrLn
 
 --
 -- Create Genesis command implementation
@@ -356,64 +378,79 @@ writeOutput Nothing                   = Text.putStrLn
 runGenesisCreateCmd
   :: KeyOutputFormat
   -> GenesisDir
-  -> Word  -- ^ num genesis & delegate keys to make
-  -> Word  -- ^ num utxo keys to make
+  -> Word
+  -- ^ num genesis & delegate keys to make
+  -> Word
+  -- ^ num utxo keys to make
   -> Maybe SystemStart
   -> Maybe Lovelace
   -> NetworkId
   -> ExceptT GenesisCmdError IO ()
 runGenesisCreateCmd
-    fmt (GenesisDir rootdir)
-    genNumGenesisKeys genNumUTxOKeys
-    mStart mAmount network = do
+  fmt
+  (GenesisDir rootdir)
+  genNumGenesisKeys
+  genNumUTxOKeys
+  mStart
+  mAmount
+  network = do
+    liftIO $ do
+      createDirectoryIfMissing False rootdir
+      createDirectoryIfMissing False gendir
+      createDirectoryIfMissing False deldir
+      createDirectoryIfMissing False utxodir
 
-  liftIO $ do
-    createDirectoryIfMissing False rootdir
-    createDirectoryIfMissing False gendir
-    createDirectoryIfMissing False deldir
-    createDirectoryIfMissing False utxodir
+    template <- readShelleyGenesisWithDefault (rootdir </> "genesis.spec.json") adjustTemplate
+    alonzoGenesis <- readAlonzoGenesis (rootdir </> "genesis.alonzo.spec.json")
+    conwayGenesis <- readConwayGenesis (rootdir </> "genesis.conway.spec.json")
 
-  template <- readShelleyGenesisWithDefault (rootdir </> "genesis.spec.json") adjustTemplate
-  alonzoGenesis <- readAlonzoGenesis (rootdir </> "genesis.alonzo.spec.json")
-  conwayGenesis <- readConwayGenesis (rootdir </> "genesis.conway.spec.json")
+    forM_ [1 .. genNumGenesisKeys] $ \index -> do
+      createGenesisKeys gendir index
+      createDelegateKeys fmt deldir index
 
-  forM_ [ 1 .. genNumGenesisKeys ] $ \index -> do
-    createGenesisKeys  gendir  index
-    createDelegateKeys fmt deldir index
+    forM_ [1 .. genNumUTxOKeys] $ \index ->
+      createUtxoKeys utxodir index
 
-  forM_ [ 1 .. genNumUTxOKeys ] $ \index ->
-    createUtxoKeys utxodir index
+    genDlgs <- readGenDelegsMap gendir deldir
+    utxoAddrs <- readInitialFundAddresses utxodir network
+    start <- maybe (SystemStart <$> getCurrentTimePlus30) pure mStart
 
-  genDlgs <- readGenDelegsMap gendir deldir
-  utxoAddrs <- readInitialFundAddresses utxodir network
-  start <- maybe (SystemStart <$> getCurrentTimePlus30) pure mStart
+    let shelleyGenesis =
+          updateTemplate
+            -- Shelley genesis parameters
+            start
+            genDlgs
+            mAmount
+            utxoAddrs
+            mempty
+            (Lovelace 0)
+            []
+            []
+            template
 
-  let shelleyGenesis =
-        updateTemplate
-          -- Shelley genesis parameters
-          start genDlgs mAmount utxoAddrs mempty (Lovelace 0) [] [] template
+    void $ writeFileGenesis (rootdir </> "genesis.json") $ WritePretty shelleyGenesis
+    void $ writeFileGenesis (rootdir </> "genesis.alonzo.json") $ WritePretty alonzoGenesis
+    void $ writeFileGenesis (rootdir </> "genesis.conway.json") $ WritePretty conwayGenesis
+   where
+    -- TODO: rationalise the naming convention on these genesis json files.
 
-  void $ writeFileGenesis (rootdir </> "genesis.json")        $ WritePretty shelleyGenesis
-  void $ writeFileGenesis (rootdir </> "genesis.alonzo.json") $ WritePretty alonzoGenesis
-  void $ writeFileGenesis (rootdir </> "genesis.conway.json") $ WritePretty conwayGenesis
-  --TODO: rationalise the naming convention on these genesis json files.
-  where
-    adjustTemplate t = t { sgNetworkMagic = unNetworkMagic (toNetworkMagic network) }
-    gendir  = rootdir </> "genesis-keys"
-    deldir  = rootdir </> "delegate-keys"
+    adjustTemplate t = t {sgNetworkMagic = unNetworkMagic (toNetworkMagic network)}
+    gendir = rootdir </> "genesis-keys"
+    deldir = rootdir </> "delegate-keys"
     utxodir = rootdir </> "utxo-keys"
 
-toSKeyJSON :: Key a => SigningKey a -> ByteString
+toSKeyJSON :: (Key a) => SigningKey a -> ByteString
 toSKeyJSON = LBS.toStrict . textEnvelopeToJSON Nothing
 
-toVkeyJSON :: ()
-  => Key a
-  => HasTypeProxy a
+toVkeyJSON
+  :: ()
+  => (Key a)
+  => (HasTypeProxy a)
   => SigningKey a
   -> ByteString
 toVkeyJSON = LBS.toStrict . textEnvelopeToJSON Nothing . getVerificationKey
 
-toVkeyJSON' :: Key a => VerificationKey a -> ByteString
+toVkeyJSON' :: (Key a) => VerificationKey a -> ByteString
 toVkeyJSON' = LBS.toStrict . textEnvelopeToJSON Nothing
 
 toOpCert :: (OperationalCertificate, OperationalCertificateIssueCounter) -> ByteString
@@ -422,12 +459,17 @@ toOpCert = LBS.toStrict . textEnvelopeToJSON Nothing . fst
 toCounter :: (OperationalCertificate, OperationalCertificateIssueCounter) -> ByteString
 toCounter = LBS.toStrict . textEnvelopeToJSON Nothing . snd
 
-generateShelleyNodeSecrets :: [SigningKey GenesisDelegateExtendedKey] -> [VerificationKey GenesisKey]
-    -> IO (Map (Hash GenesisKey)
-      ( Hash GenesisDelegateKey, Hash VrfKey)
+generateShelleyNodeSecrets
+  :: [SigningKey GenesisDelegateExtendedKey]
+  -> [VerificationKey GenesisKey]
+  -> IO
+      ( Map
+          (Hash GenesisKey)
+          (Hash GenesisDelegateKey, Hash VrfKey)
       , [SigningKey VrfKey]
       , [SigningKey KesKey]
-      , [(OperationalCertificate, OperationalCertificateIssueCounter)])
+      , [(OperationalCertificate, OperationalCertificateIssueCounter)]
+      )
 generateShelleyNodeSecrets shelleyDelegateKeys shelleyGenesisvkeys = do
   let
     shelleyDelegatevkeys :: [VerificationKey GenesisDelegateKey]
@@ -438,30 +480,41 @@ generateShelleyNodeSecrets shelleyDelegateKeys shelleyGenesisvkeys = do
   let
     opCertInputs :: [(VerificationKey KesKey, SigningKey GenesisDelegateExtendedKey)]
     opCertInputs = zip (map getVerificationKey kesKeys) shelleyDelegateKeys
-    createOpCert :: (VerificationKey KesKey, SigningKey GenesisDelegateExtendedKey) -> (OperationalCertificate, OperationalCertificateIssueCounter)
+    createOpCert
+      :: (VerificationKey KesKey, SigningKey GenesisDelegateExtendedKey)
+      -> (OperationalCertificate, OperationalCertificateIssueCounter)
     createOpCert (kesKey, delegateKey) = either (error . show) id eResult
-      where
-        eResult = issueOperationalCertificate kesKey (Right delegateKey) (KESPeriod 0) counter
-        counter = OperationalCertificateIssueCounter 0 (convert . getVerificationKey $ delegateKey)
-        convert :: VerificationKey GenesisDelegateExtendedKey
-                -> VerificationKey StakePoolKey
-        convert = (castVerificationKey :: VerificationKey GenesisDelegateKey
-                                       -> VerificationKey StakePoolKey)
-                . (castVerificationKey :: VerificationKey GenesisDelegateExtendedKey
-                                       -> VerificationKey GenesisDelegateKey)
+     where
+      eResult = issueOperationalCertificate kesKey (Right delegateKey) (KESPeriod 0) counter
+      counter = OperationalCertificateIssueCounter 0 (convert . getVerificationKey $ delegateKey)
+      convert
+        :: VerificationKey GenesisDelegateExtendedKey
+        -> VerificationKey StakePoolKey
+      convert =
+        ( castVerificationKey
+            :: VerificationKey GenesisDelegateKey
+            -> VerificationKey StakePoolKey
+        )
+          . ( castVerificationKey
+                :: VerificationKey GenesisDelegateExtendedKey
+                -> VerificationKey GenesisDelegateKey
+            )
 
     opCerts :: [(OperationalCertificate, OperationalCertificateIssueCounter)]
     opCerts = map createOpCert opCertInputs
 
     vrfvkeys = map getVerificationKey vrfKeys
-    combinedMap :: [ ( VerificationKey GenesisKey
-                     , VerificationKey GenesisDelegateKey
-                     , VerificationKey VrfKey
-                     )
-                   ]
+    combinedMap
+      :: [ ( VerificationKey GenesisKey
+           , VerificationKey GenesisDelegateKey
+           , VerificationKey VrfKey
+           )
+         ]
     combinedMap = zip3 shelleyGenesisvkeys shelleyDelegatevkeys vrfvkeys
-    hashKeys :: (VerificationKey GenesisKey, VerificationKey GenesisDelegateKey, VerificationKey VrfKey) -> (Hash GenesisKey, (Hash GenesisDelegateKey, Hash VrfKey))
-    hashKeys (genesis,delegate,vrf) = (verificationKeyHash genesis, (verificationKeyHash delegate, verificationKeyHash vrf));
+    hashKeys
+      :: (VerificationKey GenesisKey, VerificationKey GenesisDelegateKey, VerificationKey VrfKey)
+      -> (Hash GenesisKey, (Hash GenesisDelegateKey, Hash VrfKey))
+    hashKeys (genesis, delegate, vrf) = (verificationKeyHash genesis, (verificationKeyHash delegate, verificationKeyHash vrf))
     delegateMap :: Map (Hash GenesisKey) (Hash GenesisDelegateKey, Hash VrfKey)
     delegateMap = Map.fromList . map hashKeys $ combinedMap
 
@@ -471,124 +524,158 @@ generateShelleyNodeSecrets shelleyDelegateKeys shelleyGenesisvkeys = do
 -- Create Genesis Cardano command implementation
 --
 
-runGenesisCreateCardanoCmd :: GenesisDir
-                 -> Word  -- ^ num genesis & delegate keys to make
-                 -> Word  -- ^ num utxo keys to make
-                 -> Maybe SystemStart
-                 -> Maybe Lovelace
-                 -> BlockCount
-                 -> Word     -- ^ slot length in ms
-                 -> Rational
-                 -> NetworkId
-                 -> FilePath -- ^ Byron Genesis
-                 -> FilePath -- ^ Shelley Genesis
-                 -> FilePath -- ^ Alonzo Genesis
-                 -> FilePath -- ^ Conway Genesis
-                 -> Maybe FilePath
-                 -> ExceptT GenesisCmdError IO ()
-runGenesisCreateCardanoCmd (GenesisDir rootdir)
-                 genNumGenesisKeys genNumUTxOKeys
-                 mStart mAmount mSecurity slotLength mSlotCoeff
-                 network byronGenesisT shelleyGenesisT alonzoGenesisT conwayGenesisT mNodeCfg = do
-  start <- maybe (SystemStart <$> getCurrentTimePlus30) pure mStart
-  (byronGenesis', byronSecrets) <- convertToShelleyError $ Byron.mkGenesis $ byronParams start
-  let
-    byronGenesis = byronGenesis'
-      { gdProtocolParameters = (gdProtocolParameters byronGenesis') {
-          ppSlotDuration = floor ( toRational slotLength * recip mSlotCoeff )
-        }
-      }
+runGenesisCreateCardanoCmd
+  :: GenesisDir
+  -> Word
+  -- ^ num genesis & delegate keys to make
+  -> Word
+  -- ^ num utxo keys to make
+  -> Maybe SystemStart
+  -> Maybe Lovelace
+  -> BlockCount
+  -> Word
+  -- ^ slot length in ms
+  -> Rational
+  -> NetworkId
+  -> FilePath
+  -- ^ Byron Genesis
+  -> FilePath
+  -- ^ Shelley Genesis
+  -> FilePath
+  -- ^ Alonzo Genesis
+  -> FilePath
+  -- ^ Conway Genesis
+  -> Maybe FilePath
+  -> ExceptT GenesisCmdError IO ()
+runGenesisCreateCardanoCmd
+  (GenesisDir rootdir)
+  genNumGenesisKeys
+  genNumUTxOKeys
+  mStart
+  mAmount
+  mSecurity
+  slotLength
+  mSlotCoeff
+  network
+  byronGenesisT
+  shelleyGenesisT
+  alonzoGenesisT
+  conwayGenesisT
+  mNodeCfg = do
+    start <- maybe (SystemStart <$> getCurrentTimePlus30) pure mStart
+    (byronGenesis', byronSecrets) <- convertToShelleyError $ Byron.mkGenesis $ byronParams start
+    let
+      byronGenesis =
+        byronGenesis'
+          { gdProtocolParameters =
+              (gdProtocolParameters byronGenesis')
+                { ppSlotDuration = floor (toRational slotLength * recip mSlotCoeff)
+                }
+          }
 
-    genesisKeys = gsDlgIssuersSecrets byronSecrets
-    byronGenesisKeys = map ByronSigningKey genesisKeys
-    shelleyGenesisKeys = map convertGenesisKey genesisKeys
-    shelleyGenesisvkeys :: [VerificationKey GenesisKey]
-    shelleyGenesisvkeys = map (castVerificationKey . getVerificationKey) shelleyGenesisKeys
+      genesisKeys = gsDlgIssuersSecrets byronSecrets
+      byronGenesisKeys = map ByronSigningKey genesisKeys
+      shelleyGenesisKeys = map convertGenesisKey genesisKeys
+      shelleyGenesisvkeys :: [VerificationKey GenesisKey]
+      shelleyGenesisvkeys = map (castVerificationKey . getVerificationKey) shelleyGenesisKeys
 
-    delegateKeys = gsRichSecrets byronSecrets
-    byronDelegateKeys = map ByronSigningKey delegateKeys
-    shelleyDelegateKeys :: [SigningKey GenesisDelegateExtendedKey]
-    shelleyDelegateKeys = map convertDelegate delegateKeys
-    shelleyDelegatevkeys :: [VerificationKey GenesisDelegateKey]
-    shelleyDelegatevkeys = map (castVerificationKey . getVerificationKey) shelleyDelegateKeys
+      delegateKeys = gsRichSecrets byronSecrets
+      byronDelegateKeys = map ByronSigningKey delegateKeys
+      shelleyDelegateKeys :: [SigningKey GenesisDelegateExtendedKey]
+      shelleyDelegateKeys = map convertDelegate delegateKeys
+      shelleyDelegatevkeys :: [VerificationKey GenesisDelegateKey]
+      shelleyDelegatevkeys = map (castVerificationKey . getVerificationKey) shelleyDelegateKeys
 
-    utxoKeys = gsPoorSecrets byronSecrets
-    byronUtxoKeys = map (ByronSigningKey . Genesis.poorSecretToKey) utxoKeys
-    shelleyUtxoKeys = map (convertPoor . Genesis.poorSecretToKey) utxoKeys
+      utxoKeys = gsPoorSecrets byronSecrets
+      byronUtxoKeys = map (ByronSigningKey . Genesis.poorSecretToKey) utxoKeys
+      shelleyUtxoKeys = map (convertPoor . Genesis.poorSecretToKey) utxoKeys
 
-  dlgCerts <- convertToShelleyError $ mapM (findDelegateCert byronGenesis) byronDelegateKeys
-  let
-    overrideShelleyGenesis t = t
-      { sgNetworkMagic = unNetworkMagic (toNetworkMagic network)
-      , sgNetworkId = toShelleyNetwork network
-      , sgActiveSlotsCoeff = fromMaybe (error $ "Could not convert from Rational: " ++ show mSlotCoeff) $ Ledger.boundRational mSlotCoeff
-      , sgSecurityParam = unBlockCount mSecurity
-      , sgUpdateQuorum = fromIntegral $ ((genNumGenesisKeys `div` 3) * 2) + 1
-      , sgEpochLength = EpochSize $ floor $ (fromIntegral (unBlockCount mSecurity) * 10) / mSlotCoeff
-      , sgMaxLovelaceSupply = 45000000000000000
-      , sgSystemStart = getSystemStart start
-      , sgSlotLength = secondsToNominalDiffTimeMicro $ MkFixed (fromIntegral slotLength) * 1000
-      }
-  shelleyGenesisTemplate <- liftIO $ overrideShelleyGenesis . fromRight (error "shelley genesis template not found") <$> readAndDecodeShelleyGenesis shelleyGenesisT
-  alonzoGenesis <- readAlonzoGenesis alonzoGenesisT
-  conwayGenesis <- readConwayGenesis conwayGenesisT
-  (delegateMap, vrfKeys, kesKeys, opCerts) <- liftIO $ generateShelleyNodeSecrets shelleyDelegateKeys shelleyGenesisvkeys
-  let
-    shelleyGenesis :: ShelleyGenesis StandardCrypto
-    shelleyGenesis = updateTemplate start delegateMap Nothing [] mempty 0 [] [] shelleyGenesisTemplate
+    dlgCerts <- convertToShelleyError $ mapM (findDelegateCert byronGenesis) byronDelegateKeys
+    let
+      overrideShelleyGenesis t =
+        t
+          { sgNetworkMagic = unNetworkMagic (toNetworkMagic network)
+          , sgNetworkId = toShelleyNetwork network
+          , sgActiveSlotsCoeff =
+              fromMaybe (error $ "Could not convert from Rational: " ++ show mSlotCoeff) $
+                Ledger.boundRational mSlotCoeff
+          , sgSecurityParam = unBlockCount mSecurity
+          , sgUpdateQuorum = fromIntegral $ ((genNumGenesisKeys `div` 3) * 2) + 1
+          , sgEpochLength = EpochSize $ floor $ (fromIntegral (unBlockCount mSecurity) * 10) / mSlotCoeff
+          , sgMaxLovelaceSupply = 45000000000000000
+          , sgSystemStart = getSystemStart start
+          , sgSlotLength = secondsToNominalDiffTimeMicro $ MkFixed (fromIntegral slotLength) * 1000
+          }
+    shelleyGenesisTemplate <-
+      liftIO $
+        overrideShelleyGenesis . fromRight (error "shelley genesis template not found")
+          <$> readAndDecodeShelleyGenesis shelleyGenesisT
+    alonzoGenesis <- readAlonzoGenesis alonzoGenesisT
+    conwayGenesis <- readConwayGenesis conwayGenesisT
+    (delegateMap, vrfKeys, kesKeys, opCerts) <-
+      liftIO $ generateShelleyNodeSecrets shelleyDelegateKeys shelleyGenesisvkeys
+    let
+      shelleyGenesis :: ShelleyGenesis StandardCrypto
+      shelleyGenesis = updateTemplate start delegateMap Nothing [] mempty 0 [] [] shelleyGenesisTemplate
 
-  liftIO $ do
-    createDirectoryIfMissing False rootdir
-    createDirectoryIfMissing False gendir
-    createDirectoryIfMissing False deldir
-    createDirectoryIfMissing False utxodir
+    liftIO $ do
+      createDirectoryIfMissing False rootdir
+      createDirectoryIfMissing False gendir
+      createDirectoryIfMissing False deldir
+      createDirectoryIfMissing False utxodir
 
-    writeSecrets gendir "byron" "key" serialiseToRawBytes byronGenesisKeys
-    writeSecrets gendir "shelley" "skey" toSKeyJSON shelleyGenesisKeys
-    writeSecrets gendir "shelley" "vkey" toVkeyJSON shelleyGenesisKeys
+      writeSecrets gendir "byron" "key" serialiseToRawBytes byronGenesisKeys
+      writeSecrets gendir "shelley" "skey" toSKeyJSON shelleyGenesisKeys
+      writeSecrets gendir "shelley" "vkey" toVkeyJSON shelleyGenesisKeys
 
-    writeSecrets deldir "byron" "key" serialiseToRawBytes byronDelegateKeys
-    writeSecrets deldir "shelley" "skey" toSKeyJSON shelleyDelegateKeys
-    writeSecrets deldir "shelley" "vkey" toVkeyJSON' shelleyDelegatevkeys
-    writeSecrets deldir "shelley" "vrf.skey" toSKeyJSON vrfKeys
-    writeSecrets deldir "shelley" "vrf.vkey" toVkeyJSON vrfKeys
-    writeSecrets deldir "shelley" "kes.skey" toSKeyJSON kesKeys
-    writeSecrets deldir "shelley" "kes.vkey" toVkeyJSON kesKeys
+      writeSecrets deldir "byron" "key" serialiseToRawBytes byronDelegateKeys
+      writeSecrets deldir "shelley" "skey" toSKeyJSON shelleyDelegateKeys
+      writeSecrets deldir "shelley" "vkey" toVkeyJSON' shelleyDelegatevkeys
+      writeSecrets deldir "shelley" "vrf.skey" toSKeyJSON vrfKeys
+      writeSecrets deldir "shelley" "vrf.vkey" toVkeyJSON vrfKeys
+      writeSecrets deldir "shelley" "kes.skey" toSKeyJSON kesKeys
+      writeSecrets deldir "shelley" "kes.vkey" toVkeyJSON kesKeys
 
-    writeSecrets utxodir "byron" "key" serialiseToRawBytes byronUtxoKeys
-    writeSecrets utxodir "shelley" "skey" toSKeyJSON shelleyUtxoKeys
-    writeSecrets utxodir "shelley" "vkey" toVkeyJSON shelleyUtxoKeys
+      writeSecrets utxodir "byron" "key" serialiseToRawBytes byronUtxoKeys
+      writeSecrets utxodir "shelley" "skey" toSKeyJSON shelleyUtxoKeys
+      writeSecrets utxodir "shelley" "vkey" toVkeyJSON shelleyUtxoKeys
 
-    writeSecrets deldir "byron" "cert.json" serialiseDelegationCert dlgCerts
+      writeSecrets deldir "byron" "cert.json" serialiseDelegationCert dlgCerts
 
-    writeSecrets deldir "shelley" "opcert.json" toOpCert opCerts
-    writeSecrets deldir "shelley" "counter.json" toCounter opCerts
+      writeSecrets deldir "shelley" "opcert.json" toOpCert opCerts
+      writeSecrets deldir "shelley" "counter.json" toCounter opCerts
 
-  byronGenesisHash <- writeFileGenesis (rootdir </> "byron-genesis.json") $ WriteCanonical byronGenesis
-  shelleyGenesisHash <- writeFileGenesis (rootdir </> "shelley-genesis.json") $ WritePretty shelleyGenesis
-  alonzoGenesisHash <- writeFileGenesis (rootdir </> "alonzo-genesis.json") $ WritePretty alonzoGenesis
-  conwayGenesisHash <- writeFileGenesis (rootdir </> "conway-genesis.json") $ WritePretty conwayGenesis
+    byronGenesisHash <-
+      writeFileGenesis (rootdir </> "byron-genesis.json") $ WriteCanonical byronGenesis
+    shelleyGenesisHash <-
+      writeFileGenesis (rootdir </> "shelley-genesis.json") $ WritePretty shelleyGenesis
+    alonzoGenesisHash <-
+      writeFileGenesis (rootdir </> "alonzo-genesis.json") $ WritePretty alonzoGenesis
+    conwayGenesisHash <-
+      writeFileGenesis (rootdir </> "conway-genesis.json") $ WritePretty conwayGenesis
 
-  liftIO $ do
-    case mNodeCfg of
-      Nothing -> pure ()
-      Just nodeCfg -> do
-        nodeConfig <- Yaml.decodeFileThrow nodeCfg
-        let
-          setHash field hash = Aeson.insert field $ String $ Crypto.hashToTextAsHex hash
-          updateConfig :: Yaml.Value -> Yaml.Value
-          updateConfig (Object obj) = Object
-              $ setHash "ByronGenesisHash" byronGenesisHash
-              $ setHash "ShelleyGenesisHash" shelleyGenesisHash
-              $ setHash "AlonzoGenesisHash" alonzoGenesisHash
-              $ setHash "ConwayGenesisHash" conwayGenesisHash
-              obj
-          updateConfig x = x
-          newConfig :: Yaml.Value
-          newConfig = updateConfig nodeConfig
-        encodeFile (rootdir </> "node-config.json") newConfig
-
-  where
+    liftIO $ do
+      case mNodeCfg of
+        Nothing -> pure ()
+        Just nodeCfg -> do
+          nodeConfig <- Yaml.decodeFileThrow nodeCfg
+          let
+            setHash field hash = Aeson.insert field $ String $ Crypto.hashToTextAsHex hash
+            updateConfig :: Yaml.Value -> Yaml.Value
+            updateConfig (Object obj) =
+              Object $
+                setHash "ByronGenesisHash" byronGenesisHash $
+                  setHash "ShelleyGenesisHash" shelleyGenesisHash $
+                    setHash "AlonzoGenesisHash" alonzoGenesisHash $
+                      setHash
+                        "ConwayGenesisHash"
+                        conwayGenesisHash
+                        obj
+            updateConfig x = x
+            newConfig :: Yaml.Value
+            newConfig = updateConfig nodeConfig
+          encodeFile (rootdir </> "node-config.json") newConfig
+   where
     convertToShelleyError = withExceptT GenesisCmdByronError
     convertGenesisKey :: Byron.SigningKey -> SigningKey GenesisExtendedKey
     convertGenesisKey (Byron.SigningKey xsk) = GenesisExtendedSigningKey xsk
@@ -599,20 +686,32 @@ runGenesisCreateCardanoCmd (GenesisDir rootdir)
     convertPoor :: Byron.SigningKey -> SigningKey ByronKey
     convertPoor = ByronSigningKey
 
-    byronParams start = Byron.GenesisParameters (getSystemStart start) byronGenesisT mSecurity byronNetwork byronBalance byronFakeAvvm byronAvvmFactor Nothing
-    gendir  = rootdir </> "genesis-keys"
-    deldir  = rootdir </> "delegate-keys"
+    byronParams start =
+      Byron.GenesisParameters
+        (getSystemStart start)
+        byronGenesisT
+        mSecurity
+        byronNetwork
+        byronBalance
+        byronFakeAvvm
+        byronAvvmFactor
+        Nothing
+    gendir = rootdir </> "genesis-keys"
+    deldir = rootdir </> "delegate-keys"
     utxodir = rootdir </> "utxo-keys"
-    byronNetwork = CC.AProtocolMagic
-                      (Annotated (toByronProtocolMagicId network) ())
-                      (toByronRequiresNetworkMagic network)
-    byronBalance = TestnetBalanceOptions
+    byronNetwork =
+      CC.AProtocolMagic
+        (Annotated (toByronProtocolMagicId network) ())
+        (toByronRequiresNetworkMagic network)
+    byronBalance =
+      TestnetBalanceOptions
         { tboRichmen = genNumGenesisKeys
         , tboPoors = genNumUTxOKeys
         , tboTotalBalance = fromMaybe zeroLovelace $ toByronLovelace (fromMaybe 0 mAmount)
         , tboRichmenShare = 0
         }
-    byronFakeAvvm = FakeAvvmOptions
+    byronFakeAvvm =
+      FakeAvvmOptions
         { faoCount = 0
         , faoOneBalance = zeroLovelace
         }
@@ -623,159 +722,214 @@ runGenesisCreateCardanoCmd (GenesisDir rootdir)
     isCertForSK :: CC.SigningKey -> Dlg.Certificate -> Bool
     isCertForSK sk cert = delegateVK cert == CC.toVerification sk
 
-    findDelegateCert :: Genesis.GenesisData -> SigningKey ByronKey -> ExceptT ByronGenesisError IO Dlg.Certificate
+    findDelegateCert
+      :: Genesis.GenesisData -> SigningKey ByronKey -> ExceptT ByronGenesisError IO Dlg.Certificate
     findDelegateCert byronGenesis bSkey@(ByronSigningKey sk) = do
       case List.find (isCertForSK sk) (Map.elems $ dlgCertMap byronGenesis) of
-        Nothing -> throwE . NoGenesisDelegationForKey
-                   . Byron.prettyPublicKey $ getVerificationKey bSkey
-        Just x  -> pure x
+        Nothing ->
+          throwE
+            . NoGenesisDelegationForKey
+            . Byron.prettyPublicKey
+            $ getVerificationKey bSkey
+        Just x -> pure x
 
     dlgCertMap :: Genesis.GenesisData -> Map Byron.KeyHash Dlg.Certificate
     dlgCertMap byronGenesis = Genesis.unGenesisDelegation $ Genesis.gdHeavyDelegation byronGenesis
 
 runGenesisCreateStakedCmd
-  :: KeyOutputFormat    -- ^ key output format
+  :: KeyOutputFormat
+  -- ^ key output format
   -> GenesisDir
-  -> Word               -- ^ num genesis & delegate keys to make
-  -> Word               -- ^ num utxo keys to make
-  -> Word               -- ^ num pools to make
-  -> Word               -- ^ num delegators to make
+  -> Word
+  -- ^ num genesis & delegate keys to make
+  -> Word
+  -- ^ num utxo keys to make
+  -> Word
+  -- ^ num pools to make
+  -> Word
+  -- ^ num delegators to make
   -> Maybe SystemStart
-  -> Maybe Lovelace     -- ^ supply going to non-delegators
-  -> Lovelace           -- ^ supply going to delegators
+  -> Maybe Lovelace
+  -- ^ supply going to non-delegators
+  -> Lovelace
+  -- ^ supply going to delegators
   -> NetworkId
-  -> Word               -- ^ bulk credential files to write
-  -> Word               -- ^ pool credentials per bulk file
-  -> Word               -- ^ num stuffed UTxO entries
-  -> Maybe FilePath     -- ^ Specified stake pool relays
+  -> Word
+  -- ^ bulk credential files to write
+  -> Word
+  -- ^ pool credentials per bulk file
+  -> Word
+  -- ^ num stuffed UTxO entries
+  -> Maybe FilePath
+  -- ^ Specified stake pool relays
   -> ExceptT GenesisCmdError IO ()
 runGenesisCreateStakedCmd
-    fmt (GenesisDir rootdir)
-    genNumGenesisKeys genNumUTxOKeys genNumPools genNumStDelegs
-    mStart mNonDlgAmount stDlgAmount network
-    numBulkPoolCredFiles bulkPoolsPerFile numStuffedUtxo
-    sPoolRelayFp = do
-  liftIO $ do
-    createDirectoryIfMissing False rootdir
-    createDirectoryIfMissing False gendir
-    createDirectoryIfMissing False deldir
-    createDirectoryIfMissing False pooldir
-    createDirectoryIfMissing False stdeldir
-    createDirectoryIfMissing False utxodir
+  fmt
+  (GenesisDir rootdir)
+  genNumGenesisKeys
+  genNumUTxOKeys
+  genNumPools
+  genNumStDelegs
+  mStart
+  mNonDlgAmount
+  stDlgAmount
+  network
+  numBulkPoolCredFiles
+  bulkPoolsPerFile
+  numStuffedUtxo
+  sPoolRelayFp = do
+    liftIO $ do
+      createDirectoryIfMissing False rootdir
+      createDirectoryIfMissing False gendir
+      createDirectoryIfMissing False deldir
+      createDirectoryIfMissing False pooldir
+      createDirectoryIfMissing False stdeldir
+      createDirectoryIfMissing False utxodir
 
-  template <- readShelleyGenesisWithDefault (rootdir </> "genesis.spec.json") adjustTemplate
-  alonzoGenesis <- readAlonzoGenesis (rootdir </> "genesis.alonzo.spec.json")
-  conwayGenesis <- readConwayGenesis (rootdir </> "genesis.conway.spec.json")
+    template <- readShelleyGenesisWithDefault (rootdir </> "genesis.spec.json") adjustTemplate
+    alonzoGenesis <- readAlonzoGenesis (rootdir </> "genesis.alonzo.spec.json")
+    conwayGenesis <- readConwayGenesis (rootdir </> "genesis.conway.spec.json")
 
-  forM_ [ 1 .. genNumGenesisKeys ] $ \index -> do
-    createGenesisKeys gendir index
-    createDelegateKeys fmt deldir index
+    forM_ [1 .. genNumGenesisKeys] $ \index -> do
+      createGenesisKeys gendir index
+      createDelegateKeys fmt deldir index
 
-  forM_ [ 1 .. genNumUTxOKeys ] $ \index ->
-    createUtxoKeys utxodir index
+    forM_ [1 .. genNumUTxOKeys] $ \index ->
+      createUtxoKeys utxodir index
 
-  mayStakePoolRelays
-    <- forM sPoolRelayFp $
-       \fp -> do
-         relaySpecJsonBs <-
-           handleIOExceptT (GenesisCmdStakePoolRelayFileError fp) (LBS.readFile fp)
-         firstExceptT (GenesisCmdStakePoolRelayJsonDecodeError fp)
-           . hoistEither $ Aeson.eitherDecode relaySpecJsonBs
+    mayStakePoolRelays <-
+      forM sPoolRelayFp $
+        \fp -> do
+          relaySpecJsonBs <-
+            handleIOExceptT (GenesisCmdStakePoolRelayFileError fp) (LBS.readFile fp)
+          firstExceptT (GenesisCmdStakePoolRelayJsonDecodeError fp)
+            . hoistEither
+            $ Aeson.eitherDecode relaySpecJsonBs
 
-  poolParams <- forM [ 1 .. genNumPools ] $ \index -> do
-    createPoolCredentials fmt pooldir index
-    buildPoolParams network pooldir index (fromMaybe mempty mayStakePoolRelays)
+    poolParams <- forM [1 .. genNumPools] $ \index -> do
+      createPoolCredentials fmt pooldir index
+      buildPoolParams network pooldir index (fromMaybe mempty mayStakePoolRelays)
 
-  when (numBulkPoolCredFiles * bulkPoolsPerFile > genNumPools) $
-    left $ GenesisCmdTooFewPoolsForBulkCreds  genNumPools numBulkPoolCredFiles bulkPoolsPerFile
-  -- We generate the bulk files for the last pool indices,
-  -- so that all the non-bulk pools have stable indices at beginning:
-  let bulkOffset  = fromIntegral $ genNumPools - numBulkPoolCredFiles * bulkPoolsPerFile
-      bulkIndices :: [Word]   = [ 1 + bulkOffset .. genNumPools ]
-      bulkSlices  :: [[Word]] = List.chunksOf (fromIntegral bulkPoolsPerFile) bulkIndices
-  forM_ (zip [ 1 .. numBulkPoolCredFiles ] bulkSlices) $
-    uncurry (writeBulkPoolCredentials pooldir)
+    when (numBulkPoolCredFiles * bulkPoolsPerFile > genNumPools) $
+      left $
+        GenesisCmdTooFewPoolsForBulkCreds genNumPools numBulkPoolCredFiles bulkPoolsPerFile
+    -- We generate the bulk files for the last pool indices,
+    -- so that all the non-bulk pools have stable indices at beginning:
+    let bulkOffset = fromIntegral $ genNumPools - numBulkPoolCredFiles * bulkPoolsPerFile
+        bulkIndices :: [Word] = [1 + bulkOffset .. genNumPools]
+        bulkSlices :: [[Word]] = List.chunksOf (fromIntegral bulkPoolsPerFile) bulkIndices
+    forM_ (zip [1 .. numBulkPoolCredFiles] bulkSlices) $
+      uncurry (writeBulkPoolCredentials pooldir)
 
-  let (delegsPerPool, delegsRemaining) = divMod genNumStDelegs genNumPools
-      delegsForPool poolIx = if delegsRemaining /= 0 && poolIx == genNumPools
-        then delegsPerPool
-        else delegsPerPool + delegsRemaining
-      distribution = [pool | (pool, poolIx) <- zip poolParams [1 ..], _ <- [1 .. delegsForPool poolIx]]
+    let (delegsPerPool, delegsRemaining) = divMod genNumStDelegs genNumPools
+        delegsForPool poolIx =
+          if delegsRemaining /= 0 && poolIx == genNumPools
+            then delegsPerPool
+            else delegsPerPool + delegsRemaining
+        distribution = [pool | (pool, poolIx) <- zip poolParams [1 ..], _ <- [1 .. delegsForPool poolIx]]
 
-  g <- Random.getStdGen
+    g <- Random.getStdGen
 
-  -- Distribute M delegates across N pools:
-  delegations <- liftIO $ Lazy.forStateM g distribution $ flip computeInsecureDelegation network
+    -- Distribute M delegates across N pools:
+    delegations <- liftIO $ Lazy.forStateM g distribution $ flip computeInsecureDelegation network
 
-  let numDelegations = length delegations
+    let numDelegations = length delegations
 
-  genDlgs <- readGenDelegsMap gendir deldir
-  nonDelegAddrs <- readInitialFundAddresses utxodir network
-  start <- maybe (SystemStart <$> getCurrentTimePlus30) pure mStart
+    genDlgs <- readGenDelegsMap gendir deldir
+    nonDelegAddrs <- readInitialFundAddresses utxodir network
+    start <- maybe (SystemStart <$> getCurrentTimePlus30) pure mStart
 
-  stuffedUtxoAddrs <- liftIO $ Lazy.replicateM (fromIntegral numStuffedUtxo) genStuffedAddress
+    stuffedUtxoAddrs <- liftIO $ Lazy.replicateM (fromIntegral numStuffedUtxo) genStuffedAddress
 
-  let stake = second Ledger.ppId . mkDelegationMapEntry <$> delegations
-      stakePools = [ (Ledger.ppId poolParams', poolParams') | poolParams' <- snd . mkDelegationMapEntry <$> delegations ]
-      delegAddrs = dInitialUtxoAddr <$> delegations
-      !shelleyGenesis =
-        updateCreateStakedOutputTemplate
-          -- Shelley genesis parameters
-          start genDlgs mNonDlgAmount (length nonDelegAddrs) nonDelegAddrs stakePools stake
-          stDlgAmount numDelegations delegAddrs stuffedUtxoAddrs template
+    let stake = second Ledger.ppId . mkDelegationMapEntry <$> delegations
+        stakePools =
+          [ (Ledger.ppId poolParams', poolParams') | poolParams' <- snd . mkDelegationMapEntry <$> delegations
+          ]
+        delegAddrs = dInitialUtxoAddr <$> delegations
+        !shelleyGenesis =
+          updateCreateStakedOutputTemplate
+            -- Shelley genesis parameters
+            start
+            genDlgs
+            mNonDlgAmount
+            (length nonDelegAddrs)
+            nonDelegAddrs
+            stakePools
+            stake
+            stDlgAmount
+            numDelegations
+            delegAddrs
+            stuffedUtxoAddrs
+            template
 
-  liftIO $ LBS.writeFile (rootdir </> "genesis.json") $ Aeson.encode shelleyGenesis
+    liftIO $ LBS.writeFile (rootdir </> "genesis.json") $ Aeson.encode shelleyGenesis
 
-  void $ writeFileGenesis (rootdir </> "genesis.alonzo.json") $ WritePretty alonzoGenesis
-  void $ writeFileGenesis (rootdir </> "genesis.conway.json") $ WritePretty conwayGenesis
-  --TODO: rationalise the naming convention on these genesis json files.
+    void $ writeFileGenesis (rootdir </> "genesis.alonzo.json") $ WritePretty alonzoGenesis
+    void $ writeFileGenesis (rootdir </> "genesis.conway.json") $ WritePretty conwayGenesis
+    -- TODO: rationalise the naming convention on these genesis json files.
 
-  liftIO $ Text.hPutStrLn IO.stderr $ mconcat $
-    [ "generated genesis with: "
-    , textShow genNumGenesisKeys, " genesis keys, "
-    , textShow genNumUTxOKeys, " non-delegating UTxO keys, "
-    , textShow genNumPools, " stake pools, "
-    , textShow genNumStDelegs, " delegating UTxO keys, "
-    , textShow numDelegations, " delegation map entries, "
-    ] ++
-    [ mconcat
-      [ ", "
-      , textShow numBulkPoolCredFiles, " bulk pool credential files, "
-      , textShow bulkPoolsPerFile, " pools per bulk credential file, indices starting from "
-      , textShow bulkOffset, ", "
-      , textShow $ length bulkIndices, " total pools in bulk nodes, each bulk node having this many entries: "
-      , textShow $ length <$> bulkSlices
-      ]
-    | numBulkPoolCredFiles * bulkPoolsPerFile > 0 ]
-
-  where
-    adjustTemplate t = t { sgNetworkMagic = unNetworkMagic (toNetworkMagic network) }
-    mkDelegationMapEntry :: Delegation -> (Ledger.KeyHash Ledger.Staking StandardCrypto, Ledger.PoolParams StandardCrypto)
+    liftIO $
+      Text.hPutStrLn IO.stderr $
+        mconcat $
+          [ "generated genesis with: "
+          , textShow genNumGenesisKeys
+          , " genesis keys, "
+          , textShow genNumUTxOKeys
+          , " non-delegating UTxO keys, "
+          , textShow genNumPools
+          , " stake pools, "
+          , textShow genNumStDelegs
+          , " delegating UTxO keys, "
+          , textShow numDelegations
+          , " delegation map entries, "
+          ]
+            ++ [ mconcat
+                [ ", "
+                , textShow numBulkPoolCredFiles
+                , " bulk pool credential files, "
+                , textShow bulkPoolsPerFile
+                , " pools per bulk credential file, indices starting from "
+                , textShow bulkOffset
+                , ", "
+                , textShow $ length bulkIndices
+                , " total pools in bulk nodes, each bulk node having this many entries: "
+                , textShow $ length <$> bulkSlices
+                ]
+               | numBulkPoolCredFiles * bulkPoolsPerFile > 0
+               ]
+   where
+    adjustTemplate t = t {sgNetworkMagic = unNetworkMagic (toNetworkMagic network)}
+    mkDelegationMapEntry
+      :: Delegation -> (Ledger.KeyHash Ledger.Staking StandardCrypto, Ledger.PoolParams StandardCrypto)
     mkDelegationMapEntry d = (dDelegStaking d, dPoolParams d)
 
-    gendir   = rootdir </> "genesis-keys"
-    deldir   = rootdir </> "delegate-keys"
-    pooldir  = rootdir </> "pools"
+    gendir = rootdir </> "genesis-keys"
+    deldir = rootdir </> "delegate-keys"
+    pooldir = rootdir </> "pools"
     stdeldir = rootdir </> "stake-delegator-keys"
-    utxodir  = rootdir </> "utxo-keys"
+    utxodir = rootdir </> "utxo-keys"
 
     genStuffedAddress :: IO (AddressInEra ShelleyEra)
     genStuffedAddress =
-      shelleyAddressInEra <$>
-      (ShelleyAddress
-       <$> pure Ledger.Testnet
-       <*> (Ledger.KeyHashObj . mkKeyHash . read64BitInt
-             <$> Crypto.runSecureRandom (getRandomBytes 8))
-       <*> pure Ledger.StakeRefNull)
+      shelleyAddressInEra
+        <$> ( ShelleyAddress
+                <$> pure Ledger.Testnet
+                <*> ( Ledger.KeyHashObj . mkKeyHash . read64BitInt
+                        <$> Crypto.runSecureRandom (getRandomBytes 8)
+                    )
+                <*> pure Ledger.StakeRefNull
+            )
 
     read64BitInt :: ByteString -> Int
-    read64BitInt = (fromIntegral :: Word64 -> Int)
-      . Bin.runGet Bin.getWord64le . LBS.fromStrict
+    read64BitInt =
+      (fromIntegral :: Word64 -> Int)
+        . Bin.runGet Bin.getWord64le
+        . LBS.fromStrict
 
-    mkDummyHash :: forall h a. HashAlgorithm h => Proxy h -> Int -> Hash.Hash h a
+    mkDummyHash :: forall h a. (HashAlgorithm h) => Proxy h -> Int -> Hash.Hash h a
     mkDummyHash _ = coerce . Ledger.hashWithSerialiser @h toCBOR
 
-    mkKeyHash :: forall c discriminator. Crypto c => Int -> Ledger.KeyHash discriminator c
+    mkKeyHash :: forall c discriminator. (Crypto c) => Int -> Ledger.KeyHash discriminator c
     mkKeyHash = Ledger.KeyHash . mkDummyHash (Proxy @(ADDRHASH c))
 
 -- -------------------------------------------------------------------------------------------------
@@ -784,152 +938,164 @@ createDelegateKeys :: KeyOutputFormat -> FilePath -> Word -> ExceptT GenesisCmdE
 createDelegateKeys fmt dir index = do
   liftIO $ createDirectoryIfMissing False dir
   runGenesisKeyGenDelegateCmd
-        (File @(VerificationKey ()) $ dir </> "delegate" ++ strIndex ++ ".vkey")
-        (onlyOut coldSK)
-        (onlyOut opCertCtr)
+    (File @(VerificationKey ()) $ dir </> "delegate" ++ strIndex ++ ".vkey")
+    (onlyOut coldSK)
+    (onlyOut opCertCtr)
   runGenesisKeyGenDelegateVRF
-        (File @(VerificationKey ()) $ dir </> "delegate" ++ strIndex ++ ".vrf.vkey")
-        (File @(SigningKey ()) $ dir </> "delegate" ++ strIndex ++ ".vrf.skey")
+    (File @(VerificationKey ()) $ dir </> "delegate" ++ strIndex ++ ".vrf.vkey")
+    (File @(SigningKey ()) $ dir </> "delegate" ++ strIndex ++ ".vrf.skey")
   firstExceptT GenesisCmdNodeCmdError $ do
     runNodeKeyGenKesCmd
-        fmt
-        (onlyOut kesVK)
-        (File @(SigningKey ()) $ dir </> "delegate" ++ strIndex ++ ".kes.skey")
+      fmt
+      (onlyOut kesVK)
+      (File @(SigningKey ()) $ dir </> "delegate" ++ strIndex ++ ".kes.skey")
     runNodeIssueOpCertCmd
-        (VerificationKeyFilePath (onlyIn kesVK))
-        (onlyIn coldSK)
-        opCertCtr
-        (KESPeriod 0)
-        (File $ dir </> "opcert" ++ strIndex ++ ".cert")
+      (VerificationKeyFilePath (onlyIn kesVK))
+      (onlyIn coldSK)
+      opCertCtr
+      (KESPeriod 0)
+      (File $ dir </> "opcert" ++ strIndex ++ ".cert")
  where
-   strIndex = show index
-   kesVK = File @(VerificationKey ()) $ dir </> "delegate" ++ strIndex ++ ".kes.vkey"
-   coldSK = File @(SigningKey ()) $ dir </> "delegate" ++ strIndex ++ ".skey"
-   opCertCtr = File $ dir </> "delegate" ++ strIndex ++ ".counter"
+  strIndex = show index
+  kesVK = File @(VerificationKey ()) $ dir </> "delegate" ++ strIndex ++ ".kes.vkey"
+  coldSK = File @(SigningKey ()) $ dir </> "delegate" ++ strIndex ++ ".skey"
+  opCertCtr = File $ dir </> "delegate" ++ strIndex ++ ".counter"
 
 createGenesisKeys :: FilePath -> Word -> ExceptT GenesisCmdError IO ()
 createGenesisKeys dir index = do
   liftIO $ createDirectoryIfMissing False dir
   let strIndex = show index
   runGenesisKeyGenGenesisCmd
-        (File @(VerificationKey ()) $ dir </> "genesis" ++ strIndex ++ ".vkey")
-        (File @(SigningKey ()) $ dir </> "genesis" ++ strIndex ++ ".skey")
-
+    (File @(VerificationKey ()) $ dir </> "genesis" ++ strIndex ++ ".vkey")
+    (File @(SigningKey ()) $ dir </> "genesis" ++ strIndex ++ ".skey")
 
 createUtxoKeys :: FilePath -> Word -> ExceptT GenesisCmdError IO ()
 createUtxoKeys dir index = do
   liftIO $ createDirectoryIfMissing False dir
   let strIndex = show index
   runGenesisKeyGenUTxOCmd
-        (File @(VerificationKey ()) $ dir </> "utxo" ++ strIndex ++ ".vkey")
-        (File @(SigningKey ()) $ dir </> "utxo" ++ strIndex ++ ".skey")
+    (File @(VerificationKey ()) $ dir </> "utxo" ++ strIndex ++ ".vkey")
+    (File @(SigningKey ()) $ dir </> "utxo" ++ strIndex ++ ".skey")
 
 createPoolCredentials :: KeyOutputFormat -> FilePath -> Word -> ExceptT GenesisCmdError IO ()
 createPoolCredentials fmt dir index = do
   liftIO $ createDirectoryIfMissing False dir
   firstExceptT GenesisCmdNodeCmdError $ do
     runNodeKeyGenKesCmd
-        fmt
-        (onlyOut kesVK)
-        (File @(SigningKey ()) $ dir </> "kes" ++ strIndex ++ ".skey")
+      fmt
+      (onlyOut kesVK)
+      (File @(SigningKey ()) $ dir </> "kes" ++ strIndex ++ ".skey")
     runNodeKeyGenVrfCmd
-        fmt
-        (File @(VerificationKey ()) $ dir </> "vrf" ++ strIndex ++ ".vkey")
-        (File @(SigningKey ()) $ dir </> "vrf" ++ strIndex ++ ".skey")
+      fmt
+      (File @(VerificationKey ()) $ dir </> "vrf" ++ strIndex ++ ".vkey")
+      (File @(SigningKey ()) $ dir </> "vrf" ++ strIndex ++ ".skey")
     runNodeKeyGenColdCmd
-        fmt
-        (File @(VerificationKey ()) $ dir </> "cold" ++ strIndex ++ ".vkey")
-        (onlyOut coldSK)
-        (onlyOut opCertCtr)
+      fmt
+      (File @(VerificationKey ()) $ dir </> "cold" ++ strIndex ++ ".vkey")
+      (onlyOut coldSK)
+      (onlyOut opCertCtr)
     runNodeIssueOpCertCmd
-        (VerificationKeyFilePath (onlyIn kesVK))
-        (onlyIn coldSK)
-        opCertCtr
-        (KESPeriod 0)
-        (File $ dir </> "opcert" ++ strIndex ++ ".cert")
+      (VerificationKeyFilePath (onlyIn kesVK))
+      (onlyIn coldSK)
+      opCertCtr
+      (KESPeriod 0)
+      (File $ dir </> "opcert" ++ strIndex ++ ".cert")
   firstExceptT GenesisCmdStakeAddressCmdError $
     runStakeAddressKeyGenCmd
-        fmt
-        (File @(VerificationKey ()) $ dir </> "staking-reward" ++ strIndex ++ ".vkey")
-        (File @(SigningKey ()) $ dir </> "staking-reward" ++ strIndex ++ ".skey")
+      fmt
+      (File @(VerificationKey ()) $ dir </> "staking-reward" ++ strIndex ++ ".vkey")
+      (File @(SigningKey ()) $ dir </> "staking-reward" ++ strIndex ++ ".skey")
  where
-   strIndex = show index
-   kesVK = File @(VerificationKey ()) $ dir </> "kes" ++ strIndex ++ ".vkey"
-   coldSK = File @(SigningKey ()) $ dir </> "cold" ++ strIndex ++ ".skey"
-   opCertCtr = File $ dir </> "opcert" ++ strIndex ++ ".counter"
+  strIndex = show index
+  kesVK = File @(VerificationKey ()) $ dir </> "kes" ++ strIndex ++ ".vkey"
+  coldSK = File @(SigningKey ()) $ dir </> "cold" ++ strIndex ++ ".skey"
+  opCertCtr = File $ dir </> "opcert" ++ strIndex ++ ".counter"
 
 data Delegation = Delegation
-  { dInitialUtxoAddr  :: !(AddressInEra ShelleyEra)
-  , dDelegStaking     :: !(Ledger.KeyHash Ledger.Staking StandardCrypto)
-  , dPoolParams       :: !(Ledger.PoolParams StandardCrypto)
+  { dInitialUtxoAddr :: !(AddressInEra ShelleyEra)
+  , dDelegStaking :: !(Ledger.KeyHash Ledger.Staking StandardCrypto)
+  , dPoolParams :: !(Ledger.PoolParams StandardCrypto)
   }
   deriving (Generic, NFData)
 
 buildPoolParams
   :: NetworkId
-  -> FilePath -- ^ File directory where the necessary pool credentials were created
+  -> FilePath
+  -- ^ File directory where the necessary pool credentials were created
   -> Word
-  -> Map Word [Ledger.StakePoolRelay] -- ^ User submitted stake pool relay map
+  -> Map Word [Ledger.StakePoolRelay]
+  -- ^ User submitted stake pool relay map
   -> ExceptT GenesisCmdError IO (Ledger.PoolParams StandardCrypto)
 buildPoolParams nw dir index specifiedRelays = do
-    StakePoolVerificationKey poolColdVK
-      <- firstExceptT (GenesisCmdStakePoolCmdError . StakePoolCmdReadFileError)
-           . newExceptT $ readFileTextEnvelope (AsVerificationKey AsStakePoolKey) poolColdVKF
+  StakePoolVerificationKey poolColdVK <-
+    firstExceptT (GenesisCmdStakePoolCmdError . StakePoolCmdReadFileError)
+      . newExceptT
+      $ readFileTextEnvelope (AsVerificationKey AsStakePoolKey) poolColdVKF
 
-    VrfVerificationKey poolVrfVK
-      <- firstExceptT (GenesisCmdNodeCmdError . NodeCmdReadFileError)
-           . newExceptT $ readFileTextEnvelope (AsVerificationKey AsVrfKey) poolVrfVKF
-    rewardsSVK
-      <- firstExceptT GenesisCmdTextEnvReadFileError
-           . newExceptT $ readFileTextEnvelope (AsVerificationKey AsStakeKey) poolRewardVKF
+  VrfVerificationKey poolVrfVK <-
+    firstExceptT (GenesisCmdNodeCmdError . NodeCmdReadFileError)
+      . newExceptT
+      $ readFileTextEnvelope (AsVerificationKey AsVrfKey) poolVrfVKF
+  rewardsSVK <-
+    firstExceptT GenesisCmdTextEnvReadFileError
+      . newExceptT
+      $ readFileTextEnvelope (AsVerificationKey AsStakeKey) poolRewardVKF
 
-    pure Ledger.PoolParams
-      { Ledger.ppId          = Ledger.hashKey poolColdVK
-      , Ledger.ppVrf         = Ledger.hashVerKeyVRF poolVrfVK
-      , Ledger.ppPledge      = Ledger.Coin 0
-      , Ledger.ppCost        = Ledger.Coin 0
-      , Ledger.ppMargin      = minBound
-      , Ledger.ppRewardAcnt  =
+  pure
+    Ledger.PoolParams
+      { Ledger.ppId = Ledger.hashKey poolColdVK
+      , Ledger.ppVrf = Ledger.hashVerKeyVRF poolVrfVK
+      , Ledger.ppPledge = Ledger.Coin 0
+      , Ledger.ppCost = Ledger.Coin 0
+      , Ledger.ppMargin = minBound
+      , Ledger.ppRewardAcnt =
           toShelleyStakeAddr $ makeStakeAddress nw $ StakeCredentialByKey (verificationKeyHash rewardsSVK)
-      , Ledger.ppOwners      = mempty
-      , Ledger.ppRelays      = lookupPoolRelay specifiedRelays
-      , Ledger.ppMetadata    = Ledger.SNothing
+      , Ledger.ppOwners = mempty
+      , Ledger.ppRelays = lookupPoolRelay specifiedRelays
+      , Ledger.ppMetadata = Ledger.SNothing
       }
  where
-   lookupPoolRelay
-     :: Map Word [Ledger.StakePoolRelay] -> Seq.StrictSeq Ledger.StakePoolRelay
-   lookupPoolRelay m = maybe mempty Seq.fromList (Map.lookup index m)
+  lookupPoolRelay
+    :: Map Word [Ledger.StakePoolRelay] -> Seq.StrictSeq Ledger.StakePoolRelay
+  lookupPoolRelay m = maybe mempty Seq.fromList (Map.lookup index m)
 
-   strIndex = show index
-   poolColdVKF = File $ dir </> "cold" ++ strIndex ++ ".vkey"
-   poolVrfVKF = File $ dir </> "vrf" ++ strIndex ++ ".vkey"
-   poolRewardVKF = File $ dir </> "staking-reward" ++ strIndex ++ ".vkey"
+  strIndex = show index
+  poolColdVKF = File $ dir </> "cold" ++ strIndex ++ ".vkey"
+  poolVrfVKF = File $ dir </> "vrf" ++ strIndex ++ ".vkey"
+  poolRewardVKF = File $ dir </> "staking-reward" ++ strIndex ++ ".vkey"
 
 writeBulkPoolCredentials :: FilePath -> Word -> [Word] -> ExceptT GenesisCmdError IO ()
 writeBulkPoolCredentials dir bulkIx poolIxs = do
   creds <- mapM readPoolCreds poolIxs
   handleIOExceptT (GenesisCmdFileError . FileIOError bulkFile) $
-    LBS.writeFile bulkFile $ Aeson.encode creds
+    LBS.writeFile bulkFile $
+      Aeson.encode creds
  where
-   bulkFile = dir </> "bulk" ++ show bulkIx ++ ".creds"
+  bulkFile = dir </> "bulk" ++ show bulkIx ++ ".creds"
 
-   readPoolCreds :: Word -> ExceptT GenesisCmdError IO
-                                   (TextEnvelope, TextEnvelope, TextEnvelope)
-   readPoolCreds ix = do
-     (,,) <$> readEnvelope poolOpCert
-          <*> readEnvelope poolVrfSKF
-          <*> readEnvelope poolKesSKF
-    where
-      strIndex = show ix
-      poolOpCert = dir </> "opcert" ++ strIndex ++ ".cert"
-      poolVrfSKF = dir </> "vrf" ++ strIndex ++ ".skey"
-      poolKesSKF = dir </> "kes" ++ strIndex ++ ".skey"
-   readEnvelope :: FilePath -> ExceptT GenesisCmdError IO TextEnvelope
-   readEnvelope fp = do
-     content <- handleIOExceptT (GenesisCmdFileError . FileIOError fp) $
-                  BS.readFile fp
-     firstExceptT (GenesisCmdAesonDecodeError fp . Text.pack) . hoistEither $
-       Aeson.eitherDecodeStrict' content
+  readPoolCreds
+    :: Word
+    -> ExceptT
+        GenesisCmdError
+        IO
+        (TextEnvelope, TextEnvelope, TextEnvelope)
+  readPoolCreds ix = do
+    (,,)
+      <$> readEnvelope poolOpCert
+      <*> readEnvelope poolVrfSKF
+      <*> readEnvelope poolKesSKF
+   where
+    strIndex = show ix
+    poolOpCert = dir </> "opcert" ++ strIndex ++ ".cert"
+    poolVrfSKF = dir </> "vrf" ++ strIndex ++ ".skey"
+    poolKesSKF = dir </> "kes" ++ strIndex ++ ".skey"
+  readEnvelope :: FilePath -> ExceptT GenesisCmdError IO TextEnvelope
+  readEnvelope fp = do
+    content <-
+      handleIOExceptT (GenesisCmdFileError . FileIOError fp) $
+        BS.readFile fp
+    firstExceptT (GenesisCmdAesonDecodeError fp . Text.pack) . hoistEither $
+      Aeson.eitherDecodeStrict' content
 
 -- | This function should only be used for testing purposes.
 -- Keys returned by this function are not cryptographically secure.
@@ -939,27 +1105,31 @@ computeInsecureDelegation
   -> Ledger.PoolParams StandardCrypto
   -> IO (StdGen, Delegation)
 computeInsecureDelegation g0 nw pool = do
-    (paymentVK, g1) <- first getVerificationKey <$> generateInsecureSigningKey g0 AsPaymentKey
-    (stakeVK  , g2) <- first getVerificationKey <$> generateInsecureSigningKey g1 AsStakeKey
+  (paymentVK, g1) <- first getVerificationKey <$> generateInsecureSigningKey g0 AsPaymentKey
+  (stakeVK, g2) <- first getVerificationKey <$> generateInsecureSigningKey g1 AsStakeKey
 
-    let stakeAddressReference = StakeAddressByValue . StakeCredentialByKey . verificationKeyHash $ stakeVK
-    let initialUtxoAddr = makeShelleyAddress nw (PaymentCredentialByKey (verificationKeyHash paymentVK)) stakeAddressReference
+  let stakeAddressReference = StakeAddressByValue . StakeCredentialByKey . verificationKeyHash $ stakeVK
+  let initialUtxoAddr =
+        makeShelleyAddress nw (PaymentCredentialByKey (verificationKeyHash paymentVK)) stakeAddressReference
 
-    delegation <- pure $ force Delegation
-      { dInitialUtxoAddr = shelleyAddressInEra initialUtxoAddr
-      , dDelegStaking = Ledger.hashKey (unStakeVerificationKey stakeVK)
-      , dPoolParams = pool
-      }
+  delegation <-
+    pure $
+      force
+        Delegation
+          { dInitialUtxoAddr = shelleyAddressInEra initialUtxoAddr
+          , dDelegStaking = Ledger.hashKey (unStakeVerificationKey stakeVK)
+          , dPoolParams = pool
+          }
 
-    pure (g2, delegation)
+  pure (g2, delegation)
 
 -- | Current UTCTime plus 30 seconds
 getCurrentTimePlus30 :: ExceptT a IO UTCTime
 getCurrentTimePlus30 =
-    plus30sec <$> liftIO getCurrentTime
-  where
-    plus30sec :: UTCTime -> UTCTime
-    plus30sec = addUTCTime (30 :: NominalDiffTime)
+  plus30sec <$> liftIO getCurrentTime
+ where
+  plus30sec :: UTCTime -> UTCTime
+  plus30sec = addUTCTime (30 :: NominalDiffTime)
 
 -- | Attempts to read Shelley genesis from disk
 -- and if not found creates a default Shelley genesis.
@@ -968,20 +1138,20 @@ readShelleyGenesisWithDefault
   -> (ShelleyGenesis StandardCrypto -> ShelleyGenesis StandardCrypto)
   -> ExceptT GenesisCmdError IO (ShelleyGenesis StandardCrypto)
 readShelleyGenesisWithDefault fpath adjustDefaults = do
-    newExceptT (readAndDecodeShelleyGenesis fpath)
-      `catchError` \err ->
-        case err of
-          GenesisCmdGenesisFileReadError (FileIOError _ ioe)
-            | isDoesNotExistError ioe -> writeDefault
-          _                           -> left err
-  where
-    defaults :: ShelleyGenesis StandardCrypto
-    defaults = adjustDefaults shelleyGenesisDefaults
+  newExceptT (readAndDecodeShelleyGenesis fpath)
+    `catchError` \err ->
+      case err of
+        GenesisCmdGenesisFileReadError (FileIOError _ ioe)
+          | isDoesNotExistError ioe -> writeDefault
+        _ -> left err
+ where
+  defaults :: ShelleyGenesis StandardCrypto
+  defaults = adjustDefaults shelleyGenesisDefaults
 
-    writeDefault = do
-      handleIOExceptT (GenesisCmdGenesisFileError . FileIOError fpath) $
-        LBS.writeFile fpath (encode defaults)
-      return defaults
+  writeDefault = do
+    handleIOExceptT (GenesisCmdGenesisFileError . FileIOError fpath) $
+      LBS.writeFile fpath (encode defaults)
+    return defaults
 
 readAndDecodeShelleyGenesis
   :: FilePath
@@ -989,46 +1159,67 @@ readAndDecodeShelleyGenesis
 readAndDecodeShelleyGenesis fpath = runExceptT $ do
   lbs <- handleIOExceptT (GenesisCmdGenesisFileReadError . FileIOError fpath) $ LBS.readFile fpath
   firstExceptT (GenesisCmdGenesisFileDecodeError fpath . Text.pack)
-    . hoistEither $ Aeson.eitherDecode' lbs
+    . hoistEither
+    $ Aeson.eitherDecode' lbs
 
 updateTemplate
-    :: SystemStart  -- ^ System start time
-    -> Map (Hash GenesisKey) (Hash GenesisDelegateKey, Hash VrfKey) -- ^ Genesis delegation (not stake-based)
-    -> Maybe Lovelace -- ^ Amount of lovelace not delegated
-    -> [AddressInEra ShelleyEra] -- ^ UTxO addresses that are not delegating
-    -> Map (Ledger.KeyHash 'Ledger.Staking StandardCrypto) (Ledger.PoolParams StandardCrypto) -- ^ Genesis staking: pools/delegation map & delegated initial UTxO spec
-    -> Lovelace -- ^ Number of UTxO Addresses for delegation
-    -> [AddressInEra ShelleyEra] -- ^ UTxO Addresses for delegation
-    -> [AddressInEra ShelleyEra] -- ^ Stuffed UTxO addresses
-    -> ShelleyGenesis StandardCrypto -- ^ Template from which to build a genesis
-    -> ShelleyGenesis StandardCrypto -- ^ Updated genesis
-updateTemplate (SystemStart start)
-               genDelegMap mAmountNonDeleg utxoAddrsNonDeleg
-               poolSpecs (Lovelace amountDeleg) utxoAddrsDeleg stuffedUtxoAddrs
-               template = do
-
+  :: SystemStart
+  -- ^ System start time
+  -> Map (Hash GenesisKey) (Hash GenesisDelegateKey, Hash VrfKey)
+  -- ^ Genesis delegation (not stake-based)
+  -> Maybe Lovelace
+  -- ^ Amount of lovelace not delegated
+  -> [AddressInEra ShelleyEra]
+  -- ^ UTxO addresses that are not delegating
+  -> Map (Ledger.KeyHash 'Ledger.Staking StandardCrypto) (Ledger.PoolParams StandardCrypto)
+  -- ^ Genesis staking: pools/delegation map & delegated initial UTxO spec
+  -> Lovelace
+  -- ^ Number of UTxO Addresses for delegation
+  -> [AddressInEra ShelleyEra]
+  -- ^ UTxO Addresses for delegation
+  -> [AddressInEra ShelleyEra]
+  -- ^ Stuffed UTxO addresses
+  -> ShelleyGenesis StandardCrypto
+  -- ^ Template from which to build a genesis
+  -> ShelleyGenesis StandardCrypto
+  -- ^ Updated genesis
+updateTemplate
+  (SystemStart start)
+  genDelegMap
+  mAmountNonDeleg
+  utxoAddrsNonDeleg
+  poolSpecs
+  (Lovelace amountDeleg)
+  utxoAddrsDeleg
+  stuffedUtxoAddrs
+  template = do
     let pparamsFromTemplate = sgProtocolParams template
-        shelleyGenesis = template
-          { sgSystemStart = start
-          , sgMaxLovelaceSupply = fromIntegral $ nonDelegCoin + delegCoin
-          , sgGenDelegs = shelleyDelKeys
-          , sgInitialFunds = ListMap.fromList
-                              [ (toShelleyAddr addr, toShelleyLovelace v)
-                              | (addr, v) <-
-                                distribute (nonDelegCoin - subtractForTreasury) utxoAddrsNonDeleg ++
-                                distribute (delegCoin - subtractForTreasury)    utxoAddrsDeleg ++
-                                mkStuffedUtxo stuffedUtxoAddrs ]
-          , sgStaking =
-            ShelleyGenesisStaking
-              { sgsPools = ListMap.fromList
-                            [ (Ledger.ppId poolParams, poolParams)
-                            | poolParams <- Map.elems poolSpecs ]
-              , sgsStake = ListMap.fromMap $ Ledger.ppId <$> poolSpecs
-              }
-          , sgProtocolParams = pparamsFromTemplate
-          }
+        shelleyGenesis =
+          template
+            { sgSystemStart = start
+            , sgMaxLovelaceSupply = fromIntegral $ nonDelegCoin + delegCoin
+            , sgGenDelegs = shelleyDelKeys
+            , sgInitialFunds =
+                ListMap.fromList
+                  [ (toShelleyAddr addr, toShelleyLovelace v)
+                  | (addr, v) <-
+                      distribute (nonDelegCoin - subtractForTreasury) utxoAddrsNonDeleg
+                        ++ distribute (delegCoin - subtractForTreasury) utxoAddrsDeleg
+                        ++ mkStuffedUtxo stuffedUtxoAddrs
+                  ]
+            , sgStaking =
+                ShelleyGenesisStaking
+                  { sgsPools =
+                      ListMap.fromList
+                        [ (Ledger.ppId poolParams, poolParams)
+                        | poolParams <- Map.elems poolSpecs
+                        ]
+                  , sgsStake = ListMap.fromMap $ Ledger.ppId <$> poolSpecs
+                  }
+            , sgProtocolParams = pparamsFromTemplate
+            }
     shelleyGenesis
-  where
+   where
     maximumLovelaceSupply :: Word64
     maximumLovelaceSupply = sgMaxLovelaceSupply template
     -- If the initial funds are equal to the maximum funds, rewards cannot be created.
@@ -1042,76 +1233,100 @@ updateTemplate (SystemStart start)
     distribute funds addrs =
       fst $ List.foldl' folder ([], fromIntegral funds) addrs
      where
-       nAddrs, coinPerAddr, splitThreshold :: Integer
-       nAddrs = fromIntegral $ length addrs
-       coinPerAddr = funds `div` nAddrs
-       splitThreshold = coinPerAddr + nAddrs
+      nAddrs, coinPerAddr, splitThreshold :: Integer
+      nAddrs = fromIntegral $ length addrs
+      coinPerAddr = funds `div` nAddrs
+      splitThreshold = coinPerAddr + nAddrs
 
-       folder :: ([(AddressInEra ShelleyEra, Lovelace)], Integer)
-              -> AddressInEra ShelleyEra
-              -> ([(AddressInEra ShelleyEra, Lovelace)], Integer)
-       folder (acc, rest) addr
-         | rest > splitThreshold =
-             ((addr, Lovelace coinPerAddr) : acc, rest - coinPerAddr)
-         | otherwise = ((addr, Lovelace rest) : acc, 0)
+      folder
+        :: ([(AddressInEra ShelleyEra, Lovelace)], Integer)
+        -> AddressInEra ShelleyEra
+        -> ([(AddressInEra ShelleyEra, Lovelace)], Integer)
+      folder (acc, rest) addr
+        | rest > splitThreshold =
+            ((addr, Lovelace coinPerAddr) : acc, rest - coinPerAddr)
+        | otherwise = ((addr, Lovelace rest) : acc, 0)
 
     mkStuffedUtxo :: [AddressInEra ShelleyEra] -> [(AddressInEra ShelleyEra, Lovelace)]
-    mkStuffedUtxo xs = (, Lovelace minUtxoVal) <$> xs
-      where Coin minUtxoVal = sgProtocolParams template ^. ppMinUTxOValueL
+    mkStuffedUtxo xs = (,Lovelace minUtxoVal) <$> xs
+     where
+      Coin minUtxoVal = sgProtocolParams template ^. ppMinUTxOValueL
 
     shelleyDelKeys =
       Map.fromList
         [ (gh, Ledger.GenDelegPair gdh h)
-        | (GenesisKeyHash gh,
-           (GenesisDelegateKeyHash gdh, VrfKeyHash h)) <- Map.toList genDelegMap
+        | ( GenesisKeyHash gh
+            , (GenesisDelegateKeyHash gdh, VrfKeyHash h)
+            ) <-
+            Map.toList genDelegMap
         ]
 
-    unLovelace :: Integral a => Lovelace -> a
+    unLovelace :: (Integral a) => Lovelace -> a
     unLovelace (Lovelace coin) = fromIntegral coin
 
 updateCreateStakedOutputTemplate
-    :: SystemStart -- ^ System start time
-    -> Map (Hash GenesisKey) (Hash GenesisDelegateKey, Hash VrfKey) -- ^ Genesis delegation (not stake-based)
-    -> Maybe Lovelace -- ^ Amount of lovelace not delegated
-    -> Int -- ^ Number of UTxO addresses that are delegating
-    -> [AddressInEra ShelleyEra] -- ^ UTxO addresses that are not delegating
-    -> [(Ledger.KeyHash 'Ledger.StakePool StandardCrypto, Ledger.PoolParams StandardCrypto)] -- ^ Pool map
-    -> [(Ledger.KeyHash 'Ledger.Staking StandardCrypto, Ledger.KeyHash 'Ledger.StakePool StandardCrypto)] -- ^ Delegaton map
-    -> Lovelace -- ^ Amount of lovelace to delegate
-    -> Int -- ^ Number of UTxO address for delegationg
-    -> [AddressInEra ShelleyEra] -- ^ UTxO address for delegationg
-    -> [AddressInEra ShelleyEra] -- ^ Stuffed UTxO addresses
-    -> ShelleyGenesis StandardCrypto -- ^ Template from which to build a genesis
-    -> ShelleyGenesis StandardCrypto -- ^ Updated genesis
+  :: SystemStart
+  -- ^ System start time
+  -> Map (Hash GenesisKey) (Hash GenesisDelegateKey, Hash VrfKey)
+  -- ^ Genesis delegation (not stake-based)
+  -> Maybe Lovelace
+  -- ^ Amount of lovelace not delegated
+  -> Int
+  -- ^ Number of UTxO addresses that are delegating
+  -> [AddressInEra ShelleyEra]
+  -- ^ UTxO addresses that are not delegating
+  -> [(Ledger.KeyHash 'Ledger.StakePool StandardCrypto, Ledger.PoolParams StandardCrypto)]
+  -- ^ Pool map
+  -> [(Ledger.KeyHash 'Ledger.Staking StandardCrypto, Ledger.KeyHash 'Ledger.StakePool StandardCrypto)]
+  -- ^ Delegaton map
+  -> Lovelace
+  -- ^ Amount of lovelace to delegate
+  -> Int
+  -- ^ Number of UTxO address for delegationg
+  -> [AddressInEra ShelleyEra]
+  -- ^ UTxO address for delegationg
+  -> [AddressInEra ShelleyEra]
+  -- ^ Stuffed UTxO addresses
+  -> ShelleyGenesis StandardCrypto
+  -- ^ Template from which to build a genesis
+  -> ShelleyGenesis StandardCrypto
+  -- ^ Updated genesis
 updateCreateStakedOutputTemplate
   (SystemStart start)
-  genDelegMap mAmountNonDeleg nUtxoAddrsNonDeleg utxoAddrsNonDeleg pools stake
+  genDelegMap
+  mAmountNonDeleg
+  nUtxoAddrsNonDeleg
+  utxoAddrsNonDeleg
+  pools
+  stake
   (Lovelace amountDeleg)
-  nUtxoAddrsDeleg utxoAddrsDeleg stuffedUtxoAddrs
+  nUtxoAddrsDeleg
+  utxoAddrsDeleg
+  stuffedUtxoAddrs
   template = do
     let pparamsFromTemplate = sgProtocolParams template
-        shelleyGenesis = template
-          { sgSystemStart = start
-          , sgMaxLovelaceSupply = fromIntegral $ nonDelegCoin + delegCoin
-          , sgGenDelegs = shelleyDelKeys
-          , sgInitialFunds = ListMap.fromList
-                              [ (toShelleyAddr addr, toShelleyLovelace v)
-                              | (addr, v) <-
-                                distribute (nonDelegCoin - subtractForTreasury) nUtxoAddrsNonDeleg  utxoAddrsNonDeleg
-                                ++
-                                distribute (delegCoin - subtractForTreasury)    nUtxoAddrsDeleg     utxoAddrsDeleg
-                                ++
-                                mkStuffedUtxo stuffedUtxoAddrs
-                                ]
-          , sgStaking =
-            ShelleyGenesisStaking
-              { sgsPools = ListMap pools
-              , sgsStake = ListMap stake
-              }
-          , sgProtocolParams = pparamsFromTemplate
-          }
+        shelleyGenesis =
+          template
+            { sgSystemStart = start
+            , sgMaxLovelaceSupply = fromIntegral $ nonDelegCoin + delegCoin
+            , sgGenDelegs = shelleyDelKeys
+            , sgInitialFunds =
+                ListMap.fromList
+                  [ (toShelleyAddr addr, toShelleyLovelace v)
+                  | (addr, v) <-
+                      distribute (nonDelegCoin - subtractForTreasury) nUtxoAddrsNonDeleg utxoAddrsNonDeleg
+                        ++ distribute (delegCoin - subtractForTreasury) nUtxoAddrsDeleg utxoAddrsDeleg
+                        ++ mkStuffedUtxo stuffedUtxoAddrs
+                  ]
+            , sgStaking =
+                ShelleyGenesisStaking
+                  { sgsPools = ListMap pools
+                  , sgsStake = ListMap stake
+                  }
+            , sgProtocolParams = pparamsFromTemplate
+            }
     shelleyGenesis
-  where
+   where
     maximumLovelaceSupply :: Word64
     maximumLovelaceSupply = sgMaxLovelaceSupply template
     -- If the initial funds are equal to the maximum funds, rewards cannot be created.
@@ -1122,21 +1337,26 @@ updateCreateStakedOutputTemplate
     delegCoin = fromIntegral amountDeleg
 
     distribute :: Integer -> Int -> [AddressInEra ShelleyEra] -> [(AddressInEra ShelleyEra, Lovelace)]
-    distribute funds nAddrs addrs = zip addrs (fmap Lovelace (coinPerAddr + remainder:repeat coinPerAddr))
-      where coinPerAddr, remainder :: Integer
-            (,) coinPerAddr remainder = funds `divMod` fromIntegral nAddrs
+    distribute funds nAddrs addrs = zip addrs (fmap Lovelace (coinPerAddr + remainder : repeat coinPerAddr))
+     where
+      coinPerAddr, remainder :: Integer
+      (,) coinPerAddr remainder = funds `divMod` fromIntegral nAddrs
 
     mkStuffedUtxo :: [AddressInEra ShelleyEra] -> [(AddressInEra ShelleyEra, Lovelace)]
-    mkStuffedUtxo xs = (, Lovelace minUtxoVal) <$> xs
-      where Coin minUtxoVal = sgProtocolParams template ^. ppMinUTxOValueL
+    mkStuffedUtxo xs = (,Lovelace minUtxoVal) <$> xs
+     where
+      Coin minUtxoVal = sgProtocolParams template ^. ppMinUTxOValueL
 
-    shelleyDelKeys = Map.fromList
-      [ (gh, Ledger.GenDelegPair gdh h)
-      | (GenesisKeyHash gh,
-          (GenesisDelegateKeyHash gdh, VrfKeyHash h)) <- Map.toList genDelegMap
-      ]
+    shelleyDelKeys =
+      Map.fromList
+        [ (gh, Ledger.GenDelegPair gdh h)
+        | ( GenesisKeyHash gh
+            , (GenesisDelegateKeyHash gdh, VrfKeyHash h)
+            ) <-
+            Map.toList genDelegMap
+        ]
 
-    unLovelace :: Integral a => Lovelace -> a
+    unLovelace :: (Integral a) => Lovelace -> a
     unLovelace (Lovelace coin) = fromIntegral coin
 
 writeFileGenesis
@@ -1147,162 +1367,217 @@ writeFileGenesis fpath genesis = do
   handleIOExceptT (GenesisCmdGenesisFileError . FileIOError fpath) $
     BS.writeFile fpath content
   return $ Crypto.hashWith id content
-  where
-    content = case genesis of
-       WritePretty a -> LBS.toStrict $ encodePretty a
-       WriteCanonical a -> LBS.toStrict
-          . renderCanonicalJSON
-          . either (error "error parsing json that was just encoded!?") id
-          . parseCanonicalJSON
-          . canonicalEncodePretty $ a
+ where
+  content = case genesis of
+    WritePretty a -> LBS.toStrict $ encodePretty a
+    WriteCanonical a ->
+      LBS.toStrict
+        . renderCanonicalJSON
+        . either (error "error parsing json that was just encoded!?") id
+        . parseCanonicalJSON
+        . canonicalEncodePretty
+        $ a
 
 data WriteFileGenesis where
-  WriteCanonical :: Text.JSON.Canonical.ToJSON Identity genesis => genesis -> WriteFileGenesis
-  WritePretty :: ToJSON genesis => genesis -> WriteFileGenesis
+  WriteCanonical :: (Text.JSON.Canonical.ToJSON Identity genesis) => genesis -> WriteFileGenesis
+  WritePretty :: (ToJSON genesis) => genesis -> WriteFileGenesis
 
 -- ----------------------------------------------------------------------------
 
-readGenDelegsMap :: FilePath -> FilePath
-                 -> ExceptT GenesisCmdError IO
-                            (Map (Hash GenesisKey)
-                                 (Hash GenesisDelegateKey, Hash VrfKey))
+readGenDelegsMap
+  :: FilePath
+  -> FilePath
+  -> ExceptT
+      GenesisCmdError
+      IO
+      ( Map
+          (Hash GenesisKey)
+          (Hash GenesisDelegateKey, Hash VrfKey)
+      )
 readGenDelegsMap gendir deldir = do
-    gkm <- readGenesisKeys gendir
-    dkm <- readDelegateKeys deldir
-    vkm <- readDelegateVrfKeys deldir
+  gkm <- readGenesisKeys gendir
+  dkm <- readDelegateKeys deldir
+  vkm <- readDelegateVrfKeys deldir
 
-    let combinedMap :: Map Int (VerificationKey GenesisKey,
-                                (VerificationKey GenesisDelegateKey,
-                                 VerificationKey VrfKey))
-        combinedMap =
-          Map.intersectionWith (,)
-            gkm
-            (Map.intersectionWith (,)
-               dkm vkm)
+  let combinedMap
+        :: Map
+            Int
+            ( VerificationKey GenesisKey
+            , ( VerificationKey GenesisDelegateKey
+              , VerificationKey VrfKey
+              )
+            )
+      combinedMap =
+        Map.intersectionWith
+          (,)
+          gkm
+          ( Map.intersectionWith
+              (,)
+              dkm
+              vkm
+          )
 
-    -- All the maps should have an identical set of keys. Complain if not.
-    let gkmExtra = gkm Map.\\ combinedMap
-        dkmExtra = dkm Map.\\ combinedMap
-        vkmExtra = vkm Map.\\ combinedMap
-    unless (Map.null gkmExtra && Map.null dkmExtra && Map.null vkmExtra) $
-      throwError $ GenesisCmdMismatchedGenesisKeyFiles
-                     (Map.keys gkm) (Map.keys dkm) (Map.keys vkm)
+  -- All the maps should have an identical set of keys. Complain if not.
+  let gkmExtra = gkm Map.\\ combinedMap
+      dkmExtra = dkm Map.\\ combinedMap
+      vkmExtra = vkm Map.\\ combinedMap
+  unless (Map.null gkmExtra && Map.null dkmExtra && Map.null vkmExtra) $
+    throwError $
+      GenesisCmdMismatchedGenesisKeyFiles
+        (Map.keys gkm)
+        (Map.keys dkm)
+        (Map.keys vkm)
 
-    let delegsMap :: Map (Hash GenesisKey)
-                         (Hash GenesisDelegateKey, Hash VrfKey)
-        delegsMap =
-          Map.fromList [ (gh, (dh, vh))
-                       | (g,(d,v)) <- Map.elems combinedMap
-                       , let gh = verificationKeyHash g
-                             dh = verificationKeyHash d
-                             vh = verificationKeyHash v
-                       ]
+  let delegsMap
+        :: Map
+            (Hash GenesisKey)
+            (Hash GenesisDelegateKey, Hash VrfKey)
+      delegsMap =
+        Map.fromList
+          [ (gh, (dh, vh))
+          | (g, (d, v)) <- Map.elems combinedMap
+          , let gh = verificationKeyHash g
+                dh = verificationKeyHash d
+                vh = verificationKeyHash v
+          ]
 
-    pure delegsMap
+  pure delegsMap
 
-
-readGenesisKeys :: FilePath -> ExceptT GenesisCmdError IO
-                                       (Map Int (VerificationKey GenesisKey))
+readGenesisKeys
+  :: FilePath
+  -> ExceptT
+      GenesisCmdError
+      IO
+      (Map Int (VerificationKey GenesisKey))
 readGenesisKeys gendir = do
   files <- liftIO (listDirectory gendir)
-  fileIxs <- extractFileNameIndexes [ gendir </> file
-                                    | file <- files
-                                    , takeExtension file == ".vkey" ]
+  fileIxs <-
+    extractFileNameIndexes
+      [ gendir </> file
+      | file <- files
+      , takeExtension file == ".vkey"
+      ]
   firstExceptT GenesisCmdTextEnvReadFileError $
-    Map.fromList <$>
-      sequence
+    Map.fromList
+      <$> sequence
         [ (,) ix <$> readKey (File file)
-        | (file, ix) <- fileIxs ]
-  where
-    readKey = newExceptT
-              . readFileTextEnvelope (AsVerificationKey AsGenesisKey)
+        | (file, ix) <- fileIxs
+        ]
+ where
+  readKey =
+    newExceptT
+      . readFileTextEnvelope (AsVerificationKey AsGenesisKey)
 
-readDelegateKeys :: FilePath
-                 -> ExceptT GenesisCmdError IO
-                            (Map Int (VerificationKey GenesisDelegateKey))
+readDelegateKeys
+  :: FilePath
+  -> ExceptT
+      GenesisCmdError
+      IO
+      (Map Int (VerificationKey GenesisDelegateKey))
 readDelegateKeys deldir = do
   files <- liftIO (listDirectory deldir)
-  fileIxs <- extractFileNameIndexes [ deldir </> file
-                                    | file <- files
-                                    , takeExtensions file == ".vkey" ]
+  fileIxs <-
+    extractFileNameIndexes
+      [ deldir </> file
+      | file <- files
+      , takeExtensions file == ".vkey"
+      ]
   firstExceptT GenesisCmdTextEnvReadFileError $
-    Map.fromList <$>
-      sequence
+    Map.fromList
+      <$> sequence
         [ (,) ix <$> readKey (File file)
-        | (file, ix) <- fileIxs ]
-  where
-    readKey = newExceptT
-            . readFileTextEnvelope (AsVerificationKey AsGenesisDelegateKey)
+        | (file, ix) <- fileIxs
+        ]
+ where
+  readKey =
+    newExceptT
+      . readFileTextEnvelope (AsVerificationKey AsGenesisDelegateKey)
 
-readDelegateVrfKeys :: FilePath -> ExceptT GenesisCmdError IO
-                                           (Map Int (VerificationKey VrfKey))
+readDelegateVrfKeys
+  :: FilePath
+  -> ExceptT
+      GenesisCmdError
+      IO
+      (Map Int (VerificationKey VrfKey))
 readDelegateVrfKeys deldir = do
   files <- liftIO (listDirectory deldir)
-  fileIxs <- extractFileNameIndexes [ deldir </> file
-                                    | file <- files
-                                    , takeExtensions file == ".vrf.vkey" ]
+  fileIxs <-
+    extractFileNameIndexes
+      [ deldir </> file
+      | file <- files
+      , takeExtensions file == ".vrf.vkey"
+      ]
   firstExceptT GenesisCmdTextEnvReadFileError $
-    Map.fromList <$>
-      sequence
+    Map.fromList
+      <$> sequence
         [ (,) ix <$> readKey (File file)
-        | (file, ix) <- fileIxs ]
-  where
-    readKey = newExceptT
-            . readFileTextEnvelope (AsVerificationKey AsVrfKey)
-
+        | (file, ix) <- fileIxs
+        ]
+ where
+  readKey =
+    newExceptT
+      . readFileTextEnvelope (AsVerificationKey AsVrfKey)
 
 -- | The file path is of the form @"delegate-keys/delegate3.vkey"@.
 -- This function reads the file and extracts the index (in this case 3).
---
 extractFileNameIndex :: FilePath -> Maybe Int
 extractFileNameIndex fp =
   case filter isDigit fp of
     [] -> Nothing
     xs -> readMaybe xs
 
-extractFileNameIndexes :: [FilePath]
-                       -> ExceptT GenesisCmdError IO [(FilePath, Int)]
+extractFileNameIndexes
+  :: [FilePath]
+  -> ExceptT GenesisCmdError IO [(FilePath, Int)]
 extractFileNameIndexes files = do
-    case [ file | (file, Nothing) <- filesIxs ] of
-      []     -> return ()
-      files' -> throwError (GenesisCmdFilesNoIndex files')
-    case filter (\g -> length g > 1)
-       . List.groupBy ((==) `on` snd)
-       . List.sortBy (compare `on` snd)
-       $ [ (file, ix) | (file, Just ix) <- filesIxs ] of
-      [] -> return ()
-      (g:_) -> throwError (GenesisCmdFilesDupIndex (map fst g))
+  case [file | (file, Nothing) <- filesIxs] of
+    [] -> return ()
+    files' -> throwError (GenesisCmdFilesNoIndex files')
+  case filter (\g -> length g > 1)
+    . List.groupBy ((==) `on` snd)
+    . List.sortBy (compare `on` snd)
+    $ [(file, ix) | (file, Just ix) <- filesIxs] of
+    [] -> return ()
+    (g : _) -> throwError (GenesisCmdFilesDupIndex (map fst g))
 
-    return [ (file, ix) | (file, Just ix) <- filesIxs ]
-  where
-    filesIxs = [ (file, extractFileNameIndex file) | file <- files ]
+  return [(file, ix) | (file, Just ix) <- filesIxs]
+ where
+  filesIxs = [(file, extractFileNameIndex file) | file <- files]
 
-readInitialFundAddresses :: FilePath -> NetworkId
-                         -> ExceptT GenesisCmdError IO [AddressInEra ShelleyEra]
+readInitialFundAddresses
+  :: FilePath
+  -> NetworkId
+  -> ExceptT GenesisCmdError IO [AddressInEra ShelleyEra]
 readInitialFundAddresses utxodir nw = do
-    files <- liftIO (listDirectory utxodir)
-    vkeys <- firstExceptT GenesisCmdTextEnvReadFileError $
-               sequence
-                 [ newExceptT $
-                     readFileTextEnvelope (AsVerificationKey AsGenesisUTxOKey)
-                                          (File (utxodir </> file))
-                 | file <- files
-                 , takeExtension file == ".vkey" ]
-    return [ addr | vkey <- vkeys
-           , let vkh  = verificationKeyHash (castVerificationKey vkey)
-                 addr = makeShelleyAddressInEra nw (PaymentCredentialByKey vkh)
-                                                NoStakeAddress
-           ]
-
+  files <- liftIO (listDirectory utxodir)
+  vkeys <-
+    firstExceptT GenesisCmdTextEnvReadFileError $
+      sequence
+        [ newExceptT $
+          readFileTextEnvelope
+            (AsVerificationKey AsGenesisUTxOKey)
+            (File (utxodir </> file))
+        | file <- files
+        , takeExtension file == ".vkey"
+        ]
+  return
+    [ addr | vkey <- vkeys, let vkh = verificationKeyHash (castVerificationKey vkey)
+                                addr =
+                                  makeShelleyAddressInEra
+                                    nw
+                                    (PaymentCredentialByKey vkh)
+                                    NoStakeAddress
+    ]
 
 -- | Hash a genesis file
 runGenesisHashFileCmd :: GenesisFile -> ExceptT GenesisCmdError IO ()
 runGenesisHashFileCmd (GenesisFile fpath) = do
-   content <- handleIOExceptT (GenesisCmdGenesisFileError . FileIOError fpath) $
-              BS.readFile fpath
-   let gh :: Crypto.Hash Crypto.Blake2b_256 ByteString
-       gh = Crypto.hashWith id content
-   liftIO $ Text.putStrLn (Crypto.hashToTextAsHex gh)
+  content <-
+    handleIOExceptT (GenesisCmdGenesisFileError . FileIOError fpath) $
+      BS.readFile fpath
+  let gh :: Crypto.Hash Crypto.Blake2b_256 ByteString
+      gh = Crypto.hashWith id content
+  liftIO $ Text.putStrLn (Crypto.hashToTextAsHex gh)
 
 readAlonzoGenesis
   :: FilePath
@@ -1310,7 +1585,8 @@ readAlonzoGenesis
 readAlonzoGenesis fpath = do
   lbs <- handleIOExceptT (GenesisCmdGenesisFileError . FileIOError fpath) $ LBS.readFile fpath
   firstExceptT (GenesisCmdAesonDecodeError fpath . Text.pack)
-    . hoistEither $ Aeson.eitherDecode' lbs
+    . hoistEither
+    $ Aeson.eitherDecode' lbs
 
 readConwayGenesis
   :: FilePath
@@ -1318,14 +1594,16 @@ readConwayGenesis
 readConwayGenesis fpath = do
   lbs <- handleIOExceptT (GenesisCmdGenesisFileError . FileIOError fpath) $ LBS.readFile fpath
   firstExceptT (GenesisCmdAesonDecodeError fpath . Text.pack)
-    . hoistEither $ Aeson.eitherDecode' lbs
+    . hoistEither
+    $ Aeson.eitherDecode' lbs
 
 -- Protocol Parameters
 
---TODO: eliminate this and get only the necessary params, and get them in a more
+-- TODO: eliminate this and get only the necessary params, and get them in a more
 -- helpful way rather than requiring them as a local file.
-readProtocolParameters :: ProtocolParamsFile
-                       -> ExceptT ProtocolParamsError IO ProtocolParameters
+readProtocolParameters
+  :: ProtocolParamsFile
+  -> ExceptT ProtocolParamsError IO ProtocolParameters
 readProtocolParameters (ProtocolParamsFile fpath) = do
   pparams <- handleIOExceptT (ProtocolParamsErrorFile . FileIOError fpath) $ LBS.readFile fpath
   firstExceptT (ProtocolParamsErrorJSON fpath . Text.pack) . hoistEither $

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Genesis.hs
@@ -45,7 +45,7 @@ import Cardano.Api.Shelley
 
 import Cardano.CLI.Byron.Delegation
 import Cardano.CLI.Byron.Genesis as Byron
-import qualified Cardano.CLI.Byron.Key as Byron
+import Cardano.CLI.Byron.Key qualified as Byron
 import Cardano.CLI.EraBased.Commands.Genesis
 import Cardano.CLI.EraBased.Run.Node
   ( runNodeIssueOpCertCmd
@@ -54,7 +54,7 @@ import Cardano.CLI.EraBased.Run.Node
   , runNodeKeyGenVrfCmd
   )
 import Cardano.CLI.EraBased.Run.StakeAddress (runStakeAddressKeyGenCmd)
-import qualified Cardano.CLI.IO.Lazy as Lazy
+import Cardano.CLI.IO.Lazy qualified as Lazy
 import Cardano.CLI.Types.Common
 import Cardano.CLI.Types.Errors.GenesisCmdError
 import Cardano.CLI.Types.Errors.NodeCmdError
@@ -62,9 +62,9 @@ import Cardano.CLI.Types.Errors.ProtocolParamsError
 import Cardano.CLI.Types.Errors.StakePoolCmdError
 import Cardano.CLI.Types.Key
 import Cardano.Chain.Common (BlockCount (unBlockCount))
-import qualified Cardano.Chain.Common as Byron (KeyHash, mkKnownLovelace, rationalToLovelacePortion)
+import Cardano.Chain.Common qualified as Byron (KeyHash, mkKnownLovelace, rationalToLovelacePortion)
 import Cardano.Chain.Delegation (delegateVK)
-import qualified Cardano.Chain.Delegation as Dlg
+import Cardano.Chain.Delegation qualified as Dlg
 import Cardano.Chain.Genesis
   ( FakeAvvmOptions (..)
   , TestnetBalanceOptions (..)
@@ -73,24 +73,24 @@ import Cardano.Chain.Genesis
   , gsPoorSecrets
   , gsRichSecrets
   )
-import qualified Cardano.Chain.Genesis as Genesis
+import Cardano.Chain.Genesis qualified as Genesis
 import Cardano.Chain.Update hiding (ProtocolParameters)
-import qualified Cardano.Crypto as CC
+import Cardano.Crypto qualified as CC
 import Cardano.Crypto.Hash (HashAlgorithm)
-import qualified Cardano.Crypto.Hash as Crypto
-import qualified Cardano.Crypto.Hash as Hash
-import qualified Cardano.Crypto.Random as Crypto
-import qualified Cardano.Crypto.Signing as Byron
-import qualified Cardano.Ledger.Alonzo.Genesis as Alonzo
-import qualified Cardano.Ledger.BaseTypes as Ledger
+import Cardano.Crypto.Hash qualified as Crypto
+import Cardano.Crypto.Hash qualified as Hash
+import Cardano.Crypto.Random qualified as Crypto
+import Cardano.Crypto.Signing qualified as Byron
+import Cardano.Ledger.Alonzo.Genesis qualified as Alonzo
+import Cardano.Ledger.BaseTypes qualified as Ledger
 import Cardano.Ledger.Binary (Annotated (Annotated), ToCBOR (..))
 import Cardano.Ledger.Coin (Coin (..))
-import qualified Cardano.Ledger.Conway.Genesis as Conway
+import Cardano.Ledger.Conway.Genesis qualified as Conway
 import Cardano.Ledger.Core (ppMinUTxOValueL)
 import Cardano.Ledger.Crypto (ADDRHASH, Crypto, StandardCrypto)
 import Cardano.Ledger.Era ()
-import qualified Cardano.Ledger.Keys as Ledger
-import qualified Cardano.Ledger.Shelley.API as Ledger
+import Cardano.Ledger.Keys qualified as Ledger
+import Cardano.Ledger.Shelley.API qualified as Ledger
 import Cardano.Ledger.Shelley.Genesis (secondsToNominalDiffTimeMicro)
 import Cardano.Prelude (canonicalEncodePretty)
 import Cardano.Slotting.Slot (EpochSize (EpochSize))
@@ -109,14 +109,14 @@ import Control.Monad.Trans.Except.Extra
   , newExceptT
   )
 import Data.Aeson hiding (Key)
-import qualified Data.Aeson as Aeson
+import Data.Aeson qualified as Aeson
 import Data.Aeson.Encode.Pretty (encodePretty)
-import qualified Data.Aeson.KeyMap as Aeson
+import Data.Aeson.KeyMap qualified as Aeson
 import Data.Bifunctor (Bifunctor (..))
-import qualified Data.Binary.Get as Bin
+import Data.Binary.Get qualified as Bin
 import Data.ByteString (ByteString)
-import qualified Data.ByteString.Char8 as BS
-import qualified Data.ByteString.Lazy.Char8 as LBS
+import Data.ByteString.Char8 qualified as BS
+import Data.ByteString.Lazy.Char8 qualified as LBS
 import Data.Char (isDigit)
 import Data.Coerce (coerce)
 import Data.Data (Proxy (..))
@@ -125,31 +125,31 @@ import Data.Fixed (Fixed (MkFixed))
 import Data.Function (on)
 import Data.Functor (void)
 import Data.Functor.Identity
-import qualified Data.List as List
-import qualified Data.List.Split as List
+import Data.List qualified as List
+import Data.List.Split qualified as List
 import Data.ListMap (ListMap (..))
-import qualified Data.ListMap as ListMap
+import Data.ListMap qualified as ListMap
 import Data.Map.Strict (Map)
-import qualified Data.Map.Strict as Map
+import Data.Map.Strict qualified as Map
 import Data.Maybe (fromMaybe)
-import qualified Data.Sequence.Strict as Seq
+import Data.Sequence.Strict qualified as Seq
 import Data.String (fromString)
 import Data.Text (Text)
-import qualified Data.Text as Text
-import qualified Data.Text.IO as Text
+import Data.Text qualified as Text
+import Data.Text.IO qualified as Text
 import Data.Time.Clock (NominalDiffTime, UTCTime, addUTCTime, getCurrentTime)
 import Data.Word (Word64)
-import qualified Data.Yaml as Yaml
+import Data.Yaml qualified as Yaml
 import GHC.Generics (Generic)
 import Lens.Micro ((^.))
 import System.Directory (createDirectoryIfMissing, listDirectory)
 import System.FilePath (takeExtension, takeExtensions, (</>))
-import qualified System.IO as IO
+import System.IO qualified as IO
 import System.IO.Error (isDoesNotExistError)
 import System.Random (StdGen)
-import qualified System.Random as Random
+import System.Random qualified as Random
 import Text.JSON.Canonical (parseCanonicalJSON, renderCanonicalJSON)
-import qualified Text.JSON.Canonical (ToJSON)
+import Text.JSON.Canonical qualified (ToJSON)
 import Text.Read (readMaybe)
 
 import Crypto.Random as Crypto

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance.hs
@@ -13,18 +13,18 @@ module Cardano.CLI.EraBased.Run.Governance
   ) where
 
 import Cardano.Api
-import qualified Cardano.Api.Ledger as Ledger
+import Cardano.Api.Ledger qualified as Ledger
 import Cardano.Api.Shelley
 
 import Cardano.CLI.Types.Common
 import Cardano.CLI.Types.Errors.GovernanceCmdError
-import qualified Cardano.Ledger.Shelley.TxBody as Shelley
+import Cardano.Ledger.Shelley.TxBody qualified as Shelley
 
 import Control.Monad
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Trans.Except (ExceptT)
 import Control.Monad.Trans.Except.Extra
-import qualified Data.Map.Strict as Map
+import Data.Map.Strict qualified as Map
 
 runGovernanceMIRCertificatePayStakeAddrs
   :: ShelleyToBabbageEra era

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Actions.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Actions.hs
@@ -11,7 +11,7 @@ module Cardano.CLI.EraBased.Run.Governance.Actions
 
 import Cardano.Api
 import Cardano.Api.Ledger (coerceKeyRole)
-import qualified Cardano.Api.Ledger as Ledger
+import Cardano.Api.Ledger qualified as Ledger
 import Cardano.Api.Shelley
 
 import Cardano.CLI.EraBased.Commands.Governance.Actions
@@ -19,14 +19,14 @@ import Cardano.CLI.Read
 import Cardano.CLI.Types.Common
 import Cardano.CLI.Types.Errors.GovernanceActionsError
 import Cardano.CLI.Types.Key
-import qualified Cardano.Ledger.Conway.Governance as Ledger
+import Cardano.Ledger.Conway.Governance qualified as Ledger
 
 import Control.Monad
 import Control.Monad.Except (ExceptT)
 import Control.Monad.Trans (MonadTrans (..))
 import Control.Monad.Trans.Except.Extra
 import Data.Function
-import qualified Data.Map.Strict as Map
+import Data.Map.Strict qualified as Map
 
 runGovernanceActionCmds
   :: ()

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Actions.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Actions.hs
@@ -6,47 +6,48 @@
 
 module Cardano.CLI.EraBased.Run.Governance.Actions
   ( runGovernanceActionCmds
-  , GovernanceActionsError(..)
+  , GovernanceActionsError (..)
   ) where
 
-import           Cardano.Api
-import           Cardano.Api.Ledger (coerceKeyRole)
+import Cardano.Api
+import Cardano.Api.Ledger (coerceKeyRole)
 import qualified Cardano.Api.Ledger as Ledger
-import           Cardano.Api.Shelley
+import Cardano.Api.Shelley
 
-import           Cardano.CLI.EraBased.Commands.Governance.Actions
-import           Cardano.CLI.Read
-import           Cardano.CLI.Types.Common
-import           Cardano.CLI.Types.Errors.GovernanceActionsError
-import           Cardano.CLI.Types.Key
+import Cardano.CLI.EraBased.Commands.Governance.Actions
+import Cardano.CLI.Read
+import Cardano.CLI.Types.Common
+import Cardano.CLI.Types.Errors.GovernanceActionsError
+import Cardano.CLI.Types.Key
 import qualified Cardano.Ledger.Conway.Governance as Ledger
 
-import           Control.Monad
-import           Control.Monad.Except (ExceptT)
-import           Control.Monad.Trans (MonadTrans (..))
-import           Control.Monad.Trans.Except.Extra
-import           Data.Function
+import Control.Monad
+import Control.Monad.Except (ExceptT)
+import Control.Monad.Trans (MonadTrans (..))
+import Control.Monad.Trans.Except.Extra
+import Data.Function
 import qualified Data.Map.Strict as Map
 
-runGovernanceActionCmds :: ()
+runGovernanceActionCmds
+  :: ()
   => GovernanceActionCmds era
   -> ExceptT GovernanceActionsError IO ()
 runGovernanceActionCmds = \case
   GovernanceActionCreateConstitutionCmd cOn newConstitution ->
     runGovernanceActionCreateConstitutionCmd cOn newConstitution
-
   GovernanceActionProtocolParametersUpdateCmd sbe eNo genKeys eraBasedProtocolParametersUpdate ofp ->
-    runGovernanceActionCreateProtocolParametersUpdateCmd sbe eNo genKeys eraBasedProtocolParametersUpdate ofp
-
+    runGovernanceActionCreateProtocolParametersUpdateCmd
+      sbe
+      eNo
+      genKeys
+      eraBasedProtocolParametersUpdate
+      ofp
   GovernanceActionTreasuryWithdrawalCmd cOn treasuryWithdrawal ->
     runGovernanceActionTreasuryWithdrawalCmd cOn treasuryWithdrawal
-
   GoveranceActionCreateNewCommitteeCmd con newCommittee ->
     runGovernanceActionCreateNewCommitteeCmd con newCommittee
-
   GovernanceActionCreateNoConfidenceCmd cOn noConfidence ->
     runGovernanceActionCreateNoConfidenceCmd cOn noConfidence
-
   GovernanceActionInfoCmd cOn newInfo ->
     runGovernanceActionInfoCmd cOn newInfo
 
@@ -54,25 +55,26 @@ runGovernanceActionInfoCmd
   :: ConwayEraOnwards era
   -> NewInfoCmd
   -> ExceptT GovernanceActionsError IO ()
-runGovernanceActionInfoCmd cOn (NewInfoCmd network deposit returnAddr proposalUrl proposalHashSource  outFp) = do
+runGovernanceActionInfoCmd cOn (NewInfoCmd network deposit returnAddr proposalUrl proposalHashSource outFp) = do
   returnKeyHash <- readStakeKeyHash returnAddr
 
   proposalHash <-
     proposalHashSourceToHash proposalHashSource
       & firstExceptT GovernanceActionsCmdProposalError
 
-  let proposalAnchor = Ledger.Anchor
-        { Ledger.anchorUrl = unProposalUrl proposalUrl
-        , Ledger.anchorDataHash = proposalHash
-        }
+  let proposalAnchor =
+        Ledger.Anchor
+          { Ledger.anchorUrl = unProposalUrl proposalUrl
+          , Ledger.anchorDataHash = proposalHash
+          }
 
   let sbe = conwayEraOnwardsToShelleyBasedEra cOn
       govAction = InfoAct
       proposalProcedure = createProposalProcedure sbe network deposit returnKeyHash govAction proposalAnchor
 
-  firstExceptT GovernanceActionsCmdWriteFileError . newExceptT
-    $ conwayEraOnwardsConstraints cOn
-    $ writeFileTextEnvelope outFp Nothing proposalProcedure
+  firstExceptT GovernanceActionsCmdWriteFileError . newExceptT $
+    conwayEraOnwardsConstraints cOn $
+      writeFileTextEnvelope outFp Nothing proposalProcedure
 
 -- TODO: Conway era - update with new ledger types from cardano-ledger-conway-1.7.0.0
 runGovernanceActionCreateNoConfidenceCmd
@@ -86,52 +88,67 @@ runGovernanceActionCreateNoConfidenceCmd cOn (NoConfidenceCmd network deposit re
     proposalHashSourceToHash proposalHashSource
       & firstExceptT GovernanceActionsCmdProposalError
 
-  let proposalAnchor = Ledger.Anchor
-        { Ledger.anchorUrl = unProposalUrl proposalUrl
-        , Ledger.anchorDataHash = proposalHash
-        }
+  let proposalAnchor =
+        Ledger.Anchor
+          { Ledger.anchorUrl = unProposalUrl proposalUrl
+          , Ledger.anchorDataHash = proposalHash
+          }
 
   let sbe = conwayEraOnwardsToShelleyBasedEra cOn
       previousGovernanceAction = MotionOfNoConfidence . Ledger.SJust $ createPreviousGovernanceActionId txid ind
       proposalProcedure = createProposalProcedure sbe network deposit returnKeyHash previousGovernanceAction proposalAnchor
 
-  firstExceptT GovernanceActionsCmdWriteFileError . newExceptT
-    $ conwayEraOnwardsConstraints cOn
-    $ writeFileTextEnvelope outFp Nothing proposalProcedure
+  firstExceptT GovernanceActionsCmdWriteFileError . newExceptT $
+    conwayEraOnwardsConstraints cOn $
+      writeFileTextEnvelope outFp Nothing proposalProcedure
 
-runGovernanceActionCreateConstitutionCmd :: ()
+runGovernanceActionCreateConstitutionCmd
+  :: ()
   => ConwayEraOnwards era
   -> NewConstitutionCmd
   -> ExceptT GovernanceActionsError IO ()
-runGovernanceActionCreateConstitutionCmd cOn (NewConstitutionCmd network deposit anyStake mPrevGovActId proposalUrl proposalHashSource constitutionUrl constitutionHashSource outFp) = do
+runGovernanceActionCreateConstitutionCmd
+  cOn
+  ( NewConstitutionCmd
+      network
+      deposit
+      anyStake
+      mPrevGovActId
+      proposalUrl
+      proposalHashSource
+      constitutionUrl
+      constitutionHashSource
+      outFp
+    ) = do
+    stakeKeyHash <- readStakeKeyHash anyStake
 
-  stakeKeyHash <- readStakeKeyHash anyStake
+    proposalHash <-
+      proposalHashSourceToHash proposalHashSource
+        & firstExceptT GovernanceActionsCmdProposalError
 
-  proposalHash <-
-    proposalHashSourceToHash proposalHashSource
-      & firstExceptT GovernanceActionsCmdProposalError
+    let proposalAnchor =
+          Ledger.Anchor
+            { Ledger.anchorUrl = unProposalUrl proposalUrl
+            , Ledger.anchorDataHash = proposalHash
+            }
 
-  let proposalAnchor = Ledger.Anchor
-        { Ledger.anchorUrl = unProposalUrl proposalUrl
-        , Ledger.anchorDataHash = proposalHash
-        }
+    constitutionHash <-
+      constitutionHashSourceToHash constitutionHashSource
+        & firstExceptT GovernanceActionsCmdConstitutionError
 
-  constitutionHash <-
-    constitutionHashSourceToHash constitutionHashSource
-      & firstExceptT GovernanceActionsCmdConstitutionError
+    let prevGovActId = Ledger.maybeToStrictMaybe $ uncurry createPreviousGovernanceActionId <$> mPrevGovActId
+        constitutionAnchor =
+          Ledger.Anchor
+            { Ledger.anchorUrl = unConstitutionUrl constitutionUrl
+            , Ledger.anchorDataHash = constitutionHash
+            }
+        govAct = ProposeNewConstitution prevGovActId constitutionAnchor
+        sbe = conwayEraOnwardsToShelleyBasedEra cOn
+        proposalProcedure = createProposalProcedure sbe network deposit stakeKeyHash govAct proposalAnchor
 
-  let prevGovActId = Ledger.maybeToStrictMaybe $ uncurry createPreviousGovernanceActionId <$> mPrevGovActId
-      constitutionAnchor = Ledger.Anchor
-        { Ledger.anchorUrl = unConstitutionUrl constitutionUrl
-        , Ledger.anchorDataHash = constitutionHash
-        }
-      govAct = ProposeNewConstitution prevGovActId constitutionAnchor
-      sbe = conwayEraOnwardsToShelleyBasedEra cOn
-      proposalProcedure = createProposalProcedure sbe network deposit stakeKeyHash govAct proposalAnchor
-
-  firstExceptT GovernanceActionsCmdWriteFileError . newExceptT
-    $ conwayEraOnwardsConstraints cOn
-    $ writeFileTextEnvelope outFp Nothing proposalProcedure
+    firstExceptT GovernanceActionsCmdWriteFileError . newExceptT $
+      conwayEraOnwardsConstraints cOn $
+        writeFileTextEnvelope outFp Nothing proposalProcedure
 
 -- TODO: Conway era - After ledger bump update this function
 -- with the new ledger types
@@ -148,34 +165,38 @@ runGovernanceActionCreateNewCommitteeCmd cOn (NewCommitteeCmd network deposit re
     proposalHashSourceToHash proposalHashSource
       & firstExceptT GovernanceActionsCmdProposalError
 
-  let proposalAnchor = Ledger.Anchor
-        { Ledger.anchorUrl = unProposalUrl proposalUrl
-        , Ledger.anchorDataHash = proposalHash
-        }
+  let proposalAnchor =
+        Ledger.Anchor
+          { Ledger.anchorUrl = unProposalUrl proposalUrl
+          , Ledger.anchorDataHash = proposalHash
+          }
 
   oldCommitteeKeyHashes <- forM old $ \vkeyOrHashOrTextFile ->
     lift (readVerificationKeyOrHashOrTextEnvFile AsCommitteeColdKey vkeyOrHashOrTextFile)
       & onLeft (left . GovernanceActionsCmdReadFileError)
 
   newCommitteeKeyHashes <- forM new $ \(vkeyOrHashOrTextFile, expEpoch) -> do
-    kh <- lift (readVerificationKeyOrHashOrTextEnvFile AsCommitteeColdKey vkeyOrHashOrTextFile)
-      & onLeft (left . GovernanceActionsCmdReadFileError)
+    kh <-
+      lift (readVerificationKeyOrHashOrTextEnvFile AsCommitteeColdKey vkeyOrHashOrTextFile)
+        & onLeft (left . GovernanceActionsCmdReadFileError)
     pure (kh, expEpoch)
 
   returnKeyHash <- readStakeKeyHash retAddr
 
-  let proposeNewCommittee = ProposeNewCommittee
-                              govActIdentifier
-                              oldCommitteeKeyHashes
-                              (Map.fromList newCommitteeKeyHashes)
-                              quorumRational
+  let proposeNewCommittee =
+        ProposeNewCommittee
+          govActIdentifier
+          oldCommitteeKeyHashes
+          (Map.fromList newCommitteeKeyHashes)
+          quorumRational
       proposal = createProposalProcedure sbe network deposit returnKeyHash proposeNewCommittee proposalAnchor
 
-  firstExceptT GovernanceActionsCmdWriteFileError . newExceptT
-    $ conwayEraOnwardsConstraints cOn
-    $ writeFileTextEnvelope oFp Nothing proposal
+  firstExceptT GovernanceActionsCmdWriteFileError . newExceptT $
+    conwayEraOnwardsConstraints cOn $
+      writeFileTextEnvelope oFp Nothing proposal
 
-runGovernanceActionCreateProtocolParametersUpdateCmd :: ()
+runGovernanceActionCreateProtocolParametersUpdateCmd
+  :: ()
   => ShelleyBasedEra era
   -> EpochNo
   -> [VerificationKeyFile In]
@@ -184,11 +205,12 @@ runGovernanceActionCreateProtocolParametersUpdateCmd :: ()
   -> File () Out
   -> ExceptT GovernanceActionsError IO ()
 runGovernanceActionCreateProtocolParametersUpdateCmd sbe expEpoch genesisVerKeys eraBasedPParams oFp = do
-  genVKeys <- sequence
-    [ firstExceptT GovernanceActionsCmdReadTextEnvelopeFileError . newExceptT
-        $ readFileTextEnvelope (AsVerificationKey AsGenesisKey) vkeyFile
-    | vkeyFile <- genesisVerKeys
-    ]
+  genVKeys <-
+    sequence
+      [ firstExceptT GovernanceActionsCmdReadTextEnvelopeFileError . newExceptT $
+        readFileTextEnvelope (AsVerificationKey AsGenesisKey) vkeyFile
+      | vkeyFile <- genesisVerKeys
+      ]
 
   let updateProtocolParams = createEraBasedProtocolParamUpdate sbe eraBasedPParams
       apiUpdateProtocolParamsType = fromLedgerPParamsUpdate sbe updateProtocolParams
@@ -197,60 +219,79 @@ runGovernanceActionCreateProtocolParametersUpdateCmd sbe expEpoch genesisVerKeys
       -- depending on the era
       upProp = makeShelleyUpdateProposal apiUpdateProtocolParamsType genKeyHashes expEpoch
 
-  firstExceptT GovernanceActionsCmdWriteFileError . newExceptT
-    $ writeLazyByteStringFile oFp $ textEnvelopeToJSON Nothing upProp
+  firstExceptT GovernanceActionsCmdWriteFileError . newExceptT $
+    writeLazyByteStringFile oFp $
+      textEnvelopeToJSON Nothing upProp
 
 readStakeKeyHash :: AnyStakeIdentifier -> ExceptT GovernanceActionsError IO (Hash StakeKey)
 readStakeKeyHash anyStake =
   case anyStake of
     AnyStakeKey stake ->
       firstExceptT GovernanceActionsCmdReadFileError
-        . newExceptT $ readVerificationKeyOrHashOrFile AsStakeKey stake
-
+        . newExceptT
+        $ readVerificationKeyOrHashOrFile AsStakeKey stake
     AnyStakePoolKey stake -> do
-      StakePoolKeyHash t <- firstExceptT GovernanceActionsCmdReadFileError
-                              . newExceptT $ readVerificationKeyOrHashOrFile AsStakePoolKey stake
+      StakePoolKeyHash t <-
+        firstExceptT GovernanceActionsCmdReadFileError
+          . newExceptT
+          $ readVerificationKeyOrHashOrFile AsStakePoolKey stake
       return $ StakeKeyHash $ coerceKeyRole t
 
 runGovernanceActionTreasuryWithdrawalCmd
   :: ConwayEraOnwards era
   -> TreasuryWithdrawalCmd
   -> ExceptT GovernanceActionsError IO ()
-runGovernanceActionTreasuryWithdrawalCmd cOn (TreasuryWithdrawalCmd network deposit returnAddr proposalUrl proposalHashSource treasuryWithdrawal outFp) = do
+runGovernanceActionTreasuryWithdrawalCmd
+  cOn
+  ( TreasuryWithdrawalCmd
+      network
+      deposit
+      returnAddr
+      proposalUrl
+      proposalHashSource
+      treasuryWithdrawal
+      outFp
+    ) = do
+    proposalHash <-
+      proposalHashSourceToHash proposalHashSource
+        & firstExceptT GovernanceActionsCmdProposalError
 
-  proposalHash <-
-    proposalHashSourceToHash proposalHashSource
-      & firstExceptT GovernanceActionsCmdProposalError
+    let proposalAnchor =
+          Ledger.Anchor
+            { Ledger.anchorUrl = unProposalUrl proposalUrl
+            , Ledger.anchorDataHash = proposalHash
+            }
 
-  let proposalAnchor = Ledger.Anchor
-        { Ledger.anchorUrl = unProposalUrl proposalUrl
-        , Ledger.anchorDataHash = proposalHash
-        }
+    returnKeyHash <- readStakeKeyHash returnAddr
 
-  returnKeyHash <- readStakeKeyHash returnAddr
+    withdrawals <-
+      sequence
+        [ (network,,ll) <$> stakeIdentifiertoCredential stakeIdentifier
+        | (stakeIdentifier, ll) <- treasuryWithdrawal
+        ]
 
-  withdrawals <- sequence
-    [ (network,,ll) <$> stakeIdentifiertoCredential stakeIdentifier
-    | (stakeIdentifier,ll) <- treasuryWithdrawal
-    ]
+    let sbe = conwayEraOnwardsToShelleyBasedEra cOn
+        treasuryWithdrawals = TreasuryWithdrawal withdrawals
+        proposal = createProposalProcedure sbe network deposit returnKeyHash treasuryWithdrawals proposalAnchor
 
-  let sbe = conwayEraOnwardsToShelleyBasedEra cOn
-      treasuryWithdrawals = TreasuryWithdrawal withdrawals
-      proposal = createProposalProcedure sbe network deposit returnKeyHash treasuryWithdrawals proposalAnchor
+    firstExceptT GovernanceActionsCmdWriteFileError . newExceptT $
+      conwayEraOnwardsConstraints cOn $
+        writeFileTextEnvelope outFp Nothing proposal
 
-  firstExceptT GovernanceActionsCmdWriteFileError . newExceptT
-    $ conwayEraOnwardsConstraints cOn
-    $ writeFileTextEnvelope outFp Nothing proposal
-
-stakeIdentifiertoCredential :: AnyStakeIdentifier -> ExceptT GovernanceActionsError IO StakeCredential
+stakeIdentifiertoCredential
+  :: AnyStakeIdentifier -> ExceptT GovernanceActionsError IO StakeCredential
 stakeIdentifiertoCredential anyStake =
   case anyStake of
     AnyStakeKey stake -> do
-      hash <- firstExceptT GovernanceActionsCmdReadFileError
-                . newExceptT $ readVerificationKeyOrHashOrFile AsStakeKey stake
+      hash <-
+        firstExceptT GovernanceActionsCmdReadFileError
+          . newExceptT
+          $ readVerificationKeyOrHashOrFile AsStakeKey stake
       return $ StakeCredentialByKey hash
     AnyStakePoolKey stake -> do
-      StakePoolKeyHash t <- firstExceptT GovernanceActionsCmdReadFileError
-                              . newExceptT $ readVerificationKeyOrHashOrFile AsStakePoolKey stake
+      StakePoolKeyHash t <-
+        firstExceptT GovernanceActionsCmdReadFileError
+          . newExceptT
+          $ readVerificationKeyOrHashOrFile AsStakePoolKey stake
       -- TODO: Conway era - don't use coerceKeyRole
       return . StakeCredentialByKey $ StakeKeyHash $ coerceKeyRole t

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Committee.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Committee.hs
@@ -19,7 +19,7 @@ import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Trans (lift)
 import Control.Monad.Trans.Except.Extra
 import Data.ByteString (ByteString)
-import qualified Data.ByteString.Char8 as BS
+import Data.ByteString.Char8 qualified as BS
 import Data.Function
 
 runGovernanceCommitteeCmds

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/DRep.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/DRep.hs
@@ -12,7 +12,7 @@ module Cardano.CLI.EraBased.Run.Governance.DRep
   ) where
 
 import Cardano.Api
-import qualified Cardano.Api.Ledger as Ledger
+import Cardano.Api.Ledger qualified as Ledger
 import Cardano.Api.Shelley
 
 import Cardano.CLI.EraBased.Commands.Governance.DRep
@@ -28,7 +28,7 @@ import Control.Monad.Trans.Class
 import Control.Monad.Trans.Except
 import Control.Monad.Trans.Except.Extra
 import Data.Function
-import qualified Data.Text.Encoding as Text
+import Data.Text.Encoding qualified as Text
 
 runGovernanceDRepCmds
   :: ()

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Query.hs
@@ -13,25 +13,25 @@ module Cardano.CLI.EraBased.Run.Governance.Query
   ) where
 
 import Cardano.Api
-import qualified Cardano.Api.Ledger as Ledger
+import Cardano.Api.Ledger qualified as Ledger
 
 import Cardano.CLI.EraBased.Commands.Governance.Query
 import Cardano.CLI.Read
 import Cardano.CLI.Types.Errors.CmdError
 import Cardano.CLI.Types.Errors.GovernanceQueryError
-import qualified Ouroboros.Consensus.Cardano.Block as Consensus
+import Ouroboros.Consensus.Cardano.Block qualified as Consensus
 
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Trans.Except (ExceptT)
 import Control.Monad.Trans.Except.Extra
 import Data.Aeson ((.=))
-import qualified Data.Aeson as A
+import Data.Aeson qualified as A
 import Data.Aeson.Encode.Pretty (encodePretty)
 import Data.Bifunctor (second)
-import qualified Data.ByteString.Lazy.Char8 as LBS
+import Data.ByteString.Lazy.Char8 qualified as LBS
 import Data.Function
-import qualified Data.Map.Strict as Map
-import qualified Data.Set as Set
+import Data.Map.Strict qualified as Map
+import Data.Set qualified as Set
 import Lens.Micro ((^.))
 
 runGovernanceQueryCmds

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Vote.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Vote.hs
@@ -9,7 +9,7 @@ module Cardano.CLI.EraBased.Run.Governance.Vote
   ) where
 
 import Cardano.Api
-import qualified Cardano.Api.Ledger as Ledger
+import Cardano.Api.Ledger qualified as Ledger
 import Cardano.Api.Shelley
 
 import Cardano.CLI.EraBased.Commands.Governance.Vote

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Vote.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Vote.hs
@@ -8,23 +8,24 @@ module Cardano.CLI.EraBased.Run.Governance.Vote
   ( runGovernanceVoteCmds
   ) where
 
-import           Cardano.Api
+import Cardano.Api
 import qualified Cardano.Api.Ledger as Ledger
-import           Cardano.Api.Shelley
+import Cardano.Api.Shelley
 
-import           Cardano.CLI.EraBased.Commands.Governance.Vote
-import           Cardano.CLI.Types.Errors.CmdError
-import           Cardano.CLI.Types.Errors.GovernanceVoteCmdError
-import           Cardano.CLI.Types.Governance
-import           Cardano.CLI.Types.Key
-import           Cardano.Ledger.Keys (coerceKeyRole)
+import Cardano.CLI.EraBased.Commands.Governance.Vote
+import Cardano.CLI.Types.Errors.CmdError
+import Cardano.CLI.Types.Errors.GovernanceVoteCmdError
+import Cardano.CLI.Types.Governance
+import Cardano.CLI.Types.Key
+import Cardano.Ledger.Keys (coerceKeyRole)
 
-import           Control.Monad.Except
-import           Control.Monad.Trans.Except.Extra
-import           Data.Bifunctor
-import           Data.Function
+import Control.Monad.Except
+import Control.Monad.Trans.Except.Extra
+import Data.Bifunctor
+import Data.Function
 
-runGovernanceVoteCmds :: ()
+runGovernanceVoteCmds
+  :: ()
   => GovernanceVoteCmds era
   -> ExceptT CmdError IO ()
 runGovernanceVoteCmds = \case
@@ -37,38 +38,46 @@ runGovernanceVoteCreateCmd
   -> ExceptT GovernanceVoteCmdError IO ()
 runGovernanceVoteCreateCmd (ConwayOnwardsVote cOnwards voteChoice (govActionTxId, govActionIndex) voteStakeCred oFp) = do
   let sbe = conwayEraOnwardsToShelleyBasedEra cOnwards -- TODO: Conway era - update vote creation related function to take ConwayEraOnwards
-
   shelleyBasedEraConstraints sbe $ do
     case voteStakeCred of
       AnyDRepVerificationKeyOrHashOrFile stake -> do
-        DRepKeyHash h <- firstExceptT  GovernanceVoteCmdReadError
-                                . newExceptT $ readVerificationKeyOrHashOrTextEnvFile AsDRepKey stake
+        DRepKeyHash h <-
+          firstExceptT GovernanceVoteCmdReadError
+            . newExceptT
+            $ readVerificationKeyOrHashOrTextEnvFile AsDRepKey stake
         let vStakeCred = StakeCredentialByKey . StakeKeyHash $ coerceKeyRole h
 
-        votingCred <- hoistEither $ first GovernanceVoteCmdCredentialDecodeError $ toVotingCredential sbe vStakeCred
+        votingCred <-
+          hoistEither $ first GovernanceVoteCmdCredentialDecodeError $ toVotingCredential sbe vStakeCred
         let voter = Ledger.DRepVoter (unVotingCredential votingCred)
             govActIdentifier = createGovernanceActionId govActionTxId govActionIndex
             voteProcedure = createVotingProcedure sbe voteChoice Nothing
             votingProcedures = singletonVotingProcedures sbe voter govActIdentifier (unVotingProcedure voteProcedure)
-        firstExceptT GovernanceVoteCmdWriteError . newExceptT $ writeFileTextEnvelope oFp Nothing votingProcedures
-
+        firstExceptT GovernanceVoteCmdWriteError . newExceptT $
+          writeFileTextEnvelope oFp Nothing votingProcedures
       AnyStakePoolVerificationKeyOrHashOrFile stake -> do
-        h <- firstExceptT GovernanceVoteCmdReadError
-              . newExceptT $ readVerificationKeyOrHashOrTextEnvFile AsStakePoolKey stake
+        h <-
+          firstExceptT GovernanceVoteCmdReadError
+            . newExceptT
+            $ readVerificationKeyOrHashOrTextEnvFile AsStakePoolKey stake
 
         let voter = Ledger.StakePoolVoter (unStakePoolKeyHash h)
             govActIdentifier = createGovernanceActionId govActionTxId govActionIndex
             voteProcedure = createVotingProcedure sbe voteChoice Nothing
             votingProcedures = singletonVotingProcedures sbe voter govActIdentifier (unVotingProcedure voteProcedure)
-        firstExceptT GovernanceVoteCmdWriteError . newExceptT $ writeFileTextEnvelope oFp Nothing votingProcedures
-
+        firstExceptT GovernanceVoteCmdWriteError . newExceptT $
+          writeFileTextEnvelope oFp Nothing votingProcedures
       AnyCommitteeHotVerificationKeyOrHashOrFile stake -> do
-        CommitteeHotKeyHash h <- firstExceptT GovernanceVoteCmdReadError
-                                  . newExceptT $ readVerificationKeyOrHashOrTextEnvFile AsCommitteeHotKey stake
+        CommitteeHotKeyHash h <-
+          firstExceptT GovernanceVoteCmdReadError
+            . newExceptT
+            $ readVerificationKeyOrHashOrTextEnvFile AsCommitteeHotKey stake
         let vStakeCred = StakeCredentialByKey . StakeKeyHash $ coerceKeyRole h
-        votingCred <- hoistEither $ first GovernanceVoteCmdCredentialDecodeError $ toVotingCredential sbe vStakeCred
+        votingCred <-
+          hoistEither $ first GovernanceVoteCmdCredentialDecodeError $ toVotingCredential sbe vStakeCred
         let voter = Ledger.CommitteeVoter (Ledger.coerceKeyRole (unVotingCredential votingCred)) -- TODO Conway - remove coerceKeyRole
             govActIdentifier = createGovernanceActionId govActionTxId govActionIndex
             voteProcedure = createVotingProcedure sbe voteChoice Nothing
             votingProcedures = singletonVotingProcedures sbe voter govActIdentifier (unVotingProcedure voteProcedure)
-        firstExceptT GovernanceVoteCmdWriteError . newExceptT $ writeFileTextEnvelope oFp Nothing votingProcedures
+        firstExceptT GovernanceVoteCmdWriteError . newExceptT $
+          writeFileTextEnvelope oFp Nothing votingProcedures

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Key.hs
@@ -20,34 +20,34 @@ module Cardano.CLI.EraBased.Run.Key
   ) where
 
 import Cardano.Api
-import qualified Cardano.Api.Byron as ByronApi
+import Cardano.Api.Byron qualified as ByronApi
 import Cardano.Api.Crypto.Ed25519Bip32 (xPrvFromBytes)
 
-import qualified Cardano.CLI.Byron.Key as Byron
+import Cardano.CLI.Byron.Key qualified as Byron
 import Cardano.CLI.EraBased.Commands.Key
 import Cardano.CLI.Types.Common
 import Cardano.CLI.Types.Errors.CardanoAddressSigningKeyConversionError
 import Cardano.CLI.Types.Errors.ItnKeyConversionError
 import Cardano.CLI.Types.Errors.KeyCmdError
 import Cardano.CLI.Types.Key
-import qualified Cardano.Crypto.DSIGN as DSIGN
-import qualified Cardano.Crypto.Signing as Byron
-import qualified Cardano.Crypto.Signing as Byron.Crypto
-import qualified Cardano.Crypto.Signing as Crypto
-import qualified Cardano.Crypto.Wallet as Crypto
-import qualified Cardano.Ledger.Keys as Shelley
+import Cardano.Crypto.DSIGN qualified as DSIGN
+import Cardano.Crypto.Signing qualified as Byron
+import Cardano.Crypto.Signing qualified as Byron.Crypto
+import Cardano.Crypto.Signing qualified as Crypto
+import Cardano.Crypto.Wallet qualified as Crypto
+import Cardano.Ledger.Keys qualified as Shelley
 
-import qualified Codec.Binary.Bech32 as Bech32
-import qualified Control.Exception as Exception
+import Codec.Binary.Bech32 qualified as Bech32
+import Control.Exception qualified as Exception
 import Control.Monad.IO.Class (MonadIO (..))
 import Control.Monad.Trans.Except (ExceptT)
 import Control.Monad.Trans.Except.Extra (firstExceptT, hoistEither, left, newExceptT)
 import Data.Bifunctor (Bifunctor (..))
 import Data.ByteString (ByteString)
-import qualified Data.ByteString as BS
+import Data.ByteString qualified as BS
 import Data.Text (Text)
-import qualified Data.Text as Text
-import qualified Data.Text.Encoding as Text
+import Data.Text qualified as Text
+import Data.Text.Encoding qualified as Text
 import System.Exit (exitFailure)
 
 runKeyCmds

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Node.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Node.hs
@@ -3,7 +3,6 @@
 
 module Cardano.CLI.EraBased.Run.Node
   ( runNodeCmds
-
   , runNodeIssueOpCertCmd
   , runNodeKeyGenColdCmd
   , runNodeKeyGenKesCmd
@@ -12,32 +11,33 @@ module Cardano.CLI.EraBased.Run.Node
   , runNodeNewCounterCmd
   ) where
 
-import           Cardano.Api
-import           Cardano.Api.Shelley
+import Cardano.Api
+import Cardano.Api.Shelley
 
-import           Cardano.CLI.EraBased.Commands.Node
-import           Cardano.CLI.Types.Common
-import           Cardano.CLI.Types.Errors.NodeCmdError
-import           Cardano.CLI.Types.Key
+import Cardano.CLI.EraBased.Commands.Node
+import Cardano.CLI.Types.Common
+import Cardano.CLI.Types.Errors.NodeCmdError
+import Cardano.CLI.Types.Key
 
-import           Control.Monad.IO.Class (MonadIO (..))
-import           Control.Monad.Trans.Except (ExceptT)
-import           Control.Monad.Trans.Except.Extra (firstExceptT, hoistEither, newExceptT)
+import Control.Monad.IO.Class (MonadIO (..))
+import Control.Monad.Trans.Except (ExceptT)
+import Control.Monad.Trans.Except.Extra (firstExceptT, hoistEither, newExceptT)
 import qualified Data.ByteString.Char8 as BS
-import           Data.String (fromString)
-import           Data.Word (Word64)
+import Data.String (fromString)
+import Data.Word (Word64)
 
 {- HLINT ignore "Reduce duplication" -}
 
-runNodeCmds :: ()
+runNodeCmds
+  :: ()
   => NodeCmds era
   -> ExceptT NodeCmdError IO ()
 runNodeCmds = \case
   NodeKeyGenCold fmt vk sk ctr ->
     runNodeKeyGenColdCmd fmt vk sk ctr
-  NodeKeyGenKES  fmt vk sk ->
+  NodeKeyGenKES fmt vk sk ->
     runNodeKeyGenKesCmd fmt vk sk
-  NodeKeyGenVRF  fmt vk sk ->
+  NodeKeyGenVRF fmt vk sk ->
     runNodeKeyGenVrfCmd fmt vk sk
   NodeKeyHashVRF vk mOutFp ->
     runNodeKeyHashVrfCmd vk mOutFp
@@ -53,52 +53,52 @@ runNodeKeyGenColdCmd
   -> OpCertCounterFile Out
   -> ExceptT NodeCmdError IO ()
 runNodeKeyGenColdCmd fmt vkeyPath skeyPath ocertCtrPath = do
-    skey <- liftIO $ generateSigningKey AsStakePoolKey
-    let vkey = getVerificationKey skey
+  skey <- liftIO $ generateSigningKey AsStakePoolKey
+  let vkey = getVerificationKey skey
 
-    case fmt of
-      KeyOutputFormatTextEnvelope ->
-        firstExceptT NodeCmdWriteFileError
-          . newExceptT
-          $ writeLazyByteStringFile skeyPath
-          $ textEnvelopeToJSON (Just skeyDesc) skey
-      KeyOutputFormatBech32 ->
-        firstExceptT NodeCmdWriteFileError
-          . newExceptT
-          $ writeTextFile skeyPath
-          $ serialiseToBech32 skey
+  case fmt of
+    KeyOutputFormatTextEnvelope ->
+      firstExceptT NodeCmdWriteFileError
+        . newExceptT
+        $ writeLazyByteStringFile skeyPath
+        $ textEnvelopeToJSON (Just skeyDesc) skey
+    KeyOutputFormatBech32 ->
+      firstExceptT NodeCmdWriteFileError
+        . newExceptT
+        $ writeTextFile skeyPath
+        $ serialiseToBech32 skey
 
-    case fmt of
-      KeyOutputFormatTextEnvelope ->
-        firstExceptT NodeCmdWriteFileError
-          . newExceptT
-          $ writeLazyByteStringFile vkeyPath
-          $ textEnvelopeToJSON (Just vkeyDesc) vkey
-      KeyOutputFormatBech32 ->
-        firstExceptT NodeCmdWriteFileError
-          . newExceptT
-          $ writeTextFile vkeyPath
-          $ serialiseToBech32 vkey
+  case fmt of
+    KeyOutputFormatTextEnvelope ->
+      firstExceptT NodeCmdWriteFileError
+        . newExceptT
+        $ writeLazyByteStringFile vkeyPath
+        $ textEnvelopeToJSON (Just vkeyDesc) vkey
+    KeyOutputFormatBech32 ->
+      firstExceptT NodeCmdWriteFileError
+        . newExceptT
+        $ writeTextFile vkeyPath
+        $ serialiseToBech32 vkey
 
-    firstExceptT NodeCmdWriteFileError
-      . newExceptT
-      $ writeLazyByteStringFile ocertCtrPath
-      $ textEnvelopeToJSON (Just ocertCtrDesc)
-      $ OperationalCertificateIssueCounter initialCounter vkey
-  where
-    skeyDesc :: TextEnvelopeDescr
-    skeyDesc = "Stake Pool Operator Signing Key"
+  firstExceptT NodeCmdWriteFileError
+    . newExceptT
+    $ writeLazyByteStringFile ocertCtrPath
+    $ textEnvelopeToJSON (Just ocertCtrDesc)
+    $ OperationalCertificateIssueCounter initialCounter vkey
+ where
+  skeyDesc :: TextEnvelopeDescr
+  skeyDesc = "Stake Pool Operator Signing Key"
 
-    vkeyDesc :: TextEnvelopeDescr
-    vkeyDesc = "Stake Pool Operator Verification Key"
+  vkeyDesc :: TextEnvelopeDescr
+  vkeyDesc = "Stake Pool Operator Verification Key"
 
-    ocertCtrDesc :: TextEnvelopeDescr
-    ocertCtrDesc = "Next certificate issue number: "
-                <> fromString (show initialCounter)
+  ocertCtrDesc :: TextEnvelopeDescr
+  ocertCtrDesc =
+    "Next certificate issue number: "
+      <> fromString (show initialCounter)
 
-    initialCounter :: Word64
-    initialCounter = 0
-
+  initialCounter :: Word64
+  initialCounter = 0
 
 runNodeKeyGenKesCmd
   :: KeyOutputFormat
@@ -133,13 +133,12 @@ runNodeKeyGenKesCmd fmt vkeyPath skeyPath = do
         . newExceptT
         $ writeTextFile vkeyPath
         $ serialiseToBech32 vkey
+ where
+  skeyDesc :: TextEnvelopeDescr
+  skeyDesc = "KES Signing Key"
 
-  where
-    skeyDesc :: TextEnvelopeDescr
-    skeyDesc = "KES Signing Key"
-
-    vkeyDesc :: TextEnvelopeDescr
-    vkeyDesc = "KES Verification Key"
+  vkeyDesc :: TextEnvelopeDescr
+  vkeyDesc = "KES Verification Key"
 
 runNodeKeyGenVrfCmd
   :: KeyOutputFormat
@@ -174,18 +173,20 @@ runNodeKeyGenVrfCmd fmt vkeyPath skeyPath = do
         . newExceptT
         $ writeTextFile vkeyPath
         $ serialiseToBech32 vkey
-  where
-    skeyDesc, vkeyDesc :: TextEnvelopeDescr
-    skeyDesc = "VRF Signing Key"
-    vkeyDesc = "VRF Verification Key"
+ where
+  skeyDesc, vkeyDesc :: TextEnvelopeDescr
+  skeyDesc = "VRF Signing Key"
+  vkeyDesc = "VRF Verification Key"
 
-runNodeKeyHashVrfCmd :: VerificationKeyOrFile VrfKey
-                  -> Maybe (File () Out)
-                  -> ExceptT NodeCmdError IO ()
+runNodeKeyHashVrfCmd
+  :: VerificationKeyOrFile VrfKey
+  -> Maybe (File () Out)
+  -> ExceptT NodeCmdError IO ()
 runNodeKeyHashVrfCmd verKeyOrFile mOutputFp = do
-  vkey <- firstExceptT NodeCmdReadKeyFileError
-    . newExceptT
-    $ readVerificationKeyOrFile AsVrfKey verKeyOrFile
+  vkey <-
+    firstExceptT NodeCmdReadKeyFileError
+      . newExceptT
+      $ readVerificationKeyOrFile AsVrfKey verKeyOrFile
 
   let hexKeyHash = serialiseToRawBytesHex (verificationKeyHash vkey)
 
@@ -193,95 +194,105 @@ runNodeKeyHashVrfCmd verKeyOrFile mOutputFp = do
     Just fpath -> liftIO $ BS.writeFile (unFile fpath) hexKeyHash
     Nothing -> liftIO $ BS.putStrLn hexKeyHash
 
-
-runNodeNewCounterCmd :: ColdVerificationKeyOrFile
-                  -> Word
-                  -> OpCertCounterFile InOut
-                  -> ExceptT NodeCmdError IO ()
+runNodeNewCounterCmd
+  :: ColdVerificationKeyOrFile
+  -> Word
+  -> OpCertCounterFile InOut
+  -> ExceptT NodeCmdError IO ()
 runNodeNewCounterCmd coldVerKeyOrFile counter ocertCtrPath = do
-
-    vkey <- firstExceptT NodeCmdReadFileError . newExceptT $
+  vkey <-
+    firstExceptT NodeCmdReadFileError . newExceptT $
       readColdVerificationKeyOrFile coldVerKeyOrFile
 
-    let ocertIssueCounter =
-          OperationalCertificateIssueCounter (fromIntegral counter) vkey
+  let ocertIssueCounter =
+        OperationalCertificateIssueCounter (fromIntegral counter) vkey
 
-    firstExceptT NodeCmdWriteFileError . newExceptT
-      $ writeLazyByteStringFile (onlyOut ocertCtrPath)
-      $ textEnvelopeToJSON Nothing ocertIssueCounter
+  firstExceptT NodeCmdWriteFileError . newExceptT $
+    writeLazyByteStringFile (onlyOut ocertCtrPath) $
+      textEnvelopeToJSON Nothing ocertIssueCounter
 
-
-runNodeIssueOpCertCmd :: VerificationKeyOrFile KesKey
-                   -- ^ This is the hot KES verification key.
-                   -> SigningKeyFile In
-                   -- ^ This is the cold signing key.
-                   -> OpCertCounterFile InOut
-                   -- ^ Counter that establishes the precedence
-                   -- of the operational certificate.
-                   -> KESPeriod
-                   -- ^ Start of the validity period for this certificate.
-                   -> File () Out
-                   -> ExceptT NodeCmdError IO ()
+runNodeIssueOpCertCmd
+  :: VerificationKeyOrFile KesKey
+  -- ^ This is the hot KES verification key.
+  -> SigningKeyFile In
+  -- ^ This is the cold signing key.
+  -> OpCertCounterFile InOut
+  -- ^ Counter that establishes the precedence
+  -- of the operational certificate.
+  -> KESPeriod
+  -- ^ Start of the validity period for this certificate.
+  -> File () Out
+  -> ExceptT NodeCmdError IO ()
 runNodeIssueOpCertCmd kesVerKeyOrFile stakePoolSKeyFile ocertCtrPath kesPeriod certFile = do
-
-    ocertIssueCounter <- firstExceptT NodeCmdReadFileError
+  ocertIssueCounter <-
+    firstExceptT NodeCmdReadFileError
       . newExceptT
       $ readFileTextEnvelope AsOperationalCertificateIssueCounter (onlyIn ocertCtrPath)
 
-    verKeyKes <- firstExceptT NodeCmdReadKeyFileError
+  verKeyKes <-
+    firstExceptT NodeCmdReadKeyFileError
       . newExceptT
       $ readVerificationKeyOrFile AsKesKey kesVerKeyOrFile
 
-    signKey <- firstExceptT NodeCmdReadKeyFileError
+  signKey <-
+    firstExceptT NodeCmdReadKeyFileError
       . newExceptT
       $ readKeyFileAnyOf
-          bech32PossibleBlockIssuers
-          textEnvPossibleBlockIssuers
-          stakePoolSKeyFile
+        bech32PossibleBlockIssuers
+        textEnvPossibleBlockIssuers
+        stakePoolSKeyFile
 
-    (ocert, nextOcertCtr) <-
-      firstExceptT NodeCmdOperationalCertificateIssueError
-        . hoistEither
-        $ issueOperationalCertificate
-            verKeyKes
-            signKey
-            kesPeriod
-            ocertIssueCounter
+  (ocert, nextOcertCtr) <-
+    firstExceptT NodeCmdOperationalCertificateIssueError
+      . hoistEither
+      $ issueOperationalCertificate
+        verKeyKes
+        signKey
+        kesPeriod
+        ocertIssueCounter
 
-    -- Write the counter first, to reduce the chance of ending up with
-    -- a new cert but without updating the counter.
-    firstExceptT NodeCmdWriteFileError
-      . newExceptT
-      $ writeLazyByteStringFile (onlyOut ocertCtrPath)
-      $ textEnvelopeToJSON (Just $ ocertCtrDesc $ getCounter nextOcertCtr) nextOcertCtr
+  -- Write the counter first, to reduce the chance of ending up with
+  -- a new cert but without updating the counter.
+  firstExceptT NodeCmdWriteFileError
+    . newExceptT
+    $ writeLazyByteStringFile (onlyOut ocertCtrPath)
+    $ textEnvelopeToJSON (Just $ ocertCtrDesc $ getCounter nextOcertCtr) nextOcertCtr
 
-    firstExceptT NodeCmdWriteFileError
-      . newExceptT
-      $ writeLazyByteStringFile certFile
-      $ textEnvelopeToJSON Nothing ocert
-  where
-    getCounter :: OperationalCertificateIssueCounter -> Word64
-    getCounter (OperationalCertificateIssueCounter n _) = n
+  firstExceptT NodeCmdWriteFileError
+    . newExceptT
+    $ writeLazyByteStringFile certFile
+    $ textEnvelopeToJSON Nothing ocert
+ where
+  getCounter :: OperationalCertificateIssueCounter -> Word64
+  getCounter (OperationalCertificateIssueCounter n _) = n
 
-    ocertCtrDesc :: Word64 -> TextEnvelopeDescr
-    ocertCtrDesc n = "Next certificate issue number: " <> fromString (show n)
+  ocertCtrDesc :: Word64 -> TextEnvelopeDescr
+  ocertCtrDesc n = "Next certificate issue number: " <> fromString (show n)
 
-    textEnvPossibleBlockIssuers
-      :: [FromSomeType HasTextEnvelope
-                       (Either (SigningKey StakePoolKey)
-                               (SigningKey GenesisDelegateExtendedKey))]
-    textEnvPossibleBlockIssuers =
-      [ FromSomeType (AsSigningKey AsStakePoolKey)        Left
-      , FromSomeType (AsSigningKey AsGenesisDelegateKey) (Left . castSigningKey)
-      , FromSomeType (AsSigningKey AsGenesisDelegateExtendedKey) Right
-      ]
+  textEnvPossibleBlockIssuers
+    :: [ FromSomeType
+          HasTextEnvelope
+          ( Either
+              (SigningKey StakePoolKey)
+              (SigningKey GenesisDelegateExtendedKey)
+          )
+       ]
+  textEnvPossibleBlockIssuers =
+    [ FromSomeType (AsSigningKey AsStakePoolKey) Left
+    , FromSomeType (AsSigningKey AsGenesisDelegateKey) (Left . castSigningKey)
+    , FromSomeType (AsSigningKey AsGenesisDelegateExtendedKey) Right
+    ]
 
-    bech32PossibleBlockIssuers
-      :: [FromSomeType SerialiseAsBech32
-                       (Either (SigningKey StakePoolKey)
-                               (SigningKey GenesisDelegateExtendedKey))]
-    bech32PossibleBlockIssuers =
-      [FromSomeType (AsSigningKey AsStakePoolKey) Left]
+  bech32PossibleBlockIssuers
+    :: [ FromSomeType
+          SerialiseAsBech32
+          ( Either
+              (SigningKey StakePoolKey)
+              (SigningKey GenesisDelegateExtendedKey)
+          )
+       ]
+  bech32PossibleBlockIssuers =
+    [FromSomeType (AsSigningKey AsStakePoolKey) Left]
 
 -- | Read a cold verification key or file.
 --

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Node.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Node.hs
@@ -22,7 +22,7 @@ import Cardano.CLI.Types.Key
 import Control.Monad.IO.Class (MonadIO (..))
 import Control.Monad.Trans.Except (ExceptT)
 import Control.Monad.Trans.Except.Extra (firstExceptT, hoistEither, newExceptT)
-import qualified Data.ByteString.Char8 as BS
+import Data.ByteString.Char8 qualified as BS
 import Data.String (fromString)
 import Data.Word (Word64)
 

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Query.hs
@@ -35,9 +35,9 @@ module Cardano.CLI.EraBased.Run.Query
   ) where
 
 import Cardano.Api hiding (QueryInShelleyBasedEra (..))
-import qualified Cardano.Api as Api
+import Cardano.Api qualified as Api
 import Cardano.Api.Byron hiding (QueryInShelleyBasedEra (..))
-import qualified Cardano.Api.Ledger as Ledger
+import Cardano.Api.Ledger qualified as Ledger
 import Cardano.Api.Shelley hiding (QueryInShelleyBasedEra (..))
 
 import Cardano.CLI.EraBased.Commands.Query
@@ -51,26 +51,26 @@ import Cardano.CLI.Types.Key
   ( VerificationKeyOrHashOrFile
   , readVerificationKeyOrHashOrFile
   )
-import qualified Cardano.CLI.Types.Output as O
+import Cardano.CLI.Types.Output qualified as O
 import Cardano.Crypto.Hash (hashToBytesAsHex)
-import qualified Cardano.Crypto.Hash.Blake2b as Blake2b
-import qualified Cardano.Ledger.BaseTypes as L
-import qualified Cardano.Ledger.Core as Core
-import qualified Cardano.Ledger.Crypto as Crypto
+import Cardano.Crypto.Hash.Blake2b qualified as Blake2b
+import Cardano.Ledger.BaseTypes qualified as L
+import Cardano.Ledger.Core qualified as Core
+import Cardano.Ledger.Crypto qualified as Crypto
 import Cardano.Ledger.Keys (KeyHash (..), KeyRole (..))
 import Cardano.Ledger.SafeHash (SafeHash)
 import Cardano.Ledger.Shelley.LedgerState
   ( PState (psFutureStakePoolParams, psRetiring, psStakePoolParams)
   )
-import qualified Cardano.Ledger.Shelley.LedgerState as SL
+import Cardano.Ledger.Shelley.LedgerState qualified as SL
 import Cardano.Slotting.EpochInfo (EpochInfo (..), epochInfoSlotToUTCTime, hoistEpochInfo)
 import Ouroboros.Consensus.BlockchainTime.WallClock.Types
   ( RelativeTime (..)
   , toRelativeTime
   )
-import qualified Ouroboros.Consensus.HardFork.History as Consensus
-import qualified Ouroboros.Consensus.Protocol.Abstract as Consensus
-import qualified Ouroboros.Consensus.Protocol.Praos.Common as Consensus
+import Ouroboros.Consensus.HardFork.History qualified as Consensus
+import Ouroboros.Consensus.Protocol.Abstract qualified as Consensus
+import Ouroboros.Consensus.Protocol.Praos.Common qualified as Consensus
 import Ouroboros.Consensus.Protocol.TPraos (StandardCrypto)
 import Ouroboros.Network.Block (Serialised (..))
 
@@ -83,25 +83,25 @@ import Control.Monad.Trans.Except.Extra
 import Data.Aeson as Aeson
 import Data.Aeson.Encode.Pretty (encodePretty)
 import Data.Bifunctor (Bifunctor (..))
-import qualified Data.ByteString.Lazy.Char8 as LBS
+import Data.ByteString.Lazy.Char8 qualified as LBS
 import Data.Coerce (coerce)
 import Data.Function ((&))
 import Data.Functor ((<&>))
-import qualified Data.List as List
+import Data.List qualified as List
 import Data.Map.Strict (Map)
-import qualified Data.Map.Strict as Map
+import Data.Map.Strict qualified as Map
 import Data.Proxy (Proxy (..))
 import Data.Set (Set)
-import qualified Data.Set as Set
+import Data.Set qualified as Set
 import Data.Text (Text)
-import qualified Data.Text as Text
-import qualified Data.Text.Encoding as Text
-import qualified Data.Text.IO as T
-import qualified Data.Text.IO as Text
+import Data.Text qualified as Text
+import Data.Text.Encoding qualified as Text
+import Data.Text.IO qualified as T
+import Data.Text.IO qualified as Text
 import Data.Time.Clock
 import Numeric (showEFloat)
 import Prettyprinter
-import qualified System.IO as IO
+import System.IO qualified as IO
 import Text.Printf (printf)
 
 {- HLINT ignore "Move brackets to avoid $" -}

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Query.hs
@@ -12,7 +12,6 @@
 
 module Cardano.CLI.EraBased.Run.Query
   ( runQueryCmds
-
   , runQueryConstitutionHashCmd
   , runQueryKesPeriodInfoCmd
   , runQueryLeadershipScheduleCmd
@@ -28,86 +27,106 @@ module Cardano.CLI.EraBased.Run.Query
   , runQueryTipCmd
   , runQueryTxMempoolCmd
   , runQueryUTxOCmd
-
-  , DelegationsAndRewards(..)
+  , DelegationsAndRewards (..)
   , renderQueryCmdError
   , renderLocalStateQueryError
   , renderOpCertIntervalInformation
   , percentage
   ) where
 
-import           Cardano.Api hiding (QueryInShelleyBasedEra (..))
+import Cardano.Api hiding (QueryInShelleyBasedEra (..))
 import qualified Cardano.Api as Api
-import           Cardano.Api.Byron hiding (QueryInShelleyBasedEra (..))
+import Cardano.Api.Byron hiding (QueryInShelleyBasedEra (..))
 import qualified Cardano.Api.Ledger as Ledger
-import           Cardano.Api.Shelley hiding (QueryInShelleyBasedEra (..))
+import Cardano.Api.Shelley hiding (QueryInShelleyBasedEra (..))
 
-import           Cardano.CLI.EraBased.Commands.Query
-import           Cardano.CLI.EraBased.Run.Genesis (readAndDecodeShelleyGenesis)
-import           Cardano.CLI.Helpers (pPrintCBOR)
-import           Cardano.CLI.Pretty
-import           Cardano.CLI.Types.Common
-import           Cardano.CLI.Types.Errors.QueryCmdError
-import           Cardano.CLI.Types.Errors.QueryCmdLocalStateQueryError
-import           Cardano.CLI.Types.Key (VerificationKeyOrHashOrFile,
-                   readVerificationKeyOrHashOrFile)
+import Cardano.CLI.EraBased.Commands.Query
+import Cardano.CLI.EraBased.Run.Genesis (readAndDecodeShelleyGenesis)
+import Cardano.CLI.Helpers (pPrintCBOR)
+import Cardano.CLI.Pretty
+import Cardano.CLI.Types.Common
+import Cardano.CLI.Types.Errors.QueryCmdError
+import Cardano.CLI.Types.Errors.QueryCmdLocalStateQueryError
+import Cardano.CLI.Types.Key
+  ( VerificationKeyOrHashOrFile
+  , readVerificationKeyOrHashOrFile
+  )
 import qualified Cardano.CLI.Types.Output as O
-import           Cardano.Crypto.Hash (hashToBytesAsHex)
+import Cardano.Crypto.Hash (hashToBytesAsHex)
 import qualified Cardano.Crypto.Hash.Blake2b as Blake2b
 import qualified Cardano.Ledger.BaseTypes as L
 import qualified Cardano.Ledger.Core as Core
 import qualified Cardano.Ledger.Crypto as Crypto
-import           Cardano.Ledger.Keys (KeyHash (..), KeyRole (..))
-import           Cardano.Ledger.SafeHash (SafeHash)
-import           Cardano.Ledger.Shelley.LedgerState
-                   (PState (psFutureStakePoolParams, psRetiring, psStakePoolParams))
+import Cardano.Ledger.Keys (KeyHash (..), KeyRole (..))
+import Cardano.Ledger.SafeHash (SafeHash)
+import Cardano.Ledger.Shelley.LedgerState
+  ( PState (psFutureStakePoolParams, psRetiring, psStakePoolParams)
+  )
 import qualified Cardano.Ledger.Shelley.LedgerState as SL
-import           Cardano.Slotting.EpochInfo (EpochInfo (..), epochInfoSlotToUTCTime, hoistEpochInfo)
-import           Ouroboros.Consensus.BlockchainTime.WallClock.Types (RelativeTime (..),
-                   toRelativeTime)
+import Cardano.Slotting.EpochInfo (EpochInfo (..), epochInfoSlotToUTCTime, hoistEpochInfo)
+import Ouroboros.Consensus.BlockchainTime.WallClock.Types
+  ( RelativeTime (..)
+  , toRelativeTime
+  )
 import qualified Ouroboros.Consensus.HardFork.History as Consensus
 import qualified Ouroboros.Consensus.Protocol.Abstract as Consensus
 import qualified Ouroboros.Consensus.Protocol.Praos.Common as Consensus
-import           Ouroboros.Consensus.Protocol.TPraos (StandardCrypto)
-import           Ouroboros.Network.Block (Serialised (..))
+import Ouroboros.Consensus.Protocol.TPraos (StandardCrypto)
+import Ouroboros.Network.Block (Serialised (..))
 
-import           Control.Monad (forM, forM_, join)
-import           Control.Monad.IO.Class (MonadIO)
-import           Control.Monad.IO.Unlift (MonadIO (..))
-import           Control.Monad.Trans.Class
-import           Control.Monad.Trans.Except
-import           Control.Monad.Trans.Except.Extra
-import           Data.Aeson as Aeson
-import           Data.Aeson.Encode.Pretty (encodePretty)
-import           Data.Bifunctor (Bifunctor (..))
+import Control.Monad (forM, forM_, join)
+import Control.Monad.IO.Class (MonadIO)
+import Control.Monad.IO.Unlift (MonadIO (..))
+import Control.Monad.Trans.Class
+import Control.Monad.Trans.Except
+import Control.Monad.Trans.Except.Extra
+import Data.Aeson as Aeson
+import Data.Aeson.Encode.Pretty (encodePretty)
+import Data.Bifunctor (Bifunctor (..))
 import qualified Data.ByteString.Lazy.Char8 as LBS
-import           Data.Coerce (coerce)
-import           Data.Function ((&))
-import           Data.Functor ((<&>))
+import Data.Coerce (coerce)
+import Data.Function ((&))
+import Data.Functor ((<&>))
 import qualified Data.List as List
-import           Data.Map.Strict (Map)
+import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import           Data.Proxy (Proxy (..))
-import           Data.Set (Set)
+import Data.Proxy (Proxy (..))
+import Data.Set (Set)
 import qualified Data.Set as Set
-import           Data.Text (Text)
+import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import qualified Data.Text.IO as T
 import qualified Data.Text.IO as Text
-import           Data.Time.Clock
-import           Numeric (showEFloat)
-import           Prettyprinter
+import Data.Time.Clock
+import Numeric (showEFloat)
+import Prettyprinter
 import qualified System.IO as IO
-import           Text.Printf (printf)
+import Text.Printf (printf)
 
 {- HLINT ignore "Move brackets to avoid $" -}
 {- HLINT ignore "Redundant flip" -}
 
 runQueryCmds :: QueryCmds era -> ExceptT QueryCmdError IO ()
 runQueryCmds = \case
-  QueryLeadershipSchedule mNodeSocketPath consensusModeParams network shelleyGenFp poolid vrkSkeyFp whichSchedule outputAs ->
-    runQueryLeadershipScheduleCmd mNodeSocketPath consensusModeParams network shelleyGenFp poolid vrkSkeyFp whichSchedule outputAs
+  QueryLeadershipSchedule
+    mNodeSocketPath
+    consensusModeParams
+    network
+    shelleyGenFp
+    poolid
+    vrkSkeyFp
+    whichSchedule
+    outputAs ->
+      runQueryLeadershipScheduleCmd
+        mNodeSocketPath
+        consensusModeParams
+        network
+        shelleyGenFp
+        poolid
+        vrkSkeyFp
+        whichSchedule
+        outputAs
   QueryProtocolParameters' mNodeSocketPath consensusModeParams network mOutFile ->
     runQueryProtocolParametersCmd mNodeSocketPath consensusModeParams network mOutFile
   QueryConstitutionHash mNodeSocketPath consensusModeParams network mOutFile ->
@@ -147,33 +166,36 @@ runQueryConstitutionHashCmd socketPath (AnyConsensusModeParams cModeParams) netw
   let localNodeConnInfo = LocalNodeConnectInfo cModeParams network socketPath
 
   result <- liftIO $ executeLocalStateQueryExpr localNodeConnInfo Nothing $ runExceptT $ do
-    anyE@(AnyCardanoEra era) <- lift (determineEraExpr cModeParams)
-      & onLeft (left . QueryCmdUnsupportedNtcVersion)
+    anyE@(AnyCardanoEra era) <-
+      lift (determineEraExpr cModeParams)
+        & onLeft (left . QueryCmdUnsupportedNtcVersion)
 
-    sbe <- requireShelleyBasedEra era
-      & onNothing (left QueryCmdByronEra)
+    sbe <-
+      requireShelleyBasedEra era
+        & onNothing (left QueryCmdByronEra)
 
     let cMode = consensusModeOnly cModeParams
 
-    eInMode <- toEraInMode era cMode
-      & hoistMaybe (QueryCmdEraConsensusModeMismatch (AnyConsensusMode cMode) anyE)
+    eInMode <-
+      toEraInMode era cMode
+        & hoistMaybe (QueryCmdEraConsensusModeMismatch (AnyConsensusMode cMode) anyE)
 
     lift (shelleyBasedEraConstraints sbe (queryConstitutionHash eInMode sbe))
       & onLeft (left . QueryCmdUnsupportedNtcVersion)
       & onLeft (left . QueryCmdEraMismatch)
 
   writeConstitutionHash mOutFile =<< except (join (first QueryCmdAcquireFailure result))
-  where
-    writeConstitutionHash
-      :: Maybe (File () Out)
-      -> Maybe (SafeHash StandardCrypto L.AnchorData)
-      -> ExceptT QueryCmdError IO ()
-    writeConstitutionHash mOutFile' cHash =
-      case mOutFile' of
-        Nothing -> liftIO $ LBS.putStrLn (encodePretty cHash)
-        Just (File fpath) ->
-          handleIOExceptT (QueryCmdWriteFileError . FileIOError fpath) $
-            LBS.writeFile fpath (encodePretty cHash)
+ where
+  writeConstitutionHash
+    :: Maybe (File () Out)
+    -> Maybe (SafeHash StandardCrypto L.AnchorData)
+    -> ExceptT QueryCmdError IO ()
+  writeConstitutionHash mOutFile' cHash =
+    case mOutFile' of
+      Nothing -> liftIO $ LBS.putStrLn (encodePretty cHash)
+      Just (File fpath) ->
+        handleIOExceptT (QueryCmdWriteFileError . FileIOError fpath) $
+          LBS.writeFile fpath (encodePretty cHash)
 
 runQueryProtocolParametersCmd
   :: SocketPath
@@ -183,32 +205,36 @@ runQueryProtocolParametersCmd
   -> ExceptT QueryCmdError IO ()
 runQueryProtocolParametersCmd socketPath (AnyConsensusModeParams cModeParams) network mOutFile = do
   let localNodeConnInfo = LocalNodeConnectInfo cModeParams network socketPath
-  anyE@(AnyCardanoEra era) <- firstExceptT QueryCmdAcquireFailure $ newExceptT $ determineEra cModeParams localNodeConnInfo
+  anyE@(AnyCardanoEra era) <-
+    firstExceptT QueryCmdAcquireFailure $ newExceptT $ determineEra cModeParams localNodeConnInfo
   sbe <- case cardanoEraStyle era of
-            LegacyByronEra -> left QueryCmdByronEra
-            ShelleyBasedEra sbe -> return sbe
+    LegacyByronEra -> left QueryCmdByronEra
+    ShelleyBasedEra sbe -> return sbe
   let cMode = consensusModeOnly cModeParams
-  eInMode <- toEraInMode era cMode
-                 & hoistMaybe (QueryCmdEraConsensusModeMismatch (AnyConsensusMode cMode) anyE)
+  eInMode <-
+    toEraInMode era cMode
+      & hoistMaybe (QueryCmdEraConsensusModeMismatch (AnyConsensusMode cMode) anyE)
 
   let qInMode = QueryInEra eInMode $ QueryInShelleyBasedEra sbe Api.QueryProtocolParameters
-  pp <- firstExceptT QueryCmdConvenienceError
-          . newExceptT $ executeQueryAnyMode era localNodeConnInfo qInMode
+  pp <-
+    firstExceptT QueryCmdConvenienceError
+      . newExceptT
+      $ executeQueryAnyMode era localNodeConnInfo qInMode
   writeProtocolParameters sbe mOutFile pp
-  where
-    -- TODO: Conway era - use ledger PParams JSON
-    writeProtocolParameters
-      :: ShelleyBasedEra era
-      -> Maybe (File () Out)
-      -> Ledger.PParams (ShelleyLedgerEra era)
-      -> ExceptT QueryCmdError IO ()
-    writeProtocolParameters sbe mOutFile' pparams =
-      let apiPParamsJSON = (encodePretty $ fromLedgerPParams sbe pparams)
-      in case mOutFile' of
-        Nothing -> liftIO $ LBS.putStrLn apiPParamsJSON
-        Just (File fpath) ->
-          handleIOExceptT (QueryCmdWriteFileError . FileIOError fpath) $
-            LBS.writeFile fpath apiPParamsJSON
+ where
+  -- TODO: Conway era - use ledger PParams JSON
+  writeProtocolParameters
+    :: ShelleyBasedEra era
+    -> Maybe (File () Out)
+    -> Ledger.PParams (ShelleyLedgerEra era)
+    -> ExceptT QueryCmdError IO ()
+  writeProtocolParameters sbe mOutFile' pparams =
+    let apiPParamsJSON = (encodePretty $ fromLedgerPParams sbe pparams)
+     in case mOutFile' of
+          Nothing -> liftIO $ LBS.putStrLn apiPParamsJSON
+          Just (File fpath) ->
+            handleIOExceptT (QueryCmdWriteFileError . FileIOError fpath) $
+              LBS.writeFile fpath apiPParamsJSON
 
 -- | Calculate the percentage sync rendered as text.
 percentage
@@ -221,16 +247,17 @@ percentage
   -- ^ 'tipTime'.  The time of the tip of the block chain to which we need to sync.
   -> Text
 percentage tolerance a b = Text.pack (printf "%.2f" pc)
-  where -- All calculations are in seconds (Integer)
-        t  = relativeTimeSeconds tolerance
-        -- Plus 1 to prevent division by zero.  The 's' prefix stands for strictly-positive.
-        sa = relativeTimeSeconds a + 1
-        sb = relativeTimeSeconds b + 1
-        -- Fast forward the 'nowTime` by the tolerance, but don't let the result exceed the tip time.
-        ua = min (sa + t) sb
-        ub = sb
-        -- Final percentage to render as text.
-        pc = id @Double (fromIntegral ua / fromIntegral  ub) * 100.0
+ where
+  -- All calculations are in seconds (Integer)
+  t = relativeTimeSeconds tolerance
+  -- Plus 1 to prevent division by zero.  The 's' prefix stands for strictly-positive.
+  sa = relativeTimeSeconds a + 1
+  sb = relativeTimeSeconds b + 1
+  -- Fast forward the 'nowTime` by the tolerance, but don't let the result exceed the tip time.
+  ua = min (sa + t) sb
+  ub = sb
+  -- Final percentage to render as text.
+  pc = id @Double (fromIntegral ua / fromIntegral ub) * 100.0
 
 relativeTimeSeconds :: RelativeTime -> Integer
 relativeTimeSeconds (RelativeTime dt) = floor (nominalDiffTimeToSeconds dt)
@@ -238,7 +265,7 @@ relativeTimeSeconds (RelativeTime dt) = floor (nominalDiffTimeToSeconds dt)
 -- | Query the chain tip via the chain sync protocol.
 --
 -- This is a fallback query to support older versions of node to client protocol.
-queryChainTipViaChainSync :: MonadIO m => LocalNodeConnectInfo mode -> m ChainTip
+queryChainTipViaChainSync :: (MonadIO m) => LocalNodeConnectInfo mode -> m ChainTip
 queryChainTipViaChainSync localNodeConnInfo = do
   liftIO . T.hPutStrLn IO.stderr $
     "Warning: Local header state query unavailable. Falling back to chain sync query"
@@ -255,30 +282,34 @@ runQueryTipCmd socketPath (AnyConsensusModeParams cModeParams) network mOutFile 
     CardanoMode -> do
       let localNodeConnInfo = LocalNodeConnectInfo cModeParams network socketPath
 
-      eLocalState <- ExceptT $ fmap sequence $
-        executeLocalStateQueryExpr localNodeConnInfo Nothing $ runExceptT $ do
-          era <- lift queryCurrentEra & onLeft (left . QueryCmdUnsupportedNtcVersion)
-          eraHistory <- lift queryEraHistory & onLeft (left . QueryCmdUnsupportedNtcVersion)
-          mChainBlockNo <- lift queryChainBlockNo & onLeft (left . QueryCmdUnsupportedNtcVersion) & fmap Just
-          mChainPoint <- lift queryChainPoint & onLeft (left . QueryCmdUnsupportedNtcVersion) & fmap Just
-          mSystemStart <- lift querySystemStart & onLeft (left . QueryCmdUnsupportedNtcVersion) & fmap Just
+      eLocalState <- ExceptT $
+        fmap sequence $
+          executeLocalStateQueryExpr localNodeConnInfo Nothing $
+            runExceptT $ do
+              era <- lift queryCurrentEra & onLeft (left . QueryCmdUnsupportedNtcVersion)
+              eraHistory <- lift queryEraHistory & onLeft (left . QueryCmdUnsupportedNtcVersion)
+              mChainBlockNo <- lift queryChainBlockNo & onLeft (left . QueryCmdUnsupportedNtcVersion) & fmap Just
+              mChainPoint <- lift queryChainPoint & onLeft (left . QueryCmdUnsupportedNtcVersion) & fmap Just
+              mSystemStart <- lift querySystemStart & onLeft (left . QueryCmdUnsupportedNtcVersion) & fmap Just
 
-          return O.QueryTipLocalState
-            { O.era = era
-            , O.eraHistory = eraHistory
-            , O.mSystemStart = mSystemStart
-            , O.mChainTip = makeChainTip <$> mChainBlockNo <*> mChainPoint
-            }
+              return
+                O.QueryTipLocalState
+                  { O.era = era
+                  , O.eraHistory = eraHistory
+                  , O.mSystemStart = mSystemStart
+                  , O.mChainTip = makeChainTip <$> mChainBlockNo <*> mChainPoint
+                  }
 
       mLocalState <- hushM (first QueryCmdAcquireFailure eLocalState) $ \e ->
         liftIO . T.hPutStrLn IO.stderr $ "Warning: Local state unavailable: " <> renderQueryCmdError e
 
-      chainTip <- pure (mLocalState >>= O.mChainTip)
-        -- The chain tip is unavailable via local state query because we are connecting with an older
-        -- node to client protocol so we use chain sync instead which necessitates another connection.
-        -- At some point when we can stop supporting the older node to client protocols, this fallback
-        -- can be removed.
-        & onNothing (queryChainTipViaChainSync localNodeConnInfo)
+      chainTip <-
+        pure (mLocalState >>= O.mChainTip)
+          -- The chain tip is unavailable via local state query because we are connecting with an older
+          -- node to client protocol so we use chain sync instead which necessitates another connection.
+          -- At some point when we can stop supporting the older node to client protocols, this fallback
+          -- can be removed.
+          & onNothing (queryChainTipViaChainSync localNodeConnInfo)
 
       let tipSlotNo :: SlotNo = case chainTip of
             ChainTipAtGenesis -> 0
@@ -289,20 +320,22 @@ runQueryTipCmd socketPath (AnyConsensusModeParams cModeParams) network mOutFile 
           Left e -> do
             liftIO . T.hPutStrLn IO.stderr $
               "Warning: Epoch unavailable: " <> renderQueryCmdError (QueryCmdPastHorizon e)
-            return $ O.QueryTipLocalStateOutput
-              { O.localStateChainTip = chainTip
-              , O.mEra = Nothing
-              , O.mEpoch = Nothing
-              , O.mSyncProgress = Nothing
-              , O.mSlotInEpoch = Nothing
-              , O.mSlotsToEpochEnd = Nothing
-              }
-
+            return $
+              O.QueryTipLocalStateOutput
+                { O.localStateChainTip = chainTip
+                , O.mEra = Nothing
+                , O.mEpoch = Nothing
+                , O.mSyncProgress = Nothing
+                , O.mSlotInEpoch = Nothing
+                , O.mSlotsToEpochEnd = Nothing
+                }
           Right (epochNo, SlotsInEpoch slotsInEpoch, SlotsToEpochEnd slotsToEpochEnd) -> do
             syncProgressResult <- runExceptT $ do
-              systemStart <- fmap getSystemStart (O.mSystemStart localState) & hoistMaybe QueryCmdSystemStartUnavailable
+              systemStart <-
+                fmap getSystemStart (O.mSystemStart localState) & hoistMaybe QueryCmdSystemStartUnavailable
               nowSeconds <- toRelativeTime (SystemStart systemStart) <$> liftIO getCurrentTime
-              tipTimeResult <- getProgress tipSlotNo (O.eraHistory localState) & bimap QueryCmdPastHorizon fst & except
+              tipTimeResult <-
+                getProgress tipSlotNo (O.eraHistory localState) & bimap QueryCmdPastHorizon fst & except
 
               let tolerance = RelativeTime (secondsToNominalDiffTime 600)
 
@@ -311,19 +344,19 @@ runQueryTipCmd socketPath (AnyConsensusModeParams cModeParams) network mOutFile 
             mSyncProgress <- hushM syncProgressResult $ \e -> do
               liftIO . T.hPutStrLn IO.stderr $ "Warning: Sync progress unavailable: " <> renderQueryCmdError e
 
-            return $ O.QueryTipLocalStateOutput
-              { O.localStateChainTip = chainTip
-              , O.mEra = Just (O.era localState)
-              , O.mEpoch = Just epochNo
-              , O.mSlotInEpoch = Just slotsInEpoch
-              , O.mSlotsToEpochEnd = Just slotsToEpochEnd
-              , O.mSyncProgress = mSyncProgress
-              }
+            return $
+              O.QueryTipLocalStateOutput
+                { O.localStateChainTip = chainTip
+                , O.mEra = Just (O.era localState)
+                , O.mEpoch = Just epochNo
+                , O.mSlotInEpoch = Just slotsInEpoch
+                , O.mSlotsToEpochEnd = Just slotsToEpochEnd
+                , O.mSyncProgress = mSyncProgress
+                }
 
       case mOutFile of
         Just (File fpath) -> liftIO $ LBS.writeFile fpath $ encodePretty localStateOutput
-        Nothing                 -> liftIO $ LBS.putStrLn        $ encodePretty localStateOutput
-
+        Nothing -> liftIO $ LBS.putStrLn $ encodePretty localStateOutput
     mode -> left (QueryCmdUnsupportedMode (AnyConsensusMode mode))
 
 -- | Query the UTxO, filtered by a given set of addresses, from a Shelley node
@@ -335,36 +368,45 @@ runQueryUTxOCmd
   -> NetworkId
   -> Maybe (File () Out)
   -> ExceptT QueryCmdError IO ()
-runQueryUTxOCmd socketPath (AnyConsensusModeParams cModeParams)
-             qfilter network mOutFile = do
-  let localNodeConnInfo = LocalNodeConnectInfo cModeParams network socketPath
+runQueryUTxOCmd
+  socketPath
+  (AnyConsensusModeParams cModeParams)
+  qfilter
+  network
+  mOutFile = do
+    let localNodeConnInfo = LocalNodeConnectInfo cModeParams network socketPath
 
-  join $ lift
-    ( executeLocalStateQueryExpr localNodeConnInfo Nothing $ runExceptT $ do
-        anyE@(AnyCardanoEra era) <- lift (determineEraExpr cModeParams)
-          & onLeft (left . QueryCmdUnsupportedNtcVersion)
+    join $
+      lift
+        ( executeLocalStateQueryExpr localNodeConnInfo Nothing $ runExceptT $ do
+            anyE@(AnyCardanoEra era) <-
+              lift (determineEraExpr cModeParams)
+                & onLeft (left . QueryCmdUnsupportedNtcVersion)
 
-        let cMode = consensusModeOnly cModeParams
+            let cMode = consensusModeOnly cModeParams
 
-        sbe <- requireShelleyBasedEra era
-          & onNothing (left QueryCmdByronEra)
+            sbe <-
+              requireShelleyBasedEra era
+                & onNothing (left QueryCmdByronEra)
 
-        eInMode <- pure (toEraInMode era cMode)
-          & onNothing (left (QueryCmdEraConsensusModeMismatch (AnyConsensusMode cMode) anyE))
+            eInMode <-
+              pure (toEraInMode era cMode)
+                & onNothing (left (QueryCmdEraConsensusModeMismatch (AnyConsensusMode cMode) anyE))
 
-        eraInMode <- calcEraInMode era $ consensusModeOnly cModeParams
+            eraInMode <- calcEraInMode era $ consensusModeOnly cModeParams
 
-        requireNotByronEraInByronMode eraInMode
+            requireNotByronEraInByronMode eraInMode
 
-        utxo <- lift (queryUtxo eInMode sbe qfilter)
-          & onLeft (left . QueryCmdUnsupportedNtcVersion)
-          & onLeft (left . QueryCmdLocalStateQueryError . EraMismatchError)
+            utxo <-
+              lift (queryUtxo eInMode sbe qfilter)
+                & onLeft (left . QueryCmdUnsupportedNtcVersion)
+                & onLeft (left . QueryCmdLocalStateQueryError . EraMismatchError)
 
-        pure $ do
-          writeFilteredUTxOs sbe mOutFile utxo
-    )
-    & onLeft (left . QueryCmdAcquireFailure)
-    & onLeft left
+            pure $ do
+              writeFilteredUTxOs sbe mOutFile utxo
+        )
+        & onLeft (left . QueryCmdAcquireFailure)
+        & onLeft left
 
 runQueryKesPeriodInfoCmd
   :: SocketPath
@@ -374,8 +416,9 @@ runQueryKesPeriodInfoCmd
   -> Maybe (File () Out)
   -> ExceptT QueryCmdError IO ()
 runQueryKesPeriodInfoCmd socketPath (AnyConsensusModeParams cModeParams) network nodeOpCertFile mOutFile = do
-  opCert <- lift (readFileTextEnvelope AsOperationalCertificate nodeOpCertFile)
-    & onLeft (left . QueryCmdOpCertCounterReadError)
+  opCert <-
+    lift (readFileTextEnvelope AsOperationalCertificate nodeOpCertFile)
+      & onLeft (left . QueryCmdOpCertCounterReadError)
 
   let localNodeConnInfo = LocalNodeConnectInfo cModeParams network socketPath
 
@@ -383,213 +426,242 @@ runQueryKesPeriodInfoCmd socketPath (AnyConsensusModeParams cModeParams) network
 
   case cMode of
     CardanoMode -> do
-      join $ lift
-        ( executeLocalStateQueryExpr localNodeConnInfo Nothing $ runExceptT $ do
-            anyE@(AnyCardanoEra era) <- lift (determineEraExpr cModeParams)
-              & onLeft (left . QueryCmdUnsupportedNtcVersion)
+      join $
+        lift
+          ( executeLocalStateQueryExpr localNodeConnInfo Nothing $ runExceptT $ do
+              anyE@(AnyCardanoEra era) <-
+                lift (determineEraExpr cModeParams)
+                  & onLeft (left . QueryCmdUnsupportedNtcVersion)
 
-            sbe <- requireShelleyBasedEra era
-              & onNothing (left QueryCmdByronEra)
+              sbe <-
+                requireShelleyBasedEra era
+                  & onNothing (left QueryCmdByronEra)
 
-            eInMode <- toEraInMode era cMode
-              & hoistMaybe (QueryCmdEraConsensusModeMismatch (AnyConsensusMode cMode) anyE)
+              eInMode <-
+                toEraInMode era cMode
+                  & hoistMaybe (QueryCmdEraConsensusModeMismatch (AnyConsensusMode cMode) anyE)
 
-            -- We check that the KES period specified in the operational certificate is correct
-            -- based on the KES period defined in the genesis parameters and the current slot number
-            eraInMode <- calcEraInMode era $ consensusModeOnly cModeParams
+              -- We check that the KES period specified in the operational certificate is correct
+              -- based on the KES period defined in the genesis parameters and the current slot number
+              eraInMode <- calcEraInMode era $ consensusModeOnly cModeParams
 
-            requireNotByronEraInByronMode eraInMode
+              requireNotByronEraInByronMode eraInMode
 
-            gParams <- lift (queryGenesisParameters eInMode sbe)
-              & onLeft (left . QueryCmdUnsupportedNtcVersion)
-              & onLeft (left . QueryCmdLocalStateQueryError . EraMismatchError)
+              gParams <-
+                lift (queryGenesisParameters eInMode sbe)
+                  & onLeft (left . QueryCmdUnsupportedNtcVersion)
+                  & onLeft (left . QueryCmdLocalStateQueryError . EraMismatchError)
 
-            eraHistory <- lift queryEraHistory
-              & onLeft (left . QueryCmdUnsupportedNtcVersion)
+              eraHistory <-
+                lift queryEraHistory
+                  & onLeft (left . QueryCmdUnsupportedNtcVersion)
 
-            let eInfo = toTentativeEpochInfo eraHistory
+              let eInfo = toTentativeEpochInfo eraHistory
 
-            -- We get the operational certificate counter from the protocol state and check that
-            -- it is equivalent to what we have on disk.
-            ptclState <- lift (queryProtocolState eInMode sbe)
-              & onLeft (left . QueryCmdUnsupportedNtcVersion)
-              & onLeft (left . QueryCmdLocalStateQueryError . EraMismatchError)
+              -- We get the operational certificate counter from the protocol state and check that
+              -- it is equivalent to what we have on disk.
+              ptclState <-
+                lift (queryProtocolState eInMode sbe)
+                  & onLeft (left . QueryCmdUnsupportedNtcVersion)
+                  & onLeft (left . QueryCmdLocalStateQueryError . EraMismatchError)
 
-            pure $ do
-              chainTip <- liftIO $ getLocalChainTip localNodeConnInfo
+              pure $ do
+                chainTip <- liftIO $ getLocalChainTip localNodeConnInfo
 
-              let curKesPeriod = currentKesPeriod chainTip gParams
-                  oCertStartKesPeriod = opCertStartingKesPeriod opCert
-                  oCertEndKesPeriod = opCertEndKesPeriod gParams opCert
-                  opCertIntervalInformation = opCertIntervalInfo gParams chainTip curKesPeriod oCertStartKesPeriod oCertEndKesPeriod
+                let curKesPeriod = currentKesPeriod chainTip gParams
+                    oCertStartKesPeriod = opCertStartingKesPeriod opCert
+                    oCertEndKesPeriod = opCertEndKesPeriod gParams opCert
+                    opCertIntervalInformation = opCertIntervalInfo gParams chainTip curKesPeriod oCertStartKesPeriod oCertEndKesPeriod
 
-              (onDiskC, stateC) <- shelleyBasedEraConstraints sbe $ opCertOnDiskAndStateCounters ptclState opCert
+                (onDiskC, stateC) <- shelleyBasedEraConstraints sbe $ opCertOnDiskAndStateCounters ptclState opCert
 
-              let counterInformation = opCertNodeAndOnDiskCounters onDiskC stateC
+                let counterInformation = opCertNodeAndOnDiskCounters onDiskC stateC
 
-              -- Always render diagnostic information
-              liftIO . putStrLn $ renderOpCertIntervalInformation (unFile nodeOpCertFile) opCertIntervalInformation
-              liftIO . putStrLn $ renderOpCertNodeAndOnDiskCounterInformation (unFile nodeOpCertFile) counterInformation
+                -- Always render diagnostic information
+                liftIO . putStrLn $
+                  renderOpCertIntervalInformation (unFile nodeOpCertFile) opCertIntervalInformation
+                liftIO . putStrLn $
+                  renderOpCertNodeAndOnDiskCounterInformation (unFile nodeOpCertFile) counterInformation
 
-              let qKesInfoOutput = createQueryKesPeriodInfoOutput opCertIntervalInformation counterInformation eInfo gParams
-                  kesPeriodInfoJSON = encodePretty qKesInfoOutput
+                let qKesInfoOutput = createQueryKesPeriodInfoOutput opCertIntervalInformation counterInformation eInfo gParams
+                    kesPeriodInfoJSON = encodePretty qKesInfoOutput
 
-              liftIO $ LBS.putStrLn kesPeriodInfoJSON
-              forM_ mOutFile (\(File oFp) ->
-                handleIOExceptT (QueryCmdWriteFileError . FileIOError oFp)
-                  $ LBS.writeFile oFp kesPeriodInfoJSON)
-        )
-        & onLeft (left . QueryCmdAcquireFailure)
-        & onLeft left
-
+                liftIO $ LBS.putStrLn kesPeriodInfoJSON
+                forM_
+                  mOutFile
+                  ( \(File oFp) ->
+                      handleIOExceptT (QueryCmdWriteFileError . FileIOError oFp) $
+                        LBS.writeFile oFp kesPeriodInfoJSON
+                  )
+          )
+          & onLeft (left . QueryCmdAcquireFailure)
+          & onLeft left
     mode -> left . QueryCmdUnsupportedMode $ AnyConsensusMode mode
-
  where
-   currentKesPeriod :: ChainTip -> GenesisParameters era -> CurrentKesPeriod
-   currentKesPeriod ChainTipAtGenesis _ = CurrentKesPeriod 0
-   currentKesPeriod (ChainTip currSlot _ _) gParams =
-     let slotsPerKesPeriod = fromIntegral $ protocolParamSlotsPerKESPeriod gParams
+  currentKesPeriod :: ChainTip -> GenesisParameters era -> CurrentKesPeriod
+  currentKesPeriod ChainTipAtGenesis _ = CurrentKesPeriod 0
+  currentKesPeriod (ChainTip currSlot _ _) gParams =
+    let slotsPerKesPeriod = fromIntegral $ protocolParamSlotsPerKESPeriod gParams
      in CurrentKesPeriod $ unSlotNo currSlot `div` slotsPerKesPeriod
 
-   opCertStartingKesPeriod :: OperationalCertificate -> OpCertStartingKesPeriod
-   opCertStartingKesPeriod = OpCertStartingKesPeriod . fromIntegral . getKesPeriod
+  opCertStartingKesPeriod :: OperationalCertificate -> OpCertStartingKesPeriod
+  opCertStartingKesPeriod = OpCertStartingKesPeriod . fromIntegral . getKesPeriod
 
-   opCertEndKesPeriod :: GenesisParameters era -> OperationalCertificate -> OpCertEndingKesPeriod
-   opCertEndKesPeriod gParams oCert =
-     let OpCertStartingKesPeriod start = opCertStartingKesPeriod oCert
-         maxKesEvo = fromIntegral $ protocolParamMaxKESEvolutions gParams
+  opCertEndKesPeriod :: GenesisParameters era -> OperationalCertificate -> OpCertEndingKesPeriod
+  opCertEndKesPeriod gParams oCert =
+    let OpCertStartingKesPeriod start = opCertStartingKesPeriod oCert
+        maxKesEvo = fromIntegral $ protocolParamMaxKESEvolutions gParams
      in OpCertEndingKesPeriod $ start + maxKesEvo
 
-   -- See OCERT rule in Shelley Spec: https://hydra.iohk.io/job/Cardano/cardano-ledger-specs/shelleyLedgerSpec/latest/download-by-type/doc-pdf/ledger-spec
-   opCertIntervalInfo
-     :: GenesisParameters era
-     -> ChainTip
-     -> CurrentKesPeriod
-     -> OpCertStartingKesPeriod
-     -> OpCertEndingKesPeriod
-     -> OpCertIntervalInformation
-   opCertIntervalInfo gParams currSlot' c s e@(OpCertEndingKesPeriod oCertEnd) =
-       let cSlot = case currSlot' of
-                       (ChainTip cSlotN _ _) -> unSlotNo cSlotN
-                       ChainTipAtGenesis -> 0
-           slotsTillExp = SlotsTillKesKeyExpiry . SlotNo $ (oCertEnd * fromIntegral (protocolParamSlotsPerKESPeriod gParams)) - cSlot
-       in O.createOpCertIntervalInfo c s e (Just slotsTillExp)
+  -- See OCERT rule in Shelley Spec: https://hydra.iohk.io/job/Cardano/cardano-ledger-specs/shelleyLedgerSpec/latest/download-by-type/doc-pdf/ledger-spec
+  opCertIntervalInfo
+    :: GenesisParameters era
+    -> ChainTip
+    -> CurrentKesPeriod
+    -> OpCertStartingKesPeriod
+    -> OpCertEndingKesPeriod
+    -> OpCertIntervalInformation
+  opCertIntervalInfo gParams currSlot' c s e@(OpCertEndingKesPeriod oCertEnd) =
+    let cSlot = case currSlot' of
+          (ChainTip cSlotN _ _) -> unSlotNo cSlotN
+          ChainTipAtGenesis -> 0
+        slotsTillExp =
+          SlotsTillKesKeyExpiry . SlotNo $
+            (oCertEnd * fromIntegral (protocolParamSlotsPerKESPeriod gParams)) - cSlot
+     in O.createOpCertIntervalInfo c s e (Just slotsTillExp)
 
-   opCertNodeAndOnDiskCounters
-     :: OpCertOnDiskCounter
-     -> Maybe OpCertNodeStateCounter
-     -> OpCertNodeAndOnDiskCounterInformation
-   opCertNodeAndOnDiskCounters o@(OpCertOnDiskCounter odc) (Just n@(OpCertNodeStateCounter nsc))
-     | odc < nsc = OpCertOnDiskCounterBehindNodeState o n
-     | odc > nsc + 1 = OpCertOnDiskCounterTooFarAheadOfNodeState o n
-     | odc == nsc + 1 = OpCertOnDiskCounterAheadOfNodeState o n
-     | otherwise = OpCertOnDiskCounterEqualToNodeState o n
-   opCertNodeAndOnDiskCounters o Nothing = OpCertNoBlocksMintedYet o
+  opCertNodeAndOnDiskCounters
+    :: OpCertOnDiskCounter
+    -> Maybe OpCertNodeStateCounter
+    -> OpCertNodeAndOnDiskCounterInformation
+  opCertNodeAndOnDiskCounters o@(OpCertOnDiskCounter odc) (Just n@(OpCertNodeStateCounter nsc))
+    | odc < nsc = OpCertOnDiskCounterBehindNodeState o n
+    | odc > nsc + 1 = OpCertOnDiskCounterTooFarAheadOfNodeState o n
+    | odc == nsc + 1 = OpCertOnDiskCounterAheadOfNodeState o n
+    | otherwise = OpCertOnDiskCounterEqualToNodeState o n
+  opCertNodeAndOnDiskCounters o Nothing = OpCertNoBlocksMintedYet o
 
-   opCertExpiryUtcTime
-     :: Tentative (EpochInfo (Either Text))
-     -> GenesisParameters era
-     -> OpCertEndingKesPeriod
-     -> Maybe UTCTime
-   opCertExpiryUtcTime eInfo gParams (OpCertEndingKesPeriod oCertExpiryKesPeriod) =
-     let time = epochInfoSlotToUTCTime
-                  (tentative eInfo)
-                  (SystemStart $ protocolParamSystemStart gParams)
-                  (fromIntegral $ oCertExpiryKesPeriod * fromIntegral (protocolParamSlotsPerKESPeriod gParams))
+  opCertExpiryUtcTime
+    :: Tentative (EpochInfo (Either Text))
+    -> GenesisParameters era
+    -> OpCertEndingKesPeriod
+    -> Maybe UTCTime
+  opCertExpiryUtcTime eInfo gParams (OpCertEndingKesPeriod oCertExpiryKesPeriod) =
+    let time =
+          epochInfoSlotToUTCTime
+            (tentative eInfo)
+            (SystemStart $ protocolParamSystemStart gParams)
+            (fromIntegral $ oCertExpiryKesPeriod * fromIntegral (protocolParamSlotsPerKESPeriod gParams))
      in case time of
           Left _ -> Nothing
           Right t -> Just t
 
-   renderOpCertNodeAndOnDiskCounterInformation :: FilePath -> OpCertNodeAndOnDiskCounterInformation -> String
-   renderOpCertNodeAndOnDiskCounterInformation opCertFile opCertCounterInfo =
-     case opCertCounterInfo of
+  renderOpCertNodeAndOnDiskCounterInformation
+    :: FilePath -> OpCertNodeAndOnDiskCounterInformation -> String
+  renderOpCertNodeAndOnDiskCounterInformation opCertFile opCertCounterInfo =
+    case opCertCounterInfo of
       OpCertOnDiskCounterEqualToNodeState _ _ ->
         renderStringDefault $
-          green "✓" <+> hang 0
+          green "✓"
+            <+> hang
+              0
               ( vsep
-                [ "The operational certificate counter agrees with the node protocol state counter"
-                ]
+                  [ "The operational certificate counter agrees with the node protocol state counter"
+                  ]
               )
       OpCertOnDiskCounterAheadOfNodeState _ _ ->
         renderStringDefault $
-          green "✓" <+> hang 0
+          green "✓"
+            <+> hang
+              0
               ( vsep
-                [ "The operational certificate counter ahead of the node protocol state counter by 1"
-                ]
+                  [ "The operational certificate counter ahead of the node protocol state counter by 1"
+                  ]
               )
       OpCertOnDiskCounterTooFarAheadOfNodeState onDiskC nodeStateC ->
         renderStringDefault $
-          red "✗" <+> hang 0
-            ( vsep
-              [ "The operational certificate counter too far ahead of the node protocol state counter in the operational certificate at: " <> pretty opCertFile
-              , "On disk operational certificate counter: " <> pretty (unOpCertOnDiskCounter onDiskC)
-              , "Protocol state counter: " <> pretty (unOpCertNodeStateCounter nodeStateC)
-              ]
-            )
+          red "✗"
+            <+> hang
+              0
+              ( vsep
+                  [ "The operational certificate counter too far ahead of the node protocol state counter in the operational certificate at: "
+                      <> pretty opCertFile
+                  , "On disk operational certificate counter: " <> pretty (unOpCertOnDiskCounter onDiskC)
+                  , "Protocol state counter: " <> pretty (unOpCertNodeStateCounter nodeStateC)
+                  ]
+              )
       OpCertOnDiskCounterBehindNodeState onDiskC nodeStateC ->
         renderStringDefault $
-          red "✗" <+> hang 0
-            ( vsep
-              [ "The protocol state counter is greater than the counter in the operational certificate at: " <> pretty opCertFile
-              , "On disk operational certificate counter: " <> pretty (unOpCertOnDiskCounter onDiskC)
-              , "Protocol state counter: " <> pretty (unOpCertNodeStateCounter nodeStateC)
-              ]
-            )
+          red "✗"
+            <+> hang
+              0
+              ( vsep
+                  [ "The protocol state counter is greater than the counter in the operational certificate at: "
+                      <> pretty opCertFile
+                  , "On disk operational certificate counter: " <> pretty (unOpCertOnDiskCounter onDiskC)
+                  , "Protocol state counter: " <> pretty (unOpCertNodeStateCounter nodeStateC)
+                  ]
+              )
       OpCertNoBlocksMintedYet (OpCertOnDiskCounter onDiskC) ->
         renderStringDefault $
-          red "✗" <+> hang 0
-            ( vsep
-              [ "No blocks minted so far with the operational certificate at: " <> pretty opCertFile
-              , "On disk operational certificate counter: " <> pretty onDiskC
-              ]
-            )
+          red "✗"
+            <+> hang
+              0
+              ( vsep
+                  [ "No blocks minted so far with the operational certificate at: " <> pretty opCertFile
+                  , "On disk operational certificate counter: " <> pretty onDiskC
+                  ]
+              )
 
-
-   createQueryKesPeriodInfoOutput
-     :: OpCertIntervalInformation
-     -> OpCertNodeAndOnDiskCounterInformation
-     -> Tentative (EpochInfo (Either Text))
-     -> GenesisParameters era
-     -> O.QueryKesPeriodInfoOutput
-   createQueryKesPeriodInfoOutput oCertIntervalInfo oCertCounterInfo eInfo gParams  =
-     let (e, mStillExp) = case oCertIntervalInfo of
-                            OpCertWithinInterval _ end _ sTillExp -> (end, Just sTillExp)
-                            OpCertStartingKesPeriodIsInTheFuture _ end _ -> (end, Nothing)
-                            OpCertExpired _ end _ -> (end, Nothing)
-                            OpCertSomeOtherError _ end _ -> (end, Nothing)
-         (onDiskCounter, mNodeCounter) = case oCertCounterInfo of
-                                           OpCertOnDiskCounterEqualToNodeState d n -> (d, Just n)
-                                           OpCertOnDiskCounterAheadOfNodeState d n -> (d, Just n)
-                                           OpCertOnDiskCounterTooFarAheadOfNodeState d n -> (d, Just n)
-                                           OpCertOnDiskCounterBehindNodeState d n -> (d, Just n)
-                                           OpCertNoBlocksMintedYet d -> (d, Nothing)
-
+  createQueryKesPeriodInfoOutput
+    :: OpCertIntervalInformation
+    -> OpCertNodeAndOnDiskCounterInformation
+    -> Tentative (EpochInfo (Either Text))
+    -> GenesisParameters era
+    -> O.QueryKesPeriodInfoOutput
+  createQueryKesPeriodInfoOutput oCertIntervalInfo oCertCounterInfo eInfo gParams =
+    let (e, mStillExp) = case oCertIntervalInfo of
+          OpCertWithinInterval _ end _ sTillExp -> (end, Just sTillExp)
+          OpCertStartingKesPeriodIsInTheFuture _ end _ -> (end, Nothing)
+          OpCertExpired _ end _ -> (end, Nothing)
+          OpCertSomeOtherError _ end _ -> (end, Nothing)
+        (onDiskCounter, mNodeCounter) = case oCertCounterInfo of
+          OpCertOnDiskCounterEqualToNodeState d n -> (d, Just n)
+          OpCertOnDiskCounterAheadOfNodeState d n -> (d, Just n)
+          OpCertOnDiskCounterTooFarAheadOfNodeState d n -> (d, Just n)
+          OpCertOnDiskCounterBehindNodeState d n -> (d, Just n)
+          OpCertNoBlocksMintedYet d -> (d, Nothing)
      in O.QueryKesPeriodInfoOutput
-        { O.qKesOpCertIntervalInformation = oCertIntervalInfo
-        , O.qKesInfoNodeStateOperationalCertNo = mNodeCounter
-        , O.qKesInfoOnDiskOperationalCertNo = onDiskCounter
-        , O.qKesInfoMaxKesKeyEvolutions = fromIntegral $ protocolParamMaxKESEvolutions gParams
-        , O.qKesInfoSlotsPerKesPeriod = fromIntegral $ protocolParamSlotsPerKESPeriod gParams
-        , O.qKesInfoKesKeyExpiry =
-            case mStillExp of
-              Just _ -> opCertExpiryUtcTime eInfo gParams e
-              Nothing -> Nothing
-        }
+          { O.qKesOpCertIntervalInformation = oCertIntervalInfo
+          , O.qKesInfoNodeStateOperationalCertNo = mNodeCounter
+          , O.qKesInfoOnDiskOperationalCertNo = onDiskCounter
+          , O.qKesInfoMaxKesKeyEvolutions = fromIntegral $ protocolParamMaxKESEvolutions gParams
+          , O.qKesInfoSlotsPerKesPeriod = fromIntegral $ protocolParamSlotsPerKESPeriod gParams
+          , O.qKesInfoKesKeyExpiry =
+              case mStillExp of
+                Just _ -> opCertExpiryUtcTime eInfo gParams e
+                Nothing -> Nothing
+          }
 
-   -- We get the operational certificate counter from the protocol state and check that
-   -- it is equivalent to what we have on disk.
-   opCertOnDiskAndStateCounters :: forall era . ()
-      => Consensus.PraosProtocolSupportsNode (ConsensusProtocol era)
-      => FromCBOR (Consensus.ChainDepState (ConsensusProtocol era))
-      => Crypto.ADDRHASH (Consensus.PraosProtocolSupportsNodeCrypto (ConsensusProtocol era)) ~ Blake2b.Blake2b_224
-      => ProtocolState era
-      -> OperationalCertificate
-      -> ExceptT QueryCmdError IO (OpCertOnDiskCounter, Maybe OpCertNodeStateCounter)
-   opCertOnDiskAndStateCounters ptclState opCert@(OperationalCertificate _ stakePoolVKey) = do
+  -- We get the operational certificate counter from the protocol state and check that
+  -- it is equivalent to what we have on disk.
+  opCertOnDiskAndStateCounters
+    :: forall era
+     . ()
+    => (Consensus.PraosProtocolSupportsNode (ConsensusProtocol era))
+    => (FromCBOR (Consensus.ChainDepState (ConsensusProtocol era)))
+    => ( Crypto.ADDRHASH (Consensus.PraosProtocolSupportsNodeCrypto (ConsensusProtocol era))
+          ~ Blake2b.Blake2b_224
+       )
+    => ProtocolState era
+    -> OperationalCertificate
+    -> ExceptT QueryCmdError IO (OpCertOnDiskCounter, Maybe OpCertNodeStateCounter)
+  opCertOnDiskAndStateCounters ptclState opCert@(OperationalCertificate _ stakePoolVKey) = do
     let onDiskOpCertCount = fromIntegral $ getOpCertCount opCert
 
-    chainDepState <- pure (decodeProtocolState ptclState)
-      & onLeft (left . QueryCmdProtocolStateDecodeFailure)
+    chainDepState <-
+      pure (decodeProtocolState ptclState)
+        & onLeft (left . QueryCmdProtocolStateDecodeFailure)
 
     -- We need the stake pool id to determine what the counter of our SPO
     -- should be.
@@ -603,50 +675,63 @@ runQueryKesPeriodInfoCmd socketPath (AnyConsensusModeParams cModeParams) network
       Just ptclStateCounter -> return (OpCertOnDiskCounter onDiskOpCertCount, Just $ OpCertNodeStateCounter ptclStateCounter)
       Nothing -> return (OpCertOnDiskCounter onDiskOpCertCount, Nothing)
 
-
 renderOpCertIntervalInformation :: FilePath -> OpCertIntervalInformation -> String
 renderOpCertIntervalInformation opCertFile opCertInfo = case opCertInfo of
   OpCertWithinInterval _start _end _current _stillExp ->
     renderStringDefault $
-      green "✓" <+> hang 0
-        ( vsep
-          [ "Operational certificate's KES period is within the correct KES period interval"
-          ]
-        )
-  OpCertStartingKesPeriodIsInTheFuture (OpCertStartingKesPeriod start) (OpCertEndingKesPeriod end) (CurrentKesPeriod current) ->
-    renderStringDefault $
-      red "✗" <+> hang 0
-        ( vsep
-          [ "Node operational certificate at: " <> pretty opCertFile <> " has an incorrectly specified starting KES period. "
-          , "Current KES period: " <> pretty current
-          , "Operational certificate's starting KES period: " <> pretty start
-          , "Operational certificate's expiry KES period: " <> pretty end
-          ]
-        )
+      green "✓"
+        <+> hang
+          0
+          ( vsep
+              [ "Operational certificate's KES period is within the correct KES period interval"
+              ]
+          )
+  OpCertStartingKesPeriodIsInTheFuture
+    (OpCertStartingKesPeriod start)
+    (OpCertEndingKesPeriod end)
+    (CurrentKesPeriod current) ->
+      renderStringDefault $
+        red "✗"
+          <+> hang
+            0
+            ( vsep
+                [ "Node operational certificate at: "
+                    <> pretty opCertFile
+                    <> " has an incorrectly specified starting KES period. "
+                , "Current KES period: " <> pretty current
+                , "Operational certificate's starting KES period: " <> pretty start
+                , "Operational certificate's expiry KES period: " <> pretty end
+                ]
+            )
   OpCertExpired _ (OpCertEndingKesPeriod end) (CurrentKesPeriod current) ->
     renderStringDefault $
-      red "✗" <+> hang 0
-        ( vsep
-          [ "Node operational certificate at: " <> pretty opCertFile <> " has expired. "
-          , "Current KES period: " <> pretty current
-          , "Operational certificate's expiry KES period: " <> pretty end
-          ]
-        )
-
-  OpCertSomeOtherError (OpCertStartingKesPeriod start) (OpCertEndingKesPeriod end) (CurrentKesPeriod current) ->
-    renderStringDefault $
-      red "✗" <+> hang 0
-        ( vsep
-          [ "An unknown error occurred with operational certificate at: " <> pretty opCertFile
-          , "Current KES period: " <> pretty current
-          , "Operational certificate's starting KES period: " <> pretty start
-          , "Operational certificate's expiry KES period: " <> pretty end
-          ]
-        )
+      red "✗"
+        <+> hang
+          0
+          ( vsep
+              [ "Node operational certificate at: " <> pretty opCertFile <> " has expired. "
+              , "Current KES period: " <> pretty current
+              , "Operational certificate's expiry KES period: " <> pretty end
+              ]
+          )
+  OpCertSomeOtherError
+    (OpCertStartingKesPeriod start)
+    (OpCertEndingKesPeriod end)
+    (CurrentKesPeriod current) ->
+      renderStringDefault $
+        red "✗"
+          <+> hang
+            0
+            ( vsep
+                [ "An unknown error occurred with operational certificate at: " <> pretty opCertFile
+                , "Current KES period: " <> pretty current
+                , "Operational certificate's starting KES period: " <> pretty start
+                , "Operational certificate's expiry KES period: " <> pretty end
+                ]
+            )
 
 -- | Query the current and future parameters for a stake pool, including the retirement date.
 -- Any of these may be empty (in which case a null will be displayed).
---
 runQueryPoolStateCmd
   :: SocketPath
   -> AnyConsensusModeParams
@@ -656,32 +741,37 @@ runQueryPoolStateCmd
 runQueryPoolStateCmd socketPath (AnyConsensusModeParams cModeParams) network poolIds = do
   let localNodeConnInfo = LocalNodeConnectInfo cModeParams network socketPath
 
-  join $ lift
-    ( executeLocalStateQueryExpr localNodeConnInfo Nothing $ runExceptT $ do
-        anyE@(AnyCardanoEra era) <- lift (determineEraExpr cModeParams)
-          & onLeft (left . QueryCmdUnsupportedNtcVersion)
+  join $
+    lift
+      ( executeLocalStateQueryExpr localNodeConnInfo Nothing $ runExceptT $ do
+          anyE@(AnyCardanoEra era) <-
+            lift (determineEraExpr cModeParams)
+              & onLeft (left . QueryCmdUnsupportedNtcVersion)
 
-        let cMode = consensusModeOnly cModeParams
+          let cMode = consensusModeOnly cModeParams
 
-        sbe <- requireShelleyBasedEra era
-          & onNothing (left QueryCmdByronEra)
+          sbe <-
+            requireShelleyBasedEra era
+              & onNothing (left QueryCmdByronEra)
 
-        eInMode <- toEraInMode era cMode
-          & hoistMaybe (QueryCmdEraConsensusModeMismatch (AnyConsensusMode cMode) anyE)
+          eInMode <-
+            toEraInMode era cMode
+              & hoistMaybe (QueryCmdEraConsensusModeMismatch (AnyConsensusMode cMode) anyE)
 
-        eraInMode <- calcEraInMode era $ consensusModeOnly cModeParams
+          eraInMode <- calcEraInMode era $ consensusModeOnly cModeParams
 
-        requireNotByronEraInByronMode eraInMode
+          requireNotByronEraInByronMode eraInMode
 
-        result <- lift (queryPoolState eInMode sbe $ Just $ Set.fromList poolIds)
-          & onLeft (left . QueryCmdUnsupportedNtcVersion)
-          & onLeft (left . QueryCmdLocalStateQueryError . EraMismatchError)
+          result <-
+            lift (queryPoolState eInMode sbe $ Just $ Set.fromList poolIds)
+              & onLeft (left . QueryCmdUnsupportedNtcVersion)
+              & onLeft (left . QueryCmdLocalStateQueryError . EraMismatchError)
 
-        pure $ do
-          shelleyBasedEraConstraints sbe writePoolState result
-    )
-    & onLeft (left . QueryCmdAcquireFailure)
-    & onLeft left
+          pure $ do
+            shelleyBasedEraConstraints sbe writePoolState result
+      )
+      & onLeft (left . QueryCmdAcquireFailure)
+      & onLeft left
 
 -- | Query the local mempool state
 runQueryTxMempoolCmd
@@ -695,23 +785,26 @@ runQueryTxMempoolCmd socketPath (AnyConsensusModeParams cModeParams) network que
   let localNodeConnInfo = LocalNodeConnectInfo cModeParams network socketPath
 
   localQuery <- case query of
-      TxMempoolQueryTxExists tx -> do
-        anyE@(AnyCardanoEra era) <- lift (executeLocalStateQueryExpr localNodeConnInfo Nothing (determineEraExpr cModeParams))
+    TxMempoolQueryTxExists tx -> do
+      anyE@(AnyCardanoEra era) <-
+        lift (executeLocalStateQueryExpr localNodeConnInfo Nothing (determineEraExpr cModeParams))
           & onLeft (left . QueryCmdAcquireFailure)
           & onLeft (left . QueryCmdUnsupportedNtcVersion)
-        let cMode = consensusModeOnly cModeParams
-        eInMode <- toEraInMode era cMode
+      let cMode = consensusModeOnly cModeParams
+      eInMode <-
+        toEraInMode era cMode
           & hoistMaybe (QueryCmdEraConsensusModeMismatch (AnyConsensusMode cMode) anyE)
-        pure $ LocalTxMonitoringQueryTx $ TxIdInMode tx eInMode
-      TxMempoolQueryNextTx -> pure LocalTxMonitoringSendNextTx
-      TxMempoolQueryInfo -> pure LocalTxMonitoringMempoolInformation
+      pure $ LocalTxMonitoringQueryTx $ TxIdInMode tx eInMode
+    TxMempoolQueryNextTx -> pure LocalTxMonitoringSendNextTx
+    TxMempoolQueryInfo -> pure LocalTxMonitoringMempoolInformation
 
   result <- liftIO $ queryTxMonitoringLocal localNodeConnInfo localQuery
   let renderedResult = encodePretty result
   case mOutFile of
     Nothing -> liftIO $ LBS.putStrLn renderedResult
-    Just (File oFp) -> handleIOExceptT (QueryCmdWriteFileError . FileIOError oFp)
-        $ LBS.writeFile oFp renderedResult
+    Just (File oFp) ->
+      handleIOExceptT (QueryCmdWriteFileError . FileIOError oFp) $
+        LBS.writeFile oFp renderedResult
 
 runQuerySlotNumberCmd
   :: SocketPath
@@ -736,36 +829,41 @@ runQueryStakeSnapshotCmd
 runQueryStakeSnapshotCmd socketPath (AnyConsensusModeParams cModeParams) network allOrOnlyPoolIds mOutFile = do
   let localNodeConnInfo = LocalNodeConnectInfo cModeParams network socketPath
 
-  join $ lift
-    ( executeLocalStateQueryExpr localNodeConnInfo Nothing $ runExceptT $ do
-        anyE@(AnyCardanoEra era) <- lift (determineEraExpr cModeParams)
-          & onLeft (left . QueryCmdUnsupportedNtcVersion)
+  join $
+    lift
+      ( executeLocalStateQueryExpr localNodeConnInfo Nothing $ runExceptT $ do
+          anyE@(AnyCardanoEra era) <-
+            lift (determineEraExpr cModeParams)
+              & onLeft (left . QueryCmdUnsupportedNtcVersion)
 
-        let cMode = consensusModeOnly cModeParams
+          let cMode = consensusModeOnly cModeParams
 
-        sbe <- requireShelleyBasedEra era
-          & onNothing (left QueryCmdByronEra)
+          sbe <-
+            requireShelleyBasedEra era
+              & onNothing (left QueryCmdByronEra)
 
-        eInMode <- toEraInMode era cMode
-          & hoistMaybe (QueryCmdEraConsensusModeMismatch (AnyConsensusMode cMode) anyE)
+          eInMode <-
+            toEraInMode era cMode
+              & hoistMaybe (QueryCmdEraConsensusModeMismatch (AnyConsensusMode cMode) anyE)
 
-        let poolFilter = case allOrOnlyPoolIds of
-              All -> Nothing
-              Only poolIds -> Just $ Set.fromList poolIds
+          let poolFilter = case allOrOnlyPoolIds of
+                All -> Nothing
+                Only poolIds -> Just $ Set.fromList poolIds
 
-        eraInMode2 <- calcEraInMode era $ consensusModeOnly cModeParams
+          eraInMode2 <- calcEraInMode era $ consensusModeOnly cModeParams
 
-        requireNotByronEraInByronMode eraInMode2
+          requireNotByronEraInByronMode eraInMode2
 
-        result <- lift (queryStakeSnapshot eInMode sbe poolFilter)
-          & onLeft (left . QueryCmdUnsupportedNtcVersion)
-          & onLeft (left . QueryCmdLocalStateQueryError . EraMismatchError)
+          result <-
+            lift (queryStakeSnapshot eInMode sbe poolFilter)
+              & onLeft (left . QueryCmdUnsupportedNtcVersion)
+              & onLeft (left . QueryCmdLocalStateQueryError . EraMismatchError)
 
-        pure $ do
-          shelleyBasedEraConstraints sbe (writeStakeSnapshots mOutFile) result
-    )
-    & onLeft (left . QueryCmdAcquireFailure)
-    & onLeft left
+          pure $ do
+            shelleyBasedEraConstraints sbe (writeStakeSnapshots mOutFile) result
+      )
+      & onLeft (left . QueryCmdAcquireFailure)
+      & onLeft left
 
 runQueryLedgerStateCmd
   :: SocketPath
@@ -776,32 +874,37 @@ runQueryLedgerStateCmd
 runQueryLedgerStateCmd socketPath (AnyConsensusModeParams cModeParams) network mOutFile = do
   let localNodeConnInfo = LocalNodeConnectInfo cModeParams network socketPath
 
-  join $ lift
-    ( executeLocalStateQueryExpr localNodeConnInfo Nothing $ runExceptT $ do
-        anyE@(AnyCardanoEra era) <- lift (determineEraExpr cModeParams)
-          & onLeft (left . QueryCmdUnsupportedNtcVersion)
+  join $
+    lift
+      ( executeLocalStateQueryExpr localNodeConnInfo Nothing $ runExceptT $ do
+          anyE@(AnyCardanoEra era) <-
+            lift (determineEraExpr cModeParams)
+              & onLeft (left . QueryCmdUnsupportedNtcVersion)
 
-        let cMode = consensusModeOnly cModeParams
+          let cMode = consensusModeOnly cModeParams
 
-        sbe <- requireShelleyBasedEra era
-          & onNothing (left QueryCmdByronEra)
+          sbe <-
+            requireShelleyBasedEra era
+              & onNothing (left QueryCmdByronEra)
 
-        eInMode <- pure (toEraInMode era cMode)
-          & onNothing (left (QueryCmdEraConsensusModeMismatch (AnyConsensusMode cMode) anyE))
+          eInMode <-
+            pure (toEraInMode era cMode)
+              & onNothing (left (QueryCmdEraConsensusModeMismatch (AnyConsensusMode cMode) anyE))
 
-        eraInMode <- calcEraInMode era $ consensusModeOnly cModeParams
+          eraInMode <- calcEraInMode era $ consensusModeOnly cModeParams
 
-        requireNotByronEraInByronMode eraInMode
+          requireNotByronEraInByronMode eraInMode
 
-        result <- lift (queryDebugLedgerState eInMode sbe)
-          & onLeft (left . QueryCmdUnsupportedNtcVersion)
-          & onLeft (left . QueryCmdLocalStateQueryError . EraMismatchError)
+          result <-
+            lift (queryDebugLedgerState eInMode sbe)
+              & onLeft (left . QueryCmdUnsupportedNtcVersion)
+              & onLeft (left . QueryCmdLocalStateQueryError . EraMismatchError)
 
-        pure $ do
-          shelleyBasedEraConstraints sbe (writeLedgerState mOutFile) result
-    )
-    & onLeft (left . QueryCmdAcquireFailure)
-    & onLeft left
+          pure $ do
+            shelleyBasedEraConstraints sbe (writeLedgerState mOutFile) result
+      )
+      & onLeft (left . QueryCmdAcquireFailure)
+      & onLeft left
 
 runQueryProtocolStateCmd
   :: SocketPath
@@ -812,38 +915,42 @@ runQueryProtocolStateCmd
 runQueryProtocolStateCmd socketPath (AnyConsensusModeParams cModeParams) network mOutFile = do
   let localNodeConnInfo = LocalNodeConnectInfo cModeParams network socketPath
 
-  join $ lift
-    ( executeLocalStateQueryExpr localNodeConnInfo Nothing $ runExceptT $ do
-        anyE@(AnyCardanoEra era) <- lift (determineEraExpr cModeParams)
-          & onLeft (left . QueryCmdUnsupportedNtcVersion)
+  join $
+    lift
+      ( executeLocalStateQueryExpr localNodeConnInfo Nothing $ runExceptT $ do
+          anyE@(AnyCardanoEra era) <-
+            lift (determineEraExpr cModeParams)
+              & onLeft (left . QueryCmdUnsupportedNtcVersion)
 
-        let cMode = consensusModeOnly cModeParams
+          let cMode = consensusModeOnly cModeParams
 
-        sbe <- requireShelleyBasedEra era
-          & onNothing (left QueryCmdByronEra)
+          sbe <-
+            requireShelleyBasedEra era
+              & onNothing (left QueryCmdByronEra)
 
-        eInMode <- pure (toEraInMode era cMode)
-          & onNothing (left (QueryCmdEraConsensusModeMismatch (AnyConsensusMode cMode) anyE))
+          eInMode <-
+            pure (toEraInMode era cMode)
+              & onNothing (left (QueryCmdEraConsensusModeMismatch (AnyConsensusMode cMode) anyE))
 
-        eraInMode <- calcEraInMode era $ consensusModeOnly cModeParams
+          eraInMode <- calcEraInMode era $ consensusModeOnly cModeParams
 
-        requireNotByronEraInByronMode eraInMode
+          requireNotByronEraInByronMode eraInMode
 
-        result <- lift (queryProtocolState eInMode sbe)
-          & onLeft (left . QueryCmdUnsupportedNtcVersion)
-          & onLeft (left . QueryCmdLocalStateQueryError . EraMismatchError)
+          result <-
+            lift (queryProtocolState eInMode sbe)
+              & onLeft (left . QueryCmdUnsupportedNtcVersion)
+              & onLeft (left . QueryCmdLocalStateQueryError . EraMismatchError)
 
-        pure $ do
-          case cMode of
-            CardanoMode -> shelleyBasedEraConstraints sbe $ writeProtocolState mOutFile result
-            mode -> left . QueryCmdUnsupportedMode $ AnyConsensusMode mode
-    )
-    & onLeft (left . QueryCmdAcquireFailure)
-    & onLeft left
+          pure $ do
+            case cMode of
+              CardanoMode -> shelleyBasedEraConstraints sbe $ writeProtocolState mOutFile result
+              mode -> left . QueryCmdUnsupportedMode $ AnyConsensusMode mode
+      )
+      & onLeft (left . QueryCmdAcquireFailure)
+      & onLeft left
 
 -- | Query the current delegations and reward accounts, filtered by a given
 -- set of addresses, from a Shelley node via the local state query protocol.
-
 runQueryStakeAddressInfoCmd
   :: SocketPath
   -> AnyConsensusModeParams
@@ -854,34 +961,39 @@ runQueryStakeAddressInfoCmd
 runQueryStakeAddressInfoCmd socketPath (AnyConsensusModeParams cModeParams) (StakeAddress _ addr) network mOutFile = do
   let localNodeConnInfo = LocalNodeConnectInfo cModeParams network socketPath
 
-  join $ lift
-    ( executeLocalStateQueryExpr localNodeConnInfo Nothing $ runExceptT $ do
-        anyE@(AnyCardanoEra era) <- lift (determineEraExpr cModeParams)
-          & onLeft (left . QueryCmdUnsupportedNtcVersion)
+  join $
+    lift
+      ( executeLocalStateQueryExpr localNodeConnInfo Nothing $ runExceptT $ do
+          anyE@(AnyCardanoEra era) <-
+            lift (determineEraExpr cModeParams)
+              & onLeft (left . QueryCmdUnsupportedNtcVersion)
 
-        let cMode = consensusModeOnly cModeParams
+          let cMode = consensusModeOnly cModeParams
 
-        sbe <- requireShelleyBasedEra era
-          & onNothing (left QueryCmdByronEra)
+          sbe <-
+            requireShelleyBasedEra era
+              & onNothing (left QueryCmdByronEra)
 
-        eInMode <- pure (toEraInMode era cMode)
-          & onNothing (left (QueryCmdEraConsensusModeMismatch (AnyConsensusMode cMode) anyE))
+          eInMode <-
+            pure (toEraInMode era cMode)
+              & onNothing (left (QueryCmdEraConsensusModeMismatch (AnyConsensusMode cMode) anyE))
 
-        let stakeAddr = Set.singleton $ fromShelleyStakeCredential addr
+          let stakeAddr = Set.singleton $ fromShelleyStakeCredential addr
 
-        eraInMode <- calcEraInMode era $ consensusModeOnly cModeParams
+          eraInMode <- calcEraInMode era $ consensusModeOnly cModeParams
 
-        requireNotByronEraInByronMode eraInMode
+          requireNotByronEraInByronMode eraInMode
 
-        result <- lift (queryStakeAddresses eInMode sbe stakeAddr network)
-          & onLeft (left . QueryCmdUnsupportedNtcVersion)
-          & onLeft (left . QueryCmdLocalStateQueryError . EraMismatchError)
+          result <-
+            lift (queryStakeAddresses eInMode sbe stakeAddr network)
+              & onLeft (left . QueryCmdUnsupportedNtcVersion)
+              & onLeft (left . QueryCmdLocalStateQueryError . EraMismatchError)
 
-        pure $ do
-          writeStakeAddressInfo mOutFile $ DelegationsAndRewards result
-    )
-    & onLeft (left . QueryCmdAcquireFailure)
-    & onLeft left
+          pure $ do
+            writeStakeAddressInfo mOutFile $ DelegationsAndRewards result
+      )
+      & onLeft (left . QueryCmdAcquireFailure)
+      & onLeft left
 
 -- -------------------------------------------------------------------------------------------------
 
@@ -893,16 +1005,17 @@ writeStakeAddressInfo mOutFile delegsAndRewards =
   case mOutFile of
     Nothing -> liftIO $ LBS.putStrLn (encodePretty delegsAndRewards)
     Just (File fpath) ->
-      handleIOExceptT (QueryCmdWriteFileError . FileIOError fpath)
-        $ LBS.writeFile fpath (encodePretty delegsAndRewards)
+      handleIOExceptT (QueryCmdWriteFileError . FileIOError fpath) $
+        LBS.writeFile fpath (encodePretty delegsAndRewards)
 
-writeLedgerState :: forall era ledgerera.
-                    ShelleyLedgerEra era ~ ledgerera
-                 => ToJSON (DebugLedgerState era)
-                 => FromCBOR (DebugLedgerState era)
-                 => Maybe (File () Out)
-                 -> SerialisedDebugLedgerState era
-                 -> ExceptT QueryCmdError IO ()
+writeLedgerState
+  :: forall era ledgerera
+   . (ShelleyLedgerEra era ~ ledgerera)
+  => (ToJSON (DebugLedgerState era))
+  => (FromCBOR (DebugLedgerState era))
+  => Maybe (File () Out)
+  -> SerialisedDebugLedgerState era
+  -> ExceptT QueryCmdError IO ()
 writeLedgerState mOutFile qState@(SerialisedDebugLedgerState serLedgerState) =
   case mOutFile of
     Nothing ->
@@ -910,55 +1023,68 @@ writeLedgerState mOutFile qState@(SerialisedDebugLedgerState serLedgerState) =
         Left bs -> firstExceptT QueryCmdHelpersError $ pPrintCBOR bs
         Right ledgerState -> liftIO . LBS.putStrLn $ Aeson.encode ledgerState
     Just (File fpath) ->
-      handleIOExceptT (QueryCmdWriteFileError . FileIOError fpath)
-        $ LBS.writeFile fpath $ unSerialised serLedgerState
+      handleIOExceptT (QueryCmdWriteFileError . FileIOError fpath) $
+        LBS.writeFile fpath $
+          unSerialised serLedgerState
 
-writeStakeSnapshots :: forall era ledgerera. ()
-  => ShelleyLedgerEra era ~ ledgerera
-  => Core.EraCrypto ledgerera ~ StandardCrypto
+writeStakeSnapshots
+  :: forall era ledgerera
+   . ()
+  => (ShelleyLedgerEra era ~ ledgerera)
+  => (Core.EraCrypto ledgerera ~ StandardCrypto)
   => Maybe (File () Out)
   -> SerialisedStakeSnapshots era
   -> ExceptT QueryCmdError IO ()
 writeStakeSnapshots mOutFile qState = do
-  StakeSnapshot snapshot <- pure (decodeStakeSnapshot qState)
-    & onLeft (left . QueryCmdStakeSnapshotDecodeError)
+  StakeSnapshot snapshot <-
+    pure (decodeStakeSnapshot qState)
+      & onLeft (left . QueryCmdStakeSnapshotDecodeError)
 
   -- Calculate the three pool and active stake values for the given pool
   liftIO . maybe LBS.putStrLn (LBS.writeFile . unFile) mOutFile $ encodePretty snapshot
 
 -- | This function obtains the pool parameters, equivalent to the following jq query on the output of query ledger-state
 --   .nesEs.esLState.lsDPState.dpsPState.psStakePoolParams.<pool_id>
-writePoolState :: forall era ledgerera. ()
-  => ShelleyLedgerEra era ~ ledgerera
-  => Core.EraCrypto ledgerera ~ StandardCrypto
-  => Core.Era ledgerera
+writePoolState
+  :: forall era ledgerera
+   . ()
+  => (ShelleyLedgerEra era ~ ledgerera)
+  => (Core.EraCrypto ledgerera ~ StandardCrypto)
+  => (Core.Era ledgerera)
   => SerialisedPoolState era
   -> ExceptT QueryCmdError IO ()
 writePoolState serialisedCurrentEpochState = do
-  PoolState poolState <- pure (decodePoolState serialisedCurrentEpochState)
-    & onLeft (left . QueryCmdPoolStateDecodeError)
+  PoolState poolState <-
+    pure (decodePoolState serialisedCurrentEpochState)
+      & onLeft (left . QueryCmdPoolStateDecodeError)
 
-  let hks = Set.toList $ Set.fromList $ Map.keys (psStakePoolParams poolState)
-            <> Map.keys (psFutureStakePoolParams poolState) <> Map.keys (psRetiring poolState)
+  let hks =
+        Set.toList $
+          Set.fromList $
+            Map.keys (psStakePoolParams poolState)
+              <> Map.keys (psFutureStakePoolParams poolState)
+              <> Map.keys (psRetiring poolState)
 
   let poolStates :: Map (KeyHash 'StakePool StandardCrypto) (Params StandardCrypto)
-      poolStates = Map.fromList $ hks <&>
-        ( \hk ->
-          ( hk
-          , Params
-            { poolParameters        = Map.lookup hk (SL.psStakePoolParams  poolState)
-            , futurePoolParameters  = Map.lookup hk (SL.psFutureStakePoolParams poolState)
-            , retiringEpoch         = Map.lookup hk (SL.psRetiring poolState)
-            }
-          )
-        )
+      poolStates =
+        Map.fromList $
+          hks
+            <&> ( \hk ->
+                    ( hk
+                    , Params
+                        { poolParameters = Map.lookup hk (SL.psStakePoolParams poolState)
+                        , futurePoolParameters = Map.lookup hk (SL.psFutureStakePoolParams poolState)
+                        , retiringEpoch = Map.lookup hk (SL.psRetiring poolState)
+                        }
+                    )
+                )
 
   liftIO . LBS.putStrLn $ encodePretty poolStates
 
-writeProtocolState ::
-  ( FromCBOR (Consensus.ChainDepState (ConsensusProtocol era))
-  , ToJSON (Consensus.ChainDepState (ConsensusProtocol era))
-  )
+writeProtocolState
+  :: ( FromCBOR (Consensus.ChainDepState (ConsensusProtocol era))
+     , ToJSON (Consensus.ChainDepState (ConsensusProtocol era))
+     )
   => Maybe (File () Out)
   -> ProtocolState era
   -> ExceptT QueryCmdError IO ()
@@ -969,12 +1095,14 @@ writeProtocolState mOutFile ps@(ProtocolState pstate) =
       Right chainDepstate -> liftIO . LBS.putStrLn $ encodePretty chainDepstate
     Just (File fpath) ->
       handleIOExceptT (QueryCmdWriteFileError . FileIOError fpath)
-        . LBS.writeFile fpath $ unSerialised pstate
+        . LBS.writeFile fpath
+        $ unSerialised pstate
 
-writeFilteredUTxOs :: Api.ShelleyBasedEra era
-                   -> Maybe (File () Out)
-                   -> UTxO era
-                   -> ExceptT QueryCmdError IO ()
+writeFilteredUTxOs
+  :: Api.ShelleyBasedEra era
+  -> Maybe (File () Out)
+  -> UTxO era
+  -> ExceptT QueryCmdError IO ()
 writeFilteredUTxOs sbe mOutFile utxo =
   case mOutFile of
     Nothing -> liftIO $ printFilteredUTxOs sbe utxo
@@ -987,9 +1115,9 @@ writeFilteredUTxOs sbe mOutFile utxo =
         ShelleyBasedEraBabbage -> writeUTxo fpath utxo
         ShelleyBasedEraConway -> writeUTxo fpath utxo
  where
-   writeUTxo fpath utxo' =
-     handleIOExceptT (QueryCmdWriteFileError . FileIOError fpath)
-       $ LBS.writeFile fpath (encodePretty utxo')
+  writeUTxo fpath utxo' =
+    handleIOExceptT (QueryCmdWriteFileError . FileIOError fpath) $
+      LBS.writeFile fpath (encodePretty utxo')
 
 printFilteredUTxOs :: Api.ShelleyBasedEra era -> UTxO era -> IO ()
 printFilteredUTxOs sbe (UTxO utxo) = do
@@ -1000,7 +1128,7 @@ printFilteredUTxOs sbe (UTxO utxo) = do
       mapM_ (printUtxo sbe) $ Map.toList utxo
     ShelleyBasedEraAllegra ->
       mapM_ (printUtxo sbe) $ Map.toList utxo
-    ShelleyBasedEraMary    ->
+    ShelleyBasedEraMary ->
       mapM_ (printUtxo sbe) $ Map.toList utxo
     ShelleyBasedEraAlonzo ->
       mapM_ (printUtxo sbe) $ Map.toList utxo
@@ -1008,11 +1136,10 @@ printFilteredUTxOs sbe (UTxO utxo) = do
       mapM_ (printUtxo sbe) $ Map.toList utxo
     ShelleyBasedEraConway ->
       mapM_ (printUtxo sbe) $ Map.toList utxo
-
  where
-   title :: Text
-   title =
-     "                           TxHash                                 TxIx        Amount"
+  title :: Text
+  title =
+    "                           TxHash                                 TxIx        Amount"
 
 printUtxo
   :: Api.ShelleyBasedEra era
@@ -1022,59 +1149,58 @@ printUtxo sbe txInOutTuple =
   case sbe of
     ShelleyBasedEraShelley ->
       let (TxIn (TxId txhash) (TxIx index), TxOut _ value _ _) = txInOutTuple
-      in Text.putStrLn $
-           mconcat
-             [ Text.decodeLatin1 (hashToBytesAsHex txhash)
-             , textShowN 6 index
-             , "        " <> printableValue value
-             ]
-
+       in Text.putStrLn $
+            mconcat
+              [ Text.decodeLatin1 (hashToBytesAsHex txhash)
+              , textShowN 6 index
+              , "        " <> printableValue value
+              ]
     ShelleyBasedEraAllegra ->
       let (TxIn (TxId txhash) (TxIx index), TxOut _ value _ _) = txInOutTuple
-      in Text.putStrLn $
-           mconcat
-             [ Text.decodeLatin1 (hashToBytesAsHex txhash)
-             , textShowN 6 index
-             , "        " <> printableValue value
-             ]
+       in Text.putStrLn $
+            mconcat
+              [ Text.decodeLatin1 (hashToBytesAsHex txhash)
+              , textShowN 6 index
+              , "        " <> printableValue value
+              ]
     ShelleyBasedEraMary ->
       let (TxIn (TxId txhash) (TxIx index), TxOut _ value _ _) = txInOutTuple
-      in Text.putStrLn $
-           mconcat
-             [ Text.decodeLatin1 (hashToBytesAsHex txhash)
-             , textShowN 6 index
-             , "        " <> printableValue value
-             ]
+       in Text.putStrLn $
+            mconcat
+              [ Text.decodeLatin1 (hashToBytesAsHex txhash)
+              , textShowN 6 index
+              , "        " <> printableValue value
+              ]
     ShelleyBasedEraAlonzo ->
       let (TxIn (TxId txhash) (TxIx index), TxOut _ value mDatum _) = txInOutTuple
-      in Text.putStrLn $
-           mconcat
-             [ Text.decodeLatin1 (hashToBytesAsHex txhash)
-             , textShowN 6 index
-             , "        " <> printableValue value <> " + " <> Text.pack (show mDatum)
-             ]
+       in Text.putStrLn $
+            mconcat
+              [ Text.decodeLatin1 (hashToBytesAsHex txhash)
+              , textShowN 6 index
+              , "        " <> printableValue value <> " + " <> Text.pack (show mDatum)
+              ]
     ShelleyBasedEraBabbage ->
       let (TxIn (TxId txhash) (TxIx index), TxOut _ value mDatum _) = txInOutTuple
-      in Text.putStrLn $
-           mconcat
-             [ Text.decodeLatin1 (hashToBytesAsHex txhash)
-             , textShowN 6 index
-             , "        " <> printableValue value <> " + " <> Text.pack (show mDatum)
-             ]
+       in Text.putStrLn $
+            mconcat
+              [ Text.decodeLatin1 (hashToBytesAsHex txhash)
+              , textShowN 6 index
+              , "        " <> printableValue value <> " + " <> Text.pack (show mDatum)
+              ]
     ShelleyBasedEraConway ->
       let (TxIn (TxId txhash) (TxIx index), TxOut _ value mDatum _) = txInOutTuple
-      in Text.putStrLn $
-           mconcat
-             [ Text.decodeLatin1 (hashToBytesAsHex txhash)
-             , textShowN 6 index
-             , "        " <> printableValue value <> " + " <> Text.pack (show mDatum)
-             ]
+       in Text.putStrLn $
+            mconcat
+              [ Text.decodeLatin1 (hashToBytesAsHex txhash)
+              , textShowN 6 index
+              , "        " <> printableValue value <> " + " <> Text.pack (show mDatum)
+              ]
  where
-  textShowN :: Show a => Int -> a -> Text
+  textShowN :: (Show a) => Int -> a -> Text
   textShowN len x =
     let str = show x
         slen = length str
-    in Text.pack $ replicate (max 1 (len - slen)) ' ' ++ str
+     in Text.pack $ replicate (max 1 (len - slen)) ' ' ++ str
 
   printableValue :: TxOutValue era -> Text
   printableValue (TxOutValue _ val) = renderValue val
@@ -1089,28 +1215,33 @@ runQueryStakePoolsCmd
 runQueryStakePoolsCmd socketPath (AnyConsensusModeParams cModeParams) network mOutFile = do
   let localNodeConnInfo = LocalNodeConnectInfo cModeParams network socketPath
 
-  join $ lift
-    ( executeLocalStateQueryExpr localNodeConnInfo Nothing $ runExceptT @QueryCmdError $ do
-        anyE@(AnyCardanoEra era) <- case consensusModeOnly cModeParams of
-          ByronMode -> return $ AnyCardanoEra ByronEra
-          ShelleyMode -> return $ AnyCardanoEra ShelleyEra
-          CardanoMode -> lift queryCurrentEra & onLeft (left . QueryCmdUnsupportedNtcVersion)
+  join $
+    lift
+      ( executeLocalStateQueryExpr localNodeConnInfo Nothing $ runExceptT @QueryCmdError $ do
+          anyE@(AnyCardanoEra era) <- case consensusModeOnly cModeParams of
+            ByronMode -> return $ AnyCardanoEra ByronEra
+            ShelleyMode -> return $ AnyCardanoEra ShelleyEra
+            CardanoMode -> lift queryCurrentEra & onLeft (left . QueryCmdUnsupportedNtcVersion)
 
-        let cMode = consensusModeOnly cModeParams
+          let cMode = consensusModeOnly cModeParams
 
-        eInMode <- toEraInMode era cMode
-          & hoistMaybe (QueryCmdEraConsensusModeMismatch (AnyConsensusMode cMode) anyE)
+          eInMode <-
+            toEraInMode era cMode
+              & hoistMaybe (QueryCmdEraConsensusModeMismatch (AnyConsensusMode cMode) anyE)
 
-        sbe <- requireShelleyBasedEra era
-          & onNothing (left QueryCmdByronEra)
+          sbe <-
+            requireShelleyBasedEra era
+              & onNothing (left QueryCmdByronEra)
 
-        poolIds <- lift (queryStakePools eInMode sbe)
-          & onLeft (left . QueryCmdUnsupportedNtcVersion)
-          & onLeft (left . QueryCmdEraMismatch)
+          poolIds <-
+            lift (queryStakePools eInMode sbe)
+              & onLeft (left . QueryCmdUnsupportedNtcVersion)
+              & onLeft (left . QueryCmdEraMismatch)
 
-        pure $ do
-          writeStakePools mOutFile poolIds
-    ) & onLeft (left . QueryCmdAcquireFailure)
+          pure $ do
+            writeStakePools mOutFile poolIds
+      )
+      & onLeft (left . QueryCmdAcquireFailure)
       & onLeft left
 
 writeStakePools
@@ -1120,7 +1251,6 @@ writeStakePools
 writeStakePools (Just (File outFile)) stakePools =
   handleIOExceptT (QueryCmdWriteFileError . FileIOError outFile) $
     LBS.writeFile outFile (encodePretty stakePools)
-
 writeStakePools Nothing stakePools =
   forM_ (Set.toList stakePools) $ \poolId ->
     liftIO . putStrLn $ Text.unpack (serialiseToBech32 poolId)
@@ -1134,32 +1264,37 @@ runQueryStakeDistributionCmd
 runQueryStakeDistributionCmd socketPath (AnyConsensusModeParams cModeParams) network mOutFile = do
   let localNodeConnInfo = LocalNodeConnectInfo cModeParams network socketPath
 
-  join $ lift
-    ( executeLocalStateQueryExpr localNodeConnInfo Nothing $ runExceptT $ do
-        anyE@(AnyCardanoEra era) <- lift (determineEraExpr cModeParams)
-          & onLeft (left . QueryCmdUnsupportedNtcVersion)
+  join $
+    lift
+      ( executeLocalStateQueryExpr localNodeConnInfo Nothing $ runExceptT $ do
+          anyE@(AnyCardanoEra era) <-
+            lift (determineEraExpr cModeParams)
+              & onLeft (left . QueryCmdUnsupportedNtcVersion)
 
-        let cMode = consensusModeOnly cModeParams
+          let cMode = consensusModeOnly cModeParams
 
-        sbe <- requireShelleyBasedEra era
-          & onNothing (left QueryCmdByronEra)
+          sbe <-
+            requireShelleyBasedEra era
+              & onNothing (left QueryCmdByronEra)
 
-        eInMode <- pure (toEraInMode era cMode)
-          & onNothing (left (QueryCmdEraConsensusModeMismatch (AnyConsensusMode cMode) anyE))
+          eInMode <-
+            pure (toEraInMode era cMode)
+              & onNothing (left (QueryCmdEraConsensusModeMismatch (AnyConsensusMode cMode) anyE))
 
-        eraInMode <- calcEraInMode era $ consensusModeOnly cModeParams
+          eraInMode <- calcEraInMode era $ consensusModeOnly cModeParams
 
-        requireNotByronEraInByronMode eraInMode
+          requireNotByronEraInByronMode eraInMode
 
-        result <- lift (queryStakeDistribution eInMode sbe)
-          & onLeft (left . QueryCmdUnsupportedNtcVersion)
-          & onLeft (left . QueryCmdLocalStateQueryError . EraMismatchError)
+          result <-
+            lift (queryStakeDistribution eInMode sbe)
+              & onLeft (left . QueryCmdUnsupportedNtcVersion)
+              & onLeft (left . QueryCmdLocalStateQueryError . EraMismatchError)
 
-        pure $ do
-          writeStakeDistribution mOutFile result
-    )
-    & onLeft (left . QueryCmdAcquireFailure)
-    & onLeft left
+          pure $ do
+            writeStakeDistribution mOutFile result
+      )
+      & onLeft (left . QueryCmdAcquireFailure)
+      & onLeft left
 
 writeStakeDistribution
   :: Maybe (File () Out)
@@ -1168,10 +1303,8 @@ writeStakeDistribution
 writeStakeDistribution (Just (File outFile)) stakeDistrib =
   handleIOExceptT (QueryCmdWriteFileError . FileIOError outFile) $
     LBS.writeFile outFile (encodePretty stakeDistrib)
-
 writeStakeDistribution Nothing stakeDistrib =
   liftIO $ printStakeDistribution stakeDistrib
-
 
 printStakeDistribution :: Map PoolId Rational -> IO ()
 printStakeDistribution stakeDistrib = do
@@ -1179,134 +1312,168 @@ printStakeDistribution stakeDistrib = do
   putStrLn $ replicate (Text.length title + 2) '-'
   sequence_
     [ putStrLn $ showStakeDistr poolId stakeFraction
-    | (poolId, stakeFraction) <- Map.toList stakeDistrib ]
+    | (poolId, stakeFraction) <- Map.toList stakeDistrib
+    ]
  where
-   title :: Text
-   title =
-     "                           PoolId                                 Stake frac"
+  title :: Text
+  title =
+    "                           PoolId                                 Stake frac"
 
-   showStakeDistr :: PoolId
-                  -> Rational
-                  -- ^ Stake fraction
-                  -> String
-   showStakeDistr poolId stakeFraction =
-     concat
-       [ Text.unpack (serialiseToBech32 poolId)
-       , "   "
-       , showEFloat (Just 3) (fromRational stakeFraction :: Double) ""
-       ]
+  showStakeDistr
+    :: PoolId
+    -> Rational
+    -- \^ Stake fraction
+    -> String
+  showStakeDistr poolId stakeFraction =
+    concat
+      [ Text.unpack (serialiseToBech32 poolId)
+      , "   "
+      , showEFloat (Just 3) (fromRational stakeFraction :: Double) ""
+      ]
 
 runQueryLeadershipScheduleCmd
   :: SocketPath
   -> AnyConsensusModeParams
   -> NetworkId
-  -> GenesisFile -- ^ Shelley genesis
+  -> GenesisFile
+  -- ^ Shelley genesis
   -> VerificationKeyOrHashOrFile StakePoolKey
-  -> SigningKeyFile In -- ^ VRF signing key
+  -> SigningKeyFile In
+  -- ^ VRF signing key
   -> EpochLeadershipSchedule
   -> Maybe (File () Out)
   -> ExceptT QueryCmdError IO ()
 runQueryLeadershipScheduleCmd
-    socketPath (AnyConsensusModeParams cModeParams) network
-    (GenesisFile genFile) coldVerKeyFile vrfSkeyFp
-    whichSchedule mJsonOutputFile = do
-  let localNodeConnInfo = LocalNodeConnectInfo cModeParams network socketPath
+  socketPath
+  (AnyConsensusModeParams cModeParams)
+  network
+  (GenesisFile genFile)
+  coldVerKeyFile
+  vrfSkeyFp
+  whichSchedule
+  mJsonOutputFile = do
+    let localNodeConnInfo = LocalNodeConnectInfo cModeParams network socketPath
 
-  poolid <- lift (readVerificationKeyOrHashOrFile AsStakePoolKey coldVerKeyFile)
-    & onLeft (left . QueryCmdTextReadError)
+    poolid <-
+      lift (readVerificationKeyOrHashOrFile AsStakePoolKey coldVerKeyFile)
+        & onLeft (left . QueryCmdTextReadError)
 
-  vrkSkey <- lift (readFileTextEnvelope (AsSigningKey AsVrfKey) vrfSkeyFp)
-    & onLeft (left . QueryCmdTextEnvelopeReadError)
+    vrkSkey <-
+      lift (readFileTextEnvelope (AsSigningKey AsVrfKey) vrfSkeyFp)
+        & onLeft (left . QueryCmdTextEnvelopeReadError)
 
-  shelleyGenesis <- lift (readAndDecodeShelleyGenesis genFile)
-    & onLeft (left . QueryCmdGenesisReadError)
+    shelleyGenesis <-
+      lift (readAndDecodeShelleyGenesis genFile)
+        & onLeft (left . QueryCmdGenesisReadError)
 
-  join $ lift
-    ( executeLocalStateQueryExpr localNodeConnInfo Nothing $ runExceptT $ do
-        anyE@(AnyCardanoEra era) <- lift (determineEraExpr cModeParams)
-          & onLeft (left . QueryCmdUnsupportedNtcVersion)
+    join $
+      lift
+        ( executeLocalStateQueryExpr localNodeConnInfo Nothing $ runExceptT $ do
+            anyE@(AnyCardanoEra era) <-
+              lift (determineEraExpr cModeParams)
+                & onLeft (left . QueryCmdUnsupportedNtcVersion)
 
-        sbe <- requireShelleyBasedEra era
-          & onNothing (left QueryCmdByronEra)
+            sbe <-
+              requireShelleyBasedEra era
+                & onNothing (left QueryCmdByronEra)
 
-        let cMode = consensusModeOnly cModeParams
+            let cMode = consensusModeOnly cModeParams
 
-        case cMode of
-          CardanoMode -> do
-            eInMode <- toEraInMode era cMode
-                & hoistMaybe (QueryCmdEraConsensusModeMismatch (AnyConsensusMode cMode) anyE)
+            case cMode of
+              CardanoMode -> do
+                eInMode <-
+                  toEraInMode era cMode
+                    & hoistMaybe (QueryCmdEraConsensusModeMismatch (AnyConsensusMode cMode) anyE)
 
-            eraInMode <- calcEraInMode era $ consensusModeOnly cModeParams
+                eraInMode <- calcEraInMode era $ consensusModeOnly cModeParams
 
-            requireNotByronEraInByronMode eraInMode
+                requireNotByronEraInByronMode eraInMode
 
-            pparams <- lift (queryProtocolParameters eInMode sbe)
-              & onLeft (left . QueryCmdUnsupportedNtcVersion)
-              & onLeft (left . QueryCmdLocalStateQueryError . EraMismatchError)
+                pparams <-
+                  lift (queryProtocolParameters eInMode sbe)
+                    & onLeft (left . QueryCmdUnsupportedNtcVersion)
+                    & onLeft (left . QueryCmdLocalStateQueryError . EraMismatchError)
 
-            ptclState <- lift (queryProtocolState eInMode sbe)
-              & onLeft (left . QueryCmdUnsupportedNtcVersion)
-              & onLeft (left . QueryCmdLocalStateQueryError . EraMismatchError)
+                ptclState <-
+                  lift (queryProtocolState eInMode sbe)
+                    & onLeft (left . QueryCmdUnsupportedNtcVersion)
+                    & onLeft (left . QueryCmdLocalStateQueryError . EraMismatchError)
 
-            eraHistory <- lift queryEraHistory
-              & onLeft (left . QueryCmdUnsupportedNtcVersion)
+                eraHistory <-
+                  lift queryEraHistory
+                    & onLeft (left . QueryCmdUnsupportedNtcVersion)
 
-            let eInfo = toEpochInfo eraHistory
+                let eInfo = toEpochInfo eraHistory
 
-            curentEpoch <- lift (queryEpoch eInMode sbe)
-              & onLeft (left . QueryCmdUnsupportedNtcVersion)
-              & onLeft (left . QueryCmdLocalStateQueryError . EraMismatchError)
+                curentEpoch <-
+                  lift (queryEpoch eInMode sbe)
+                    & onLeft (left . QueryCmdUnsupportedNtcVersion)
+                    & onLeft (left . QueryCmdLocalStateQueryError . EraMismatchError)
 
-            case whichSchedule of
-              CurrentEpoch -> do
-                serCurrentEpochState <- lift (queryPoolDistribution eInMode sbe (Just (Set.singleton poolid)))
-                  & onLeft (left . QueryCmdUnsupportedNtcVersion)
-                  & onLeft (left . QueryCmdLocalStateQueryError . EraMismatchError)
+                case whichSchedule of
+                  CurrentEpoch -> do
+                    serCurrentEpochState <-
+                      lift (queryPoolDistribution eInMode sbe (Just (Set.singleton poolid)))
+                        & onLeft (left . QueryCmdUnsupportedNtcVersion)
+                        & onLeft (left . QueryCmdLocalStateQueryError . EraMismatchError)
 
+                    pure $ do
+                      schedule <-
+                        firstExceptT QueryCmdLeaderShipError $
+                          hoistEither $
+                            shelleyBasedEraConstraints sbe $
+                              currentEpochEligibleLeadershipSlots
+                                sbe
+                                shelleyGenesis
+                                eInfo
+                                pparams
+                                ptclState
+                                poolid
+                                vrkSkey
+                                serCurrentEpochState
+                                curentEpoch
+
+                      writeSchedule mJsonOutputFile eInfo shelleyGenesis schedule
+                  NextEpoch -> do
+                    serCurrentEpochState <-
+                      lift (queryCurrentEpochState eInMode sbe)
+                        & onLeft (left . QueryCmdUnsupportedNtcVersion)
+                        & onLeft (left . QueryCmdLocalStateQueryError . EraMismatchError)
+
+                    pure $ do
+                      tip <- liftIO $ getLocalChainTip localNodeConnInfo
+
+                      schedule <-
+                        firstExceptT QueryCmdLeaderShipError $
+                          hoistEither $
+                            shelleyBasedEraConstraints sbe $
+                              nextEpochEligibleLeadershipSlots
+                                sbe
+                                shelleyGenesis
+                                serCurrentEpochState
+                                ptclState
+                                poolid
+                                vrkSkey
+                                pparams
+                                eInfo
+                                (tip, curentEpoch)
+
+                      writeSchedule mJsonOutputFile eInfo shelleyGenesis schedule
+              mode ->
                 pure $ do
-                  schedule <- firstExceptT QueryCmdLeaderShipError $ hoistEither
-                    $ shelleyBasedEraConstraints sbe
-                    $ currentEpochEligibleLeadershipSlots
-                      sbe
-                      shelleyGenesis
-                      eInfo
-                      pparams
-                      ptclState
-                      poolid
-                      vrkSkey
-                      serCurrentEpochState
-                      curentEpoch
-
-                  writeSchedule mJsonOutputFile eInfo shelleyGenesis schedule
-
-              NextEpoch -> do
-                serCurrentEpochState <- lift (queryCurrentEpochState eInMode sbe)
-                  & onLeft (left . QueryCmdUnsupportedNtcVersion)
-                  & onLeft (left . QueryCmdLocalStateQueryError . EraMismatchError)
-
-                pure $ do
-                  tip <- liftIO $ getLocalChainTip localNodeConnInfo
-
-                  schedule <- firstExceptT QueryCmdLeaderShipError $ hoistEither
-                    $ shelleyBasedEraConstraints sbe
-                    $ nextEpochEligibleLeadershipSlots sbe shelleyGenesis
-                      serCurrentEpochState ptclState poolid vrkSkey pparams
-                      eInfo (tip, curentEpoch)
-
-                  writeSchedule mJsonOutputFile eInfo shelleyGenesis schedule
-          mode ->
-            pure $ do
-              left . QueryCmdUnsupportedMode $ AnyConsensusMode mode
-    )
-    & onLeft (left . QueryCmdAcquireFailure)
-    & onLeft left
-  where
+                  left . QueryCmdUnsupportedMode $ AnyConsensusMode mode
+        )
+        & onLeft (left . QueryCmdAcquireFailure)
+        & onLeft left
+   where
     writeSchedule mOutFile eInfo shelleyGenesis schedule =
       case mOutFile of
-        Nothing -> liftIO $ printLeadershipScheduleAsText schedule eInfo (SystemStart $ sgSystemStart shelleyGenesis)
+        Nothing ->
+          liftIO $ printLeadershipScheduleAsText schedule eInfo (SystemStart $ sgSystemStart shelleyGenesis)
         Just (File jsonOutputFile) ->
-          liftIO $ LBS.writeFile jsonOutputFile $
-            printLeadershipScheduleAsJson schedule eInfo (SystemStart $ sgSystemStart shelleyGenesis)
+          liftIO $
+            LBS.writeFile jsonOutputFile $
+              printLeadershipScheduleAsJson schedule eInfo (SystemStart $ sgSystemStart shelleyGenesis)
 
     printLeadershipScheduleAsText
       :: Set SlotNo
@@ -1318,28 +1485,29 @@ runQueryLeadershipScheduleCmd
       putStrLn $ replicate (Text.length title + 2) '-'
       sequence_
         [ putStrLn $ showLeadershipSlot slot eInfo sStart
-        | slot <- Set.toList leadershipSlots ]
-      where
-        title :: Text
-        title =
-          "     SlotNo                          UTC Time              "
+        | slot <- Set.toList leadershipSlots
+        ]
+     where
+      title :: Text
+      title =
+        "     SlotNo                          UTC Time              "
 
-        showLeadershipSlot
-          :: SlotNo
-          -> EpochInfo (Either Text)
-          -> SystemStart
-          -> String
-        showLeadershipSlot lSlot@(SlotNo sn) eInfo' sStart' =
-          case epochInfoSlotToUTCTime eInfo' sStart' lSlot of
-            Right slotTime ->
-              concat
+      showLeadershipSlot
+        :: SlotNo
+        -> EpochInfo (Either Text)
+        -> SystemStart
+        -> String
+      showLeadershipSlot lSlot@(SlotNo sn) eInfo' sStart' =
+        case epochInfoSlotToUTCTime eInfo' sStart' lSlot of
+          Right slotTime ->
+            concat
               [ "     "
               , show sn
               , "                   "
               , show slotTime
               ]
-            Left err ->
-              concat
+          Left err ->
+            concat
               [ "     "
               , show sn
               , "                   "
@@ -1352,26 +1520,26 @@ runQueryLeadershipScheduleCmd
       -> LBS.ByteString
     printLeadershipScheduleAsJson leadershipSlots eInfo sStart =
       encodePretty $ showLeadershipSlot <$> List.sort (Set.toList leadershipSlots)
-      where
-        showLeadershipSlot :: SlotNo -> Aeson.Value
-        showLeadershipSlot lSlot@(SlotNo sn) =
-          case epochInfoSlotToUTCTime eInfo sStart lSlot of
-            Right slotTime ->
-              Aeson.object
-                [ "slotNumber" Aeson..= sn
-                , "slotTime" Aeson..= slotTime
-                ]
-            Left err ->
-              Aeson.object
-                [ "slotNumber" Aeson..= sn
-                , "error" Aeson..= Text.unpack err
-                ]
-
+     where
+      showLeadershipSlot :: SlotNo -> Aeson.Value
+      showLeadershipSlot lSlot@(SlotNo sn) =
+        case epochInfoSlotToUTCTime eInfo sStart lSlot of
+          Right slotTime ->
+            Aeson.object
+              [ "slotNumber" Aeson..= sn
+              , "slotTime" Aeson..= slotTime
+              ]
+          Left err ->
+            Aeson.object
+              [ "slotNumber" Aeson..= sn
+              , "error" Aeson..= Text.unpack err
+              ]
 
 -- Helpers
 
-calcEraInMode :: ()
-  => Monad m
+calcEraInMode
+  :: ()
+  => (Monad m)
   => CardanoEra era
   -> ConsensusMode mode
   -> ExceptT QueryCmdError m (EraInMode era mode)
@@ -1379,8 +1547,9 @@ calcEraInMode era mode =
   pure (toEraInMode era mode)
     & onNothing (left (QueryCmdEraConsensusModeMismatch (AnyConsensusMode mode) (anyCardanoEra era)))
 
-requireNotByronEraInByronMode :: ()
-  => Monad m
+requireNotByronEraInByronMode
+  :: ()
+  => (Monad m)
   => EraInMode era mode
   -> ExceptT QueryCmdError m ()
 requireNotByronEraInByronMode = \case
@@ -1389,13 +1558,13 @@ requireNotByronEraInByronMode = \case
 
 toEpochInfo :: EraHistory CardanoMode -> EpochInfo (Either Text)
 toEpochInfo (EraHistory _ interpreter) =
-  hoistEpochInfo (first (Text.pack . show) . runExcept)
-    $ Consensus.interpreterToEpochInfo interpreter
+  hoistEpochInfo (first (Text.pack . show) . runExcept) $
+    Consensus.interpreterToEpochInfo interpreter
 
 -- | A value that is tentative or produces a tentative value if used.  These values
 -- are considered accurate only if some future event such as a hard fork does not
 -- render them invalid.
-newtype Tentative a = Tentative { tentative :: a } deriving (Eq, Show)
+newtype Tentative a = Tentative {tentative :: a} deriving (Eq, Show)
 
 -- | Get an Epoch Info that computes tentative values.  The values computed are
 -- tentative because it uses an interpreter that is extended past the horizon.
@@ -1404,10 +1573,9 @@ newtype Tentative a = Tentative { tentative :: a } deriving (Eq, Show)
 -- "tentative" because they can change in the event of a hard fork.
 toTentativeEpochInfo :: EraHistory CardanoMode -> Tentative (EpochInfo (Either Text))
 toTentativeEpochInfo (EraHistory _ interpreter) =
-  Tentative
-    $ hoistEpochInfo (first (Text.pack . show) . runExcept)
-    $ Consensus.interpreterToEpochInfo (Consensus.unsafeExtendSafeZone interpreter)
-
+  Tentative $
+    hoistEpochInfo (first (Text.pack . show) . runExcept) $
+      Consensus.interpreterToEpochInfo (Consensus.unsafeExtendSafeZone interpreter)
 
 -- | Get slot number for timestamp, or an error if the UTC timestamp is before 'SystemStart' or after N+1 era
 utcTimeToSlotNo
@@ -1422,11 +1590,13 @@ utcTimeToSlotNo socketPath (AnyConsensusModeParams cModeParams) network utcTime 
     CardanoMode -> do
       lift
         ( executeLocalStateQueryExpr localNodeConnInfo Nothing $ runExceptT $ do
-            systemStart <- lift querySystemStart
-              & onLeft (left . QueryCmdUnsupportedNtcVersion)
+            systemStart <-
+              lift querySystemStart
+                & onLeft (left . QueryCmdUnsupportedNtcVersion)
 
-            eraHistory <- lift queryEraHistory
-              & onLeft (left . QueryCmdUnsupportedNtcVersion)
+            eraHistory <-
+              lift queryEraHistory
+                & onLeft (left . QueryCmdUnsupportedNtcVersion)
 
             let relTime = toRelativeTime systemStart utcTime
 
@@ -1435,5 +1605,4 @@ utcTimeToSlotNo socketPath (AnyConsensusModeParams cModeParams) network utcTime 
         )
         & onLeft (left . QueryCmdAcquireFailure)
         & onLeft left
-
     mode -> left . QueryCmdUnsupportedMode $ AnyConsensusMode mode

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/StakeAddress.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/StakeAddress.hs
@@ -18,7 +18,7 @@ module Cardano.CLI.EraBased.Run.StakeAddress
   ) where
 
 import Cardano.Api
-import qualified Cardano.Api.Ledger as Ledger
+import Cardano.Api.Ledger qualified as Ledger
 import Cardano.Api.Shelley
 
 import Cardano.CLI.EraBased.Commands.StakeAddress
@@ -39,9 +39,9 @@ import Control.Monad.Trans.Except.Extra
   , newExceptT
   , onLeft
   )
-import qualified Data.ByteString.Char8 as BS
+import Data.ByteString.Char8 qualified as BS
 import Data.Function ((&))
-import qualified Data.Text.IO as Text
+import Data.Text.IO qualified as Text
 
 runStakeAddressCmds
   :: ()

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/StakePool.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/StakePool.hs
@@ -12,14 +12,14 @@ module Cardano.CLI.EraBased.Run.StakePool
   ) where
 
 import Cardano.Api
-import qualified Cardano.Api.Ledger as Ledger
+import Cardano.Api.Ledger qualified as Ledger
 import Cardano.Api.Shelley
 
 import Cardano.CLI.EraBased.Commands.StakePool
 import Cardano.CLI.Types.Common
 import Cardano.CLI.Types.Errors.StakePoolCmdError
 import Cardano.CLI.Types.Key (VerificationKeyOrFile, readVerificationKeyOrFile)
-import qualified Cardano.Ledger.Slot as Shelley
+import Cardano.Ledger.Slot qualified as Shelley
 
 import Control.Monad.IO.Class (MonadIO (..))
 import Control.Monad.Trans (lift)
@@ -32,7 +32,7 @@ import Control.Monad.Trans.Except.Extra
   , newExceptT
   , onLeft
   )
-import qualified Data.ByteString.Char8 as BS
+import Data.ByteString.Char8 qualified as BS
 import Data.Function ((&))
 
 runStakePoolCmds

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/TextView.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/TextView.hs
@@ -3,26 +3,26 @@
 
 module Cardano.CLI.EraBased.Run.TextView
   ( runTextViewCmds
-
   , runTextViewInfoCmd
   ) where
 
-import           Cardano.Api
+import Cardano.Api
 
-import           Cardano.CLI.EraBased.Commands.TextView
-import           Cardano.CLI.Helpers (pPrintCBOR)
-import           Cardano.CLI.Types.Errors.TextViewFileError
+import Cardano.CLI.EraBased.Commands.TextView
+import Cardano.CLI.Helpers (pPrintCBOR)
+import Cardano.CLI.Types.Errors.TextViewFileError
 
-import           Control.Monad.IO.Class (MonadIO (..))
-import           Control.Monad.Trans.Except (ExceptT)
-import           Control.Monad.Trans.Except.Extra (firstExceptT, newExceptT)
+import Control.Monad.IO.Class (MonadIO (..))
+import Control.Monad.Trans.Except (ExceptT)
+import Control.Monad.Trans.Except.Extra (firstExceptT, newExceptT)
 import qualified Data.ByteString.Lazy.Char8 as LBS
 
 runTextViewCmds :: TextViewCmds era -> ExceptT TextViewFileError IO ()
 runTextViewCmds = \case
   TextViewInfo fpath mOutfile -> runTextViewInfoCmd fpath mOutfile
 
-runTextViewInfoCmd :: ()
+runTextViewInfoCmd
+  :: ()
   => FilePath
   -> Maybe (File () Out)
   -> ExceptT TextViewFileError IO ()

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/TextView.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/TextView.hs
@@ -15,7 +15,7 @@ import Cardano.CLI.Types.Errors.TextViewFileError
 import Control.Monad.IO.Class (MonadIO (..))
 import Control.Monad.Trans.Except (ExceptT)
 import Control.Monad.Trans.Except.Extra (firstExceptT, newExceptT)
-import qualified Data.ByteString.Lazy.Char8 as LBS
+import Data.ByteString.Lazy.Char8 qualified as LBS
 
 runTextViewCmds :: TextViewCmds era -> ExceptT TextViewFileError IO ()
 runTextViewCmds = \case

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Transaction.hs
@@ -28,7 +28,7 @@ module Cardano.CLI.EraBased.Run.Transaction
 
 import Cardano.Api
 import Cardano.Api.Byron hiding (SomeByronSigningKey (..))
-import qualified Cardano.Api.Ledger as Ledger
+import Cardano.Api.Ledger qualified as Ledger
 import Cardano.Api.Shelley
 
 import Cardano.CLI.EraBased.Commands.Transaction
@@ -42,8 +42,8 @@ import Cardano.CLI.Types.Errors.TxValidationError
 import Cardano.CLI.Types.Governance
 import Cardano.CLI.Types.Output (renderScriptCosts)
 import Cardano.CLI.Types.TxFeature
-import qualified Cardano.Ledger.Alonzo.Core as Ledger
-import qualified Ouroboros.Network.Protocol.LocalTxSubmission.Client as Net.Tx
+import Cardano.Ledger.Alonzo.Core qualified as Ledger
+import Ouroboros.Network.Protocol.LocalTxSubmission.Client qualified as Net.Tx
 
 import Control.Monad (forM)
 import Control.Monad.IO.Class (MonadIO (..))
@@ -60,23 +60,23 @@ import Control.Monad.Trans.Except.Extra
   )
 import Data.Aeson.Encode.Pretty (encodePretty)
 import Data.Bifunctor (Bifunctor (..))
-import qualified Data.ByteString.Char8 as BS
-import qualified Data.ByteString.Lazy.Char8 as LBS
+import Data.ByteString.Char8 qualified as BS
+import Data.ByteString.Lazy.Char8 qualified as LBS
 import Data.Data ((:~:) (..))
 import Data.Foldable (Foldable (..))
 import Data.Function ((&))
-import qualified Data.List as List
+import Data.List qualified as List
 import Data.Map.Strict (Map)
-import qualified Data.Map.Strict as Map
+import Data.Map.Strict qualified as Map
 import Data.Maybe (catMaybes, fromMaybe)
 import Data.Set (Set)
-import qualified Data.Set as Set
+import Data.Set qualified as Set
 import Data.Text (Text)
-import qualified Data.Text as Text
-import qualified Data.Text.IO as Text
+import Data.Text qualified as Text
+import Data.Text.IO qualified as Text
 import Data.Type.Equality (TestEquality (..))
 import Lens.Micro ((^.))
-import qualified System.IO as IO
+import System.IO qualified as IO
 
 runTransactionCmds :: TransactionCmds era -> ExceptT TxCmdError IO ()
 runTransactionCmds cmd =

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Transaction.hs
@@ -6,8 +6,8 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections #-}
-
 {-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
+
 {-# HLINT ignore "Unused LANGUAGE pragma" #-}
 
 module Cardano.CLI.EraBased.Run.Transaction
@@ -26,77 +26,172 @@ module Cardano.CLI.EraBased.Run.Transaction
   , runTxSignWitnessCmd
   ) where
 
-import           Cardano.Api
-import           Cardano.Api.Byron hiding (SomeByronSigningKey (..))
+import Cardano.Api
+import Cardano.Api.Byron hiding (SomeByronSigningKey (..))
 import qualified Cardano.Api.Ledger as Ledger
-import           Cardano.Api.Shelley
+import Cardano.Api.Shelley
 
-import           Cardano.CLI.EraBased.Commands.Transaction
-import           Cardano.CLI.EraBased.Run.Genesis
-import           Cardano.CLI.Json.Friendly (friendlyTxBS, friendlyTxBodyBS)
-import           Cardano.CLI.Read
-import           Cardano.CLI.Types.Common
-import           Cardano.CLI.Types.Errors.BootstrapWitnessError
-import           Cardano.CLI.Types.Errors.TxCmdError
-import           Cardano.CLI.Types.Errors.TxValidationError
-import           Cardano.CLI.Types.Governance
-import           Cardano.CLI.Types.Output (renderScriptCosts)
-import           Cardano.CLI.Types.TxFeature
+import Cardano.CLI.EraBased.Commands.Transaction
+import Cardano.CLI.EraBased.Run.Genesis
+import Cardano.CLI.Json.Friendly (friendlyTxBS, friendlyTxBodyBS)
+import Cardano.CLI.Read
+import Cardano.CLI.Types.Common
+import Cardano.CLI.Types.Errors.BootstrapWitnessError
+import Cardano.CLI.Types.Errors.TxCmdError
+import Cardano.CLI.Types.Errors.TxValidationError
+import Cardano.CLI.Types.Governance
+import Cardano.CLI.Types.Output (renderScriptCosts)
+import Cardano.CLI.Types.TxFeature
 import qualified Cardano.Ledger.Alonzo.Core as Ledger
 import qualified Ouroboros.Network.Protocol.LocalTxSubmission.Client as Net.Tx
 
-import           Control.Monad (forM)
-import           Control.Monad.IO.Class (MonadIO (..))
-import           Control.Monad.Trans (MonadTrans (..))
-import           Control.Monad.Trans.Except
-import           Control.Monad.Trans.Except.Extra (firstExceptT, hoistEither, hoistMaybe, left,
-                   newExceptT, onLeft, onNothing)
-import           Data.Aeson.Encode.Pretty (encodePretty)
-import           Data.Bifunctor (Bifunctor (..))
+import Control.Monad (forM)
+import Control.Monad.IO.Class (MonadIO (..))
+import Control.Monad.Trans (MonadTrans (..))
+import Control.Monad.Trans.Except
+import Control.Monad.Trans.Except.Extra
+  ( firstExceptT
+  , hoistEither
+  , hoistMaybe
+  , left
+  , newExceptT
+  , onLeft
+  , onNothing
+  )
+import Data.Aeson.Encode.Pretty (encodePretty)
+import Data.Bifunctor (Bifunctor (..))
 import qualified Data.ByteString.Char8 as BS
 import qualified Data.ByteString.Lazy.Char8 as LBS
-import           Data.Data ((:~:) (..))
-import           Data.Foldable (Foldable (..))
-import           Data.Function ((&))
+import Data.Data ((:~:) (..))
+import Data.Foldable (Foldable (..))
+import Data.Function ((&))
 import qualified Data.List as List
-import           Data.Map.Strict (Map)
+import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import           Data.Maybe (catMaybes, fromMaybe)
-import           Data.Set (Set)
+import Data.Maybe (catMaybes, fromMaybe)
+import Data.Set (Set)
 import qualified Data.Set as Set
-import           Data.Text (Text)
+import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
-import           Data.Type.Equality (TestEquality (..))
-import           Lens.Micro ((^.))
+import Data.Type.Equality (TestEquality (..))
+import Lens.Micro ((^.))
 import qualified System.IO as IO
 
 runTransactionCmds :: TransactionCmds era -> ExceptT TxCmdError IO ()
 runTransactionCmds cmd =
   case cmd of
     TxBuild
-        era mNodeSocketPath consensusModeParams nid mScriptValidity mOverrideWits txins readOnlyRefIns
-        reqSigners txinsc mReturnColl mTotCollateral txouts changeAddr mValue mLowBound
-        mUpperBound certs wdrls metadataSchema scriptFiles metadataFiles mUpProp mconwayVote
-        mNewConstitution outputOptions ->
-      runTxBuildCmd
-        era mNodeSocketPath consensusModeParams nid mScriptValidity mOverrideWits txins readOnlyRefIns
-        reqSigners txinsc mReturnColl mTotCollateral txouts changeAddr mValue mLowBound
-        mUpperBound certs wdrls metadataSchema scriptFiles metadataFiles mUpProp mconwayVote
-        mNewConstitution outputOptions
+      era
+      mNodeSocketPath
+      consensusModeParams
+      nid
+      mScriptValidity
+      mOverrideWits
+      txins
+      readOnlyRefIns
+      reqSigners
+      txinsc
+      mReturnColl
+      mTotCollateral
+      txouts
+      changeAddr
+      mValue
+      mLowBound
+      mUpperBound
+      certs
+      wdrls
+      metadataSchema
+      scriptFiles
+      metadataFiles
+      mUpProp
+      mconwayVote
+      mNewConstitution
+      outputOptions ->
+        runTxBuildCmd
+          era
+          mNodeSocketPath
+          consensusModeParams
+          nid
+          mScriptValidity
+          mOverrideWits
+          txins
+          readOnlyRefIns
+          reqSigners
+          txinsc
+          mReturnColl
+          mTotCollateral
+          txouts
+          changeAddr
+          mValue
+          mLowBound
+          mUpperBound
+          certs
+          wdrls
+          metadataSchema
+          scriptFiles
+          metadataFiles
+          mUpProp
+          mconwayVote
+          mNewConstitution
+          outputOptions
     TxBuildRaw
-        era mScriptValidity txins readOnlyRefIns txinsc mReturnColl
-        mTotColl reqSigners txouts mValue mLowBound mUpperBound fee certs wdrls
-        metadataSchema scriptFiles metadataFiles mProtocolParamsFile mUpProp out ->
-      runTxBuildRawCmd era mScriptValidity txins readOnlyRefIns txinsc mReturnColl
-        mTotColl reqSigners txouts mValue mLowBound mUpperBound fee certs wdrls
-        metadataSchema scriptFiles metadataFiles mProtocolParamsFile mUpProp out
+      era
+      mScriptValidity
+      txins
+      readOnlyRefIns
+      txinsc
+      mReturnColl
+      mTotColl
+      reqSigners
+      txouts
+      mValue
+      mLowBound
+      mUpperBound
+      fee
+      certs
+      wdrls
+      metadataSchema
+      scriptFiles
+      metadataFiles
+      mProtocolParamsFile
+      mUpProp
+      out ->
+        runTxBuildRawCmd
+          era
+          mScriptValidity
+          txins
+          readOnlyRefIns
+          txinsc
+          mReturnColl
+          mTotColl
+          reqSigners
+          txouts
+          mValue
+          mLowBound
+          mUpperBound
+          fee
+          certs
+          wdrls
+          metadataSchema
+          scriptFiles
+          metadataFiles
+          mProtocolParamsFile
+          mUpProp
+          out
     TxSign txinfile skfiles network txoutfile ->
       runTxSignCmd txinfile skfiles network txoutfile
     TxSubmit mNodeSocketPath anyConsensusModeParams network txFp ->
       runTxSubmitCmd mNodeSocketPath anyConsensusModeParams network txFp
     TxCalculateMinFee txbody nw pParamsFile nInputs nOutputs nShelleyKeyWitnesses nByronKeyWitnesses ->
-      runTxCalculateMinFeeCmd txbody nw pParamsFile nInputs nOutputs nShelleyKeyWitnesses nByronKeyWitnesses
+      runTxCalculateMinFeeCmd
+        txbody
+        nw
+        pParamsFile
+        nInputs
+        nOutputs
+        nShelleyKeyWitnesses
+        nByronKeyWitnesses
     TxCalculateMinRequiredUTxO era pParamsFile txOuts ->
       runTxCalculateMinRequiredUTxOCmd era pParamsFile txOuts
     TxHashScriptData scriptDataOrFile ->
@@ -116,26 +211,37 @@ runTransactionCmds cmd =
 -- Building transactions
 --
 
-runTxBuildCmd :: ()
+runTxBuildCmd
+  :: ()
   => CardanoEra era
   -> SocketPath
   -> AnyConsensusModeParams
   -> NetworkId
   -> Maybe ScriptValidity
-  -> Maybe Word -- ^ Override the required number of tx witnesses
-  -> [(TxIn, Maybe (ScriptWitnessFiles WitCtxTxIn))] -- ^ Transaction inputs with optional spending scripts
-  -> [TxIn] -- ^ Read only reference inputs
-  -> [RequiredSigner] -- ^ Required signers
-  -> [TxIn] -- ^ Transaction inputs for collateral, only key witnesses, no scripts.
-  -> Maybe TxOutAnyEra -- ^ Return collateral
-  -> Maybe Lovelace -- ^ Total collateral
+  -> Maybe Word
+  -- ^ Override the required number of tx witnesses
+  -> [(TxIn, Maybe (ScriptWitnessFiles WitCtxTxIn))]
+  -- ^ Transaction inputs with optional spending scripts
+  -> [TxIn]
+  -- ^ Read only reference inputs
+  -> [RequiredSigner]
+  -- ^ Required signers
+  -> [TxIn]
+  -- ^ Transaction inputs for collateral, only key witnesses, no scripts.
+  -> Maybe TxOutAnyEra
+  -- ^ Return collateral
+  -> Maybe Lovelace
+  -- ^ Total collateral
   -> [TxOutAnyEra]
   -> TxOutChangeAddress
   -> Maybe (Value, [ScriptWitnessFiles WitCtxMint])
-  -> Maybe SlotNo -- ^ Validity lower bound
-  -> Maybe SlotNo -- ^ Validity upper bound
+  -> Maybe SlotNo
+  -- ^ Validity lower bound
+  -> Maybe SlotNo
+  -- ^ Validity upper bound
   -> [(CertificateFile, Maybe (ScriptWitnessFiles WitCtxStake))]
-  -> [(StakeAddress, Lovelace, Maybe (ScriptWitnessFiles WitCtxStake))] -- ^ Withdrawals with potential script witness
+  -> [(StakeAddress, Lovelace, Maybe (ScriptWitnessFiles WitCtxStake))]
+  -- ^ Withdrawals with potential script witness
   -> TxMetadataJsonSchema
   -> [ScriptFile]
   -> [MetadataFile]
@@ -145,133 +251,203 @@ runTxBuildCmd :: ()
   -> TxBuildOutputOptions
   -> ExceptT TxCmdError IO ()
 runTxBuildCmd
-    era socketPath consensusModeParams@(AnyConsensusModeParams cModeParams) nid
-    mScriptValidity mOverrideWits txins readOnlyRefIns reqSigners txinsc mReturnColl mTotCollateral txouts
-    changeAddr mValue mLowBound mUpperBound certs wdrls metadataSchema scriptFiles metadataFiles mUpProp
-    conwayVotes newProposals outputOptions = do
+  era
+  socketPath
+  consensusModeParams@(AnyConsensusModeParams cModeParams)
+  nid
+  mScriptValidity
+  mOverrideWits
+  txins
+  readOnlyRefIns
+  reqSigners
+  txinsc
+  mReturnColl
+  mTotCollateral
+  txouts
+  changeAddr
+  mValue
+  mLowBound
+  mUpperBound
+  certs
+  wdrls
+  metadataSchema
+  scriptFiles
+  metadataFiles
+  mUpProp
+  conwayVotes
+  newProposals
+  outputOptions = do
+    -- The user can specify an era prior to the era that the node is currently in.
+    -- We cannot use the user specified era to construct a query against a node because it may differ
+    -- from the node's era and this will result in the 'QueryEraMismatch' failure.
 
-  -- The user can specify an era prior to the era that the node is currently in.
-  -- We cannot use the user specified era to construct a query against a node because it may differ
-  -- from the node's era and this will result in the 'QueryEraMismatch' failure.
+    let localNodeConnInfo =
+          LocalNodeConnectInfo
+            { localConsensusModeParams = cModeParams
+            , localNodeNetworkId = nid
+            , localNodeSocketPath = socketPath
+            }
 
-  let localNodeConnInfo = LocalNodeConnectInfo
-                            { localConsensusModeParams = cModeParams
-                            , localNodeNetworkId = nid
-                            , localNodeSocketPath = socketPath
-                            }
+    inputsAndMaybeScriptWits <- firstExceptT TxCmdScriptWitnessError $ readScriptWitnessFiles era txins
+    certFilesAndMaybeScriptWits <-
+      firstExceptT TxCmdScriptWitnessError $ readScriptWitnessFiles era certs
 
-  inputsAndMaybeScriptWits <- firstExceptT TxCmdScriptWitnessError $ readScriptWitnessFiles era txins
-  certFilesAndMaybeScriptWits <- firstExceptT TxCmdScriptWitnessError $ readScriptWitnessFiles era certs
+    -- TODO: Conway Era - How can we make this more composable?
+    certsAndMaybeScriptWits <-
+      case cardanoEraStyle era of
+        LegacyByronEra -> return []
+        ShelleyBasedEra {} ->
+          sequence
+            [ fmap
+              (,mSwit)
+              ( firstExceptT TxCmdReadTextViewFileError . newExceptT $
+                  readFileTextEnvelope AsCertificate (File certFile)
+              )
+            | (CertificateFile certFile, mSwit) <- certFilesAndMaybeScriptWits
+            ]
+    withdrawalsAndMaybeScriptWits <-
+      firstExceptT TxCmdScriptWitnessError $
+        readScriptWitnessFilesThruple era wdrls
+    txMetadata <-
+      firstExceptT TxCmdMetadataError
+        . newExceptT
+        $ readTxMetadata era metadataSchema metadataFiles
+    valuesWithScriptWits <- readValueScriptWitnesses era $ fromMaybe mempty mValue
+    scripts <-
+      firstExceptT TxCmdScriptFileError $
+        mapM (readFileScriptInAnyLang . unScriptFile) scriptFiles
+    txAuxScripts <-
+      hoistEither $ first TxCmdAuxScriptsValidationError $ validateTxAuxScripts era scripts
 
-  -- TODO: Conway Era - How can we make this more composable?
-  certsAndMaybeScriptWits <-
-    case cardanoEraStyle era of
-      LegacyByronEra -> return []
-      ShelleyBasedEra{} ->
-        sequence
-          [ fmap (,mSwit) (firstExceptT TxCmdReadTextViewFileError . newExceptT $
-              readFileTextEnvelope AsCertificate (File certFile))
-          | (CertificateFile certFile, mSwit) <- certFilesAndMaybeScriptWits
-          ]
-  withdrawalsAndMaybeScriptWits <- firstExceptT TxCmdScriptWitnessError
-                                     $ readScriptWitnessFilesThruple era wdrls
-  txMetadata <- firstExceptT TxCmdMetadataError
-                  . newExceptT $ readTxMetadata era metadataSchema metadataFiles
-  valuesWithScriptWits <- readValueScriptWitnesses era $ fromMaybe mempty mValue
-  scripts <- firstExceptT TxCmdScriptFileError $
-                     mapM (readFileScriptInAnyLang . unScriptFile) scriptFiles
-  txAuxScripts <- hoistEither $ first TxCmdAuxScriptsValidationError $ validateTxAuxScripts era scripts
+    mProp <- forM mUpProp $ \(UpdateProposalFile upFp) ->
+      firstExceptT
+        TxCmdReadTextViewFileError
+        (newExceptT $ readFileTextEnvelope AsUpdateProposal (File upFp))
+    requiredSigners <-
+      mapM (firstExceptT TxCmdRequiredSignerError . newExceptT . readRequiredSigner) reqSigners
+    mReturnCollateral <- forM mReturnColl $ toTxOutInAnyEra era
 
-  mProp <- forM mUpProp $ \(UpdateProposalFile upFp) ->
-    firstExceptT TxCmdReadTextViewFileError (newExceptT $ readFileTextEnvelope AsUpdateProposal (File upFp))
-  requiredSigners  <- mapM (firstExceptT TxCmdRequiredSignerError .  newExceptT . readRequiredSigner) reqSigners
-  mReturnCollateral <- forM mReturnColl $ toTxOutInAnyEra era
+    txOuts <- mapM (toTxOutInAnyEra era) txouts
 
-  txOuts <- mapM (toTxOutInAnyEra era) txouts
+    -- Conway related
+    votes <-
+      inEonForEra
+        (pure emptyVotingProcedures)
+        (\w -> firstExceptT TxCmdVoteError $ ExceptT (readVotingProceduresFiles w conwayVotes))
+        era
 
-  -- Conway related
-  votes <-
-    inEonForEra
-      (pure emptyVotingProcedures)
-      (\w -> firstExceptT TxCmdVoteError $ ExceptT (readVotingProceduresFiles w conwayVotes))
-      era
+    proposals <-
+      newExceptT $
+        first TxCmdConstitutionError
+          <$> readTxGovernanceActions era newProposals
 
-  proposals <- newExceptT $ first TxCmdConstitutionError
-                  <$> readTxGovernanceActions era newProposals
+    -- the same collateral input can be used for several plutus scripts
+    let filteredTxinsc = Set.toList $ Set.fromList txinsc
 
-  -- the same collateral input can be used for several plutus scripts
-  let filteredTxinsc = Set.toList $ Set.fromList txinsc
+    -- We need to construct the txBodycontent outside of runTxBuild
+    BalancedTxBody txBodycontent balancedTxBody _ _ <-
+      runTxBuild
+        era
+        socketPath
+        consensusModeParams
+        nid
+        mScriptValidity
+        inputsAndMaybeScriptWits
+        readOnlyRefIns
+        filteredTxinsc
+        mReturnCollateral
+        mTotCollateral
+        txOuts
+        changeAddr
+        valuesWithScriptWits
+        mLowBound
+        mUpperBound
+        certsAndMaybeScriptWits
+        withdrawalsAndMaybeScriptWits
+        requiredSigners
+        txAuxScripts
+        txMetadata
+        mProp
+        mOverrideWits
+        votes
+        proposals
+        outputOptions
 
-  -- We need to construct the txBodycontent outside of runTxBuild
-  BalancedTxBody txBodycontent balancedTxBody _ _ <-
-    runTxBuild
-      era socketPath consensusModeParams nid mScriptValidity inputsAndMaybeScriptWits readOnlyRefIns filteredTxinsc
-      mReturnCollateral mTotCollateral txOuts changeAddr valuesWithScriptWits mLowBound
-      mUpperBound certsAndMaybeScriptWits withdrawalsAndMaybeScriptWits
-      requiredSigners txAuxScripts txMetadata mProp mOverrideWits votes proposals outputOptions
+    mScriptWits <-
+      case cardanoEraStyle era of
+        LegacyByronEra -> return []
+        ShelleyBasedEra sbe -> return $ collectTxBodyScriptWitnesses sbe txBodycontent
 
-  mScriptWits <-
-    case cardanoEraStyle era of
-      LegacyByronEra -> return []
-      ShelleyBasedEra sbe -> return $ collectTxBodyScriptWitnesses sbe txBodycontent
+    let allReferenceInputs =
+          getAllReferenceInputs
+            inputsAndMaybeScriptWits
+            (snd valuesWithScriptWits)
+            certsAndMaybeScriptWits
+            withdrawalsAndMaybeScriptWits
+            readOnlyRefIns
 
-  let allReferenceInputs = getAllReferenceInputs
-                             inputsAndMaybeScriptWits
-                             (snd valuesWithScriptWits)
-                             certsAndMaybeScriptWits
-                             withdrawalsAndMaybeScriptWits
-                             readOnlyRefIns
+    let inputsThatRequireWitnessing = [input | (input, _) <- inputsAndMaybeScriptWits]
+        allTxInputs = inputsThatRequireWitnessing ++ allReferenceInputs ++ filteredTxinsc
 
-  let inputsThatRequireWitnessing = [input | (input,_) <- inputsAndMaybeScriptWits]
-      allTxInputs = inputsThatRequireWitnessing ++ allReferenceInputs ++ filteredTxinsc
+    -- TODO: Calculating the script cost should live as a different command.
+    -- Why? Because then we can simply read a txbody and figure out
+    -- the script cost vs having to build the tx body each time
+    case outputOptions of
+      OutputScriptCostOnly fp -> do
+        let BuildTxWith mTxProtocolParams = txProtocolParams txBodycontent
 
-  -- TODO: Calculating the script cost should live as a different command.
-  -- Why? Because then we can simply read a txbody and figure out
-  -- the script cost vs having to build the tx body each time
-  case outputOptions of
-    OutputScriptCostOnly fp -> do
-      let BuildTxWith mTxProtocolParams = txProtocolParams txBodycontent
+        pparams <- pure mTxProtocolParams & onNothing (left TxCmdProtocolParametersNotPresentInTxBody)
+        executionUnitPrices <-
+          pure (getExecutionUnitPrices era pparams) & onNothing (left TxCmdPParamExecutionUnitsNotAvailable)
+        let consensusMode = consensusModeOnly cModeParams
 
-      pparams <- pure mTxProtocolParams & onNothing (left TxCmdProtocolParametersNotPresentInTxBody)
-      executionUnitPrices <- pure (getExecutionUnitPrices era pparams) & onNothing (left TxCmdPParamExecutionUnitsNotAvailable)
-      let consensusMode = consensusModeOnly cModeParams
+        case consensusMode of
+          CardanoMode -> do
+            AnyCardanoEra nodeEra <-
+              lift (executeLocalStateQueryExpr localNodeConnInfo Nothing (determineEraExpr cModeParams))
+                & onLeft (left . TxCmdQueryConvenienceError . AcqFailure)
+                & onLeft (left . TxCmdQueryConvenienceError . QceUnsupportedNtcVersion)
 
-      case consensusMode of
-        CardanoMode -> do
-          AnyCardanoEra nodeEra <- lift (executeLocalStateQueryExpr localNodeConnInfo Nothing (determineEraExpr cModeParams))
-            & onLeft (left . TxCmdQueryConvenienceError . AcqFailure)
-            & onLeft (left . TxCmdQueryConvenienceError . QceUnsupportedNtcVersion)
+            (nodeEraUTxO, _, eraHistory, systemStart, _, _, _) <-
+              lift
+                ( executeLocalStateQueryExpr
+                    localNodeConnInfo
+                    Nothing
+                    (queryStateForBalancedTx nodeEra allTxInputs [])
+                )
+                & onLeft (left . TxCmdQueryConvenienceError . AcqFailure)
+                & onLeft (left . TxCmdQueryConvenienceError)
 
-          (nodeEraUTxO, _, eraHistory, systemStart, _, _, _) <-
-            lift (executeLocalStateQueryExpr localNodeConnInfo Nothing (queryStateForBalancedTx nodeEra allTxInputs []))
-              & onLeft (left . TxCmdQueryConvenienceError . AcqFailure)
-              & onLeft (left . TxCmdQueryConvenienceError)
+            -- Why do we cast the era? The user can specify an era prior to the era that the node is currently in.
+            -- We cannot use the user specified era to construct a query against a node because it may differ
+            -- from the node's era and this will result in the 'QueryEraMismatch' failure.
+            txEraUtxo <-
+              cardanoEraConstraints era $ pure (eraCast era nodeEraUTxO) & onLeft (left . TxCmdTxEraCastErr)
 
-          -- Why do we cast the era? The user can specify an era prior to the era that the node is currently in.
-          -- We cannot use the user specified era to construct a query against a node because it may differ
-          -- from the node's era and this will result in the 'QueryEraMismatch' failure.
-          txEraUtxo <- cardanoEraConstraints era $ pure (eraCast era nodeEraUTxO) & onLeft (left . TxCmdTxEraCastErr)
+            scriptExecUnitsMap <-
+              firstExceptT TxCmdTxExecUnitsErr $
+                hoistEither $
+                  evaluateTransactionExecutionUnits
+                    systemStart
+                    (toLedgerEpochInfo eraHistory)
+                    pparams
+                    txEraUtxo
+                    balancedTxBody
 
-          scriptExecUnitsMap <-
-            firstExceptT TxCmdTxExecUnitsErr $ hoistEither
-              $ evaluateTransactionExecutionUnits
-                  systemStart (toLedgerEpochInfo eraHistory)
-                  pparams txEraUtxo balancedTxBody
-
-          scriptCostOutput <-
-            firstExceptT TxCmdPlutusScriptCostErr $ hoistEither
-              $ renderScriptCosts
-                  txEraUtxo
-                  executionUnitPrices
-                  mScriptWits
-                  scriptExecUnitsMap
-          liftIO $ LBS.writeFile (unFile fp) $ encodePretty scriptCostOutput
-        _ -> left TxCmdPlutusScriptsRequireCardanoMode
-
-    OutputTxBodyOnly fpath ->
-      let noWitTx = makeSignedTransaction [] balancedTxBody
-      in  lift (cardanoEraConstraints era $ writeTxFileTextEnvelopeCddl fpath noWitTx)
-            & onLeft (left . TxCmdWriteFileError)
+            scriptCostOutput <-
+              firstExceptT TxCmdPlutusScriptCostErr $
+                hoistEither $
+                  renderScriptCosts
+                    txEraUtxo
+                    executionUnitPrices
+                    mScriptWits
+                    scriptExecUnitsMap
+            liftIO $ LBS.writeFile (unFile fp) $ encodePretty scriptCostOutput
+          _ -> left TxCmdPlutusScriptsRequireCardanoMode
+      OutputTxBodyOnly fpath ->
+        let noWitTx = makeSignedTransaction [] balancedTxBody
+         in lift (cardanoEraConstraints era $ writeTxFileTextEnvelopeCddl fpath noWitTx)
+              & onLeft (left . TxCmdWriteFileError)
 
 getExecutionUnitPrices :: CardanoEra era -> LedgerProtocolParameters era -> Maybe Ledger.Prices
 getExecutionUnitPrices cEra (LedgerProtocolParameters pp) = do
@@ -288,16 +464,23 @@ runTxBuildRawCmd
   :: CardanoEra era
   -> Maybe ScriptValidity
   -> [(TxIn, Maybe (ScriptWitnessFiles WitCtxTxIn))]
-  -> [TxIn] -- ^ Read only reference inputs
-  -> [TxIn] -- ^ Transaction inputs for collateral, only key witnesses, no scripts.
+  -> [TxIn]
+  -- ^ Read only reference inputs
+  -> [TxIn]
+  -- ^ Transaction inputs for collateral, only key witnesses, no scripts.
   -> Maybe TxOutAnyEra
-  -> Maybe Lovelace -- ^ Total collateral
+  -> Maybe Lovelace
+  -- ^ Total collateral
   -> [RequiredSigner]
   -> [TxOutAnyEra]
-  -> Maybe (Value, [ScriptWitnessFiles WitCtxMint]) -- ^ Multi-Asset value with script witness
-  -> Maybe SlotNo -- ^ Validity lower bound
-  -> Maybe SlotNo -- ^ Validity upper bound
-  -> Maybe Lovelace -- ^ Tx fee
+  -> Maybe (Value, [ScriptWitnessFiles WitCtxMint])
+  -- ^ Multi-Asset value with script witness
+  -> Maybe SlotNo
+  -- ^ Validity lower bound
+  -> Maybe SlotNo
+  -- ^ Validity upper bound
+  -> Maybe Lovelace
+  -- ^ Tx fee
   -> [(CertificateFile, Maybe (ScriptWitnessFiles WitCtxStake))]
   -> [(StakeAddress, Lovelace, Maybe (ScriptWitnessFiles WitCtxStake))]
   -> TxMetadataJsonSchema
@@ -308,66 +491,116 @@ runTxBuildRawCmd
   -> TxBodyFile Out
   -> ExceptT TxCmdError IO ()
 runTxBuildRawCmd
-  era mScriptValidity txins readOnlyRefIns txinsc mReturnColl
-  mTotColl reqSigners txouts mValue mLowBound mUpperBound fee certs wdrls
-  metadataSchema scriptFiles metadataFiles mpParamsFile mUpProp out = do
-  inputsAndMaybeScriptWits <- firstExceptT TxCmdScriptWitnessError
-                                $ readScriptWitnessFiles era txins
-  certFilesAndMaybeScriptWits <- firstExceptT TxCmdScriptWitnessError
-                                   $ readScriptWitnessFiles era certs
+  era
+  mScriptValidity
+  txins
+  readOnlyRefIns
+  txinsc
+  mReturnColl
+  mTotColl
+  reqSigners
+  txouts
+  mValue
+  mLowBound
+  mUpperBound
+  fee
+  certs
+  wdrls
+  metadataSchema
+  scriptFiles
+  metadataFiles
+  mpParamsFile
+  mUpProp
+  out = do
+    inputsAndMaybeScriptWits <-
+      firstExceptT TxCmdScriptWitnessError $
+        readScriptWitnessFiles era txins
+    certFilesAndMaybeScriptWits <-
+      firstExceptT TxCmdScriptWitnessError $
+        readScriptWitnessFiles era certs
 
-  -- TODO: Conway era - How can we make this more composable?
-  certsAndMaybeScriptWits <-
+    -- TODO: Conway era - How can we make this more composable?
+    certsAndMaybeScriptWits <-
       case cardanoEraStyle era of
         LegacyByronEra -> return []
-        ShelleyBasedEra{} ->
+        ShelleyBasedEra {} ->
           sequence
-            [ fmap (,mSwit) (firstExceptT TxCmdReadTextViewFileError . newExceptT $
-                readFileTextEnvelope AsCertificate (File certFile))
+            [ fmap
+              (,mSwit)
+              ( firstExceptT TxCmdReadTextViewFileError . newExceptT $
+                  readFileTextEnvelope AsCertificate (File certFile)
+              )
             | (CertificateFile certFile, mSwit) <- certFilesAndMaybeScriptWits
             ]
 
-  withdrawalsAndMaybeScriptWits <- firstExceptT TxCmdScriptWitnessError
-                                     $ readScriptWitnessFilesThruple era wdrls
-  txMetadata <- firstExceptT TxCmdMetadataError
-                  . newExceptT $ readTxMetadata era metadataSchema metadataFiles
-  valuesWithScriptWits <- readValueScriptWitnesses era $ fromMaybe mempty mValue
-  scripts <- firstExceptT TxCmdScriptFileError $
-                     mapM (readFileScriptInAnyLang . unScriptFile) scriptFiles
-  txAuxScripts <- hoistEither $ first TxCmdAuxScriptsValidationError $ validateTxAuxScripts era scripts
+    withdrawalsAndMaybeScriptWits <-
+      firstExceptT TxCmdScriptWitnessError $
+        readScriptWitnessFilesThruple era wdrls
+    txMetadata <-
+      firstExceptT TxCmdMetadataError
+        . newExceptT
+        $ readTxMetadata era metadataSchema metadataFiles
+    valuesWithScriptWits <- readValueScriptWitnesses era $ fromMaybe mempty mValue
+    scripts <-
+      firstExceptT TxCmdScriptFileError $
+        mapM (readFileScriptInAnyLang . unScriptFile) scriptFiles
+    txAuxScripts <-
+      hoistEither $ first TxCmdAuxScriptsValidationError $ validateTxAuxScripts era scripts
 
-  -- TODO: Conway era - update readProtocolParameters to rely on Ledger.PParams JSON instances
-  pparams <- forM mpParamsFile $ \ppf ->
-    firstExceptT TxCmdProtocolParamsError (readProtocolParameters ppf)
+    -- TODO: Conway era - update readProtocolParameters to rely on Ledger.PParams JSON instances
+    pparams <- forM mpParamsFile $ \ppf ->
+      firstExceptT TxCmdProtocolParamsError (readProtocolParameters ppf)
 
-  mLedgerPParams <- case cardanoEraStyle era of
-    LegacyByronEra -> return Nothing
-    ShelleyBasedEra sbe ->
-      forM pparams $ \pp ->
-        firstExceptT TxCmdProtocolParamsConverstionError
-         . hoistEither $ convertToLedgerProtocolParameters sbe pp
+    mLedgerPParams <- case cardanoEraStyle era of
+      LegacyByronEra -> return Nothing
+      ShelleyBasedEra sbe ->
+        forM pparams $ \pp ->
+          firstExceptT TxCmdProtocolParamsConverstionError
+            . hoistEither
+            $ convertToLedgerProtocolParameters sbe pp
 
-  mProp <- forM mUpProp $ \(UpdateProposalFile upFp) ->
-    firstExceptT TxCmdReadTextViewFileError (newExceptT $ readFileTextEnvelope AsUpdateProposal (File upFp))
+    mProp <- forM mUpProp $ \(UpdateProposalFile upFp) ->
+      firstExceptT
+        TxCmdReadTextViewFileError
+        (newExceptT $ readFileTextEnvelope AsUpdateProposal (File upFp))
 
-  requiredSigners  <- mapM (firstExceptT TxCmdRequiredSignerError .  newExceptT . readRequiredSigner) reqSigners
-  mReturnCollateral <- forM mReturnColl $ toTxOutInAnyEra era
-  txOuts <- mapM (toTxOutInAnyEra era) txouts
+    requiredSigners <-
+      mapM (firstExceptT TxCmdRequiredSignerError . newExceptT . readRequiredSigner) reqSigners
+    mReturnCollateral <- forM mReturnColl $ toTxOutInAnyEra era
+    txOuts <- mapM (toTxOutInAnyEra era) txouts
 
     -- the same collateral input can be used for several plutus scripts
-  let filteredTxinsc = Set.toList $ Set.fromList txinsc
+    let filteredTxinsc = Set.toList $ Set.fromList txinsc
 
-  txBody <- hoistEither $ runTxBuildRaw era mScriptValidity inputsAndMaybeScriptWits readOnlyRefIns filteredTxinsc
-                          mReturnCollateral mTotColl txOuts mLowBound mUpperBound fee valuesWithScriptWits
-                          certsAndMaybeScriptWits withdrawalsAndMaybeScriptWits requiredSigners txAuxScripts
-                          txMetadata mLedgerPParams mProp
+    txBody <-
+      hoistEither $
+        runTxBuildRaw
+          era
+          mScriptValidity
+          inputsAndMaybeScriptWits
+          readOnlyRefIns
+          filteredTxinsc
+          mReturnCollateral
+          mTotColl
+          txOuts
+          mLowBound
+          mUpperBound
+          fee
+          valuesWithScriptWits
+          certsAndMaybeScriptWits
+          withdrawalsAndMaybeScriptWits
+          requiredSigners
+          txAuxScripts
+          txMetadata
+          mLedgerPParams
+          mProp
 
-  let noWitTx = makeSignedTransaction [] txBody
-  lift (getIsCardanoEraConstraint era $ writeTxFileTextEnvelopeCddl out noWitTx)
-    & onLeft (left . TxCmdWriteFileError)
+    let noWitTx = makeSignedTransaction [] txBody
+    lift (getIsCardanoEraConstraint era $ writeTxFileTextEnvelopeCddl out noWitTx)
+      & onLeft (left . TxCmdWriteFileError)
 
-
-runTxBuildRaw :: ()
+runTxBuildRaw
+  :: ()
   => CardanoEra era
   -> Maybe ScriptValidity
   -- ^ Mark script as expected to pass or fail validation
@@ -400,46 +633,60 @@ runTxBuildRaw :: ()
   -> Maybe (LedgerProtocolParameters era)
   -> Maybe UpdateProposal
   -> Either TxCmdError (TxBody era)
-runTxBuildRaw era
-              mScriptValidity inputsAndMaybeScriptWits
-              readOnlyRefIns txinsc
-              mReturnCollateral mTotCollateral txouts
-              mLowerBound mUpperBound
-              mFee valuesWithScriptWits
-              certsAndMaybeSriptWits withdrawals reqSigners
-              txAuxScripts txMetadata mpparams mUpdateProp = do
-
-    let allReferenceInputs = getAllReferenceInputs
-                               inputsAndMaybeScriptWits
-                               (snd valuesWithScriptWits)
-                               certsAndMaybeSriptWits
-                               withdrawals
-                               readOnlyRefIns
+runTxBuildRaw
+  era
+  mScriptValidity
+  inputsAndMaybeScriptWits
+  readOnlyRefIns
+  txinsc
+  mReturnCollateral
+  mTotCollateral
+  txouts
+  mLowerBound
+  mUpperBound
+  mFee
+  valuesWithScriptWits
+  certsAndMaybeSriptWits
+  withdrawals
+  reqSigners
+  txAuxScripts
+  txMetadata
+  mpparams
+  mUpdateProp = do
+    let allReferenceInputs =
+          getAllReferenceInputs
+            inputsAndMaybeScriptWits
+            (snd valuesWithScriptWits)
+            certsAndMaybeSriptWits
+            withdrawals
+            readOnlyRefIns
 
     validatedCollateralTxIns <- validateTxInsCollateral era txinsc
     validatedRefInputs <- validateTxInsReference era allReferenceInputs
-    validatedTotCollateral
-      <- first TxCmdTotalCollateralValidationError $ validateTxTotalCollateral era mTotCollateral
-    validatedRetCol
-      <- first TxCmdReturnCollateralValidationError $ validateTxReturnCollateral era mReturnCollateral
-    validatedFee
-      <- first TxCmdTxFeeValidationError $ validateTxFee era mFee
-    validatedBounds <- (,) <$> first TxCmdTxValidityLowerBoundValidationError (validateTxValidityLowerBound era mLowerBound)
-                           <*> first TxCmdTxValidityUpperBoundValidationError (validateTxValidityUpperBound era mUpperBound)
-    validatedReqSigners
-      <- first TxCmdRequiredSignersValidationError $ validateRequiredSigners era reqSigners
-    validatedPParams
-      <- first TxCmdProtocolParametersValidationError $ validateProtocolParameters era mpparams
-    validatedTxWtdrwls
-      <- first TxCmdTxWithdrawalsValidationError $ validateTxWithdrawals era withdrawals
-    validatedTxCerts
-      <- first TxCmdTxCertificatesValidationError $ validateTxCertificates era certsAndMaybeSriptWits
-    validatedTxUpProp
-      <- first TxCmdTxUpdateProposalValidationError $ validateTxUpdateProposal era mUpdateProp
-    validatedMintValue
-      <- createTxMintValue era valuesWithScriptWits
-    validatedTxScriptValidity
-      <- first TxCmdScriptValidityValidationError $ validateTxScriptValidity era mScriptValidity
+    validatedTotCollateral <-
+      first TxCmdTotalCollateralValidationError $ validateTxTotalCollateral era mTotCollateral
+    validatedRetCol <-
+      first TxCmdReturnCollateralValidationError $ validateTxReturnCollateral era mReturnCollateral
+    validatedFee <-
+      first TxCmdTxFeeValidationError $ validateTxFee era mFee
+    validatedBounds <-
+      (,)
+        <$> first TxCmdTxValidityLowerBoundValidationError (validateTxValidityLowerBound era mLowerBound)
+        <*> first TxCmdTxValidityUpperBoundValidationError (validateTxValidityUpperBound era mUpperBound)
+    validatedReqSigners <-
+      first TxCmdRequiredSignersValidationError $ validateRequiredSigners era reqSigners
+    validatedPParams <-
+      first TxCmdProtocolParametersValidationError $ validateProtocolParameters era mpparams
+    validatedTxWtdrwls <-
+      first TxCmdTxWithdrawalsValidationError $ validateTxWithdrawals era withdrawals
+    validatedTxCerts <-
+      first TxCmdTxCertificatesValidationError $ validateTxCertificates era certsAndMaybeSriptWits
+    validatedTxUpProp <-
+      first TxCmdTxUpdateProposalValidationError $ validateTxUpdateProposal era mUpdateProp
+    validatedMintValue <-
+      createTxMintValue era valuesWithScriptWits
+    validatedTxScriptValidity <-
+      first TxCmdScriptValidityValidationError $ validateTxScriptValidity era mScriptValidity
     let validatedTxProposalProcedures = Nothing -- TODO: Conwary era
         validatedTxVotes = Nothing -- TODO: Conwary era
     let txBodyContent =
@@ -466,9 +713,11 @@ runTxBuildRaw era
             }
 
     first TxCmdTxBodyError $
-      getIsCardanoEraConstraint era $ createAndValidateTransactionBody txBodyContent
+      getIsCardanoEraConstraint era $
+        createAndValidateTransactionBody txBodyContent
 
-runTxBuild :: ()
+runTxBuild
+  :: ()
   => CardanoEra era
   -> SocketPath
   -> AnyConsensusModeParams
@@ -509,168 +758,227 @@ runTxBuild :: ()
   -> TxBuildOutputOptions
   -> ExceptT TxCmdError IO (BalancedTxBody era)
 runTxBuild
-    era socketPath (AnyConsensusModeParams cModeParams) networkId mScriptValidity
-    inputsAndMaybeScriptWits readOnlyRefIns txinsc mReturnCollateral mTotCollateral txouts
-    (TxOutChangeAddress changeAddr) valuesWithScriptWits mLowerBound mUpperBound
-    certsAndMaybeScriptWits withdrawals reqSigners txAuxScripts txMetadata
-    mUpdatePropF mOverrideWits votes proposals outputOptions = do
+  era
+  socketPath
+  (AnyConsensusModeParams cModeParams)
+  networkId
+  mScriptValidity
+  inputsAndMaybeScriptWits
+  readOnlyRefIns
+  txinsc
+  mReturnCollateral
+  mTotCollateral
+  txouts
+  (TxOutChangeAddress changeAddr)
+  valuesWithScriptWits
+  mLowerBound
+  mUpperBound
+  certsAndMaybeScriptWits
+  withdrawals
+  reqSigners
+  txAuxScripts
+  txMetadata
+  mUpdatePropF
+  mOverrideWits
+  votes
+  proposals
+  outputOptions = do
+    let consensusMode = consensusModeOnly cModeParams
+        dummyFee = Just $ Lovelace 0
+        inputsThatRequireWitnessing = [input | (input, _) <- inputsAndMaybeScriptWits]
 
-  let consensusMode = consensusModeOnly cModeParams
-      dummyFee = Just $ Lovelace 0
-      inputsThatRequireWitnessing = [input | (input,_) <- inputsAndMaybeScriptWits]
+    -- Pure
+    let allReferenceInputs =
+          getAllReferenceInputs
+            inputsAndMaybeScriptWits
+            (snd valuesWithScriptWits)
+            certsAndMaybeScriptWits
+            withdrawals
+            readOnlyRefIns
 
-  -- Pure
-  let allReferenceInputs = getAllReferenceInputs
-                             inputsAndMaybeScriptWits
-                             (snd valuesWithScriptWits)
-                             certsAndMaybeScriptWits
-                             withdrawals readOnlyRefIns
+    validatedCollateralTxIns <- hoistEither $ validateTxInsCollateral era txinsc
+    validatedRefInputs <- hoistEither $ validateTxInsReference era allReferenceInputs
+    validatedTotCollateral <-
+      hoistEither $
+        first TxCmdTotalCollateralValidationError $
+          validateTxTotalCollateral era mTotCollateral
+    validatedRetCol <-
+      hoistEither $
+        first TxCmdReturnCollateralValidationError $
+          validateTxReturnCollateral era mReturnCollateral
+    dFee <- hoistEither $ first TxCmdTxFeeValidationError $ validateTxFee era dummyFee
+    validatedBounds <-
+      (,)
+        <$> hoistEither
+          (first TxCmdTxValidityLowerBoundValidationError $ validateTxValidityLowerBound era mLowerBound)
+        <*> hoistEither
+          (first TxCmdTxValidityUpperBoundValidationError $ validateTxValidityUpperBound era mUpperBound)
+    validatedReqSigners <-
+      hoistEither (first TxCmdRequiredSignersValidationError $ validateRequiredSigners era reqSigners)
+    validatedTxWtdrwls <-
+      hoistEither (first TxCmdTxWithdrawalsValidationError $ validateTxWithdrawals era withdrawals)
+    validatedTxCerts <-
+      hoistEither
+        (first TxCmdTxCertificatesValidationError $ validateTxCertificates era certsAndMaybeScriptWits)
+    validatedTxUpProp <-
+      hoistEither (first TxCmdTxUpdateProposalValidationError $ validateTxUpdateProposal era mUpdatePropF)
+    validatedMintValue <- hoistEither $ createTxMintValue era valuesWithScriptWits
+    validatedTxScriptValidity <-
+      hoistEither
+        (first TxCmdScriptValidityValidationError $ validateTxScriptValidity era mScriptValidity)
 
-  validatedCollateralTxIns <- hoistEither $ validateTxInsCollateral era txinsc
-  validatedRefInputs <- hoistEither $ validateTxInsReference era allReferenceInputs
-  validatedTotCollateral
-    <- hoistEither $ first TxCmdTotalCollateralValidationError $ validateTxTotalCollateral era mTotCollateral
-  validatedRetCol
-    <- hoistEither $ first TxCmdReturnCollateralValidationError $ validateTxReturnCollateral era mReturnCollateral
-  dFee <- hoistEither $ first TxCmdTxFeeValidationError $ validateTxFee era dummyFee
-  validatedBounds <- (,) <$> hoistEither (first TxCmdTxValidityLowerBoundValidationError $ validateTxValidityLowerBound era mLowerBound)
-                         <*> hoistEither (first TxCmdTxValidityUpperBoundValidationError $ validateTxValidityUpperBound era mUpperBound)
-  validatedReqSigners <- hoistEither (first TxCmdRequiredSignersValidationError $ validateRequiredSigners era reqSigners)
-  validatedTxWtdrwls <- hoistEither (first TxCmdTxWithdrawalsValidationError $ validateTxWithdrawals era withdrawals)
-  validatedTxCerts <- hoistEither (first TxCmdTxCertificatesValidationError $ validateTxCertificates era certsAndMaybeScriptWits)
-  validatedTxUpProp <- hoistEither (first TxCmdTxUpdateProposalValidationError $ validateTxUpdateProposal era mUpdatePropF)
-  validatedMintValue <- hoistEither $ createTxMintValue era valuesWithScriptWits
-  validatedTxScriptValidity <- hoistEither (first TxCmdScriptValidityValidationError $ validateTxScriptValidity era mScriptValidity)
+    case (consensusMode, cardanoEraStyle era) of
+      (CardanoMode, ShelleyBasedEra _) -> do
+        _ <-
+          toEraInMode era CardanoMode
+            & hoistMaybe
+              ( TxCmdEraConsensusModeMismatchTxBalance
+                  outputOptions
+                  (AnyConsensusMode CardanoMode)
+                  (AnyCardanoEra era)
+              )
 
-  case (consensusMode, cardanoEraStyle era) of
-    (CardanoMode, ShelleyBasedEra _) -> do
-      _ <- toEraInMode era CardanoMode
-            & hoistMaybe (TxCmdEraConsensusModeMismatchTxBalance outputOptions (AnyConsensusMode CardanoMode) (AnyCardanoEra era))
+        let allTxInputs = inputsThatRequireWitnessing ++ allReferenceInputs ++ txinsc
+            localNodeConnInfo =
+              LocalNodeConnectInfo
+                { localConsensusModeParams = CardanoModeParams $ EpochSlots 21600
+                , localNodeNetworkId = networkId
+                , localNodeSocketPath = socketPath
+                }
 
-      let allTxInputs = inputsThatRequireWitnessing ++ allReferenceInputs ++ txinsc
-          localNodeConnInfo = LocalNodeConnectInfo
-                                     { localConsensusModeParams = CardanoModeParams $ EpochSlots 21600
-                                     , localNodeNetworkId = networkId
-                                     , localNodeSocketPath = socketPath
-                                     }
+        AnyCardanoEra nodeEra <-
+          lift (executeLocalStateQueryExpr localNodeConnInfo Nothing (determineEraExpr cModeParams))
+            & onLeft (left . TxCmdQueryConvenienceError . AcqFailure)
+            & onLeft (left . TxCmdQueryConvenienceError . QceUnsupportedNtcVersion)
 
-      AnyCardanoEra nodeEra <- lift (executeLocalStateQueryExpr localNodeConnInfo Nothing (determineEraExpr cModeParams))
-        & onLeft (left . TxCmdQueryConvenienceError . AcqFailure)
-        & onLeft (left . TxCmdQueryConvenienceError . QceUnsupportedNtcVersion)
+        Refl <-
+          testEquality era nodeEra
+            & hoistMaybe (TxCmdTxEraCastErr $ EraCastError ("nodeEra" :: Text) era nodeEra)
 
-      Refl <- testEquality era nodeEra
-              & hoistMaybe (TxCmdTxEraCastErr $ EraCastError ("nodeEra" :: Text) era nodeEra)
+        let certs =
+              case validatedTxCerts of
+                TxCertificates _ cs _ -> cs
+                _ -> []
 
-      let certs =
-            case validatedTxCerts of
-              TxCertificates _ cs _ -> cs
-              _ -> []
+        (txEraUtxo, pparams, eraHistory, systemStart, stakePools, stakeDelegDeposits, drepDelegDeposits) <-
+          lift
+            ( executeLocalStateQueryExpr localNodeConnInfo Nothing $
+                queryStateForBalancedTx nodeEra allTxInputs certs
+            )
+            & onLeft (left . TxCmdQueryConvenienceError . AcqFailure)
+            & onLeft (left . TxCmdQueryConvenienceError)
 
-      (txEraUtxo, pparams, eraHistory, systemStart, stakePools, stakeDelegDeposits, drepDelegDeposits) <-
-        lift (executeLocalStateQueryExpr localNodeConnInfo Nothing $ queryStateForBalancedTx nodeEra allTxInputs certs)
-          & onLeft (left . TxCmdQueryConvenienceError . AcqFailure)
-          & onLeft (left . TxCmdQueryConvenienceError)
+        validatedPParams <-
+          hoistEither $
+            first TxCmdProtocolParametersValidationError $
+              validateProtocolParameters era (Just pparams)
 
-      validatedPParams <- hoistEither $ first TxCmdProtocolParametersValidationError
-                                      $ validateProtocolParameters era (Just pparams)
+        let validatedTxProposalProcedures = proposals
+            validatedTxVotes = votes
+            txBodyContent =
+              TxBodyContent
+                { txIns = validateTxIns inputsAndMaybeScriptWits
+                , txInsCollateral = validatedCollateralTxIns
+                , txInsReference = validatedRefInputs
+                , txOuts = txouts
+                , txTotalCollateral = validatedTotCollateral
+                , txReturnCollateral = validatedRetCol
+                , txFee = dFee
+                , txValidityRange = validatedBounds
+                , txMetadata = txMetadata
+                , txAuxScripts = txAuxScripts
+                , txExtraKeyWits = validatedReqSigners
+                , txProtocolParams = validatedPParams
+                , txWithdrawals = validatedTxWtdrwls
+                , txCertificates = validatedTxCerts
+                , txUpdateProposal = validatedTxUpProp
+                , txMintValue = validatedMintValue
+                , txScriptValidity = validatedTxScriptValidity
+                , txProposalProcedures = inEraEonMaybe era (`Featured` validatedTxProposalProcedures)
+                , txVotingProcedures = inEraEonMaybe era (`Featured` validatedTxVotes)
+                }
 
-      let validatedTxProposalProcedures = proposals
-          validatedTxVotes = votes
-          txBodyContent =
-            TxBodyContent
-              { txIns = validateTxIns inputsAndMaybeScriptWits
-              , txInsCollateral = validatedCollateralTxIns
-              , txInsReference = validatedRefInputs
-              , txOuts = txouts
-              , txTotalCollateral = validatedTotCollateral
-              , txReturnCollateral = validatedRetCol
-              , txFee = dFee
-              , txValidityRange = validatedBounds
-              , txMetadata = txMetadata
-              , txAuxScripts = txAuxScripts
-              , txExtraKeyWits = validatedReqSigners
-              , txProtocolParams = validatedPParams
-              , txWithdrawals = validatedTxWtdrwls
-              , txCertificates = validatedTxCerts
-              , txUpdateProposal = validatedTxUpProp
-              , txMintValue = validatedMintValue
-              , txScriptValidity = validatedTxScriptValidity
-              , txProposalProcedures = inEraEonMaybe era (`Featured` validatedTxProposalProcedures)
-              , txVotingProcedures = inEraEonMaybe era (`Featured` validatedTxVotes)
-              }
-
-      firstExceptT TxCmdTxInsDoNotExist
-        . hoistEither $ txInsExistInUTxO allTxInputs txEraUtxo
-      firstExceptT TxCmdQueryNotScriptLocked
-        . hoistEither $ notScriptLockedTxIns txinsc txEraUtxo
-
-      cAddr <- pure (anyAddressInEra era changeAddr)
-        & onLeft (error $ "runTxBuild: Byron address used: " <> show changeAddr) -- should this throw instead?
-
-      balancedTxBody@(BalancedTxBody _ _ _ fee) <-
-        firstExceptT TxCmdBalanceTxBody
+        firstExceptT TxCmdTxInsDoNotExist
           . hoistEither
-          $ makeTransactionBodyAutoBalance systemStart (toLedgerEpochInfo eraHistory)
-                                           pparams stakePools stakeDelegDeposits drepDelegDeposits
-                                           txEraUtxo txBodyContent cAddr mOverrideWits
+          $ txInsExistInUTxO allTxInputs txEraUtxo
+        firstExceptT TxCmdQueryNotScriptLocked
+          . hoistEither
+          $ notScriptLockedTxIns txinsc txEraUtxo
 
-      liftIO $ putStrLn $ "Estimated transaction fee: " <> (show fee :: String)
+        cAddr <-
+          pure (anyAddressInEra era changeAddr)
+            & onLeft (error $ "runTxBuild: Byron address used: " <> show changeAddr) -- should this throw instead?
+        balancedTxBody@(BalancedTxBody _ _ _ fee) <-
+          firstExceptT TxCmdBalanceTxBody
+            . hoistEither
+            $ makeTransactionBodyAutoBalance
+              systemStart
+              (toLedgerEpochInfo eraHistory)
+              pparams
+              stakePools
+              stakeDelegDeposits
+              drepDelegDeposits
+              txEraUtxo
+              txBodyContent
+              cAddr
+              mOverrideWits
 
-      return balancedTxBody
+        liftIO $ putStrLn $ "Estimated transaction fee: " <> (show fee :: String)
 
-    (CardanoMode, LegacyByronEra) -> left TxCmdByronEra
-
-    (wrongMode, _) -> left (TxCmdUnsupportedMode (AnyConsensusMode wrongMode))
+        return balancedTxBody
+      (CardanoMode, LegacyByronEra) -> left TxCmdByronEra
+      (wrongMode, _) -> left (TxCmdUnsupportedMode (AnyConsensusMode wrongMode))
 
 -- ----------------------------------------------------------------------------
 -- Transaction body validation and conversion
 --
 
-txFeatureMismatch :: ()
-  => Monad m
+txFeatureMismatch
+  :: ()
+  => (Monad m)
   => CardanoEra era
   -> TxFeature
   -> ExceptT TxCmdError m a
 txFeatureMismatch era feature =
-    hoistEither . Left $ TxCmdTxFeatureMismatch (anyCardanoEra era) feature
+  hoistEither . Left $ TxCmdTxFeatureMismatch (anyCardanoEra era) feature
 
-txFeatureMismatchPure :: CardanoEra era
-                      -> TxFeature
-                      -> Either TxCmdError a
+txFeatureMismatchPure
+  :: CardanoEra era
+  -> TxFeature
+  -> Either TxCmdError a
 txFeatureMismatchPure era feature =
-    Left (TxCmdTxFeatureMismatch (anyCardanoEra era) feature)
-
+  Left (TxCmdTxFeatureMismatch (anyCardanoEra era) feature)
 
 validateTxIns
   :: [(TxIn, Maybe (ScriptWitness WitCtxTxIn era))]
   -> [(TxIn, BuildTxWith BuildTx (Witness WitCtxTxIn era))]
 validateTxIns = map convert
  where
-   convert
-     :: (TxIn, Maybe (ScriptWitness WitCtxTxIn era))
-     -> (TxIn, BuildTxWith BuildTx (Witness WitCtxTxIn era))
-   convert (txin, mScriptWitness) =
-     case mScriptWitness of
-       Just sWit ->
-         (txin , BuildTxWith $ ScriptWitness ScriptWitnessForSpending sWit)
-       Nothing ->
-         (txin, BuildTxWith $ KeyWitness KeyWitnessForSpending)
+  convert
+    :: (TxIn, Maybe (ScriptWitness WitCtxTxIn era))
+    -> (TxIn, BuildTxWith BuildTx (Witness WitCtxTxIn era))
+  convert (txin, mScriptWitness) =
+    case mScriptWitness of
+      Just sWit ->
+        (txin, BuildTxWith $ ScriptWitness ScriptWitnessForSpending sWit)
+      Nothing ->
+        (txin, BuildTxWith $ KeyWitness KeyWitnessForSpending)
 
-
-validateTxInsCollateral :: CardanoEra era
-                        -> [TxIn]
-                        -> Either TxCmdError (TxInsCollateral era)
-validateTxInsCollateral _   []    = return TxInsCollateralNone
+validateTxInsCollateral
+  :: CardanoEra era
+  -> [TxIn]
+  -> Either TxCmdError (TxInsCollateral era)
+validateTxInsCollateral _ [] = return TxInsCollateralNone
 validateTxInsCollateral era txins =
-    case collateralSupportedInEra era of
-      Nothing -> txFeatureMismatchPure era TxFeatureCollateral
-      Just supported -> return (TxInsCollateral supported txins)
+  case collateralSupportedInEra era of
+    Nothing -> txFeatureMismatchPure era TxFeatureCollateral
+    Just supported -> return (TxInsCollateral supported txins)
 
 validateTxInsReference
   :: CardanoEra era
   -> [TxIn]
   -> Either TxCmdError (TxInsReference BuildTx era)
-validateTxInsReference _ []  = return TxInsReferenceNone
+validateTxInsReference _ [] = return TxInsReferenceNone
 validateTxInsReference era allRefIns =
   caseByronToAlonzoOrBabbageEraOnwards
     (const $ txFeatureMismatchPure era TxFeatureReferenceInputs)
@@ -678,33 +986,36 @@ validateTxInsReference era allRefIns =
     era
 
 getAllReferenceInputs
- :: [(TxIn, Maybe (ScriptWitness WitCtxTxIn era))]
- -> [ScriptWitness WitCtxMint era]
- -> [(Certificate era, Maybe (ScriptWitness WitCtxStake era))]
- -> [(StakeAddress, Lovelace, Maybe (ScriptWitness WitCtxStake era))]
- -> [TxIn] -- ^ Read only reference inputs
- -> [TxIn]
+  :: [(TxIn, Maybe (ScriptWitness WitCtxTxIn era))]
+  -> [ScriptWitness WitCtxMint era]
+  -> [(Certificate era, Maybe (ScriptWitness WitCtxStake era))]
+  -> [(StakeAddress, Lovelace, Maybe (ScriptWitness WitCtxStake era))]
+  -> [TxIn]
+  -- ^ Read only reference inputs
+  -> [TxIn]
 getAllReferenceInputs txins mintWitnesses certFiles withdrawals readOnlyRefIns = do
   let txinsWitByRefInputs = [getReferenceInput sWit | (_, Just sWit) <- txins]
       mintingRefInputs = map getReferenceInput mintWitnesses
       certsWitByRefInputs = [getReferenceInput sWit | (_, Just sWit) <- certFiles]
       withdrawalsWitByRefInputs = [getReferenceInput sWit | (_, _, Just sWit) <- withdrawals]
 
-  catMaybes $ concat [ txinsWitByRefInputs
-                     , mintingRefInputs
-                     , certsWitByRefInputs
-                     , withdrawalsWitByRefInputs
-                     , map Just readOnlyRefIns
-                     ]
+  catMaybes $
+    concat
+      [ txinsWitByRefInputs
+      , mintingRefInputs
+      , certsWitByRefInputs
+      , withdrawalsWitByRefInputs
+      , map Just readOnlyRefIns
+      ]
  where
   getReferenceInput
     :: ScriptWitness witctx era -> Maybe TxIn
   getReferenceInput sWit =
     case sWit of
       PlutusScriptWitness _ _ (PReferenceScript refIn _) _ _ _ -> Just refIn
-      PlutusScriptWitness _ _ PScript{} _ _ _ -> Nothing
-      SimpleScriptWitness _ (SReferenceScript refIn _)  -> Just refIn
-      SimpleScriptWitness _ SScript{}  -> Nothing
+      PlutusScriptWitness _ _ PScript {} _ _ _ -> Nothing
+      SimpleScriptWitness _ (SReferenceScript refIn _) -> Just refIn
+      SimpleScriptWitness _ SScript {} -> Nothing
 
 toAddressInAnyEra
   :: CardanoEra era
@@ -712,10 +1023,11 @@ toAddressInAnyEra
   -> Either TxCmdError (AddressInEra era)
 toAddressInAnyEra era addrAny = runExcept $ do
   case addrAny of
-    AddressByron   bAddr -> pure (AddressInEra ByronAddressInAnyEra bAddr)
+    AddressByron bAddr -> pure (AddressInEra ByronAddressInAnyEra bAddr)
     AddressShelley sAddr -> do
-      sbe <- requireShelleyBasedEra era
-        & onNothing (txFeatureMismatch era TxFeatureShelleyAddresses)
+      sbe <-
+        requireShelleyBasedEra era
+          & onNothing (txFeatureMismatch era TxFeatureShelleyAddresses)
 
       pure (AddressInEra (ShelleyAddressInEra sbe) sAddr)
 
@@ -725,16 +1037,17 @@ toTxOutValueInAnyEra
   -> Either TxCmdError (TxOutValue era)
 toTxOutValueInAnyEra era val =
   caseByronToAllegraOrMaryEraOnwards
-    (\w ->
-      case valueToLovelace val of
-        Just l  -> return (TxOutAdaOnly w l)
-        Nothing -> txFeatureMismatchPure era TxFeatureMultiAssetOutputs
+    ( \w ->
+        case valueToLovelace val of
+          Just l -> return (TxOutAdaOnly w l)
+          Nothing -> txFeatureMismatchPure era TxFeatureMultiAssetOutputs
     )
     (\w -> return (TxOutValue w val))
     era
 
 -- TODO move this to cardano-api
-caseAlonzoOnlyOrBabbageEraOnwards :: ()
+caseAlonzoOnlyOrBabbageEraOnwards
+  :: ()
   => (AlonzoEraOnly era -> a)
   -> (BabbageEraOnwards era -> a)
   -> AlonzoEraOnwards era
@@ -742,125 +1055,136 @@ caseAlonzoOnlyOrBabbageEraOnwards :: ()
 caseAlonzoOnlyOrBabbageEraOnwards l r = \case
   AlonzoEraOnwardsAlonzo -> l AlonzoEraOnlyAlonzo
   AlonzoEraOnwardsBabbage -> r BabbageEraOnwardsBabbage
-  AlonzoEraOnwardsConway  -> r BabbageEraOnwardsConway
+  AlonzoEraOnwardsConway -> r BabbageEraOnwardsConway
 
 -- TODO move this to cardano-api
-alonzoEraOnlyToAlonzoEraOnwards :: ()
+alonzoEraOnlyToAlonzoEraOnwards
+  :: ()
   => AlonzoEraOnly era
   -> AlonzoEraOnwards era
 alonzoEraOnlyToAlonzoEraOnwards = \case
   AlonzoEraOnlyAlonzo -> AlonzoEraOnwardsAlonzo
 
-toTxOutInAnyEra :: CardanoEra era
-                -> TxOutAnyEra
-                -> ExceptT TxCmdError IO (TxOut CtxTx era)
+toTxOutInAnyEra
+  :: CardanoEra era
+  -> TxOutAnyEra
+  -> ExceptT TxCmdError IO (TxOut CtxTx era)
 toTxOutInAnyEra era (TxOutAnyEra addr' val' mDatumHash refScriptFp) = do
   addr <- hoistEither $ toAddressInAnyEra era addr'
   val <- hoistEither $ toTxOutValueInAnyEra era val'
-  (datum, refScript)
-    <- caseByronToMaryOrAlonzoEraOnwards
-         (const $ pure (TxOutDatumNone, ReferenceScriptNone))
-         (\w ->
-            caseAlonzoOnlyOrBabbageEraOnwards
-              (\wa ->
+  (datum, refScript) <-
+    caseByronToMaryOrAlonzoEraOnwards
+      (const $ pure (TxOutDatumNone, ReferenceScriptNone))
+      ( \w ->
+          caseAlonzoOnlyOrBabbageEraOnwards
+            ( \wa ->
                 (,)
                   <$> toTxAlonzoDatum (alonzoEraOnlyToAlonzoEraOnwards wa) mDatumHash
                   <*> pure ReferenceScriptNone
-              )
-              (\wbo -> toTxDatumReferenceScriptBabbage w wbo mDatumHash refScriptFp)
-              w
-         )
-         era
+            )
+            (\wbo -> toTxDatumReferenceScriptBabbage w wbo mDatumHash refScriptFp)
+            w
+      )
+      era
 
   pure $ TxOut addr val datum refScript
-  where
-    getReferenceScript :: ()
-      => ReferenceScriptAnyEra
-      -> BabbageEraOnwards era
-      -> ExceptT TxCmdError IO (ReferenceScript era)
-    getReferenceScript ReferenceScriptAnyEraNone _ = return ReferenceScriptNone
-    getReferenceScript (ReferenceScriptAnyEra fp) supp = do
-      ReferenceScript supp
-        <$> firstExceptT TxCmdScriptFileError (readFileScriptInAnyLang fp)
+ where
+  getReferenceScript
+    :: ()
+    => ReferenceScriptAnyEra
+    -> BabbageEraOnwards era
+    -> ExceptT TxCmdError IO (ReferenceScript era)
+  getReferenceScript ReferenceScriptAnyEraNone _ = return ReferenceScriptNone
+  getReferenceScript (ReferenceScriptAnyEra fp) supp = do
+    ReferenceScript supp
+      <$> firstExceptT TxCmdScriptFileError (readFileScriptInAnyLang fp)
 
-    toTxDatumReferenceScriptBabbage :: ()
-      => AlonzoEraOnwards era
-      -> BabbageEraOnwards era
-      -> TxOutDatumAnyEra
-      -> ReferenceScriptAnyEra
-      -> ExceptT TxCmdError IO (TxOutDatum CtxTx era, ReferenceScript era)
-    toTxDatumReferenceScriptBabbage sDataSupp inlineRefSupp cliDatum refScriptFp' = do
-      refScript <- getReferenceScript refScriptFp' inlineRefSupp
-      case cliDatum of
-        TxOutDatumByNone -> do
-          pure (TxOutDatumNone, refScript)
-        TxOutDatumByHashOnly dh -> do
-          pure (TxOutDatumHash sDataSupp dh, refScript)
-        TxOutDatumByHashOf fileOrSdata -> do
-          sData <- firstExceptT TxCmdScriptDataError
-                      $ readScriptDataOrFile fileOrSdata
-          pure (TxOutDatumHash sDataSupp $ hashScriptDataBytes sData, refScript)
-        TxOutDatumByValue fileOrSdata -> do
-          sData <- firstExceptT TxCmdScriptDataError
-                      $ readScriptDataOrFile fileOrSdata
-          pure (TxOutDatumInTx sDataSupp sData, refScript)
-        TxOutInlineDatumByValue fileOrSdata -> do
-          sData <- firstExceptT TxCmdScriptDataError
-                      $ readScriptDataOrFile fileOrSdata
-          pure (TxOutDatumInline inlineRefSupp sData, refScript)
+  toTxDatumReferenceScriptBabbage
+    :: ()
+    => AlonzoEraOnwards era
+    -> BabbageEraOnwards era
+    -> TxOutDatumAnyEra
+    -> ReferenceScriptAnyEra
+    -> ExceptT TxCmdError IO (TxOutDatum CtxTx era, ReferenceScript era)
+  toTxDatumReferenceScriptBabbage sDataSupp inlineRefSupp cliDatum refScriptFp' = do
+    refScript <- getReferenceScript refScriptFp' inlineRefSupp
+    case cliDatum of
+      TxOutDatumByNone -> do
+        pure (TxOutDatumNone, refScript)
+      TxOutDatumByHashOnly dh -> do
+        pure (TxOutDatumHash sDataSupp dh, refScript)
+      TxOutDatumByHashOf fileOrSdata -> do
+        sData <-
+          firstExceptT TxCmdScriptDataError $
+            readScriptDataOrFile fileOrSdata
+        pure (TxOutDatumHash sDataSupp $ hashScriptDataBytes sData, refScript)
+      TxOutDatumByValue fileOrSdata -> do
+        sData <-
+          firstExceptT TxCmdScriptDataError $
+            readScriptDataOrFile fileOrSdata
+        pure (TxOutDatumInTx sDataSupp sData, refScript)
+      TxOutInlineDatumByValue fileOrSdata -> do
+        sData <-
+          firstExceptT TxCmdScriptDataError $
+            readScriptDataOrFile fileOrSdata
+        pure (TxOutDatumInline inlineRefSupp sData, refScript)
 
-    toTxAlonzoDatum :: ()
-      => AlonzoEraOnwards era
-      -> TxOutDatumAnyEra
-      -> ExceptT TxCmdError IO (TxOutDatum CtxTx era)
-    toTxAlonzoDatum supp cliDatum =
-      case cliDatum of
-        TxOutDatumByHashOnly h -> pure (TxOutDatumHash supp h)
-        TxOutDatumByHashOf sDataOrFile -> do
-          sData <- firstExceptT TxCmdScriptDataError
-                    $ readScriptDataOrFile sDataOrFile
-          pure (TxOutDatumHash supp $ hashScriptDataBytes sData)
-        TxOutDatumByValue sDataOrFile -> do
-          sData <- firstExceptT TxCmdScriptDataError
-                    $ readScriptDataOrFile sDataOrFile
-          pure (TxOutDatumInTx supp sData)
-        TxOutInlineDatumByValue _ ->
-          txFeatureMismatch era TxFeatureInlineDatums
-        TxOutDatumByNone -> pure TxOutDatumNone
-
+  toTxAlonzoDatum
+    :: ()
+    => AlonzoEraOnwards era
+    -> TxOutDatumAnyEra
+    -> ExceptT TxCmdError IO (TxOutDatum CtxTx era)
+  toTxAlonzoDatum supp cliDatum =
+    case cliDatum of
+      TxOutDatumByHashOnly h -> pure (TxOutDatumHash supp h)
+      TxOutDatumByHashOf sDataOrFile -> do
+        sData <-
+          firstExceptT TxCmdScriptDataError $
+            readScriptDataOrFile sDataOrFile
+        pure (TxOutDatumHash supp $ hashScriptDataBytes sData)
+      TxOutDatumByValue sDataOrFile -> do
+        sData <-
+          firstExceptT TxCmdScriptDataError $
+            readScriptDataOrFile sDataOrFile
+        pure (TxOutDatumInTx supp sData)
+      TxOutInlineDatumByValue _ ->
+        txFeatureMismatch era TxFeatureInlineDatums
+      TxOutDatumByNone -> pure TxOutDatumNone
 
 -- TODO: Currently we specify the policyId with the '--mint' option on the cli
 -- and we added a separate '--policy-id' parser that parses the policy id for the
 -- given reference input (since we don't have the script in this case). To avoid asking
 -- for the policy id twice (in the build command) we can potentially query the UTxO and
 -- access the script (and therefore the policy id).
-createTxMintValue :: forall era. CardanoEra era
-                  -> (Value, [ScriptWitness WitCtxMint era])
-                  -> Either TxCmdError (TxMintValue BuildTx era)
+createTxMintValue
+  :: forall era
+   . CardanoEra era
+  -> (Value, [ScriptWitness WitCtxMint era])
+  -> Either TxCmdError (TxMintValue BuildTx era)
 createTxMintValue era (val, scriptWitnesses) =
   if List.null (valueToList val) && List.null scriptWitnesses
-  then return TxMintNone
-  else do
-    caseByronToAllegraOrMaryEraOnwards
-      (const (txFeatureMismatchPure era TxFeatureMintValue))
-      (\w -> do
-        -- The set of policy ids for which we need witnesses:
-        let witnessesNeededSet :: Set PolicyId
-            witnessesNeededSet =
-              Set.fromList [ pid | (AssetId pid _, _) <- valueToList val ]
+    then return TxMintNone
+    else do
+      caseByronToAllegraOrMaryEraOnwards
+        (const (txFeatureMismatchPure era TxFeatureMintValue))
+        ( \w -> do
+            -- The set of policy ids for which we need witnesses:
+            let witnessesNeededSet :: Set PolicyId
+                witnessesNeededSet =
+                  Set.fromList [pid | (AssetId pid _, _) <- valueToList val]
 
-        let witnessesProvidedMap :: Map PolicyId (ScriptWitness WitCtxMint era)
-            witnessesProvidedMap = Map.fromList $ gatherMintingWitnesses scriptWitnesses
+            let witnessesProvidedMap :: Map PolicyId (ScriptWitness WitCtxMint era)
+                witnessesProvidedMap = Map.fromList $ gatherMintingWitnesses scriptWitnesses
 
-            witnessesProvidedSet = Map.keysSet witnessesProvidedMap
+                witnessesProvidedSet = Map.keysSet witnessesProvidedMap
 
-        -- Check not too many, nor too few:
-        validateAllWitnessesProvided   witnessesNeededSet witnessesProvidedSet
-        validateNoUnnecessaryWitnesses witnessesNeededSet witnessesProvidedSet
+            -- Check not too many, nor too few:
+            validateAllWitnessesProvided witnessesNeededSet witnessesProvidedSet
+            validateNoUnnecessaryWitnesses witnessesNeededSet witnessesProvidedSet
 
-        return (TxMintValue w val (BuildTxWith witnessesProvidedMap))
-      )
-      era
+            return (TxMintValue w val (BuildTxWith witnessesProvidedMap))
+        )
+        era
  where
   gatherMintingWitnesses
     :: [ScriptWitness WitCtxMint era]
@@ -874,25 +1198,24 @@ createTxMintValue era (val, scriptWitnesses) =
   validateAllWitnessesProvided witnessesNeeded witnessesProvided
     | null witnessesMissing = return ()
     | otherwise = Left (TxCmdPolicyIdsMissing witnessesMissing)
-    where
-      witnessesMissing = Set.elems (witnessesNeeded Set.\\ witnessesProvided)
+   where
+    witnessesMissing = Set.elems (witnessesNeeded Set.\\ witnessesProvided)
 
   validateNoUnnecessaryWitnesses witnessesNeeded witnessesProvided
     | null witnessesExtra = return ()
     | otherwise = Left (TxCmdPolicyIdsExcess witnessesExtra)
-    where
-      witnessesExtra = Set.elems (witnessesProvided Set.\\ witnessesNeeded)
+   where
+    witnessesExtra = Set.elems (witnessesProvided Set.\\ witnessesNeeded)
 
 scriptWitnessPolicyId :: ScriptWitness witctx era -> Maybe PolicyId
 scriptWitnessPolicyId (SimpleScriptWitness _ (SScript script)) =
-   Just . scriptPolicyId $ SimpleScript script
+  Just . scriptPolicyId $ SimpleScript script
 scriptWitnessPolicyId (SimpleScriptWitness _ (SReferenceScript _ mPid)) =
-   PolicyId <$> mPid
+  PolicyId <$> mPid
 scriptWitnessPolicyId (PlutusScriptWitness _ version (PScript script) _ _ _) =
-   Just . scriptPolicyId $ PlutusScript version script
+  Just . scriptPolicyId $ PlutusScript version script
 scriptWitnessPolicyId (PlutusScriptWitness _ _ (PReferenceScript _ mPid) _ _ _) =
-   PolicyId <$> mPid
-
+  PolicyId <$> mPid
 
 readValueScriptWitnesses
   :: CardanoEra era
@@ -906,14 +1229,18 @@ readValueScriptWitnesses era (v, sWitFiles) = do
 -- Transaction signing
 --
 
-runTxSignCmd :: ()
+runTxSignCmd
+  :: ()
   => InputTxBodyOrTxFile
   -> [WitnessSigningData]
   -> Maybe NetworkId
   -> TxFile Out
   -> ExceptT TxCmdError IO ()
 runTxSignCmd txOrTxBody witSigningData mnw outTxFile = do
-  sks <-  mapM (firstExceptT TxCmdReadWitnessSigningDataError . newExceptT . readWitnessSigningData) witSigningData
+  sks <-
+    mapM
+      (firstExceptT TxCmdReadWitnessSigningDataError . newExceptT . readWitnessSigningData)
+      witSigningData
 
   let (sksByron, sksShelley) = partitionSomeWitnesses $ map categoriseSomeSigningWitness sks
 
@@ -923,13 +1250,14 @@ runTxSignCmd txOrTxBody witSigningData mnw outTxFile = do
       anyTx <- lift (readFileTx inputTxFile) & onLeft (left . TxCmdCddlError)
 
       InAnyShelleyBasedEra _era tx <-
-          onlyInShelleyBasedEras "sign for Byron era transactions" anyTx
+        onlyInShelleyBasedEras "sign for Byron era transactions" anyTx
 
       let (txbody, existingTxKeyWits) = getTxBodyAndWitnesses tx
 
-      byronWitnesses <- firstExceptT TxCmdBootstrapWitnessError
-                          . hoistEither
-                          $ mkShelleyBootstrapWitnesses mnw txbody sksByron
+      byronWitnesses <-
+        firstExceptT TxCmdBootstrapWitnessError
+          . hoistEither
+          $ mkShelleyBootstrapWitnesses mnw txbody sksByron
 
       let newShelleyKeyWits = map (makeShelleyKeyWitness txbody) sksShelley
           allKeyWits = existingTxKeyWits ++ newShelleyKeyWits ++ byronWitnesses
@@ -937,84 +1265,89 @@ runTxSignCmd txOrTxBody witSigningData mnw outTxFile = do
 
       lift (writeTxFileTextEnvelopeCddl outTxFile signedTx)
         & onLeft (left . TxCmdWriteFileError)
-
     InputTxBodyFile (File txbodyFilePath) -> do
       txbodyFile <- liftIO $ fileOrPipe txbodyFilePath
-      unwitnessed <- firstExceptT TxCmdCddlError . newExceptT
-                       $ readFileTxBody txbodyFile
+      unwitnessed <-
+        firstExceptT TxCmdCddlError . newExceptT $
+          readFileTxBody txbodyFile
 
       case unwitnessed of
         IncompleteCddlFormattedTx anyTx -> do
-         InAnyShelleyBasedEra _era unwitTx <-
-           onlyInShelleyBasedEras "sign for Byron era transactions" anyTx
+          InAnyShelleyBasedEra _era unwitTx <-
+            onlyInShelleyBasedEras "sign for Byron era transactions" anyTx
 
-         let txbody = getTxBody unwitTx
-         -- Byron witnesses require the network ID. This can either be provided
-         -- directly or derived from a provided Byron address.
-         byronWitnesses <- firstExceptT TxCmdBootstrapWitnessError
-           . hoistEither
-           $ mkShelleyBootstrapWitnesses mnw txbody sksByron
-
-         let shelleyKeyWitnesses = map (makeShelleyKeyWitness txbody) sksShelley
-             tx = makeSignedTransaction (byronWitnesses ++ shelleyKeyWitnesses) txbody
-
-         lift (writeTxFileTextEnvelopeCddl outTxFile tx)
-            & onLeft (left . TxCmdWriteFileError)
-
-        UnwitnessedCliFormattedTxBody anyTxbody -> do
-          InAnyShelleyBasedEra _era txbody <-
-            --TODO: in principle we should be able to support Byron era txs too
-            onlyInShelleyBasedEras "sign for Byron era transactions" anyTxbody
+          let txbody = getTxBody unwitTx
           -- Byron witnesses require the network ID. This can either be provided
           -- directly or derived from a provided Byron address.
-          byronWitnesses <- firstExceptT TxCmdBootstrapWitnessError
-            . hoistEither
-            $ mkShelleyBootstrapWitnesses mnw txbody sksByron
+          byronWitnesses <-
+            firstExceptT TxCmdBootstrapWitnessError
+              . hoistEither
+              $ mkShelleyBootstrapWitnesses mnw txbody sksByron
 
           let shelleyKeyWitnesses = map (makeShelleyKeyWitness txbody) sksShelley
               tx = makeSignedTransaction (byronWitnesses ++ shelleyKeyWitnesses) txbody
 
-          firstExceptT TxCmdWriteFileError . newExceptT
-            $ writeLazyByteStringFile outTxFile
-            $ textEnvelopeToJSON Nothing tx
+          lift (writeTxFileTextEnvelopeCddl outTxFile tx)
+            & onLeft (left . TxCmdWriteFileError)
+        UnwitnessedCliFormattedTxBody anyTxbody -> do
+          InAnyShelleyBasedEra _era txbody <-
+            -- TODO: in principle we should be able to support Byron era txs too
+            onlyInShelleyBasedEras "sign for Byron era transactions" anyTxbody
+          -- Byron witnesses require the network ID. This can either be provided
+          -- directly or derived from a provided Byron address.
+          byronWitnesses <-
+            firstExceptT TxCmdBootstrapWitnessError
+              . hoistEither
+              $ mkShelleyBootstrapWitnesses mnw txbody sksByron
+
+          let shelleyKeyWitnesses = map (makeShelleyKeyWitness txbody) sksShelley
+              tx = makeSignedTransaction (byronWitnesses ++ shelleyKeyWitnesses) txbody
+
+          firstExceptT TxCmdWriteFileError . newExceptT $
+            writeLazyByteStringFile outTxFile $
+              textEnvelopeToJSON Nothing tx
 
 -- ----------------------------------------------------------------------------
 -- Transaction submission
 --
 
-runTxSubmitCmd :: ()
+runTxSubmitCmd
+  :: ()
   => SocketPath
   -> AnyConsensusModeParams
   -> NetworkId
   -> FilePath
   -> ExceptT TxCmdError IO ()
 runTxSubmitCmd socketPath (AnyConsensusModeParams cModeParams) network txFilePath = do
-    txFile <- liftIO $ fileOrPipe txFilePath
-    InAnyCardanoEra era tx <- lift (readFileTx txFile) & onLeft (left . TxCmdCddlError)
-    let cMode = AnyConsensusMode $ consensusModeOnly cModeParams
-    eraInMode <- hoistMaybe
-                   (TxCmdEraConsensusModeMismatch (Just txFilePath) cMode (AnyCardanoEra era))
-                   (toEraInMode era $ consensusModeOnly cModeParams)
-    let txInMode = TxInMode tx eraInMode
-        localNodeConnInfo = LocalNodeConnectInfo
-                              { localConsensusModeParams = cModeParams
-                              , localNodeNetworkId = network
-                              , localNodeSocketPath = socketPath
-                              }
+  txFile <- liftIO $ fileOrPipe txFilePath
+  InAnyCardanoEra era tx <- lift (readFileTx txFile) & onLeft (left . TxCmdCddlError)
+  let cMode = AnyConsensusMode $ consensusModeOnly cModeParams
+  eraInMode <-
+    hoistMaybe
+      (TxCmdEraConsensusModeMismatch (Just txFilePath) cMode (AnyCardanoEra era))
+      (toEraInMode era $ consensusModeOnly cModeParams)
+  let txInMode = TxInMode tx eraInMode
+      localNodeConnInfo =
+        LocalNodeConnectInfo
+          { localConsensusModeParams = cModeParams
+          , localNodeNetworkId = network
+          , localNodeSocketPath = socketPath
+          }
 
-    res <- liftIO $ submitTxToNodeLocal localNodeConnInfo txInMode
-    case res of
-      Net.Tx.SubmitSuccess -> liftIO $ Text.putStrLn "Transaction successfully submitted."
-      Net.Tx.SubmitFail reason ->
-        case reason of
-          TxValidationErrorInMode err _eraInMode -> left . TxCmdTxSubmitError . Text.pack $ show err
-          TxValidationEraMismatch mismatchErr -> left $ TxCmdTxSubmitErrorEraMismatch mismatchErr
+  res <- liftIO $ submitTxToNodeLocal localNodeConnInfo txInMode
+  case res of
+    Net.Tx.SubmitSuccess -> liftIO $ Text.putStrLn "Transaction successfully submitted."
+    Net.Tx.SubmitFail reason ->
+      case reason of
+        TxValidationErrorInMode err _eraInMode -> left . TxCmdTxSubmitError . Text.pack $ show err
+        TxValidationEraMismatch mismatchErr -> left $ TxCmdTxSubmitErrorEraMismatch mismatchErr
 
 -- ----------------------------------------------------------------------------
 -- Transaction fee calculation
 --
 
-runTxCalculateMinFeeCmd :: ()
+runTxCalculateMinFeeCmd
+  :: ()
   => TxBodyFile In
   -> NetworkId
   -> ProtocolParamsFile
@@ -1023,44 +1356,53 @@ runTxCalculateMinFeeCmd :: ()
   -> TxShelleyWitnessCount
   -> TxByronWitnessCount
   -> ExceptT TxCmdError IO ()
-runTxCalculateMinFeeCmd (File txbodyFilePath) nw pParamsFile
-                     (TxInCount nInputs) (TxOutCount nOutputs)
-                     (TxShelleyWitnessCount nShelleyKeyWitnesses)
-                     (TxByronWitnessCount nByronKeyWitnesses) = do
-
+runTxCalculateMinFeeCmd
+  (File txbodyFilePath)
+  nw
+  pParamsFile
+  (TxInCount nInputs)
+  (TxOutCount nOutputs)
+  (TxShelleyWitnessCount nShelleyKeyWitnesses)
+  (TxByronWitnessCount nByronKeyWitnesses) = do
     txbodyFile <- liftIO $ fileOrPipe txbodyFilePath
-    unwitnessed <- firstExceptT TxCmdCddlError . newExceptT
-                     $ readFileTxBody txbodyFile
+    unwitnessed <-
+      firstExceptT TxCmdCddlError . newExceptT $
+        readFileTxBody txbodyFile
     pparams <- firstExceptT TxCmdProtocolParamsError $ readProtocolParameters pParamsFile
     case unwitnessed of
       IncompleteCddlFormattedTx anyTx -> do
         InAnyShelleyBasedEra _era unwitTx <-
           onlyInShelleyBasedEras "sign for Byron era transactions" anyTx
-        let txbody =  getTxBody unwitTx
+        let txbody = getTxBody unwitTx
         let tx = makeSignedTransaction [] txbody
-            Lovelace fee = estimateTransactionFee
-                             nw
-                             (protocolParamTxFeeFixed pparams)
-                             (protocolParamTxFeePerByte pparams)
-                             tx
-                             nInputs nOutputs
-                             nByronKeyWitnesses nShelleyKeyWitnesses
+            Lovelace fee =
+              estimateTransactionFee
+                nw
+                (protocolParamTxFeeFixed pparams)
+                (protocolParamTxFeePerByte pparams)
+                tx
+                nInputs
+                nOutputs
+                nByronKeyWitnesses
+                nShelleyKeyWitnesses
 
         liftIO $ putStrLn $ (show fee :: String) <> " Lovelace"
-
       UnwitnessedCliFormattedTxBody anyTxBody -> do
         InAnyShelleyBasedEra _era txbody <-
-              --TODO: in principle we should be able to support Byron era txs too
-              onlyInShelleyBasedEras "calculate-min-fee for Byron era transactions" anyTxBody
+          -- TODO: in principle we should be able to support Byron era txs too
+          onlyInShelleyBasedEras "calculate-min-fee for Byron era transactions" anyTxBody
 
         let tx = makeSignedTransaction [] txbody
-            Lovelace fee = estimateTransactionFee
-                             nw
-                             (protocolParamTxFeeFixed pparams)
-                             (protocolParamTxFeePerByte pparams)
-                             tx
-                             nInputs nOutputs
-                             nByronKeyWitnesses nShelleyKeyWitnesses
+            Lovelace fee =
+              estimateTransactionFee
+                nw
+                (protocolParamTxFeeFixed pparams)
+                (protocolParamTxFeePerByte pparams)
+                tx
+                nInputs
+                nOutputs
+                nByronKeyWitnesses
+                nShelleyKeyWitnesses
 
         liftIO $ putStrLn $ (show fee :: String) <> " Lovelace"
 
@@ -1068,7 +1410,8 @@ runTxCalculateMinFeeCmd (File txbodyFilePath) nw pParamsFile
 -- Transaction fee calculation
 --
 
-runTxCalculateMinRequiredUTxOCmd :: ()
+runTxCalculateMinRequiredUTxOCmd
+  :: ()
   => CardanoEra era
   -> ProtocolParamsFile
   -> TxOutAnyEra
@@ -1079,43 +1422,41 @@ runTxCalculateMinRequiredUTxOCmd era pParamsFile txOut = do
   case cardanoEraStyle era of
     LegacyByronEra -> error "runTxCalculateMinRequiredUTxOCmd: Byron era not implemented yet"
     ShelleyBasedEra sbe -> do
-      firstExceptT TxCmdPParamsErr . hoistEither
-        $ checkProtocolParameters sbe pp
+      firstExceptT TxCmdPParamsErr . hoistEither $
+        checkProtocolParameters sbe pp
       pp' <- hoistEither . first TxCmdProtocolParamsConverstionError $ toLedgerPParams sbe pp
       let minValue = calculateMinimumUTxO sbe out pp'
       liftIO . IO.print $ minValue
 
 runTxCreatePolicyIdCmd :: ScriptFile -> ExceptT TxCmdError IO ()
 runTxCreatePolicyIdCmd (ScriptFile sFile) = do
-  ScriptInAnyLang _ script <- firstExceptT TxCmdScriptFileError $
-                                readFileScriptInAnyLang sFile
+  ScriptInAnyLang _ script <-
+    firstExceptT TxCmdScriptFileError $
+      readFileScriptInAnyLang sFile
   liftIO . Text.putStrLn . serialiseToRawBytesHexText $ hashScript script
 
-
 -- | Error reading the data required to construct a key witness.
-
-
 partitionSomeWitnesses
   :: [ByronOrShelleyWitness]
   -> ( [ShelleyBootstrapWitnessSigningKeyData]
      , [ShelleyWitnessSigningKey]
      )
 partitionSomeWitnesses = reversePartitionedWits . foldl' go mempty
-  where
-    reversePartitionedWits (bw, skw) =
-      (reverse bw, reverse skw)
+ where
+  reversePartitionedWits (bw, skw) =
+    (reverse bw, reverse skw)
 
-    go (byronAcc, shelleyKeyAcc) byronOrShelleyWit =
-      case byronOrShelleyWit of
-        AByronWitness byronWit ->
-          (byronWit:byronAcc, shelleyKeyAcc)
-        AShelleyKeyWitness shelleyKeyWit ->
-          (byronAcc, shelleyKeyWit:shelleyKeyAcc)
+  go (byronAcc, shelleyKeyAcc) byronOrShelleyWit =
+    case byronOrShelleyWit of
+      AByronWitness byronWit ->
+        (byronWit : byronAcc, shelleyKeyAcc)
+      AShelleyKeyWitness shelleyKeyWit ->
+        (byronAcc, shelleyKeyWit : shelleyKeyAcc)
 
 -- | Construct a Shelley bootstrap witness (i.e. a Byron key witness in the
 -- Shelley era).
 mkShelleyBootstrapWitness
-  :: IsShelleyBasedEra era
+  :: (IsShelleyBasedEra era)
   => Maybe NetworkId
   -> TxBody era
   -> ShelleyBootstrapWitnessSigningKeyData
@@ -1130,7 +1471,7 @@ mkShelleyBootstrapWitness _ txBody (ShelleyBootstrapWitnessSigningKeyData skey (
 -- | Attempt to construct Shelley bootstrap witnesses until an error is
 -- encountered.
 mkShelleyBootstrapWitnesses
-  :: IsShelleyBasedEra era
+  :: (IsShelleyBasedEra era)
   => Maybe NetworkId
   -> TxBody era
   -> [ShelleyBootstrapWitnessSigningKeyData]
@@ -1138,54 +1479,57 @@ mkShelleyBootstrapWitnesses
 mkShelleyBootstrapWitnesses mnw txBody =
   mapM (mkShelleyBootstrapWitness mnw txBody)
 
-
 -- ----------------------------------------------------------------------------
 -- Other misc small commands
 --
 
-runTxHashScriptDataCmd :: ()
+runTxHashScriptDataCmd
+  :: ()
   => ScriptDataOrFile
   -> ExceptT TxCmdError IO ()
 runTxHashScriptDataCmd scriptDataOrFile = do
-    d <- firstExceptT TxCmdScriptDataError $ readScriptDataOrFile scriptDataOrFile
-    liftIO $ BS.putStrLn $ serialiseToRawBytesHex (hashScriptDataBytes d)
+  d <- firstExceptT TxCmdScriptDataError $ readScriptDataOrFile scriptDataOrFile
+  liftIO $ BS.putStrLn $ serialiseToRawBytesHex (hashScriptDataBytes d)
 
-runTxGetTxIdCmd :: ()
+runTxGetTxIdCmd
+  :: ()
   => InputTxBodyOrTxFile
   -> ExceptT TxCmdError IO ()
 runTxGetTxIdCmd txfile = do
-    InAnyCardanoEra _era txbody <-
-      case txfile of
-        InputTxBodyFile (File txbodyFilePath) -> do
-          txbodyFile <- liftIO $ fileOrPipe txbodyFilePath
-          unwitnessed <- firstExceptT TxCmdCddlError . newExceptT
-                           $ readFileTxBody txbodyFile
-          case unwitnessed of
-            UnwitnessedCliFormattedTxBody anyTxBody -> return anyTxBody
-            IncompleteCddlFormattedTx (InAnyCardanoEra era tx) ->
-              return (InAnyCardanoEra era (getTxBody tx))
+  InAnyCardanoEra _era txbody <-
+    case txfile of
+      InputTxBodyFile (File txbodyFilePath) -> do
+        txbodyFile <- liftIO $ fileOrPipe txbodyFilePath
+        unwitnessed <-
+          firstExceptT TxCmdCddlError . newExceptT $
+            readFileTxBody txbodyFile
+        case unwitnessed of
+          UnwitnessedCliFormattedTxBody anyTxBody -> return anyTxBody
+          IncompleteCddlFormattedTx (InAnyCardanoEra era tx) ->
+            return (InAnyCardanoEra era (getTxBody tx))
+      InputTxFile (File txFilePath) -> do
+        txFile <- liftIO $ fileOrPipe txFilePath
+        InAnyCardanoEra era tx <- lift (readFileTx txFile) & onLeft (left . TxCmdCddlError)
+        return . InAnyCardanoEra era $ getTxBody tx
 
-        InputTxFile (File txFilePath) -> do
-          txFile <- liftIO $ fileOrPipe txFilePath
-          InAnyCardanoEra era tx <- lift (readFileTx txFile) & onLeft (left . TxCmdCddlError)
-          return . InAnyCardanoEra era $ getTxBody tx
+  liftIO $ BS.putStrLn $ serialiseToRawBytesHex (getTxId txbody)
 
-    liftIO $ BS.putStrLn $ serialiseToRawBytesHex (getTxId txbody)
-
-runTxViewCmd :: ()
+runTxViewCmd
+  :: ()
   => InputTxBodyOrTxFile
   -> ExceptT TxCmdError IO ()
 runTxViewCmd = \case
   InputTxBodyFile (File txbodyFilePath) -> do
     txbodyFile <- liftIO $ fileOrPipe txbodyFilePath
-    unwitnessed <- firstExceptT TxCmdCddlError . newExceptT
-                     $ readFileTxBody txbodyFile
+    unwitnessed <-
+      firstExceptT TxCmdCddlError . newExceptT $
+        readFileTxBody txbodyFile
     InAnyCardanoEra era txbody <-
       case unwitnessed of
         UnwitnessedCliFormattedTxBody anyTxBody -> pure anyTxBody
         IncompleteCddlFormattedTx (InAnyCardanoEra era tx) ->
           pure $ InAnyCardanoEra era (getTxBody tx)
-    --TODO: Why are we maintaining friendlyTxBodyBS and friendlyTxBS?
+    -- TODO: Why are we maintaining friendlyTxBodyBS and friendlyTxBS?
     -- In the case of a transaction body, we can simply call makeSignedTransaction []
     -- to get a transaction which allows us to reuse friendlyTxBS!
     liftIO $ BS.putStr $ friendlyTxBodyBS era txbody
@@ -1194,12 +1538,12 @@ runTxViewCmd = \case
     InAnyCardanoEra era tx <- lift (readFileTx txFile) & onLeft (left . TxCmdCddlError)
     liftIO $ BS.putStr $ friendlyTxBS era tx
 
-
 -- ----------------------------------------------------------------------------
 -- Witness commands
 --
 
-runTxCreateWitnessCmd :: ()
+runTxCreateWitnessCmd
+  :: ()
   => TxBodyFile In
   -> WitnessSigningData
   -> Maybe NetworkId
@@ -1207,36 +1551,40 @@ runTxCreateWitnessCmd :: ()
   -> ExceptT TxCmdError IO ()
 runTxCreateWitnessCmd (File txbodyFilePath) witSignData mbNw oFile = do
   txbodyFile <- liftIO $ fileOrPipe txbodyFilePath
-  unwitnessed <- firstExceptT TxCmdCddlError . newExceptT
-                   $ readFileTxBody txbodyFile
+  unwitnessed <-
+    firstExceptT TxCmdCddlError . newExceptT $
+      readFileTxBody txbodyFile
   case unwitnessed of
     IncompleteCddlFormattedTx anyTx -> do
-     InAnyShelleyBasedEra sbe cddlTx <-
-       onlyInShelleyBasedEras "sign for Byron era transactions" anyTx
+      InAnyShelleyBasedEra sbe cddlTx <-
+        onlyInShelleyBasedEras "sign for Byron era transactions" anyTx
 
-     let txbody = getTxBody cddlTx
-     someWit <- firstExceptT TxCmdReadWitnessSigningDataError
-                  . newExceptT $ readWitnessSigningData witSignData
-     witness <-
-       case categoriseSomeSigningWitness someWit of
-         -- Byron witnesses require the network ID. This can either be provided
-         -- directly or derived from a provided Byron address.
-         AByronWitness bootstrapWitData ->
-           firstExceptT TxCmdBootstrapWitnessError
-             . hoistEither
-             $ mkShelleyBootstrapWitness mbNw txbody bootstrapWitData
-         AShelleyKeyWitness skShelley ->
-           pure $ makeShelleyKeyWitness txbody skShelley
+      let txbody = getTxBody cddlTx
+      someWit <-
+        firstExceptT TxCmdReadWitnessSigningDataError
+          . newExceptT
+          $ readWitnessSigningData witSignData
+      witness <-
+        case categoriseSomeSigningWitness someWit of
+          -- Byron witnesses require the network ID. This can either be provided
+          -- directly or derived from a provided Byron address.
+          AByronWitness bootstrapWitData ->
+            firstExceptT TxCmdBootstrapWitnessError
+              . hoistEither
+              $ mkShelleyBootstrapWitness mbNw txbody bootstrapWitData
+          AShelleyKeyWitness skShelley ->
+            pure $ makeShelleyKeyWitness txbody skShelley
 
-     firstExceptT TxCmdWriteFileError . newExceptT
-       $ writeTxWitnessFileTextEnvelopeCddl sbe oFile witness
-
+      firstExceptT TxCmdWriteFileError . newExceptT $
+        writeTxWitnessFileTextEnvelopeCddl sbe oFile witness
     UnwitnessedCliFormattedTxBody anyTxbody -> do
       InAnyShelleyBasedEra _era txbody <-
         onlyInShelleyBasedEras "sign for Byron era transactions" anyTxbody
 
-      someWit <- firstExceptT TxCmdReadWitnessSigningDataError
-                   . newExceptT $ readWitnessSigningData witSignData
+      someWit <-
+        firstExceptT TxCmdReadWitnessSigningDataError
+          . newExceptT
+          $ readWitnessSigningData witSignData
 
       witness <-
         case categoriseSomeSigningWitness someWit of
@@ -1249,67 +1597,78 @@ runTxCreateWitnessCmd (File txbodyFilePath) witSignData mbNw oFile = do
           AShelleyKeyWitness skShelley ->
             pure $ makeShelleyKeyWitness txbody skShelley
 
-      firstExceptT TxCmdWriteFileError . newExceptT
-        $ writeLazyByteStringFile oFile
-        $ textEnvelopeToJSON Nothing witness
+      firstExceptT TxCmdWriteFileError . newExceptT $
+        writeLazyByteStringFile oFile $
+          textEnvelopeToJSON Nothing witness
 
-runTxSignWitnessCmd :: ()
+runTxSignWitnessCmd
+  :: ()
   => TxBodyFile In
   -> [WitnessFile]
   -> File () Out
   -> ExceptT TxCmdError IO ()
 runTxSignWitnessCmd (File txbodyFilePath) witnessFiles oFp = do
-    txbodyFile <- liftIO $ fileOrPipe txbodyFilePath
-    unwitnessed <- firstExceptT TxCmdCddlError . newExceptT
-                     $ readFileTxBody txbodyFile
-    case unwitnessed of
-      UnwitnessedCliFormattedTxBody (InAnyCardanoEra era txbody) -> do
-        witnesses <-
-          sequence
-            [ do InAnyCardanoEra era' witness <- firstExceptT TxCmdCddlWitnessError . newExceptT
-                                                   $ readFileTxKeyWitness file
-                 case testEquality era era' of
-                   Nothing   -> left $ TxCmdWitnessEraMismatch
-                                         (AnyCardanoEra era)
-                                         (AnyCardanoEra era')
-                                         witnessFile
-                   Just Refl -> return witness
-            | witnessFile@(WitnessFile file) <- witnessFiles
-            ]
+  txbodyFile <- liftIO $ fileOrPipe txbodyFilePath
+  unwitnessed <-
+    firstExceptT TxCmdCddlError . newExceptT $
+      readFileTxBody txbodyFile
+  case unwitnessed of
+    UnwitnessedCliFormattedTxBody (InAnyCardanoEra era txbody) -> do
+      witnesses <-
+        sequence
+          [ do
+            InAnyCardanoEra era' witness <-
+              firstExceptT TxCmdCddlWitnessError . newExceptT $
+                readFileTxKeyWitness file
+            case testEquality era era' of
+              Nothing ->
+                left $
+                  TxCmdWitnessEraMismatch
+                    (AnyCardanoEra era)
+                    (AnyCardanoEra era')
+                    witnessFile
+              Just Refl -> return witness
+          | witnessFile@(WitnessFile file) <- witnessFiles
+          ]
 
-        let tx = makeSignedTransaction witnesses txbody
-        firstExceptT TxCmdWriteFileError
-          . newExceptT
-          $ writeLazyByteStringFile oFp
-          $ textEnvelopeToJSON Nothing tx
+      let tx = makeSignedTransaction witnesses txbody
+      firstExceptT TxCmdWriteFileError
+        . newExceptT
+        $ writeLazyByteStringFile oFp
+        $ textEnvelopeToJSON Nothing tx
+    IncompleteCddlFormattedTx (InAnyCardanoEra era anyTx) -> do
+      let txbody = getTxBody anyTx
 
-      IncompleteCddlFormattedTx (InAnyCardanoEra era anyTx) -> do
-        let txbody = getTxBody anyTx
+      witnesses <-
+        sequence
+          [ do
+            InAnyCardanoEra era' witness <-
+              firstExceptT TxCmdCddlWitnessError . newExceptT $
+                readFileTxKeyWitness file
+            case testEquality era era' of
+              Nothing ->
+                left $
+                  TxCmdWitnessEraMismatch
+                    (AnyCardanoEra era)
+                    (AnyCardanoEra era')
+                    witnessFile
+              Just Refl -> return witness
+          | witnessFile@(WitnessFile file) <- witnessFiles
+          ]
 
-        witnesses <-
-          sequence
-            [ do InAnyCardanoEra era' witness <- firstExceptT TxCmdCddlWitnessError . newExceptT
-                                                   $ readFileTxKeyWitness file
-                 case testEquality era era' of
-                   Nothing   -> left $ TxCmdWitnessEraMismatch
-                                         (AnyCardanoEra era)
-                                         (AnyCardanoEra era')
-                                         witnessFile
-                   Just Refl -> return witness
-            | witnessFile@(WitnessFile file) <- witnessFiles ]
+      let tx = makeSignedTransaction witnesses txbody
 
-        let tx = makeSignedTransaction witnesses txbody
-
-        lift (writeTxFileTextEnvelopeCddl oFp tx) & onLeft (left . TxCmdWriteFileError)
-
+      lift (writeTxFileTextEnvelopeCddl oFp tx) & onLeft (left . TxCmdWriteFileError)
 
 -- | Constrain the era to be Shelley based. Fail for the Byron era.
---
-onlyInShelleyBasedEras :: Text
-                       -> InAnyCardanoEra a
-                       -> ExceptT TxCmdError IO
-                                  (InAnyShelleyBasedEra a)
+onlyInShelleyBasedEras
+  :: Text
+  -> InAnyCardanoEra a
+  -> ExceptT
+      TxCmdError
+      IO
+      (InAnyShelleyBasedEra a)
 onlyInShelleyBasedEras notImplMsg (InAnyCardanoEra era x) =
-    case cardanoEraStyle era of
-      LegacyByronEra      -> left (TxCmdNotImplemented notImplMsg)
-      ShelleyBasedEra sbe -> return (InAnyShelleyBasedEra sbe x)
+  case cardanoEraStyle era of
+    LegacyByronEra -> left (TxCmdNotImplemented notImplMsg)
+    ShelleyBasedEra sbe -> return (InAnyShelleyBasedEra sbe x)

--- a/cardano-cli/src/Cardano/CLI/Helpers.hs
+++ b/cardano-cli/src/Cardano/CLI/Helpers.hs
@@ -16,9 +16,9 @@ module Cardano.CLI.Helpers
 
 import Cardano.CLI.Types.Common
 import Cardano.Chain.Block (decCBORABlockOrBoundary)
-import qualified Cardano.Chain.Delegation as Delegation
-import qualified Cardano.Chain.UTxO as UTxO
-import qualified Cardano.Chain.Update as Update
+import Cardano.Chain.Delegation qualified as Delegation
+import Cardano.Chain.UTxO qualified as UTxO
+import Cardano.Chain.Update qualified as Update
 import Cardano.Ledger.Binary (byronProtVer, toPlainDecoder)
 import Cardano.Ledger.Binary.Plain (Decoder, fromCBOR)
 
@@ -32,16 +32,16 @@ import Control.Monad.Trans.Except (ExceptT)
 import Control.Monad.Trans.Except.Extra (handleIOExceptT, left)
 import Data.Bifunctor (Bifunctor (..))
 import Data.ByteString (ByteString)
-import qualified Data.ByteString as BS
-import qualified Data.ByteString.Lazy as LB
+import Data.ByteString qualified as BS
+import Data.ByteString.Lazy qualified as LB
 import Data.Functor (void)
 import Data.Text (Text)
-import qualified Data.Text as Text
-import qualified Data.Text.IO as Text
+import Data.Text qualified as Text
+import Data.Text.IO qualified as Text
 import System.Console.ANSI
-import qualified System.Console.ANSI as ANSI
-import qualified System.Directory as IO
-import qualified System.IO as IO
+import System.Console.ANSI qualified as ANSI
+import System.Directory qualified as IO
+import System.IO qualified as IO
 
 data HelpersError
   = CBORPrettyPrintError !DeserialiseFailure

--- a/cardano-cli/src/Cardano/CLI/IO/Compat.hs
+++ b/cardano-cli/src/Cardano/CLI/IO/Compat.hs
@@ -18,4 +18,4 @@ posixSetOtherAndGroupModes = do
   _ <- setFileCreationMask (otherModes `unionFileModes` groupModes)
 #endif
 
-  pure ()
+pure ()

--- a/cardano-cli/src/Cardano/CLI/IO/GitRev.hs
+++ b/cardano-cli/src/Cardano/CLI/IO/GitRev.hs
@@ -1,27 +1,28 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE ForeignFunctionInterface #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE ForeignFunctionInterface #-}
 
 module Cardano.CLI.IO.GitRev
   ( gitRev
   ) where
 
-import           Data.Text (Text)
+import Data.Text (Text)
 import qualified Data.Text as T
 
-import           Cardano.Git.RevFromGit (gitRevFromGit)
-import           GHC.Foreign (peekCStringLen)
-import           Foreign.C.String (CString)
-import           System.IO (utf8)
-import           System.IO.Unsafe (unsafeDupablePerformIO)
+import Cardano.Git.RevFromGit (gitRevFromGit)
+import Foreign.C.String (CString)
+import GHC.Foreign (peekCStringLen)
+import System.IO (utf8)
+import System.IO.Unsafe (unsafeDupablePerformIO)
 
 foreign import ccall "&_cardano_git_rev" c_gitrev :: CString
 
 gitRev :: Text
-gitRev | gitRevEmbed /= zeroRev = gitRevEmbed
-       | T.null fromGit         = zeroRev
-       | otherwise              = fromGit
+gitRev
+  | gitRevEmbed /= zeroRev = gitRevEmbed
+  | T.null fromGit = zeroRev
+  | otherwise = fromGit
  where
   -- Git revision embedded after compilation using
   -- Data.FileEmbed.injectWith. If nothing has been injected,
@@ -29,8 +30,8 @@ gitRev | gitRevEmbed /= zeroRev = gitRevEmbed
   gitRevEmbed :: Text
   gitRevEmbed = T.pack $ drop 28 $ unsafeDupablePerformIO (peekCStringLen utf8 (c_gitrev, 68))
 
-  -- Git revision found during compilation by running git. If
-  -- git could not be run, then this will be empty.
+-- Git revision found during compilation by running git. If
+-- git could not be run, then this will be empty.
 #if defined(arm_HOST_ARCH)
   -- cross compiling to arm fails; due to a linker bug
   fromGit = ""

--- a/cardano-cli/src/Cardano/CLI/IO/GitRev.hs
+++ b/cardano-cli/src/Cardano/CLI/IO/GitRev.hs
@@ -8,7 +8,7 @@ module Cardano.CLI.IO.GitRev
   ) where
 
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 
 import Cardano.Git.RevFromGit (gitRevFromGit)
 import Foreign.C.String (CString)

--- a/cardano-cli/src/Cardano/CLI/IO/Lazy.hs
+++ b/cardano-cli/src/Cardano/CLI/IO/Lazy.hs
@@ -16,8 +16,8 @@ import Control.Monad.IO.Unlift
   , UnliftIO (unliftIO)
   , askUnliftIO
   )
-import qualified Data.List as L
-import qualified System.IO.Unsafe as IO
+import Data.List qualified as L
+import System.IO.Unsafe qualified as IO
 
 replicateM :: (MonadUnliftIO m) => Int -> m a -> m [a]
 replicateM n f = sequenceM (L.replicate n f)

--- a/cardano-cli/src/Cardano/CLI/IO/Lazy.hs
+++ b/cardano-cli/src/Cardano/CLI/IO/Lazy.hs
@@ -10,15 +10,19 @@ module Cardano.CLI.IO.Lazy
   , forStateM
   ) where
 
-import           Control.Monad.IO.Unlift (MonadIO (liftIO), MonadUnliftIO, UnliftIO (unliftIO),
-                   askUnliftIO)
+import Control.Monad.IO.Unlift
+  ( MonadIO (liftIO)
+  , MonadUnliftIO
+  , UnliftIO (unliftIO)
+  , askUnliftIO
+  )
 import qualified Data.List as L
 import qualified System.IO.Unsafe as IO
 
-replicateM :: MonadUnliftIO m => Int -> m a -> m [a]
+replicateM :: (MonadUnliftIO m) => Int -> m a -> m [a]
 replicateM n f = sequenceM (L.replicate n f)
 
-sequenceM :: MonadUnliftIO m => [m a] -> m [a]
+sequenceM :: (MonadUnliftIO m) => [m a] -> m [a]
 sequenceM as = do
   f <- askUnliftIO
   liftIO $ sequenceIO (L.map (unliftIO f) as)
@@ -28,38 +32,39 @@ sequenceM as = do
 --
 -- It is intended to be like the "standard" 'traverse' except
 -- that the list is generated lazily.
-traverseM :: MonadUnliftIO m => (a -> m b) -> [a] -> m [b]
+traverseM :: (MonadUnliftIO m) => (a -> m b) -> [a] -> m [b]
 traverseM f as = do
   u <- askUnliftIO
   liftIO $ IO.unsafeInterleaveIO (go u as)
-  where
-    go _ [] = pure []
-    go !u (v:vs) = do
-      !res <- unliftIO u (f v)
-      rest <- IO.unsafeInterleaveIO (go u vs)
-      pure (res:rest)
+ where
+  go _ [] = pure []
+  go !u (v : vs) = do
+    !res <- unliftIO u (f v)
+    rest <- IO.unsafeInterleaveIO (go u vs)
+    pure (res : rest)
 
-traverseStateM :: forall m s a b. MonadUnliftIO m => s -> (s -> a -> m (s, b)) -> [a] -> m [b]
+traverseStateM :: forall m s a b. (MonadUnliftIO m) => s -> (s -> a -> m (s, b)) -> [a] -> m [b]
 traverseStateM s f as = do
   u <- askUnliftIO
   liftIO $ IO.unsafeInterleaveIO (go s u as)
-  where
-    go :: s -> UnliftIO m -> [a] -> IO [b]
-    go _ _ [] = pure []
-    go t !u (v:vs) = do
-      (t', !res) <- unliftIO u (f t v)
-      rest <- IO.unsafeInterleaveIO (go t' u vs)
-      pure (res:rest)
+ where
+  go :: s -> UnliftIO m -> [a] -> IO [b]
+  go _ _ [] = pure []
+  go t !u (v : vs) = do
+    (t', !res) <- unliftIO u (f t v)
+    rest <- IO.unsafeInterleaveIO (go t' u vs)
+    pure (res : rest)
 
-forM :: MonadUnliftIO m => [a] -> (a -> m b) -> m [b]
+forM :: (MonadUnliftIO m) => [a] -> (a -> m b) -> m [b]
 forM = flip traverseM
 
-forStateM :: MonadUnliftIO m => s -> [a] -> (s -> a -> m (s, b)) -> m [b]
+forStateM :: (MonadUnliftIO m) => s -> [a] -> (s -> a -> m (s, b)) -> m [b]
 forStateM s as f = traverseStateM s f as
 
 -- Internal
 sequenceIO :: [IO a] -> IO [a]
 sequenceIO = IO.unsafeInterleaveIO . go
-  where go :: [IO a] -> IO [a]
-        go []       = return []
-        go (fa:fas) = (:) <$> fa <*> IO.unsafeInterleaveIO (go fas)
+ where
+  go :: [IO a] -> IO [a]
+  go [] = return []
+  go (fa : fas) = (:) <$> fa <*> IO.unsafeInterleaveIO (go fas)

--- a/cardano-cli/src/Cardano/CLI/Json/Friendly.hs
+++ b/cardano-cli/src/Cardano/CLI/Json/Friendly.hs
@@ -15,7 +15,7 @@ module Cardano.CLI.Json.Friendly (friendlyTxBS, friendlyTxBodyBS) where
 
 import Cardano.Api as Api
 import Cardano.Api.Byron (KeyWitness (ByronKeyWitness))
-import qualified Cardano.Api.Ledger as Ledger
+import Cardano.Api.Ledger qualified as Ledger
 import Cardano.Api.Shelley
   ( Address (ShelleyAddress)
   , Hash (..)
@@ -28,26 +28,26 @@ import Cardano.Api.Shelley
   , toShelleyStakeCredential
   )
 
-import qualified Cardano.Ledger.Conway.TxCert as ConwayLedger
-import qualified Cardano.Ledger.Credential as Shelley
-import qualified Cardano.Ledger.Shelley.API as Shelley
+import Cardano.Ledger.Conway.TxCert qualified as ConwayLedger
+import Cardano.Ledger.Credential qualified as Shelley
+import Cardano.Ledger.Shelley.API qualified as Shelley
 
 import Data.Aeson (Value (..), object, toJSON, (.=))
-import qualified Data.Aeson as Aeson
-import qualified Data.Aeson.Key as Aeson
-import qualified Data.Aeson.Types as Aeson
+import Data.Aeson qualified as Aeson
+import Data.Aeson.Key qualified as Aeson
+import Data.Aeson.Types qualified as Aeson
 import Data.ByteString (ByteString)
-import qualified Data.ByteString.Char8 as BSC
+import Data.ByteString.Char8 qualified as BSC
 import Data.Char (isAscii)
 import Data.Function ((&))
 import Data.Functor ((<&>))
-import qualified Data.Map.Strict as Map
+import Data.Map.Strict qualified as Map
 import Data.Maybe (catMaybes, isJust, maybeToList)
 import Data.Ratio (numerator)
-import qualified Data.Text as Text
+import Data.Text qualified as Text
 import Data.Yaml (array)
 import Data.Yaml.Pretty (setConfCompare)
-import qualified Data.Yaml.Pretty as Yaml
+import Data.Yaml.Pretty qualified as Yaml
 import GHC.Real (denominator)
 import GHC.Unicode (isAlphaNum)
 

--- a/cardano-cli/src/Cardano/CLI/Legacy/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Commands.hs
@@ -5,30 +5,30 @@ module Cardano.CLI.Legacy.Commands
   , renderLegacyCommand
   ) where
 
-import           Cardano.CLI.Legacy.Commands.Address
-import           Cardano.CLI.Legacy.Commands.Genesis
-import           Cardano.CLI.Legacy.Commands.Governance
-import           Cardano.CLI.Legacy.Commands.Key
-import           Cardano.CLI.Legacy.Commands.Node
-import           Cardano.CLI.Legacy.Commands.Query
-import           Cardano.CLI.Legacy.Commands.StakeAddress
-import           Cardano.CLI.Legacy.Commands.StakePool
-import           Cardano.CLI.Legacy.Commands.TextView
-import           Cardano.CLI.Legacy.Commands.Transaction
+import Cardano.CLI.Legacy.Commands.Address
+import Cardano.CLI.Legacy.Commands.Genesis
+import Cardano.CLI.Legacy.Commands.Governance
+import Cardano.CLI.Legacy.Commands.Key
+import Cardano.CLI.Legacy.Commands.Node
+import Cardano.CLI.Legacy.Commands.Query
+import Cardano.CLI.Legacy.Commands.StakeAddress
+import Cardano.CLI.Legacy.Commands.StakePool
+import Cardano.CLI.Legacy.Commands.TextView
+import Cardano.CLI.Legacy.Commands.Transaction
 
-import           Data.Text (Text)
+import Data.Text (Text)
 
 data LegacyCmds
-  = LegacyAddressCmds       LegacyAddressCmds
-  | LegacyGenesisCmds       LegacyGenesisCmds
-  | LegacyGovernanceCmds    LegacyGovernanceCmds
-  | LegacyKeyCmds           LegacyKeyCmds
-  | LegacyNodeCmds          LegacyNodeCmds
-  | LegacyQueryCmds         LegacyQueryCmds
-  | LegacyStakeAddressCmds  LegacyStakeAddressCmds
-  | LegacyStakePoolCmds     LegacyStakePoolCmds
-  | LegacyTextViewCmds      LegacyTextViewCmds
-  | LegacyTransactionCmds   LegacyTransactionCmds
+  = LegacyAddressCmds LegacyAddressCmds
+  | LegacyGenesisCmds LegacyGenesisCmds
+  | LegacyGovernanceCmds LegacyGovernanceCmds
+  | LegacyKeyCmds LegacyKeyCmds
+  | LegacyNodeCmds LegacyNodeCmds
+  | LegacyQueryCmds LegacyQueryCmds
+  | LegacyStakeAddressCmds LegacyStakeAddressCmds
+  | LegacyStakePoolCmds LegacyStakePoolCmds
+  | LegacyTextViewCmds LegacyTextViewCmds
+  | LegacyTransactionCmds LegacyTransactionCmds
 
 renderLegacyCommand :: LegacyCmds -> Text
 renderLegacyCommand = \case

--- a/cardano-cli/src/Cardano/CLI/Legacy/Commands/Address.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Commands/Address.hs
@@ -6,14 +6,14 @@ module Cardano.CLI.Legacy.Commands.Address
   , renderLegacyAddressCmds
   ) where
 
-import           Cardano.Api.Shelley hiding (QueryInShelleyBasedEra (..))
+import Cardano.Api.Shelley hiding (QueryInShelleyBasedEra (..))
 
-import           Cardano.CLI.Types.Common
-import           Cardano.CLI.Types.Key
+import Cardano.CLI.Types.Common
+import Cardano.CLI.Types.Key
 
-import           Prelude
+import Prelude
 
-import           Data.Text (Text)
+import Data.Text (Text)
 
 data LegacyAddressCmds
   = AddressKeyGen
@@ -32,7 +32,7 @@ data LegacyAddressCmds
   | AddressInfo
       Text
       (Maybe (File () Out))
-  deriving Show
+  deriving (Show)
 
 renderLegacyAddressCmds :: LegacyAddressCmds -> Text
 renderLegacyAddressCmds = \case

--- a/cardano-cli/src/Cardano/CLI/Legacy/Commands/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Commands/Genesis.hs
@@ -6,12 +6,12 @@ module Cardano.CLI.Legacy.Commands.Genesis
   , renderLegacyGenesisCmds
   ) where
 
-import           Cardano.Api.Shelley
+import Cardano.Api.Shelley
 
-import           Cardano.Chain.Common (BlockCount)
-import           Cardano.CLI.Types.Common
+import Cardano.CLI.Types.Common
+import Cardano.Chain.Common (BlockCount)
 
-import           Data.Text (Text)
+import Data.Text (Text)
 
 data LegacyGenesisCmds
   = GenesisCreate
@@ -37,7 +37,8 @@ data LegacyGenesisCmds
       FilePath
       FilePath
       (Maybe FilePath)
-  | GenesisCreateStaked
+  | -- | Relay specification filepath
+    GenesisCreateStaked
       KeyOutputFormat
       GenesisDir
       Word
@@ -51,7 +52,7 @@ data LegacyGenesisCmds
       Word
       Word
       Word
-      (Maybe FilePath) -- ^ Relay specification filepath
+      (Maybe FilePath)
   | GenesisKeyGenGenesis
       (VerificationKeyFile Out)
       (SigningKeyFile Out)
@@ -77,7 +78,7 @@ data LegacyGenesisCmds
       (Maybe (File () Out))
   | GenesisHashFile
       GenesisFile
-  deriving Show
+  deriving (Show)
 
 renderLegacyGenesisCmds :: LegacyGenesisCmds -> Text
 renderLegacyGenesisCmds = \case

--- a/cardano-cli/src/Cardano/CLI/Legacy/Commands/Governance.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Commands/Governance.hs
@@ -4,13 +4,13 @@
 
 module Cardano.CLI.Legacy.Commands.Governance where
 
-import           Cardano.Api
-import           Cardano.Api.Shelley
+import Cardano.Api
+import Cardano.Api.Shelley
 
-import           Cardano.CLI.Types.Common
-import           Cardano.CLI.Types.Key
+import Cardano.CLI.Types.Common
+import Cardano.CLI.Types.Key
 
-import           Data.Text (Text)
+import Data.Text (Text)
 
 data LegacyGovernanceCmds
   = GovernanceMIRPayStakeAddressesCertificate
@@ -31,7 +31,8 @@ data LegacyGovernanceCmds
       (VerificationKeyOrHashOrFile VrfKey)
       (File () Out)
   | GovernanceUpdateProposal
-      (File () Out) EpochNo
+      (File () Out)
+      EpochNo
       [VerificationKeyFile In]
       ProtocolParametersUpdate
       (Maybe FilePath)
@@ -48,7 +49,7 @@ data LegacyGovernanceCmds
       (File GovernancePoll In) -- Poll file
       (File (Tx ()) In) -- Tx file
       (Maybe (File () Out)) -- Tx file
-  deriving Show
+  deriving (Show)
 
 renderLegacyGovernanceCmds :: LegacyGovernanceCmds -> Text
 renderLegacyGovernanceCmds = \case
@@ -57,7 +58,6 @@ renderLegacyGovernanceCmds = \case
   GovernanceMIRTransfer _ _ _ TransferToTreasury -> "governance create-mir-certificate transfer-to-treasury"
   GovernanceMIRTransfer _ _ _ TransferToReserves -> "governance create-mir-certificate transfer-to-reserves"
   GovernanceUpdateProposal {} -> "governance create-update-proposal"
-  GovernanceCreatePoll{} -> "governance create-poll"
-  GovernanceAnswerPoll{} -> "governance answer-poll"
-  GovernanceVerifyPoll{} -> "governance verify-poll"
-
+  GovernanceCreatePoll {} -> "governance create-poll"
+  GovernanceAnswerPoll {} -> "governance answer-poll"
+  GovernanceVerifyPoll {} -> "governance verify-poll"

--- a/cardano-cli/src/Cardano/CLI/Legacy/Commands/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Commands/Key.hs
@@ -6,22 +6,22 @@ module Cardano.CLI.Legacy.Commands.Key
   , renderLegacyKeyCmds
   ) where
 
-import           Cardano.Api.Shelley
+import Cardano.Api.Shelley
 
-import           Cardano.CLI.Types.Common
+import Cardano.CLI.Types.Common
 
-import           Data.Text (Text)
+import Data.Text (Text)
 
 data LegacyKeyCmds
   = KeyGetVerificationKey (SigningKeyFile In) (VerificationKeyFile Out)
-  | KeyNonExtendedKey  (VerificationKeyFile In) (VerificationKeyFile Out)
+  | KeyNonExtendedKey (VerificationKeyFile In) (VerificationKeyFile Out)
   | KeyConvertByronKey (Maybe Text) ByronKeyType (SomeKeyFile In) (File () Out)
   | KeyConvertByronGenesisVKey VerificationKeyBase64 (File () Out)
   | KeyConvertITNStakeKey (SomeKeyFile In) (File () Out)
   | KeyConvertITNExtendedToStakeKey (SomeKeyFile In) (File () Out)
   | KeyConvertITNBip32ToStakeKey (SomeKeyFile In) (File () Out)
   | KeyConvertCardanoAddressSigningKey CardanoAddressKeyType (SigningKeyFile In) (File () Out)
-  deriving Show
+  deriving (Show)
 
 renderLegacyKeyCmds :: LegacyKeyCmds -> Text
 renderLegacyKeyCmds = \case

--- a/cardano-cli/src/Cardano/CLI/Legacy/Commands/Node.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Commands/Node.hs
@@ -6,12 +6,12 @@ module Cardano.CLI.Legacy.Commands.Node
   , renderLegacyNodeCmds
   ) where
 
-import           Cardano.Api.Shelley
+import Cardano.Api.Shelley
 
-import           Cardano.CLI.Types.Common
-import           Cardano.CLI.Types.Key
+import Cardano.CLI.Types.Common
+import Cardano.CLI.Types.Key
 
-import           Data.Text (Text)
+import Data.Text (Text)
 
 data LegacyNodeCmds
   = NodeKeyGenCold
@@ -38,8 +38,9 @@ data LegacyNodeCmds
       (VerificationKeyOrFile KesKey)
       (SigningKeyFile In)
       (OpCertCounterFile InOut)
-      KESPeriod (File () Out)
-  deriving Show
+      KESPeriod
+      (File () Out)
+  deriving (Show)
 
 renderLegacyNodeCmds :: LegacyNodeCmds -> Text
 renderLegacyNodeCmds = \case
@@ -48,4 +49,4 @@ renderLegacyNodeCmds = \case
   NodeKeyGenVRF {} -> "node key-gen-VRF"
   NodeKeyHashVRF {} -> "node key-hash-VRF"
   NodeNewCounter {} -> "node new-counter"
-  NodeIssueOpCert{} -> "node issue-op-cert"
+  NodeIssueOpCert {} -> "node issue-op-cert"

--- a/cardano-cli/src/Cardano/CLI/Legacy/Commands/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Commands/Query.hs
@@ -6,16 +6,16 @@ module Cardano.CLI.Legacy.Commands.Query
   , renderLegacyQueryCmds
   ) where
 
-import           Cardano.Api.Shelley hiding (QueryInShelleyBasedEra (..))
+import Cardano.Api.Shelley hiding (QueryInShelleyBasedEra (..))
 
-import           Cardano.CLI.Types.Common
-import           Cardano.CLI.Types.Key
+import Cardano.CLI.Types.Common
+import Cardano.CLI.Types.Key
 
-import           Data.Text (Text)
-import           Data.Time.Clock
+import Data.Text (Text)
+import Data.Time.Clock
 
-data LegacyQueryCmds =
-    QueryLeadershipSchedule
+data LegacyQueryCmds
+  = QueryLeadershipSchedule
       SocketPath
       AnyConsensusModeParams
       NetworkId
@@ -100,7 +100,7 @@ data LegacyQueryCmds =
       AnyConsensusModeParams
       NetworkId
       UTCTime
-  deriving Show
+  deriving (Show)
 
 renderLegacyQueryCmds :: LegacyQueryCmds -> Text
 renderLegacyQueryCmds = \case
@@ -119,9 +119,9 @@ renderLegacyQueryCmds = \case
   QueryPoolState' {} -> "query pool-state"
   QueryTxMempool _ _ _ query _ -> "query tx-mempool" <> renderTxMempoolQuery query
   QuerySlotNumber {} -> "query slot-number"
-  where
-    renderTxMempoolQuery query =
-      case query of
-        TxMempoolQueryTxExists tx -> "tx-exists " <> serialiseToRawBytesHexText tx
-        TxMempoolQueryNextTx -> "next-tx"
-        TxMempoolQueryInfo -> "info"
+ where
+  renderTxMempoolQuery query =
+    case query of
+      TxMempoolQueryTxExists tx -> "tx-exists " <> serialiseToRawBytesHexText tx
+      TxMempoolQueryNextTx -> "next-tx"
+      TxMempoolQueryInfo -> "info"

--- a/cardano-cli/src/Cardano/CLI/Legacy/Commands/StakeAddress.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Commands/StakeAddress.hs
@@ -7,14 +7,14 @@ module Cardano.CLI.Legacy.Commands.StakeAddress
   , renderLegacyStakeAddressCmds
   ) where
 
-import           Cardano.Api.Shelley
+import Cardano.Api.Shelley
 
-import           Cardano.CLI.Types.Common
-import           Cardano.CLI.Types.Key
+import Cardano.CLI.Types.Common
+import Cardano.CLI.Types.Key
 
-import           Prelude
+import Prelude
 
-import           Data.Text (Text)
+import Data.Text (Text)
 
 data LegacyStakeAddressCmds
   = StakeAddressKeyGenCmd
@@ -43,7 +43,7 @@ data LegacyStakeAddressCmds
       StakeIdentifier
       (Maybe Lovelace)
       (File () Out)
-  deriving Show
+  deriving (Show)
 
 renderLegacyStakeAddressCmds :: LegacyStakeAddressCmds -> Text
 renderLegacyStakeAddressCmds = \case

--- a/cardano-cli/src/Cardano/CLI/Legacy/Commands/StakePool.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Commands/StakePool.hs
@@ -6,14 +6,14 @@ module Cardano.CLI.Legacy.Commands.StakePool
   , renderLegacyStakePoolCmds
   ) where
 
-import           Cardano.Api.Shelley hiding (QueryInShelleyBasedEra (..))
+import Cardano.Api.Shelley hiding (QueryInShelleyBasedEra (..))
 
-import           Cardano.CLI.Types.Common
-import           Cardano.CLI.Types.Key
+import Cardano.CLI.Types.Common
+import Cardano.CLI.Types.Key
 
-import           Prelude
+import Prelude
 
-import           Data.Text (Text)
+import Data.Text (Text)
 
 data LegacyStakePoolCmds
   = StakePoolDeregistrationCertificateCmd
@@ -54,7 +54,7 @@ data LegacyStakePoolCmds
       -- ^ Stake pool metadata.
       NetworkId
       (File () Out)
-  deriving Show
+  deriving (Show)
 
 renderLegacyStakePoolCmds :: LegacyStakePoolCmds -> Text
 renderLegacyStakePoolCmds = \case

--- a/cardano-cli/src/Cardano/CLI/Legacy/Commands/TextView.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Commands/TextView.hs
@@ -6,13 +6,13 @@ module Cardano.CLI.Legacy.Commands.TextView
   , renderLegacyTextViewCmds
   ) where
 
-import           Cardano.Api.Shelley
+import Cardano.Api.Shelley
 
-import           Data.Text (Text)
+import Data.Text (Text)
 
 data LegacyTextViewCmds
   = TextViewInfo !FilePath (Maybe (File () Out))
-  deriving Show
+  deriving (Show)
 
 renderLegacyTextViewCmds :: LegacyTextViewCmds -> Text
 renderLegacyTextViewCmds = \case

--- a/cardano-cli/src/Cardano/CLI/Legacy/Commands/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Commands/Transaction.hs
@@ -6,12 +6,12 @@ module Cardano.CLI.Legacy.Commands.Transaction
   , renderLegacyTransactionCmds
   ) where
 
-import           Cardano.Api.Shelley
+import Cardano.Api.Shelley
 
-import           Cardano.CLI.Types.Common
-import           Cardano.CLI.Types.Governance
+import Cardano.CLI.Types.Common
+import Cardano.CLI.Types.Governance
 
-import           Data.Text (Text)
+import Data.Text (Text)
 
 data LegacyTransactionCmds
   = TxBuildRaw
@@ -49,14 +49,14 @@ data LegacyTransactionCmds
       (Maybe ProtocolParamsFile)
       (Maybe UpdateProposalFile)
       (TxBodyFile Out)
-
-    -- | Like 'TxBuildRaw' but without the fee, and with a change output.
-  | TxBuild
+  | -- | Like 'TxBuildRaw' but without the fee, and with a change output.
+    TxBuild
       SocketPath
       AnyCardanoEra
       AnyConsensusModeParams
       NetworkId
-      (Maybe ScriptValidity) -- ^ Mark script as expected to pass or fail validation
+      (Maybe ScriptValidity)
+      -- ^ Mark script as expected to pass or fail validation
       (Maybe Word)
       -- ^ Override the required number of tx witnesses
       [(TxIn, Maybe (ScriptWitnessFiles WitCtxTxIn))]

--- a/cardano-cli/src/Cardano/CLI/Legacy/Options.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Options.hs
@@ -45,8 +45,8 @@ import Data.Maybe (fromMaybe, maybeToList)
 import Data.Text (Text)
 import Data.Word (Word64)
 import Options.Applicative hiding (help, str)
-import qualified Options.Applicative as Opt
-import qualified Options.Applicative.Help as H
+import Options.Applicative qualified as Opt
+import Options.Applicative.Help qualified as H
 import Prettyprinter (line, pretty)
 
 {- HLINT ignore "Use <$>" -}

--- a/cardano-cli/src/Cardano/CLI/Legacy/Options.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Options.hs
@@ -13,42 +13,41 @@ module Cardano.CLI.Legacy.Options
 
     -- * Field parser and renderers
   , parseTxIn
-
   , pLegacyCardanoEra
   , pKeyRegistDeposit
   , pStakePoolRegistrationParserRequirements
   , pStakePoolVerificationKeyOrHashOrFile
   ) where
 
-import           Cardano.Api hiding (QueryInShelleyBasedEra (..))
-import           Cardano.Api.Shelley hiding (QueryInShelleyBasedEra (..))
+import Cardano.Api hiding (QueryInShelleyBasedEra (..))
+import Cardano.Api.Shelley hiding (QueryInShelleyBasedEra (..))
 
-import           Cardano.Chain.Common (BlockCount (BlockCount))
-import           Cardano.CLI.Environment (EnvCli (..))
-import           Cardano.CLI.EraBased.Options.Common
-import           Cardano.CLI.Legacy.Commands
-import           Cardano.CLI.Legacy.Commands.Address
-import           Cardano.CLI.Legacy.Commands.Genesis
-import           Cardano.CLI.Legacy.Commands.Governance
-import           Cardano.CLI.Legacy.Commands.Key
-import           Cardano.CLI.Legacy.Commands.Node
-import           Cardano.CLI.Legacy.Commands.Query
-import           Cardano.CLI.Legacy.Commands.StakeAddress
-import           Cardano.CLI.Legacy.Commands.StakePool
-import           Cardano.CLI.Legacy.Commands.TextView
-import           Cardano.CLI.Legacy.Commands.Transaction
-import           Cardano.CLI.Parser
-import           Cardano.CLI.Types.Common
+import Cardano.CLI.Environment (EnvCli (..))
+import Cardano.CLI.EraBased.Options.Common
+import Cardano.CLI.Legacy.Commands
+import Cardano.CLI.Legacy.Commands.Address
+import Cardano.CLI.Legacy.Commands.Genesis
+import Cardano.CLI.Legacy.Commands.Governance
+import Cardano.CLI.Legacy.Commands.Key
+import Cardano.CLI.Legacy.Commands.Node
+import Cardano.CLI.Legacy.Commands.Query
+import Cardano.CLI.Legacy.Commands.StakeAddress
+import Cardano.CLI.Legacy.Commands.StakePool
+import Cardano.CLI.Legacy.Commands.TextView
+import Cardano.CLI.Legacy.Commands.Transaction
+import Cardano.CLI.Parser
+import Cardano.CLI.Types.Common
+import Cardano.Chain.Common (BlockCount (BlockCount))
 
-import           Data.Foldable
-import           Data.Function
-import           Data.Maybe (fromMaybe, maybeToList)
-import           Data.Text (Text)
-import           Data.Word (Word64)
-import           Options.Applicative hiding (help, str)
+import Data.Foldable
+import Data.Function
+import Data.Maybe (fromMaybe, maybeToList)
+import Data.Text (Text)
+import Data.Word (Word64)
+import Options.Applicative hiding (help, str)
 import qualified Options.Applicative as Opt
 import qualified Options.Applicative.Help as H
-import           Prettyprinter (line, pretty)
+import Prettyprinter (line, pretty)
 
 {- HLINT ignore "Use <$>" -}
 {- HLINT ignore "Move brackets to avoid $" -}
@@ -59,485 +58,542 @@ import           Prettyprinter (line, pretty)
 
 parseLegacyCmds :: EnvCli -> Parser LegacyCmds
 parseLegacyCmds envCli =
-  Opt.hsubparser $ mconcat
-    [ Opt.metavar "Legacy commands"
-    , Opt.commandGroup "Legacy commands"
-    , Opt.command "address"
-        $ Opt.info (LegacyAddressCmds <$> pAddressCmds envCli)
-        $ Opt.progDesc "Payment address commands"
-    , Opt.command "stake-address"
-        $ Opt.info (LegacyStakeAddressCmds <$> pStakeAddressCmds envCli)
-        $ Opt.progDesc "Stake address commands"
-    , Opt.command "key"
-        $ Opt.info (LegacyKeyCmds <$> pKeyCmds)
-        $ Opt.progDesc "Key utility commands"
-    , Opt.command "transaction"
-        $ Opt.info (LegacyTransactionCmds <$> pTransaction envCli)
-        $ Opt.progDesc "Transaction commands"
-    , Opt.command "node"
-        $ Opt.info (LegacyNodeCmds <$> pNodeCmds)
-        $ Opt.progDesc "Node operation commands"
-    , Opt.command "stake-pool"
-        $ Opt.info (LegacyStakePoolCmds <$> pStakePoolCmds envCli)
-        $ Opt.progDesc "Stake pool commands"
-    , Opt.command "query"
-        $ Opt.info (LegacyQueryCmds <$> pQueryCmds envCli) . Opt.progDesc
-        $ mconcat
-            [ "Node query commands. Will query the local node whose Unix domain socket "
-            , "is obtained from the CARDANO_NODE_SOCKET_PATH environment variable."
-            ]
-    , Opt.command "genesis"
-        $ Opt.info (LegacyGenesisCmds <$> pGenesisCmds envCli)
-        $ Opt.progDesc "Genesis block commands"
-    , Opt.command "governance"
-        $ Opt.info (LegacyGovernanceCmds <$> pGovernanceCmds envCli)
-        $ Opt.progDesc "Governance commands"
-    , Opt.command "text-view"
-        $ Opt.info (LegacyTextViewCmds <$> pTextViewCmds) . Opt.progDesc
-        $ mconcat
-            [ "Commands for dealing with Shelley TextView files. "
-            , "Transactions, addresses etc are stored on disk as TextView files."
-            ]
-    ]
+  Opt.hsubparser $
+    mconcat
+      [ Opt.metavar "Legacy commands"
+      , Opt.commandGroup "Legacy commands"
+      , Opt.command "address" $
+          Opt.info (LegacyAddressCmds <$> pAddressCmds envCli) $
+            Opt.progDesc "Payment address commands"
+      , Opt.command "stake-address" $
+          Opt.info (LegacyStakeAddressCmds <$> pStakeAddressCmds envCli) $
+            Opt.progDesc "Stake address commands"
+      , Opt.command "key" $
+          Opt.info (LegacyKeyCmds <$> pKeyCmds) $
+            Opt.progDesc "Key utility commands"
+      , Opt.command "transaction" $
+          Opt.info (LegacyTransactionCmds <$> pTransaction envCli) $
+            Opt.progDesc "Transaction commands"
+      , Opt.command "node" $
+          Opt.info (LegacyNodeCmds <$> pNodeCmds) $
+            Opt.progDesc "Node operation commands"
+      , Opt.command "stake-pool" $
+          Opt.info (LegacyStakePoolCmds <$> pStakePoolCmds envCli) $
+            Opt.progDesc "Stake pool commands"
+      , Opt.command "query" $
+          Opt.info (LegacyQueryCmds <$> pQueryCmds envCli) . Opt.progDesc $
+            mconcat
+              [ "Node query commands. Will query the local node whose Unix domain socket "
+              , "is obtained from the CARDANO_NODE_SOCKET_PATH environment variable."
+              ]
+      , Opt.command "genesis" $
+          Opt.info (LegacyGenesisCmds <$> pGenesisCmds envCli) $
+            Opt.progDesc "Genesis block commands"
+      , Opt.command "governance" $
+          Opt.info (LegacyGovernanceCmds <$> pGovernanceCmds envCli) $
+            Opt.progDesc "Governance commands"
+      , Opt.command "text-view" $
+          Opt.info (LegacyTextViewCmds <$> pTextViewCmds) . Opt.progDesc $
+            mconcat
+              [ "Commands for dealing with Shelley TextView files. "
+              , "Transactions, addresses etc are stored on disk as TextView files."
+              ]
+      ]
 
 pTextViewCmds :: Parser LegacyTextViewCmds
 pTextViewCmds =
   asum
-    [ subParser "decode-cbor"
-        (Opt.info (TextViewInfo <$> pCBORInFile <*> pMaybeOutputFile)
-          $ Opt.progDesc "Print a TextView file as decoded CBOR."
-          )
+    [ subParser
+        "decode-cbor"
+        ( Opt.info (TextViewInfo <$> pCBORInFile <*> pMaybeOutputFile) $
+            Opt.progDesc "Print a TextView file as decoded CBOR."
+        )
     ]
 
 pAddressCmds :: EnvCli -> Parser LegacyAddressCmds
 pAddressCmds envCli =
-   asum
-     [ subParser "key-gen"
-         (Opt.info pAddressKeyGen $ Opt.progDesc "Create an address key pair.")
-     , subParser "key-hash"
-         (Opt.info pAddressKeyHash $ Opt.progDesc "Print the hash of an address key.")
-     , subParser "build"
-         (Opt.info pAddressBuild $ Opt.progDesc "Build a Shelley payment address, with optional delegation to a stake address.")
-     , subParser "info"
-         (Opt.info pAddressInfo $ Opt.progDesc "Print information about an address.")
-     ]
-  where
-    pAddressKeyGen :: Parser LegacyAddressCmds
-    pAddressKeyGen =
-      AddressKeyGen
-        <$> pKeyOutputFormat
-        <*> pAddressKeyType
-        <*> pVerificationKeyFileOut
-        <*> pSigningKeyFileOut
+  asum
+    [ subParser
+        "key-gen"
+        (Opt.info pAddressKeyGen $ Opt.progDesc "Create an address key pair.")
+    , subParser
+        "key-hash"
+        (Opt.info pAddressKeyHash $ Opt.progDesc "Print the hash of an address key.")
+    , subParser
+        "build"
+        ( Opt.info pAddressBuild $
+            Opt.progDesc "Build a Shelley payment address, with optional delegation to a stake address."
+        )
+    , subParser
+        "info"
+        (Opt.info pAddressInfo $ Opt.progDesc "Print information about an address.")
+    ]
+ where
+  pAddressKeyGen :: Parser LegacyAddressCmds
+  pAddressKeyGen =
+    AddressKeyGen
+      <$> pKeyOutputFormat
+      <*> pAddressKeyType
+      <*> pVerificationKeyFileOut
+      <*> pSigningKeyFileOut
 
-    pAddressKeyHash :: Parser LegacyAddressCmds
-    pAddressKeyHash =
-      AddressKeyHash
-        <$> pPaymentVerificationKeyTextOrFile
-        <*> pMaybeOutputFile
+  pAddressKeyHash :: Parser LegacyAddressCmds
+  pAddressKeyHash =
+    AddressKeyHash
+      <$> pPaymentVerificationKeyTextOrFile
+      <*> pMaybeOutputFile
 
-    pAddressBuild :: Parser LegacyAddressCmds
-    pAddressBuild = AddressBuild
+  pAddressBuild :: Parser LegacyAddressCmds
+  pAddressBuild =
+    AddressBuild
       <$> pPaymentVerifier
       <*> Opt.optional pStakeIdentifier
       <*> pNetworkId envCli
       <*> pMaybeOutputFile
 
-    pAddressInfo :: Parser LegacyAddressCmds
-    pAddressInfo = AddressInfo <$> pAddress <*> pMaybeOutputFile
+  pAddressInfo :: Parser LegacyAddressCmds
+  pAddressInfo = AddressInfo <$> pAddress <*> pMaybeOutputFile
 
 pStakeAddressCmds :: EnvCli -> Parser LegacyStakeAddressCmds
 pStakeAddressCmds envCli =
-    asum
-      [ subParser "key-gen"
-          $ Opt.info pStakeAddressKeyGenCmd
-          $ Opt.progDesc "Create a stake address key pair"
-      , subParser "build"
-          $ Opt.info pStakeAddressBuildCmd
-          $ Opt.progDesc "Build a stake address"
-      , subParser "key-hash"
-          $ Opt.info pStakeAddressKeyHashCmd
-          $ Opt.progDesc "Print the hash of a stake address key."
-      , subParser "registration-certificate"
-          $ Opt.info pStakeAddressRegistrationCertificateCmd
-          $ Opt.progDesc "Create a stake address registration certificate"
-      , subParser "deregistration-certificate"
-          $ Opt.info pStakeAddressDeregistrationCertificateCmd
-          $ Opt.progDesc "Create a stake address deregistration certificate"
-      , subParser "delegation-certificate"
-          $ Opt.info pStakeAddressStakeDelegationCertificateCmd
-          $ Opt.progDesc "Create a stake address pool delegation certificate"
-      ]
-  where
-    pStakeAddressKeyGenCmd :: Parser LegacyStakeAddressCmds
-    pStakeAddressKeyGenCmd =
-      StakeAddressKeyGenCmd
-        <$> pKeyOutputFormat
-        <*> pVerificationKeyFileOut
-        <*> pSigningKeyFileOut
+  asum
+    [ subParser "key-gen" $
+        Opt.info pStakeAddressKeyGenCmd $
+          Opt.progDesc "Create a stake address key pair"
+    , subParser "build" $
+        Opt.info pStakeAddressBuildCmd $
+          Opt.progDesc "Build a stake address"
+    , subParser "key-hash" $
+        Opt.info pStakeAddressKeyHashCmd $
+          Opt.progDesc "Print the hash of a stake address key."
+    , subParser "registration-certificate" $
+        Opt.info pStakeAddressRegistrationCertificateCmd $
+          Opt.progDesc "Create a stake address registration certificate"
+    , subParser "deregistration-certificate" $
+        Opt.info pStakeAddressDeregistrationCertificateCmd $
+          Opt.progDesc "Create a stake address deregistration certificate"
+    , subParser "delegation-certificate" $
+        Opt.info pStakeAddressStakeDelegationCertificateCmd $
+          Opt.progDesc "Create a stake address pool delegation certificate"
+    ]
+ where
+  pStakeAddressKeyGenCmd :: Parser LegacyStakeAddressCmds
+  pStakeAddressKeyGenCmd =
+    StakeAddressKeyGenCmd
+      <$> pKeyOutputFormat
+      <*> pVerificationKeyFileOut
+      <*> pSigningKeyFileOut
 
-    pStakeAddressKeyHashCmd :: Parser LegacyStakeAddressCmds
-    pStakeAddressKeyHashCmd =
-      StakeAddressKeyHashCmd
-        <$> pStakeVerificationKeyOrFile Nothing
-        <*> pMaybeOutputFile
+  pStakeAddressKeyHashCmd :: Parser LegacyStakeAddressCmds
+  pStakeAddressKeyHashCmd =
+    StakeAddressKeyHashCmd
+      <$> pStakeVerificationKeyOrFile Nothing
+      <*> pMaybeOutputFile
 
-    pStakeAddressBuildCmd :: Parser LegacyStakeAddressCmds
-    pStakeAddressBuildCmd =
-      StakeAddressBuildCmd
-        <$> pStakeVerifier
-        <*> pNetworkId envCli
-        <*> pMaybeOutputFile
+  pStakeAddressBuildCmd :: Parser LegacyStakeAddressCmds
+  pStakeAddressBuildCmd =
+    StakeAddressBuildCmd
+      <$> pStakeVerifier
+      <*> pNetworkId envCli
+      <*> pMaybeOutputFile
 
-    pStakeAddressRegistrationCertificateCmd :: Parser LegacyStakeAddressCmds
-    pStakeAddressRegistrationCertificateCmd =
-      StakeAddressRegistrationCertificateCmd
-        <$> pAnyShelleyBasedEra envCli
-        <*> pStakeIdentifier
-        <*> optional pKeyRegistDeposit
-        <*> pOutputFile
+  pStakeAddressRegistrationCertificateCmd :: Parser LegacyStakeAddressCmds
+  pStakeAddressRegistrationCertificateCmd =
+    StakeAddressRegistrationCertificateCmd
+      <$> pAnyShelleyBasedEra envCli
+      <*> pStakeIdentifier
+      <*> optional pKeyRegistDeposit
+      <*> pOutputFile
 
-    pStakeAddressDeregistrationCertificateCmd :: Parser LegacyStakeAddressCmds
-    pStakeAddressDeregistrationCertificateCmd =
-      StakeAddressDeregistrationCertificateCmd
-        <$> pAnyShelleyBasedEra envCli
-        <*> pStakeIdentifier
-        <*> optional pKeyRegistDeposit
-        <*> pOutputFile
+  pStakeAddressDeregistrationCertificateCmd :: Parser LegacyStakeAddressCmds
+  pStakeAddressDeregistrationCertificateCmd =
+    StakeAddressDeregistrationCertificateCmd
+      <$> pAnyShelleyBasedEra envCli
+      <*> pStakeIdentifier
+      <*> optional pKeyRegistDeposit
+      <*> pOutputFile
 
-    pStakeAddressStakeDelegationCertificateCmd :: Parser LegacyStakeAddressCmds
-    pStakeAddressStakeDelegationCertificateCmd =
-      StakeAddressDelegationCertificateCmd
-        <$> pAnyShelleyBasedEra envCli
-        <*> pStakeIdentifier
-        <*> pStakePoolVerificationKeyOrHashOrFile Nothing
-        <*> pOutputFile
+  pStakeAddressStakeDelegationCertificateCmd :: Parser LegacyStakeAddressCmds
+  pStakeAddressStakeDelegationCertificateCmd =
+    StakeAddressDelegationCertificateCmd
+      <$> pAnyShelleyBasedEra envCli
+      <*> pStakeIdentifier
+      <*> pStakePoolVerificationKeyOrHashOrFile Nothing
+      <*> pOutputFile
 
 pKeyCmds :: Parser LegacyKeyCmds
 pKeyCmds =
   asum
-    [ subParser "verification-key"
-        $ Opt.info pKeyGetVerificationKey
-        $ Opt.progDesc
-        $ mconcat
-            [ "Get a verification key from a signing key. This "
-            , " supports all key types."
-            ]
-    , subParser "non-extended-key"
-        $ Opt.info pKeyNonExtendedKey
-        $ Opt.progDesc
-        $ mconcat
-            [ "Get a non-extended verification key from an "
-            , "extended verification key. This supports all "
-            , "extended key types."
-            ]
-    , subParser "convert-byron-key"
-        $ Opt.info pKeyConvertByronKey
-        $ Opt.progDesc
-        $ mconcat
-            [ "Convert a Byron payment, genesis or genesis "
-            , "delegate key (signing or verification) to a "
-            , "corresponding Shelley-format key."
-            ]
-    , subParser "convert-byron-genesis-vkey"
-        $ Opt.info pKeyConvertByronGenesisVKey
-        $ Opt.progDesc
-        $ mconcat
-            [ "Convert a Base64-encoded Byron genesis "
-            , "verification key to a Shelley genesis "
-            , "verification key"
-            ]
-    , subParser "convert-itn-key"
-        $ Opt.info pKeyConvertITNKey
-        $ Opt.progDesc
-        $ mconcat
-            [ "Convert an Incentivized Testnet (ITN) non-extended "
-            , "(Ed25519) signing or verification key to a "
-            , "corresponding Shelley stake key"
-            ]
-    , subParser "convert-itn-extended-key"
-        $ Opt.info pKeyConvertITNExtendedKey
-        $ Opt.progDesc
-        $ mconcat
-            [ "Convert an Incentivized Testnet (ITN) extended "
-            , "(Ed25519Extended) signing key to a corresponding "
-            , "Shelley stake signing key"
-            ]
-    , subParser "convert-itn-bip32-key"
-        $ Opt.info pKeyConvertITNBip32Key
-        $ Opt.progDesc
-        $ mconcat
-            [ "Convert an Incentivized Testnet (ITN) BIP32 "
-            , "(Ed25519Bip32) signing key to a corresponding "
-            , "Shelley stake signing key"
-            ]
-    , subParser "convert-cardano-address-key"
-        $ Opt.info pKeyConvertCardanoAddressSigningKey
-        $ Opt.progDesc
-        $ mconcat
-            [ "Convert a cardano-address extended signing key "
-            , "to a corresponding Shelley-format key."
-            ]
+    [ subParser "verification-key" $
+        Opt.info pKeyGetVerificationKey $
+          Opt.progDesc $
+            mconcat
+              [ "Get a verification key from a signing key. This "
+              , " supports all key types."
+              ]
+    , subParser "non-extended-key" $
+        Opt.info pKeyNonExtendedKey $
+          Opt.progDesc $
+            mconcat
+              [ "Get a non-extended verification key from an "
+              , "extended verification key. This supports all "
+              , "extended key types."
+              ]
+    , subParser "convert-byron-key" $
+        Opt.info pKeyConvertByronKey $
+          Opt.progDesc $
+            mconcat
+              [ "Convert a Byron payment, genesis or genesis "
+              , "delegate key (signing or verification) to a "
+              , "corresponding Shelley-format key."
+              ]
+    , subParser "convert-byron-genesis-vkey" $
+        Opt.info pKeyConvertByronGenesisVKey $
+          Opt.progDesc $
+            mconcat
+              [ "Convert a Base64-encoded Byron genesis "
+              , "verification key to a Shelley genesis "
+              , "verification key"
+              ]
+    , subParser "convert-itn-key" $
+        Opt.info pKeyConvertITNKey $
+          Opt.progDesc $
+            mconcat
+              [ "Convert an Incentivized Testnet (ITN) non-extended "
+              , "(Ed25519) signing or verification key to a "
+              , "corresponding Shelley stake key"
+              ]
+    , subParser "convert-itn-extended-key" $
+        Opt.info pKeyConvertITNExtendedKey $
+          Opt.progDesc $
+            mconcat
+              [ "Convert an Incentivized Testnet (ITN) extended "
+              , "(Ed25519Extended) signing key to a corresponding "
+              , "Shelley stake signing key"
+              ]
+    , subParser "convert-itn-bip32-key" $
+        Opt.info pKeyConvertITNBip32Key $
+          Opt.progDesc $
+            mconcat
+              [ "Convert an Incentivized Testnet (ITN) BIP32 "
+              , "(Ed25519Bip32) signing key to a corresponding "
+              , "Shelley stake signing key"
+              ]
+    , subParser "convert-cardano-address-key" $
+        Opt.info pKeyConvertCardanoAddressSigningKey $
+          Opt.progDesc $
+            mconcat
+              [ "Convert a cardano-address extended signing key "
+              , "to a corresponding Shelley-format key."
+              ]
     ]
-  where
-    pKeyGetVerificationKey :: Parser LegacyKeyCmds
-    pKeyGetVerificationKey =
-      KeyGetVerificationKey
-        <$> pSigningKeyFileIn
-        <*> pVerificationKeyFileOut
+ where
+  pKeyGetVerificationKey :: Parser LegacyKeyCmds
+  pKeyGetVerificationKey =
+    KeyGetVerificationKey
+      <$> pSigningKeyFileIn
+      <*> pVerificationKeyFileOut
 
-    pKeyNonExtendedKey :: Parser LegacyKeyCmds
-    pKeyNonExtendedKey =
-      KeyNonExtendedKey
-        <$> pExtendedVerificationKeyFileIn
-        <*> pVerificationKeyFileOut
+  pKeyNonExtendedKey :: Parser LegacyKeyCmds
+  pKeyNonExtendedKey =
+    KeyNonExtendedKey
+      <$> pExtendedVerificationKeyFileIn
+      <*> pVerificationKeyFileOut
 
-    pKeyConvertByronKey :: Parser LegacyKeyCmds
-    pKeyConvertByronKey =
-      KeyConvertByronKey
-        <$> optional pPassword
-        <*> pByronKeyType
-        <*> pByronKeyFile
-        <*> pOutputFile
+  pKeyConvertByronKey :: Parser LegacyKeyCmds
+  pKeyConvertByronKey =
+    KeyConvertByronKey
+      <$> optional pPassword
+      <*> pByronKeyType
+      <*> pByronKeyFile
+      <*> pOutputFile
 
-    pPassword :: Parser Text
-    pPassword =
-      Opt.strOption $ mconcat
+  pPassword :: Parser Text
+  pPassword =
+    Opt.strOption $
+      mconcat
         [ Opt.long "password"
         , Opt.metavar "TEXT"
         , Opt.help "Password for signing key (if applicable)."
         ]
 
-    pByronKeyType :: Parser ByronKeyType
-    pByronKeyType =
-      asum
-        [ Opt.flag' (ByronPaymentKey NonLegacyByronKeyFormat) $ mconcat
+  pByronKeyType :: Parser ByronKeyType
+  pByronKeyType =
+    asum
+      [ Opt.flag' (ByronPaymentKey NonLegacyByronKeyFormat) $
+          mconcat
             [ Opt.long "byron-payment-key-type"
             , Opt.help "Use a Byron-era payment key."
             ]
-        , Opt.flag' (ByronPaymentKey LegacyByronKeyFormat) $ mconcat
+      , Opt.flag' (ByronPaymentKey LegacyByronKeyFormat) $
+          mconcat
             [ Opt.long "legacy-byron-payment-key-type"
             , Opt.help "Use a Byron-era payment key, in legacy SL format."
             ]
-        , Opt.flag' (ByronGenesisKey NonLegacyByronKeyFormat) $ mconcat
+      , Opt.flag' (ByronGenesisKey NonLegacyByronKeyFormat) $
+          mconcat
             [ Opt.long "byron-genesis-key-type"
             , Opt.help "Use a Byron-era genesis key."
             ]
-        , Opt.flag' (ByronGenesisKey LegacyByronKeyFormat) $ mconcat
+      , Opt.flag' (ByronGenesisKey LegacyByronKeyFormat) $
+          mconcat
             [ Opt.long "legacy-byron-genesis-key-type"
             , Opt.help "Use a Byron-era genesis key, in legacy SL format."
             ]
-        , Opt.flag' (ByronDelegateKey NonLegacyByronKeyFormat) $ mconcat
+      , Opt.flag' (ByronDelegateKey NonLegacyByronKeyFormat) $
+          mconcat
             [ Opt.long "byron-genesis-delegate-key-type"
             , Opt.help "Use a Byron-era genesis delegate key."
             ]
-        , Opt.flag' (ByronDelegateKey LegacyByronKeyFormat) $ mconcat
+      , Opt.flag' (ByronDelegateKey LegacyByronKeyFormat) $
+          mconcat
             [ Opt.long "legacy-byron-genesis-delegate-key-type"
             , Opt.help "Use a Byron-era genesis delegate key, in legacy SL format."
             ]
-        ]
+      ]
 
-    pByronKeyFile :: Parser (SomeKeyFile In)
-    pByronKeyFile =
-      asum
-        [ ASigningKeyFile      <$> pByronSigningKeyFile
-        , AVerificationKeyFile <$> pByronVerificationKeyFile
-        ]
+  pByronKeyFile :: Parser (SomeKeyFile In)
+  pByronKeyFile =
+    asum
+      [ ASigningKeyFile <$> pByronSigningKeyFile
+      , AVerificationKeyFile <$> pByronVerificationKeyFile
+      ]
 
-    pByronSigningKeyFile :: Parser (SigningKeyFile In)
-    pByronSigningKeyFile =
-      fmap File $ Opt.strOption $ mconcat
-        [ Opt.long "byron-signing-key-file"
-        , Opt.metavar "FILE"
-        , Opt.help "Input filepath of the Byron-format signing key."
-        , Opt.completer (Opt.bashCompleter "file")
-        ]
+  pByronSigningKeyFile :: Parser (SigningKeyFile In)
+  pByronSigningKeyFile =
+    fmap File $
+      Opt.strOption $
+        mconcat
+          [ Opt.long "byron-signing-key-file"
+          , Opt.metavar "FILE"
+          , Opt.help "Input filepath of the Byron-format signing key."
+          , Opt.completer (Opt.bashCompleter "file")
+          ]
 
-    pByronVerificationKeyFile :: Parser (VerificationKeyFile In)
-    pByronVerificationKeyFile =
-      fmap File $ Opt.strOption $ mconcat
-        [ Opt.long "byron-verification-key-file"
-        , Opt.metavar "FILE"
-        , Opt.help "Input filepath of the Byron-format verification key."
-        , Opt.completer (Opt.bashCompleter "file")
-        ]
+  pByronVerificationKeyFile :: Parser (VerificationKeyFile In)
+  pByronVerificationKeyFile =
+    fmap File $
+      Opt.strOption $
+        mconcat
+          [ Opt.long "byron-verification-key-file"
+          , Opt.metavar "FILE"
+          , Opt.help "Input filepath of the Byron-format verification key."
+          , Opt.completer (Opt.bashCompleter "file")
+          ]
 
-    pKeyConvertByronGenesisVKey :: Parser LegacyKeyCmds
-    pKeyConvertByronGenesisVKey =
-      KeyConvertByronGenesisVKey
-        <$> pByronGenesisVKeyBase64
-        <*> pOutputFile
+  pKeyConvertByronGenesisVKey :: Parser LegacyKeyCmds
+  pKeyConvertByronGenesisVKey =
+    KeyConvertByronGenesisVKey
+      <$> pByronGenesisVKeyBase64
+      <*> pOutputFile
 
-    pByronGenesisVKeyBase64 :: Parser VerificationKeyBase64
-    pByronGenesisVKeyBase64 =
-      fmap VerificationKeyBase64 $ Opt.strOption $ mconcat
-        [ Opt.long "byron-genesis-verification-key"
-        , Opt.metavar "BASE64"
-        , Opt.help "Base64 string for the Byron genesis verification key."
-        ]
+  pByronGenesisVKeyBase64 :: Parser VerificationKeyBase64
+  pByronGenesisVKeyBase64 =
+    fmap VerificationKeyBase64 $
+      Opt.strOption $
+        mconcat
+          [ Opt.long "byron-genesis-verification-key"
+          , Opt.metavar "BASE64"
+          , Opt.help "Base64 string for the Byron genesis verification key."
+          ]
 
-    pKeyConvertITNKey :: Parser LegacyKeyCmds
-    pKeyConvertITNKey =
-      KeyConvertITNStakeKey
-        <$> pITNKeyFIle
-        <*> pOutputFile
+  pKeyConvertITNKey :: Parser LegacyKeyCmds
+  pKeyConvertITNKey =
+    KeyConvertITNStakeKey
+      <$> pITNKeyFIle
+      <*> pOutputFile
 
-    pKeyConvertITNExtendedKey :: Parser LegacyKeyCmds
-    pKeyConvertITNExtendedKey =
-      KeyConvertITNExtendedToStakeKey
-        <$> pITNSigningKeyFile
-        <*> pOutputFile
+  pKeyConvertITNExtendedKey :: Parser LegacyKeyCmds
+  pKeyConvertITNExtendedKey =
+    KeyConvertITNExtendedToStakeKey
+      <$> pITNSigningKeyFile
+      <*> pOutputFile
 
-    pKeyConvertITNBip32Key :: Parser LegacyKeyCmds
-    pKeyConvertITNBip32Key =
-      KeyConvertITNBip32ToStakeKey
-        <$> pITNSigningKeyFile
-        <*> pOutputFile
+  pKeyConvertITNBip32Key :: Parser LegacyKeyCmds
+  pKeyConvertITNBip32Key =
+    KeyConvertITNBip32ToStakeKey
+      <$> pITNSigningKeyFile
+      <*> pOutputFile
 
-    pITNKeyFIle :: Parser (SomeKeyFile direction)
-    pITNKeyFIle =
-      asum
-        [ pITNSigningKeyFile
-        , pITNVerificationKeyFile
-        ]
+  pITNKeyFIle :: Parser (SomeKeyFile direction)
+  pITNKeyFIle =
+    asum
+      [ pITNSigningKeyFile
+      , pITNVerificationKeyFile
+      ]
 
-    pITNSigningKeyFile :: Parser (SomeKeyFile direction)
-    pITNSigningKeyFile =
-      fmap (ASigningKeyFile . File) $ Opt.strOption $ mconcat
-        [ Opt.long "itn-signing-key-file"
-        , Opt.metavar "FILE"
-        , Opt.help "Filepath of the ITN signing key."
-        , Opt.completer (Opt.bashCompleter "file")
-        ]
+  pITNSigningKeyFile :: Parser (SomeKeyFile direction)
+  pITNSigningKeyFile =
+    fmap (ASigningKeyFile . File) $
+      Opt.strOption $
+        mconcat
+          [ Opt.long "itn-signing-key-file"
+          , Opt.metavar "FILE"
+          , Opt.help "Filepath of the ITN signing key."
+          , Opt.completer (Opt.bashCompleter "file")
+          ]
 
-    pITNVerificationKeyFile :: Parser (SomeKeyFile direction)
-    pITNVerificationKeyFile =
-      fmap (AVerificationKeyFile . File) $ Opt.strOption $ mconcat
-        [ Opt.long "itn-verification-key-file"
-        , Opt.metavar "FILE"
-        , Opt.help "Filepath of the ITN verification key."
-        , Opt.completer (Opt.bashCompleter "file")
-        ]
+  pITNVerificationKeyFile :: Parser (SomeKeyFile direction)
+  pITNVerificationKeyFile =
+    fmap (AVerificationKeyFile . File) $
+      Opt.strOption $
+        mconcat
+          [ Opt.long "itn-verification-key-file"
+          , Opt.metavar "FILE"
+          , Opt.help "Filepath of the ITN verification key."
+          , Opt.completer (Opt.bashCompleter "file")
+          ]
 
-    pKeyConvertCardanoAddressSigningKey :: Parser LegacyKeyCmds
-    pKeyConvertCardanoAddressSigningKey =
-      KeyConvertCardanoAddressSigningKey
-        <$> pCardanoAddressKeyType
-        <*> pSigningKeyFileIn
-        <*> pOutputFile
+  pKeyConvertCardanoAddressSigningKey :: Parser LegacyKeyCmds
+  pKeyConvertCardanoAddressSigningKey =
+    KeyConvertCardanoAddressSigningKey
+      <$> pCardanoAddressKeyType
+      <*> pSigningKeyFileIn
+      <*> pOutputFile
 
-    pCardanoAddressKeyType :: Parser CardanoAddressKeyType
-    pCardanoAddressKeyType =
-      asum
-        [ Opt.flag' CardanoAddressShelleyPaymentKey $ mconcat
+  pCardanoAddressKeyType :: Parser CardanoAddressKeyType
+  pCardanoAddressKeyType =
+    asum
+      [ Opt.flag' CardanoAddressShelleyPaymentKey $
+          mconcat
             [ Opt.long "shelley-payment-key"
             , Opt.help "Use a Shelley-era extended payment key."
             ]
-        , Opt.flag' CardanoAddressShelleyStakeKey $ mconcat
+      , Opt.flag' CardanoAddressShelleyStakeKey $
+          mconcat
             [ Opt.long "shelley-stake-key"
             , Opt.help "Use a Shelley-era extended stake key."
             ]
-        , Opt.flag' CardanoAddressIcarusPaymentKey $ mconcat
+      , Opt.flag' CardanoAddressIcarusPaymentKey $
+          mconcat
             [ Opt.long "icarus-payment-key"
             , Opt.help "Use a Byron-era extended payment key formatted in the Icarus style."
             ]
-        , Opt.flag' CardanoAddressByronPaymentKey $ mconcat
+      , Opt.flag' CardanoAddressByronPaymentKey $
+          mconcat
             [ Opt.long "byron-payment-key"
             , Opt.help "Use a Byron-era extended payment key formatted in the deprecated Byron style."
             ]
-        ]
+      ]
 
 pTransaction :: EnvCli -> Parser LegacyTransactionCmds
 pTransaction envCli =
   asum
-    [ subParser "build-raw"
-        $ Opt.info pTransactionBuildRaw $ Opt.progDescDoc $ Just $ mconcat
-          [ pretty @String "Build a transaction (low-level, inconvenient)"
-          , line
-          , line
-          , H.yellow $ mconcat
-            [ "Please note the order of some cmd options is crucial. If used incorrectly may produce "
-            , "undesired tx body. See nested [] notation above for details."
-            ]
-          ]
-    , subParser "build"
-        $ Opt.info pTransactionBuild $ Opt.progDescDoc $ Just $ mconcat
-          [ pretty @String "Build a balanced transaction (automatically calculates fees)"
-          , line
-          , line
-          , H.yellow $ mconcat
-            [ "Please note "
-            , H.underline "the order"
-            , " of some cmd options is crucial. If used incorrectly may produce "
-            , "undesired tx body. See nested [] notation above for details."
-            ]
-          ]
-    , subParser "sign"
+    [ subParser "build-raw" $
+        Opt.info pTransactionBuildRaw $
+          Opt.progDescDoc $
+            Just $
+              mconcat
+                [ pretty @String "Build a transaction (low-level, inconvenient)"
+                , line
+                , line
+                , H.yellow $
+                    mconcat
+                      [ "Please note the order of some cmd options is crucial. If used incorrectly may produce "
+                      , "undesired tx body. See nested [] notation above for details."
+                      ]
+                ]
+    , subParser "build" $
+        Opt.info pTransactionBuild $
+          Opt.progDescDoc $
+            Just $
+              mconcat
+                [ pretty @String "Build a balanced transaction (automatically calculates fees)"
+                , line
+                , line
+                , H.yellow $
+                    mconcat
+                      [ "Please note "
+                      , H.underline "the order"
+                      , " of some cmd options is crucial. If used incorrectly may produce "
+                      , "undesired tx body. See nested [] notation above for details."
+                      ]
+                ]
+    , subParser
+        "sign"
         (Opt.info pTransactionSign $ Opt.progDesc "Sign a transaction")
-    , subParser "witness"
+    , subParser
+        "witness"
         (Opt.info pTransactionCreateWitness $ Opt.progDesc "Create a transaction witness")
-    , subParser "assemble"
-        (Opt.info pTransactionAssembleTxBodyWit
-          $ Opt.progDesc "Assemble a tx body and witness(es) to form a transaction")
+    , subParser
+        "assemble"
+        ( Opt.info pTransactionAssembleTxBodyWit $
+            Opt.progDesc "Assemble a tx body and witness(es) to form a transaction"
+        )
     , pSignWitnessBackwardCompatible
-    , subParser "submit"
-        (Opt.info pTransactionSubmit . Opt.progDesc $
-           mconcat
-             [ "Submit a transaction to the local node whose Unix domain socket "
-             , "is obtained from the CARDANO_NODE_SOCKET_PATH environment variable."
-             ]
-          )
-    , subParser "policyid"
-        (Opt.info pTransactionPolicyId $ Opt.progDesc "Calculate the PolicyId from the monetary policy script.")
-    , subParser "calculate-min-fee"
+    , subParser
+        "submit"
+        ( Opt.info pTransactionSubmit . Opt.progDesc $
+            mconcat
+              [ "Submit a transaction to the local node whose Unix domain socket "
+              , "is obtained from the CARDANO_NODE_SOCKET_PATH environment variable."
+              ]
+        )
+    , subParser
+        "policyid"
+        ( Opt.info pTransactionPolicyId $
+            Opt.progDesc "Calculate the PolicyId from the monetary policy script."
+        )
+    , subParser
+        "calculate-min-fee"
         (Opt.info pTransactionCalculateMinFee $ Opt.progDesc "Calculate the minimum fee for a transaction.")
-    , subParser "calculate-min-required-utxo"
-        (Opt.info pTransactionCalculateMinReqUTxO $ Opt.progDesc "Calculate the minimum required UTxO for a transaction output.")
+    , subParser
+        "calculate-min-required-utxo"
+        ( Opt.info pTransactionCalculateMinReqUTxO $
+            Opt.progDesc "Calculate the minimum required UTxO for a transaction output."
+        )
     , pCalculateMinRequiredUtxoBackwardCompatible
-    , subParser "hash-script-data"
+    , subParser
+        "hash-script-data"
         (Opt.info pTxHashScriptData $ Opt.progDesc "Calculate the hash of script data.")
-    , subParser "txid"
+    , subParser
+        "txid"
         (Opt.info pTransactionId $ Opt.progDesc "Print a transaction identifier.")
     , subParser "view" $
-        Opt.info pTransactionView $ Opt.progDesc "Print a transaction."
+        Opt.info pTransactionView $
+          Opt.progDesc "Print a transaction."
     ]
  where
   -- Backwards compatible parsers
   calcMinValueInfo :: ParserInfo LegacyTransactionCmds
   calcMinValueInfo =
-    Opt.info pTransactionCalculateMinReqUTxO
-      $ Opt.progDesc "DEPRECATED: Use 'calculate-min-required-utxo' instead."
+    Opt.info pTransactionCalculateMinReqUTxO $
+      Opt.progDesc "DEPRECATED: Use 'calculate-min-required-utxo' instead."
 
   pCalculateMinRequiredUtxoBackwardCompatible :: Parser LegacyTransactionCmds
   pCalculateMinRequiredUtxoBackwardCompatible =
-    Opt.subparser
-      $ Opt.command "calculate-min-value" calcMinValueInfo <> Opt.internal
+    Opt.subparser $
+      Opt.command "calculate-min-value" calcMinValueInfo <> Opt.internal
 
   assembleInfo :: ParserInfo LegacyTransactionCmds
   assembleInfo =
-    Opt.info pTransactionAssembleTxBodyWit
-      $ Opt.progDesc "Assemble a tx body and witness(es) to form a transaction"
+    Opt.info pTransactionAssembleTxBodyWit $
+      Opt.progDesc "Assemble a tx body and witness(es) to form a transaction"
 
   pSignWitnessBackwardCompatible :: Parser LegacyTransactionCmds
   pSignWitnessBackwardCompatible =
-    Opt.subparser
-      $ Opt.command "sign-witness" assembleInfo <> Opt.internal
+    Opt.subparser $
+      Opt.command "sign-witness" assembleInfo <> Opt.internal
 
   pScriptValidity :: Parser ScriptValidity
-  pScriptValidity = asum
-    [ Opt.flag' ScriptValid $ mconcat
-      [ Opt.long "script-valid"
-      , Opt.help "Assertion that the script is valid. (default)"
+  pScriptValidity =
+    asum
+      [ Opt.flag' ScriptValid $
+          mconcat
+            [ Opt.long "script-valid"
+            , Opt.help "Assertion that the script is valid. (default)"
+            ]
+      , Opt.flag' ScriptInvalid $
+          mconcat
+            [ Opt.long "script-invalid"
+            , Opt.help $
+                mconcat
+                  [ "Assertion that the script is invalid.  "
+                  , "If a transaction is submitted with such a script, "
+                  , "the script will fail and the collateral will be taken."
+                  ]
+            ]
       ]
-    , Opt.flag' ScriptInvalid $ mconcat
-      [ Opt.long "script-invalid"
-      , Opt.help $ mconcat
-        [ "Assertion that the script is invalid.  "
-        , "If a transaction is submitted with such a script, "
-        , "the script will fail and the collateral will be taken."
-        ]
-      ]
-    ]
 
   pTransactionBuild :: Parser LegacyTransactionCmds
   pTransactionBuild =
@@ -562,10 +618,12 @@ pTransaction envCli =
       <*> many (pCertificateFile AutoBalance)
       <*> many (pWithdrawal AutoBalance)
       <*> pTxMetadataJsonSchema
-      <*> many (pScriptFor
-                  "auxiliary-script-file"
-                  Nothing
-                  "Filepath of auxiliary script(s)")
+      <*> many
+        ( pScriptFor
+            "auxiliary-script-file"
+            Nothing
+            "Filepath of auxiliary script(s)"
+        )
       <*> many pMetadataFile
       <*> optional pUpdateProposalFile
       <*> many (pFileInDirection "vote-file" "Filepath of the vote.")
@@ -574,11 +632,13 @@ pTransaction envCli =
 
   pChangeAddress :: Parser TxOutChangeAddress
   pChangeAddress =
-    fmap TxOutChangeAddress $ Opt.option (readerFromParsecParser parseAddressAny) $ mconcat
-      [ Opt.long "change-address"
-      , Opt.metavar "ADDRESS"
-      , Opt.help "Address where ADA in excess of the tx fee will go to."
-      ]
+    fmap TxOutChangeAddress $
+      Opt.option (readerFromParsecParser parseAddressAny) $
+        mconcat
+          [ Opt.long "change-address"
+          , Opt.metavar "ADDRESS"
+          , Opt.help "Address where ADA in excess of the tx fee will go to."
+          ]
 
   pTransactionBuildRaw :: Parser LegacyTransactionCmds
   pTransactionBuildRaw =
@@ -596,7 +656,7 @@ pTransaction envCli =
       <*> optional pInvalidBefore
       <*> optional pInvalidHereafter
       <*> optional pTxFee
-      <*> many (pCertificateFile ManualBalance )
+      <*> many (pCertificateFile ManualBalance)
       <*> many (pWithdrawal ManualBalance)
       <*> pTxMetadataJsonSchema
       <*> many (pScriptFor "auxiliary-script-file" Nothing "Filepath of auxiliary script(s)")
@@ -605,7 +665,7 @@ pTransaction envCli =
       <*> optional pUpdateProposalFile
       <*> pTxBodyFileOut
 
-  pTransactionSign  :: Parser LegacyTransactionCmds
+  pTransactionSign :: Parser LegacyTransactionCmds
   pTransactionSign =
     TxSign
       <$> pInputTxOrTxBodyFile
@@ -651,20 +711,21 @@ pTransaction envCli =
       <*> pTxByronWitnessCount
 
   pTransactionCalculateMinReqUTxO :: Parser LegacyTransactionCmds
-  pTransactionCalculateMinReqUTxO = TxCalculateMinRequiredUTxO
-    <$> pLegacyCardanoEra envCli
-    <*> pProtocolParamsFile
-    <*> pTxOut
+  pTransactionCalculateMinReqUTxO =
+    TxCalculateMinRequiredUTxO
+      <$> pLegacyCardanoEra envCli
+      <*> pProtocolParamsFile
+      <*> pTxOut
 
   pTxHashScriptData :: Parser LegacyTransactionCmds
   pTxHashScriptData =
-    fmap TxHashScriptData
-      $ pScriptDataOrFile
-          "script-data"
-          "The script data, in JSON syntax."
-          "The script data, in the given JSON file."
+    fmap TxHashScriptData $
+      pScriptDataOrFile
+        "script-data"
+        "The script data, in JSON syntax."
+        "The script data, in the given JSON file."
 
-  pTransactionId  :: Parser LegacyTransactionCmds
+  pTransactionId :: Parser LegacyTransactionCmds
   pTransactionId = TxGetTxId <$> pInputTxOrTxBodyFile
 
   pTransactionView :: Parser LegacyTransactionCmds
@@ -673,718 +734,761 @@ pTransaction envCli =
 pNodeCmds :: Parser LegacyNodeCmds
 pNodeCmds =
   asum
-    [ subParser "key-gen" . Opt.info pKeyGenOperator . Opt.progDesc $ mconcat
-      [ "Create a key pair for a node operator's offline "
-      , "key and a new certificate issue counter"
-      ]
-    , subParser "key-gen-KES" . Opt.info pKeyGenKES . Opt.progDesc $ mconcat
-      [ "Create a key pair for a node KES operational key"
-      ]
-    , subParser "key-gen-VRF" . Opt.info pKeyGenVRF . Opt.progDesc $ mconcat
-      [ "Create a key pair for a node VRF operational key"
-      ]
-    , subParser "key-hash-VRF". Opt.info pKeyHashVRF . Opt.progDesc $ mconcat
-      [ "Print hash of a node's operational VRF key."
-      ]
-    , subParser "new-counter" . Opt.info pNewCounter . Opt.progDesc $ mconcat
-      [ "Create a new certificate issue counter"
-      ]
-    , subParser "issue-op-cert" . Opt.info pIssueOpCert . Opt.progDesc $ mconcat
-      [ "Issue a node operational certificate"
-      ]
+    [ subParser "key-gen" . Opt.info pKeyGenOperator . Opt.progDesc $
+        mconcat
+          [ "Create a key pair for a node operator's offline "
+          , "key and a new certificate issue counter"
+          ]
+    , subParser "key-gen-KES" . Opt.info pKeyGenKES . Opt.progDesc $
+        mconcat
+          [ "Create a key pair for a node KES operational key"
+          ]
+    , subParser "key-gen-VRF" . Opt.info pKeyGenVRF . Opt.progDesc $
+        mconcat
+          [ "Create a key pair for a node VRF operational key"
+          ]
+    , subParser "key-hash-VRF" . Opt.info pKeyHashVRF . Opt.progDesc $
+        mconcat
+          [ "Print hash of a node's operational VRF key."
+          ]
+    , subParser "new-counter" . Opt.info pNewCounter . Opt.progDesc $
+        mconcat
+          [ "Create a new certificate issue counter"
+          ]
+    , subParser "issue-op-cert" . Opt.info pIssueOpCert . Opt.progDesc $
+        mconcat
+          [ "Issue a node operational certificate"
+          ]
     ]
-  where
-    pKeyGenOperator :: Parser LegacyNodeCmds
-    pKeyGenOperator =
-      NodeKeyGenCold
-        <$> pKeyOutputFormat
-        <*> pColdVerificationKeyFile
-        <*> pColdSigningKeyFile
-        <*> pOperatorCertIssueCounterFile
+ where
+  pKeyGenOperator :: Parser LegacyNodeCmds
+  pKeyGenOperator =
+    NodeKeyGenCold
+      <$> pKeyOutputFormat
+      <*> pColdVerificationKeyFile
+      <*> pColdSigningKeyFile
+      <*> pOperatorCertIssueCounterFile
 
-    pKeyGenKES :: Parser LegacyNodeCmds
-    pKeyGenKES =
-      NodeKeyGenKES
-        <$> pKeyOutputFormat
-        <*> pVerificationKeyFileOut
-        <*> pSigningKeyFileOut
+  pKeyGenKES :: Parser LegacyNodeCmds
+  pKeyGenKES =
+    NodeKeyGenKES
+      <$> pKeyOutputFormat
+      <*> pVerificationKeyFileOut
+      <*> pSigningKeyFileOut
 
-    pKeyGenVRF :: Parser LegacyNodeCmds
-    pKeyGenVRF =
-      NodeKeyGenVRF
-        <$> pKeyOutputFormat
-        <*> pVerificationKeyFileOut
-        <*> pSigningKeyFileOut
+  pKeyGenVRF :: Parser LegacyNodeCmds
+  pKeyGenVRF =
+    NodeKeyGenVRF
+      <$> pKeyOutputFormat
+      <*> pVerificationKeyFileOut
+      <*> pSigningKeyFileOut
 
-    pKeyHashVRF :: Parser LegacyNodeCmds
-    pKeyHashVRF =
-      NodeKeyHashVRF
-        <$> pVerificationKeyOrFileIn AsVrfKey
-        <*> pMaybeOutputFile
+  pKeyHashVRF :: Parser LegacyNodeCmds
+  pKeyHashVRF =
+    NodeKeyHashVRF
+      <$> pVerificationKeyOrFileIn AsVrfKey
+      <*> pMaybeOutputFile
 
-    pNewCounter :: Parser LegacyNodeCmds
-    pNewCounter =
-      NodeNewCounter
-        <$> pColdVerificationKeyOrFile Nothing
-        <*> pCounterValue
-        <*> pOperatorCertIssueCounterFile
+  pNewCounter :: Parser LegacyNodeCmds
+  pNewCounter =
+    NodeNewCounter
+      <$> pColdVerificationKeyOrFile Nothing
+      <*> pCounterValue
+      <*> pOperatorCertIssueCounterFile
 
-    pCounterValue :: Parser Word
-    pCounterValue =
-      Opt.option Opt.auto $ mconcat
+  pCounterValue :: Parser Word
+  pCounterValue =
+    Opt.option Opt.auto $
+      mconcat
         [ Opt.long "counter-value"
         , Opt.metavar "INT"
         , Opt.help "The next certificate issue counter value to use."
         ]
 
-    pIssueOpCert :: Parser LegacyNodeCmds
-    pIssueOpCert =
-      NodeIssueOpCert
-        <$> pKesVerificationKeyOrFile
-        <*> pColdSigningKeyFile
-        <*> pOperatorCertIssueCounterFile
-        <*> pKesPeriod
-        <*> pOutputFile
+  pIssueOpCert :: Parser LegacyNodeCmds
+  pIssueOpCert =
+    NodeIssueOpCert
+      <$> pKesVerificationKeyOrFile
+      <*> pColdSigningKeyFile
+      <*> pOperatorCertIssueCounterFile
+      <*> pKesPeriod
+      <*> pOutputFile
 
 pStakePoolCmds :: EnvCli -> Parser LegacyStakePoolCmds
-pStakePoolCmds  envCli =
+pStakePoolCmds envCli =
   asum
-    [ subParser "registration-certificate"
-        $ Opt.info (pStakePoolRegistrationCertificiateCmd envCli)
-        $ Opt.progDesc "Create a stake pool registration certificate"
-    , subParser "deregistration-certificate"
-        $ Opt.info (pStakePoolDeregistrationCertificateCmd envCli)
-        $ Opt.progDesc "Create a stake pool deregistration certificate"
-    , subParser "id"
-        $ Opt.info pStakePoolId
-        $ Opt.progDesc "Build pool id from the offline key"
-    , subParser "metadata-hash"
-        $ Opt.info pStakePoolMetadataHashCmd
-        $ Opt.progDesc "Print the hash of pool metadata."
+    [ subParser "registration-certificate" $
+        Opt.info (pStakePoolRegistrationCertificiateCmd envCli) $
+          Opt.progDesc "Create a stake pool registration certificate"
+    , subParser "deregistration-certificate" $
+        Opt.info (pStakePoolDeregistrationCertificateCmd envCli) $
+          Opt.progDesc "Create a stake pool deregistration certificate"
+    , subParser "id" $
+        Opt.info pStakePoolId $
+          Opt.progDesc "Build pool id from the offline key"
+    , subParser "metadata-hash" $
+        Opt.info pStakePoolMetadataHashCmd $
+          Opt.progDesc "Print the hash of pool metadata."
     ]
-  where
-    pStakePoolId :: Parser LegacyStakePoolCmds
-    pStakePoolId =
-      StakePoolIdCmd
-        <$> pStakePoolVerificationKeyOrFile Nothing
-        <*> pPoolIdOutputFormat
-        <*> pMaybeOutputFile
+ where
+  pStakePoolId :: Parser LegacyStakePoolCmds
+  pStakePoolId =
+    StakePoolIdCmd
+      <$> pStakePoolVerificationKeyOrFile Nothing
+      <*> pPoolIdOutputFormat
+      <*> pMaybeOutputFile
 
-    pStakePoolMetadataHashCmd :: Parser LegacyStakePoolCmds
-    pStakePoolMetadataHashCmd =
-      StakePoolMetadataHashCmd
-        <$> pPoolMetadataFile
-        <*> pMaybeOutputFile
+  pStakePoolMetadataHashCmd :: Parser LegacyStakePoolCmds
+  pStakePoolMetadataHashCmd =
+    StakePoolMetadataHashCmd
+      <$> pPoolMetadataFile
+      <*> pMaybeOutputFile
 
 pQueryCmds :: EnvCli -> Parser LegacyQueryCmds
 pQueryCmds envCli =
   asum
-    [ subParser "protocol-parameters"
-        $ Opt.info pQueryProtocolParameters
-        $ Opt.progDesc "Get the node's current protocol parameters"
-    , subParser "constitution-hash"
-        $ Opt.info pQueryConstitutionHash
-        $ Opt.progDesc "Get the constitution hash"
-    , subParser "tip"
-        $ Opt.info pQueryTip
-        $ Opt.progDesc "Get the node's current tip (slot no, hash, block no)"
-    , subParser "stake-pools"
-        $ Opt.info pQueryStakePools
-        $ Opt.progDesc "Get the node's current set of stake pool ids"
-    , subParser "stake-distribution"
-        $ Opt.info pQueryStakeDistribution
-        $ Opt.progDesc "Get the node's current aggregated stake distribution"
-    , subParser "stake-address-info"
-        $ Opt.info pQueryStakeAddressInfo
-        $ Opt.progDesc $ mconcat
-            [ "Get the current delegations and reward accounts filtered by stake address."
-            ]
-    , subParser "utxo"
-        $ Opt.info pQueryUTxO
-        $ Opt.progDesc $ mconcat
-            [ "Get a portion of the current UTxO: by tx in, by address or the whole."
-            ]
-    , subParser "ledger-state"
-        $ Opt.info pQueryLedgerState
-        $ Opt.progDesc $ mconcat
-            [ "Dump the current ledger state of the node (Ledger.NewEpochState -- advanced command)"
-            ]
-    , subParser "protocol-state"
-        $ Opt.info pQueryProtocolState
-        $ Opt.progDesc $ mconcat
-            [ "Dump the current protocol state of the node (Ledger.ChainDepState -- advanced command)"
-            ]
-    , subParser "stake-snapshot"
-        $ Opt.info pQueryStakeSnapshot
-        $ Opt.progDesc $ mconcat
-            [ "Obtain the three stake snapshots for a pool, plus the total active stake (advanced command)"
-            ]
-    , hiddenSubParser "pool-params"
-        $ Opt.info pQueryPoolState
-        $ Opt.progDesc $ mconcat
-            [ "DEPRECATED.  Use query pool-state instead.  Dump the pool parameters "
-            , "(Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced command)"
-            ]
-    , subParser "leadership-schedule"
-        $ Opt.info pLeadershipSchedule
-        $ Opt.progDesc "Get the slots the node is expected to mint a block in (advanced command)"
-    , subParser "kes-period-info"
-        $ Opt.info pKesPeriodInfo
-        $ Opt.progDesc "Get information about the current KES period and your node's operational certificate."
-    , subParser "pool-state"
-        $ Opt.info pQueryPoolState
-        $ Opt.progDesc "Dump the pool state"
-    , subParser "tx-mempool"
-        $ Opt.info pQueryTxMempool
-        $ Opt.progDesc "Local Mempool info"
-    , subParser "slot-number"
-        $ Opt.info pQuerySlotNumber
-        $ Opt.progDesc "Query slot number for UTC timestamp"
-    ]
-  where
-    pQueryProtocolParameters :: Parser LegacyQueryCmds
-    pQueryProtocolParameters =
-      QueryProtocolParameters'
-        <$> pSocketPath envCli
-        <*> pConsensusModeParams
-        <*> pNetworkId envCli
-        <*> pMaybeOutputFile
-
-    pQueryConstitutionHash :: Parser LegacyQueryCmds
-    pQueryConstitutionHash =
-      QueryConstitutionHash
-        <$> pSocketPath envCli
-        <*> pConsensusModeParams
-        <*> pNetworkId envCli
-        <*> pMaybeOutputFile
-
-    pQueryTip :: Parser LegacyQueryCmds
-    pQueryTip =
-      QueryTip
-        <$> pSocketPath envCli
-        <*> pConsensusModeParams
-        <*> pNetworkId envCli
-        <*> pMaybeOutputFile
-
-    pQueryUTxO :: Parser LegacyQueryCmds
-    pQueryUTxO =
-      QueryUTxO'
-        <$> pSocketPath envCli
-        <*> pConsensusModeParams
-        <*> pQueryUTxOFilter
-        <*> pNetworkId envCli
-        <*> pMaybeOutputFile
-
-    pQueryStakePools :: Parser LegacyQueryCmds
-    pQueryStakePools =
-      QueryStakePools'
-        <$> pSocketPath envCli
-        <*> pConsensusModeParams
-        <*> pNetworkId envCli
-        <*> pMaybeOutputFile
-
-    pQueryStakeDistribution :: Parser LegacyQueryCmds
-    pQueryStakeDistribution =
-      QueryStakeDistribution'
-        <$> pSocketPath envCli
-        <*> pConsensusModeParams
-        <*> pNetworkId envCli
-        <*> pMaybeOutputFile
-
-    pQueryStakeAddressInfo :: Parser LegacyQueryCmds
-    pQueryStakeAddressInfo =
-      QueryStakeAddressInfo
-        <$> pSocketPath envCli
-        <*> pConsensusModeParams
-        <*> pFilterByStakeAddress
-        <*> pNetworkId envCli
-        <*> pMaybeOutputFile
-
-    pQueryLedgerState :: Parser LegacyQueryCmds
-    pQueryLedgerState =
-      QueryDebugLedgerState'
-        <$> pSocketPath envCli
-        <*> pConsensusModeParams
-        <*> pNetworkId envCli
-        <*> pMaybeOutputFile
-
-    pQueryProtocolState :: Parser LegacyQueryCmds
-    pQueryProtocolState =
-      QueryProtocolState'
-        <$> pSocketPath envCli
-        <*> pConsensusModeParams
-        <*> pNetworkId envCli
-        <*> pMaybeOutputFile
-
-    pAllStakePoolsOrOnly :: Parser (AllOrOnly [Hash StakePoolKey])
-    pAllStakePoolsOrOnly = pAll <|> pOnly
-      where pAll :: Parser (AllOrOnly [Hash StakePoolKey])
-            pAll = Opt.flag' All $ mconcat
-              [ Opt.long "all-stake-pools"
-              , Opt.help "Query for all stake pools"
+    [ subParser "protocol-parameters" $
+        Opt.info pQueryProtocolParameters $
+          Opt.progDesc "Get the node's current protocol parameters"
+    , subParser "constitution-hash" $
+        Opt.info pQueryConstitutionHash $
+          Opt.progDesc "Get the constitution hash"
+    , subParser "tip" $
+        Opt.info pQueryTip $
+          Opt.progDesc "Get the node's current tip (slot no, hash, block no)"
+    , subParser "stake-pools" $
+        Opt.info pQueryStakePools $
+          Opt.progDesc "Get the node's current set of stake pool ids"
+    , subParser "stake-distribution" $
+        Opt.info pQueryStakeDistribution $
+          Opt.progDesc "Get the node's current aggregated stake distribution"
+    , subParser "stake-address-info" $
+        Opt.info pQueryStakeAddressInfo $
+          Opt.progDesc $
+            mconcat
+              [ "Get the current delegations and reward accounts filtered by stake address."
               ]
-            pOnly :: Parser (AllOrOnly [Hash StakePoolKey])
-            pOnly = Only <$> many (pStakePoolVerificationKeyHash Nothing)
+    , subParser "utxo" $
+        Opt.info pQueryUTxO $
+          Opt.progDesc $
+            mconcat
+              [ "Get a portion of the current UTxO: by tx in, by address or the whole."
+              ]
+    , subParser "ledger-state" $
+        Opt.info pQueryLedgerState $
+          Opt.progDesc $
+            mconcat
+              [ "Dump the current ledger state of the node (Ledger.NewEpochState -- advanced command)"
+              ]
+    , subParser "protocol-state" $
+        Opt.info pQueryProtocolState $
+          Opt.progDesc $
+            mconcat
+              [ "Dump the current protocol state of the node (Ledger.ChainDepState -- advanced command)"
+              ]
+    , subParser "stake-snapshot" $
+        Opt.info pQueryStakeSnapshot $
+          Opt.progDesc $
+            mconcat
+              [ "Obtain the three stake snapshots for a pool, plus the total active stake (advanced command)"
+              ]
+    , hiddenSubParser "pool-params" $
+        Opt.info pQueryPoolState $
+          Opt.progDesc $
+            mconcat
+              [ "DEPRECATED.  Use query pool-state instead.  Dump the pool parameters "
+              , "(Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced command)"
+              ]
+    , subParser "leadership-schedule" $
+        Opt.info pLeadershipSchedule $
+          Opt.progDesc "Get the slots the node is expected to mint a block in (advanced command)"
+    , subParser "kes-period-info" $
+        Opt.info pKesPeriodInfo $
+          Opt.progDesc "Get information about the current KES period and your node's operational certificate."
+    , subParser "pool-state" $
+        Opt.info pQueryPoolState $
+          Opt.progDesc "Dump the pool state"
+    , subParser "tx-mempool" $
+        Opt.info pQueryTxMempool $
+          Opt.progDesc "Local Mempool info"
+    , subParser "slot-number" $
+        Opt.info pQuerySlotNumber $
+          Opt.progDesc "Query slot number for UTC timestamp"
+    ]
+ where
+  pQueryProtocolParameters :: Parser LegacyQueryCmds
+  pQueryProtocolParameters =
+    QueryProtocolParameters'
+      <$> pSocketPath envCli
+      <*> pConsensusModeParams
+      <*> pNetworkId envCli
+      <*> pMaybeOutputFile
 
-    pQueryStakeSnapshot :: Parser LegacyQueryCmds
-    pQueryStakeSnapshot =
-      QueryStakeSnapshot'
-        <$> pSocketPath envCli
-        <*> pConsensusModeParams
-        <*> pNetworkId envCli
-        <*> pAllStakePoolsOrOnly
-        <*> pMaybeOutputFile
+  pQueryConstitutionHash :: Parser LegacyQueryCmds
+  pQueryConstitutionHash =
+    QueryConstitutionHash
+      <$> pSocketPath envCli
+      <*> pConsensusModeParams
+      <*> pNetworkId envCli
+      <*> pMaybeOutputFile
 
-    pQueryPoolState :: Parser LegacyQueryCmds
-    pQueryPoolState =
-      QueryPoolState'
-        <$> pSocketPath envCli
-        <*> pConsensusModeParams
-        <*> pNetworkId envCli
-        <*> many (pStakePoolVerificationKeyHash Nothing)
+  pQueryTip :: Parser LegacyQueryCmds
+  pQueryTip =
+    QueryTip
+      <$> pSocketPath envCli
+      <*> pConsensusModeParams
+      <*> pNetworkId envCli
+      <*> pMaybeOutputFile
 
-    pQueryTxMempool :: Parser LegacyQueryCmds
-    pQueryTxMempool =
-      QueryTxMempool
-        <$> pSocketPath envCli
-        <*> pConsensusModeParams
-        <*> pNetworkId envCli
-        <*> pTxMempoolQuery
-        <*> pMaybeOutputFile
-      where
-        pTxMempoolQuery :: Parser TxMempoolQuery
-        pTxMempoolQuery = asum
-          [ subParser "info"
-              $ Opt.info (pure TxMempoolQueryInfo)
-              $ Opt.progDesc "Ask the node about the current mempool's capacity and sizes"
-          , subParser "next-tx"
-              $ Opt.info (pure TxMempoolQueryNextTx)
-              $ Opt.progDesc "Requests the next transaction from the mempool's current list"
-          , subParser "tx-exists"
-              $ Opt.info (TxMempoolQueryTxExists <$> argument Opt.str (metavar "TX_ID"))
-              $ Opt.progDesc "Query if a particular transaction exists in the mempool"
+  pQueryUTxO :: Parser LegacyQueryCmds
+  pQueryUTxO =
+    QueryUTxO'
+      <$> pSocketPath envCli
+      <*> pConsensusModeParams
+      <*> pQueryUTxOFilter
+      <*> pNetworkId envCli
+      <*> pMaybeOutputFile
+
+  pQueryStakePools :: Parser LegacyQueryCmds
+  pQueryStakePools =
+    QueryStakePools'
+      <$> pSocketPath envCli
+      <*> pConsensusModeParams
+      <*> pNetworkId envCli
+      <*> pMaybeOutputFile
+
+  pQueryStakeDistribution :: Parser LegacyQueryCmds
+  pQueryStakeDistribution =
+    QueryStakeDistribution'
+      <$> pSocketPath envCli
+      <*> pConsensusModeParams
+      <*> pNetworkId envCli
+      <*> pMaybeOutputFile
+
+  pQueryStakeAddressInfo :: Parser LegacyQueryCmds
+  pQueryStakeAddressInfo =
+    QueryStakeAddressInfo
+      <$> pSocketPath envCli
+      <*> pConsensusModeParams
+      <*> pFilterByStakeAddress
+      <*> pNetworkId envCli
+      <*> pMaybeOutputFile
+
+  pQueryLedgerState :: Parser LegacyQueryCmds
+  pQueryLedgerState =
+    QueryDebugLedgerState'
+      <$> pSocketPath envCli
+      <*> pConsensusModeParams
+      <*> pNetworkId envCli
+      <*> pMaybeOutputFile
+
+  pQueryProtocolState :: Parser LegacyQueryCmds
+  pQueryProtocolState =
+    QueryProtocolState'
+      <$> pSocketPath envCli
+      <*> pConsensusModeParams
+      <*> pNetworkId envCli
+      <*> pMaybeOutputFile
+
+  pAllStakePoolsOrOnly :: Parser (AllOrOnly [Hash StakePoolKey])
+  pAllStakePoolsOrOnly = pAll <|> pOnly
+   where
+    pAll :: Parser (AllOrOnly [Hash StakePoolKey])
+    pAll =
+      Opt.flag' All $
+        mconcat
+          [ Opt.long "all-stake-pools"
+          , Opt.help "Query for all stake pools"
           ]
-    pLeadershipSchedule :: Parser LegacyQueryCmds
-    pLeadershipSchedule =
-      QueryLeadershipSchedule
-        <$> pSocketPath envCli
-        <*> pConsensusModeParams
-        <*> pNetworkId envCli
-        <*> pGenesisFile "Shelley genesis filepath"
-        <*> pStakePoolVerificationKeyOrHashOrFile Nothing
-        <*> pVrfSigningKeyFile
-        <*> pWhichLeadershipSchedule
-        <*> pMaybeOutputFile
+    pOnly :: Parser (AllOrOnly [Hash StakePoolKey])
+    pOnly = Only <$> many (pStakePoolVerificationKeyHash Nothing)
 
-    pKesPeriodInfo :: Parser LegacyQueryCmds
-    pKesPeriodInfo =
-      QueryKesPeriodInfo
-        <$> pSocketPath envCli
-        <*> pConsensusModeParams
-        <*> pNetworkId envCli
-        <*> pOperationalCertificateFile
-        <*> pMaybeOutputFile
+  pQueryStakeSnapshot :: Parser LegacyQueryCmds
+  pQueryStakeSnapshot =
+    QueryStakeSnapshot'
+      <$> pSocketPath envCli
+      <*> pConsensusModeParams
+      <*> pNetworkId envCli
+      <*> pAllStakePoolsOrOnly
+      <*> pMaybeOutputFile
 
-    pQuerySlotNumber :: Parser LegacyQueryCmds
-    pQuerySlotNumber =
-      QuerySlotNumber
-        <$> pSocketPath envCli
-        <*> pConsensusModeParams
-        <*> pNetworkId envCli
-        <*> pUtcTimestamp
-          where
-            pUtcTimestamp =
-              convertTime <$> (Opt.strArgument . mconcat)
-                [ Opt.metavar "TIMESTAMP"
-                , Opt.help "UTC timestamp in YYYY-MM-DDThh:mm:ssZ format"
-                ]
+  pQueryPoolState :: Parser LegacyQueryCmds
+  pQueryPoolState =
+    QueryPoolState'
+      <$> pSocketPath envCli
+      <*> pConsensusModeParams
+      <*> pNetworkId envCli
+      <*> many (pStakePoolVerificationKeyHash Nothing)
 
+  pQueryTxMempool :: Parser LegacyQueryCmds
+  pQueryTxMempool =
+    QueryTxMempool
+      <$> pSocketPath envCli
+      <*> pConsensusModeParams
+      <*> pNetworkId envCli
+      <*> pTxMempoolQuery
+      <*> pMaybeOutputFile
+   where
+    pTxMempoolQuery :: Parser TxMempoolQuery
+    pTxMempoolQuery =
+      asum
+        [ subParser "info" $
+            Opt.info (pure TxMempoolQueryInfo) $
+              Opt.progDesc "Ask the node about the current mempool's capacity and sizes"
+        , subParser "next-tx" $
+            Opt.info (pure TxMempoolQueryNextTx) $
+              Opt.progDesc "Requests the next transaction from the mempool's current list"
+        , subParser "tx-exists" $
+            Opt.info (TxMempoolQueryTxExists <$> argument Opt.str (metavar "TX_ID")) $
+              Opt.progDesc "Query if a particular transaction exists in the mempool"
+        ]
+  pLeadershipSchedule :: Parser LegacyQueryCmds
+  pLeadershipSchedule =
+    QueryLeadershipSchedule
+      <$> pSocketPath envCli
+      <*> pConsensusModeParams
+      <*> pNetworkId envCli
+      <*> pGenesisFile "Shelley genesis filepath"
+      <*> pStakePoolVerificationKeyOrHashOrFile Nothing
+      <*> pVrfSigningKeyFile
+      <*> pWhichLeadershipSchedule
+      <*> pMaybeOutputFile
+
+  pKesPeriodInfo :: Parser LegacyQueryCmds
+  pKesPeriodInfo =
+    QueryKesPeriodInfo
+      <$> pSocketPath envCli
+      <*> pConsensusModeParams
+      <*> pNetworkId envCli
+      <*> pOperationalCertificateFile
+      <*> pMaybeOutputFile
+
+  pQuerySlotNumber :: Parser LegacyQueryCmds
+  pQuerySlotNumber =
+    QuerySlotNumber
+      <$> pSocketPath envCli
+      <*> pConsensusModeParams
+      <*> pNetworkId envCli
+      <*> pUtcTimestamp
+   where
+    pUtcTimestamp =
+      convertTime
+        <$> (Opt.strArgument . mconcat)
+          [ Opt.metavar "TIMESTAMP"
+          , Opt.help "UTC timestamp in YYYY-MM-DDThh:mm:ssZ format"
+          ]
 
 -- TODO: Conway era - move to Cardano.CLI.Conway.Parsers
 pGovernanceCmds :: EnvCli -> Parser LegacyGovernanceCmds
 pGovernanceCmds envCli =
   asum
-    [ subParser "create-mir-certificate"
-        $ Opt.info (pLegacyMIRPayStakeAddresses <|> mirCertParsers)
-        $ Opt.progDesc "Create an MIR (Move Instantaneous Rewards) certificate"
-    , subParser "create-genesis-key-delegation-certificate"
-        $ Opt.info pGovernanceGenesisKeyDelegationCertificate
-        $ Opt.progDesc "Create a genesis key delegation certificate"
-    , subParser "create-update-proposal"
-        $ Opt.info pUpdateProposal
-        $ Opt.progDesc "Create an update proposal"
-    , subParser "create-poll"
-        $ Opt.info pGovernanceCreatePoll
-        $ Opt.progDesc "Create an SPO poll"
-    , subParser "answer-poll"
-        $ Opt.info pGovernanceAnswerPoll
-        $ Opt.progDesc "Answer an SPO poll"
-    , subParser "verify-poll"
-        $ Opt.info pGovernanceVerifyPoll
-        $ Opt.progDesc "Verify an answer to a given SPO poll"
+    [ subParser "create-mir-certificate" $
+        Opt.info (pLegacyMIRPayStakeAddresses <|> mirCertParsers) $
+          Opt.progDesc "Create an MIR (Move Instantaneous Rewards) certificate"
+    , subParser "create-genesis-key-delegation-certificate" $
+        Opt.info pGovernanceGenesisKeyDelegationCertificate $
+          Opt.progDesc "Create a genesis key delegation certificate"
+    , subParser "create-update-proposal" $
+        Opt.info pUpdateProposal $
+          Opt.progDesc "Create an update proposal"
+    , subParser "create-poll" $
+        Opt.info pGovernanceCreatePoll $
+          Opt.progDesc "Create an SPO poll"
+    , subParser "answer-poll" $
+        Opt.info pGovernanceAnswerPoll $
+          Opt.progDesc "Answer an SPO poll"
+    , subParser "verify-poll" $
+        Opt.info pGovernanceVerifyPoll $
+          Opt.progDesc "Verify an answer to a given SPO poll"
     ]
-  where
-    mirCertParsers :: Parser LegacyGovernanceCmds
-    mirCertParsers = asum
-      [ subParser "stake-addresses"
-        $ Opt.info pLegacyMIRPayStakeAddresses
-        $ Opt.progDesc "Create an MIR certificate to pay stake addresses"
-      , subParser "transfer-to-treasury"
-        $ Opt.info pLegacyMIRTransferToTreasury
-        $ Opt.progDesc "Create an MIR certificate to transfer from the reserves pot to the treasury pot"
-      , subParser "transfer-to-rewards"
-        $ Opt.info pLegacyMIRTransferToReserves
-        $ Opt.progDesc "Create an MIR certificate to transfer from the treasury pot to the reserves pot"
+ where
+  mirCertParsers :: Parser LegacyGovernanceCmds
+  mirCertParsers =
+    asum
+      [ subParser "stake-addresses" $
+          Opt.info pLegacyMIRPayStakeAddresses $
+            Opt.progDesc "Create an MIR certificate to pay stake addresses"
+      , subParser "transfer-to-treasury" $
+          Opt.info pLegacyMIRTransferToTreasury $
+            Opt.progDesc "Create an MIR certificate to transfer from the reserves pot to the treasury pot"
+      , subParser "transfer-to-rewards" $
+          Opt.info pLegacyMIRTransferToReserves $
+            Opt.progDesc "Create an MIR certificate to transfer from the treasury pot to the reserves pot"
       ]
 
-    pLegacyMIRPayStakeAddresses :: Parser LegacyGovernanceCmds
-    pLegacyMIRPayStakeAddresses =
-      GovernanceMIRPayStakeAddressesCertificate
-        <$> pAnyShelleyToBabbageEra envCli
-        <*> pMIRPot
-        <*> some pStakeAddress
-        <*> some pRewardAmt
-        <*> pOutputFile
+  pLegacyMIRPayStakeAddresses :: Parser LegacyGovernanceCmds
+  pLegacyMIRPayStakeAddresses =
+    GovernanceMIRPayStakeAddressesCertificate
+      <$> pAnyShelleyToBabbageEra envCli
+      <*> pMIRPot
+      <*> some pStakeAddress
+      <*> some pRewardAmt
+      <*> pOutputFile
 
-    pLegacyMIRTransferToTreasury :: Parser LegacyGovernanceCmds
-    pLegacyMIRTransferToTreasury =
-      GovernanceMIRTransfer
-        <$> pAnyShelleyToBabbageEra envCli
-        <*> pTransferAmt
-        <*> pOutputFile
-        <*> pure TransferToTreasury
+  pLegacyMIRTransferToTreasury :: Parser LegacyGovernanceCmds
+  pLegacyMIRTransferToTreasury =
+    GovernanceMIRTransfer
+      <$> pAnyShelleyToBabbageEra envCli
+      <*> pTransferAmt
+      <*> pOutputFile
+      <*> pure TransferToTreasury
 
-    pLegacyMIRTransferToReserves :: Parser LegacyGovernanceCmds
-    pLegacyMIRTransferToReserves =
-      GovernanceMIRTransfer
-        <$> pAnyShelleyToBabbageEra envCli
-        <*> pTransferAmt
-        <*> pOutputFile
-        <*> pure TransferToReserves
+  pLegacyMIRTransferToReserves :: Parser LegacyGovernanceCmds
+  pLegacyMIRTransferToReserves =
+    GovernanceMIRTransfer
+      <$> pAnyShelleyToBabbageEra envCli
+      <*> pTransferAmt
+      <*> pOutputFile
+      <*> pure TransferToReserves
 
-    pGovernanceGenesisKeyDelegationCertificate :: Parser LegacyGovernanceCmds
-    pGovernanceGenesisKeyDelegationCertificate =
-      GovernanceGenesisKeyDelegationCertificate
-        <$> pAnyShelleyBasedEra envCli
-        <*> pGenesisVerificationKeyOrHashOrFile
-        <*> pGenesisDelegateVerificationKeyOrHashOrFile
-        <*> pVrfVerificationKeyOrHashOrFile
-        <*> pOutputFile
+  pGovernanceGenesisKeyDelegationCertificate :: Parser LegacyGovernanceCmds
+  pGovernanceGenesisKeyDelegationCertificate =
+    GovernanceGenesisKeyDelegationCertificate
+      <$> pAnyShelleyBasedEra envCli
+      <*> pGenesisVerificationKeyOrHashOrFile
+      <*> pGenesisDelegateVerificationKeyOrHashOrFile
+      <*> pVrfVerificationKeyOrHashOrFile
+      <*> pOutputFile
 
-    pUpdateProposal :: Parser LegacyGovernanceCmds
-    pUpdateProposal =
-      GovernanceUpdateProposal
-        <$> pOutputFile
-        <*> pEpochNoUpdateProp
-        <*> some pGenesisVerificationKeyFile
-        <*> pProtocolParametersUpdate
-        <*> optional pCostModels
+  pUpdateProposal :: Parser LegacyGovernanceCmds
+  pUpdateProposal =
+    GovernanceUpdateProposal
+      <$> pOutputFile
+      <*> pEpochNoUpdateProp
+      <*> some pGenesisVerificationKeyFile
+      <*> pProtocolParametersUpdate
+      <*> optional pCostModels
 
-    pGovernanceCreatePoll :: Parser LegacyGovernanceCmds
-    pGovernanceCreatePoll =
-      GovernanceCreatePoll
-        <$> pPollQuestion
-        <*> some pPollAnswer
-        <*> optional pPollNonce
-        <*> pOutputFile
+  pGovernanceCreatePoll :: Parser LegacyGovernanceCmds
+  pGovernanceCreatePoll =
+    GovernanceCreatePoll
+      <$> pPollQuestion
+      <*> some pPollAnswer
+      <*> optional pPollNonce
+      <*> pOutputFile
 
-    pGovernanceAnswerPoll :: Parser LegacyGovernanceCmds
-    pGovernanceAnswerPoll =
-      GovernanceAnswerPoll
-        <$> pPollFile
-        <*> optional pPollAnswerIndex
-        <*> optional pOutputFile
+  pGovernanceAnswerPoll :: Parser LegacyGovernanceCmds
+  pGovernanceAnswerPoll =
+    GovernanceAnswerPoll
+      <$> pPollFile
+      <*> optional pPollAnswerIndex
+      <*> optional pOutputFile
 
-    pGovernanceVerifyPoll :: Parser LegacyGovernanceCmds
-    pGovernanceVerifyPoll =
-      GovernanceVerifyPoll
-        <$> pPollFile
-        <*> pPollTxFile
-        <*> optional pOutputFile
+  pGovernanceVerifyPoll :: Parser LegacyGovernanceCmds
+  pGovernanceVerifyPoll =
+    GovernanceVerifyPoll
+      <$> pPollFile
+      <*> pPollTxFile
+      <*> optional pOutputFile
 
 pGenesisCmds :: EnvCli -> Parser LegacyGenesisCmds
 pGenesisCmds envCli =
   asum
-    [ subParser "key-gen-genesis"
-        $ Opt.info pGenesisKeyGen
-        $ Opt.progDesc "Create a Shelley genesis key pair"
-    , subParser "key-gen-delegate"
-        $ Opt.info pGenesisDelegateKeyGen
-        $ Opt.progDesc "Create a Shelley genesis delegate key pair"
-    , subParser "key-gen-utxo"
-        $ Opt.info pGenesisUTxOKeyGen
-        $ Opt.progDesc "Create a Shelley genesis UTxO key pair"
-    , subParser "key-hash"
-        $ Opt.info pGenesisKeyHash
-        $ Opt.progDesc "Print the identifier (hash) of a public key"
-    , subParser "get-ver-key"
-        $ Opt.info pGenesisVerKey
-        $ Opt.progDesc "Derive the verification key from a signing key"
-    , subParser "initial-addr"
-        $ Opt.info pGenesisAddr
-        $ Opt.progDesc "Get the address for an initial UTxO based on the verification key"
-    , subParser "initial-txin"
-        $ Opt.info pGenesisTxIn
-        $ Opt.progDesc "Get the TxIn for an initial UTxO based on the verification key"
-    , subParser "create-cardano"
-        $ Opt.info pGenesisCreateCardano
-        $ Opt.progDesc
-        $ mconcat
-            [ "Create a Byron and Shelley genesis file from a genesis "
-            , "template and genesis/delegation/spending keys."
-            ]
-    , subParser "create"
-        $ Opt.info pGenesisCreate
-        $ Opt.progDesc
-        $ mconcat
-            [ "Create a Shelley genesis file from a genesis "
-            , "template and genesis/delegation/spending keys."
-            ]
-    , subParser "create-staked"
-        $ Opt.info pGenesisCreateStaked
-        $ Opt.progDesc
-        $ mconcat
-            [ "Create a staked Shelley genesis file from a genesis "
-            , "template and genesis/delegation/spending keys."
-            ]
-    , subParser "hash"
-        $ Opt.info pGenesisHash
-        $ Opt.progDesc "Compute the hash of a genesis file"
+    [ subParser "key-gen-genesis" $
+        Opt.info pGenesisKeyGen $
+          Opt.progDesc "Create a Shelley genesis key pair"
+    , subParser "key-gen-delegate" $
+        Opt.info pGenesisDelegateKeyGen $
+          Opt.progDesc "Create a Shelley genesis delegate key pair"
+    , subParser "key-gen-utxo" $
+        Opt.info pGenesisUTxOKeyGen $
+          Opt.progDesc "Create a Shelley genesis UTxO key pair"
+    , subParser "key-hash" $
+        Opt.info pGenesisKeyHash $
+          Opt.progDesc "Print the identifier (hash) of a public key"
+    , subParser "get-ver-key" $
+        Opt.info pGenesisVerKey $
+          Opt.progDesc "Derive the verification key from a signing key"
+    , subParser "initial-addr" $
+        Opt.info pGenesisAddr $
+          Opt.progDesc "Get the address for an initial UTxO based on the verification key"
+    , subParser "initial-txin" $
+        Opt.info pGenesisTxIn $
+          Opt.progDesc "Get the TxIn for an initial UTxO based on the verification key"
+    , subParser "create-cardano" $
+        Opt.info pGenesisCreateCardano $
+          Opt.progDesc $
+            mconcat
+              [ "Create a Byron and Shelley genesis file from a genesis "
+              , "template and genesis/delegation/spending keys."
+              ]
+    , subParser "create" $
+        Opt.info pGenesisCreate $
+          Opt.progDesc $
+            mconcat
+              [ "Create a Shelley genesis file from a genesis "
+              , "template and genesis/delegation/spending keys."
+              ]
+    , subParser "create-staked" $
+        Opt.info pGenesisCreateStaked $
+          Opt.progDesc $
+            mconcat
+              [ "Create a staked Shelley genesis file from a genesis "
+              , "template and genesis/delegation/spending keys."
+              ]
+    , subParser "hash" $
+        Opt.info pGenesisHash $
+          Opt.progDesc "Compute the hash of a genesis file"
     ]
-  where
-    pGenesisKeyGen :: Parser LegacyGenesisCmds
-    pGenesisKeyGen =
-      GenesisKeyGenGenesis
-        <$> pVerificationKeyFileOut
-        <*> pSigningKeyFileOut
+ where
+  pGenesisKeyGen :: Parser LegacyGenesisCmds
+  pGenesisKeyGen =
+    GenesisKeyGenGenesis
+      <$> pVerificationKeyFileOut
+      <*> pSigningKeyFileOut
 
-    pGenesisDelegateKeyGen :: Parser LegacyGenesisCmds
-    pGenesisDelegateKeyGen =
-      GenesisKeyGenDelegate
-        <$> pVerificationKeyFileOut
-        <*> pSigningKeyFileOut
-        <*> pOperatorCertIssueCounterFile
+  pGenesisDelegateKeyGen :: Parser LegacyGenesisCmds
+  pGenesisDelegateKeyGen =
+    GenesisKeyGenDelegate
+      <$> pVerificationKeyFileOut
+      <*> pSigningKeyFileOut
+      <*> pOperatorCertIssueCounterFile
 
-    pGenesisUTxOKeyGen :: Parser LegacyGenesisCmds
-    pGenesisUTxOKeyGen =
-      GenesisKeyGenUTxO
-        <$> pVerificationKeyFileOut
-        <*> pSigningKeyFileOut
+  pGenesisUTxOKeyGen :: Parser LegacyGenesisCmds
+  pGenesisUTxOKeyGen =
+    GenesisKeyGenUTxO
+      <$> pVerificationKeyFileOut
+      <*> pSigningKeyFileOut
 
-    pGenesisKeyHash :: Parser LegacyGenesisCmds
-    pGenesisKeyHash =
-      GenesisCmdKeyHash
-        <$> pVerificationKeyFileIn
+  pGenesisKeyHash :: Parser LegacyGenesisCmds
+  pGenesisKeyHash =
+    GenesisCmdKeyHash
+      <$> pVerificationKeyFileIn
 
-    pGenesisVerKey :: Parser LegacyGenesisCmds
-    pGenesisVerKey =
-      GenesisVerKey
-        <$> pVerificationKeyFileOut
-        <*> pSigningKeyFileIn
+  pGenesisVerKey :: Parser LegacyGenesisCmds
+  pGenesisVerKey =
+    GenesisVerKey
+      <$> pVerificationKeyFileOut
+      <*> pSigningKeyFileIn
 
-    pGenesisAddr :: Parser LegacyGenesisCmds
-    pGenesisAddr =
-      GenesisAddr
-        <$> pVerificationKeyFileIn
-        <*> pNetworkId envCli
-        <*> pMaybeOutputFile
+  pGenesisAddr :: Parser LegacyGenesisCmds
+  pGenesisAddr =
+    GenesisAddr
+      <$> pVerificationKeyFileIn
+      <*> pNetworkId envCli
+      <*> pMaybeOutputFile
 
-    pGenesisTxIn :: Parser LegacyGenesisCmds
-    pGenesisTxIn =
-      GenesisTxIn
-        <$> pVerificationKeyFileIn
-        <*> pNetworkId envCli
-        <*> pMaybeOutputFile
+  pGenesisTxIn :: Parser LegacyGenesisCmds
+  pGenesisTxIn =
+    GenesisTxIn
+      <$> pVerificationKeyFileIn
+      <*> pNetworkId envCli
+      <*> pMaybeOutputFile
 
-    pGenesisCreateCardano :: Parser LegacyGenesisCmds
-    pGenesisCreateCardano =
-      GenesisCreateCardano
-        <$> pGenesisDir
-        <*> pGenesisNumGenesisKeys
-        <*> pGenesisNumUTxOKeys
-        <*> pMaybeSystemStart
-        <*> pInitialSupplyNonDelegated
-        <*> (BlockCount <$> pSecurityParam)
-        <*> pSlotLength
-        <*> pSlotCoefficient
-        <*> pNetworkId envCli
-        <*> parseFilePath
-              "byron-template"
-              "JSON file with genesis defaults for each byron."
-        <*> parseFilePath
-              "shelley-template"
-              "JSON file with genesis defaults for each shelley."
-        <*> parseFilePath
-              "alonzo-template"
-              "JSON file with genesis defaults for alonzo."
-        <*> parseFilePath
-              "conway-template"
-              "JSON file with genesis defaults for conway."
-        <*> pNodeConfigTemplate
+  pGenesisCreateCardano :: Parser LegacyGenesisCmds
+  pGenesisCreateCardano =
+    GenesisCreateCardano
+      <$> pGenesisDir
+      <*> pGenesisNumGenesisKeys
+      <*> pGenesisNumUTxOKeys
+      <*> pMaybeSystemStart
+      <*> pInitialSupplyNonDelegated
+      <*> (BlockCount <$> pSecurityParam)
+      <*> pSlotLength
+      <*> pSlotCoefficient
+      <*> pNetworkId envCli
+      <*> parseFilePath
+        "byron-template"
+        "JSON file with genesis defaults for each byron."
+      <*> parseFilePath
+        "shelley-template"
+        "JSON file with genesis defaults for each shelley."
+      <*> parseFilePath
+        "alonzo-template"
+        "JSON file with genesis defaults for alonzo."
+      <*> parseFilePath
+        "conway-template"
+        "JSON file with genesis defaults for conway."
+      <*> pNodeConfigTemplate
 
-    pGenesisCreate :: Parser LegacyGenesisCmds
-    pGenesisCreate =
-      GenesisCreate
-        <$> pKeyOutputFormat
-        <*> pGenesisDir
-        <*> pGenesisNumGenesisKeys
-        <*> pGenesisNumUTxOKeys
-        <*> pMaybeSystemStart
-        <*> pInitialSupplyNonDelegated
-        <*> pNetworkId envCli
+  pGenesisCreate :: Parser LegacyGenesisCmds
+  pGenesisCreate =
+    GenesisCreate
+      <$> pKeyOutputFormat
+      <*> pGenesisDir
+      <*> pGenesisNumGenesisKeys
+      <*> pGenesisNumUTxOKeys
+      <*> pMaybeSystemStart
+      <*> pInitialSupplyNonDelegated
+      <*> pNetworkId envCli
 
-    pGenesisCreateStaked :: Parser LegacyGenesisCmds
-    pGenesisCreateStaked =
-      GenesisCreateStaked
-        <$> pKeyOutputFormat
-        <*> pGenesisDir
-        <*> pGenesisNumGenesisKeys
-        <*> pGenesisNumUTxOKeys
-        <*> pGenesisNumPools
-        <*> pGenesisNumStDelegs
-        <*> pMaybeSystemStart
-        <*> pInitialSupplyNonDelegated
-        <*> pInitialSupplyDelegated
-        <*> pNetworkId envCli
-        <*> pBulkPoolCredFiles
-        <*> pBulkPoolsPerFile
-        <*> pStuffedUtxoCount
-        <*> Opt.optional pRelayJsonFp
+  pGenesisCreateStaked :: Parser LegacyGenesisCmds
+  pGenesisCreateStaked =
+    GenesisCreateStaked
+      <$> pKeyOutputFormat
+      <*> pGenesisDir
+      <*> pGenesisNumGenesisKeys
+      <*> pGenesisNumUTxOKeys
+      <*> pGenesisNumPools
+      <*> pGenesisNumStDelegs
+      <*> pMaybeSystemStart
+      <*> pInitialSupplyNonDelegated
+      <*> pInitialSupplyDelegated
+      <*> pNetworkId envCli
+      <*> pBulkPoolCredFiles
+      <*> pBulkPoolsPerFile
+      <*> pStuffedUtxoCount
+      <*> Opt.optional pRelayJsonFp
 
-    pGenesisHash :: Parser LegacyGenesisCmds
-    pGenesisHash =
-      GenesisHashFile <$> pGenesisFile "The genesis file."
+  pGenesisHash :: Parser LegacyGenesisCmds
+  pGenesisHash =
+    GenesisHashFile <$> pGenesisFile "The genesis file."
 
-    pGenesisDir :: Parser GenesisDir
-    pGenesisDir =
-      fmap GenesisDir $ Opt.strOption $ mconcat
-        [ Opt.long "genesis-dir"
-        , Opt.metavar "DIR"
-        , Opt.help "The genesis directory containing the genesis template and required genesis/delegation/spending keys."
-        ]
+  pGenesisDir :: Parser GenesisDir
+  pGenesisDir =
+    fmap GenesisDir $
+      Opt.strOption $
+        mconcat
+          [ Opt.long "genesis-dir"
+          , Opt.metavar "DIR"
+          , Opt.help
+              "The genesis directory containing the genesis template and required genesis/delegation/spending keys."
+          ]
 
-    pMaybeSystemStart :: Parser (Maybe SystemStart)
-    pMaybeSystemStart =
-      Opt.optional $ fmap (SystemStart . convertTime) $ Opt.strOption $ mconcat
-        [ Opt.long "start-time"
-        , Opt.metavar "UTC-TIME"
-        , Opt.help "The genesis start time in YYYY-MM-DDThh:mm:ssZ format. If unspecified, will be the current time +30 seconds."
-        ]
+  pMaybeSystemStart :: Parser (Maybe SystemStart)
+  pMaybeSystemStart =
+    Opt.optional $
+      fmap (SystemStart . convertTime) $
+        Opt.strOption $
+          mconcat
+            [ Opt.long "start-time"
+            , Opt.metavar "UTC-TIME"
+            , Opt.help
+                "The genesis start time in YYYY-MM-DDThh:mm:ssZ format. If unspecified, will be the current time +30 seconds."
+            ]
 
-    pGenesisNumGenesisKeys :: Parser Word
-    pGenesisNumGenesisKeys =
-      Opt.option Opt.auto $ mconcat
+  pGenesisNumGenesisKeys :: Parser Word
+  pGenesisNumGenesisKeys =
+    Opt.option Opt.auto $
+      mconcat
         [ Opt.long "gen-genesis-keys"
         , Opt.metavar "INT"
         , Opt.help "The number of genesis keys to make [default is 3]."
         , Opt.value 3
         ]
 
-    pNodeConfigTemplate :: Parser (Maybe FilePath)
-    pNodeConfigTemplate = optional $ parseFilePath "node-config-template" "the node config template"
+  pNodeConfigTemplate :: Parser (Maybe FilePath)
+  pNodeConfigTemplate = optional $ parseFilePath "node-config-template" "the node config template"
 
-    pGenesisNumUTxOKeys :: Parser Word
-    pGenesisNumUTxOKeys =
-      Opt.option Opt.auto $ mconcat
+  pGenesisNumUTxOKeys :: Parser Word
+  pGenesisNumUTxOKeys =
+    Opt.option Opt.auto $
+      mconcat
         [ Opt.long "gen-utxo-keys"
         , Opt.metavar "INT"
         , Opt.help "The number of UTxO keys to make [default is 0]."
         , Opt.value 0
         ]
 
-    pGenesisNumPools :: Parser Word
-    pGenesisNumPools =
-      Opt.option Opt.auto $ mconcat
+  pGenesisNumPools :: Parser Word
+  pGenesisNumPools =
+    Opt.option Opt.auto $
+      mconcat
         [ Opt.long "gen-pools"
         , Opt.metavar "INT"
         , Opt.help "The number of stake pool credential sets to make [default is 0]."
         , Opt.value 0
         ]
 
-    pGenesisNumStDelegs :: Parser Word
-    pGenesisNumStDelegs =
-      Opt.option Opt.auto $ mconcat
+  pGenesisNumStDelegs :: Parser Word
+  pGenesisNumStDelegs =
+    Opt.option Opt.auto $
+      mconcat
         [ Opt.long "gen-stake-delegs"
         , Opt.metavar "INT"
         , Opt.help "The number of stake delegator credential sets to make [default is 0]."
         , Opt.value 0
         ]
 
-    pStuffedUtxoCount :: Parser Word
-    pStuffedUtxoCount =
-      Opt.option Opt.auto $ mconcat
+  pStuffedUtxoCount :: Parser Word
+  pStuffedUtxoCount =
+    Opt.option Opt.auto $
+      mconcat
         [ Opt.long "num-stuffed-utxo"
         , Opt.metavar "INT"
         , Opt.help "The number of fake UTxO entries to generate [default is 0]."
         , Opt.value 0
         ]
 
-    pRelayJsonFp :: Parser FilePath
-    pRelayJsonFp =
-      Opt.strOption $ mconcat
+  pRelayJsonFp :: Parser FilePath
+  pRelayJsonFp =
+    Opt.strOption $
+      mconcat
         [ Opt.long "relay-specification-file"
         , Opt.metavar "FILE"
         , Opt.help "JSON file specified the relays of each stake pool."
         , Opt.completer (Opt.bashCompleter "file")
         ]
 
-    pInitialSupplyNonDelegated :: Parser (Maybe Lovelace)
-    pInitialSupplyNonDelegated =
-      Opt.optional $ fmap Lovelace $ Opt.option Opt.auto $ mconcat
-        [ Opt.long "supply"
-        , Opt.metavar "LOVELACE"
-        , Opt.help "The initial coin supply in Lovelace which will be evenly distributed across initial, non-delegating stake holders."
-        ]
+  pInitialSupplyNonDelegated :: Parser (Maybe Lovelace)
+  pInitialSupplyNonDelegated =
+    Opt.optional $
+      fmap Lovelace $
+        Opt.option Opt.auto $
+          mconcat
+            [ Opt.long "supply"
+            , Opt.metavar "LOVELACE"
+            , Opt.help
+                "The initial coin supply in Lovelace which will be evenly distributed across initial, non-delegating stake holders."
+            ]
 
-    pInitialSupplyDelegated :: Parser Lovelace
-    pInitialSupplyDelegated =
-      fmap (Lovelace . fromMaybe 0) $ Opt.optional $ Opt.option Opt.auto $ mconcat
-        [ Opt.long "supply-delegated"
-        , Opt.metavar "LOVELACE"
-        , Opt.help "The initial coin supply in Lovelace which will be evenly distributed across initial, delegating stake holders."
-        , Opt.value 0
-        ]
+  pInitialSupplyDelegated :: Parser Lovelace
+  pInitialSupplyDelegated =
+    fmap (Lovelace . fromMaybe 0) $
+      Opt.optional $
+        Opt.option Opt.auto $
+          mconcat
+            [ Opt.long "supply-delegated"
+            , Opt.metavar "LOVELACE"
+            , Opt.help
+                "The initial coin supply in Lovelace which will be evenly distributed across initial, delegating stake holders."
+            , Opt.value 0
+            ]
 
-    pSecurityParam :: Parser Word64
-    pSecurityParam =
-      Opt.option Opt.auto $ mconcat
+  pSecurityParam :: Parser Word64
+  pSecurityParam =
+    Opt.option Opt.auto $
+      mconcat
         [ Opt.long "security-param"
         , Opt.metavar "INT"
         , Opt.help "Security parameter for genesis file [default is 108]."
         , Opt.value 108
         ]
 
-    pSlotLength :: Parser Word
-    pSlotLength =
-      Opt.option Opt.auto $ mconcat
+  pSlotLength :: Parser Word
+  pSlotLength =
+    Opt.option Opt.auto $
+      mconcat
         [ Opt.long "slot-length"
         , Opt.metavar "INT"
         , Opt.help "slot length (ms) parameter for genesis file [default is 1000]."
         , Opt.value 1000
         ]
 
-
-    pSlotCoefficient :: Parser Rational
-    pSlotCoefficient =
-      Opt.option readRationalUnitInterval $ mconcat
+  pSlotCoefficient :: Parser Rational
+  pSlotCoefficient =
+    Opt.option readRationalUnitInterval $
+      mconcat
         [ Opt.long "slot-coefficient"
         , Opt.metavar "RATIONAL"
         , Opt.help "Slot Coefficient for genesis file [default is .05]."
         , Opt.value 0.05
         ]
 
-    pBulkPoolCredFiles :: Parser Word
-    pBulkPoolCredFiles =
-      Opt.option Opt.auto $ mconcat
+  pBulkPoolCredFiles :: Parser Word
+  pBulkPoolCredFiles =
+    Opt.option Opt.auto $
+      mconcat
         [ Opt.long "bulk-pool-cred-files"
         , Opt.metavar "INT"
         , Opt.help "Generate bulk pool credential files [default is 0]."
         , Opt.value 0
         ]
 
-    pBulkPoolsPerFile :: Parser Word
-    pBulkPoolsPerFile =
-      Opt.option Opt.auto $ mconcat
+  pBulkPoolsPerFile :: Parser Word
+  pBulkPoolsPerFile =
+    Opt.option Opt.auto $
+      mconcat
         [ Opt.long "bulk-pools-per-file"
         , Opt.metavar "INT"
         , Opt.help "Each bulk pool to contain this many pool credential sets [default is 0]."
@@ -1417,36 +1521,45 @@ pStakePoolDeregistrationCertificateCmd envCli =
 
 pLegacyCardanoEra :: EnvCli -> Parser AnyCardanoEra
 pLegacyCardanoEra envCli =
-  asum $ mconcat
-    [ [ Opt.flag' (AnyCardanoEra ByronEra) $ mconcat
-        [ Opt.long "byron-era"
-        , Opt.help "Specify the Byron era"
+  asum $
+    mconcat
+      [
+        [ Opt.flag' (AnyCardanoEra ByronEra) $
+            mconcat
+              [ Opt.long "byron-era"
+              , Opt.help "Specify the Byron era"
+              ]
+        , Opt.flag' (AnyCardanoEra ShelleyEra) $
+            mconcat
+              [ Opt.long "shelley-era"
+              , Opt.help "Specify the Shelley era"
+              ]
+        , Opt.flag' (AnyCardanoEra AllegraEra) $
+            mconcat
+              [ Opt.long "allegra-era"
+              , Opt.help "Specify the Allegra era"
+              ]
+        , Opt.flag' (AnyCardanoEra MaryEra) $
+            mconcat
+              [ Opt.long "mary-era"
+              , Opt.help "Specify the Mary era"
+              ]
+        , Opt.flag' (AnyCardanoEra AlonzoEra) $
+            mconcat
+              [ Opt.long "alonzo-era"
+              , Opt.help "Specify the Alonzo era"
+              ]
+        , Opt.flag' (AnyCardanoEra BabbageEra) $
+            mconcat
+              [ Opt.long "babbage-era"
+              , Opt.help "Specify the Babbage era (default)"
+              ]
         ]
-      , Opt.flag' (AnyCardanoEra ShelleyEra) $ mconcat
-        [ Opt.long "shelley-era"
-        , Opt.help "Specify the Shelley era"
-        ]
-      , Opt.flag' (AnyCardanoEra AllegraEra) $ mconcat
-        [ Opt.long "allegra-era"
-        , Opt.help "Specify the Allegra era"
-        ]
-      , Opt.flag' (AnyCardanoEra MaryEra) $ mconcat
-        [ Opt.long "mary-era"
-        , Opt.help "Specify the Mary era"
-        ]
-      , Opt.flag' (AnyCardanoEra AlonzoEra) $ mconcat
-        [ Opt.long "alonzo-era"
-        , Opt.help "Specify the Alonzo era"
-        ]
-      , Opt.flag' (AnyCardanoEra BabbageEra) $ mconcat
-        [ Opt.long "babbage-era"
-        , Opt.help "Specify the Babbage era (default)"
-        ]
+      , maybeToList $ pure <$> envCliAnyCardanoEra envCli
+      , -- TODO is this default needed anymore?
+        pure $ pure defaultCardanoEra
       ]
-    , maybeToList $ pure <$> envCliAnyCardanoEra envCli
-    -- TODO is this default needed anymore?
-    , pure $ pure defaultCardanoEra
-  ]
-    where
-      defaultCardanoEra = defaultShelleyBasedEra & \(AnyShelleyBasedEra era) ->
-        AnyCardanoEra (shelleyBasedToCardanoEra era)
+ where
+  defaultCardanoEra =
+    defaultShelleyBasedEra & \(AnyShelleyBasedEra era) ->
+      AnyCardanoEra (shelleyBasedToCardanoEra era)

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run.hs
@@ -4,31 +4,31 @@ module Cardano.CLI.Legacy.Run
   ( runLegacyCmds
   ) where
 
-import           Cardano.CLI.Legacy.Options
-import           Cardano.CLI.Legacy.Run.Address
-import           Cardano.CLI.Legacy.Run.Genesis
-import           Cardano.CLI.Legacy.Run.Governance
-import           Cardano.CLI.Legacy.Run.Key
-import           Cardano.CLI.Legacy.Run.Node
-import           Cardano.CLI.Legacy.Run.Query
-import           Cardano.CLI.Legacy.Run.StakeAddress
-import           Cardano.CLI.Legacy.Run.StakePool
-import           Cardano.CLI.Legacy.Run.TextView
-import           Cardano.CLI.Legacy.Run.Transaction
-import           Cardano.CLI.Types.Errors.CmdError
+import Cardano.CLI.Legacy.Options
+import Cardano.CLI.Legacy.Run.Address
+import Cardano.CLI.Legacy.Run.Genesis
+import Cardano.CLI.Legacy.Run.Governance
+import Cardano.CLI.Legacy.Run.Key
+import Cardano.CLI.Legacy.Run.Node
+import Cardano.CLI.Legacy.Run.Query
+import Cardano.CLI.Legacy.Run.StakeAddress
+import Cardano.CLI.Legacy.Run.StakePool
+import Cardano.CLI.Legacy.Run.TextView
+import Cardano.CLI.Legacy.Run.Transaction
+import Cardano.CLI.Types.Errors.CmdError
 
-import           Control.Monad.Trans.Except (ExceptT)
-import           Control.Monad.Trans.Except.Extra (firstExceptT)
+import Control.Monad.Trans.Except (ExceptT)
+import Control.Monad.Trans.Except.Extra (firstExceptT)
 
 runLegacyCmds :: LegacyCmds -> ExceptT CmdError IO ()
 runLegacyCmds = \case
-  LegacyAddressCmds      cmd -> firstExceptT CmdAddressError $ runLegacyAddressCmds cmd
-  LegacyGenesisCmds      cmd -> firstExceptT CmdGenesisError $ runLegacyGenesisCmds cmd
-  LegacyGovernanceCmds   cmd -> firstExceptT CmdGovernanceCmdError $ runLegacyGovernanceCmds cmd
-  LegacyKeyCmds          cmd -> firstExceptT CmdKeyError $ runLegacyKeyCmds cmd
-  LegacyNodeCmds         cmd -> firstExceptT CmdNodeError $ runLegacyNodeCmds cmd
-  LegacyQueryCmds        cmd -> firstExceptT CmdQueryError $ runLegacyQueryCmds cmd
+  LegacyAddressCmds cmd -> firstExceptT CmdAddressError $ runLegacyAddressCmds cmd
+  LegacyGenesisCmds cmd -> firstExceptT CmdGenesisError $ runLegacyGenesisCmds cmd
+  LegacyGovernanceCmds cmd -> firstExceptT CmdGovernanceCmdError $ runLegacyGovernanceCmds cmd
+  LegacyKeyCmds cmd -> firstExceptT CmdKeyError $ runLegacyKeyCmds cmd
+  LegacyNodeCmds cmd -> firstExceptT CmdNodeError $ runLegacyNodeCmds cmd
+  LegacyQueryCmds cmd -> firstExceptT CmdQueryError $ runLegacyQueryCmds cmd
   LegacyStakeAddressCmds cmd -> firstExceptT CmdStakeAddressError $ runLegacyStakeAddressCmds cmd
-  LegacyStakePoolCmds    cmd -> firstExceptT CmdStakePoolError $ runLegacyStakePoolCmds cmd
-  LegacyTextViewCmds     cmd -> firstExceptT CmdTextViewError $ runLegacyTextViewCmds cmd
-  LegacyTransactionCmds  cmd -> firstExceptT CmdTransactionError $ runLegacyTransactionCmds cmd
+  LegacyStakePoolCmds cmd -> firstExceptT CmdStakePoolError $ runLegacyStakePoolCmds cmd
+  LegacyTextViewCmds cmd -> firstExceptT CmdTextViewError $ runLegacyTextViewCmds cmd
+  LegacyTransactionCmds cmd -> firstExceptT CmdTransactionError $ runLegacyTransactionCmds cmd

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Address.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Address.hs
@@ -9,21 +9,24 @@ module Cardano.CLI.Legacy.Run.Address
   ( runLegacyAddressCmds
   ) where
 
-import           Cardano.Api
+import Cardano.Api
 
-import           Cardano.CLI.EraBased.Run.Address
-import           Cardano.CLI.EraBased.Run.Address.Info
-import           Cardano.CLI.Legacy.Commands.Address
-import           Cardano.CLI.Types.Common
-import           Cardano.CLI.Types.Errors.AddressCmdError
-import           Cardano.CLI.Types.Errors.AddressInfoError
-import           Cardano.CLI.Types.Key (PaymentVerifier (..), StakeIdentifier (..),
-                   VerificationKeyTextOrFile)
+import Cardano.CLI.EraBased.Run.Address
+import Cardano.CLI.EraBased.Run.Address.Info
+import Cardano.CLI.Legacy.Commands.Address
+import Cardano.CLI.Types.Common
+import Cardano.CLI.Types.Errors.AddressCmdError
+import Cardano.CLI.Types.Errors.AddressInfoError
+import Cardano.CLI.Types.Key
+  ( PaymentVerifier (..)
+  , StakeIdentifier (..)
+  , VerificationKeyTextOrFile
+  )
 
-import           Control.Monad.Trans.Except (ExceptT)
-import           Control.Monad.Trans.Except.Extra (firstExceptT)
-import           Data.Function
-import           Data.Text (Text)
+import Control.Monad.Trans.Except (ExceptT)
+import Control.Monad.Trans.Except.Extra (firstExceptT)
+import Data.Function
+import Data.Text (Text)
 
 runLegacyAddressCmds :: LegacyAddressCmds -> ExceptT AddressCmdError IO ()
 runLegacyAddressCmds = \case
@@ -36,7 +39,8 @@ runLegacyAddressCmds = \case
   AddressInfo txt mOFp ->
     runLegacyAddressInfoCmd txt mOFp & firstExceptT AddressCmdAddressInfoError
 
-runLegacyAddressKeyGenCmd :: ()
+runLegacyAddressKeyGenCmd
+  :: ()
   => KeyOutputFormat
   -> AddressKeyType
   -> VerificationKeyFile Out
@@ -44,13 +48,15 @@ runLegacyAddressKeyGenCmd :: ()
   -> ExceptT AddressCmdError IO ()
 runLegacyAddressKeyGenCmd = runAddressKeyGenCmd
 
-runLegacyAddressKeyHashCmd :: ()
+runLegacyAddressKeyHashCmd
+  :: ()
   => VerificationKeyTextOrFile
   -> Maybe (File () Out)
   -> ExceptT AddressCmdError IO ()
 runLegacyAddressKeyHashCmd = runAddressKeyHashCmd
 
-runLegacyAddressBuildCmd :: ()
+runLegacyAddressBuildCmd
+  :: ()
   => PaymentVerifier
   -> Maybe StakeIdentifier
   -> NetworkId
@@ -58,7 +64,8 @@ runLegacyAddressBuildCmd :: ()
   -> ExceptT AddressCmdError IO ()
 runLegacyAddressBuildCmd = runAddressBuildCmd
 
-runLegacyAddressInfoCmd :: ()
+runLegacyAddressInfoCmd
+  :: ()
   => Text
   -> Maybe (File () Out)
   -> ExceptT AddressInfoError IO ()

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Genesis.hs
@@ -1,22 +1,21 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
-
 {-# OPTIONS_GHC -Wno-unticked-promoted-constructors #-}
 
 module Cardano.CLI.Legacy.Run.Genesis
   ( runLegacyGenesisCmds
   ) where
 
-import           Cardano.Api
+import Cardano.Api
 
-import           Cardano.Chain.Common (BlockCount)
-import           Cardano.CLI.EraBased.Run.Genesis
-import           Cardano.CLI.Legacy.Commands.Genesis
-import           Cardano.CLI.Types.Common
-import           Cardano.CLI.Types.Errors.GenesisCmdError
+import Cardano.CLI.EraBased.Run.Genesis
+import Cardano.CLI.Legacy.Commands.Genesis
+import Cardano.CLI.Types.Common
+import Cardano.CLI.Types.Errors.GenesisCmdError
+import Cardano.Chain.Common (BlockCount)
 
-import           Control.Monad.Trans.Except (ExceptT)
+import Control.Monad.Trans.Except (ExceptT)
 
 runLegacyGenesisCmds :: LegacyGenesisCmds -> ExceptT GenesisCmdError IO ()
 runLegacyGenesisCmds = \case
@@ -43,20 +42,23 @@ runLegacyGenesisCmds = \case
   GenesisHashFile gf ->
     runLegacyGenesisHashFileCmd gf
 
-runLegacyGenesisKeyGenGenesisCmd :: ()
+runLegacyGenesisKeyGenGenesisCmd
+  :: ()
   => VerificationKeyFile Out
   -> SigningKeyFile Out
   -> ExceptT GenesisCmdError IO ()
 runLegacyGenesisKeyGenGenesisCmd = runGenesisKeyGenGenesisCmd
 
-runLegacyGenesisKeyGenDelegateCmd :: ()
+runLegacyGenesisKeyGenDelegateCmd
+  :: ()
   => VerificationKeyFile Out
   -> SigningKeyFile Out
   -> OpCertCounterFile Out
   -> ExceptT GenesisCmdError IO ()
 runLegacyGenesisKeyGenDelegateCmd = runGenesisKeyGenDelegateCmd
 
-runLegacyGenesisKeyGenUTxOCmd :: ()
+runLegacyGenesisKeyGenUTxOCmd
+  :: ()
   => VerificationKeyFile Out
   -> SigningKeyFile Out
   -> ExceptT GenesisCmdError IO ()
@@ -65,75 +67,101 @@ runLegacyGenesisKeyGenUTxOCmd = runGenesisKeyGenUTxOCmd
 runLegacyGenesisKeyHashCmd :: VerificationKeyFile In -> ExceptT GenesisCmdError IO ()
 runLegacyGenesisKeyHashCmd = runGenesisKeyHashCmd
 
-runLegacyGenesisVerKeyCmd ::
-     VerificationKeyFile Out
+runLegacyGenesisVerKeyCmd
+  :: VerificationKeyFile Out
   -> SigningKeyFile In
   -> ExceptT GenesisCmdError IO ()
 runLegacyGenesisVerKeyCmd = runGenesisVerKeyCmd
 
-runLegacyGenesisTxInCmd :: ()
+runLegacyGenesisTxInCmd
+  :: ()
   => VerificationKeyFile In
   -> NetworkId
   -> Maybe (File () Out)
   -> ExceptT GenesisCmdError IO ()
 runLegacyGenesisTxInCmd = runGenesisTxInCmd
 
-runLegacyGenesisAddrCmd :: ()
+runLegacyGenesisAddrCmd
+  :: ()
   => VerificationKeyFile In
   -> NetworkId
   -> Maybe (File () Out)
   -> ExceptT GenesisCmdError IO ()
 runLegacyGenesisAddrCmd = runGenesisAddrCmd
 
-runLegacyGenesisCreateCmd :: ()
+runLegacyGenesisCreateCmd
+  :: ()
   => KeyOutputFormat
   -> GenesisDir
-  -> Word  -- ^ num genesis & delegate keys to make
-  -> Word  -- ^ num utxo keys to make
+  -> Word
+  -- ^ num genesis & delegate keys to make
+  -> Word
+  -- ^ num utxo keys to make
   -> Maybe SystemStart
   -> Maybe Lovelace
   -> NetworkId
   -> ExceptT GenesisCmdError IO ()
 runLegacyGenesisCreateCmd = runGenesisCreateCmd
 
-runLegacyGenesisCreateCardanoCmd :: ()
+runLegacyGenesisCreateCardanoCmd
+  :: ()
   => GenesisDir
-  -> Word  -- ^ num genesis & delegate keys to make
-  -> Word  -- ^ num utxo keys to make
+  -> Word
+  -- ^ num genesis & delegate keys to make
+  -> Word
+  -- ^ num utxo keys to make
   -> Maybe SystemStart
   -> Maybe Lovelace
   -> BlockCount
-  -> Word     -- ^ slot length in ms
+  -> Word
+  -- ^ slot length in ms
   -> Rational
   -> NetworkId
-  -> FilePath -- ^ Byron Genesis
-  -> FilePath -- ^ Shelley Genesis
-  -> FilePath -- ^ Alonzo Genesis
-  -> FilePath -- ^ Conway Genesis
+  -> FilePath
+  -- ^ Byron Genesis
+  -> FilePath
+  -- ^ Shelley Genesis
+  -> FilePath
+  -- ^ Alonzo Genesis
+  -> FilePath
+  -- ^ Conway Genesis
   -> Maybe FilePath
   -> ExceptT GenesisCmdError IO ()
 runLegacyGenesisCreateCardanoCmd = runGenesisCreateCardanoCmd
 
-runLegacyGenesisCreateStakedCmd :: ()
-  => KeyOutputFormat    -- ^ key output format
+runLegacyGenesisCreateStakedCmd
+  :: ()
+  => KeyOutputFormat
+  -- ^ key output format
   -> GenesisDir
-  -> Word               -- ^ num genesis & delegate keys to make
-  -> Word               -- ^ num utxo keys to make
-  -> Word               -- ^ num pools to make
-  -> Word               -- ^ num delegators to make
+  -> Word
+  -- ^ num genesis & delegate keys to make
+  -> Word
+  -- ^ num utxo keys to make
+  -> Word
+  -- ^ num pools to make
+  -> Word
+  -- ^ num delegators to make
   -> Maybe SystemStart
-  -> Maybe Lovelace     -- ^ supply going to non-delegators
-  -> Lovelace           -- ^ supply going to delegators
+  -> Maybe Lovelace
+  -- ^ supply going to non-delegators
+  -> Lovelace
+  -- ^ supply going to delegators
   -> NetworkId
-  -> Word               -- ^ bulk credential files to write
-  -> Word               -- ^ pool credentials per bulk file
-  -> Word               -- ^ num stuffed UTxO entries
-  -> Maybe FilePath     -- ^ Specified stake pool relays
+  -> Word
+  -- ^ bulk credential files to write
+  -> Word
+  -- ^ pool credentials per bulk file
+  -> Word
+  -- ^ num stuffed UTxO entries
+  -> Maybe FilePath
+  -- ^ Specified stake pool relays
   -> ExceptT GenesisCmdError IO ()
 runLegacyGenesisCreateStakedCmd = runGenesisCreateStakedCmd
 
 -- | Hash a genesis file
-runLegacyGenesisHashFileCmd :: ()
+runLegacyGenesisHashFileCmd
+  :: ()
   => GenesisFile
   -> ExceptT GenesisCmdError IO ()
 runLegacyGenesisHashFileCmd = runGenesisHashFileCmd

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Governance.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Governance.hs
@@ -8,35 +8,35 @@ module Cardano.CLI.Legacy.Run.Governance
   ( runLegacyGovernanceCmds
   ) where
 
-import           Cardano.Api
+import Cardano.Api
 import qualified Cardano.Api.Ledger as Ledger
-import           Cardano.Api.Shelley
+import Cardano.Api.Shelley
 import qualified Cardano.Api.Shelley as Api
 
-import           Cardano.CLI.EraBased.Run.Governance
-import           Cardano.CLI.Legacy.Commands.Governance
-import           Cardano.CLI.Read
-import           Cardano.CLI.Types.Common
-import           Cardano.CLI.Types.Errors.GovernanceCmdError
-import           Cardano.CLI.Types.Key
+import Cardano.CLI.EraBased.Run.Governance
+import Cardano.CLI.Legacy.Commands.Governance
+import Cardano.CLI.Read
+import Cardano.CLI.Types.Common
+import Cardano.CLI.Types.Errors.GovernanceCmdError
+import Cardano.CLI.Types.Key
 
-import           Control.Monad
-import           Control.Monad.IO.Class
-import           Control.Monad.Trans.Class (lift)
-import           Control.Monad.Trans.Except (ExceptT)
-import           Control.Monad.Trans.Except.Extra
-import           Data.Aeson (eitherDecode)
+import Control.Monad
+import Control.Monad.IO.Class
+import Control.Monad.Trans.Class (lift)
+import Control.Monad.Trans.Except (ExceptT)
+import Control.Monad.Trans.Except.Extra
+import Data.Aeson (eitherDecode)
 import qualified Data.ByteString.Char8 as BSC
 import qualified Data.ByteString.Lazy as LB
-import           Data.Function ((&))
-import           Data.String (fromString)
-import           Data.Text (Text)
+import Data.Function ((&))
+import Data.String (fromString)
+import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import qualified Data.Text.IO as Text
 import qualified Data.Text.Read as Text
+import System.IO (stderr, stdin, stdout)
 import qualified System.IO as IO
-import           System.IO (stderr, stdin, stdout)
 
 runLegacyGovernanceCmds :: LegacyGovernanceCmds -> ExceptT GovernanceCmdError IO ()
 runLegacyGovernanceCmds = \case
@@ -58,8 +58,10 @@ runLegacyGovernanceCmds = \case
 runLegacyGovernanceMIRCertificatePayStakeAddrs
   :: AnyShelleyToBabbageEra
   -> Ledger.MIRPot
-  -> [StakeAddress] -- ^ Stake addresses
-  -> [Lovelace]     -- ^ Corresponding reward amounts (same length)
+  -> [StakeAddress]
+  -- ^ Stake addresses
+  -> [Lovelace]
+  -- ^ Corresponding reward amounts (same length)
   -> File () Out
   -> ExceptT GovernanceCmdError IO ()
 runLegacyGovernanceMIRCertificatePayStakeAddrs (AnyShelleyToBabbageEra w) =
@@ -81,29 +83,34 @@ runLegacyGovernanceGenesisKeyDelegationCertificate
   -> VerificationKeyOrHashOrFile VrfKey
   -> File () Out
   -> ExceptT GovernanceCmdError IO ()
-runLegacyGovernanceGenesisKeyDelegationCertificate (AnyShelleyBasedEra sbe)
-                                             genVkOrHashOrFp
-                                             genDelVkOrHashOrFp
-                                             vrfVkOrHashOrFp
-                                             oFp = do
-  genesisVkHash <- firstExceptT GovernanceCmdKeyReadError
-    . newExceptT
-    $ readVerificationKeyOrHashOrTextEnvFile AsGenesisKey genVkOrHashOrFp
-  genesisDelVkHash <-firstExceptT GovernanceCmdKeyReadError
-    . newExceptT
-    $ readVerificationKeyOrHashOrTextEnvFile AsGenesisDelegateKey genDelVkOrHashOrFp
-  vrfVkHash <- firstExceptT GovernanceCmdKeyReadError
-    . newExceptT
-    $ readVerificationKeyOrHashOrFile AsVrfKey vrfVkOrHashOrFp
+runLegacyGovernanceGenesisKeyDelegationCertificate
+  (AnyShelleyBasedEra sbe)
+  genVkOrHashOrFp
+  genDelVkOrHashOrFp
+  vrfVkOrHashOrFp
+  oFp = do
+    genesisVkHash <-
+      firstExceptT GovernanceCmdKeyReadError
+        . newExceptT
+        $ readVerificationKeyOrHashOrTextEnvFile AsGenesisKey genVkOrHashOrFp
+    genesisDelVkHash <-
+      firstExceptT GovernanceCmdKeyReadError
+        . newExceptT
+        $ readVerificationKeyOrHashOrTextEnvFile AsGenesisDelegateKey genDelVkOrHashOrFp
+    vrfVkHash <-
+      firstExceptT GovernanceCmdKeyReadError
+        . newExceptT
+        $ readVerificationKeyOrHashOrFile AsVrfKey vrfVkOrHashOrFp
 
-  req <- hoistEither $ createGenesisDelegationRequirements sbe genesisVkHash genesisDelVkHash vrfVkHash
-  let genKeyDelegCert = makeGenesisKeyDelegationCertificate req
+    req <-
+      hoistEither $ createGenesisDelegationRequirements sbe genesisVkHash genesisDelVkHash vrfVkHash
+    let genKeyDelegCert = makeGenesisKeyDelegationCertificate req
 
-  firstExceptT GovernanceCmdTextEnvWriteError
-    . newExceptT
-    $ writeLazyByteStringFile oFp
-    $ textEnvelopeToJSON (Just genKeyDelegCertDesc) genKeyDelegCert
-  where
+    firstExceptT GovernanceCmdTextEnvWriteError
+      . newExceptT
+      $ writeLazyByteStringFile oFp
+      $ textEnvelopeToJSON (Just genKeyDelegCertDesc) genKeyDelegCert
+   where
     genKeyDelegCertDesc :: TextEnvelopeDescr
     genKeyDelegCertDesc = "Genesis Key Delegation Certificate"
 
@@ -134,7 +141,8 @@ runLegacyGovernanceUpdateProposal
   -> [VerificationKeyFile In]
   -- ^ Genesis verification keys
   -> ProtocolParametersUpdate
-  -> Maybe FilePath -- ^ Cost models file path
+  -> Maybe FilePath
+  -- ^ Cost models file path
   -> ExceptT GovernanceCmdError IO ()
 runLegacyGovernanceUpdateProposal upFile eNo genVerKeyFiles upPprams mCostModelFp = do
   finalUpPprams <- case mCostModelFp of
@@ -142,8 +150,9 @@ runLegacyGovernanceUpdateProposal upFile eNo genVerKeyFiles upPprams mCostModelF
     Just fp -> do
       costModelsBs <- handleIOExceptT (GovernanceCmdCostModelReadError . FileIOError fp) $ LB.readFile fp
 
-      cModels <- pure (eitherDecode costModelsBs)
-        & onLeft (left . GovernanceCmdCostModelsJsonDecodeErr fp . Text.pack)
+      cModels <-
+        pure (eitherDecode costModelsBs)
+          & onLeft (left . GovernanceCmdCostModelsJsonDecodeErr fp . Text.pack)
 
       let costModels = fromAlonzoCostModels cModels
 
@@ -153,15 +162,18 @@ runLegacyGovernanceUpdateProposal upFile eNo genVerKeyFiles upPprams mCostModelF
 
   when (finalUpPprams == mempty) $ left GovernanceCmdEmptyUpdateProposalError
 
-  genVKeys <- sequence
-    [ firstExceptT GovernanceCmdTextEnvReadError . newExceptT $ readFileTextEnvelope (AsVerificationKey AsGenesisKey) vkeyFile
-    | vkeyFile <- genVerKeyFiles
-    ]
+  genVKeys <-
+    sequence
+      [ firstExceptT GovernanceCmdTextEnvReadError . newExceptT $
+        readFileTextEnvelope (AsVerificationKey AsGenesisKey) vkeyFile
+      | vkeyFile <- genVerKeyFiles
+      ]
   let genKeyHashes = fmap verificationKeyHash genVKeys
       upProp = makeShelleyUpdateProposal finalUpPprams genKeyHashes eNo
 
-  firstExceptT GovernanceCmdTextEnvWriteError . newExceptT
-    $ writeLazyByteStringFile upFile $ textEnvelopeToJSON Nothing upProp
+  firstExceptT GovernanceCmdTextEnvWriteError . newExceptT $
+    writeLazyByteStringFile upFile $
+      textEnvelopeToJSON Nothing upProp
 
 runLegacyGovernanceCreatePoll
   :: Text
@@ -170,120 +182,148 @@ runLegacyGovernanceCreatePoll
   -> File GovernancePoll Out
   -> ExceptT GovernanceCmdError IO ()
 runLegacyGovernanceCreatePoll govPollQuestion govPollAnswers govPollNonce out = do
-  let poll = GovernancePoll{ govPollQuestion, govPollAnswers, govPollNonce }
+  let poll = GovernancePoll {govPollQuestion, govPollAnswers, govPollNonce}
 
   let description = fromString $ "An on-chain poll for SPOs: " <> Text.unpack govPollQuestion
   firstExceptT GovernanceCmdTextEnvWriteError . newExceptT $
     writeFileTextEnvelope out (Just description) poll
 
-  let metadata = asTxMetadata poll
-        & metadataToJson TxMetadataJsonDetailedSchema
+  let metadata =
+        asTxMetadata poll
+          & metadataToJson TxMetadataJsonDetailedSchema
 
   let outPath = unFile out & Text.encodeUtf8 . Text.pack
 
   liftIO $ do
-    BSC.hPutStrLn stderr $ mconcat
-      [ "Poll created successfully.\n"
-      , "Please submit a transaction using the resulting metadata.\n"
-      ]
+    BSC.hPutStrLn stderr $
+      mconcat
+        [ "Poll created successfully.\n"
+        , "Please submit a transaction using the resulting metadata.\n"
+        ]
     BSC.hPutStrLn stdout (prettyPrintJSON metadata)
-    BSC.hPutStrLn stderr $ mconcat
-      [ "\n"
-      , "Hint (1): Use '--json-metadata-detailed-schema' and '--metadata-json-file' "
-      , "from the build or build-raw commands.\n"
-      , "Hint (2): You can redirect the standard output of this command to a JSON "
-      , "file to capture metadata.\n\n"
-      , "Note: A serialized version of the poll suitable for sharing with "
-      , "participants has been generated at '" <> outPath <> "'."
-      ]
+    BSC.hPutStrLn stderr $
+      mconcat
+        [ "\n"
+        , "Hint (1): Use '--json-metadata-detailed-schema' and '--metadata-json-file' "
+        , "from the build or build-raw commands.\n"
+        , "Hint (2): You can redirect the standard output of this command to a JSON "
+        , "file to capture metadata.\n\n"
+        , "Note: A serialized version of the poll suitable for sharing with "
+        , "participants has been generated at '" <> outPath <> "'."
+        ]
 
 runLegacyGovernanceAnswerPoll
   :: File GovernancePoll In
-  -> Maybe Word -- ^ Answer index
-  -> Maybe (File () Out) -- ^ Output file
+  -> Maybe Word
+  -- ^ Answer index
+  -> Maybe (File () Out)
+  -- ^ Output file
   -> ExceptT GovernanceCmdError IO ()
 runLegacyGovernanceAnswerPoll pollFile maybeChoice mOutFile = do
-  poll <- firstExceptT GovernanceCmdTextEnvReadError . newExceptT $
-    readFileTextEnvelope AsGovernancePoll pollFile
+  poll <-
+    firstExceptT GovernanceCmdTextEnvReadError . newExceptT $
+      readFileTextEnvelope AsGovernancePoll pollFile
 
   choice <- case maybeChoice of
     Nothing -> do
       askInteractively poll
     Just ix -> do
       validateChoice poll ix
-      liftIO $ BSC.hPutStrLn stderr $ Text.encodeUtf8 $ Text.intercalate "\n"
-        [ govPollQuestion poll
-        , "→ " <> (govPollAnswers poll !! fromIntegral ix)
-        , ""
-        ]
+      liftIO $
+        BSC.hPutStrLn stderr $
+          Text.encodeUtf8 $
+            Text.intercalate
+              "\n"
+              [ govPollQuestion poll
+              , "→ " <> (govPollAnswers poll !! fromIntegral ix)
+              , ""
+              ]
       pure ix
 
-  let pollAnswer = GovernancePollAnswer
-        { govAnsPoll = hashGovernancePoll poll
-        , govAnsChoice = choice
-        }
+  let pollAnswer =
+        GovernancePollAnswer
+          { govAnsPoll = hashGovernancePoll poll
+          , govAnsChoice = choice
+          }
   let metadata =
         metadataToJson TxMetadataJsonDetailedSchema (asTxMetadata pollAnswer)
 
-  liftIO $ BSC.hPutStrLn stderr $ mconcat
-      [ "Poll answer created successfully.\n"
-      , "Please submit a transaction using the resulting metadata.\n"
-      , "To be valid, the transaction must also be signed using a valid key\n"
-      , "identifying your stake pool (e.g. your cold key).\n"
-      ]
+  liftIO $
+    BSC.hPutStrLn stderr $
+      mconcat
+        [ "Poll answer created successfully.\n"
+        , "Please submit a transaction using the resulting metadata.\n"
+        , "To be valid, the transaction must also be signed using a valid key\n"
+        , "identifying your stake pool (e.g. your cold key).\n"
+        ]
 
   lift (writeByteStringOutput mOutFile (prettyPrintJSON metadata))
     & onLeft (left . GovernanceCmdWriteFileError)
 
-  liftIO $ BSC.hPutStrLn stderr $ mconcat
-      [ "\n"
-      , "Hint (1): Use '--json-metadata-detailed-schema' and '--metadata-json-file' "
-      , "from the build or build-raw commands.\n"
-      , "Hint (2): You can redirect the standard output of this command to a JSON "
-      , "file to capture metadata."
-      ]
+  liftIO $
+    BSC.hPutStrLn stderr $
+      mconcat
+        [ "\n"
+        , "Hint (1): Use '--json-metadata-detailed-schema' and '--metadata-json-file' "
+        , "from the build or build-raw commands.\n"
+        , "Hint (2): You can redirect the standard output of this command to a JSON "
+        , "file to capture metadata."
+        ]
  where
   validateChoice :: GovernancePoll -> Word -> ExceptT GovernanceCmdError IO ()
-  validateChoice GovernancePoll{govPollAnswers} ix = do
+  validateChoice GovernancePoll {govPollAnswers} ix = do
     let maxAnswerIndex = length govPollAnswers - 1
-    when (fromIntegral ix > maxAnswerIndex) $ left $
-      GovernanceCmdPollOutOfBoundAnswer maxAnswerIndex
+    when (fromIntegral ix > maxAnswerIndex) $
+      left $
+        GovernanceCmdPollOutOfBoundAnswer maxAnswerIndex
 
   askInteractively :: GovernancePoll -> ExceptT GovernanceCmdError IO Word
-  askInteractively poll@GovernancePoll{govPollQuestion, govPollAnswers} = do
-    liftIO $ BSC.hPutStrLn stderr $ Text.encodeUtf8 $ Text.intercalate "\n"
-      ( govPollQuestion
-      : [ "[" <> textShow ix <> "] " <> answer
-        | (ix :: Int, answer) <- zip [0..] govPollAnswers
-        ]
-      )
+  askInteractively poll@GovernancePoll {govPollQuestion, govPollAnswers} = do
+    liftIO $
+      BSC.hPutStrLn stderr $
+        Text.encodeUtf8 $
+          Text.intercalate
+            "\n"
+            ( govPollQuestion
+                : [ "[" <> textShow ix <> "] " <> answer
+                  | (ix :: Int, answer) <- zip [0 ..] govPollAnswers
+                  ]
+            )
     liftIO $ BSC.hPutStrLn stderr ""
     liftIO $ BSC.hPutStr stderr "Please indicate an answer (by index): "
     txt <- liftIO $ Text.hGetLine stdin
     liftIO $ BSC.hPutStrLn stderr ""
     case Text.decimal txt of
-      Right (choice, rest) | Text.null rest ->
-        choice <$ validateChoice poll choice
+      Right (choice, rest)
+        | Text.null rest ->
+            choice <$ validateChoice poll choice
       _ ->
         left GovernanceCmdPollInvalidChoice
 
 runLegacyGovernanceVerifyPoll
   :: File GovernancePoll In
   -> File (Api.Tx ()) In
-  -> Maybe (File () Out) -- ^ Output file
+  -> Maybe (File () Out)
+  -- ^ Output file
   -> ExceptT GovernanceCmdError IO ()
 runLegacyGovernanceVerifyPoll pollFile txFile mOutFile = do
-  poll <- firstExceptT GovernanceCmdTextEnvReadError . newExceptT $
-    readFileTextEnvelope AsGovernancePoll pollFile
+  poll <-
+    firstExceptT GovernanceCmdTextEnvReadError . newExceptT $
+      readFileTextEnvelope AsGovernancePoll pollFile
 
   txFileOrPipe <- liftIO $ fileOrPipe (unFile txFile)
-  tx <- firstExceptT GovernanceCmdCddlError . newExceptT $
-    readFileTx txFileOrPipe
+  tx <-
+    firstExceptT GovernanceCmdCddlError . newExceptT $
+      readFileTx txFileOrPipe
 
-  signatories <- firstExceptT GovernanceCmdVerifyPollError . newExceptT $ pure $
-    verifyPollAnswer poll tx
+  signatories <-
+    firstExceptT GovernanceCmdVerifyPollError . newExceptT $
+      pure $
+        verifyPollAnswer poll tx
 
-  liftIO $ IO.hPutStrLn stderr $ "Found valid poll answer with " <> show (length signatories) <> " signatories"
+  liftIO $
+    IO.hPutStrLn stderr $
+      "Found valid poll answer with " <> show (length signatories) <> " signatories"
 
   lift (writeByteStringOutput mOutFile (prettyPrintJSON signatories))
     & onLeft (left . GovernanceCmdWriteFileError)

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Governance.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Governance.hs
@@ -9,9 +9,9 @@ module Cardano.CLI.Legacy.Run.Governance
   ) where
 
 import Cardano.Api
-import qualified Cardano.Api.Ledger as Ledger
+import Cardano.Api.Ledger qualified as Ledger
 import Cardano.Api.Shelley
-import qualified Cardano.Api.Shelley as Api
+import Cardano.Api.Shelley qualified as Api
 
 import Cardano.CLI.EraBased.Run.Governance
 import Cardano.CLI.Legacy.Commands.Governance
@@ -26,17 +26,17 @@ import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.Except (ExceptT)
 import Control.Monad.Trans.Except.Extra
 import Data.Aeson (eitherDecode)
-import qualified Data.ByteString.Char8 as BSC
-import qualified Data.ByteString.Lazy as LB
+import Data.ByteString.Char8 qualified as BSC
+import Data.ByteString.Lazy qualified as LB
 import Data.Function ((&))
 import Data.String (fromString)
 import Data.Text (Text)
-import qualified Data.Text as Text
-import qualified Data.Text.Encoding as Text
-import qualified Data.Text.IO as Text
-import qualified Data.Text.Read as Text
+import Data.Text qualified as Text
+import Data.Text.Encoding qualified as Text
+import Data.Text.IO qualified as Text
+import Data.Text.Read qualified as Text
 import System.IO (stderr, stdin, stdout)
-import qualified System.IO as IO
+import System.IO qualified as IO
 
 runLegacyGovernanceCmds :: LegacyGovernanceCmds -> ExceptT GovernanceCmdError IO ()
 runLegacyGovernanceCmds = \case

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Key.hs
@@ -5,17 +5,18 @@ module Cardano.CLI.Legacy.Run.Key
   ( runLegacyKeyCmds
   ) where
 
-import           Cardano.Api
+import Cardano.Api
 
-import           Cardano.CLI.EraBased.Run.Key
-import           Cardano.CLI.Legacy.Commands.Key
-import           Cardano.CLI.Types.Common
-import           Cardano.CLI.Types.Errors.KeyCmdError
+import Cardano.CLI.EraBased.Run.Key
+import Cardano.CLI.Legacy.Commands.Key
+import Cardano.CLI.Types.Common
+import Cardano.CLI.Types.Errors.KeyCmdError
 
-import           Control.Monad.Trans.Except (ExceptT)
-import           Data.Text (Text)
+import Control.Monad.Trans.Except (ExceptT)
+import Data.Text (Text)
 
-runLegacyKeyCmds :: ()
+runLegacyKeyCmds
+  :: ()
   => LegacyKeyCmds
   -> ExceptT KeyCmdError IO ()
 runLegacyKeyCmds = \case
@@ -36,29 +37,38 @@ runLegacyKeyCmds = \case
   KeyConvertCardanoAddressSigningKey keyType skfOld skfNew ->
     runLegacyConvertCardanoAddressSigningKeyCmd keyType skfOld skfNew
 
-runLegacyGetVerificationKeyCmd :: ()
+runLegacyGetVerificationKeyCmd
+  :: ()
   => SigningKeyFile In
   -> VerificationKeyFile Out
   -> ExceptT KeyCmdError IO ()
 runLegacyGetVerificationKeyCmd = runGetVerificationKeyCmd
 
-runLegacyConvertToNonExtendedKeyCmd :: ()
+runLegacyConvertToNonExtendedKeyCmd
+  :: ()
   => VerificationKeyFile In
   -> VerificationKeyFile Out
   -> ExceptT KeyCmdError IO ()
 runLegacyConvertToNonExtendedKeyCmd = runConvertToNonExtendedKeyCmd
 
-runLegacyConvertByronKeyCmd :: ()
-  => Maybe Text      -- ^ Password (if applicable)
+runLegacyConvertByronKeyCmd
+  :: ()
+  => Maybe Text
+  -- ^ Password (if applicable)
   -> ByronKeyType
-  -> SomeKeyFile In  -- ^ Input file: old format
-  -> File () Out     -- ^ Output file: new format
+  -> SomeKeyFile In
+  -- ^ Input file: old format
+  -> File () Out
+  -- ^ Output file: new format
   -> ExceptT KeyCmdError IO ()
 runLegacyConvertByronKeyCmd = runConvertByronKeyCmd
 
-runLegacyConvertByronGenesisVerificationKeyCmd :: ()
-  => VerificationKeyBase64  -- ^ Input key raw old format
-  -> File () Out            -- ^ Output file: new format
+runLegacyConvertByronGenesisVerificationKeyCmd
+  :: ()
+  => VerificationKeyBase64
+  -- ^ Input key raw old format
+  -> File () Out
+  -- ^ Output file: new format
   -> ExceptT KeyCmdError IO ()
 runLegacyConvertByronGenesisVerificationKeyCmd = runConvertByronGenesisVerificationKeyCmd
 
@@ -66,25 +76,29 @@ runLegacyConvertByronGenesisVerificationKeyCmd = runConvertByronGenesisVerificat
 -- ITN verification/signing key conversion to Haskell verficiation/signing keys
 --------------------------------------------------------------------------------
 
-runLegacyConvertITNStakeKeyCmd :: ()
+runLegacyConvertITNStakeKeyCmd
+  :: ()
   => SomeKeyFile In
   -> File () Out
   -> ExceptT KeyCmdError IO ()
 runLegacyConvertITNStakeKeyCmd = runConvertITNStakeKeyCmd
 
-runLegacyConvertITNExtendedToStakeKeyCmd :: ()
+runLegacyConvertITNExtendedToStakeKeyCmd
+  :: ()
   => SomeKeyFile In
   -> File () Out
   -> ExceptT KeyCmdError IO ()
 runLegacyConvertITNExtendedToStakeKeyCmd = runConvertITNExtendedToStakeKeyCmd
 
-runLegacyConvertITNBip32ToStakeKeyCmd :: ()
+runLegacyConvertITNBip32ToStakeKeyCmd
+  :: ()
   => SomeKeyFile In
   -> File () Out
   -> ExceptT KeyCmdError IO ()
 runLegacyConvertITNBip32ToStakeKeyCmd = runConvertITNBip32ToStakeKeyCmd
 
-runLegacyConvertCardanoAddressSigningKeyCmd :: ()
+runLegacyConvertCardanoAddressSigningKeyCmd
+  :: ()
   => CardanoAddressKeyType
   -> SigningKeyFile In
   -> File () Out

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Node.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Node.hs
@@ -5,28 +5,29 @@ module Cardano.CLI.Legacy.Run.Node
   ( runLegacyNodeCmds
   ) where
 
-import           Cardano.Api
-import           Cardano.Api.Shelley
+import Cardano.Api
+import Cardano.Api.Shelley
 
-import           Cardano.CLI.EraBased.Run.Node
-import           Cardano.CLI.Legacy.Commands.Node
-import           Cardano.CLI.Types.Common
-import           Cardano.CLI.Types.Errors.NodeCmdError
-import           Cardano.CLI.Types.Key
+import Cardano.CLI.EraBased.Run.Node
+import Cardano.CLI.Legacy.Commands.Node
+import Cardano.CLI.Types.Common
+import Cardano.CLI.Types.Errors.NodeCmdError
+import Cardano.CLI.Types.Key
 
-import           Control.Monad.Trans.Except (ExceptT)
+import Control.Monad.Trans.Except (ExceptT)
 
 {- HLINT ignore "Reduce duplication" -}
 
-runLegacyNodeCmds :: ()
+runLegacyNodeCmds
+  :: ()
   => LegacyNodeCmds
   -> ExceptT NodeCmdError IO ()
 runLegacyNodeCmds = \case
   NodeKeyGenCold fmt vk sk ctr ->
     runLegacyNodeKeyGenColdCmd fmt vk sk ctr
-  NodeKeyGenKES  fmt vk sk ->
+  NodeKeyGenKES fmt vk sk ->
     runLegacyNodeKeyGenKesCmd fmt vk sk
-  NodeKeyGenVRF  fmt vk sk ->
+  NodeKeyGenVRF fmt vk sk ->
     runLegacyNodeKeyGenVrfCmd fmt vk sk
   NodeKeyHashVRF vk mOutFp ->
     runLegacyNodeKeyHashVrfCmd vk mOutFp
@@ -35,7 +36,8 @@ runLegacyNodeCmds = \case
   NodeIssueOpCert vk sk ctr p out ->
     runLegacyNodeIssueOpCertCmd vk sk ctr p out
 
-runLegacyNodeKeyGenColdCmd :: ()
+runLegacyNodeKeyGenColdCmd
+  :: ()
   => KeyOutputFormat
   -> VerificationKeyFile Out
   -> SigningKeyFile Out
@@ -43,34 +45,39 @@ runLegacyNodeKeyGenColdCmd :: ()
   -> ExceptT NodeCmdError IO ()
 runLegacyNodeKeyGenColdCmd = runNodeKeyGenColdCmd
 
-runLegacyNodeKeyGenKesCmd :: ()
+runLegacyNodeKeyGenKesCmd
+  :: ()
   => KeyOutputFormat
   -> VerificationKeyFile Out
   -> SigningKeyFile Out
   -> ExceptT NodeCmdError IO ()
 runLegacyNodeKeyGenKesCmd = runNodeKeyGenKesCmd
 
-runLegacyNodeKeyGenVrfCmd :: ()
+runLegacyNodeKeyGenVrfCmd
+  :: ()
   => KeyOutputFormat
   -> VerificationKeyFile Out
   -> SigningKeyFile Out
   -> ExceptT NodeCmdError IO ()
 runLegacyNodeKeyGenVrfCmd = runNodeKeyGenVrfCmd
 
-runLegacyNodeKeyHashVrfCmd :: ()
+runLegacyNodeKeyHashVrfCmd
+  :: ()
   => VerificationKeyOrFile VrfKey
   -> Maybe (File () Out)
   -> ExceptT NodeCmdError IO ()
 runLegacyNodeKeyHashVrfCmd = runNodeKeyHashVrfCmd
 
-runLegacyNodeNewCounterCmd :: ()
+runLegacyNodeNewCounterCmd
+  :: ()
   => ColdVerificationKeyOrFile
   -> Word
   -> OpCertCounterFile InOut
   -> ExceptT NodeCmdError IO ()
 runLegacyNodeNewCounterCmd = runNodeNewCounterCmd
 
-runLegacyNodeIssueOpCertCmd :: ()
+runLegacyNodeIssueOpCertCmd
+  :: ()
   => VerificationKeyOrFile KesKey
   -- ^ This is the hot KES verification key.
   -> SigningKeyFile In

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Query.hs
@@ -1,29 +1,44 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
-
 {-# OPTIONS_GHC -Wno-unticked-promoted-constructors #-}
 
 module Cardano.CLI.Legacy.Run.Query
   ( runLegacyQueryCmds
   ) where
 
-import           Cardano.Api hiding (QueryInShelleyBasedEra (..))
-import           Cardano.Api.Shelley hiding (QueryInShelleyBasedEra (..))
+import Cardano.Api hiding (QueryInShelleyBasedEra (..))
+import Cardano.Api.Shelley hiding (QueryInShelleyBasedEra (..))
 
 import qualified Cardano.CLI.EraBased.Run.Query as EraBased
-import           Cardano.CLI.Legacy.Commands.Query
-import           Cardano.CLI.Types.Common
-import           Cardano.CLI.Types.Errors.QueryCmdError
-import           Cardano.CLI.Types.Key (VerificationKeyOrHashOrFile)
+import Cardano.CLI.Legacy.Commands.Query
+import Cardano.CLI.Types.Common
+import Cardano.CLI.Types.Errors.QueryCmdError
+import Cardano.CLI.Types.Key (VerificationKeyOrHashOrFile)
 
-import           Control.Monad.Trans.Except
-import           Data.Time.Clock
+import Control.Monad.Trans.Except
+import Data.Time.Clock
 
 runLegacyQueryCmds :: LegacyQueryCmds -> ExceptT QueryCmdError IO ()
 runLegacyQueryCmds = \case
-  QueryLeadershipSchedule mNodeSocketPath consensusModeParams network shelleyGenFp poolid vrkSkeyFp whichSchedule outputAs ->
-    runLegacyQueryLeadershipScheduleCmd mNodeSocketPath consensusModeParams network shelleyGenFp poolid vrkSkeyFp whichSchedule outputAs
+  QueryLeadershipSchedule
+    mNodeSocketPath
+    consensusModeParams
+    network
+    shelleyGenFp
+    poolid
+    vrkSkeyFp
+    whichSchedule
+    outputAs ->
+      runLegacyQueryLeadershipScheduleCmd
+        mNodeSocketPath
+        consensusModeParams
+        network
+        shelleyGenFp
+        poolid
+        vrkSkeyFp
+        whichSchedule
+        outputAs
   QueryProtocolParameters' mNodeSocketPath consensusModeParams network mOutFile ->
     runLegacyQueryProtocolParametersCmd mNodeSocketPath consensusModeParams network mOutFile
   QueryConstitutionHash mNodeSocketPath consensusModeParams network mOutFile ->
@@ -53,7 +68,8 @@ runLegacyQueryCmds = \case
   QuerySlotNumber mNodeSocketPath consensusModeParams network utcTime ->
     runLegacyQuerySlotNumberCmd mNodeSocketPath consensusModeParams network utcTime
 
-runLegacyQueryConstitutionHashCmd :: ()
+runLegacyQueryConstitutionHashCmd
+  :: ()
   => SocketPath
   -> AnyConsensusModeParams
   -> NetworkId
@@ -61,7 +77,8 @@ runLegacyQueryConstitutionHashCmd :: ()
   -> ExceptT QueryCmdError IO ()
 runLegacyQueryConstitutionHashCmd = EraBased.runQueryConstitutionHashCmd
 
-runLegacyQueryProtocolParametersCmd :: ()
+runLegacyQueryProtocolParametersCmd
+  :: ()
   => SocketPath
   -> AnyConsensusModeParams
   -> NetworkId
@@ -69,7 +86,8 @@ runLegacyQueryProtocolParametersCmd :: ()
   -> ExceptT QueryCmdError IO ()
 runLegacyQueryProtocolParametersCmd = EraBased.runQueryProtocolParametersCmd
 
-runLegacyQueryTipCmd :: ()
+runLegacyQueryTipCmd
+  :: ()
   => SocketPath
   -> AnyConsensusModeParams
   -> NetworkId
@@ -79,7 +97,8 @@ runLegacyQueryTipCmd = EraBased.runQueryTipCmd
 
 -- | Query the UTxO, filtered by a given set of addresses, from a Shelley node
 -- via the local state query protocol.
-runLegacyQueryUTxOCmd :: ()
+runLegacyQueryUTxOCmd
+  :: ()
   => SocketPath
   -> AnyConsensusModeParams
   -> QueryUTxOFilter
@@ -88,7 +107,8 @@ runLegacyQueryUTxOCmd :: ()
   -> ExceptT QueryCmdError IO ()
 runLegacyQueryUTxOCmd = EraBased.runQueryUTxOCmd
 
-runLegacyQueryKesPeriodInfoCmd :: ()
+runLegacyQueryKesPeriodInfoCmd
+  :: ()
   => SocketPath
   -> AnyConsensusModeParams
   -> NetworkId
@@ -99,8 +119,8 @@ runLegacyQueryKesPeriodInfoCmd = EraBased.runQueryKesPeriodInfoCmd
 
 -- | Query the current and future parameters for a stake pool, including the retirement date.
 -- Any of these may be empty (in which case a null will be displayed).
---
-runLegacyQueryPoolStateCmd :: ()
+runLegacyQueryPoolStateCmd
+  :: ()
   => SocketPath
   -> AnyConsensusModeParams
   -> NetworkId
@@ -109,7 +129,8 @@ runLegacyQueryPoolStateCmd :: ()
 runLegacyQueryPoolStateCmd = EraBased.runQueryPoolStateCmd
 
 -- | Query the local mempool state
-runLegacyQueryTxMempoolCmd :: ()
+runLegacyQueryTxMempoolCmd
+  :: ()
   => SocketPath
   -> AnyConsensusModeParams
   -> NetworkId
@@ -118,7 +139,8 @@ runLegacyQueryTxMempoolCmd :: ()
   -> ExceptT QueryCmdError IO ()
 runLegacyQueryTxMempoolCmd = EraBased.runQueryTxMempoolCmd
 
-runLegacyQuerySlotNumberCmd :: ()
+runLegacyQuerySlotNumberCmd
+  :: ()
   => SocketPath
   -> AnyConsensusModeParams
   -> NetworkId
@@ -129,7 +151,8 @@ runLegacyQuerySlotNumberCmd = EraBased.runQuerySlotNumberCmd
 -- | Obtain stake snapshot information for a pool, plus information about the total active stake.
 -- This information can be used for leader slot calculation, for example, and has been requested by SPOs.
 -- Obtaining the information directly is significantly more time and memory efficient than using a full ledger state dump.
-runLegacyQueryStakeSnapshotCmd :: ()
+runLegacyQueryStakeSnapshotCmd
+  :: ()
   => SocketPath
   -> AnyConsensusModeParams
   -> NetworkId
@@ -138,7 +161,8 @@ runLegacyQueryStakeSnapshotCmd :: ()
   -> ExceptT QueryCmdError IO ()
 runLegacyQueryStakeSnapshotCmd = EraBased.runQueryStakeSnapshotCmd
 
-runLegacyQueryLedgerStateCmd :: ()
+runLegacyQueryLedgerStateCmd
+  :: ()
   => SocketPath
   -> AnyConsensusModeParams
   -> NetworkId
@@ -146,7 +170,8 @@ runLegacyQueryLedgerStateCmd :: ()
   -> ExceptT QueryCmdError IO ()
 runLegacyQueryLedgerStateCmd = EraBased.runQueryLedgerStateCmd
 
-runLegacyQueryProtocolStateCmd :: ()
+runLegacyQueryProtocolStateCmd
+  :: ()
   => SocketPath
   -> AnyConsensusModeParams
   -> NetworkId
@@ -156,8 +181,8 @@ runLegacyQueryProtocolStateCmd = EraBased.runQueryProtocolStateCmd
 
 -- | Query the current delegations and reward accounts, filtered by a given
 -- set of addresses, from a Shelley node via the local state query protocol.
-
-runLegacyQueryStakeAddressInfoCmd :: ()
+runLegacyQueryStakeAddressInfoCmd
+  :: ()
   => SocketPath
   -> AnyConsensusModeParams
   -> StakeAddress
@@ -166,7 +191,8 @@ runLegacyQueryStakeAddressInfoCmd :: ()
   -> ExceptT QueryCmdError IO ()
 runLegacyQueryStakeAddressInfoCmd = EraBased.runQueryStakeAddressInfoCmd
 
-runLegacyQueryStakePoolsCmd :: ()
+runLegacyQueryStakePoolsCmd
+  :: ()
   => SocketPath
   -> AnyConsensusModeParams
   -> NetworkId
@@ -174,7 +200,8 @@ runLegacyQueryStakePoolsCmd :: ()
   -> ExceptT QueryCmdError IO ()
 runLegacyQueryStakePoolsCmd = EraBased.runQueryStakePoolsCmd
 
-runLegacyQueryStakeDistributionCmd :: ()
+runLegacyQueryStakeDistributionCmd
+  :: ()
   => SocketPath
   -> AnyConsensusModeParams
   -> NetworkId
@@ -182,13 +209,16 @@ runLegacyQueryStakeDistributionCmd :: ()
   -> ExceptT QueryCmdError IO ()
 runLegacyQueryStakeDistributionCmd = EraBased.runQueryStakeDistributionCmd
 
-runLegacyQueryLeadershipScheduleCmd :: ()
+runLegacyQueryLeadershipScheduleCmd
+  :: ()
   => SocketPath
   -> AnyConsensusModeParams
   -> NetworkId
-  -> GenesisFile -- ^ Shelley genesis
+  -> GenesisFile
+  -- ^ Shelley genesis
   -> VerificationKeyOrHashOrFile StakePoolKey
-  -> SigningKeyFile In -- ^ VRF signing key
+  -> SigningKeyFile In
+  -- ^ VRF signing key
   -> EpochLeadershipSchedule
   -> Maybe (File () Out)
   -> ExceptT QueryCmdError IO ()

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Query.hs
@@ -10,7 +10,7 @@ module Cardano.CLI.Legacy.Run.Query
 import Cardano.Api hiding (QueryInShelleyBasedEra (..))
 import Cardano.Api.Shelley hiding (QueryInShelleyBasedEra (..))
 
-import qualified Cardano.CLI.EraBased.Run.Query as EraBased
+import Cardano.CLI.EraBased.Run.Query qualified as EraBased
 import Cardano.CLI.Legacy.Commands.Query
 import Cardano.CLI.Types.Common
 import Cardano.CLI.Types.Errors.QueryCmdError

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/StakeAddress.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/StakeAddress.hs
@@ -5,18 +5,19 @@ module Cardano.CLI.Legacy.Run.StakeAddress
   ( runLegacyStakeAddressCmds
   ) where
 
-import           Cardano.Api
-import           Cardano.Api.Shelley
+import Cardano.Api
+import Cardano.Api.Shelley
 
-import           Cardano.CLI.EraBased.Run.StakeAddress
-import           Cardano.CLI.Legacy.Commands.StakeAddress
-import           Cardano.CLI.Types.Common
-import           Cardano.CLI.Types.Errors.StakeAddressCmdError
-import           Cardano.CLI.Types.Key
+import Cardano.CLI.EraBased.Run.StakeAddress
+import Cardano.CLI.Legacy.Commands.StakeAddress
+import Cardano.CLI.Types.Common
+import Cardano.CLI.Types.Errors.StakeAddressCmdError
+import Cardano.CLI.Types.Key
 
-import           Control.Monad.Trans.Except (ExceptT)
+import Control.Monad.Trans.Except (ExceptT)
 
-runLegacyStakeAddressCmds :: ()
+runLegacyStakeAddressCmds
+  :: ()
   => LegacyStakeAddressCmds
   -> ExceptT StakeAddressCmdError IO ()
 runLegacyStakeAddressCmds = \case
@@ -33,7 +34,8 @@ runLegacyStakeAddressCmds = \case
   StakeAddressDeregistrationCertificateCmd anyEra stakeIdentifier mDeposit outputFp ->
     runLegacyStakeAddressDeregistrationCertificateCmd anyEra stakeIdentifier mDeposit outputFp
 
-runLegacyStakeAddressKeyGenCmd :: ()
+runLegacyStakeAddressKeyGenCmd
+  :: ()
   => KeyOutputFormat
   -> VerificationKeyFile Out
   -> SigningKeyFile Out
@@ -41,14 +43,16 @@ runLegacyStakeAddressKeyGenCmd :: ()
 runLegacyStakeAddressKeyGenCmd =
   runStakeAddressKeyGenCmd
 
-runLegacyStakeAddressKeyHashCmd :: ()
+runLegacyStakeAddressKeyHashCmd
+  :: ()
   => VerificationKeyOrFile StakeKey
   -> Maybe (File () Out)
   -> ExceptT StakeAddressCmdError IO ()
 runLegacyStakeAddressKeyHashCmd =
   runStakeAddressKeyHashCmd
 
-runLegacyStakeAddressBuildCmd :: ()
+runLegacyStakeAddressBuildCmd
+  :: ()
   => StakeVerifier
   -> NetworkId
   -> Maybe (File () Out)
@@ -56,16 +60,19 @@ runLegacyStakeAddressBuildCmd :: ()
 runLegacyStakeAddressBuildCmd =
   runStakeAddressBuildCmd
 
-runLegacyStakeAddressRegistrationCertificateCmd :: ()
+runLegacyStakeAddressRegistrationCertificateCmd
+  :: ()
   => AnyShelleyBasedEra
   -> StakeIdentifier
-  -> Maybe Lovelace -- ^ Deposit required in conway era
+  -> Maybe Lovelace
+  -- ^ Deposit required in conway era
   -> File () Out
   -> ExceptT StakeAddressCmdError IO ()
 runLegacyStakeAddressRegistrationCertificateCmd (AnyShelleyBasedEra sbe) =
   runStakeAddressRegistrationCertificateCmd sbe
 
-runLegacyStakeAddresslDelegationCertificateCmd :: ()
+runLegacyStakeAddresslDelegationCertificateCmd
+  :: ()
   => AnyShelleyBasedEra
   -> StakeIdentifier
   -- ^ Delegator stake verification key, verification key file or script file.
@@ -77,10 +84,12 @@ runLegacyStakeAddresslDelegationCertificateCmd :: ()
 runLegacyStakeAddresslDelegationCertificateCmd (AnyShelleyBasedEra sbe) =
   runStakeAddressStakeDelegationCertificateCmd sbe
 
-runLegacyStakeAddressDeregistrationCertificateCmd :: ()
+runLegacyStakeAddressDeregistrationCertificateCmd
+  :: ()
   => AnyShelleyBasedEra
   -> StakeIdentifier
-  -> Maybe Lovelace -- ^ Deposit required in conway era
+  -> Maybe Lovelace
+  -- ^ Deposit required in conway era
   -> File () Out
   -> ExceptT StakeAddressCmdError IO ()
 runLegacyStakeAddressDeregistrationCertificateCmd (AnyShelleyBasedEra sbe) =

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/StakePool.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/StakePool.hs
@@ -14,7 +14,7 @@ import Cardano.CLI.Legacy.Commands.StakePool
 import Cardano.CLI.Types.Common
 import Cardano.CLI.Types.Errors.StakePoolCmdError
 import Cardano.CLI.Types.Key (VerificationKeyOrFile)
-import qualified Cardano.Ledger.Slot as Shelley
+import Cardano.Ledger.Slot qualified as Shelley
 
 import Control.Monad.Trans.Except (ExceptT)
 

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/StakePool.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/StakePool.hs
@@ -6,19 +6,20 @@ module Cardano.CLI.Legacy.Run.StakePool
   ( runLegacyStakePoolCmds
   ) where
 
-import           Cardano.Api
-import           Cardano.Api.Shelley
+import Cardano.Api
+import Cardano.Api.Shelley
 
-import           Cardano.CLI.EraBased.Run.StakePool
-import           Cardano.CLI.Legacy.Commands.StakePool
-import           Cardano.CLI.Types.Common
-import           Cardano.CLI.Types.Errors.StakePoolCmdError
-import           Cardano.CLI.Types.Key (VerificationKeyOrFile)
+import Cardano.CLI.EraBased.Run.StakePool
+import Cardano.CLI.Legacy.Commands.StakePool
+import Cardano.CLI.Types.Common
+import Cardano.CLI.Types.Errors.StakePoolCmdError
+import Cardano.CLI.Types.Key (VerificationKeyOrFile)
 import qualified Cardano.Ledger.Slot as Shelley
 
-import           Control.Monad.Trans.Except (ExceptT)
+import Control.Monad.Trans.Except (ExceptT)
 
-runLegacyStakePoolCmds :: ()
+runLegacyStakePoolCmds
+  :: ()
   => LegacyStakePoolCmds
   -> ExceptT StakePoolCmdError IO ()
 runLegacyStakePoolCmds = \case
@@ -28,13 +29,38 @@ runLegacyStakePoolCmds = \case
     runLegacyStakePoolIdCmd sPvkey outputFormat mOutFile
   StakePoolMetadataHashCmd poolMdFile mOutFile ->
     runLegacyStakePoolMetadataHashCmd poolMdFile mOutFile
-  StakePoolRegistrationCertificateCmd anyEra sPvkey vrfVkey pldg pCost pMrgn rwdVerFp ownerVerFps relays mbMetadata network outfp ->
-    runLegacyStakePoolRegistrationCertificateCmd anyEra sPvkey vrfVkey pldg pCost pMrgn rwdVerFp ownerVerFps relays mbMetadata network outfp
+  StakePoolRegistrationCertificateCmd
+    anyEra
+    sPvkey
+    vrfVkey
+    pldg
+    pCost
+    pMrgn
+    rwdVerFp
+    ownerVerFps
+    relays
+    mbMetadata
+    network
+    outfp ->
+      runLegacyStakePoolRegistrationCertificateCmd
+        anyEra
+        sPvkey
+        vrfVkey
+        pldg
+        pCost
+        pMrgn
+        rwdVerFp
+        ownerVerFps
+        relays
+        mbMetadata
+        network
+        outfp
 
 -- | Create a stake pool registration cert.
 -- TODO: Metadata and more stake pool relay support to be
 -- added in the future.
-runLegacyStakePoolRegistrationCertificateCmd :: ()
+runLegacyStakePoolRegistrationCertificateCmd
+  :: ()
   => AnyShelleyBasedEra
   -> VerificationKeyOrFile StakePoolKey
   -- ^ Stake pool verification key.
@@ -61,7 +87,8 @@ runLegacyStakePoolRegistrationCertificateCmd = \case
   AnyShelleyBasedEra sbe ->
     runStakePoolRegistrationCertificateCmd sbe
 
-runLegacyStakePoolDeregistrationCertificateCmd :: ()
+runLegacyStakePoolDeregistrationCertificateCmd
+  :: ()
   => AnyShelleyBasedEra
   -> VerificationKeyOrFile StakePoolKey
   -> Shelley.EpochNo
@@ -71,7 +98,8 @@ runLegacyStakePoolDeregistrationCertificateCmd = \case
   AnyShelleyBasedEra sbe ->
     runStakePoolRetirementCertificateCmd sbe
 
-runLegacyStakePoolIdCmd :: ()
+runLegacyStakePoolIdCmd
+  :: ()
   => VerificationKeyOrFile StakePoolKey
   -> IdOutputFormat
   -> Maybe (File () Out)
@@ -79,7 +107,8 @@ runLegacyStakePoolIdCmd :: ()
 runLegacyStakePoolIdCmd =
   runStakePoolIdCmd
 
-runLegacyStakePoolMetadataHashCmd :: ()
+runLegacyStakePoolMetadataHashCmd
+  :: ()
   => StakePoolMetadataFile In
   -> Maybe (File () Out)
   -> ExceptT StakePoolCmdError IO ()

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/TextView.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/TextView.hs
@@ -5,19 +5,20 @@ module Cardano.CLI.Legacy.Run.TextView
   ( runLegacyTextViewCmds
   ) where
 
-import           Cardano.Api
+import Cardano.Api
 
-import           Cardano.CLI.EraBased.Run.TextView
-import           Cardano.CLI.Legacy.Commands.TextView
-import           Cardano.CLI.Types.Errors.TextViewFileError
+import Cardano.CLI.EraBased.Run.TextView
+import Cardano.CLI.Legacy.Commands.TextView
+import Cardano.CLI.Types.Errors.TextViewFileError
 
-import           Control.Monad.Trans.Except (ExceptT)
+import Control.Monad.Trans.Except (ExceptT)
 
 runLegacyTextViewCmds :: LegacyTextViewCmds -> ExceptT TextViewFileError IO ()
 runLegacyTextViewCmds = \case
   TextViewInfo fpath mOutfile -> runLegacyTextViewInfoCmd fpath mOutfile
 
-runLegacyTextViewInfoCmd :: ()
+runLegacyTextViewInfoCmd
+  :: ()
   => FilePath
   -> Maybe (File () Out)
   -> ExceptT TextViewFileError IO ()

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Transaction.hs
@@ -8,40 +8,130 @@ module Cardano.CLI.Legacy.Run.Transaction
   ( runLegacyTransactionCmds
   ) where
 
-import           Cardano.Api
+import Cardano.Api
 
-import           Cardano.CLI.EraBased.Run.Transaction
-import           Cardano.CLI.Legacy.Commands.Transaction
-import           Cardano.CLI.Types.Common
-import           Cardano.CLI.Types.Errors.TxCmdError
-import           Cardano.CLI.Types.Governance
+import Cardano.CLI.EraBased.Run.Transaction
+import Cardano.CLI.Legacy.Commands.Transaction
+import Cardano.CLI.Types.Common
+import Cardano.CLI.Types.Errors.TxCmdError
+import Cardano.CLI.Types.Governance
 
-import           Control.Monad.Trans.Except
-
+import Control.Monad.Trans.Except
 
 runLegacyTransactionCmds :: LegacyTransactionCmds -> ExceptT TxCmdError IO ()
 runLegacyTransactionCmds cmd =
   case cmd of
-    TxBuild mNodeSocketPath era consensusModeParams nid mScriptValidity mOverrideWits txins readOnlyRefIns
-            reqSigners txinsc mReturnColl mTotCollateral txouts changeAddr mValue mLowBound
-            mUpperBound certs wdrls metadataSchema scriptFiles metadataFiles mUpProp mconwayVote
-            mNewConstitution outputOptions -> do
-      runLegacyTxBuildCmd mNodeSocketPath era consensusModeParams nid mScriptValidity mOverrideWits txins readOnlyRefIns
-            reqSigners txinsc mReturnColl mTotCollateral txouts changeAddr mValue mLowBound
-            mUpperBound certs wdrls metadataSchema scriptFiles metadataFiles mUpProp mconwayVote
-            mNewConstitution outputOptions
-    TxBuildRaw era mScriptValidity txins readOnlyRefIns txinsc mReturnColl
-               mTotColl reqSigners txouts mValue mLowBound mUpperBound fee certs wdrls
-               metadataSchema scriptFiles metadataFiles mProtocolParamsFile mUpProp out -> do
-      runLegacyTxBuildRawCmd era mScriptValidity txins readOnlyRefIns txinsc mReturnColl
-               mTotColl reqSigners txouts mValue mLowBound mUpperBound fee certs wdrls
-               metadataSchema scriptFiles metadataFiles mProtocolParamsFile mUpProp out
+    TxBuild
+      mNodeSocketPath
+      era
+      consensusModeParams
+      nid
+      mScriptValidity
+      mOverrideWits
+      txins
+      readOnlyRefIns
+      reqSigners
+      txinsc
+      mReturnColl
+      mTotCollateral
+      txouts
+      changeAddr
+      mValue
+      mLowBound
+      mUpperBound
+      certs
+      wdrls
+      metadataSchema
+      scriptFiles
+      metadataFiles
+      mUpProp
+      mconwayVote
+      mNewConstitution
+      outputOptions -> do
+        runLegacyTxBuildCmd
+          mNodeSocketPath
+          era
+          consensusModeParams
+          nid
+          mScriptValidity
+          mOverrideWits
+          txins
+          readOnlyRefIns
+          reqSigners
+          txinsc
+          mReturnColl
+          mTotCollateral
+          txouts
+          changeAddr
+          mValue
+          mLowBound
+          mUpperBound
+          certs
+          wdrls
+          metadataSchema
+          scriptFiles
+          metadataFiles
+          mUpProp
+          mconwayVote
+          mNewConstitution
+          outputOptions
+    TxBuildRaw
+      era
+      mScriptValidity
+      txins
+      readOnlyRefIns
+      txinsc
+      mReturnColl
+      mTotColl
+      reqSigners
+      txouts
+      mValue
+      mLowBound
+      mUpperBound
+      fee
+      certs
+      wdrls
+      metadataSchema
+      scriptFiles
+      metadataFiles
+      mProtocolParamsFile
+      mUpProp
+      out -> do
+        runLegacyTxBuildRawCmd
+          era
+          mScriptValidity
+          txins
+          readOnlyRefIns
+          txinsc
+          mReturnColl
+          mTotColl
+          reqSigners
+          txouts
+          mValue
+          mLowBound
+          mUpperBound
+          fee
+          certs
+          wdrls
+          metadataSchema
+          scriptFiles
+          metadataFiles
+          mProtocolParamsFile
+          mUpProp
+          out
     TxSign txinfile skfiles network txoutfile ->
       runLegacyTxSignCmd txinfile skfiles network txoutfile
     TxSubmit mNodeSocketPath anyConsensusModeParams network txFp ->
       runLegacyTxSubmitCmd mNodeSocketPath anyConsensusModeParams network txFp
     TxCalculateMinFee txbody nw pParamsFile nInputs nOutputs nShelleyKeyWitnesses nByronKeyWitnesses ->
-      runLegacyTxCalculateMinFeeCmd txbody nw pParamsFile nInputs nOutputs nShelleyKeyWitnesses nByronKeyWitnesses
+      runLegacyTxCalculateMinFeeCmd
+        txbody
+        nw
+        pParamsFile
+        nInputs
+        nOutputs
+        nShelleyKeyWitnesses
+        nByronKeyWitnesses
     TxCalculateMinRequiredUTxO era pParamsFile txOuts' ->
       runLegacyTxCalculateMinRequiredUTxOCmd era pParamsFile txOuts'
     TxHashScriptData scriptDataOrFile ->
@@ -61,26 +151,37 @@ runLegacyTransactionCmds cmd =
 -- Building transactions
 --
 
-runLegacyTxBuildCmd :: ()
+runLegacyTxBuildCmd
+  :: ()
   => SocketPath
   -> AnyCardanoEra
   -> AnyConsensusModeParams
   -> NetworkId
   -> Maybe ScriptValidity
-  -> Maybe Word -- ^ Override the required number of tx witnesses
-  -> [(TxIn, Maybe (ScriptWitnessFiles WitCtxTxIn))] -- ^ Transaction inputs with optional spending scripts
-  -> [TxIn] -- ^ Read only reference inputs
-  -> [RequiredSigner] -- ^ Required signers
-  -> [TxIn] -- ^ Transaction inputs for collateral, only key witnesses, no scripts.
-  -> Maybe TxOutAnyEra -- ^ Return collateral
-  -> Maybe Lovelace -- ^ Total collateral
+  -> Maybe Word
+  -- ^ Override the required number of tx witnesses
+  -> [(TxIn, Maybe (ScriptWitnessFiles WitCtxTxIn))]
+  -- ^ Transaction inputs with optional spending scripts
+  -> [TxIn]
+  -- ^ Read only reference inputs
+  -> [RequiredSigner]
+  -- ^ Required signers
+  -> [TxIn]
+  -- ^ Transaction inputs for collateral, only key witnesses, no scripts.
+  -> Maybe TxOutAnyEra
+  -- ^ Return collateral
+  -> Maybe Lovelace
+  -- ^ Total collateral
   -> [TxOutAnyEra]
   -> TxOutChangeAddress
   -> Maybe (Value, [ScriptWitnessFiles WitCtxMint])
-  -> Maybe SlotNo -- ^ Validity lower bound
-  -> Maybe SlotNo -- ^ Validity upper bound
+  -> Maybe SlotNo
+  -- ^ Validity lower bound
+  -> Maybe SlotNo
+  -- ^ Validity upper bound
   -> [(CertificateFile, Maybe (ScriptWitnessFiles WitCtxStake))]
-  -> [(StakeAddress, Lovelace, Maybe (ScriptWitnessFiles WitCtxStake))] -- ^ Withdrawals with potential script witness
+  -> [(StakeAddress, Lovelace, Maybe (ScriptWitnessFiles WitCtxStake))]
+  -- ^ Withdrawals with potential script witness
   -> TxMetadataJsonSchema
   -> [ScriptFile]
   -> [MetadataFile]
@@ -91,20 +192,28 @@ runLegacyTxBuildCmd :: ()
   -> ExceptT TxCmdError IO ()
 runLegacyTxBuildCmd socketPath (AnyCardanoEra era) = runTxBuildCmd era socketPath
 
-runLegacyTxBuildRawCmd :: ()
+runLegacyTxBuildRawCmd
+  :: ()
   => AnyCardanoEra
   -> Maybe ScriptValidity
   -> [(TxIn, Maybe (ScriptWitnessFiles WitCtxTxIn))]
-  -> [TxIn] -- ^ Read only reference inputs
-  -> [TxIn] -- ^ Transaction inputs for collateral, only key witnesses, no scripts.
+  -> [TxIn]
+  -- ^ Read only reference inputs
+  -> [TxIn]
+  -- ^ Transaction inputs for collateral, only key witnesses, no scripts.
   -> Maybe TxOutAnyEra
-  -> Maybe Lovelace -- ^ Total collateral
+  -> Maybe Lovelace
+  -- ^ Total collateral
   -> [RequiredSigner]
   -> [TxOutAnyEra]
-  -> Maybe (Value, [ScriptWitnessFiles WitCtxMint]) -- ^ Multi-Asset value with script witness
-  -> Maybe SlotNo -- ^ Validity lower bound
-  -> Maybe SlotNo -- ^ Validity upper bound
-  -> Maybe Lovelace -- ^ Tx fee
+  -> Maybe (Value, [ScriptWitnessFiles WitCtxMint])
+  -- ^ Multi-Asset value with script witness
+  -> Maybe SlotNo
+  -- ^ Validity lower bound
+  -> Maybe SlotNo
+  -- ^ Validity upper bound
+  -> Maybe Lovelace
+  -- ^ Tx fee
   -> [(CertificateFile, Maybe (ScriptWitnessFiles WitCtxStake))]
   -> [(StakeAddress, Lovelace, Maybe (ScriptWitnessFiles WitCtxStake))]
   -> TxMetadataJsonSchema
@@ -116,14 +225,16 @@ runLegacyTxBuildRawCmd :: ()
   -> ExceptT TxCmdError IO ()
 runLegacyTxBuildRawCmd (AnyCardanoEra era) = runTxBuildRawCmd era
 
-runLegacyTxSignCmd :: InputTxBodyOrTxFile
-          -> [WitnessSigningData]
-          -> Maybe NetworkId
-          -> TxFile Out
-          -> ExceptT TxCmdError IO ()
+runLegacyTxSignCmd
+  :: InputTxBodyOrTxFile
+  -> [WitnessSigningData]
+  -> Maybe NetworkId
+  -> TxFile Out
+  -> ExceptT TxCmdError IO ()
 runLegacyTxSignCmd = runTxSignCmd
 
-runLegacyTxSubmitCmd :: ()
+runLegacyTxSubmitCmd
+  :: ()
   => SocketPath
   -> AnyConsensusModeParams
   -> NetworkId
@@ -131,7 +242,8 @@ runLegacyTxSubmitCmd :: ()
   -> ExceptT TxCmdError IO ()
 runLegacyTxSubmitCmd = runTxSubmitCmd
 
-runLegacyTxCalculateMinFeeCmd :: ()
+runLegacyTxCalculateMinFeeCmd
+  :: ()
   => TxBodyFile In
   -> NetworkId
   -> ProtocolParamsFile
@@ -142,7 +254,8 @@ runLegacyTxCalculateMinFeeCmd :: ()
   -> ExceptT TxCmdError IO ()
 runLegacyTxCalculateMinFeeCmd = runTxCalculateMinFeeCmd
 
-runLegacyTxCalculateMinRequiredUTxOCmd :: ()
+runLegacyTxCalculateMinRequiredUTxOCmd
+  :: ()
   => AnyCardanoEra
   -> ProtocolParamsFile
   -> TxOutAnyEra
@@ -161,7 +274,8 @@ runLegacyTxGetTxIdCmd = runTxGetTxIdCmd
 runLegacyTxViewCmd :: InputTxBodyOrTxFile -> ExceptT TxCmdError IO ()
 runLegacyTxViewCmd = runTxViewCmd
 
-runLegacyTxCreateWitnessCmd :: ()
+runLegacyTxCreateWitnessCmd
+  :: ()
   => TxBodyFile In
   -> WitnessSigningData
   -> Maybe NetworkId
@@ -169,7 +283,8 @@ runLegacyTxCreateWitnessCmd :: ()
   -> ExceptT TxCmdError IO ()
 runLegacyTxCreateWitnessCmd = runTxCreateWitnessCmd
 
-runLegacyTxSignWitnessCmd :: ()
+runLegacyTxSignWitnessCmd
+  :: ()
   => TxBodyFile In
   -> [WitnessFile]
   -> File () Out

--- a/cardano-cli/src/Cardano/CLI/Options.hs
+++ b/cardano-cli/src/Cardano/CLI/Options.hs
@@ -21,8 +21,8 @@ import Cardano.CLI.Run.Ping (parsePingCmd)
 
 import Data.Foldable
 import Options.Applicative
-import qualified Options.Applicative as Opt
-import qualified Prettyprinter as PP
+import Options.Applicative qualified as Opt
+import Prettyprinter qualified as PP
 
 opts :: EnvCli -> ParserInfo ClientCommand
 opts envCli =

--- a/cardano-cli/src/Cardano/CLI/Options.hs
+++ b/cardano-cli/src/Cardano/CLI/Options.hs
@@ -8,40 +8,43 @@ module Cardano.CLI.Options
   , pref
   ) where
 
-import           Cardano.Api (CardanoEra (..), ShelleyBasedEra (..))
+import Cardano.Api (CardanoEra (..), ShelleyBasedEra (..))
 
-import           Cardano.CLI.Byron.Parsers (backwardsCompatibilityCommands, parseByronCommands)
-import           Cardano.CLI.Environment (EnvCli)
-import           Cardano.CLI.EraBased.Commands
-import           Cardano.CLI.EraBased.Options.Common
-import           Cardano.CLI.Legacy.Options (parseLegacyCmds)
-import           Cardano.CLI.Render (customRenderHelp)
-import           Cardano.CLI.Run (ClientCommand (..))
-import           Cardano.CLI.Run.Ping (parsePingCmd)
+import Cardano.CLI.Byron.Parsers (backwardsCompatibilityCommands, parseByronCommands)
+import Cardano.CLI.Environment (EnvCli)
+import Cardano.CLI.EraBased.Commands
+import Cardano.CLI.EraBased.Options.Common
+import Cardano.CLI.Legacy.Options (parseLegacyCmds)
+import Cardano.CLI.Render (customRenderHelp)
+import Cardano.CLI.Run (ClientCommand (..))
+import Cardano.CLI.Run.Ping (parsePingCmd)
 
-import           Data.Foldable
-import           Options.Applicative
+import Data.Foldable
+import Options.Applicative
 import qualified Options.Applicative as Opt
 import qualified Prettyprinter as PP
 
 opts :: EnvCli -> ParserInfo ClientCommand
 opts envCli =
-  Opt.info (parseClientCommand envCli <**> Opt.helper) $ mconcat
-    [ Opt.fullDesc
-    , Opt.header $ mconcat
-      [ "cardano-cli - General purpose command-line utility to interact with cardano-node."
-      , " Provides specific commands to manage keys, addresses, build & submit transactions,"
-      , " certificates, etc."
+  Opt.info (parseClientCommand envCli <**> Opt.helper) $
+    mconcat
+      [ Opt.fullDesc
+      , Opt.header $
+          mconcat
+            [ "cardano-cli - General purpose command-line utility to interact with cardano-node."
+            , " Provides specific commands to manage keys, addresses, build & submit transactions,"
+            , " certificates, etc."
+            ]
       ]
-    ]
 
 pref :: ParserPrefs
 pref =
-  Opt.prefs $ mconcat
-    [ showHelpOnEmpty
-    , helpEmbedBriefDesc PP.align
-    , helpRenderHelp customRenderHelp
-    ]
+  Opt.prefs $
+    mconcat
+      [ showHelpOnEmpty
+      , helpEmbedBriefDesc PP.align
+      , helpRenderHelp customRenderHelp
+      ]
 
 parseClientCommand :: EnvCli -> Parser ClientCommand
 parseClientCommand envCli =
@@ -51,8 +54,8 @@ parseClientCommand envCli =
     -- so we list it first.
     [ parseAnyEra envCli
     , parseLegacy envCli
-    -- , parseTopLevelLatest envCli -- TODO restore this when the governance command group is fully operational
-    , parseTopLevelLegacy envCli
+    , -- , parseTopLevelLatest envCli -- TODO restore this when the governance command group is fully operational
+      parseTopLevelLegacy envCli
     , parseByron envCli
     , parsePing
     , backwardsCompatibilityCommands envCli
@@ -62,11 +65,12 @@ parseClientCommand envCli =
 parseByron :: EnvCli -> Parser ClientCommand
 parseByron mNetworkId =
   fmap ByronCommand $
-  subparser $ mconcat
-    [ commandGroup "Byron specific commands"
-    , metavar "Byron specific commands"
-    , command' "byron" "Byron specific commands" $ parseByronCommands mNetworkId
-    ]
+    subparser $
+      mconcat
+        [ commandGroup "Byron specific commands"
+        , metavar "Byron specific commands"
+        , command' "byron" "Byron specific commands" $ parseByronCommands mNetworkId
+        ]
 
 parsePing :: Parser ClientCommand
 parsePing = CliPingCommand <$> parsePingCmd
@@ -76,9 +80,9 @@ parseAnyEra envCli = AnyEraCommand <$> pAnyEraCommand envCli
 
 parseLegacy :: EnvCli -> Parser ClientCommand
 parseLegacy envCli =
-  subParser "legacy"
-    $ Opt.info (LegacyCmds <$> parseLegacyCmds envCli)
-    $ Opt.progDesc "Legacy commands"
+  subParser "legacy" $
+    Opt.info (LegacyCmds <$> parseLegacyCmds envCli) $
+      Opt.progDesc "Legacy commands"
 
 _parseTopLevelLatest :: EnvCli -> Parser ClientCommand
 _parseTopLevelLatest envCli =
@@ -93,22 +97,23 @@ parseTopLevelLegacy envCli = LegacyCmds <$> parseLegacyCmds envCli
 parseDisplayVersion :: ParserInfo a -> Parser ClientCommand
 parseDisplayVersion allParserInfo =
   asum
-    [ subparser $ mconcat
-        [ commandGroup "Miscellaneous commands"
-        , metavar "Miscellaneous commands"
-        , command'
-            "help"
-            "Show all help"
-            (pure (Help pref allParserInfo))
-        , command'
-            "version"
-            "Show the cardano-cli version"
-            (pure DisplayVersion)
-        ]
-
-    , flag' DisplayVersion $ mconcat
-        [ long "version"
-        , help "Show the cardano-cli version"
-        , hidden
-        ]
+    [ subparser $
+        mconcat
+          [ commandGroup "Miscellaneous commands"
+          , metavar "Miscellaneous commands"
+          , command'
+              "help"
+              "Show all help"
+              (pure (Help pref allParserInfo))
+          , command'
+              "version"
+              "Show the cardano-cli version"
+              (pure DisplayVersion)
+          ]
+    , flag' DisplayVersion $
+        mconcat
+          [ long "version"
+          , help "Show the cardano-cli version"
+          , hidden
+          ]
     ]

--- a/cardano-cli/src/Cardano/CLI/Parser.hs
+++ b/cardano-cli/src/Cardano/CLI/Parser.hs
@@ -13,17 +13,17 @@ module Cardano.CLI.Parser
   ) where
 
 import Cardano.CLI.Types.Common
-import qualified Cardano.Ledger.BaseTypes as Shelley
+import Cardano.Ledger.BaseTypes qualified as Shelley
 
-import qualified Data.Attoparsec.ByteString.Char8 as Atto
+import Data.Attoparsec.ByteString.Char8 qualified as Atto
 import Data.ByteString (ByteString)
-import qualified Data.ByteString.Char8 as BSC
+import Data.ByteString.Char8 qualified as BSC
 import Data.Foldable
 import Data.Ratio ((%))
 import Data.Text (Text)
-import qualified Data.Text as Text
-import qualified Data.Text.Encoding as Text
-import qualified Options.Applicative as Opt
+import Data.Text qualified as Text
+import Data.Text.Encoding qualified as Text
+import Options.Applicative qualified as Opt
 
 readIdOutputFormat :: Opt.ReadM IdOutputFormat
 readIdOutputFormat = do

--- a/cardano-cli/src/Cardano/CLI/Parser.hs
+++ b/cardano-cli/src/Cardano/CLI/Parser.hs
@@ -12,15 +12,15 @@ module Cardano.CLI.Parser
   , eDNSName
   ) where
 
-import           Cardano.CLI.Types.Common
+import Cardano.CLI.Types.Common
 import qualified Cardano.Ledger.BaseTypes as Shelley
 
 import qualified Data.Attoparsec.ByteString.Char8 as Atto
-import           Data.ByteString (ByteString)
+import Data.ByteString (ByteString)
 import qualified Data.ByteString.Char8 as BSC
-import           Data.Foldable
-import           Data.Ratio ((%))
-import           Data.Text (Text)
+import Data.Foldable
+import Data.Ratio ((%))
+import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import qualified Options.Applicative as Opt
@@ -32,10 +32,11 @@ readIdOutputFormat = do
     "hex" -> pure IdOutputFormatHex
     "bech32" -> pure IdOutputFormatBech32
     _ ->
-      fail $ mconcat
-        [ "Invalid output format: " <> show s
-        , ". Accepted output formats are \"hex\" and \"bech32\"."
-        ]
+      fail $
+        mconcat
+          [ "Invalid output format: " <> show s
+          , ". Accepted output formats are \"hex\" and \"bech32\"."
+          ]
 
 readKeyOutputFormat :: Opt.ReadM KeyOutputFormat
 readKeyOutputFormat = do
@@ -44,10 +45,11 @@ readKeyOutputFormat = do
     "text-envelope" -> pure KeyOutputFormatTextEnvelope
     "bech32" -> pure KeyOutputFormatBech32
     _ ->
-      fail $ mconcat
-        [ "Invalid key output format: " <> show s
-        , ". Accepted output formats are \"text-envelope\" and \"bech32\"."
-        ]
+      fail $
+        mconcat
+          [ "Invalid key output format: " <> show s
+          , ". Accepted output formats are \"text-envelope\" and \"bech32\"."
+          ]
 
 readURIOfMaxLength :: Int -> Opt.ReadM Text
 readURIOfMaxLength maxLen =
@@ -60,24 +62,26 @@ readStringOfMaxLength maxLen = do
   if strLen <= maxLen
     then pure s
     else
-      fail $ mconcat
-        [ "The provided string must have at most 64 characters, but it has "
-        , show strLen
-        , " characters."
-        ]
+      fail $
+        mconcat
+          [ "The provided string must have at most 64 characters, but it has "
+          , show strLen
+          , " characters."
+          ]
 
 readRationalUnitInterval :: Opt.ReadM Rational
 readRationalUnitInterval = readRational >>= checkUnitInterval
-  where
-   checkUnitInterval :: Rational -> Opt.ReadM Rational
-   checkUnitInterval q
-     | q >= 0 && q <= 1 = return q
-     | otherwise        = fail "Please enter a value in the range [0,1]"
+ where
+  checkUnitInterval :: Rational -> Opt.ReadM Rational
+  checkUnitInterval q
+    | q >= 0 && q <= 1 = return q
+    | otherwise = fail "Please enter a value in the range [0,1]"
 
 readFractionAsRational :: Opt.ReadM Rational
 readFractionAsRational = readerFromAttoParser fractionalAsRational
-  where fractionalAsRational :: Atto.Parser Rational
-        fractionalAsRational = (%) <$> (Atto.decimal @Integer <* Atto.char '/') <*> Atto.decimal @Integer
+ where
+  fractionalAsRational :: Atto.Parser Rational
+  fractionalAsRational = (%) <$> (Atto.decimal @Integer <* Atto.char '/') <*> Atto.decimal @Integer
 
 readRational :: Opt.ReadM Rational
 readRational =

--- a/cardano-cli/src/Cardano/CLI/Pretty.hs
+++ b/cardano-cli/src/Cardano/CLI/Pretty.hs
@@ -14,15 +14,15 @@ module Cardano.CLI.Pretty
   , white
   ) where
 
-import qualified Control.Concurrent.QSem as IO
+import Control.Concurrent.QSem qualified as IO
 import Control.Exception (bracket_)
 import Control.Monad.IO.Class (MonadIO, liftIO)
-import qualified Data.Text.Lazy as TextLazy
-import qualified Data.Text.Lazy.IO as TextLazy
+import Data.Text.Lazy qualified as TextLazy
+import Data.Text.Lazy.IO qualified as TextLazy
 import Prettyprinter
 import Prettyprinter.Render.Terminal
-import qualified System.IO as IO
-import qualified System.IO.Unsafe as IO
+import System.IO qualified as IO
+import System.IO.Unsafe qualified as IO
 
 type Ann = AnsiStyle
 

--- a/cardano-cli/src/Cardano/CLI/Pretty.hs
+++ b/cardano-cli/src/Cardano/CLI/Pretty.hs
@@ -1,27 +1,26 @@
 module Cardano.CLI.Pretty
-  ( Ann,
-    putLn,
-    hPutLn,
-    renderDefault,
-    renderStringDefault,
-
-    black,
-    red,
-    green,
-    yellow,
-    blue,
-    magenta,
-    cyan,
-    white,
+  ( Ann
+  , putLn
+  , hPutLn
+  , renderDefault
+  , renderStringDefault
+  , black
+  , red
+  , green
+  , yellow
+  , blue
+  , magenta
+  , cyan
+  , white
   ) where
 
 import qualified Control.Concurrent.QSem as IO
-import           Control.Exception (bracket_)
-import           Control.Monad.IO.Class (MonadIO, liftIO)
+import Control.Exception (bracket_)
+import Control.Monad.IO.Class (MonadIO, liftIO)
 import qualified Data.Text.Lazy as TextLazy
 import qualified Data.Text.Lazy.IO as TextLazy
-import           Prettyprinter
-import           Prettyprinter.Render.Terminal
+import Prettyprinter
+import Prettyprinter.Render.Terminal
 import qualified System.IO as IO
 import qualified System.IO.Unsafe as IO
 
@@ -34,17 +33,17 @@ sem = IO.unsafePerformIO $ IO.newQSem 1
 consoleBracket :: IO a -> IO a
 consoleBracket = bracket_ (IO.waitQSem sem) (IO.signalQSem sem)
 
-putLn :: MonadIO m => Doc AnsiStyle -> m ()
+putLn :: (MonadIO m) => Doc AnsiStyle -> m ()
 putLn = liftIO . consoleBracket . TextLazy.putStrLn . renderDefault
 
-hPutLn :: MonadIO m => IO.Handle -> Doc AnsiStyle -> m ()
+hPutLn :: (MonadIO m) => IO.Handle -> Doc AnsiStyle -> m ()
 hPutLn h = liftIO . consoleBracket . TextLazy.hPutStr h . renderDefault
 
 renderStringDefault :: Doc AnsiStyle -> String
-renderStringDefault =  TextLazy.unpack . renderDefault
+renderStringDefault = TextLazy.unpack . renderDefault
 
 renderDefault :: Doc AnsiStyle -> TextLazy.Text
-renderDefault =  renderLazy . layoutPretty defaultLayoutOptions
+renderDefault = renderLazy . layoutPretty defaultLayoutOptions
 
 black :: Doc AnsiStyle -> Doc AnsiStyle
 black = annotate (color Black)

--- a/cardano-cli/src/Cardano/CLI/Read.hs
+++ b/cardano-cli/src/Cardano/CLI/Read.hs
@@ -84,26 +84,26 @@ module Cardano.CLI.Read
   ) where
 
 import Cardano.Api as Api
-import qualified Cardano.Api.Ledger as L
+import Cardano.Api.Ledger qualified as L
 import Cardano.Api.Shelley as Api
 
-import qualified Cardano.Binary as CBOR
+import Cardano.Binary qualified as CBOR
 import Cardano.CLI.Types.Common
 import Cardano.CLI.Types.Errors.DelegationError
 import Cardano.CLI.Types.Errors.ScriptDecodeError
 import Cardano.CLI.Types.Errors.StakeCredentialError
 import Cardano.CLI.Types.Governance
 import Cardano.CLI.Types.Key
-import qualified Cardano.Crypto.Hash.Class as Crypto
-import qualified Cardano.Ledger.BaseTypes as L
-import qualified Cardano.Ledger.BaseTypes as Ledger
-import qualified Cardano.Ledger.Conway.Governance as Ledger
-import qualified Cardano.Ledger.Credential as Ledger
-import qualified Cardano.Ledger.Crypto as Crypto
-import qualified Cardano.Ledger.Crypto as Ledger
-import qualified Cardano.Ledger.Keys as Ledger
-import qualified Cardano.Ledger.SafeHash as L
-import qualified Cardano.Ledger.SafeHash as Ledger
+import Cardano.Crypto.Hash.Class qualified as Crypto
+import Cardano.Ledger.BaseTypes qualified as L
+import Cardano.Ledger.BaseTypes qualified as Ledger
+import Cardano.Ledger.Conway.Governance qualified as Ledger
+import Cardano.Ledger.Credential qualified as Ledger
+import Cardano.Ledger.Crypto qualified as Crypto
+import Cardano.Ledger.Crypto qualified as Ledger
+import Cardano.Ledger.Keys qualified as Ledger
+import Cardano.Ledger.SafeHash qualified as L
+import Cardano.Ledger.SafeHash qualified as Ledger
 
 import Prelude
 
@@ -113,26 +113,26 @@ import Control.Monad.IO.Class
 import Control.Monad.Trans (MonadTrans (..))
 import Control.Monad.Trans.Except
 import Control.Monad.Trans.Except.Extra
-import qualified Data.Aeson as Aeson
+import Data.Aeson qualified as Aeson
 import Data.Bifunctor
 import Data.ByteString (ByteString)
-import qualified Data.ByteString as BS
-import qualified Data.ByteString.Base16 as Base16
-import qualified Data.ByteString.Builder as Builder
-import qualified Data.ByteString.Lazy.Char8 as LBS
+import Data.ByteString qualified as BS
+import Data.ByteString.Base16 qualified as Base16
+import Data.ByteString.Builder qualified as Builder
+import Data.ByteString.Lazy.Char8 qualified as LBS
 import Data.Function ((&))
 import Data.IORef (IORef, newIORef, readIORef, writeIORef)
-import qualified Data.List as List
-import qualified Data.Map.Strict as Map
+import Data.List qualified as List
+import Data.Map.Strict qualified as Map
 import Data.String
 import Data.Text (Text)
-import qualified Data.Text as Text
-import qualified Data.Text.Encoding as Text
-import qualified Data.Text.Encoding.Error as Text
+import Data.Text qualified as Text
+import Data.Text.Encoding qualified as Text
+import Data.Text.Encoding.Error qualified as Text
 import Data.Word
 import GHC.IO.Handle (hClose, hIsSeekable)
 import GHC.IO.Handle.FD (openFileBlocking)
-import qualified Options.Applicative as Opt
+import Options.Applicative qualified as Opt
 import System.IO (IOMode (ReadMode))
 
 -- Metadata

--- a/cardano-cli/src/Cardano/CLI/Render.hs
+++ b/cardano-cli/src/Cardano/CLI/Render.hs
@@ -7,14 +7,14 @@ module Cardano.CLI.Render
 import Cardano.Api (textShow)
 
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import Options.Applicative
 import Options.Applicative.Help.Ann
 import Options.Applicative.Help.Types (helpText, renderHelp)
 import Prettyprinter
 import Prettyprinter.Render.Util.SimpleDocTree
-import qualified System.Environment as IO
-import qualified System.IO.Unsafe as IO
+import System.Environment qualified as IO
+import System.IO.Unsafe qualified as IO
 
 cliHelpTraceEnabled :: Bool
 cliHelpTraceEnabled = IO.unsafePerformIO $ do

--- a/cardano-cli/src/Cardano/CLI/Render.hs
+++ b/cardano-cli/src/Cardano/CLI/Render.hs
@@ -4,15 +4,15 @@ module Cardano.CLI.Render
   ( customRenderHelp
   ) where
 
-import           Cardano.Api (textShow)
+import Cardano.Api (textShow)
 
-import           Data.Text (Text)
+import Data.Text (Text)
 import qualified Data.Text as T
-import           Options.Applicative
-import           Options.Applicative.Help.Ann
-import           Options.Applicative.Help.Types (helpText, renderHelp)
-import           Prettyprinter
-import           Prettyprinter.Render.Util.SimpleDocTree
+import Options.Applicative
+import Options.Applicative.Help.Ann
+import Options.Applicative.Help.Types (helpText, renderHelp)
+import Prettyprinter
+import Prettyprinter.Render.Util.SimpleDocTree
 import qualified System.Environment as IO
 import qualified System.IO.Unsafe as IO
 
@@ -27,33 +27,37 @@ cliHelpTraceEnabled = IO.unsafePerformIO $ do
 -- tools can be used to inspect tracing that aids in describing the structure of the output
 -- document.
 customRenderHelp :: Int -> ParserHelp -> String
-customRenderHelp = if cliHelpTraceEnabled
-  then customRenderHelpAsHtml
-  else customRenderHelpAsAnsi
+customRenderHelp =
+  if cliHelpTraceEnabled
+    then customRenderHelpAsHtml
+    else customRenderHelpAsAnsi
 
 customRenderHelpAsHtml :: Int -> ParserHelp -> String
-customRenderHelpAsHtml cols
-  = T.unpack
-  . wrapper
-  . renderSimplyDecorated id renderElement
-  . treeForm
-  . layoutSmart (LayoutOptions (AvailablePerLine cols 1.0))
-  . helpText
-  where
-    renderElement :: Ann -> Text -> Text
-    renderElement ann x = if cliHelpTraceEnabled
+customRenderHelpAsHtml cols =
+  T.unpack
+    . wrapper
+    . renderSimplyDecorated id renderElement
+    . treeForm
+    . layoutSmart (LayoutOptions (AvailablePerLine cols 1.0))
+    . helpText
+ where
+  renderElement :: Ann -> Text -> Text
+  renderElement ann x =
+    if cliHelpTraceEnabled
       then case ann of
         AnnTrace _ name -> "<span name=" <> textShow name <> ">" <> x <> "</span>"
         AnnStyle _ -> x
       else x
-    wrapper = if cliHelpTraceEnabled
-      then id
-        . ("<html>\n" <>)
-        . ("<body>\n" <>)
-        . ("<pre>\n" <>)
-        . (<> "\n</html>")
-        . (<> "\n</body>")
-        . (<> "\n</pre>")
+  wrapper =
+    if cliHelpTraceEnabled
+      then
+        id
+          . ("<html>\n" <>)
+          . ("<body>\n" <>)
+          . ("<pre>\n" <>)
+          . (<> "\n</html>")
+          . (<> "\n</body>")
+          . (<> "\n</pre>")
       else id
 
 customRenderHelpAsAnsi :: Int -> ParserHelp -> String

--- a/cardano-cli/src/Cardano/CLI/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Run.hs
@@ -3,54 +3,62 @@
 
 -- | Dispatch for running all the CLI commands
 module Cardano.CLI.Run
-  ( ClientCommand(..)
+  ( ClientCommand (..)
   , ClientCommandErrors
   , renderClientCommandError
   , runClientCommand
   ) where
 
-import           Cardano.CLI.Byron.Commands (ByronCommand)
-import           Cardano.CLI.Byron.Run (ByronClientCmdError, renderByronClientCmdError,
-                   runByronClientCommand)
-import           Cardano.CLI.EraBased.Commands
-import           Cardano.CLI.EraBased.Run
-import           Cardano.CLI.IO.GitRev (gitRev)
-import           Cardano.CLI.Legacy.Commands
-import           Cardano.CLI.Legacy.Run (runLegacyCmds)
-import           Cardano.CLI.Render (customRenderHelp)
-import           Cardano.CLI.Run.Ping (PingClientCmdError (..), PingCmd (..),
-                   renderPingClientCmdError, runPingCmd)
-import           Cardano.CLI.Types.Errors.CmdError
+import Cardano.CLI.Byron.Commands (ByronCommand)
+import Cardano.CLI.Byron.Run
+  ( ByronClientCmdError
+  , renderByronClientCmdError
+  , runByronClientCommand
+  )
+import Cardano.CLI.EraBased.Commands
+import Cardano.CLI.EraBased.Run
+import Cardano.CLI.IO.GitRev (gitRev)
+import Cardano.CLI.Legacy.Commands
+import Cardano.CLI.Legacy.Run (runLegacyCmds)
+import Cardano.CLI.Render (customRenderHelp)
+import Cardano.CLI.Run.Ping
+  ( PingClientCmdError (..)
+  , PingCmd (..)
+  , renderPingClientCmdError
+  , runPingCmd
+  )
+import Cardano.CLI.Types.Errors.CmdError
 
-import           Control.Monad (forM_)
-import           Control.Monad.IO.Unlift (MonadIO (..))
-import           Control.Monad.Trans.Except (ExceptT)
-import           Control.Monad.Trans.Except.Extra (firstExceptT)
+import Control.Monad (forM_)
+import Control.Monad.IO.Unlift (MonadIO (..))
+import Control.Monad.Trans.Except (ExceptT)
+import Control.Monad.Trans.Except.Extra (firstExceptT)
 import qualified Data.List as L
-import           Data.Text (Text)
+import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
-import           Data.Version (showVersion)
-import           Options.Applicative.Help.Core
-import           Options.Applicative.Types (OptReader (..), Option (..), Parser (..),
-                   ParserInfo (..), ParserPrefs (..))
-import           System.Info (arch, compilerName, compilerVersion, os)
+import Data.Version (showVersion)
+import Options.Applicative.Help.Core
+import Options.Applicative.Types
+  ( OptReader (..)
+  , Option (..)
+  , Parser (..)
+  , ParserInfo (..)
+  , ParserPrefs (..)
+  )
 import qualified System.IO as IO
+import System.Info (arch, compilerName, compilerVersion, os)
 
-import           Paths_cardano_cli (version)
+import Paths_cardano_cli (version)
 
 -- | Sub-commands of 'cardano-cli'.
-data ClientCommand =
-    AnyEraCommand AnyEraCommand
-
-    -- | Byron Related Commands
-  | ByronCommand ByronCommand
-
-    -- | Legacy shelley-based Commands
-  | LegacyCmds LegacyCmds
-
+data ClientCommand
+  = AnyEraCommand AnyEraCommand
+  | -- | Byron Related Commands
+    ByronCommand ByronCommand
+  | -- | Legacy shelley-based Commands
+    LegacyCmds LegacyCmds
   | CliPingCommand PingCmd
-
   | forall a. Help ParserPrefs (ParserInfo a)
   | DisplayVersion
 
@@ -85,38 +93,46 @@ renderClientCommandError = \case
 
 runDisplayVersion :: ExceptT ClientCommandErrors IO ()
 runDisplayVersion = do
-  liftIO . Text.putStrLn $ mconcat
-    [ "cardano-cli ", renderVersion version
-    , " - ", Text.pack os, "-", Text.pack arch
-    , " - ", Text.pack compilerName, "-", renderVersion compilerVersion
-    , "\ngit rev ", gitRev
-    ]
-  where
-    renderVersion = Text.pack . showVersion
-
+  liftIO . Text.putStrLn $
+    mconcat
+      [ "cardano-cli "
+      , renderVersion version
+      , " - "
+      , Text.pack os
+      , "-"
+      , Text.pack arch
+      , " - "
+      , Text.pack compilerName
+      , "-"
+      , renderVersion compilerVersion
+      , "\ngit rev "
+      , gitRev
+      ]
+ where
+  renderVersion = Text.pack . showVersion
 
 helpAll :: ParserPrefs -> String -> [String] -> ParserInfo a -> IO ()
 helpAll pprefs progn rnames parserInfo = do
   IO.putStrLn $ customRenderHelp 80 (usage_help parserInfo)
   IO.putStrLn ""
   go (infoParser parserInfo)
-  where
-    go :: Parser a -> IO ()
-    go p = case p of
-      NilP _ -> return ()
-      OptP optP -> case optMain optP of
-        CmdReader _ cs -> do
-          forM_ cs $ \(c, subParserInfo) ->
-              helpAll pprefs progn (c:rnames) subParserInfo
-        _ -> return ()
-      AltP pa pb -> go pa >> go pb
-      MultP pf px -> go pf >> go px
-      BindP pa _ -> go pa
-    usage_help i =
-      mconcat
-        [ usageHelp (pure . parserUsage pprefs (infoParser i) . L.unwords $ progn : reverse rnames)
-        , descriptionHelp (infoProgDesc i)
-        ]
+ where
+  go :: Parser a -> IO ()
+  go p = case p of
+    NilP _ -> return ()
+    OptP optP -> case optMain optP of
+      CmdReader _ cs -> do
+        forM_ cs $ \(c, subParserInfo) ->
+          helpAll pprefs progn (c : rnames) subParserInfo
+      _ -> return ()
+    AltP pa pb -> go pa >> go pb
+    MultP pf px -> go pf >> go px
+    BindP pa _ -> go pa
+  usage_help i =
+    mconcat
+      [ usageHelp (pure . parserUsage pprefs (infoParser i) . L.unwords $ progn : reverse rnames)
+      , descriptionHelp (infoProgDesc i)
+      ]
 
 runHelp :: ParserPrefs -> ParserInfo a -> ExceptT ClientCommandErrors IO ()
 runHelp pprefs allParserInfo = liftIO $ helpAll pprefs "cardano-cli" [] allParserInfo

--- a/cardano-cli/src/Cardano/CLI/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Run.hs
@@ -33,10 +33,10 @@ import Control.Monad (forM_)
 import Control.Monad.IO.Unlift (MonadIO (..))
 import Control.Monad.Trans.Except (ExceptT)
 import Control.Monad.Trans.Except.Extra (firstExceptT)
-import qualified Data.List as L
+import Data.List qualified as L
 import Data.Text (Text)
-import qualified Data.Text as Text
-import qualified Data.Text.IO as Text
+import Data.Text qualified as Text
+import Data.Text.IO qualified as Text
 import Data.Version (showVersion)
 import Options.Applicative.Help.Core
 import Options.Applicative.Types
@@ -46,7 +46,7 @@ import Options.Applicative.Types
   , ParserInfo (..)
   , ParserPrefs (..)
   )
-import qualified System.IO as IO
+import System.IO qualified as IO
 import System.Info (arch, compilerName, compilerVersion, os)
 
 import Paths_cardano_cli (version)

--- a/cardano-cli/src/Cardano/CLI/Run/Ping.hs
+++ b/cardano-cli/src/Cardano/CLI/Run/Ping.hs
@@ -11,11 +11,11 @@ module Cardano.CLI.Run.Ping
   , parsePingCmd
   ) where
 
-import qualified Cardano.Network.Ping as CNP
+import Cardano.Network.Ping qualified as CNP
 
 import Control.Applicative ((<|>))
 import Control.Concurrent.Class.MonadSTM.Strict (StrictTMVar)
-import qualified Control.Concurrent.Class.MonadSTM.Strict as STM
+import Control.Concurrent.Class.MonadSTM.Strict qualified as STM
 import Control.Exception (SomeException)
 import Control.Monad (forM, unless)
 import Control.Monad.Class.MonadAsync (MonadAsync (async, wait, waitCatch))
@@ -24,16 +24,16 @@ import Control.Monad.Trans.Except (ExceptT)
 import Control.Monad.Trans.Except.Extra (left)
 import Control.Tracer (Tracer (..))
 import Data.List (foldl')
-import qualified Data.List as L
+import Data.List qualified as L
 import Data.Text (Text)
-import qualified Data.Text as T
+import Data.Text qualified as T
 import Data.Word (Word32)
 import Network.Socket (AddrInfo)
-import qualified Network.Socket as Socket
-import qualified Options.Applicative as Opt
-import qualified Prettyprinter as PP
-import qualified System.Exit as IO
-import qualified System.IO as IO
+import Network.Socket qualified as Socket
+import Options.Applicative qualified as Opt
+import Prettyprinter qualified as PP
+import System.Exit qualified as IO
+import System.IO qualified as IO
 
 newtype PingClientCmdError = PingClientCmdError [(AddrInfo, SomeException)]
 

--- a/cardano-cli/src/Cardano/CLI/Run/Ping.hs
+++ b/cardano-cli/src/Cardano/CLI/Run/Ping.hs
@@ -4,8 +4,8 @@
 {- HLINT ignore "Move brackets to avoid $" -}
 
 module Cardano.CLI.Run.Ping
-  ( PingCmd(..)
-  , PingClientCmdError(..)
+  ( PingCmd (..)
+  , PingClientCmdError (..)
   , renderPingClientCmdError
   , runPingCmd
   , parsePingCmd
@@ -13,22 +13,22 @@ module Cardano.CLI.Run.Ping
 
 import qualified Cardano.Network.Ping as CNP
 
-import           Control.Applicative ((<|>))
-import           Control.Concurrent.Class.MonadSTM.Strict (StrictTMVar)
+import Control.Applicative ((<|>))
+import Control.Concurrent.Class.MonadSTM.Strict (StrictTMVar)
 import qualified Control.Concurrent.Class.MonadSTM.Strict as STM
-import           Control.Exception (SomeException)
-import           Control.Monad (forM, unless)
-import           Control.Monad.Class.MonadAsync (MonadAsync (async, wait, waitCatch))
-import           Control.Monad.IO.Class (liftIO)
-import           Control.Monad.Trans.Except (ExceptT)
-import           Control.Monad.Trans.Except.Extra (left)
-import           Control.Tracer (Tracer (..))
-import           Data.List (foldl')
+import Control.Exception (SomeException)
+import Control.Monad (forM, unless)
+import Control.Monad.Class.MonadAsync (MonadAsync (async, wait, waitCatch))
+import Control.Monad.IO.Class (liftIO)
+import Control.Monad.Trans.Except (ExceptT)
+import Control.Monad.Trans.Except.Extra (left)
+import Control.Tracer (Tracer (..))
+import Data.List (foldl')
 import qualified Data.List as L
-import           Data.Text (Text)
+import Data.Text (Text)
 import qualified Data.Text as T
-import           Data.Word (Word32)
-import           Network.Socket (AddrInfo)
+import Data.Word (Word32)
+import Network.Socket (AddrInfo)
 import qualified Network.Socket as Socket
 import qualified Options.Applicative as Opt
 import qualified Prettyprinter as PP
@@ -50,31 +50,35 @@ maybeUnixSockEndPoint = \case
   UnixSockEndPoint sock -> Just sock
 
 data PingCmd = PingCmd
-  { pingCmdCount           :: !Word32
-  , pingCmdEndPoint        :: !EndPoint
-  , pingCmdPort            :: !String
-  , pingCmdMagic           :: !Word32
-  , pingCmdJson            :: !Bool
-  , pingCmdQuiet           :: !Bool
+  { pingCmdCount :: !Word32
+  , pingCmdEndPoint :: !EndPoint
+  , pingCmdPort :: !String
+  , pingCmdMagic :: !Word32
+  , pingCmdJson :: !Bool
+  , pingCmdQuiet :: !Bool
   , pingOptsHandshakeQuery :: !Bool
-  } deriving (Eq, Show)
+  }
+  deriving (Eq, Show)
 
-pingClient :: Tracer IO CNP.LogMsg -> Tracer IO String -> PingCmd -> [CNP.NodeVersion] -> AddrInfo -> IO ()
+pingClient
+  :: Tracer IO CNP.LogMsg -> Tracer IO String -> PingCmd -> [CNP.NodeVersion] -> AddrInfo -> IO ()
 pingClient stdout stderr cmd = CNP.pingClient stdout stderr opts
-  where opts = CNP.PingOpts
-          { CNP.pingOptsQuiet          = pingCmdQuiet cmd
-          , CNP.pingOptsJson           = pingCmdJson cmd
-          , CNP.pingOptsCount          = pingCmdCount cmd
-          , CNP.pingOptsHost           = maybeHostEndPoint (pingCmdEndPoint cmd)
-          , CNP.pingOptsUnixSock       = maybeUnixSockEndPoint (pingCmdEndPoint cmd)
-          , CNP.pingOptsPort           = pingCmdPort cmd
-          , CNP.pingOptsMagic          = pingCmdMagic cmd
-          , CNP.pingOptsHandshakeQuery = pingOptsHandshakeQuery cmd
-          }
+ where
+  opts =
+    CNP.PingOpts
+      { CNP.pingOptsQuiet = pingCmdQuiet cmd
+      , CNP.pingOptsJson = pingCmdJson cmd
+      , CNP.pingOptsCount = pingCmdCount cmd
+      , CNP.pingOptsHost = maybeHostEndPoint (pingCmdEndPoint cmd)
+      , CNP.pingOptsUnixSock = maybeUnixSockEndPoint (pingCmdEndPoint cmd)
+      , CNP.pingOptsPort = pingCmdPort cmd
+      , CNP.pingOptsMagic = pingCmdMagic cmd
+      , CNP.pingOptsHandshakeQuery = pingOptsHandshakeQuery cmd
+      }
 
 runPingCmd :: PingCmd -> ExceptT PingClientCmdError IO ()
 runPingCmd options = do
-  let hints = Socket.defaultHints { Socket.addrSocketType = Socket.Stream }
+  let hints = Socket.defaultHints {Socket.addrSocketType = Socket.Stream}
 
   msgQueue <- liftIO STM.newEmptyTMVarIO
 
@@ -85,21 +89,28 @@ runPingCmd options = do
       addrs <- liftIO $ Socket.getAddrInfo (Just hints) (Just host) (Just (pingCmdPort options))
       return (addrs, CNP.supportedNodeToNodeVersions $ pingCmdMagic options)
     UnixSockEndPoint fname -> do
-      let addr = Socket.AddrInfo
-            [] Socket.AF_UNIX Socket.Stream
-            Socket.defaultProtocol (Socket.SockAddrUnix fname) Nothing
+      let addr =
+            Socket.AddrInfo
+              []
+              Socket.AF_UNIX
+              Socket.Stream
+              Socket.defaultProtocol
+              (Socket.SockAddrUnix fname)
+              Nothing
       return ([addr], CNP.supportedNodeToClientVersions $ pingCmdMagic options)
 
   -- Logger async thread handle
   laid <- liftIO . async $ CNP.logger msgQueue (pingCmdJson options) (pingOptsHandshakeQuery options)
   -- Ping client thread handles
-  caids <- forM addresses $ liftIO . async . pingClient (Tracer $ doLog msgQueue) (Tracer doErrLog) options versions
+  caids <-
+    forM addresses $
+      liftIO . async . pingClient (Tracer $ doLog msgQueue) (Tracer doErrLog) options versions
   res <- L.zip addresses <$> mapM (liftIO . waitCatch) caids
   liftIO $ doLog msgQueue CNP.LogEnd
   liftIO $ wait laid
 
   -- Collect errors 'es' from failed pings and 'addrs' from successful pings.
-  let (es, addrs) = foldl' partition ([],[]) res
+  let (es, addrs) = foldl' partition ([], []) res
 
   -- Report any errors
   case (es, addrs) of
@@ -108,99 +119,116 @@ runPingCmd options = do
     (_, _) -> do
       unless (pingCmdQuiet options) $ mapM_ (liftIO . IO.hPrint IO.stderr) es
       liftIO IO.exitSuccess
+ where
+  partition
+    :: ([(AddrInfo, SomeException)], [AddrInfo])
+    -> (AddrInfo, Either SomeException ())
+    -> ([(AddrInfo, SomeException)], [AddrInfo])
+  partition (es, as) (a, Left e) = ((a, e) : es, as)
+  partition (es, as) (a, Right _) = (es, a : as)
 
-  where
-    partition :: ([(AddrInfo, SomeException)], [AddrInfo])
-              -> (AddrInfo, Either SomeException ())
-              -> ([(AddrInfo, SomeException)], [AddrInfo])
-    partition (es, as) (a, Left e)  = ((a, e) : es, as)
-    partition (es, as) (a, Right _) = (es, a : as)
+  doLog :: StrictTMVar IO CNP.LogMsg -> CNP.LogMsg -> IO ()
+  doLog msgQueue msg = STM.atomically $ STM.putTMVar msgQueue msg
 
-    doLog :: StrictTMVar IO CNP.LogMsg -> CNP.LogMsg -> IO ()
-    doLog msgQueue msg = STM.atomically $ STM.putTMVar msgQueue msg
-
-    doErrLog :: String -> IO ()
-    doErrLog = IO.hPutStrLn IO.stderr
+  doErrLog :: String -> IO ()
+  doErrLog = IO.hPutStrLn IO.stderr
 
 renderPingClientCmdError :: PingClientCmdError -> Text
 renderPingClientCmdError = \case
   PingClientCmdError es -> T.intercalate "\n" $ T.pack . show <$> es
 
 parsePingCmd :: Opt.Parser PingCmd
-parsePingCmd = Opt.hsubparser $ mconcat
-  [ Opt.metavar "ping"
-  , Opt.command "ping" $ Opt.info pPing $ Opt.progDescDoc $ Just $ mconcat
-    [ PP.pretty @String "Ping a cardano node either using node-to-node or node-to-client protocol. "
-    , PP.pretty @String "It negotiates a handshake and keeps sending keep alive messages."
-    ]
-  ]
+parsePingCmd =
+  Opt.hsubparser $
+    mconcat
+      [ Opt.metavar "ping"
+      , Opt.command "ping" $
+          Opt.info pPing $
+            Opt.progDescDoc $
+              Just $
+                mconcat
+                  [ PP.pretty @String "Ping a cardano node either using node-to-node or node-to-client protocol. "
+                  , PP.pretty @String "It negotiates a handshake and keeps sending keep alive messages."
+                  ]
+      ]
 
 pHost :: Opt.Parser String
 pHost =
-  Opt.strOption $ mconcat
-    [ Opt.long "host"
-    , Opt.short 'h'
-    , Opt.metavar "HOST"
-    , Opt.help "Hostname/IP, e.g. relay.iohk.example."
-    ]
+  Opt.strOption $
+    mconcat
+      [ Opt.long "host"
+      , Opt.short 'h'
+      , Opt.metavar "HOST"
+      , Opt.help "Hostname/IP, e.g. relay.iohk.example."
+      ]
 
 pUnixSocket :: Opt.Parser String
 pUnixSocket =
-  Opt.strOption $ mconcat
-    [ Opt.long "unixsock"
-    , Opt.short 'u'
-    , Opt.metavar "SOCKET"
-    , Opt.help "Unix socket, e.g. file.socket."
-    ]
+  Opt.strOption $
+    mconcat
+      [ Opt.long "unixsock"
+      , Opt.short 'u'
+      , Opt.metavar "SOCKET"
+      , Opt.help "Unix socket, e.g. file.socket."
+      ]
 
 pEndPoint :: Opt.Parser EndPoint
 pEndPoint = fmap HostEndPoint pHost <|> fmap UnixSockEndPoint pUnixSocket
 
 pPing :: Opt.Parser PingCmd
-pPing = PingCmd
-  <$> ( Opt.option Opt.auto $ mconcat
-        [ Opt.long "count"
-        , Opt.short 'c'
-        , Opt.metavar "COUNT"
-        , Opt.help $ mconcat
-          [ "Stop after sending count requests and receiving count responses.  "
-          , "If this option is not specified, ping will operate until interrupted.  "
-          ]
-        , Opt.value maxBound
-        ]
-      )
-  <*> pEndPoint
-  <*> ( Opt.strOption $ mconcat
-        [ Opt.long "port"
-        , Opt.short 'p'
-        , Opt.metavar "PORT"
-        , Opt.help "Port number, e.g. 1234."
-        , Opt.value "3001"
-        ]
-      )
-  <*> ( Opt.option Opt.auto $ mconcat
-        [ Opt.long "magic"
-        , Opt.short 'm'
-        , Opt.metavar "MAGIC"
-        , Opt.help "Network magic."
-        , Opt.value CNP.mainnetMagic
-        ]
-      )
-  <*> ( Opt.switch $ mconcat
-        [ Opt.long "json"
-        , Opt.short 'j'
-        , Opt.help "JSON output flag."
-        ]
-      )
-  <*> ( Opt.switch $ mconcat
-        [ Opt.long "quiet"
-        , Opt.short 'q'
-        , Opt.help "Quiet flag, CSV/JSON only output"
-        ]
-      )
-  <*> ( Opt.switch $ mconcat
-        [ Opt.long "query-versions"
-        , Opt.short 'Q'
-        , Opt.help "Query the supported protocol versions using the handshake protocol and terminate the connection."
-        ]
-      )
+pPing =
+  PingCmd
+    <$> ( Opt.option Opt.auto $
+            mconcat
+              [ Opt.long "count"
+              , Opt.short 'c'
+              , Opt.metavar "COUNT"
+              , Opt.help $
+                  mconcat
+                    [ "Stop after sending count requests and receiving count responses.  "
+                    , "If this option is not specified, ping will operate until interrupted.  "
+                    ]
+              , Opt.value maxBound
+              ]
+        )
+    <*> pEndPoint
+    <*> ( Opt.strOption $
+            mconcat
+              [ Opt.long "port"
+              , Opt.short 'p'
+              , Opt.metavar "PORT"
+              , Opt.help "Port number, e.g. 1234."
+              , Opt.value "3001"
+              ]
+        )
+    <*> ( Opt.option Opt.auto $
+            mconcat
+              [ Opt.long "magic"
+              , Opt.short 'm'
+              , Opt.metavar "MAGIC"
+              , Opt.help "Network magic."
+              , Opt.value CNP.mainnetMagic
+              ]
+        )
+    <*> ( Opt.switch $
+            mconcat
+              [ Opt.long "json"
+              , Opt.short 'j'
+              , Opt.help "JSON output flag."
+              ]
+        )
+    <*> ( Opt.switch $
+            mconcat
+              [ Opt.long "quiet"
+              , Opt.short 'q'
+              , Opt.help "Quiet flag, CSV/JSON only output"
+              ]
+        )
+    <*> ( Opt.switch $
+            mconcat
+              [ Opt.long "query-versions"
+              , Opt.short 'Q'
+              , Opt.help
+                  "Query the supported protocol versions using the handshake protocol and terminate the connection."
+              ]
+        )

--- a/cardano-cli/src/Cardano/CLI/TopHandler.hs
+++ b/cardano-cli/src/Cardano/CLI/TopHandler.hs
@@ -44,13 +44,12 @@ module Cardano.CLI.TopHandler
 -- (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 -- OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import           Prelude
+import Prelude
 
-import           Control.Exception
-import           System.Environment
-import           System.Exit
-import           System.IO
-
+import Control.Exception
+import System.Environment
+import System.Exit
+import System.IO
 
 -- | An exception handler to use for a program top level, as an alternative to
 -- the default top level handler provided by GHC.
@@ -60,46 +59,45 @@ import           System.IO
 -- > main :: IO ()
 -- > main = toplevelExceptionHandler $ do
 -- >   ...
---
 toplevelExceptionHandler :: IO a -> IO a
 toplevelExceptionHandler prog = do
-    -- Use line buffering in case we have to print big error messages, because
-    -- by default stderr to a terminal device is NoBuffering which is slow.
-    hSetBuffering stderr LineBuffering
-    catches prog [
-        Handler rethrowAsyncExceptions
-      , Handler rethrowExitCode
-      , Handler handleSomeException
-      ]
-  where
-    -- Let async exceptions rise to the top for the default GHC top-handler.
-    -- This includes things like CTRL-C.
-    rethrowAsyncExceptions :: SomeAsyncException -> IO a
-    rethrowAsyncExceptions = throwIO
+  -- Use line buffering in case we have to print big error messages, because
+  -- by default stderr to a terminal device is NoBuffering which is slow.
+  hSetBuffering stderr LineBuffering
+  catches
+    prog
+    [ Handler rethrowAsyncExceptions
+    , Handler rethrowExitCode
+    , Handler handleSomeException
+    ]
+ where
+  -- Let async exceptions rise to the top for the default GHC top-handler.
+  -- This includes things like CTRL-C.
+  rethrowAsyncExceptions :: SomeAsyncException -> IO a
+  rethrowAsyncExceptions = throwIO
 
-    -- We don't want to print ExitCode, and it should be handled by the default
-    -- top handler because that sets the actual OS process exit code.
-    rethrowExitCode :: ExitCode -> IO a
-    rethrowExitCode = throwIO
+  -- We don't want to print ExitCode, and it should be handled by the default
+  -- top handler because that sets the actual OS process exit code.
+  rethrowExitCode :: ExitCode -> IO a
+  rethrowExitCode = throwIO
 
-    -- Print all other exceptions
-    handleSomeException :: SomeException -> IO a
-    handleSomeException e = do
-      hFlush stdout
-      progname <- getProgName
-      hPutStr stderr (renderSomeException progname e)
-      throwIO (ExitFailure 1)
+  -- Print all other exceptions
+  handleSomeException :: SomeException -> IO a
+  handleSomeException e = do
+    hFlush stdout
+    progname <- getProgName
+    hPutStr stderr (renderSomeException progname e)
+    throwIO (ExitFailure 1)
 
-    -- Print the human-readable output of 'displayException' if it differs
-    -- from the default output (of 'show'), so that the user/sysadmin
-    -- sees something readable in the log.
-    renderSomeException :: String -> SomeException -> String
-    renderSomeException progname e
-      | showOutput /= displayOutput
-      = showOutput ++ "\n\n" ++ progname ++ ": " ++ displayOutput
-
-      | otherwise
-      = "\n" ++ progname ++ ": " ++ showOutput
-      where
-        showOutput    = show e
-        displayOutput = displayException e
+  -- Print the human-readable output of 'displayException' if it differs
+  -- from the default output (of 'show'), so that the user/sysadmin
+  -- sees something readable in the log.
+  renderSomeException :: String -> SomeException -> String
+  renderSomeException progname e
+    | showOutput /= displayOutput =
+        showOutput ++ "\n\n" ++ progname ++ ": " ++ displayOutput
+    | otherwise =
+        "\n" ++ progname ++ ": " ++ showOutput
+   where
+    showOutput = show e
+    displayOutput = displayException e

--- a/cardano-cli/src/Cardano/CLI/Types/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Common.hs
@@ -76,19 +76,19 @@ module Cardano.CLI.Types.Common
   ) where
 
 import Cardano.Api
-import qualified Cardano.Api.Ledger as L
+import Cardano.Api.Ledger qualified as L
 
-import qualified Cardano.Chain.Slotting as Byron
-import qualified Cardano.Ledger.BaseTypes as L
-import qualified Cardano.Ledger.Crypto as Crypto
-import qualified Cardano.Ledger.SafeHash as L
+import Cardano.Chain.Slotting qualified as Byron
+import Cardano.Ledger.BaseTypes qualified as L
+import Cardano.Ledger.Crypto qualified as Crypto
+import Cardano.Ledger.SafeHash qualified as L
 import Cardano.Ledger.Shelley.TxBody (PoolParams (..))
 
 import Data.Aeson (FromJSON (..), ToJSON (..), object, pairs, (.=))
-import qualified Data.Aeson as Aeson
+import Data.Aeson qualified as Aeson
 import Data.String (IsString)
 import Data.Text (Text)
-import qualified Data.Text as Text
+import Data.Text qualified as Text
 import Data.Word (Word64)
 
 -- | Determines the direction in which the MIR certificate will transfer ADA.

--- a/cardano-cli/src/Cardano/CLI/Types/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Common.hs
@@ -6,28 +6,28 @@
 {-# LANGUAGE StandaloneDeriving #-}
 
 module Cardano.CLI.Types.Common
-  ( AllOrOnly(..)
-  , AddressKeyType(..)
+  ( AllOrOnly (..)
+  , AddressKeyType (..)
   , BalanceTxExecUnits (..)
-  , BlockId(..)
-  , ByronKeyFormat(..)
-  , ByronKeyType(..)
-  , CardanoAddressKeyType(..)
+  , BlockId (..)
+  , ByronKeyFormat (..)
+  , ByronKeyType (..)
+  , CardanoAddressKeyType (..)
   , CBORObject (..)
   , CertificateFile (..)
-  , ConstitutionHashSource(..)
-  , ConstitutionText(..)
-  , ConstitutionUrl(..)
+  , ConstitutionHashSource (..)
+  , ConstitutionText (..)
+  , ConstitutionUrl (..)
   , CurrentKesPeriod (..)
   , EpochLeadershipSchedule (..)
-  , File(..)
+  , File (..)
   , FileDirection (..)
-  , GenesisDir(..)
+  , GenesisDir (..)
   , GenesisFile (..)
-  , GenesisKeyFile(..)
+  , GenesisKeyFile (..)
   , InputTxBodyOrTxFile (..)
-  , KeyOutputFormat(..)
-  , MetadataFile(..)
+  , KeyOutputFormat (..)
+  , MetadataFile (..)
   , OpCertCounter
   , OpCertCounterFile
   , OpCertEndingKesPeriod (..)
@@ -39,12 +39,12 @@ module Cardano.CLI.Types.Common
   , Params (..)
   , ParserFileDirection (..)
   , IdOutputFormat (..)
-  , PrivKeyFile(..)
+  , PrivKeyFile (..)
   , ProposalFile
-  , ProposalHashSource(..)
-  , ProposalText(..)
-  , ProposalUrl(..)
-  , ProtocolParamsFile(..)
+  , ProposalHashSource (..)
+  , ProposalText (..)
+  , ProposalUrl (..)
+  , ProtocolParamsFile (..)
   , ReferenceScriptAnyEra (..)
   , RequiredSigner (..)
   , ScriptDataOrFile (..)
@@ -54,101 +54,106 @@ module Cardano.CLI.Types.Common
   , ScriptWitnessFiles (..)
   , SigningKeyFile
   , SlotsTillKesKeyExpiry (..)
-  , SomeKeyFile(..)
+  , SomeKeyFile (..)
   , StakePoolMetadataFile
-  , TransferDirection(..)
+  , TransferDirection (..)
   , TxBodyFile
-  , TxBuildOutputOptions(..)
-  , TxByronWitnessCount(..)
+  , TxBuildOutputOptions (..)
+  , TxByronWitnessCount (..)
   , TxFile
-  , TxInCount(..)
+  , TxInCount (..)
   , TxMempoolQuery (..)
   , TxOutAnyEra (..)
   , TxOutChangeAddress (..)
-  , TxOutCount(..)
+  , TxOutCount (..)
   , TxOutDatumAnyEra (..)
-  , TxShelleyWitnessCount(..)
+  , TxShelleyWitnessCount (..)
   , UpdateProposalFile (..)
-  , VerificationKeyBase64(..)
+  , VerificationKeyBase64 (..)
   , VerificationKeyFile
-  , WitnessFile(..)
-  , WitnessSigningData(..)
+  , WitnessFile (..)
+  , WitnessSigningData (..)
   ) where
 
-import           Cardano.Api
+import Cardano.Api
 import qualified Cardano.Api.Ledger as L
 
 import qualified Cardano.Chain.Slotting as Byron
 import qualified Cardano.Ledger.BaseTypes as L
 import qualified Cardano.Ledger.Crypto as Crypto
 import qualified Cardano.Ledger.SafeHash as L
-import           Cardano.Ledger.Shelley.TxBody (PoolParams (..))
+import Cardano.Ledger.Shelley.TxBody (PoolParams (..))
 
-import           Data.Aeson (FromJSON (..), ToJSON (..), object, pairs, (.=))
+import Data.Aeson (FromJSON (..), ToJSON (..), object, pairs, (.=))
 import qualified Data.Aeson as Aeson
-import           Data.String (IsString)
-import           Data.Text (Text)
+import Data.String (IsString)
+import Data.Text (Text)
 import qualified Data.Text as Text
-import           Data.Word (Word64)
+import Data.Word (Word64)
 
 -- | Determines the direction in which the MIR certificate will transfer ADA.
-data TransferDirection =
-    TransferToReserves
+data TransferDirection
+  = TransferToReserves
   | TransferToTreasury
-  deriving Show
+  deriving (Show)
 
 data OpCertCounter
 
 newtype ConstitutionUrl = ConstitutionUrl
   { unConstitutionUrl :: L.Url
-  } deriving (Eq, Show)
+  }
+  deriving (Eq, Show)
 
 newtype ConstitutionText = ConstitutionText
   { unConstitutionText :: Text
-  } deriving (Eq, Show)
+  }
+  deriving (Eq, Show)
 
 data ConstitutionHashSource
   = ConstitutionHashSourceFile (File ConstitutionText In)
   | ConstitutionHashSourceText Text
   | ConstitutionHashSourceHash (L.SafeHash Crypto.StandardCrypto L.AnchorData)
-  deriving Show
+  deriving (Show)
 
 newtype ProposalUrl = ProposalUrl
   { unProposalUrl :: L.Url
-  } deriving (Eq, Show)
+  }
+  deriving (Eq, Show)
 
 newtype ProposalText = ProposalText
   { unProposalText :: Text
-  } deriving (Eq, Show)
+  }
+  deriving (Eq, Show)
 
 data ProposalHashSource
   = ProposalHashSourceFile (File ProposalText In)
   | ProposalHashSourceText Text
   | ProposalHashSourceHash (L.SafeHash Crypto.StandardCrypto L.AnchorData)
-  deriving Show
+  deriving (Show)
 
 -- | Specify whether to render the script cost as JSON
 -- in the cli's build command.
-data TxBuildOutputOptions = OutputScriptCostOnly (File () Out)
-                          | OutputTxBodyOnly (TxBodyFile Out)
-                          deriving Show
-
+data TxBuildOutputOptions
+  = OutputScriptCostOnly (File () Out)
+  | OutputTxBodyOnly (TxBodyFile Out)
+  deriving (Show)
 
 -- | Specify what the CBOR file is
 -- i.e a block, a tx, etc
-data CBORObject = CBORBlockByron Byron.EpochSlots
-                | CBORDelegationCertificateByron
-                | CBORTxByron
-                | CBORUpdateProposalByron
-                | CBORVoteByron
-                deriving Show
+data CBORObject
+  = CBORBlockByron Byron.EpochSlots
+  | CBORDelegationCertificateByron
+  | CBORTxByron
+  | CBORUpdateProposalByron
+  | CBORVoteByron
+  deriving (Show)
 
 -- Encompasses stake certificates, stake pool certificates,
 -- genesis delegate certificates and MIR certificates.
-newtype CertificateFile = CertificateFile { unCertificateFile :: FilePath }
-                          deriving newtype (Eq, Show)
+newtype CertificateFile = CertificateFile {unCertificateFile :: FilePath}
+  deriving newtype (Eq, Show)
 
-newtype CurrentKesPeriod = CurrentKesPeriod { unCurrentKesPeriod :: Word64 } deriving (Eq, Show)
+newtype CurrentKesPeriod = CurrentKesPeriod {unCurrentKesPeriod :: Word64} deriving (Eq, Show)
 
 instance ToJSON CurrentKesPeriod where
   toJSON (CurrentKesPeriod k) = toJSON k
@@ -157,49 +162,49 @@ instance FromJSON CurrentKesPeriod where
   parseJSON v = CurrentKesPeriod <$> parseJSON v
 
 newtype GenesisFile = GenesisFile
-  { unGenesisFile :: FilePath }
+  {unGenesisFile :: FilePath}
   deriving stock (Eq, Ord)
   deriving newtype (IsString, Show)
 
 data OpCertNodeAndOnDiskCounterInformation
-  -- | The on disk operational certificate has a counter
-  -- that is equal to its corresponding counter in the
-  -- node state. The on disk operational certificate therefore
-  -- has a valid counter.
-  = OpCertOnDiskCounterEqualToNodeState
+  = -- | The on disk operational certificate has a counter
+    -- that is equal to its corresponding counter in the
+    -- node state. The on disk operational certificate therefore
+    -- has a valid counter.
+    OpCertOnDiskCounterEqualToNodeState
       OpCertOnDiskCounter
       OpCertNodeStateCounter
-  -- | The on disk operational certificate has a counter
-  -- that is ahead of the counter in the node state by 1.
-  -- The on disk operational certificate is invalid in
-  -- this case.
-  | OpCertOnDiskCounterAheadOfNodeState
+  | -- | The on disk operational certificate has a counter
+    -- that is ahead of the counter in the node state by 1.
+    -- The on disk operational certificate is invalid in
+    -- this case.
+    OpCertOnDiskCounterAheadOfNodeState
       OpCertOnDiskCounter
       OpCertNodeStateCounter
-  -- | The on disk operational certificate has a counter
-  -- that is less than the counter in the node state. The
-  -- on disk operational certificate is invalid in this case.
-  | OpCertOnDiskCounterTooFarAheadOfNodeState
+  | -- | The on disk operational certificate has a counter
+    -- that is less than the counter in the node state. The
+    -- on disk operational certificate is invalid in this case.
+    OpCertOnDiskCounterTooFarAheadOfNodeState
       OpCertOnDiskCounter
       OpCertNodeStateCounter
-  -- | The corresponding counter for operational certificate
-  -- was not found in the node state. This means the relevant
-  -- stake pool has not minted a block yet. When the stake pool
-  -- has minted a block the corresponding operational certificate's
-  -- counter will be present in the node state.
-  | OpCertOnDiskCounterBehindNodeState
+  | -- | The corresponding counter for operational certificate
+    -- was not found in the node state. This means the relevant
+    -- stake pool has not minted a block yet. When the stake pool
+    -- has minted a block the corresponding operational certificate's
+    -- counter will be present in the node state.
+    OpCertOnDiskCounterBehindNodeState
       OpCertOnDiskCounter
       OpCertNodeStateCounter
-  -- | The on disk operational certificate has a counter
-  -- that is ahead of the counter in the node state by more
-  -- than 1. The on disk operational certificate is invalid in
-  -- this case.
-  | OpCertNoBlocksMintedYet
+  | -- | The on disk operational certificate has a counter
+    -- that is ahead of the counter in the node state by more
+    -- than 1. The on disk operational certificate is invalid in
+    -- this case.
+    OpCertNoBlocksMintedYet
       OpCertOnDiskCounter
   deriving (Eq, Show)
 
-newtype OpCertOnDiskCounter = OpCertOnDiskCounter { unOpCertOnDiskCounter :: Word64 }
-                              deriving (Eq, Show)
+newtype OpCertOnDiskCounter = OpCertOnDiskCounter {unOpCertOnDiskCounter :: Word64}
+  deriving (Eq, Show)
 
 instance ToJSON OpCertOnDiskCounter where
   toJSON (OpCertOnDiskCounter k) = toJSON k
@@ -207,8 +212,8 @@ instance ToJSON OpCertOnDiskCounter where
 instance FromJSON OpCertOnDiskCounter where
   parseJSON v = OpCertOnDiskCounter <$> parseJSON v
 
-newtype OpCertNodeStateCounter = OpCertNodeStateCounter { unOpCertNodeStateCounter :: Word64 }
-                                 deriving (Eq, Show)
+newtype OpCertNodeStateCounter = OpCertNodeStateCounter {unOpCertNodeStateCounter :: Word64}
+  deriving (Eq, Show)
 
 instance ToJSON OpCertNodeStateCounter where
   toJSON (OpCertNodeStateCounter k) = toJSON k
@@ -216,8 +221,8 @@ instance ToJSON OpCertNodeStateCounter where
 instance FromJSON OpCertNodeStateCounter where
   parseJSON v = OpCertNodeStateCounter <$> parseJSON v
 
-newtype OpCertStartingKesPeriod = OpCertStartingKesPeriod { unOpCertStartingKesPeriod :: Word64 }
-                                  deriving (Eq, Show)
+newtype OpCertStartingKesPeriod = OpCertStartingKesPeriod {unOpCertStartingKesPeriod :: Word64}
+  deriving (Eq, Show)
 
 instance ToJSON OpCertStartingKesPeriod where
   toJSON (OpCertStartingKesPeriod k) = toJSON k
@@ -225,8 +230,8 @@ instance ToJSON OpCertStartingKesPeriod where
 instance FromJSON OpCertStartingKesPeriod where
   parseJSON v = OpCertStartingKesPeriod <$> parseJSON v
 
-newtype OpCertEndingKesPeriod = OpCertEndingKesPeriod { unOpCertEndingKesPeriod :: Word64 }
-                                deriving (Eq, Show)
+newtype OpCertEndingKesPeriod = OpCertEndingKesPeriod {unOpCertEndingKesPeriod :: Word64}
+  deriving (Eq, Show)
 
 instance ToJSON OpCertEndingKesPeriod where
   toJSON (OpCertEndingKesPeriod k) = toJSON k
@@ -248,7 +253,8 @@ data OpCertIntervalInformation
       OpCertStartingKesPeriod
       OpCertEndingKesPeriod
       CurrentKesPeriod
-  | OpCertSomeOtherError -- ^ Shouldn't be possible
+  | -- | Shouldn't be possible
+    OpCertSomeOtherError
       OpCertStartingKesPeriod
       OpCertEndingKesPeriod
       CurrentKesPeriod
@@ -256,8 +262,11 @@ data OpCertIntervalInformation
 
 instance FromJSON GenesisFile where
   parseJSON (Aeson.String genFp) = pure . GenesisFile $ Text.unpack genFp
-  parseJSON invalid = error $ "Parsing of GenesisFile failed due to type mismatch. "
-                           <> "Encountered: " <> show invalid
+  parseJSON invalid =
+    error $
+      "Parsing of GenesisFile failed due to type mismatch. "
+        <> "Encountered: "
+        <> show invalid
 
 -- | Some entities such as stake pools and dreps have a notion of an ID and that id can be
 -- encoded as either a bech32 or hex string.  This type is used to specify which encoding
@@ -281,37 +290,45 @@ data Params crypto = Params
   { poolParameters :: Maybe (PoolParams crypto)
   , futurePoolParameters :: Maybe (PoolParams crypto)
   , retiringEpoch :: Maybe EpochNo
-  } deriving Show
+  }
+  deriving (Show)
 
 -- | Pretty printing for pool parameters
-instance Crypto.Crypto crypto =>  ToJSON (Params crypto) where
-  toJSON (Params p fp r) = object
-    [ "poolParams" .= p
-    , "futurePoolParams" .= fp
-    , "retiring" .= r
-    ]
+instance (Crypto.Crypto crypto) => ToJSON (Params crypto) where
+  toJSON (Params p fp r) =
+    object
+      [ "poolParams" .= p
+      , "futurePoolParams" .= fp
+      , "retiring" .= r
+      ]
 
-  toEncoding (Params p fp r) = pairs $ mconcat
-    [ "poolParams" .= p
-    , "futurePoolParams" .= fp
-    , "retiring" .= r
-    ]
+  toEncoding (Params p fp r) =
+    pairs $
+      mconcat
+        [ "poolParams" .= p
+        , "futurePoolParams" .= fp
+        , "retiring" .= r
+        ]
 
 type SigningKeyFile = File (SigningKey ())
 
 type ProposalFile = File ()
 
-newtype UpdateProposalFile = UpdateProposalFile { unUpdateProposalFile :: FilePath }
-                             deriving newtype (Eq, Show)
+newtype UpdateProposalFile = UpdateProposalFile {unUpdateProposalFile :: FilePath}
+  deriving newtype (Eq, Show)
 
 type VerificationKeyFile = File (VerificationKey ())
 
-newtype ScriptFile = ScriptFile { unScriptFile :: FilePath }
-                     deriving (Eq, Show)
+newtype ScriptFile = ScriptFile {unScriptFile :: FilePath}
+  deriving (Eq, Show)
 
-data ScriptDataOrFile = ScriptDataCborFile  FilePath   -- ^ By reference to a CBOR file
-                      | ScriptDataJsonFile  FilePath   -- ^ By reference to a JSON file
-                      | ScriptDataValue     HashableScriptData -- ^ By value
+data ScriptDataOrFile
+  = -- | By reference to a CBOR file
+    ScriptDataCborFile FilePath
+  | -- | By reference to a JSON file
+    ScriptDataJsonFile FilePath
+  | -- | By value
+    ScriptDataValue HashableScriptData
   deriving (Eq, Show)
 
 type ScriptRedeemerOrFile = ScriptDataOrFile
@@ -320,48 +337,47 @@ type ScriptRedeemerOrFile = ScriptDataOrFile
 -- the script witness data representation.
 --
 -- It is era-independent, but witness context-dependent.
---
 data ScriptWitnessFiles witctx where
-     SimpleScriptWitnessFile  :: ScriptFile
-                              -> ScriptWitnessFiles witctx
-
-     PlutusScriptWitnessFiles :: ScriptFile
-                              -> ScriptDatumOrFile witctx
-                              -> ScriptRedeemerOrFile
-                              -> ExecutionUnits
-                              -> ScriptWitnessFiles witctx
-
-     -- TODO: Need to figure out how to exclude PlutusV1 scripts at the type level
-     PlutusReferenceScriptWitnessFiles
-       :: TxIn
-       -> AnyScriptLanguage
-       -> ScriptDatumOrFile witctx
-       -> ScriptRedeemerOrFile
-       -> ExecutionUnits
-       -> Maybe PolicyId -- ^ For minting reference scripts
-       -> ScriptWitnessFiles witctx
-
-     SimpleReferenceScriptWitnessFiles
-       :: TxIn
-       -> AnyScriptLanguage
-       -> Maybe PolicyId -- ^ For minting reference scripts
-       -> ScriptWitnessFiles witctx
-
+  SimpleScriptWitnessFile
+    :: ScriptFile
+    -> ScriptWitnessFiles witctx
+  PlutusScriptWitnessFiles
+    :: ScriptFile
+    -> ScriptDatumOrFile witctx
+    -> ScriptRedeemerOrFile
+    -> ExecutionUnits
+    -> ScriptWitnessFiles witctx
+  -- TODO: Need to figure out how to exclude PlutusV1 scripts at the type level
+  PlutusReferenceScriptWitnessFiles
+    :: TxIn
+    -> AnyScriptLanguage
+    -> ScriptDatumOrFile witctx
+    -> ScriptRedeemerOrFile
+    -> ExecutionUnits
+    -> Maybe PolicyId
+    -- ^ For minting reference scripts
+    -> ScriptWitnessFiles witctx
+  SimpleReferenceScriptWitnessFiles
+    :: TxIn
+    -> AnyScriptLanguage
+    -> Maybe PolicyId
+    -- ^ For minting reference scripts
+    -> ScriptWitnessFiles witctx
 
 deriving instance Show (ScriptWitnessFiles witctx)
 
 data ScriptDatumOrFile witctx where
-     ScriptDatumOrFileForTxIn    :: ScriptDataOrFile
-                                 -> ScriptDatumOrFile WitCtxTxIn
-     InlineDatumPresentAtTxIn    :: ScriptDatumOrFile WitCtxTxIn
-
-     NoScriptDatumOrFileForMint  :: ScriptDatumOrFile WitCtxMint
-     NoScriptDatumOrFileForStake :: ScriptDatumOrFile WitCtxStake
+  ScriptDatumOrFileForTxIn
+    :: ScriptDataOrFile
+    -> ScriptDatumOrFile WitCtxTxIn
+  InlineDatumPresentAtTxIn :: ScriptDatumOrFile WitCtxTxIn
+  NoScriptDatumOrFileForMint :: ScriptDatumOrFile WitCtxMint
+  NoScriptDatumOrFileForStake :: ScriptDatumOrFile WitCtxStake
 
 deriving instance Show (ScriptDatumOrFile witctx)
 
-newtype SlotsTillKesKeyExpiry = SlotsTillKesKeyExpiry { unSlotsTillKesKeyExpiry :: SlotNo }
-                                deriving (Eq, Show)
+newtype SlotsTillKesKeyExpiry = SlotsTillKesKeyExpiry {unSlotsTillKesKeyExpiry :: SlotNo}
+  deriving (Eq, Show)
 
 instance ToJSON SlotsTillKesKeyExpiry where
   toJSON (SlotsTillKesKeyExpiry k) = toJSON k
@@ -373,19 +389,20 @@ instance FromJSON SlotsTillKesKeyExpiry where
 -- address type and allowing multi-asset values. This is used as the type for
 -- values passed on the command line. It can be converted into the
 -- era-dependent 'TxOutValue' type.
---
-data TxOutAnyEra = TxOutAnyEra
-                     AddressAny
-                     Value
-                     TxOutDatumAnyEra
-                     ReferenceScriptAnyEra
+data TxOutAnyEra
+  = TxOutAnyEra
+      AddressAny
+      Value
+      TxOutDatumAnyEra
+      ReferenceScriptAnyEra
   deriving (Eq, Show)
 
-data TxOutDatumAnyEra = TxOutDatumByHashOnly (Hash ScriptData)
-                      | TxOutDatumByHashOf    ScriptDataOrFile
-                      | TxOutDatumByValue     ScriptDataOrFile
-                      | TxOutInlineDatumByValue ScriptDataOrFile
-                      | TxOutDatumByNone
+data TxOutDatumAnyEra
+  = TxOutDatumByHashOnly (Hash ScriptData)
+  | TxOutDatumByHashOf ScriptDataOrFile
+  | TxOutDatumByValue ScriptDataOrFile
+  | TxOutInlineDatumByValue ScriptDataOrFile
+  | TxOutDatumByNone
   deriving (Eq, Show)
 
 data ReferenceScriptAnyEra
@@ -400,7 +417,6 @@ data ReferenceScriptAnyEra
 --
 -- It does not use any script data hash, since that's generally not used for
 -- change outputs.
---
 newtype TxOutChangeAddress = TxOutChangeAddress AddressAny
   deriving (Eq, Show)
 
@@ -410,26 +426,26 @@ data BalanceTxExecUnits = AutoBalance | ManualBalance
 
 -- | Plutus script required signers
 data RequiredSigner
- = RequiredSignerSkeyFile (SigningKeyFile In)
- | RequiredSignerHash (Hash PaymentKey)
- deriving Show
+  = RequiredSignerSkeyFile (SigningKeyFile In)
+  | RequiredSignerHash (Hash PaymentKey)
+  deriving (Show)
 
 -- | Which leadership schedule we are interested in.
 -- TODO: Implement Previous and Next epochs
 data EpochLeadershipSchedule
   = CurrentEpoch
   | NextEpoch
-  deriving Show
+  deriving (Show)
 
 type TxBodyFile = File (TxBody ())
 
 type TxFile = File (Tx ())
 
-data TxMempoolQuery =
-      TxMempoolQueryTxExists TxId
-    | TxMempoolQueryNextTx
-    | TxMempoolQueryInfo
-  deriving Show
+data TxMempoolQuery
+  = TxMempoolQueryTxExists TxId
+  | TxMempoolQueryNextTx
+  | TxMempoolQueryInfo
+  deriving (Show)
 
 --
 -- Shelley CLI flag/option data types
@@ -441,62 +457,62 @@ newtype ProtocolParamsFile
 
 newtype TxInCount
   = TxInCount Int
-  deriving Show
+  deriving (Show)
 
 newtype TxOutCount
   = TxOutCount Int
-  deriving Show
+  deriving (Show)
 
 newtype TxShelleyWitnessCount
   = TxShelleyWitnessCount Int
-  deriving Show
+  deriving (Show)
 
 newtype TxByronWitnessCount
   = TxByronWitnessCount Int
-  deriving Show
+  deriving (Show)
 
 newtype BlockId
   = BlockId String -- Probably not a String
-  deriving Show
+  deriving (Show)
 
 newtype GenesisKeyFile
   = GenesisKeyFile FilePath
-  deriving Show
+  deriving (Show)
 
-data MetadataFile = MetadataFileJSON (File () In)
-                  | MetadataFileCBOR (File () In)
-
-  deriving Show
+data MetadataFile
+  = MetadataFileJSON (File () In)
+  | MetadataFileCBOR (File () In)
+  deriving (Show)
 
 type StakePoolMetadataFile = File StakePoolMetadata
 
 newtype GenesisDir
   = GenesisDir FilePath
-  deriving Show
+  deriving (Show)
 
 -- | Either a verification or signing key, used for conversions and other
 -- commands that make sense for both.
---
 data SomeKeyFile direction
   = AVerificationKeyFile (VerificationKeyFile direction)
   | ASigningKeyFile (SigningKeyFile direction)
-  deriving Show
+  deriving (Show)
 
 data AddressKeyType
   = AddressKeyShelley
   | AddressKeyShelleyExtended
   | AddressKeyByron
-  deriving Show
+  deriving (Show)
 
 data ByronKeyType
-  = ByronPaymentKey  ByronKeyFormat
-  | ByronGenesisKey  ByronKeyFormat
+  = ByronPaymentKey ByronKeyFormat
+  | ByronGenesisKey ByronKeyFormat
   | ByronDelegateKey ByronKeyFormat
-  deriving Show
+  deriving (Show)
 
-data ByronKeyFormat = NonLegacyByronKeyFormat
-                    | LegacyByronKeyFormat
-  deriving Show
+data ByronKeyFormat
+  = NonLegacyByronKeyFormat
+  | LegacyByronKeyFormat
+  deriving (Show)
 
 -- | The type of @cardano-address@ key.
 data CardanoAddressKeyType
@@ -504,22 +520,22 @@ data CardanoAddressKeyType
   | CardanoAddressShelleyStakeKey
   | CardanoAddressIcarusPaymentKey
   | CardanoAddressByronPaymentKey
-  deriving Show
+  deriving (Show)
 
 type OpCertCounterFile = File OpCertCounter
 
 newtype PrivKeyFile
   = PrivKeyFile FilePath
-  deriving Show
+  deriving (Show)
 
 newtype WitnessFile
   = WitnessFile FilePath
-  deriving Show
+  deriving (Show)
 
 -- | A raw verification key given in Base64, and decoded into a ByteString.
 newtype VerificationKeyBase64
   = VerificationKeyBase64 String
-  deriving Show
+  deriving (Show)
 
 -- | Data required to construct a witness.
 data WitnessSigningData
@@ -531,10 +547,10 @@ data WitnessSigningData
       --
       -- If specified, both the network ID and derivation path are extracted
       -- from the address and used in the construction of the Byron witness.
-  deriving Show
+  deriving (Show)
 
 data InputTxBodyOrTxFile = InputTxBodyFile (TxBodyFile In) | InputTxFile (TxFile In)
-  deriving Show
+  deriving (Show)
 
 data ParserFileDirection
   = Input

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/AddressCmdError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/AddressCmdError.hs
@@ -19,7 +19,7 @@ import Cardano.CLI.Types.Key
   )
 
 import Data.Text (Text)
-import qualified Data.Text as Text
+import Data.Text qualified as Text
 
 data AddressCmdError
   = AddressCmdAddressInfoError !AddressInfoError

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/AddressCmdError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/AddressCmdError.hs
@@ -5,18 +5,20 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Cardano.CLI.Types.Errors.AddressCmdError
-  ( AddressCmdError(..)
+  ( AddressCmdError (..)
   , renderAddressCmdError
   ) where
 
-import           Cardano.Api
+import Cardano.Api
 
-import           Cardano.CLI.Read
-import           Cardano.CLI.Types.Errors.AddressInfoError
-import           Cardano.CLI.Types.Key (VerificationKeyTextOrFileError (..),
-                   renderVerificationKeyTextOrFileError)
+import Cardano.CLI.Read
+import Cardano.CLI.Types.Errors.AddressInfoError
+import Cardano.CLI.Types.Key
+  ( VerificationKeyTextOrFileError (..)
+  , renderVerificationKeyTextOrFileError
+  )
 
-import           Data.Text (Text)
+import Data.Text (Text)
 import qualified Data.Text as Text
 
 data AddressCmdError
@@ -26,7 +28,7 @@ data AddressCmdError
   | AddressCmdVerificationKeyTextOrFileError !VerificationKeyTextOrFileError
   | AddressCmdWriteFileError !(FileError ())
   | AddressCmdExpectedPaymentVerificationKey SomeAddressVerificationKey
-  deriving Show
+  deriving (Show)
 
 renderAddressCmdError :: AddressCmdError -> Text
 renderAddressCmdError err =

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/AddressInfoError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/AddressInfoError.hs
@@ -1,13 +1,13 @@
 module Cardano.CLI.Types.Errors.AddressInfoError
-  ( AddressInfoError(..)
+  ( AddressInfoError (..)
   ) where
 
-import           Cardano.Api
+import Cardano.Api
 
-import           Data.Text (Text)
+import Data.Text (Text)
 
 newtype AddressInfoError = ShelleyAddressInvalid Text
-  deriving Show
+  deriving (Show)
 
 instance Error AddressInfoError where
   displayError (ShelleyAddressInvalid addrTxt) =

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/BootstrapWitnessError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/BootstrapWitnessError.hs
@@ -1,17 +1,17 @@
 module Cardano.CLI.Types.Errors.BootstrapWitnessError
-  ( BootstrapWitnessError(..)
+  ( BootstrapWitnessError (..)
   , renderBootstrapWitnessError
   ) where
 
-import           Data.Text (Text)
+import Data.Text (Text)
 
 -- | Error constructing a Shelley bootstrap witness (i.e. a Byron key witness
 -- in the Shelley era).
 data BootstrapWitnessError
-  = MissingNetworkIdOrByronAddressError
-  -- ^ Neither a network ID nor a Byron address were provided to construct the
-  -- Shelley bootstrap witness. One or the other is required.
-  deriving Show
+  = -- | Neither a network ID nor a Byron address were provided to construct the
+    -- Shelley bootstrap witness. One or the other is required.
+    MissingNetworkIdOrByronAddressError
+  deriving (Show)
 
 -- | Render an error message for a 'BootstrapWitnessError'.
 renderBootstrapWitnessError :: BootstrapWitnessError -> Text

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/CardanoAddressSigningKeyConversionError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/CardanoAddressSigningKeyConversionError.hs
@@ -1,22 +1,22 @@
 module Cardano.CLI.Types.Errors.CardanoAddressSigningKeyConversionError
-  ( CardanoAddressSigningKeyConversionError(..)
+  ( CardanoAddressSigningKeyConversionError (..)
   , renderCardanoAddressSigningKeyConversionError
   ) where
 
-import           Cardano.Api
+import Cardano.Api
 
-import           Data.ByteString (ByteString)
-import           Data.Text (Text)
+import Data.ByteString (ByteString)
+import Data.Text (Text)
 import qualified Data.Text as Text
 
 -- | An error that can occur while converting a @cardano-address@ extended
 -- signing key.
 data CardanoAddressSigningKeyConversionError
-  = CardanoAddressSigningKeyBech32DecodeError !Bech32DecodeError
-  -- ^ There was an error in decoding the string as Bech32.
-  | CardanoAddressSigningKeyDeserialisationError !ByteString
-  -- ^ There was an error in converting the @cardano-address@ extended signing
-  -- key.
+  = -- | There was an error in decoding the string as Bech32.
+    CardanoAddressSigningKeyBech32DecodeError !Bech32DecodeError
+  | -- | There was an error in converting the @cardano-address@ extended signing
+    -- key.
+    CardanoAddressSigningKeyDeserialisationError !ByteString
   deriving (Show, Eq)
 
 instance Error CardanoAddressSigningKeyConversionError where

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/CardanoAddressSigningKeyConversionError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/CardanoAddressSigningKeyConversionError.hs
@@ -7,7 +7,7 @@ import Cardano.Api
 
 import Data.ByteString (ByteString)
 import Data.Text (Text)
-import qualified Data.Text as Text
+import Data.Text qualified as Text
 
 -- | An error that can occur while converting a @cardano-address@ extended
 -- signing key.

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/CmdError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/CmdError.hs
@@ -25,7 +25,7 @@ import Cardano.CLI.Types.Errors.TextViewFileError
 import Cardano.CLI.Types.Errors.TxCmdError
 
 import Data.Text (Text)
-import qualified Data.Text as Text
+import Data.Text qualified as Text
 
 data CmdError
   = CmdAddressError !AddressCmdError

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/CmdError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/CmdError.hs
@@ -1,74 +1,74 @@
 {-# LANGUAGE LambdaCase #-}
 
 module Cardano.CLI.Types.Errors.CmdError
-  ( CmdError(..)
+  ( CmdError (..)
   , renderCmdError
   ) where
 
-import           Cardano.Api
+import Cardano.Api
 
-import           Cardano.CLI.Types.Errors.DelegationError
-import           Cardano.CLI.Types.Errors.GovernanceActionsError
-import           Cardano.CLI.Types.Errors.GovernanceCmdError
-import           Cardano.CLI.Types.Errors.GovernanceCommitteeError
-import           Cardano.CLI.Types.Errors.GovernanceQueryError
-import           Cardano.CLI.Types.Errors.GovernanceVoteCmdError
-import           Cardano.CLI.Types.Errors.RegistrationError
-import           Cardano.CLI.Types.Errors.AddressCmdError
-import           Cardano.CLI.Types.Errors.GenesisCmdError
-import           Cardano.CLI.Types.Errors.KeyCmdError
-import           Cardano.CLI.Types.Errors.NodeCmdError
-import           Cardano.CLI.Types.Errors.QueryCmdError
-import           Cardano.CLI.Types.Errors.StakeAddressCmdError
-import           Cardano.CLI.Types.Errors.TextViewFileError
-import           Cardano.CLI.Types.Errors.TxCmdError
-import           Cardano.CLI.Types.Errors.StakePoolCmdError
+import Cardano.CLI.Types.Errors.AddressCmdError
+import Cardano.CLI.Types.Errors.DelegationError
+import Cardano.CLI.Types.Errors.GenesisCmdError
+import Cardano.CLI.Types.Errors.GovernanceActionsError
+import Cardano.CLI.Types.Errors.GovernanceCmdError
+import Cardano.CLI.Types.Errors.GovernanceCommitteeError
+import Cardano.CLI.Types.Errors.GovernanceQueryError
+import Cardano.CLI.Types.Errors.GovernanceVoteCmdError
+import Cardano.CLI.Types.Errors.KeyCmdError
+import Cardano.CLI.Types.Errors.NodeCmdError
+import Cardano.CLI.Types.Errors.QueryCmdError
+import Cardano.CLI.Types.Errors.RegistrationError
+import Cardano.CLI.Types.Errors.StakeAddressCmdError
+import Cardano.CLI.Types.Errors.StakePoolCmdError
+import Cardano.CLI.Types.Errors.TextViewFileError
+import Cardano.CLI.Types.Errors.TxCmdError
 
-import           Data.Text (Text)
+import Data.Text (Text)
 import qualified Data.Text as Text
 
 data CmdError
-  = CmdAddressError               !AddressCmdError
-  | CmdEraDelegationError         !DelegationError
-  | CmdGenesisError               !GenesisCmdError
-  | CmdGovernanceActionError      !GovernanceActionsError
-  | CmdGovernanceCmdError         !GovernanceCmdError
-  | CmdGovernanceCommitteeError   !GovernanceCommitteeError
-  | CmdGovernanceQueryError       !GovernanceQueryError
-  | CmdGovernanceVoteError        !GovernanceVoteCmdError
-  | CmdKeyError                   !KeyCmdError
-  | CmdNodeError                  !NodeCmdError
-  | CmdQueryError                 !QueryCmdError
-  | CmdRegistrationError          !RegistrationError
-  | CmdStakeAddressError          !StakeAddressCmdError
-  | CmdStakePoolError             !StakePoolCmdError
-  | CmdTextViewError              !TextViewFileError
-  | CmdTransactionError           !TxCmdError
+  = CmdAddressError !AddressCmdError
+  | CmdEraDelegationError !DelegationError
+  | CmdGenesisError !GenesisCmdError
+  | CmdGovernanceActionError !GovernanceActionsError
+  | CmdGovernanceCmdError !GovernanceCmdError
+  | CmdGovernanceCommitteeError !GovernanceCommitteeError
+  | CmdGovernanceQueryError !GovernanceQueryError
+  | CmdGovernanceVoteError !GovernanceVoteCmdError
+  | CmdKeyError !KeyCmdError
+  | CmdNodeError !NodeCmdError
+  | CmdQueryError !QueryCmdError
+  | CmdRegistrationError !RegistrationError
+  | CmdStakeAddressError !StakeAddressCmdError
+  | CmdStakePoolError !StakePoolCmdError
+  | CmdTextViewError !TextViewFileError
+  | CmdTransactionError !TxCmdError
 
 renderCmdError :: Text -> CmdError -> Text
 renderCmdError cmdText = \case
-  CmdAddressError               e -> renderError renderAddressCmdError e
-  CmdEraDelegationError         e -> renderError (Text.pack . displayError) e
-  CmdGenesisError               e -> renderError (Text.pack . displayError) e
-  CmdGovernanceActionError      e -> renderError (Text.pack . displayError) e
-  CmdGovernanceCmdError         e -> renderError (Text.pack . displayError) e
-  CmdGovernanceCommitteeError   e -> renderError (Text.pack . displayError) e
-  CmdGovernanceQueryError       e -> renderError (Text.pack . displayError) e
-  CmdGovernanceVoteError        e -> renderError (Text.pack . displayError) e
-  CmdKeyError                   e -> renderError renderKeyCmdError e
-  CmdNodeError                  e -> renderError renderNodeCmdError e
-  CmdQueryError                 e -> renderError renderQueryCmdError e
-  CmdRegistrationError          e -> renderError (Text.pack . displayError) e
-  CmdStakeAddressError          e -> renderError (Text.pack . displayError) e
-  CmdStakePoolError             e -> renderError renderStakePoolCmdError e
-  CmdTextViewError              e -> renderError renderTextViewFileError e
-  CmdTransactionError           e -> renderError renderTxCmdError e
-  where
-    renderError :: (a -> Text) -> a -> Text
-    renderError renderer shelCliCmdErr =
-      mconcat
-        [ "Command failed: "
-        , cmdText
-        , "  Error: "
-        , renderer shelCliCmdErr
-        ]
+  CmdAddressError e -> renderError renderAddressCmdError e
+  CmdEraDelegationError e -> renderError (Text.pack . displayError) e
+  CmdGenesisError e -> renderError (Text.pack . displayError) e
+  CmdGovernanceActionError e -> renderError (Text.pack . displayError) e
+  CmdGovernanceCmdError e -> renderError (Text.pack . displayError) e
+  CmdGovernanceCommitteeError e -> renderError (Text.pack . displayError) e
+  CmdGovernanceQueryError e -> renderError (Text.pack . displayError) e
+  CmdGovernanceVoteError e -> renderError (Text.pack . displayError) e
+  CmdKeyError e -> renderError renderKeyCmdError e
+  CmdNodeError e -> renderError renderNodeCmdError e
+  CmdQueryError e -> renderError renderQueryCmdError e
+  CmdRegistrationError e -> renderError (Text.pack . displayError) e
+  CmdStakeAddressError e -> renderError (Text.pack . displayError) e
+  CmdStakePoolError e -> renderError renderStakePoolCmdError e
+  CmdTextViewError e -> renderError renderTextViewFileError e
+  CmdTransactionError e -> renderError renderTxCmdError e
+ where
+  renderError :: (a -> Text) -> a -> Text
+  renderError renderer shelCliCmdErr =
+    mconcat
+      [ "Command failed: "
+      , cmdText
+      , "  Error: "
+      , renderer shelCliCmdErr
+      ]

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/DelegationError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/DelegationError.hs
@@ -3,14 +3,14 @@
 {-# LANGUAGE LambdaCase #-}
 
 module Cardano.CLI.Types.Errors.DelegationError
-  ( DelegationError(..)
+  ( DelegationError (..)
   ) where
 
-import           Cardano.Api
+import Cardano.Api
 
-import           Cardano.CLI.Types.Errors.StakeCredentialError
+import Cardano.CLI.Types.Errors.StakeCredentialError
 
-import           GHC.Generics (Generic)
+import GHC.Generics (Generic)
 
 data DelegationError
   = DelegationReadError !(FileError InputDecodeError)

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/GenesisCmdError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/GenesisCmdError.hs
@@ -2,20 +2,20 @@
 {-# LANGUAGE LambdaCase #-}
 
 module Cardano.CLI.Types.Errors.GenesisCmdError
-  ( GenesisCmdError(..)
+  ( GenesisCmdError (..)
   ) where
 
-import           Cardano.Api
+import Cardano.Api
 
-import           Cardano.CLI.Byron.Genesis as Byron
-import           Cardano.CLI.Types.Common
-import           Cardano.CLI.Types.Errors.AddressCmdError
-import           Cardano.CLI.Types.Errors.NodeCmdError
-import           Cardano.CLI.Types.Errors.StakeAddressCmdError
-import           Cardano.CLI.Types.Errors.StakePoolCmdError
+import Cardano.CLI.Byron.Genesis as Byron
+import Cardano.CLI.Types.Common
+import Cardano.CLI.Types.Errors.AddressCmdError
+import Cardano.CLI.Types.Errors.NodeCmdError
+import Cardano.CLI.Types.Errors.StakeAddressCmdError
+import Cardano.CLI.Types.Errors.StakePoolCmdError
 
-import           Control.Exception (IOException)
-import           Data.Text (Text)
+import Control.Exception (IOException)
+import Data.Text (Text)
 import qualified Data.Text as Text
 
 data GenesisCmdError
@@ -28,7 +28,10 @@ data GenesisCmdError
   | GenesisCmdFilesNoIndex [FilePath]
   | GenesisCmdFilesDupIndex [FilePath]
   | GenesisCmdTextEnvReadFileError !(FileError TextEnvelopeError)
-  | GenesisCmdUnexpectedAddressVerificationKey !(VerificationKeyFile In) !Text !SomeAddressVerificationKey
+  | GenesisCmdUnexpectedAddressVerificationKey
+      !(VerificationKeyFile In)
+      !Text
+      !SomeAddressVerificationKey
   | GenesisCmdTooFewPoolsForBulkCreds !Word !Word !Word
   | GenesisCmdAddressCmdError !AddressCmdError
   | GenesisCmdNodeCmdError !NodeCmdError
@@ -38,7 +41,7 @@ data GenesisCmdError
   | GenesisCmdByronError !ByronGenesisError
   | GenesisCmdStakePoolRelayFileError !FilePath !IOException
   | GenesisCmdStakePoolRelayJsonDecodeError !FilePath !String
-  deriving Show
+  deriving (Show)
 
 instance Error GenesisCmdError where
   displayError =
@@ -49,9 +52,14 @@ instance Error GenesisCmdError where
       GenesisCmdFileError fe -> displayError fe
       GenesisCmdMismatchedGenesisKeyFiles gfiles dfiles vfiles ->
         "Mismatch between the files found:\n"
-          <> "Genesis key file indexes:      " <> show gfiles <> "\n"
-          <> "Delegate key file indexes:     " <> show dfiles <> "\n"
-          <> "Delegate VRF key file indexes: " <> show vfiles
+          <> "Genesis key file indexes:      "
+          <> show gfiles
+          <> "\n"
+          <> "Delegate key file indexes:     "
+          <> show dfiles
+          <> "\n"
+          <> "Delegate VRF key file indexes: "
+          <> show vfiles
       GenesisCmdFilesNoIndex files ->
         "The genesis keys files are expected to have a numeric index but these do not:\n"
           <> unlines files
@@ -59,15 +67,25 @@ instance Error GenesisCmdError where
         "The genesis keys files are expected to have a unique numeric index but these do not:\n"
           <> unlines files
       GenesisCmdTextEnvReadFileError fileErr -> displayError fileErr
-      GenesisCmdUnexpectedAddressVerificationKey (File file) expect got -> mconcat
-        [ "Unexpected address verification key type in file ", file
-        , ", expected: ", Text.unpack expect, ", got: ", Text.unpack (renderSomeAddressVerificationKey got)
-        ]
-      GenesisCmdTooFewPoolsForBulkCreds pools files perPool -> mconcat
-        [ "Number of pools requested for generation (", show pools
-        , ") is insufficient to fill ", show files
-        , " bulk files, with ", show perPool, " pools per file."
-        ]
+      GenesisCmdUnexpectedAddressVerificationKey (File file) expect got ->
+        mconcat
+          [ "Unexpected address verification key type in file "
+          , file
+          , ", expected: "
+          , Text.unpack expect
+          , ", got: "
+          , Text.unpack (renderSomeAddressVerificationKey got)
+          ]
+      GenesisCmdTooFewPoolsForBulkCreds pools files perPool ->
+        mconcat
+          [ "Number of pools requested for generation ("
+          , show pools
+          , ") is insufficient to fill "
+          , show files
+          , " bulk files, with "
+          , show perPool
+          , " pools per file."
+          ]
       GenesisCmdAddressCmdError e ->
         Text.unpack $ renderAddressCmdError e
       GenesisCmdNodeCmdError e ->
@@ -79,13 +97,19 @@ instance Error GenesisCmdError where
       GenesisCmdCostModelsError fp ->
         "Cost model is invalid: " <> fp
       GenesisCmdGenesisFileDecodeError fp e ->
-       "Error while decoding Shelley genesis at: " <> fp <>
-       " Error: " <>  Text.unpack e
+        "Error while decoding Shelley genesis at: "
+          <> fp
+          <> " Error: "
+          <> Text.unpack e
       GenesisCmdGenesisFileReadError e -> displayError e
       GenesisCmdByronError e -> show e
       GenesisCmdStakePoolRelayFileError fp e ->
-        "Error occurred while reading the stake pool relay specification file: " <> fp <>
-        " Error: " <> show e
+        "Error occurred while reading the stake pool relay specification file: "
+          <> fp
+          <> " Error: "
+          <> show e
       GenesisCmdStakePoolRelayJsonDecodeError fp e ->
-        "Error occurred while decoding the stake pool relay specification file: " <> fp <>
-        " Error: " <>  e
+        "Error occurred while decoding the stake pool relay specification file: "
+          <> fp
+          <> " Error: "
+          <> e

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/GenesisCmdError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/GenesisCmdError.hs
@@ -16,7 +16,7 @@ import Cardano.CLI.Types.Errors.StakePoolCmdError
 
 import Control.Exception (IOException)
 import Data.Text (Text)
-import qualified Data.Text as Text
+import Data.Text qualified as Text
 
 data GenesisCmdError
   = GenesisCmdAesonDecodeError !FilePath !Text

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/GovernanceActionsError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/GovernanceActionsError.hs
@@ -1,12 +1,12 @@
 {-# LANGUAGE LambdaCase #-}
 
 module Cardano.CLI.Types.Errors.GovernanceActionsError
-  ( GovernanceActionsError(..)
+  ( GovernanceActionsError (..)
   ) where
 
-import           Cardano.Api
+import Cardano.Api
 
-import           Cardano.CLI.Read
+import Cardano.CLI.Read
 
 data GovernanceActionsError
   = GovernanceActionsCmdConstitutionError ConstitutionError
@@ -14,7 +14,7 @@ data GovernanceActionsError
   | GovernanceActionsCmdReadFileError (FileError InputDecodeError)
   | GovernanceActionsCmdReadTextEnvelopeFileError (FileError TextEnvelopeError)
   | GovernanceActionsCmdWriteFileError (FileError ())
-  deriving Show
+  deriving (Show)
 
 instance Error GovernanceActionsError where
   displayError = \case

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/GovernanceCmdError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/GovernanceCmdError.hs
@@ -4,15 +4,15 @@
 
 module Cardano.CLI.Types.Errors.GovernanceCmdError where
 
-import           Cardano.Api
-import           Cardano.Api.Shelley
+import Cardano.Api
+import Cardano.Api.Shelley
 
-import           Cardano.Binary (DecoderError)
-import           Cardano.CLI.Read
-import           Cardano.CLI.Types.Errors.StakeAddressCmdError
+import Cardano.Binary (DecoderError)
+import Cardano.CLI.Read
+import Cardano.CLI.Types.Errors.StakeAddressCmdError
 
 import qualified Data.List as List
-import           Data.Text (Text)
+import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Lazy as TL
 import qualified Data.Text.Lazy.Builder as TL
@@ -24,8 +24,8 @@ data GovernanceCmdError
   | VotingCredentialDecodeGovCmdEror DecoderError
   | WriteFileError (FileError ())
   | ReadFileError (FileError InputDecodeError)
-    -- Governance action related
-  | GovernanceCmdConstitutionError ConstitutionError
+  | -- Governance action related
+    GovernanceCmdConstitutionError ConstitutionError
   | GovernanceCmdProposalError ProposalError
   | GovernanceCmdTextEnvReadError !(FileError TextEnvelopeError)
   | GovernanceCmdCddlError !CddlError
@@ -41,20 +41,20 @@ data GovernanceCmdError
       -- ^ Number of reward amounts
   | GovernanceCmdCostModelsJsonDecodeErr !FilePath !Text
   | GovernanceCmdEmptyCostModel !FilePath
-  | GovernanceCmdUnexpectedKeyType
+  | -- | Expected key types
+    GovernanceCmdUnexpectedKeyType
       ![TextEnvelopeType]
-      -- ^ Expected key types
-  | GovernanceCmdPollOutOfBoundAnswer
+  | -- | Maximum answer index
+    GovernanceCmdPollOutOfBoundAnswer
       !Int
-      -- ^ Maximum answer index
   | GovernanceCmdPollInvalidChoice
   | GovernanceCmdDecoderError !DecoderError
   | GovernanceCmdVerifyPollError !GovernancePollError
   | GovernanceCmdWriteFileError !(FileError ())
-  -- Legacy - remove me after cardano-cli transitions to new era based structure
-  | GovernanceCmdMIRCertNotSupportedInConway
+  | -- Legacy - remove me after cardano-cli transitions to new era based structure
+    GovernanceCmdMIRCertNotSupportedInConway
   | GovernanceCmdGenesisDelegationNotSupportedInConway
-  deriving Show
+  deriving (Show)
 
 instance Error GovernanceCmdError where
   displayError = \case
@@ -83,17 +83,20 @@ instance Error GovernanceCmdError where
     GovernanceCmdEmptyUpdateProposalError ->
       "Empty update proposals are not allowed."
     GovernanceCmdMIRCertificateKeyRewardMistmach fp nStakeVerKeys nRewards ->
-      "Error creating the MIR certificate at: " <> fp
-      <> " The number of staking keys: " <> show nStakeVerKeys
-      <> " and the number of reward amounts: " <> show nRewards
-      <> " are not equivalent."
+      "Error creating the MIR certificate at: "
+        <> fp
+        <> " The number of staking keys: "
+        <> show nStakeVerKeys
+        <> " and the number of reward amounts: "
+        <> show nRewards
+        <> " are not equivalent."
     GovernanceCmdCostModelsJsonDecodeErr fp msg ->
       "Error decoding cost model: " <> Text.unpack msg <> " at: " <> fp
     GovernanceCmdEmptyCostModel fp ->
       "The decoded cost model was empty at: " <> fp
     GovernanceCmdUnexpectedKeyType expectedTypes ->
       "Unexpected poll key type; expected one of: "
-      <> List.intercalate ", " (show <$> expectedTypes)
+        <> List.intercalate ", " (show <$> expectedTypes)
     GovernanceCmdPollOutOfBoundAnswer maxIdx ->
       "Poll answer out of bounds. Choices are between 0 and " <> show maxIdx
     GovernanceCmdPollInvalidChoice ->
@@ -108,5 +111,5 @@ instance Error GovernanceCmdError where
       "MIR certificates are not supported in Conway era onwards."
     GovernanceCmdGenesisDelegationNotSupportedInConway ->
       "Genesis delegation is not supported in Conway era onwards."
-    where
-      renderDecoderError = TL.unpack . TL.toLazyText . B.build
+   where
+    renderDecoderError = TL.unpack . TL.toLazyText . B.build

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/GovernanceCmdError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/GovernanceCmdError.hs
@@ -11,12 +11,12 @@ import Cardano.Binary (DecoderError)
 import Cardano.CLI.Read
 import Cardano.CLI.Types.Errors.StakeAddressCmdError
 
-import qualified Data.List as List
+import Data.List qualified as List
 import Data.Text (Text)
-import qualified Data.Text as Text
-import qualified Data.Text.Lazy as TL
-import qualified Data.Text.Lazy.Builder as TL
-import qualified Formatting.Buildable as B
+import Data.Text qualified as Text
+import Data.Text.Lazy qualified as TL
+import Data.Text.Lazy.Builder qualified as TL
+import Formatting.Buildable qualified as B
 
 data GovernanceCmdError
   = -- Voting related

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/GovernanceCommitteeError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/GovernanceCommitteeError.hs
@@ -1,10 +1,10 @@
 {-# LANGUAGE LambdaCase #-}
 
 module Cardano.CLI.Types.Errors.GovernanceCommitteeError
-  ( GovernanceCommitteeError(..)
+  ( GovernanceCommitteeError (..)
   ) where
 
-import           Cardano.Api
+import Cardano.Api
 
 data GovernanceCommitteeError
   = GovernanceCommitteeCmdKeyDecodeError InputDecodeError
@@ -12,7 +12,7 @@ data GovernanceCommitteeError
   | GovernanceCommitteeCmdTextEnvReadFileError (FileError TextEnvelopeError)
   | GovernanceCommitteeCmdTextEnvWriteError (FileError ())
   | GovernanceCommitteeCmdWriteFileError (FileError ())
-  deriving Show
+  deriving (Show)
 
 instance Error GovernanceCommitteeError where
   displayError = \case

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/GovernanceQueryError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/GovernanceQueryError.hs
@@ -7,7 +7,7 @@ import Cardano.Api.Shelley
 
 import Ouroboros.Consensus.Cardano.Block (EraMismatch)
 
-import qualified Data.Text as T
+import Data.Text qualified as T
 
 data GovernanceQueryError
   = GovernanceQueryWriteFileError !(FileError ())

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/GovernanceQueryError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/GovernanceQueryError.hs
@@ -1,13 +1,13 @@
 {-# LANGUAGE LambdaCase #-}
+
 module Cardano.CLI.Types.Errors.GovernanceQueryError where
 
-import           Cardano.Api
-import           Cardano.Api.Shelley
+import Cardano.Api
+import Cardano.Api.Shelley
 
-import           Ouroboros.Consensus.Cardano.Block (EraMismatch)
+import Ouroboros.Consensus.Cardano.Block (EraMismatch)
 
 import qualified Data.Text as T
-
 
 data GovernanceQueryError
   = GovernanceQueryWriteFileError !(FileError ())
@@ -16,7 +16,7 @@ data GovernanceQueryError
   | GovernanceQueryUnsupportedNtcVersion !UnsupportedNtcVersionError
   | GovernanceQueryEraMismatch !EraMismatch
   | GovernanceQueryDRepKeyError !(FileError InputDecodeError)
-  deriving Show
+  deriving (Show)
 
 instance Error GovernanceQueryError where
   displayError = \case
@@ -25,12 +25,21 @@ instance Error GovernanceQueryError where
     GovernanceQueryAcqireFailureError err ->
       show err
     GovernanceQueryEraConsensusModeMismatch mode era ->
-      "Era " <> T.unpack (renderEra era) <> " does not support consensus mode " <> T.unpack (renderMode mode) <> "."
-    GovernanceQueryUnsupportedNtcVersion (UnsupportedNtcVersionError minNtcVersion ntcVersion) -> unlines
-      [ "Unsupported feature for the node-to-client protocol version."
-      , "This query requires at least " <> show minNtcVersion <> " but the node negotiated " <> show ntcVersion <> "."
-      , "Later node versions support later protocol versions (but development protocol versions are not enabled in the node by default)."
-      ]
+      "Era "
+        <> T.unpack (renderEra era)
+        <> " does not support consensus mode "
+        <> T.unpack (renderMode mode)
+        <> "."
+    GovernanceQueryUnsupportedNtcVersion (UnsupportedNtcVersionError minNtcVersion ntcVersion) ->
+      unlines
+        [ "Unsupported feature for the node-to-client protocol version."
+        , "This query requires at least "
+            <> show minNtcVersion
+            <> " but the node negotiated "
+            <> show ntcVersion
+            <> "."
+        , "Later node versions support later protocol versions (but development protocol versions are not enabled in the node by default)."
+        ]
     GovernanceQueryEraMismatch err ->
       "A query from a certain era was applied to a ledger from a different era: " <> show err
     GovernanceQueryDRepKeyError err ->

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/GovernanceVoteCmdError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/GovernanceVoteCmdError.hs
@@ -4,9 +4,9 @@
 
 module Cardano.CLI.Types.Errors.GovernanceVoteCmdError where
 
-import           Cardano.Api.Shelley
+import Cardano.Api.Shelley
 
-import           Cardano.Binary (DecoderError)
+import Cardano.Binary (DecoderError)
 
 import qualified Data.Text.Lazy as TL
 import qualified Data.Text.Lazy.Builder as TL
@@ -16,7 +16,7 @@ data GovernanceVoteCmdError
   = GovernanceVoteCmdReadError !(FileError InputDecodeError)
   | GovernanceVoteCmdCredentialDecodeError !DecoderError
   | GovernanceVoteCmdWriteError !(FileError ())
-  deriving Show
+  deriving (Show)
 
 instance Error GovernanceVoteCmdError where
   displayError = \case
@@ -26,5 +26,5 @@ instance Error GovernanceVoteCmdError where
       "Cannot decode voting credential: " <> renderDecoderError e
     GovernanceVoteCmdWriteError e ->
       "Cannot write vote: " <> displayError e
-    where
-      renderDecoderError = TL.unpack . TL.toLazyText . B.build
+   where
+    renderDecoderError = TL.unpack . TL.toLazyText . B.build

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/GovernanceVoteCmdError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/GovernanceVoteCmdError.hs
@@ -8,9 +8,9 @@ import Cardano.Api.Shelley
 
 import Cardano.Binary (DecoderError)
 
-import qualified Data.Text.Lazy as TL
-import qualified Data.Text.Lazy.Builder as TL
-import qualified Formatting.Buildable as B
+import Data.Text.Lazy qualified as TL
+import Data.Text.Lazy.Builder qualified as TL
+import Formatting.Buildable qualified as B
 
 data GovernanceVoteCmdError
   = GovernanceVoteCmdReadError !(FileError InputDecodeError)

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/ItnKeyConversionError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/ItnKeyConversionError.hs
@@ -12,9 +12,9 @@ import Cardano.Api
 
 import Control.Exception (Exception (..), IOException)
 import Data.ByteString (ByteString)
-import qualified Data.ByteString.Char8 as BSC
+import Data.ByteString.Char8 qualified as BSC
 import Data.Text (Text)
-import qualified Data.Text as Text
+import Data.Text qualified as Text
 
 -- | An error that can occur while converting an Incentivized Testnet (ITN)
 -- key.

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/ItnKeyConversionError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/ItnKeyConversionError.hs
@@ -4,16 +4,16 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Cardano.CLI.Types.Errors.ItnKeyConversionError
-  ( ItnKeyConversionError(..)
+  ( ItnKeyConversionError (..)
   , renderConversionError
   ) where
 
-import           Cardano.Api
+import Cardano.Api
 
-import           Control.Exception (Exception (..), IOException)
-import           Data.ByteString (ByteString)
+import Control.Exception (Exception (..), IOException)
+import Data.ByteString (ByteString)
 import qualified Data.ByteString.Char8 as BSC
-import           Data.Text (Text)
+import Data.Text (Text)
 import qualified Data.Text as Text
 
 -- | An error that can occur while converting an Incentivized Testnet (ITN)
@@ -23,7 +23,7 @@ data ItnKeyConversionError
   | ItnReadBech32FileError !FilePath !IOException
   | ItnSigningKeyDeserialisationError !ByteString
   | ItnVerificationKeyDeserialisationError !ByteString
-  deriving Show
+  deriving (Show)
 
 -- | Render an error message for an 'ItnKeyConversionError'.
 renderConversionError :: ItnKeyConversionError -> Text
@@ -32,8 +32,10 @@ renderConversionError err =
     ItnKeyBech32DecodeError decErr ->
       "Error decoding Bech32 key: " <> Text.pack (displayError decErr)
     ItnReadBech32FileError fp readErr ->
-      "Error reading Bech32 key at: " <> textShow fp
-                        <> " Error: " <> Text.pack (displayException readErr)
+      "Error reading Bech32 key at: "
+        <> textShow fp
+        <> " Error: "
+        <> Text.pack (displayException readErr)
     ItnSigningKeyDeserialisationError _sKey ->
       -- Sensitive data, such as the signing key, is purposely not included in
       -- the error message.

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/KeyCmdError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/KeyCmdError.hs
@@ -10,13 +10,13 @@ module Cardano.CLI.Types.Errors.KeyCmdError
 
 import Cardano.Api
 
-import qualified Cardano.CLI.Byron.Key as Byron
+import Cardano.CLI.Byron.Key qualified as Byron
 import Cardano.CLI.Types.Errors.CardanoAddressSigningKeyConversionError
 import Cardano.CLI.Types.Errors.ItnKeyConversionError
 import Cardano.CLI.Types.Key
 
 import Data.Text (Text)
-import qualified Data.Text as Text
+import Data.Text qualified as Text
 
 data KeyCmdError
   = KeyCmdReadFileError !(FileError TextEnvelopeError)

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/KeyCmdError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/KeyCmdError.hs
@@ -4,18 +4,18 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Cardano.CLI.Types.Errors.KeyCmdError
-  ( KeyCmdError(..)
+  ( KeyCmdError (..)
   , renderKeyCmdError
   ) where
 
-import           Cardano.Api
+import Cardano.Api
 
 import qualified Cardano.CLI.Byron.Key as Byron
-import           Cardano.CLI.Types.Errors.CardanoAddressSigningKeyConversionError
-import           Cardano.CLI.Types.Errors.ItnKeyConversionError
-import           Cardano.CLI.Types.Key
+import Cardano.CLI.Types.Errors.CardanoAddressSigningKeyConversionError
+import Cardano.CLI.Types.Errors.ItnKeyConversionError
+import Cardano.CLI.Types.Key
 
-import           Data.Text (Text)
+import Data.Text (Text)
 import qualified Data.Text as Text
 
 data KeyCmdError
@@ -23,10 +23,10 @@ data KeyCmdError
   | KeyCmdReadKeyFileError !(FileError InputDecodeError)
   | KeyCmdWriteFileError !(FileError ())
   | KeyCmdByronKeyFailure !Byron.ByronKeyFailure
-  | KeyCmdByronKeyParseError
+  | -- | Text representation of the parse error. Unfortunately, the actual
+    -- error type isn't exported.
+    KeyCmdByronKeyParseError
       !Text
-      -- ^ Text representation of the parse error. Unfortunately, the actual
-      -- error type isn't exported.
   | KeyCmdItnKeyConvError !ItnKeyConversionError
   | KeyCmdWrongKeyTypeError
   | KeyCmdCardanoAddressSigningKeyFileError
@@ -34,7 +34,7 @@ data KeyCmdError
   | KeyCmdNonLegacyKey !FilePath
   | KeyCmdExpectedExtendedVerificationKey SomeAddressVerificationKey
   | KeyCmdVerificationKeyReadError VerificationKeyTextOrFileError
-  deriving Show
+  deriving (Show)
 
 renderKeyCmdError :: KeyCmdError -> Text
 renderKeyCmdError err =
@@ -50,7 +50,9 @@ renderKeyCmdError err =
     KeyCmdCardanoAddressSigningKeyFileError fileErr ->
       Text.pack (displayError fileErr)
     KeyCmdNonLegacyKey fp ->
-      "Signing key at: " <> Text.pack fp <> " is not a legacy Byron signing key and should not need to be converted."
+      "Signing key at: "
+        <> Text.pack fp
+        <> " is not a legacy Byron signing key and should not need to be converted."
     KeyCmdVerificationKeyReadError e -> renderVerificationKeyTextOrFileError e
     KeyCmdExpectedExtendedVerificationKey someVerKey ->
       "Expected an extended verification key but got: " <> renderSomeAddressVerificationKey someVerKey

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/NodeCmdError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/NodeCmdError.hs
@@ -1,13 +1,13 @@
 {-# LANGUAGE DataKinds #-}
 
 module Cardano.CLI.Types.Errors.NodeCmdError
-  ( NodeCmdError(..)
+  ( NodeCmdError (..)
   , renderNodeCmdError
   ) where
 
-import           Cardano.Api
+import Cardano.Api
 
-import           Data.Text (Text)
+import Data.Text (Text)
 import qualified Data.Text as Text
 
 {- HLINT ignore "Reduce duplication" -}
@@ -22,20 +22,19 @@ data NodeCmdError
       -- ^ Target path
       FilePath
       -- ^ Temp path
-  deriving Show
+  deriving (Show)
 
 renderNodeCmdError :: NodeCmdError -> Text
 renderNodeCmdError err =
   case err of
     NodeCmdVrfSigningKeyCreationError targetPath tempPath ->
-      Text.pack $ "Error creating VRF signing key file. Target path: " <> targetPath
-      <> " Temporary path: " <> tempPath
-
+      Text.pack $
+        "Error creating VRF signing key file. Target path: "
+          <> targetPath
+          <> " Temporary path: "
+          <> tempPath
     NodeCmdReadFileError fileErr -> Text.pack (displayError fileErr)
-
     NodeCmdReadKeyFileError fileErr -> Text.pack (displayError fileErr)
-
     NodeCmdWriteFileError fileErr -> Text.pack (displayError fileErr)
-
     NodeCmdOperationalCertificateIssueError issueErr ->
       Text.pack (displayError issueErr)

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/NodeCmdError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/NodeCmdError.hs
@@ -8,7 +8,7 @@ module Cardano.CLI.Types.Errors.NodeCmdError
 import Cardano.Api
 
 import Data.Text (Text)
-import qualified Data.Text as Text
+import Data.Text qualified as Text
 
 {- HLINT ignore "Reduce duplication" -}
 

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/ProtocolParamsError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/ProtocolParamsError.hs
@@ -4,13 +4,13 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Cardano.CLI.Types.Errors.ProtocolParamsError
-  ( ProtocolParamsError(..)
+  ( ProtocolParamsError (..)
   , renderProtocolParamsError
   ) where
 
-import           Cardano.Api
+import Cardano.Api
 
-import           Data.Text (Text)
+import Data.Text (Text)
 import qualified Data.Text as Text
 
 data ProtocolParamsError

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/ProtocolParamsError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/ProtocolParamsError.hs
@@ -11,7 +11,7 @@ module Cardano.CLI.Types.Errors.ProtocolParamsError
 import Cardano.Api
 
 import Data.Text (Text)
-import qualified Data.Text as Text
+import Data.Text qualified as Text
 
 data ProtocolParamsError
   = ProtocolParamsErrorFile (FileError ())

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/QueryCmdError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/QueryCmdError.hs
@@ -20,11 +20,11 @@ import Cardano.CLI.Helpers (HelpersError (..), renderHelpersError)
 import Cardano.CLI.Types.Errors.GenesisCmdError
 import Cardano.CLI.Types.Errors.QueryCmdLocalStateQueryError
 import Ouroboros.Consensus.Cardano.Block as Consensus (EraMismatch (..))
-import qualified Ouroboros.Consensus.HardFork.History.Qry as Qry
+import Ouroboros.Consensus.HardFork.History.Qry qualified as Qry
 
-import qualified Data.ByteString.Lazy.Char8 as LBS
+import Data.ByteString.Lazy.Char8 qualified as LBS
 import Data.Text (Text)
-import qualified Data.Text as Text
+import Data.Text qualified as Text
 import Data.Text.Lazy (toStrict)
 import Data.Text.Lazy.Builder (toLazyText)
 import Formatting.Buildable (build)

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/QueryCmdError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/QueryCmdError.hs
@@ -8,26 +8,26 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Cardano.CLI.Types.Errors.QueryCmdError
-  ( QueryCmdError(..)
+  ( QueryCmdError (..)
   , renderQueryCmdError
   ) where
 
-import           Cardano.Api hiding (QueryInShelleyBasedEra (..))
-import           Cardano.Api.Shelley hiding (QueryInShelleyBasedEra (..))
+import Cardano.Api hiding (QueryInShelleyBasedEra (..))
+import Cardano.Api.Shelley hiding (QueryInShelleyBasedEra (..))
 
-import           Cardano.Binary (DecoderError)
-import           Cardano.CLI.Helpers (HelpersError (..), renderHelpersError)
-import           Cardano.CLI.Types.Errors.GenesisCmdError
-import           Cardano.CLI.Types.Errors.QueryCmdLocalStateQueryError
-import           Ouroboros.Consensus.Cardano.Block as Consensus (EraMismatch (..))
+import Cardano.Binary (DecoderError)
+import Cardano.CLI.Helpers (HelpersError (..), renderHelpersError)
+import Cardano.CLI.Types.Errors.GenesisCmdError
+import Cardano.CLI.Types.Errors.QueryCmdLocalStateQueryError
+import Ouroboros.Consensus.Cardano.Block as Consensus (EraMismatch (..))
 import qualified Ouroboros.Consensus.HardFork.History.Qry as Qry
 
 import qualified Data.ByteString.Lazy.Char8 as LBS
-import           Data.Text (Text)
+import Data.Text (Text)
 import qualified Data.Text as Text
-import           Data.Text.Lazy (toStrict)
-import           Data.Text.Lazy.Builder (toLazyText)
-import           Formatting.Buildable (build)
+import Data.Text.Lazy (toStrict)
+import Data.Text.Lazy.Builder (toLazyText)
+import Formatting.Buildable (build)
 
 {- HLINT ignore "Move brackets to avoid $" -}
 {- HLINT ignore "Redundant flip" -}
@@ -54,7 +54,7 @@ data QueryCmdError
   | QueryCmdStakeSnapshotDecodeError DecoderError
   | QueryCmdUnsupportedNtcVersion !UnsupportedNtcVersionError
   | QueryCmdProtocolParameterConversionError !ProtocolParametersConversionError
-  deriving Show
+  deriving (Show)
 
 renderQueryCmdError :: QueryCmdError -> Text
 renderQueryCmdError err =
@@ -65,11 +65,16 @@ renderQueryCmdError err =
     QueryCmdAcquireFailure acquireFail -> Text.pack $ show acquireFail
     QueryCmdByronEra -> "This query cannot be used for the Byron era"
     QueryCmdEraConsensusModeMismatch (AnyConsensusMode cMode) (AnyCardanoEra era) ->
-      "Consensus mode and era mismatch. Consensus mode: " <> textShow cMode <>
-      " Era: " <> textShow era
+      "Consensus mode and era mismatch. Consensus mode: "
+        <> textShow cMode
+        <> " Era: "
+        <> textShow era
     QueryCmdEraMismatch (EraMismatch ledgerEra queryEra) ->
-      "\nAn error mismatch occurred." <> "\nSpecified query era: " <> queryEra <>
-      "\nCurrent ledger era: " <> ledgerEra
+      "\nAn error mismatch occurred."
+        <> "\nSpecified query era: "
+        <> queryEra
+        <> "\nCurrent ledger era: "
+        <> ledgerEra
     QueryCmdUnsupportedMode mode -> "Unsupported mode: " <> renderMode mode
     QueryCmdPastHorizon e -> "Past horizon: " <> textShow e
     QueryCmdSystemStartUnavailable -> "System start unavailable"
@@ -85,9 +90,13 @@ renderQueryCmdError err =
     QueryCmdStakeSnapshotDecodeError decoderError ->
       "Failed to decode StakeSnapshot.  Error: " <> Text.pack (show decoderError)
     QueryCmdUnsupportedNtcVersion (UnsupportedNtcVersionError minNtcVersion ntcVersion) ->
-      "Unsupported feature for the node-to-client protocol version.\n" <>
-      "This query requires at least " <> textShow minNtcVersion <> " but the node negotiated " <> textShow ntcVersion <> ".\n" <>
-      "Later node versions support later protocol versions (but development protocol versions are not enabled in the node by default)."
+      "Unsupported feature for the node-to-client protocol version.\n"
+        <> "This query requires at least "
+        <> textShow minNtcVersion
+        <> " but the node negotiated "
+        <> textShow ntcVersion
+        <> ".\n"
+        <> "Later node versions support later protocol versions (but development protocol versions are not enabled in the node by default)."
     QueryCmdProtocolParameterConversionError ppce ->
       Text.pack $ "Failed to convert protocol parameter: " <> displayError ppce
     QueryCmdConvenienceError qce -> renderQueryConvenienceError qce

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/QueryCmdLocalStateQueryError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/QueryCmdLocalStateQueryError.hs
@@ -1,19 +1,19 @@
 module Cardano.CLI.Types.Errors.QueryCmdLocalStateQueryError
-  ( QueryCmdLocalStateQueryError(..)
+  ( QueryCmdLocalStateQueryError (..)
   , renderLocalStateQueryError
   ) where
 
-import           Cardano.Api
+import Cardano.Api
 
-import           Ouroboros.Consensus.Cardano.Block (EraMismatch (..))
+import Ouroboros.Consensus.Cardano.Block (EraMismatch (..))
 
-import           Data.Text (Text)
+import Data.Text (Text)
 
 -- | An error that can occur while querying a node's local state.
 newtype QueryCmdLocalStateQueryError
-  = EraMismatchError EraMismatch
-  -- ^ A query from a certain era was applied to a ledger from a different
-  -- era.
+  = -- | A query from a certain era was applied to a ledger from a different
+    -- era.
+    EraMismatchError EraMismatch
   deriving (Eq, Show)
 
 renderLocalStateQueryError :: QueryCmdLocalStateQueryError -> Text

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/RegistrationError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/RegistrationError.hs
@@ -1,20 +1,20 @@
 {-# LANGUAGE LambdaCase #-}
 
 module Cardano.CLI.Types.Errors.RegistrationError
-  ( RegistrationError(..)
+  ( RegistrationError (..)
   ) where
 
-import           Cardano.Api
+import Cardano.Api
 
-import           Cardano.CLI.Types.Errors.StakeAddressRegistrationError
-import           Cardano.CLI.Types.Errors.StakeCredentialError
+import Cardano.CLI.Types.Errors.StakeAddressRegistrationError
+import Cardano.CLI.Types.Errors.StakeCredentialError
 
 data RegistrationError
   = RegistrationReadError !(FileError InputDecodeError)
   | RegistrationWriteFileError !(FileError ())
   | RegistrationStakeCredentialError !StakeCredentialError
   | RegistrationStakeError !StakeAddressRegistrationError
-  deriving Show
+  deriving (Show)
 
 instance Error RegistrationError where
   displayError = \case

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/ScriptDecodeError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/ScriptDecodeError.hs
@@ -1,19 +1,19 @@
 {-# LANGUAGE LambdaCase #-}
 
 module Cardano.CLI.Types.Errors.ScriptDecodeError
-  ( ScriptDecodeError(..)
+  ( ScriptDecodeError (..)
   ) where
 
-import           Cardano.Api
+import Cardano.Api
 
 --
 -- Handling decoding the variety of script languages and formats
 --
 
-data ScriptDecodeError =
-    ScriptDecodeTextEnvelopeError TextEnvelopeError
+data ScriptDecodeError
+  = ScriptDecodeTextEnvelopeError TextEnvelopeError
   | ScriptDecodeSimpleScriptError JsonDecodeError
-  deriving Show
+  deriving (Show)
 
 instance Error ScriptDecodeError where
   displayError = \case

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/StakeAddressCmdError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/StakeAddressCmdError.hs
@@ -1,15 +1,15 @@
 {-# LANGUAGE LambdaCase #-}
 
 module Cardano.CLI.Types.Errors.StakeAddressCmdError
-  ( StakeAddressCmdError(..)
+  ( StakeAddressCmdError (..)
   ) where
 
-import           Cardano.Api
+import Cardano.Api
 
-import           Cardano.CLI.Types.Errors.ScriptDecodeError
-import           Cardano.CLI.Types.Errors.StakeAddressRegistrationError
-import           Cardano.CLI.Types.Errors.StakeCredentialError
 import Cardano.CLI.Types.Errors.DelegationError
+import Cardano.CLI.Types.Errors.ScriptDecodeError
+import Cardano.CLI.Types.Errors.StakeAddressRegistrationError
+import Cardano.CLI.Types.Errors.StakeCredentialError
 
 data StakeAddressCmdError
   = StakeAddressCmdReadKeyFileError !(FileError InputDecodeError)
@@ -18,13 +18,13 @@ data StakeAddressCmdError
   | StakeAddressCmdWriteFileError !(FileError ())
   | StakeAddressCmdDelegationError !DelegationError
   | StakeAddressCmdRegistrationError !StakeAddressRegistrationError
-  deriving Show
+  deriving (Show)
 
 instance Error StakeAddressCmdError where
   displayError = \case
-    StakeAddressCmdReadKeyFileError e       -> displayError e
-    StakeAddressCmdReadScriptFileError e    -> displayError e
-    StakeAddressCmdStakeCredentialError e   -> displayError e
-    StakeAddressCmdWriteFileError e         -> displayError e
-    StakeAddressCmdDelegationError e        -> displayError e
-    StakeAddressCmdRegistrationError e      -> displayError e
+    StakeAddressCmdReadKeyFileError e -> displayError e
+    StakeAddressCmdReadScriptFileError e -> displayError e
+    StakeAddressCmdStakeCredentialError e -> displayError e
+    StakeAddressCmdWriteFileError e -> displayError e
+    StakeAddressCmdDelegationError e -> displayError e
+    StakeAddressCmdRegistrationError e -> displayError e

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/StakeAddressDelegationError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/StakeAddressDelegationError.hs
@@ -3,19 +3,22 @@
 {-# LANGUAGE TypeApplications #-}
 
 module Cardano.CLI.Types.Errors.StakeAddressDelegationError
-  ( StakeAddressDelegationError(..)
+  ( StakeAddressDelegationError (..)
   ) where
 
-import           Cardano.Api
+import Cardano.Api
 
 import qualified Data.Text as Text
 
-newtype StakeAddressDelegationError = VoteDelegationNotSupported AnyShelleyToBabbageEra deriving Show
+newtype StakeAddressDelegationError = VoteDelegationNotSupported AnyShelleyToBabbageEra
+  deriving (Show)
 
 instance Error StakeAddressDelegationError where
   displayError = \case
     VoteDelegationNotSupported (AnyShelleyToBabbageEra stbe) -> "Vote delegation not supported in " <> eraTxt stbe <> " era."
-      where
-        eraTxt :: forall era. ShelleyToBabbageEra era -> String
-        eraTxt stbe' = shelleyToBabbageEraConstraints stbe' $
-          Text.unpack . renderEra $ AnyCardanoEra (cardanoEra @era)
+     where
+      eraTxt :: forall era. ShelleyToBabbageEra era -> String
+      eraTxt stbe' =
+        shelleyToBabbageEraConstraints stbe' $
+          Text.unpack . renderEra $
+            AnyCardanoEra (cardanoEra @era)

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/StakeAddressDelegationError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/StakeAddressDelegationError.hs
@@ -8,7 +8,7 @@ module Cardano.CLI.Types.Errors.StakeAddressDelegationError
 
 import Cardano.Api
 
-import qualified Data.Text as Text
+import Data.Text qualified as Text
 
 newtype StakeAddressDelegationError = VoteDelegationNotSupported AnyShelleyToBabbageEra
   deriving (Show)

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/StakeAddressRegistrationError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/StakeAddressRegistrationError.hs
@@ -1,13 +1,13 @@
 {-# LANGUAGE LambdaCase #-}
 
 module Cardano.CLI.Types.Errors.StakeAddressRegistrationError
-  ( StakeAddressRegistrationError(..)
+  ( StakeAddressRegistrationError (..)
   ) where
 
-import           Cardano.Api
+import Cardano.Api
 
 data StakeAddressRegistrationError = StakeAddressRegistrationDepositRequired
-  deriving Show
+  deriving (Show)
 
 instance Error StakeAddressRegistrationError where
   displayError = \case

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/StakeCredentialError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/StakeCredentialError.hs
@@ -1,17 +1,17 @@
 {-# LANGUAGE LambdaCase #-}
 
 module Cardano.CLI.Types.Errors.StakeCredentialError
-  ( StakeCredentialError(..)
+  ( StakeCredentialError (..)
   ) where
 
-import           Cardano.Api
+import Cardano.Api
 
-import           Cardano.CLI.Types.Errors.ScriptDecodeError
+import Cardano.CLI.Types.Errors.ScriptDecodeError
 
 data StakeCredentialError
   = StakeCredentialScriptDecodeError (FileError ScriptDecodeError)
   | StakeCredentialInputDecodeError (FileError InputDecodeError)
-  deriving Show
+  deriving (Show)
 
 instance Error StakeCredentialError where
   displayError = \case

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/StakePoolCmdError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/StakePoolCmdError.hs
@@ -11,7 +11,7 @@ module Cardano.CLI.Types.Errors.StakePoolCmdError
 import Cardano.Api
 
 import Data.Text (Text)
-import qualified Data.Text as Text
+import Data.Text qualified as Text
 
 data StakePoolCmdError
   = StakePoolCmdReadFileError !(FileError TextEnvelopeError)

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/StakePoolCmdError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/StakePoolCmdError.hs
@@ -4,13 +4,13 @@
 {-# LANGUAGE RankNTypes #-}
 
 module Cardano.CLI.Types.Errors.StakePoolCmdError
-  ( StakePoolCmdError(..)
+  ( StakePoolCmdError (..)
   , renderStakePoolCmdError
   ) where
 
-import           Cardano.Api
+import Cardano.Api
 
-import           Data.Text (Text)
+import Data.Text (Text)
 import qualified Data.Text as Text
 
 data StakePoolCmdError
@@ -18,7 +18,7 @@ data StakePoolCmdError
   | StakePoolCmdReadKeyFileError !(FileError InputDecodeError)
   | StakePoolCmdWriteFileError !(FileError ())
   | StakePoolCmdMetadataValidationError !StakePoolMetadataValidationError
-  deriving Show
+  deriving (Show)
 
 renderStakePoolCmdError :: StakePoolCmdError -> Text
 renderStakePoolCmdError = \case

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/TextViewFileError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/TextViewFileError.hs
@@ -10,7 +10,7 @@ import Cardano.Api
 import Cardano.CLI.Helpers (HelpersError, renderHelpersError)
 
 import Data.Text (Text)
-import qualified Data.Text as Text
+import Data.Text qualified as Text
 
 data TextViewFileError
   = TextViewReadFileError (FileError TextEnvelopeError)

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/TextViewFileError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/TextViewFileError.hs
@@ -1,21 +1,21 @@
 {-# LANGUAGE DataKinds #-}
 
 module Cardano.CLI.Types.Errors.TextViewFileError
-  ( TextViewFileError(..)
+  ( TextViewFileError (..)
   , renderTextViewFileError
   ) where
 
-import           Cardano.Api
+import Cardano.Api
 
-import           Cardano.CLI.Helpers (HelpersError, renderHelpersError)
+import Cardano.CLI.Helpers (HelpersError, renderHelpersError)
 
-import           Data.Text (Text)
+import Data.Text (Text)
 import qualified Data.Text as Text
 
 data TextViewFileError
   = TextViewReadFileError (FileError TextEnvelopeError)
   | TextViewCBORPrettyPrintError !HelpersError
-  deriving Show
+  deriving (Show)
 
 renderTextViewFileError :: TextViewFileError -> Text
 renderTextViewFileError err =

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/TxCmdError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/TxCmdError.hs
@@ -6,23 +6,23 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Cardano.CLI.Types.Errors.TxCmdError
-  ( TxCmdError(..)
+  ( TxCmdError (..)
   , renderTxCmdError
   ) where
 
-import           Cardano.Api
-import           Cardano.Api.Shelley
+import Cardano.Api
+import Cardano.Api.Shelley
 
-import           Cardano.CLI.Read
-import           Cardano.CLI.Types.Common
-import           Cardano.CLI.Types.Errors.ProtocolParamsError
-import           Cardano.CLI.Types.Errors.BootstrapWitnessError
-import           Cardano.CLI.Types.Errors.TxValidationError
-import           Cardano.CLI.Types.Output
-import           Cardano.CLI.Types.TxFeature
-import           Ouroboros.Consensus.Cardano.Block (EraMismatch (..))
+import Cardano.CLI.Read
+import Cardano.CLI.Types.Common
+import Cardano.CLI.Types.Errors.BootstrapWitnessError
+import Cardano.CLI.Types.Errors.ProtocolParamsError
+import Cardano.CLI.Types.Errors.TxValidationError
+import Cardano.CLI.Types.Output
+import Cardano.CLI.Types.TxFeature
+import Ouroboros.Consensus.Cardano.Block (EraMismatch (..))
 
-import           Data.Text (Text)
+import Data.Text (Text)
 import qualified Data.Text as Text
 
 {- HLINT ignore "Use let" -}
@@ -37,11 +37,11 @@ data TxCmdError
   | TxCmdReadTextViewFileError !(FileError TextEnvelopeError)
   | TxCmdReadWitnessSigningDataError !ReadWitnessSigningDataError
   | TxCmdWriteFileError !(FileError ())
-  | TxCmdEraConsensusModeMismatch
+  | -- | Era
+    TxCmdEraConsensusModeMismatch
       !(Maybe FilePath)
       !AnyConsensusMode
       !AnyCardanoEra
-      -- ^ Era
   | TxCmdBootstrapWitnessError !BootstrapWitnessError
   | TxCmdTxSubmitError !Text
   | TxCmdTxSubmitErrorEraMismatch !EraMismatch
@@ -50,7 +50,7 @@ data TxCmdError
   | TxCmdNotImplemented !Text
   | TxCmdWitnessEraMismatch !AnyCardanoEra !AnyCardanoEra !WitnessFile
   | TxCmdPolicyIdsMissing ![PolicyId]
-  | TxCmdPolicyIdsExcess  ![PolicyId]
+  | TxCmdPolicyIdsExcess ![PolicyId]
   | TxCmdUnsupportedMode !AnyConsensusMode
   | TxCmdByronEra
   | TxCmdEraConsensusModeMismatchTxBalance
@@ -75,8 +75,8 @@ data TxCmdError
   | TxCmdCddlError CddlError
   | TxCmdCddlWitnessError CddlWitnessError
   | TxCmdRequiredSignerError RequiredSignerError
-  -- Validation errors
-  | TxCmdAuxScriptsValidationError TxAuxScriptsValidationError
+  | -- Validation errors
+    TxCmdAuxScriptsValidationError TxAuxScriptsValidationError
   | TxCmdTotalCollateralValidationError TxTotalCollateralValidationError
   | TxCmdReturnCollateralValidationError TxReturnCollateralValidationError
   | TxCmdTxFeeValidationError TxFeeValidationError
@@ -103,73 +103,98 @@ renderTxCmdError err =
       renderReadWitnessSigningDataError witSignDataErr
     TxCmdWriteFileError fileErr -> Text.pack (displayError fileErr)
     TxCmdTxSubmitError res -> "Error while submitting tx: " <> res
-    TxCmdTxSubmitErrorEraMismatch EraMismatch{ledgerEraName, otherEraName} ->
-      "The era of the node and the tx do not match. " <>
-      "The node is running in the " <> ledgerEraName <>
-      " era, but the transaction is for the " <> otherEraName <> " era."
+    TxCmdTxSubmitErrorEraMismatch EraMismatch {ledgerEraName, otherEraName} ->
+      "The era of the node and the tx do not match. "
+        <> "The node is running in the "
+        <> ledgerEraName
+        <> " era, but the transaction is for the "
+        <> otherEraName
+        <> " era."
     TxCmdBootstrapWitnessError sbwErr ->
       renderBootstrapWitnessError sbwErr
     TxCmdTxFeatureMismatch era TxFeatureImplicitFees ->
-      "An explicit transaction fee must be specified for " <>
-      renderEra era <> " era transactions."
-
-    TxCmdTxFeatureMismatch (AnyCardanoEra ShelleyEra)
-                                  TxFeatureValidityNoUpperBound ->
-      "A TTL must be specified for Shelley era transactions."
-
+      "An explicit transaction fee must be specified for "
+        <> renderEra era
+        <> " era transactions."
+    TxCmdTxFeatureMismatch
+      (AnyCardanoEra ShelleyEra)
+      TxFeatureValidityNoUpperBound ->
+        "A TTL must be specified for Shelley era transactions."
     TxCmdTxFeatureMismatch era feature ->
-      renderFeature feature <> " cannot be used for " <> renderEra era <>
-      " era transactions."
-
+      renderFeature feature
+        <> " cannot be used for "
+        <> renderEra era
+        <> " era transactions."
     TxCmdTxBodyError err' ->
       "Transaction validaton error: " <> Text.pack (displayError err')
-
     TxCmdNotImplemented msg ->
       "Feature not yet implemented: " <> msg
-
     TxCmdWitnessEraMismatch era era' (WitnessFile file) ->
-      "The era of a witness does not match the era of the transaction. " <>
-      "The transaction is for the " <> renderEra era <> " era, but the " <>
-      "witness in " <> textShow file <> " is for the " <> renderEra era' <> " era."
-
+      "The era of a witness does not match the era of the transaction. "
+        <> "The transaction is for the "
+        <> renderEra era
+        <> " era, but the "
+        <> "witness in "
+        <> textShow file
+        <> " is for the "
+        <> renderEra era'
+        <> " era."
     TxCmdEraConsensusModeMismatch fp mode era ->
-       "Submitting " <> renderEra era <> " era transaction (" <> textShow fp <>
-       ") is not supported in the " <> renderMode mode <> " consensus mode."
-    TxCmdPolicyIdsMissing policyids -> mconcat
-      [ "The \"--mint\" flag specifies an asset with a policy Id, but no "
-      , "corresponding monetary policy script has been provided as a witness "
-      , "(via the \"--mint-script-file\" flag). The policy Id in question is: "
-      , Text.intercalate ", " (map serialiseToRawBytesHexText policyids)
-      ]
-
-    TxCmdPolicyIdsExcess policyids -> mconcat
-      [ "A script provided to witness minting does not correspond to the policy "
-      , "id of any asset specified in the \"--mint\" field. The script hash is: "
-      , Text.intercalate ", " (map serialiseToRawBytesHexText policyids)
-      ]
+      "Submitting "
+        <> renderEra era
+        <> " era transaction ("
+        <> textShow fp
+        <> ") is not supported in the "
+        <> renderMode mode
+        <> " consensus mode."
+    TxCmdPolicyIdsMissing policyids ->
+      mconcat
+        [ "The \"--mint\" flag specifies an asset with a policy Id, but no "
+        , "corresponding monetary policy script has been provided as a witness "
+        , "(via the \"--mint-script-file\" flag). The policy Id in question is: "
+        , Text.intercalate ", " (map serialiseToRawBytesHexText policyids)
+        ]
+    TxCmdPolicyIdsExcess policyids ->
+      mconcat
+        [ "A script provided to witness minting does not correspond to the policy "
+        , "id of any asset specified in the \"--mint\" field. The script hash is: "
+        , Text.intercalate ", " (map serialiseToRawBytesHexText policyids)
+        ]
     TxCmdUnsupportedMode mode -> "Unsupported mode: " <> renderMode mode
     TxCmdByronEra -> "This query cannot be used for the Byron era"
     TxCmdEraConsensusModeMismatchTxBalance fp mode era ->
-       "Cannot balance " <> renderEra era <> " era transaction body (" <> textShow fp <>
-       ") because is not supported in the " <> renderMode mode <> " consensus mode."
+      "Cannot balance "
+        <> renderEra era
+        <> " era transaction body ("
+        <> textShow fp
+        <> ") because is not supported in the "
+        <> renderMode mode
+        <> " consensus mode."
     TxCmdBalanceTxBody err' -> Text.pack $ displayError err'
     TxCmdTxInsDoNotExist e ->
       renderTxInsExistError e
     TxCmdPParamsErr err' -> Text.pack $ displayError err'
-    TxCmdTextEnvCddlError textEnvErr cddlErr -> mconcat
-      [ "Failed to decode neither the cli's serialisation format nor the ledger's "
-      , "CDDL serialisation format. TextEnvelope error: " <> Text.pack (displayError textEnvErr) <> "\n"
-      , "TextEnvelopeCddl error: " <> Text.pack (displayError cddlErr)
-      ]
-    TxCmdTxExecUnitsErr err' ->  Text.pack $ displayError err'
-    TxCmdPlutusScriptCostErr err'-> Text.pack $ displayError err'
-    TxCmdPParamExecutionUnitsNotAvailable -> mconcat
-      [ "Execution units not available in the protocol parameters. This is "
-      , "likely due to not being in the Alonzo era"
-      ]
+    TxCmdTextEnvCddlError textEnvErr cddlErr ->
+      mconcat
+        [ "Failed to decode neither the cli's serialisation format nor the ledger's "
+        , "CDDL serialisation format. TextEnvelope error: " <> Text.pack (displayError textEnvErr) <> "\n"
+        , "TextEnvelopeCddl error: " <> Text.pack (displayError cddlErr)
+        ]
+    TxCmdTxExecUnitsErr err' -> Text.pack $ displayError err'
+    TxCmdPlutusScriptCostErr err' -> Text.pack $ displayError err'
+    TxCmdPParamExecutionUnitsNotAvailable ->
+      mconcat
+        [ "Execution units not available in the protocol parameters. This is "
+        , "likely due to not being in the Alonzo era"
+        ]
     TxCmdTxEraCastErr (EraCastError value fromEra toEra) ->
       "Transactions can only be produced in the same era as the node. Mismatched eras of "
-      <> textShow value <> ". Requested era: " <> renderEra (AnyCardanoEra toEra) <> ", node era: " <> renderEra (AnyCardanoEra fromEra) <> "."
+        <> textShow value
+        <> ". Requested era: "
+        <> renderEra (AnyCardanoEra toEra)
+        <> ", node era: "
+        <> renderEra (AnyCardanoEra fromEra)
+        <> "."
     TxCmdQueryConvenienceError e ->
       renderQueryConvenienceError e
     TxCmdQueryNotScriptLocked e ->

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/TxCmdError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/TxCmdError.hs
@@ -23,7 +23,7 @@ import Cardano.CLI.Types.TxFeature
 import Ouroboros.Consensus.Cardano.Block (EraMismatch (..))
 
 import Data.Text (Text)
-import qualified Data.Text as Text
+import Data.Text qualified as Text
 
 {- HLINT ignore "Use let" -}
 

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/TxValidationError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/TxValidationError.hs
@@ -40,9 +40,9 @@ import Cardano.Api.Shelley
 import Prelude
 
 import Data.Bifunctor (first)
-import qualified Data.Map.Strict as Map
+import Data.Map.Strict qualified as Map
 import Data.Maybe
-import qualified Data.Text as Text
+import Data.Text qualified as Text
 
 data ScriptLanguageValidationError
   = ScriptLanguageValidationError AnyScriptLanguage AnyCardanoEra

--- a/cardano-cli/src/Cardano/CLI/Types/Governance.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Governance.hs
@@ -3,31 +3,35 @@
 
 module Cardano.CLI.Types.Governance where
 
-import           Cardano.Api
-import           Cardano.Api.Shelley
+import Cardano.Api
+import Cardano.Api.Shelley
 
-import           Cardano.CLI.Types.Key (DRepHashSource, VerificationKeyOrFile,
-                   VerificationKeyOrHashOrFile)
+import Cardano.CLI.Types.Key
+  ( DRepHashSource
+  , VerificationKeyOrFile
+  , VerificationKeyOrHashOrFile
+  )
 
-import           Data.Word
+import Data.Word
 
 type VoteFile = File ConwayVote
 
-data ConwayVote
-  = ConwayVote
-    { cvVoteChoice :: Vote
-    , cvVoterType :: VType
-    , cvGovActionId :: (TxId, Word32)
-    , cvVotingStakeCredential :: VerificationKeyOrFile StakePoolKey
-    , cvEra :: AnyShelleyBasedEra
-    , cvFilepath :: VoteFile Out
-    } deriving Show
+data ConwayVote = ConwayVote
+  { cvVoteChoice :: Vote
+  , cvVoterType :: VType
+  , cvGovActionId :: (TxId, Word32)
+  , cvVotingStakeCredential :: VerificationKeyOrFile StakePoolKey
+  , cvEra :: AnyShelleyBasedEra
+  , cvFilepath :: VoteFile Out
+  }
+  deriving (Show)
 
 -- Vote type -- TODO: Conway era - remove me
-data VType = VCC -- committee
-           | VDR -- drep
-           | VSP -- spo
-           deriving Show
+data VType
+  = VCC -- committee
+  | VDR -- drep
+  | VSP -- spo
+  deriving (Show)
 
 data AnyVote where
   ConwayOnwardsVote
@@ -42,11 +46,9 @@ data AnyVotingStakeVerificationKeyOrHashOrFile where
   AnyDRepVerificationKeyOrHashOrFile
     :: VerificationKeyOrHashOrFile DRepKey
     -> AnyVotingStakeVerificationKeyOrHashOrFile
-
   AnyStakePoolVerificationKeyOrHashOrFile
     :: VerificationKeyOrHashOrFile StakePoolKey
     -> AnyVotingStakeVerificationKeyOrHashOrFile
-
   AnyCommitteeHotVerificationKeyOrHashOrFile
     :: VerificationKeyOrHashOrFile CommitteeHotKey
     -> AnyVotingStakeVerificationKeyOrHashOrFile

--- a/cardano-cli/src/Cardano/CLI/Types/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Key.hs
@@ -39,7 +39,7 @@ module Cardano.CLI.Types.Key
   ) where
 
 import Cardano.Api
-import qualified Cardano.Api.Ledger as L
+import Cardano.Api.Ledger qualified as L
 import Cardano.Api.Shelley
 
 import Cardano.CLI.Types.Common
@@ -49,12 +49,12 @@ import Control.Monad.Trans
 import Control.Monad.Trans.Except
 import Control.Monad.Trans.Except.Extra
 import Data.Bifunctor (Bifunctor (..))
-import qualified Data.ByteString as BS
+import Data.ByteString qualified as BS
 import Data.Function
-import qualified Data.List.NonEmpty as NE
+import Data.List.NonEmpty qualified as NE
 import Data.Text (Text)
-import qualified Data.Text as Text
-import qualified Data.Text.Encoding as Text
+import Data.Text qualified as Text
+import Data.Text.Encoding qualified as Text
 
 ------------------------------------------------------------------------------
 -- Verification key deserialisation

--- a/cardano-cli/src/Cardano/CLI/Types/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Key.hs
@@ -12,61 +12,49 @@ module Cardano.CLI.Types.Key
   ( VerificationKeyOrFile (..)
   , readVerificationKeyOrFile
   , readVerificationKeyOrTextEnvFile
-
   , VerificationKeyTextOrFile (..)
   , VerificationKeyTextOrFileError (..)
   , readVerificationKeyTextOrFileAnyOf
   , renderVerificationKeyTextOrFileError
-
   , VerificationKeyOrHashOrFile (..)
   , readVerificationKeyOrHashOrFile
   , readVerificationKeyOrHashOrTextEnvFile
-
-  , PaymentVerifier(..)
-  , StakeIdentifier(..)
-  , StakeVerifier(..)
-
+  , PaymentVerifier (..)
+  , StakeIdentifier (..)
+  , StakeVerifier (..)
   , generateKeyPair
-
   --- Legacy
-  , StakePoolRegistrationParserRequirements(..)
-
+  , StakePoolRegistrationParserRequirements (..)
   -- NewEraBased
-  , AnyDelegationTarget(..)
+  , AnyDelegationTarget (..)
   , StakeTarget (..)
-
-  , AnyRegistrationTarget(..)
-  , RegistrationTarget(..)
-
-  , ColdVerificationKeyOrFile(..)
-
-  , DRepHashSource(..)
-
+  , AnyRegistrationTarget (..)
+  , RegistrationTarget (..)
+  , ColdVerificationKeyOrFile (..)
+  , DRepHashSource (..)
   , readDRepCredential
-
-  , SomeSigningKey(..)
+  , SomeSigningKey (..)
   , withSomeSigningKey
   , readSigningKeyFile
   ) where
 
-import           Cardano.Api
+import Cardano.Api
 import qualified Cardano.Api.Ledger as L
-import           Cardano.Api.Shelley
+import Cardano.Api.Shelley
 
-import           Cardano.CLI.Types.Common
-import           Cardano.CLI.Types.Errors.DelegationError
+import Cardano.CLI.Types.Common
+import Cardano.CLI.Types.Errors.DelegationError
 
-import           Control.Monad.Trans
-import           Control.Monad.Trans.Except
-import           Control.Monad.Trans.Except.Extra
-import           Data.Bifunctor (Bifunctor (..))
+import Control.Monad.Trans
+import Control.Monad.Trans.Except
+import Control.Monad.Trans.Except.Extra
+import Data.Bifunctor (Bifunctor (..))
 import qualified Data.ByteString as BS
-import           Data.Function
+import Data.Function
 import qualified Data.List.NonEmpty as NE
-import           Data.Text (Text)
+import Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
-
 
 ------------------------------------------------------------------------------
 -- Verification key deserialisation
@@ -74,17 +62,19 @@ import qualified Data.Text.Encoding as Text
 
 -- | Either a verification key or path to a verification key file.
 data VerificationKeyOrFile keyrole
-  = VerificationKeyValue !(VerificationKey keyrole)
-  -- ^ A verification key.
-  | VerificationKeyFilePath !(VerificationKeyFile In)
-  -- ^ A path to a verification key file.
-  -- Note that this file hasn't been validated at all (whether it exists,
-  -- contains a key of the correct type, etc.)
+  = -- | A verification key.
+    VerificationKeyValue !(VerificationKey keyrole)
+  | -- | A path to a verification key file.
+    -- Note that this file hasn't been validated at all (whether it exists,
+    -- contains a key of the correct type, etc.)
+    VerificationKeyFilePath !(VerificationKeyFile In)
 
-deriving instance Show (VerificationKey keyrole)
+deriving instance
+  (Show (VerificationKey keyrole))
   => Show (VerificationKeyOrFile keyrole)
 
-deriving instance Eq (VerificationKey keyrole)
+deriving instance
+  (Eq (VerificationKey keyrole))
   => Eq (VerificationKeyOrFile keyrole)
 
 -- | Read a verification key or verification key file and return a
@@ -114,7 +104,7 @@ readVerificationKeyOrFile asType verKeyOrFile =
 -- If a filepath is provided, it will be interpreted as a text envelope
 -- formatted file.
 readVerificationKeyOrTextEnvFile
-  :: HasTextEnvelope (VerificationKey keyrole)
+  :: (HasTextEnvelope (VerificationKey keyrole))
   => AsType keyrole
   -> VerificationKeyOrFile keyrole
   -> IO (Either (FileError InputDecodeError) (VerificationKey keyrole))
@@ -138,59 +128,52 @@ data StakeIdentifier
   | StakeIdentifierAddress StakeAddress
   deriving (Eq, Show)
 
-
 data AnyRegistrationTarget where
   ShelleyToBabbageStakePoolRegTarget
     :: ShelleyToBabbageEra era
     -> StakePoolRegistrationParserRequirements
     -> AnyRegistrationTarget
-
   ShelleyToBabbageStakeKeyRegTarget
     :: ShelleyToBabbageEra era
     -> StakeIdentifier
     -> AnyRegistrationTarget
-
   ConwayOnwardRegTarget
     :: ConwayEraOnwards era
     -> RegistrationTarget era
     -> AnyRegistrationTarget
 
-data StakePoolRegistrationParserRequirements
- = StakePoolRegistrationParserRequirements
-     { sprStakePoolKey :: VerificationKeyOrFile StakePoolKey
-     -- ^ Stake pool verification key.
-     , sprVrfKey :: VerificationKeyOrFile VrfKey
-     -- ^ VRF Verification key.
-     , sprPoolPledge :: Lovelace
-     -- ^ Pool pledge.
-     , sprPoolCost :: Lovelace
-     -- ^ Pool cost.
-     , sprPoolMargin :: Rational
-     -- ^ Pool margin.
-     , sprRewardAccountKey :: VerificationKeyOrFile StakeKey
-     -- ^ Reward account verification staking key.
-     , spoPoolOwnerKeys :: [VerificationKeyOrFile StakeKey]
-     -- ^ Pool owner verification staking key(s).
-     , sprRelays :: [StakePoolRelay]
-     -- ^ Stake pool relays.
-     , sprMetadata :: Maybe StakePoolMetadataReference
-     -- ^ Stake pool metadata.
-     , sprNetworkId :: NetworkId
-     }
-
+data StakePoolRegistrationParserRequirements = StakePoolRegistrationParserRequirements
+  { sprStakePoolKey :: VerificationKeyOrFile StakePoolKey
+  -- ^ Stake pool verification key.
+  , sprVrfKey :: VerificationKeyOrFile VrfKey
+  -- ^ VRF Verification key.
+  , sprPoolPledge :: Lovelace
+  -- ^ Pool pledge.
+  , sprPoolCost :: Lovelace
+  -- ^ Pool cost.
+  , sprPoolMargin :: Rational
+  -- ^ Pool margin.
+  , sprRewardAccountKey :: VerificationKeyOrFile StakeKey
+  -- ^ Reward account verification staking key.
+  , spoPoolOwnerKeys :: [VerificationKeyOrFile StakeKey]
+  -- ^ Pool owner verification staking key(s).
+  , sprRelays :: [StakePoolRelay]
+  -- ^ Stake pool relays.
+  , sprMetadata :: Maybe StakePoolMetadataReference
+  -- ^ Stake pool metadata.
+  , sprNetworkId :: NetworkId
+  }
 
 data RegistrationTarget era where
   RegisterStakePool
     :: ConwayEraOnwards era
     -> StakePoolRegistrationParserRequirements
     -> RegistrationTarget era
-
   RegisterStakeKey
     :: ConwayEraOnwards era
     -> StakeIdentifier
     -> Lovelace
     -> RegistrationTarget era
-
   RegisterDRep
     :: ConwayEraOnwards era
     -> VerificationKeyOrHashOrFile DRepKey
@@ -202,13 +185,12 @@ data RegistrationTarget era where
 -- 1. To gain rewards. This is limited to choosing a stake pool
 -- 2. To delegate voting power. We can delegate this to a DRep, always
 -- abstain our vote or vote no confidence
-
 data AnyDelegationTarget where
   ShelleyToBabbageDelegTarget
     :: ShelleyToBabbageEra era
-    -> VerificationKeyOrHashOrFile StakePoolKey -- ^ Stake pool target
+    -> VerificationKeyOrHashOrFile StakePoolKey
+    -- ^ Stake pool target
     -> AnyDelegationTarget
-
   ConwayOnwardDelegTarget
     :: ConwayEraOnwards era
     -> StakeTarget era
@@ -222,28 +204,23 @@ data StakeTarget era where
     :: ConwayEraOnwards era
     -> VerificationKeyOrHashOrFile StakePoolKey
     -> StakeTarget era
-
   -- This delegates stake for voting
   TargetVotingDrep
     :: ConwayEraOnwards era
     -> VerificationKeyOrHashOrFile DRepKey
     -> StakeTarget era
-
   -- This delegates stake for voting and rewards
   TargetVotingDrepAndStakePool
     :: ConwayEraOnwards era
     -> VerificationKeyOrHashOrFile DRepKey
     -> VerificationKeyOrHashOrFile StakePoolKey
     -> StakeTarget era
-
   TargetAlwaysAbstain
     :: ConwayEraOnwards era
     -> StakeTarget era
-
   TargetAlwaysNoConfidence
     :: ConwayEraOnwards era
     -> StakeTarget era
-
   TargetVotingDRepScriptHash
     :: ConwayEraOnwards era
     -> ScriptHash
@@ -263,7 +240,7 @@ data VerificationKeyTextOrFile
 data VerificationKeyTextOrFileError
   = VerificationKeyTextError !InputDecodeError
   | VerificationKeyFileError !(FileError InputDecodeError)
-  deriving Show
+  deriving (Show)
 
 -- | Render an error message for a 'VerificationKeyTextOrFileError'.
 renderVerificationKeyTextOrFileError :: VerificationKeyTextOrFileError -> Text
@@ -281,26 +258,29 @@ readVerificationKeyTextOrFileAnyOf
 readVerificationKeyTextOrFileAnyOf verKeyTextOrFile =
   case verKeyTextOrFile of
     VktofVerificationKeyText vkText ->
-      pure $ first VerificationKeyTextError $
-        deserialiseAnyVerificationKey (Text.encodeUtf8 vkText)
+      pure $
+        first VerificationKeyTextError $
+          deserialiseAnyVerificationKey (Text.encodeUtf8 vkText)
     VktofVerificationKeyFile (File fp) -> do
       vkBs <- liftIO $ BS.readFile fp
-      pure $ first VerificationKeyTextError $
-        deserialiseAnyVerificationKey vkBs
-
+      pure $
+        first VerificationKeyTextError $
+          deserialiseAnyVerificationKey vkBs
 
 -- | Verification key, verification key hash, or path to a verification key
 -- file.
 data VerificationKeyOrHashOrFile keyrole
-  = VerificationKeyOrFile !(VerificationKeyOrFile keyrole)
-  -- ^ Either a verification key or path to a verification key file.
-  | VerificationKeyHash !(Hash keyrole)
-  -- ^ A verification key hash.
+  = -- | Either a verification key or path to a verification key file.
+    VerificationKeyOrFile !(VerificationKeyOrFile keyrole)
+  | -- | A verification key hash.
+    VerificationKeyHash !(Hash keyrole)
 
-deriving instance (Show (VerificationKeyOrFile keyrole), Show (Hash keyrole))
+deriving instance
+  (Show (VerificationKeyOrFile keyrole), Show (Hash keyrole))
   => Show (VerificationKeyOrHashOrFile keyrole)
 
-deriving instance (Eq (VerificationKeyOrFile keyrole), Eq (Hash keyrole))
+deriving instance
+  (Eq (VerificationKeyOrFile keyrole), Eq (Hash keyrole))
   => Eq (VerificationKeyOrHashOrFile keyrole)
 
 -- | Read a verification key or verification key hash or verification key file
@@ -326,7 +306,7 @@ readVerificationKeyOrHashOrFile asType verKeyOrHashOrFile =
 -- If a filepath is provided, it will be interpreted as a text envelope
 -- formatted file.
 readVerificationKeyOrHashOrTextEnvFile
-  :: Key keyrole
+  :: (Key keyrole)
   => AsType keyrole
   -> VerificationKeyOrHashOrFile keyrole
   -> IO (Either (FileError InputDecodeError) (Hash keyrole))
@@ -337,9 +317,10 @@ readVerificationKeyOrHashOrTextEnvFile asType verKeyOrHashOrFile =
       pure (verificationKeyHash <$> eitherVk)
     VerificationKeyHash vkHash -> pure (Right vkHash)
 
-generateKeyPair :: ()
-  => Key keyrole
-  => HasTypeProxy keyrole
+generateKeyPair
+  :: ()
+  => (Key keyrole)
+  => (HasTypeProxy keyrole)
   => AsType keyrole
   -> IO (VerificationKey keyrole, SigningKey keyrole)
 generateKeyPair asType = do
@@ -357,7 +338,7 @@ data ColdVerificationKeyOrFile
   = ColdStakePoolVerificationKey !(VerificationKey StakePoolKey)
   | ColdGenesisDelegateVerificationKey !(VerificationKey GenesisDelegateKey)
   | ColdVerificationKeyFile !(VerificationKeyFile In)
-  deriving Show
+  deriving (Show)
 
 data DRepHashSource
   = DRepHashSourceScript
@@ -366,7 +347,8 @@ data DRepHashSource
       (VerificationKeyOrHashOrFile DRepKey)
   deriving (Eq, Show)
 
-readDRepCredential :: ()
+readDRepCredential
+  :: ()
   => DRepHashSource
   -> ExceptT DelegationError IO (L.Credential 'L.DRepRole L.StandardCrypto)
 readDRepCredential = \case
@@ -378,91 +360,112 @@ readDRepCredential = \case
         & onLeft (left . DelegationDRepReadError)
     pure $ L.KeyHashObj drepKeyHash
 
-
 data SomeSigningKey
-  = AByronSigningKey                    (SigningKey ByronKey)
-  | APaymentSigningKey                  (SigningKey PaymentKey)
-  | APaymentExtendedSigningKey          (SigningKey PaymentExtendedKey)
-  | AStakeSigningKey                    (SigningKey StakeKey)
-  | AStakeExtendedSigningKey            (SigningKey StakeExtendedKey)
-  | AStakePoolSigningKey                (SigningKey StakePoolKey)
-  | AGenesisSigningKey                  (SigningKey GenesisKey)
-  | AGenesisExtendedSigningKey          (SigningKey GenesisExtendedKey)
-  | AGenesisDelegateSigningKey          (SigningKey GenesisDelegateKey)
-  | AGenesisDelegateExtendedSigningKey  (SigningKey GenesisDelegateExtendedKey)
-  | AGenesisUTxOSigningKey              (SigningKey GenesisUTxOKey)
-  | AVrfSigningKey                      (SigningKey VrfKey)
-  | AKesSigningKey                      (SigningKey KesKey)
+  = AByronSigningKey (SigningKey ByronKey)
+  | APaymentSigningKey (SigningKey PaymentKey)
+  | APaymentExtendedSigningKey (SigningKey PaymentExtendedKey)
+  | AStakeSigningKey (SigningKey StakeKey)
+  | AStakeExtendedSigningKey (SigningKey StakeExtendedKey)
+  | AStakePoolSigningKey (SigningKey StakePoolKey)
+  | AGenesisSigningKey (SigningKey GenesisKey)
+  | AGenesisExtendedSigningKey (SigningKey GenesisExtendedKey)
+  | AGenesisDelegateSigningKey (SigningKey GenesisDelegateKey)
+  | AGenesisDelegateExtendedSigningKey (SigningKey GenesisDelegateExtendedKey)
+  | AGenesisUTxOSigningKey (SigningKey GenesisUTxOKey)
+  | AVrfSigningKey (SigningKey VrfKey)
+  | AKesSigningKey (SigningKey KesKey)
 
-withSomeSigningKey :: ()
+withSomeSigningKey
+  :: ()
   => SomeSigningKey
   -> (forall keyrole. (Key keyrole, HasTypeProxy keyrole) => SigningKey keyrole -> a)
   -> a
 withSomeSigningKey ssk f =
-    case ssk of
-      AByronSigningKey                    sk -> f sk
-      APaymentSigningKey                  sk -> f sk
-      APaymentExtendedSigningKey          sk -> f sk
-      AStakeSigningKey                    sk -> f sk
-      AStakeExtendedSigningKey            sk -> f sk
-      AStakePoolSigningKey                sk -> f sk
-      AGenesisSigningKey                  sk -> f sk
-      AGenesisExtendedSigningKey          sk -> f sk
-      AGenesisDelegateSigningKey          sk -> f sk
-      AGenesisDelegateExtendedSigningKey  sk -> f sk
-      AGenesisUTxOSigningKey              sk -> f sk
-      AVrfSigningKey                      sk -> f sk
-      AKesSigningKey                      sk -> f sk
+  case ssk of
+    AByronSigningKey sk -> f sk
+    APaymentSigningKey sk -> f sk
+    APaymentExtendedSigningKey sk -> f sk
+    AStakeSigningKey sk -> f sk
+    AStakeExtendedSigningKey sk -> f sk
+    AStakePoolSigningKey sk -> f sk
+    AGenesisSigningKey sk -> f sk
+    AGenesisExtendedSigningKey sk -> f sk
+    AGenesisDelegateSigningKey sk -> f sk
+    AGenesisDelegateExtendedSigningKey sk -> f sk
+    AGenesisUTxOSigningKey sk -> f sk
+    AVrfSigningKey sk -> f sk
+    AKesSigningKey sk -> f sk
 
-readSigningKeyFile :: ()
+readSigningKeyFile
+  :: ()
   => SigningKeyFile In
   -> ExceptT (FileError InputDecodeError) IO SomeSigningKey
 readSigningKeyFile skFile =
-    newExceptT $
-      readKeyFileAnyOf bech32FileTypes textEnvFileTypes skFile
-  where
-    textEnvFileTypes =
-      [ FromSomeType (AsSigningKey AsByronKey)
-                      AByronSigningKey
-      , FromSomeType (AsSigningKey AsPaymentKey)
-                      APaymentSigningKey
-      , FromSomeType (AsSigningKey AsPaymentExtendedKey)
-                      APaymentExtendedSigningKey
-      , FromSomeType (AsSigningKey AsStakeKey)
-                      AStakeSigningKey
-      , FromSomeType (AsSigningKey AsStakeExtendedKey)
-                      AStakeExtendedSigningKey
-      , FromSomeType (AsSigningKey AsStakePoolKey)
-                      AStakePoolSigningKey
-      , FromSomeType (AsSigningKey AsGenesisKey)
-                      AGenesisSigningKey
-      , FromSomeType (AsSigningKey AsGenesisExtendedKey)
-                      AGenesisExtendedSigningKey
-      , FromSomeType (AsSigningKey AsGenesisDelegateKey)
-                      AGenesisDelegateSigningKey
-      , FromSomeType (AsSigningKey AsGenesisDelegateExtendedKey)
-                      AGenesisDelegateExtendedSigningKey
-      , FromSomeType (AsSigningKey AsGenesisUTxOKey)
-                      AGenesisUTxOSigningKey
-      , FromSomeType (AsSigningKey AsVrfKey)
-                      AVrfSigningKey
-      , FromSomeType (AsSigningKey AsKesKey)
-                      AKesSigningKey
-      ]
+  newExceptT $
+    readKeyFileAnyOf bech32FileTypes textEnvFileTypes skFile
+ where
+  textEnvFileTypes =
+    [ FromSomeType
+        (AsSigningKey AsByronKey)
+        AByronSigningKey
+    , FromSomeType
+        (AsSigningKey AsPaymentKey)
+        APaymentSigningKey
+    , FromSomeType
+        (AsSigningKey AsPaymentExtendedKey)
+        APaymentExtendedSigningKey
+    , FromSomeType
+        (AsSigningKey AsStakeKey)
+        AStakeSigningKey
+    , FromSomeType
+        (AsSigningKey AsStakeExtendedKey)
+        AStakeExtendedSigningKey
+    , FromSomeType
+        (AsSigningKey AsStakePoolKey)
+        AStakePoolSigningKey
+    , FromSomeType
+        (AsSigningKey AsGenesisKey)
+        AGenesisSigningKey
+    , FromSomeType
+        (AsSigningKey AsGenesisExtendedKey)
+        AGenesisExtendedSigningKey
+    , FromSomeType
+        (AsSigningKey AsGenesisDelegateKey)
+        AGenesisDelegateSigningKey
+    , FromSomeType
+        (AsSigningKey AsGenesisDelegateExtendedKey)
+        AGenesisDelegateExtendedSigningKey
+    , FromSomeType
+        (AsSigningKey AsGenesisUTxOKey)
+        AGenesisUTxOSigningKey
+    , FromSomeType
+        (AsSigningKey AsVrfKey)
+        AVrfSigningKey
+    , FromSomeType
+        (AsSigningKey AsKesKey)
+        AKesSigningKey
+    ]
 
-    bech32FileTypes =
-      [ FromSomeType (AsSigningKey AsPaymentKey)
-                      APaymentSigningKey
-      , FromSomeType (AsSigningKey AsPaymentExtendedKey)
-                      APaymentExtendedSigningKey
-      , FromSomeType (AsSigningKey AsStakeKey)
-                      AStakeSigningKey
-      , FromSomeType (AsSigningKey AsStakeExtendedKey)
-                      AStakeExtendedSigningKey
-      , FromSomeType (AsSigningKey AsStakePoolKey)
-                      AStakePoolSigningKey
-      , FromSomeType (AsSigningKey AsVrfKey)
-                      AVrfSigningKey
-      , FromSomeType (AsSigningKey AsKesKey)
-                      AKesSigningKey
-      ]
+  bech32FileTypes =
+    [ FromSomeType
+        (AsSigningKey AsPaymentKey)
+        APaymentSigningKey
+    , FromSomeType
+        (AsSigningKey AsPaymentExtendedKey)
+        APaymentExtendedSigningKey
+    , FromSomeType
+        (AsSigningKey AsStakeKey)
+        AStakeSigningKey
+    , FromSomeType
+        (AsSigningKey AsStakeExtendedKey)
+        AStakeExtendedSigningKey
+    , FromSomeType
+        (AsSigningKey AsStakePoolKey)
+        AStakePoolSigningKey
+    , FromSomeType
+        (AsSigningKey AsVrfKey)
+        AVrfSigningKey
+    , FromSomeType
+        (AsSigningKey AsKesKey)
+        AKesSigningKey
+    ]

--- a/cardano-cli/src/Cardano/CLI/Types/Key/VerificationKey.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Key/VerificationKey.hs
@@ -1,13 +1,13 @@
 {-# LANGUAGE DataKinds #-}
 
 module Cardano.CLI.Types.Key.VerificationKey
-  ( AnyVerificationKeySource(..)
-  , AnyVerificationKeyText(..)
+  ( AnyVerificationKeySource (..)
+  , AnyVerificationKeyText (..)
   ) where
 
-import           Cardano.Api
+import Cardano.Api
 
-import           Data.Text (Text)
+import Data.Text (Text)
 
 -- | A bech32 text encoded verification key of an unspecified key role.
 newtype AnyVerificationKeyText = AnyVerificationKeyText

--- a/cardano-cli/src/Cardano/CLI/Types/Output.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Output.hs
@@ -12,7 +12,7 @@ module Cardano.CLI.Types.Output
   ) where
 
 import Cardano.Api
-import qualified Cardano.Api.Ledger as Ledger
+import Cardano.Api.Ledger qualified as Ledger
 import Cardano.Api.Shelley
 
 import Cardano.CLI.Types.Common
@@ -21,12 +21,12 @@ import Cardano.Ledger.Shelley.Scripts ()
 import Prelude
 
 import Data.Aeson
-import qualified Data.Aeson.Key as Aeson
-import qualified Data.List as List
+import Data.Aeson.Key qualified as Aeson
+import Data.List qualified as List
 import Data.Map.Strict (Map)
-import qualified Data.Map.Strict as Map
+import Data.Map.Strict qualified as Map
 import Data.Text (Text)
-import qualified Data.Text as Text
+import Data.Text qualified as Text
 import Data.Time.Clock (UTCTime)
 import Data.Word
 

--- a/cardano-cli/src/Cardano/CLI/Types/Output.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Output.hs
@@ -4,91 +4,95 @@
 module Cardano.CLI.Types.Output
   ( PlutusScriptCostError
   , QueryKesPeriodInfoOutput (..)
-  , QueryTipLocalState(..)
-  , QueryTipLocalStateOutput(..)
+  , QueryTipLocalState (..)
+  , QueryTipLocalStateOutput (..)
   , ScriptCostOutput (..)
   , createOpCertIntervalInfo
   , renderScriptCosts
   ) where
 
-import           Cardano.Api
+import Cardano.Api
 import qualified Cardano.Api.Ledger as Ledger
-import           Cardano.Api.Shelley
+import Cardano.Api.Shelley
 
-import           Cardano.CLI.Types.Common
-import           Cardano.Ledger.Shelley.Scripts ()
+import Cardano.CLI.Types.Common
+import Cardano.Ledger.Shelley.Scripts ()
 
-import           Prelude
+import Prelude
 
-import           Data.Aeson
+import Data.Aeson
 import qualified Data.Aeson.Key as Aeson
 import qualified Data.List as List
-import           Data.Map.Strict (Map)
+import Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
-import           Data.Text (Text)
+import Data.Text (Text)
 import qualified Data.Text as Text
-import           Data.Time.Clock (UTCTime)
-import           Data.Word
+import Data.Time.Clock (UTCTime)
+import Data.Word
 
-data QueryKesPeriodInfoOutput =
-  QueryKesPeriodInfoOutput
-    { qKesOpCertIntervalInformation :: OpCertIntervalInformation
-      -- | Date of KES key expiry.
-    , qKesInfoKesKeyExpiry :: Maybe UTCTime
-      -- | The latest operational certificate number in the node's state
-      -- i.e how many times a new KES key has been generated.
-    , qKesInfoNodeStateOperationalCertNo :: Maybe OpCertNodeStateCounter
-      -- | The on disk operational certificate number.
-    , qKesInfoOnDiskOperationalCertNo :: OpCertOnDiskCounter
-      -- | The maximum number of KES key evolutions permitted per KES period.
-    , qKesInfoMaxKesKeyEvolutions :: Word64
-    , qKesInfoSlotsPerKesPeriod :: Word64
-    } deriving (Eq, Show)
+data QueryKesPeriodInfoOutput = QueryKesPeriodInfoOutput
+  { qKesOpCertIntervalInformation :: OpCertIntervalInformation
+  , qKesInfoKesKeyExpiry :: Maybe UTCTime
+  -- ^ Date of KES key expiry.
+  , qKesInfoNodeStateOperationalCertNo :: Maybe OpCertNodeStateCounter
+  -- ^ The latest operational certificate number in the node's state
+  -- i.e how many times a new KES key has been generated.
+  , qKesInfoOnDiskOperationalCertNo :: OpCertOnDiskCounter
+  -- ^ The on disk operational certificate number.
+  , qKesInfoMaxKesKeyEvolutions :: Word64
+  -- ^ The maximum number of KES key evolutions permitted per KES period.
+  , qKesInfoSlotsPerKesPeriod :: Word64
+  }
+  deriving (Eq, Show)
 
 instance ToJSON QueryKesPeriodInfoOutput where
-  toJSON (QueryKesPeriodInfoOutput opCertIntervalInfo
-                                   kesKeyExpiryTime
-                                   nodeStateOpCertNo
-                                   (OpCertOnDiskCounter onDiskOpCertNo)
-                                   maxKesKeyOps
-                                   slotsPerKesPeriod) = do
-    let (sKes, eKes, cKes, slotsTillExp) =
-          case opCertIntervalInfo of
-            OpCertWithinInterval startKes endKes currKes sUntilExp ->
-                     ( unOpCertStartingKesPeriod startKes
-                     , unOpCertEndingKesPeriod endKes
-                     , unCurrentKesPeriod currKes
-                     , Just sUntilExp
-                     )
-            OpCertStartingKesPeriodIsInTheFuture startKes endKes currKes ->
-                     ( unOpCertStartingKesPeriod startKes
-                     , unOpCertEndingKesPeriod endKes
-                     , unCurrentKesPeriod currKes
-                     , Nothing
-                     )
-            OpCertExpired startKes endKes currKes ->
-                     ( unOpCertStartingKesPeriod startKes
-                     , unOpCertEndingKesPeriod endKes
-                     , unCurrentKesPeriod currKes
-                     , Nothing
-                     )
-            OpCertSomeOtherError startKes endKes currKes ->
-                     ( unOpCertStartingKesPeriod startKes
-                     , unOpCertEndingKesPeriod endKes
-                     , unCurrentKesPeriod currKes
-                     , Nothing
-                     )
+  toJSON
+    ( QueryKesPeriodInfoOutput
+        opCertIntervalInfo
+        kesKeyExpiryTime
+        nodeStateOpCertNo
+        (OpCertOnDiskCounter onDiskOpCertNo)
+        maxKesKeyOps
+        slotsPerKesPeriod
+      ) = do
+      let (sKes, eKes, cKes, slotsTillExp) =
+            case opCertIntervalInfo of
+              OpCertWithinInterval startKes endKes currKes sUntilExp ->
+                ( unOpCertStartingKesPeriod startKes
+                , unOpCertEndingKesPeriod endKes
+                , unCurrentKesPeriod currKes
+                , Just sUntilExp
+                )
+              OpCertStartingKesPeriodIsInTheFuture startKes endKes currKes ->
+                ( unOpCertStartingKesPeriod startKes
+                , unOpCertEndingKesPeriod endKes
+                , unCurrentKesPeriod currKes
+                , Nothing
+                )
+              OpCertExpired startKes endKes currKes ->
+                ( unOpCertStartingKesPeriod startKes
+                , unOpCertEndingKesPeriod endKes
+                , unCurrentKesPeriod currKes
+                , Nothing
+                )
+              OpCertSomeOtherError startKes endKes currKes ->
+                ( unOpCertStartingKesPeriod startKes
+                , unOpCertEndingKesPeriod endKes
+                , unCurrentKesPeriod currKes
+                , Nothing
+                )
 
-    object [ "qKesCurrentKesPeriod" .= cKes
-           , "qKesStartKesInterval" .= sKes
-           , "qKesEndKesInterval" .= eKes
-           , "qKesRemainingSlotsInKesPeriod" .= slotsTillExp
-           , "qKesOnDiskOperationalCertificateNumber" .= onDiskOpCertNo
-           , "qKesNodeStateOperationalCertificateNumber" .=  nodeStateOpCertNo
-           , "qKesMaxKESEvolutions" .= maxKesKeyOps
-           , "qKesSlotsPerKesPeriod" .= slotsPerKesPeriod
-           , "qKesKesKeyExpiry" .= kesKeyExpiryTime
-           ]
+      object
+        [ "qKesCurrentKesPeriod" .= cKes
+        , "qKesStartKesInterval" .= sKes
+        , "qKesEndKesInterval" .= eKes
+        , "qKesRemainingSlotsInKesPeriod" .= slotsTillExp
+        , "qKesOnDiskOperationalCertificateNumber" .= onDiskOpCertNo
+        , "qKesNodeStateOperationalCertificateNumber" .= nodeStateOpCertNo
+        , "qKesMaxKESEvolutions" .= maxKesKeyOps
+        , "qKesSlotsPerKesPeriod" .= slotsPerKesPeriod
+        , "qKesKesKeyExpiry" .= kesKeyExpiryTime
+        ]
 
 instance FromJSON QueryKesPeriodInfoOutput where
   parseJSON = withObject "QueryKesPeriodInfoOutput" $ \o -> do
@@ -101,20 +105,21 @@ instance FromJSON QueryKesPeriodInfoOutput where
     maxKESEvolutions <- o .: "qKesMaxKESEvolutions"
     slotsPerKesPeriod <- o .: "qKesSlotsPerKesPeriod"
     kesKeyExpiry <- o .: "qKesKesKeyExpiry"
-    let opCertIntervalInfo = createOpCertIntervalInfo
-                               currentKesPeriod
-                               startKesInterval
-                               endKesInterval
-                               remainingSlotsInKesPeriod
-    return $ QueryKesPeriodInfoOutput
-         { qKesOpCertIntervalInformation = opCertIntervalInfo
-         , qKesInfoKesKeyExpiry = kesKeyExpiry
-         , qKesInfoNodeStateOperationalCertNo = nodeStateOperationalCertificateNumber
-         , qKesInfoOnDiskOperationalCertNo = onDiskOperationalCertificateNumber
-         , qKesInfoMaxKesKeyEvolutions = maxKESEvolutions
-         , qKesInfoSlotsPerKesPeriod = slotsPerKesPeriod
-         }
-
+    let opCertIntervalInfo =
+          createOpCertIntervalInfo
+            currentKesPeriod
+            startKesInterval
+            endKesInterval
+            remainingSlotsInKesPeriod
+    return $
+      QueryKesPeriodInfoOutput
+        { qKesOpCertIntervalInformation = opCertIntervalInfo
+        , qKesInfoKesKeyExpiry = kesKeyExpiry
+        , qKesInfoNodeStateOperationalCertNo = nodeStateOperationalCertificateNumber
+        , qKesInfoOnDiskOperationalCertNo = onDiskOperationalCertificateNumber
+        , qKesInfoMaxKesKeyEvolutions = maxKESEvolutions
+        , qKesInfoSlotsPerKesPeriod = slotsPerKesPeriod
+        }
 
 createOpCertIntervalInfo
   :: CurrentKesPeriod
@@ -122,23 +127,24 @@ createOpCertIntervalInfo
   -> OpCertEndingKesPeriod
   -> Maybe SlotsTillKesKeyExpiry
   -> OpCertIntervalInformation
-createOpCertIntervalInfo c@(CurrentKesPeriod cKesPeriod)
-                         s@(OpCertStartingKesPeriod oCertStart)
-                         e@(OpCertEndingKesPeriod oCertEnd)
-                         (Just tillExp)
-  | oCertStart <= cKesPeriod && cKesPeriod < oCertEnd =
-      OpCertWithinInterval s e c tillExp
-  | oCertStart > cKesPeriod = OpCertStartingKesPeriodIsInTheFuture s e c
-  | cKesPeriod >= oCertEnd = OpCertExpired s e c
-  | otherwise = OpCertSomeOtherError s e c
-createOpCertIntervalInfo c@(CurrentKesPeriod cKesPeriod)
-                         s@(OpCertStartingKesPeriod oCertStart)
-                         e@(OpCertEndingKesPeriod oCertEnd)
-                         Nothing
-  | oCertStart > cKesPeriod = OpCertStartingKesPeriodIsInTheFuture s e c
-  | cKesPeriod >= oCertEnd = OpCertExpired s e c
-  | otherwise = OpCertSomeOtherError s e c
-
+createOpCertIntervalInfo
+  c@(CurrentKesPeriod cKesPeriod)
+  s@(OpCertStartingKesPeriod oCertStart)
+  e@(OpCertEndingKesPeriod oCertEnd)
+  (Just tillExp)
+    | oCertStart <= cKesPeriod && cKesPeriod < oCertEnd =
+        OpCertWithinInterval s e c tillExp
+    | oCertStart > cKesPeriod = OpCertStartingKesPeriodIsInTheFuture s e c
+    | cKesPeriod >= oCertEnd = OpCertExpired s e c
+    | otherwise = OpCertSomeOtherError s e c
+createOpCertIntervalInfo
+  c@(CurrentKesPeriod cKesPeriod)
+  s@(OpCertStartingKesPeriod oCertStart)
+  e@(OpCertEndingKesPeriod oCertEnd)
+  Nothing
+    | oCertStart > cKesPeriod = OpCertStartingKesPeriodIsInTheFuture s e c
+    | cKesPeriod >= oCertEnd = OpCertExpired s e c
+    | otherwise = OpCertSomeOtherError s e c
 
 data QueryTipLocalState mode = QueryTipLocalState
   { era :: AnyCardanoEra
@@ -154,16 +160,17 @@ data QueryTipLocalStateOutput = QueryTipLocalStateOutput
   , mSlotInEpoch :: Maybe Word64
   , mSlotsToEpochEnd :: Maybe Word64
   , mSyncProgress :: Maybe Text
-  } deriving Show
+  }
+  deriving (Show)
 
 -- | A key-value pair difference list for encoding a JSON object.
 (..=) :: (KeyValue kv, ToJSON v) => Aeson.Key -> v -> [kv] -> [kv]
-(..=) n v = (n .= v:)
+(..=) n v = (n .= v :)
 
 -- | A key-value pair difference list for encoding a JSON object where Nothing encodes absence of the key-value pair.
 (..=?) :: (KeyValue kv, ToJSON v) => Aeson.Key -> Maybe v -> [kv] -> [kv]
 (..=?) n mv = case mv of
-  Just v -> (n .= v:)
+  Just v -> (n .= v :)
   Nothing -> id
 
 instance ToJSON QueryTipLocalStateOutput where
@@ -171,42 +178,48 @@ instance ToJSON QueryTipLocalStateOutput where
     ChainTipAtGenesis ->
       object $
         ( ("era" ..=? mEra a)
-        . ("epoch" ..=? mEpoch a)
-        . ("slotInEpoch" ..=? mSlotInEpoch a)
-        . ("slotsToEpochEnd" ..=? mSlotsToEpochEnd a)
-        . ("syncProgress" ..=? mSyncProgress a)
-        ) []
+            . ("epoch" ..=? mEpoch a)
+            . ("slotInEpoch" ..=? mSlotInEpoch a)
+            . ("slotsToEpochEnd" ..=? mSlotsToEpochEnd a)
+            . ("syncProgress" ..=? mSyncProgress a)
+        )
+          []
     ChainTip slotNo blockHeader blockNo ->
       object $
         ( ("slot" ..= slotNo)
-        . ("hash" ..= serialiseToRawBytesHexText blockHeader)
-        . ("block" ..= blockNo)
-        . ("era" ..=? mEra a)
-        . ("epoch" ..=? mEpoch a)
-        . ("slotInEpoch" ..=? mSlotInEpoch a)
-        . ("slotsToEpochEnd" ..=? mSlotsToEpochEnd a)
-        . ("syncProgress" ..=? mSyncProgress a)
-        ) []
+            . ("hash" ..= serialiseToRawBytesHexText blockHeader)
+            . ("block" ..= blockNo)
+            . ("era" ..=? mEra a)
+            . ("epoch" ..=? mEpoch a)
+            . ("slotInEpoch" ..=? mSlotInEpoch a)
+            . ("slotsToEpochEnd" ..=? mSlotsToEpochEnd a)
+            . ("syncProgress" ..=? mSyncProgress a)
+        )
+          []
   toEncoding a = case localStateChainTip a of
     ChainTipAtGenesis ->
-      pairs $ mconcat $
-        ( ("era" ..=? mEra a)
-        . ("epoch" ..=? mEpoch a)
-        . ("slotInEpoch" ..=? mSlotInEpoch a)
-        . ("slotsToEpochEnd" ..=? mSlotsToEpochEnd a)
-        . ("syncProgress" ..=? mSyncProgress a)
-        ) []
+      pairs $
+        mconcat $
+          ( ("era" ..=? mEra a)
+              . ("epoch" ..=? mEpoch a)
+              . ("slotInEpoch" ..=? mSlotInEpoch a)
+              . ("slotsToEpochEnd" ..=? mSlotsToEpochEnd a)
+              . ("syncProgress" ..=? mSyncProgress a)
+          )
+            []
     ChainTip slotNo blockHeader blockNo ->
-      pairs $ mconcat $
-        ( ("slot" ..= slotNo)
-        . ("hash" ..= serialiseToRawBytesHexText blockHeader)
-        . ("block" ..= blockNo)
-        . ("era" ..=? mEra a)
-        . ("epoch" ..=? mEpoch a)
-        . ("slotInEpoch" ..=? mSlotInEpoch a)
-        . ("slotsToEpochEnd" ..=? mSlotsToEpochEnd a)
-        . ("syncProgress" ..=? mSyncProgress a)
-        ) []
+      pairs $
+        mconcat $
+          ( ("slot" ..= slotNo)
+              . ("hash" ..= serialiseToRawBytesHexText blockHeader)
+              . ("block" ..= blockNo)
+              . ("era" ..=? mEra a)
+              . ("epoch" ..=? mEpoch a)
+              . ("slotInEpoch" ..=? mSlotInEpoch a)
+              . ("slotsToEpochEnd" ..=? mSlotsToEpochEnd a)
+              . ("syncProgress" ..=? mSyncProgress a)
+          )
+            []
 
 instance FromJSON QueryTipLocalStateOutput where
   parseJSON = withObject "QueryTipLocalStateOutput" $ \o -> do
@@ -221,60 +234,69 @@ instance FromJSON QueryTipLocalStateOutput where
     mSlotsToEpochEnd' <- o .:? "slotsToEpochEnd"
     case (mSlot, mHash, mBlock) of
       (Nothing, Nothing, Nothing) ->
-        pure $ QueryTipLocalStateOutput
-                 ChainTipAtGenesis
-                 mEra'
-                 mEpoch'
-                 mSlotInEpoch'
-                 mSlotsToEpochEnd'
-                 mSyncProgress'
+        pure $
+          QueryTipLocalStateOutput
+            ChainTipAtGenesis
+            mEra'
+            mEpoch'
+            mSlotInEpoch'
+            mSlotsToEpochEnd'
+            mSyncProgress'
       (Just slot, Just hash, Just block) ->
-        pure $ QueryTipLocalStateOutput
-                 (ChainTip slot hash block)
-                 mEra'
-                 mEpoch'
-                 mSlotInEpoch'
-                 mSlotsToEpochEnd'
-                 mSyncProgress'
-      (_,_,_) ->
-        fail $ mconcat
-          [ "QueryTipLocalStateOutput was incorrectly JSON encoded."
-          , " Expected slot, header hash and block number (ChainTip)"
-          , " or none (ChainTipAtGenesis)"
-          ]
+        pure $
+          QueryTipLocalStateOutput
+            (ChainTip slot hash block)
+            mEra'
+            mEpoch'
+            mSlotInEpoch'
+            mSlotsToEpochEnd'
+            mSyncProgress'
+      (_, _, _) ->
+        fail $
+          mconcat
+            [ "QueryTipLocalStateOutput was incorrectly JSON encoded."
+            , " Expected slot, header hash and block number (ChainTip)"
+            , " or none (ChainTipAtGenesis)"
+            ]
 
-data ScriptCostOutput =
-  ScriptCostOutput
-    { scScriptHash :: ScriptHash
-    , scExecutionUnits :: ExecutionUnits
-    , scAda :: Lovelace
-    }
+data ScriptCostOutput = ScriptCostOutput
+  { scScriptHash :: ScriptHash
+  , scExecutionUnits :: ExecutionUnits
+  , scAda :: Lovelace
+  }
 
 instance ToJSON ScriptCostOutput where
   toJSON (ScriptCostOutput sHash execUnits llCost) =
-    object [ "scriptHash" .= sHash
-           , "executionUnits" .= execUnits
-           , "lovelaceCost" .= llCost
-           ]
+    object
+      [ "scriptHash" .= sHash
+      , "executionUnits" .= execUnits
+      , "lovelaceCost" .= llCost
+      ]
 
 data PlutusScriptCostError
   = PlutusScriptCostErrPlutusScriptNotFound ScriptWitnessIndex
   | PlutusScriptCostErrExecError ScriptWitnessIndex (Maybe ScriptHash) ScriptExecutionError
-  | PlutusScriptCostErrRationalExceedsBound Ledger.Prices  ExecutionUnits
+  | PlutusScriptCostErrRationalExceedsBound Ledger.Prices ExecutionUnits
   | PlutusScriptCostErrRefInputNoScript TxIn
   | PlutusScriptCostErrRefInputNotInUTxO TxIn
-  deriving Show
-
+  deriving (Show)
 
 instance Error PlutusScriptCostError where
   displayError (PlutusScriptCostErrPlutusScriptNotFound sWitIndex) =
     "No Plutus script was found at: " <> show sWitIndex
   displayError (PlutusScriptCostErrExecError sWitIndex sHash sExecErro) =
-    "Plutus script at: " <> show sWitIndex <> " with hash: " <> show sHash <>
-    " errored with: " <> displayError sExecErro
+    "Plutus script at: "
+      <> show sWitIndex
+      <> " with hash: "
+      <> show sHash
+      <> " errored with: "
+      <> displayError sExecErro
   displayError (PlutusScriptCostErrRationalExceedsBound eUnitPrices eUnits) =
-    "Either the execution unit prices: " <> show eUnitPrices <> " or the execution units: " <>
-    show eUnits <> " or both are either too precise or not within bounds"
+    "Either the execution unit prices: "
+      <> show eUnitPrices
+      <> " or the execution units: "
+      <> show eUnits
+      <> " or both are either too precise or not within bounds"
   displayError (PlutusScriptCostErrRefInputNoScript txin) =
     "No reference script found at input: " <> Text.unpack (renderTxIn txin)
   displayError (PlutusScriptCostErrRefInputNotInUTxO txin) =
@@ -292,44 +314,43 @@ renderScriptCosts
   -- index to execution units.
   -> Either PlutusScriptCostError [ScriptCostOutput]
 renderScriptCosts (UTxO utxo) eUnitPrices scriptMapping executionCostMapping =
-  sequenceA $ Map.foldlWithKey
-    (\accum sWitInd eExecUnits -> do
-      case List.lookup sWitInd scriptMapping of
-        Just (AnyScriptWitness SimpleScriptWitness{}) -> accum
-
-        Just (AnyScriptWitness (PlutusScriptWitness _ pVer (PScript pScript) _ _ _)) -> do
-          let scriptHash = hashScript $ PlutusScript pVer pScript
-          case eExecUnits of
-            Right execUnits ->
-              case calculateExecutionUnitsLovelace eUnitPrices execUnits of
-                Just llCost ->
-                  Right (ScriptCostOutput scriptHash execUnits llCost)
-                    : accum
-                Nothing ->
-                  Left (PlutusScriptCostErrRationalExceedsBound eUnitPrices execUnits)
-                    : accum
-            Left err -> Left (PlutusScriptCostErrExecError sWitInd (Just scriptHash) err) : accum
-        -- TODO: Create a new sum type to encapsulate the fact that we can also
-        -- have a txin and render the txin in the case of reference scripts.
-        Just (AnyScriptWitness (PlutusScriptWitness _ _ (PReferenceScript refTxIn _) _ _ _)) ->
-          case Map.lookup refTxIn utxo of
-            Nothing -> Left (PlutusScriptCostErrRefInputNotInUTxO refTxIn) : accum
-            Just (TxOut _ _ _ refScript) ->
-              case refScript of
-                ReferenceScriptNone -> Left (PlutusScriptCostErrRefInputNoScript refTxIn) : accum
-                ReferenceScript _ (ScriptInAnyLang _ script) ->
-                  case eExecUnits of
-                    Right execUnits ->
-                      case calculateExecutionUnitsLovelace eUnitPrices execUnits of
-                        Just llCost ->
-                          Right (ScriptCostOutput (hashScript script) execUnits llCost)
-                            : accum
-                        Nothing ->
-                          Left (PlutusScriptCostErrRationalExceedsBound eUnitPrices execUnits)
-                            : accum
-                    Left err -> Left (PlutusScriptCostErrExecError sWitInd Nothing err) : accum
-
-
-        Nothing -> Left (PlutusScriptCostErrPlutusScriptNotFound sWitInd) : accum
-
-    ) [] executionCostMapping
+  sequenceA $
+    Map.foldlWithKey
+      ( \accum sWitInd eExecUnits -> do
+          case List.lookup sWitInd scriptMapping of
+            Just (AnyScriptWitness SimpleScriptWitness {}) -> accum
+            Just (AnyScriptWitness (PlutusScriptWitness _ pVer (PScript pScript) _ _ _)) -> do
+              let scriptHash = hashScript $ PlutusScript pVer pScript
+              case eExecUnits of
+                Right execUnits ->
+                  case calculateExecutionUnitsLovelace eUnitPrices execUnits of
+                    Just llCost ->
+                      Right (ScriptCostOutput scriptHash execUnits llCost)
+                        : accum
+                    Nothing ->
+                      Left (PlutusScriptCostErrRationalExceedsBound eUnitPrices execUnits)
+                        : accum
+                Left err -> Left (PlutusScriptCostErrExecError sWitInd (Just scriptHash) err) : accum
+            -- TODO: Create a new sum type to encapsulate the fact that we can also
+            -- have a txin and render the txin in the case of reference scripts.
+            Just (AnyScriptWitness (PlutusScriptWitness _ _ (PReferenceScript refTxIn _) _ _ _)) ->
+              case Map.lookup refTxIn utxo of
+                Nothing -> Left (PlutusScriptCostErrRefInputNotInUTxO refTxIn) : accum
+                Just (TxOut _ _ _ refScript) ->
+                  case refScript of
+                    ReferenceScriptNone -> Left (PlutusScriptCostErrRefInputNoScript refTxIn) : accum
+                    ReferenceScript _ (ScriptInAnyLang _ script) ->
+                      case eExecUnits of
+                        Right execUnits ->
+                          case calculateExecutionUnitsLovelace eUnitPrices execUnits of
+                            Just llCost ->
+                              Right (ScriptCostOutput (hashScript script) execUnits llCost)
+                                : accum
+                            Nothing ->
+                              Left (PlutusScriptCostErrRationalExceedsBound eUnitPrices execUnits)
+                                : accum
+                        Left err -> Left (PlutusScriptCostErrExecError sWitInd Nothing err) : accum
+            Nothing -> Left (PlutusScriptCostErrPlutusScriptNotFound sWitInd) : accum
+      )
+      []
+      executionCostMapping

--- a/cardano-cli/src/Cardano/CLI/Types/TxFeature.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/TxFeature.hs
@@ -1,15 +1,14 @@
 {-# LANGUAGE LambdaCase #-}
 
 module Cardano.CLI.Types.TxFeature
-  ( TxFeature(..)
+  ( TxFeature (..)
   , renderFeature
   ) where
 
-import           Data.Text (Text)
+import Data.Text (Text)
 
 -- | An enumeration of era-dependent features where we have to check that it
 -- is permissible to use this feature in this era.
---
 data TxFeature
   = TxFeatureShelleyAddresses
   | TxFeatureExplicitFees
@@ -34,30 +33,30 @@ data TxFeature
   | TxFeatureTotalCollateral
   | TxFeatureReferenceInputs
   | TxFeatureReturnCollateral
-  deriving Show
+  deriving (Show)
 
 renderFeature :: TxFeature -> Text
 renderFeature = \case
-  TxFeatureShelleyAddresses     -> "Shelley addresses"
-  TxFeatureExplicitFees         -> "Explicit fees"
-  TxFeatureImplicitFees         -> "Implicit fees"
-  TxFeatureValidityLowerBound   -> "A validity lower bound"
-  TxFeatureValidityUpperBound   -> "A validity upper bound"
+  TxFeatureShelleyAddresses -> "Shelley addresses"
+  TxFeatureExplicitFees -> "Explicit fees"
+  TxFeatureImplicitFees -> "Implicit fees"
+  TxFeatureValidityLowerBound -> "A validity lower bound"
+  TxFeatureValidityUpperBound -> "A validity upper bound"
   TxFeatureValidityNoUpperBound -> "An absent validity upper bound"
-  TxFeatureTxMetadata           -> "Transaction metadata"
-  TxFeatureAuxScripts           -> "Auxiliary scripts"
-  TxFeatureWithdrawals          -> "Reward account withdrawals"
-  TxFeatureCertificates         -> "Certificates"
-  TxFeatureMintValue            -> "Asset minting"
-  TxFeatureMultiAssetOutputs    -> "Multi-Asset outputs"
-  TxFeatureScriptWitnesses      -> "Script witnesses"
-  TxFeatureShelleyKeys          -> "Shelley keys"
-  TxFeatureCollateral           -> "Collateral inputs"
-  TxFeatureProtocolParameters   -> "Protocol parameters"
-  TxFeatureTxOutDatum           -> "Transaction output datums"
-  TxFeatureScriptValidity       -> "Script validity"
-  TxFeatureExtraKeyWits         -> "Required signers"
-  TxFeatureInlineDatums         -> "Inline datums"
-  TxFeatureTotalCollateral      -> "Total collateral"
-  TxFeatureReferenceInputs      -> "Reference inputs"
-  TxFeatureReturnCollateral     -> "Return collateral"
+  TxFeatureTxMetadata -> "Transaction metadata"
+  TxFeatureAuxScripts -> "Auxiliary scripts"
+  TxFeatureWithdrawals -> "Reward account withdrawals"
+  TxFeatureCertificates -> "Certificates"
+  TxFeatureMintValue -> "Asset minting"
+  TxFeatureMultiAssetOutputs -> "Multi-Asset outputs"
+  TxFeatureScriptWitnesses -> "Script witnesses"
+  TxFeatureShelleyKeys -> "Shelley keys"
+  TxFeatureCollateral -> "Collateral inputs"
+  TxFeatureProtocolParameters -> "Protocol parameters"
+  TxFeatureTxOutDatum -> "Transaction output datums"
+  TxFeatureScriptValidity -> "Script validity"
+  TxFeatureExtraKeyWits -> "Required signers"
+  TxFeatureInlineDatums -> "Inline datums"
+  TxFeatureTotalCollateral -> "Total collateral"
+  TxFeatureReferenceInputs -> "Reference inputs"
+  TxFeatureReturnCollateral -> "Return collateral"

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Byron/SigningKeys.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Byron/SigningKeys.hs
@@ -11,24 +11,24 @@ module Test.Golden.Byron.SigningKeys
   , hprop_print_nonLegacy_signing_key_address
   ) where
 
-import           Cardano.Api.Byron
+import Cardano.Api.Byron
 
-import           Cardano.CLI.Byron.Key (readByronSigningKey)
-import           Cardano.CLI.Byron.Legacy (decodeLegacyDelegateKey)
-import           Cardano.CLI.Types.Common
+import Cardano.CLI.Byron.Key (readByronSigningKey)
+import Cardano.CLI.Byron.Legacy (decodeLegacyDelegateKey)
+import Cardano.CLI.Types.Common
 import qualified Cardano.Crypto.Signing as Crypto
 
-import           Codec.CBOR.Read (deserialiseFromBytes)
-import           Control.Monad (void)
-import           Control.Monad.Trans.Except (runExceptT)
+import Codec.CBOR.Read (deserialiseFromBytes)
+import Control.Monad (void)
+import Control.Monad.Trans.Except (runExceptT)
 import qualified Data.ByteString.Lazy as LB
 
-import           Test.Cardano.CLI.Util
+import Test.Cardano.CLI.Util
 
-import           Hedgehog (Property, property, success)
+import Hedgehog (Property, property, success)
 import qualified Hedgehog as H
 import qualified Hedgehog.Extras.Test.Base as H
-import           Hedgehog.Internal.Property (failWith)
+import Hedgehog.Internal.Property (failWith)
 
 hprop_deserialise_legacy_signing_Key :: Property
 hprop_deserialise_legacy_signing_Key = propertyOnce $ do
@@ -48,33 +48,47 @@ hprop_print_legacy_signing_key_address :: Property
 hprop_print_legacy_signing_key_address = propertyOnce $ do
   let legKeyFp = "test/cardano-cli-golden/files/golden/byron/keys/legacy.skey"
 
-  void $ execCardanoCLI
-   [ "signing-key-address", "--byron-legacy-formats"
-   , "--testnet-magic", "42"
-   , "--secret", legKeyFp
-   ]
+  void $
+    execCardanoCLI
+      [ "signing-key-address"
+      , "--byron-legacy-formats"
+      , "--testnet-magic"
+      , "42"
+      , "--secret"
+      , legKeyFp
+      ]
 
-  void $ execCardanoCLI
-   [ "signing-key-address", "--byron-legacy-formats"
-   , "--mainnet"
-   , "--secret", legKeyFp
-   ]
+  void $
+    execCardanoCLI
+      [ "signing-key-address"
+      , "--byron-legacy-formats"
+      , "--mainnet"
+      , "--secret"
+      , legKeyFp
+      ]
 
 hprop_print_nonLegacy_signing_key_address :: Property
 hprop_print_nonLegacy_signing_key_address = propertyOnce $ do
   let nonLegKeyFp = "test/cardano-cli-golden/files/golden/byron/keys/byron.skey"
 
-  void $ execCardanoCLI
-   [ "signing-key-address", "--byron-formats"
-   , "--testnet-magic", "42"
-   , "--secret", nonLegKeyFp
-   ]
+  void $
+    execCardanoCLI
+      [ "signing-key-address"
+      , "--byron-formats"
+      , "--testnet-magic"
+      , "42"
+      , "--secret"
+      , nonLegKeyFp
+      ]
 
-  void $ execCardanoCLI
-   [ "signing-key-address", "--byron-formats"
-   , "--mainnet"
-   , "--secret", nonLegKeyFp
-   ]
+  void $
+    execCardanoCLI
+      [ "signing-key-address"
+      , "--byron-formats"
+      , "--mainnet"
+      , "--secret"
+      , nonLegKeyFp
+      ]
 
 hprop_generate_and_read_nonlegacy_signingkeys :: Property
 hprop_generate_and_read_nonlegacy_signingkeys = property $ do
@@ -89,14 +103,18 @@ hprop_migrate_legacy_to_nonlegacy_signingkeys =
     let legKeyFp = "test/cardano-cli-golden/files/golden/byron/keys/legacy.skey"
     nonLegacyKeyFp <- noteTempFile tempDir "nonlegacy.skey"
 
-    void $ execCardanoCLI
-     [ "migrate-delegate-key-from"
-     , "--from", legKeyFp
-     , "--to", nonLegacyKeyFp
-     ]
+    void $
+      execCardanoCLI
+        [ "migrate-delegate-key-from"
+        , "--from"
+        , legKeyFp
+        , "--to"
+        , nonLegacyKeyFp
+        ]
 
-    eSignKey <- H.evalIO . runExceptT . readByronSigningKey NonLegacyByronKeyFormat
-                  $ File nonLegacyKeyFp
+    eSignKey <-
+      H.evalIO . runExceptT . readByronSigningKey NonLegacyByronKeyFormat $
+        File nonLegacyKeyFp
 
     case eSignKey of
       Left err -> failWith Nothing $ show err
@@ -104,14 +122,22 @@ hprop_migrate_legacy_to_nonlegacy_signingkeys =
 
 hprop_deserialise_NonLegacy_Signing_Key_API :: Property
 hprop_deserialise_NonLegacy_Signing_Key_API = propertyOnce $ do
-  eFailOrWit <- H.evalIO . runExceptT $ readByronSigningKey NonLegacyByronKeyFormat "test/cardano-cli-golden/files/golden/byron/keys/byron.skey"
+  eFailOrWit <-
+    H.evalIO . runExceptT $
+      readByronSigningKey
+        NonLegacyByronKeyFormat
+        "test/cardano-cli-golden/files/golden/byron/keys/byron.skey"
   case eFailOrWit of
     Left keyFailure -> failWith Nothing $ show keyFailure
     Right _ -> success
 
 hprop_deserialiseLegacy_Signing_Key_API :: Property
 hprop_deserialiseLegacy_Signing_Key_API = propertyOnce $ do
-  eFailOrWit <- H.evalIO . runExceptT $ readByronSigningKey LegacyByronKeyFormat "test/cardano-cli-golden/files/golden/byron/keys/legacy.skey"
+  eFailOrWit <-
+    H.evalIO . runExceptT $
+      readByronSigningKey
+        LegacyByronKeyFormat
+        "test/cardano-cli-golden/files/golden/byron/keys/legacy.skey"
   case eFailOrWit of
     Left keyFailure -> failWith Nothing $ show keyFailure
     Right _ -> success

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Byron/SigningKeys.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Byron/SigningKeys.hs
@@ -16,18 +16,18 @@ import Cardano.Api.Byron
 import Cardano.CLI.Byron.Key (readByronSigningKey)
 import Cardano.CLI.Byron.Legacy (decodeLegacyDelegateKey)
 import Cardano.CLI.Types.Common
-import qualified Cardano.Crypto.Signing as Crypto
+import Cardano.Crypto.Signing qualified as Crypto
 
 import Codec.CBOR.Read (deserialiseFromBytes)
 import Control.Monad (void)
 import Control.Monad.Trans.Except (runExceptT)
-import qualified Data.ByteString.Lazy as LB
+import Data.ByteString.Lazy qualified as LB
 
 import Test.Cardano.CLI.Util
 
 import Hedgehog (Property, property, success)
-import qualified Hedgehog as H
-import qualified Hedgehog.Extras.Test.Base as H
+import Hedgehog qualified as H
+import Hedgehog.Extras.Test.Base qualified as H
 import Hedgehog.Internal.Property (failWith)
 
 hprop_deserialise_legacy_signing_Key :: Property

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Byron/Tx.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Byron/Tx.hs
@@ -2,23 +2,23 @@
 
 module Test.Golden.Byron.Tx where
 
-import           Cardano.Api
+import Cardano.Api
 
-import           Cardano.Chain.UTxO (ATxAux)
-import           Cardano.CLI.Byron.Tx
+import Cardano.CLI.Byron.Tx
+import Cardano.Chain.UTxO (ATxAux)
 
-import           Control.Monad (void)
-import           Control.Monad.IO.Class (liftIO)
-import           Control.Monad.Trans.Except (runExceptT)
-import           Data.ByteString (ByteString)
+import Control.Monad (void)
+import Control.Monad.IO.Class (liftIO)
+import Control.Monad.Trans.Except (runExceptT)
+import Data.ByteString (ByteString)
 import qualified Data.Text as Text
 
-import           Test.Cardano.CLI.Util
+import Test.Cardano.CLI.Util
 
-import           Hedgehog (Property, (===))
+import Hedgehog (Property, (===))
 import qualified Hedgehog as H
 import qualified Hedgehog.Extras.Test.Base as H
-import           Hedgehog.Internal.Property (failWith)
+import Hedgehog.Internal.Property (failWith)
 
 {- HLINT ignore "Use camelCase" -}
 
@@ -27,15 +27,22 @@ hprop_golden_byronTx_legacy = propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir 
   signingKey <- noteInputFile "test/cardano-cli-golden/files/golden/byron/keys/legacy.skey"
   goldenTx <- noteInputFile "test/cardano-cli-golden/files/golden/byron/tx/legacy.tx"
   createdTx <- noteTempFile tempDir "tx"
-  void $ execCardanoCLI
-    [ "byron", "transaction", "issue-utxo-expenditure"
-    , "--mainnet"
-    , "--byron-legacy-formats"
-    , "--wallet-key", signingKey
-    , "--tx", createdTx
-    , "--txin", "(796a90e0a89b292d53a6129b9f0d757429063b529d27e4f56565192a8c8da5e3,10)"
-    , "--txout", "(\"2657WMsDfac6eFirdvKVPVMxNVYuACd1RGM2arH3g1y1yaQCr1yYpb2jr2b2aSiDZ\",999)"
-    ]
+  void $
+    execCardanoCLI
+      [ "byron"
+      , "transaction"
+      , "issue-utxo-expenditure"
+      , "--mainnet"
+      , "--byron-legacy-formats"
+      , "--wallet-key"
+      , signingKey
+      , "--tx"
+      , createdTx
+      , "--txin"
+      , "(796a90e0a89b292d53a6129b9f0d757429063b529d27e4f56565192a8c8da5e3,10)"
+      , "--txout"
+      , "(\"2657WMsDfac6eFirdvKVPVMxNVYuACd1RGM2arH3g1y1yaQCr1yYpb2jr2b2aSiDZ\",999)"
+      ]
 
   compareByronTxs createdTx goldenTx
 
@@ -44,15 +51,22 @@ hprop_golden_byronTx = propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir -> do
   signingKey <- noteInputFile "test/cardano-cli-golden/files/golden/byron/keys/byron.skey"
   goldenTx <- noteInputFile "test/cardano-cli-golden/files/golden/byron/tx/normal.tx"
   createdTx <- noteTempFile tempDir "tx"
-  void $ execCardanoCLI
-    [ "byron", "transaction", "issue-utxo-expenditure"
-    , "--mainnet"
-    , "--byron-formats"
-    , "--wallet-key", signingKey
-    , "--tx", createdTx
-    , "--txin", "(796a90e0a89b292d53a6129b9f0d757429063b529d27e4f56565192a8c8da5e3,10)"
-    , "--txout", "(\"2657WMsDfac6eFirdvKVPVMxNVYuACd1RGM2arH3g1y1yaQCr1yYpb2jr2b2aSiDZ\",999)"
-    ]
+  void $
+    execCardanoCLI
+      [ "byron"
+      , "transaction"
+      , "issue-utxo-expenditure"
+      , "--mainnet"
+      , "--byron-formats"
+      , "--wallet-key"
+      , signingKey
+      , "--tx"
+      , createdTx
+      , "--txin"
+      , "(796a90e0a89b292d53a6129b9f0d757429063b529d27e4f56565192a8c8da5e3,10)"
+      , "--txout"
+      , "(\"2657WMsDfac6eFirdvKVPVMxNVYuACd1RGM2arH3g1y1yaQCr1yYpb2jr2b2aSiDZ\",999)"
+      ]
 
   compareByronTxs createdTx goldenTx
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Byron/Tx.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Byron/Tx.hs
@@ -11,13 +11,13 @@ import Control.Monad (void)
 import Control.Monad.IO.Class (liftIO)
 import Control.Monad.Trans.Except (runExceptT)
 import Data.ByteString (ByteString)
-import qualified Data.Text as Text
+import Data.Text qualified as Text
 
 import Test.Cardano.CLI.Util
 
 import Hedgehog (Property, (===))
-import qualified Hedgehog as H
-import qualified Hedgehog.Extras.Test.Base as H
+import Hedgehog qualified as H
+import Hedgehog.Extras.Test.Base qualified as H
 import Hedgehog.Internal.Property (failWith)
 
 {- HLINT ignore "Use camelCase" -}

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Byron/TxBody.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Byron/TxBody.hs
@@ -1,6 +1,6 @@
 module Test.Golden.Byron.TxBody where
 
-import           Hedgehog (Property, property, success)
+import Hedgehog (Property, property, success)
 
 {- HLINT ignore "Use camelCase" -}
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Byron/UpdateProposal.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Byron/UpdateProposal.hs
@@ -7,12 +7,12 @@ import Cardano.CLI.Byron.UpdateProposal
 import Control.Monad (void)
 import Control.Monad.IO.Class (MonadIO (..))
 import Control.Monad.Trans.Except (runExceptT)
-import qualified Data.Text as Text
+import Data.Text qualified as Text
 
 import Test.Cardano.CLI.Util
 
 import Hedgehog (Property, (===))
-import qualified Hedgehog.Extras.Test.Base as H
+import Hedgehog.Extras.Test.Base qualified as H
 import Hedgehog.Internal.Property (failWith)
 
 {- HLINT ignore "Use camelCase" -}

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Byron/UpdateProposal.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Byron/UpdateProposal.hs
@@ -2,18 +2,18 @@
 
 module Test.Golden.Byron.UpdateProposal where
 
-import           Cardano.CLI.Byron.UpdateProposal
+import Cardano.CLI.Byron.UpdateProposal
 
-import           Control.Monad (void)
-import           Control.Monad.IO.Class (MonadIO (..))
-import           Control.Monad.Trans.Except (runExceptT)
+import Control.Monad (void)
+import Control.Monad.IO.Class (MonadIO (..))
+import Control.Monad.Trans.Except (runExceptT)
 import qualified Data.Text as Text
 
-import           Test.Cardano.CLI.Util
+import Test.Cardano.CLI.Util
 
-import           Hedgehog (Property, (===))
+import Hedgehog (Property, (===))
 import qualified Hedgehog.Extras.Test.Base as H
-import           Hedgehog.Internal.Property (failWith)
+import Hedgehog.Internal.Property (failWith)
 
 {- HLINT ignore "Use camelCase" -}
 
@@ -22,28 +22,40 @@ hprop_golden_byron_update_proposal = propertyOnce $ H.moduleWorkspace "tmp" $ \t
   goldenUpdateProposal <- noteInputFile "test/cardano-cli-golden/files/golden/byron/update-proposal"
   signingKey <- noteInputFile "test/cardano-cli-golden/files/golden/byron/keys/byron.skey"
   createdUpdateProposal <- noteTempFile tempDir "byron-update-proposal"
-  void $ execCardanoCLI
-    [ "byron", "governance", "create-update-proposal"
-    , "--mainnet"
-    , "--signing-key", signingKey
-    , "--protocol-version-major", "1"
-    , "--protocol-version-minor", "0"
-    , "--protocol-version-alt", "0"
-    , "--application-name", "cardano-sl"
-    , "--software-version-num", "1"
-    , "--system-tag", "linux"
-    , "--installer-hash", "0"
-    , "--filepath", createdUpdateProposal
-    ]
+  void $
+    execCardanoCLI
+      [ "byron"
+      , "governance"
+      , "create-update-proposal"
+      , "--mainnet"
+      , "--signing-key"
+      , signingKey
+      , "--protocol-version-major"
+      , "1"
+      , "--protocol-version-minor"
+      , "0"
+      , "--protocol-version-alt"
+      , "0"
+      , "--application-name"
+      , "cardano-sl"
+      , "--software-version-num"
+      , "1"
+      , "--system-tag"
+      , "linux"
+      , "--installer-hash"
+      , "0"
+      , "--filepath"
+      , createdUpdateProposal
+      ]
 
   eGolden <- liftIO . runExceptT $ readByronUpdateProposal goldenUpdateProposal
   golden <- case eGolden of
-              Left err -> failWith Nothing . Text.unpack $ renderByronUpdateProposalError err
-              Right prop -> return prop
+    Left err -> failWith Nothing . Text.unpack $ renderByronUpdateProposalError err
+    Right prop -> return prop
 
   eCreated <- liftIO . runExceptT $ readByronUpdateProposal createdUpdateProposal
   created <- case eCreated of
-               Left err -> failWith Nothing . Text.unpack $ renderByronUpdateProposalError err
-               Right prop -> return prop
+    Left err -> failWith Nothing . Text.unpack $ renderByronUpdateProposalError err
+    Right prop -> return prop
 
   golden === created

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Byron/Vote.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Byron/Vote.hs
@@ -2,18 +2,18 @@
 
 module Test.Golden.Byron.Vote where
 
-import           Cardano.CLI.Byron.Vote
+import Cardano.CLI.Byron.Vote
 
-import           Control.Monad (void)
-import           Control.Monad.IO.Class (MonadIO (..))
-import           Control.Monad.Trans.Except (runExceptT)
+import Control.Monad (void)
+import Control.Monad.IO.Class (MonadIO (..))
+import Control.Monad.Trans.Except (runExceptT)
 import qualified Data.Text as Text
 
-import           Test.Cardano.CLI.Util
+import Test.Cardano.CLI.Util
 
-import           Hedgehog (Property, (===))
+import Hedgehog (Property, (===))
 import qualified Hedgehog.Extras.Test.Base as H
-import           Hedgehog.Internal.Property (failWith)
+import Hedgehog.Internal.Property (failWith)
 
 {- HLINT ignore "Use camelCase" -}
 
@@ -23,24 +23,30 @@ hprop_golden_byron_yes_vote = propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir 
   proposal <- noteInputFile "test/cardano-cli-golden/files/golden/byron/update-proposal"
   signingKey <- noteInputFile "test/cardano-cli-golden/files/golden/byron/keys/byron.skey"
   createdYesVote <- noteTempFile tempDir "byron-yes-vote"
-  void $ execCardanoCLI
-    [ "byron", "governance", "create-proposal-vote"
-    , "--mainnet"
-    , "--proposal-filepath", proposal
-    , "--signing-key", signingKey
-    , "--vote-yes"
-    , "--output-filepath", createdYesVote
-    ]
+  void $
+    execCardanoCLI
+      [ "byron"
+      , "governance"
+      , "create-proposal-vote"
+      , "--mainnet"
+      , "--proposal-filepath"
+      , proposal
+      , "--signing-key"
+      , signingKey
+      , "--vote-yes"
+      , "--output-filepath"
+      , createdYesVote
+      ]
 
   eGolden <- liftIO . runExceptT $ readByronVote goldenYesVote
   golden <- case eGolden of
-              Left err -> failWith Nothing . Text.unpack $ renderByronVoteError err
-              Right prop -> return prop
+    Left err -> failWith Nothing . Text.unpack $ renderByronVoteError err
+    Right prop -> return prop
 
   eCreated <- liftIO . runExceptT $ readByronVote createdYesVote
   created <- case eCreated of
-               Left err -> failWith Nothing . Text.unpack $ renderByronVoteError err
-               Right prop -> return prop
+    Left err -> failWith Nothing . Text.unpack $ renderByronVoteError err
+    Right prop -> return prop
 
   golden === created
 
@@ -50,23 +56,29 @@ hprop_golden_byron_no_vote = propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir -
   proposal <- noteInputFile "test/cardano-cli-golden/files/golden/byron/update-proposal"
   signingKey <- noteInputFile "test/cardano-cli-golden/files/golden/byron/keys/byron.skey"
   createdNoVote <- noteTempFile tempDir "byron-no-vote"
-  void $ execCardanoCLI
-    [ "byron", "governance", "create-proposal-vote"
-    , "--mainnet"
-    , "--proposal-filepath", proposal
-    , "--signing-key", signingKey
-    , "--vote-no"
-    , "--output-filepath", createdNoVote
-    ]
+  void $
+    execCardanoCLI
+      [ "byron"
+      , "governance"
+      , "create-proposal-vote"
+      , "--mainnet"
+      , "--proposal-filepath"
+      , proposal
+      , "--signing-key"
+      , signingKey
+      , "--vote-no"
+      , "--output-filepath"
+      , createdNoVote
+      ]
 
   eGolden <- liftIO . runExceptT $ readByronVote goldenNoVote
   golden <- case eGolden of
-              Left err -> failWith Nothing . Text.unpack $ renderByronVoteError err
-              Right prop -> return prop
+    Left err -> failWith Nothing . Text.unpack $ renderByronVoteError err
+    Right prop -> return prop
 
   eCreated <- liftIO . runExceptT $ readByronVote createdNoVote
   created <- case eCreated of
-               Left err -> failWith Nothing . Text.unpack $ renderByronVoteError err
-               Right prop -> return prop
+    Left err -> failWith Nothing . Text.unpack $ renderByronVoteError err
+    Right prop -> return prop
 
   golden === created

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Byron/Vote.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Byron/Vote.hs
@@ -7,12 +7,12 @@ import Cardano.CLI.Byron.Vote
 import Control.Monad (void)
 import Control.Monad.IO.Class (MonadIO (..))
 import Control.Monad.Trans.Except (runExceptT)
-import qualified Data.Text as Text
+import Data.Text qualified as Text
 
 import Test.Cardano.CLI.Util
 
 import Hedgehog (Property, (===))
-import qualified Hedgehog.Extras.Test.Base as H
+import Hedgehog.Extras.Test.Base qualified as H
 import Hedgehog.Internal.Property (failWith)
 
 {- HLINT ignore "Use camelCase" -}

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Byron/Witness.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Byron/Witness.hs
@@ -1,7 +1,6 @@
-
 module Test.Golden.Byron.Witness where
 
-import           Hedgehog (Property, property, success)
+import Hedgehog (Property, property, success)
 
 {- HLINT ignore "Use camelCase" -}
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/ErrorsSpec.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/ErrorsSpec.hs
@@ -9,183 +9,282 @@ module Test.Golden.ErrorsSpec
   , test_VoteReadError
   ) where
 
-import           Cardano.Api
-import           Cardano.Api.Shelley
+import Cardano.Api
+import Cardano.Api.Shelley
 
-import           Cardano.Binary
-import           Cardano.CLI.EraBased.Run.Governance.Actions
-import           Cardano.CLI.EraBased.Run.Governance.Committee
-import           Cardano.CLI.Read
-import           Cardano.CLI.Types.Errors.DelegationError
-import           Cardano.CLI.Types.Errors.GovernanceCmdError
-import           Cardano.CLI.Types.Errors.GovernanceVoteCmdError
-import           Cardano.CLI.Types.Errors.RegistrationError
-import           Cardano.CLI.Types.Errors.StakeAddressCmdError
-import           Cardano.CLI.Types.Errors.StakeAddressRegistrationError
-import           Cardano.CLI.Types.Errors.StakeCredentialError
+import Cardano.Binary
+import Cardano.CLI.EraBased.Run.Governance.Actions
+import Cardano.CLI.EraBased.Run.Governance.Committee
+import Cardano.CLI.Read
+import Cardano.CLI.Types.Errors.DelegationError
+import Cardano.CLI.Types.Errors.GovernanceCmdError
+import Cardano.CLI.Types.Errors.GovernanceVoteCmdError
+import Cardano.CLI.Types.Errors.RegistrationError
+import Cardano.CLI.Types.Errors.StakeAddressCmdError
+import Cardano.CLI.Types.Errors.StakeAddressRegistrationError
+import Cardano.CLI.Types.Errors.StakeCredentialError
 
-import           Data.Text.Encoding.Error
-import           GHC.Stack (HasCallStack)
+import Data.Text.Encoding.Error
+import GHC.Stack (HasCallStack)
 
 import qualified Test.Hedgehog.Golden.ErrorMessage as ErrorMessage
-import           Test.Tasty
+import Test.Tasty
 
 test_GovernanceCmdError :: TestTree
 test_GovernanceCmdError =
-  testErrorMessagesRendering "Cardano.CLI.Types.Errors.GovernanceCmdError" "GovernanceCmdError"
-    [ ("StakeCredGovCmdError"
+  testErrorMessagesRendering
+    "Cardano.CLI.Types.Errors.GovernanceCmdError"
+    "GovernanceCmdError"
+    [
+      ( "StakeCredGovCmdError"
       , StakeCredGovCmdError
-        . StakeAddressCmdReadKeyFileError
-        $ FileError "path/file.txt" InputInvalidError)
-    , ("VotingCredentialDecodeGovCmdEror"
-      , VotingCredentialDecodeGovCmdEror $ DecoderErrorEmptyList "emptylist")
-    , ("WriteFileError"
-      , WriteFileError $ FileError "path/file.txt" ())
-    , ("ReadFileError"
-      , ReadFileError $ FileError "path/file.txt" InputInvalidError)
-    , ("NonUtf8EncodedConstitution"
-      , GovernanceCmdConstitutionError
-          $ ConstitutionNotUnicodeError
-          $ DecodeError "seq" Nothing)
-    , ("GovernanceCmdTextEnvReadError"
+          . StakeAddressCmdReadKeyFileError
+          $ FileError "path/file.txt" InputInvalidError
+      )
+    ,
+      ( "VotingCredentialDecodeGovCmdEror"
+      , VotingCredentialDecodeGovCmdEror $ DecoderErrorEmptyList "emptylist"
+      )
+    ,
+      ( "WriteFileError"
+      , WriteFileError $ FileError "path/file.txt" ()
+      )
+    ,
+      ( "ReadFileError"
+      , ReadFileError $ FileError "path/file.txt" InputInvalidError
+      )
+    ,
+      ( "NonUtf8EncodedConstitution"
+      , GovernanceCmdConstitutionError $
+          ConstitutionNotUnicodeError $
+            DecodeError "seq" Nothing
+      )
+    ,
+      ( "GovernanceCmdTextEnvReadError"
       , GovernanceCmdTextEnvReadError
-        . FileError  "path/file.txt"
-        $ TextEnvelopeAesonDecodeError "cannot decode json")
-    , ("GovernanceCmdCddlError"
-      , GovernanceCmdCddlError
-        $ CddlErrorTextEnv
-          (FileError "path/file.txt" . TextEnvelopeDecodeError $ DecoderErrorCustom "todecode" "decodeerr")
-          (FileError "path/file.txt" TextEnvelopeCddlUnknownKeyWitness))
-    , ("GovernanceCmdKeyReadError"
-      , GovernanceCmdKeyReadError $ FileError "path/file.txt" InputInvalidError)
-    , ("GovernanceCmdCostModelReadError"
-      , GovernanceCmdCostModelReadError $ FileError "path/file.txt" ())
-    , ("GovernanceCmdTextEnvWriteError"
-      , GovernanceCmdTextEnvWriteError $ FileError "path/file.txt" ())
-    , ("GovernanceCmdEmptyUpdateProposalError"
-      , GovernanceCmdEmptyUpdateProposalError)
-    , ("GovernanceCmdMIRCertificateKeyRewardMistmach"
-       ,GovernanceCmdMIRCertificateKeyRewardMistmach "path/file.txt" 1 2)
-    , ("GovernanceCmdCostModelsJsonDecodeErr"
-      , GovernanceCmdCostModelsJsonDecodeErr "path/file.txt" "jsonerr")
-    , ("GovernanceCmdEmptyCostModel"
-      , GovernanceCmdEmptyCostModel "path/file.txt")
-    , ("GovernanceCmdUnexpectedKeyType"
-      , GovernanceCmdUnexpectedKeyType (TextEnvelopeType <$> ["env1", "env2"]))
-    , ("GovernanceCmdPollOutOfBoundAnswer"
-      , GovernanceCmdPollOutOfBoundAnswer 4)
-    , ("GovernanceCmdPollInvalidChoice"
-      , GovernanceCmdPollInvalidChoice)
-    , ("GovernanceCmdDecoderError"
-      , GovernanceCmdDecoderError $ DecoderErrorEmptyList "empty")
-    , ("GovernanceCmdVerifyPollError"
-      , GovernanceCmdVerifyPollError ErrGovernancePollNoAnswer)
-    , ("GovernanceCmdWriteFileError"
-      , GovernanceCmdWriteFileError $ FileError "path/file.txt" ())
-    , ("GovernanceCmdMIRCertNotSupportedInConway"
-      , GovernanceCmdMIRCertNotSupportedInConway)
-    , ("GovernanceCmdGenesisDelegationNotSupportedInConway"
-      , GovernanceCmdGenesisDelegationNotSupportedInConway)
+          . FileError "path/file.txt"
+          $ TextEnvelopeAesonDecodeError "cannot decode json"
+      )
+    ,
+      ( "GovernanceCmdCddlError"
+      , GovernanceCmdCddlError $
+          CddlErrorTextEnv
+            (FileError "path/file.txt" . TextEnvelopeDecodeError $ DecoderErrorCustom "todecode" "decodeerr")
+            (FileError "path/file.txt" TextEnvelopeCddlUnknownKeyWitness)
+      )
+    ,
+      ( "GovernanceCmdKeyReadError"
+      , GovernanceCmdKeyReadError $ FileError "path/file.txt" InputInvalidError
+      )
+    ,
+      ( "GovernanceCmdCostModelReadError"
+      , GovernanceCmdCostModelReadError $ FileError "path/file.txt" ()
+      )
+    ,
+      ( "GovernanceCmdTextEnvWriteError"
+      , GovernanceCmdTextEnvWriteError $ FileError "path/file.txt" ()
+      )
+    ,
+      ( "GovernanceCmdEmptyUpdateProposalError"
+      , GovernanceCmdEmptyUpdateProposalError
+      )
+    ,
+      ( "GovernanceCmdMIRCertificateKeyRewardMistmach"
+      , GovernanceCmdMIRCertificateKeyRewardMistmach "path/file.txt" 1 2
+      )
+    ,
+      ( "GovernanceCmdCostModelsJsonDecodeErr"
+      , GovernanceCmdCostModelsJsonDecodeErr "path/file.txt" "jsonerr"
+      )
+    ,
+      ( "GovernanceCmdEmptyCostModel"
+      , GovernanceCmdEmptyCostModel "path/file.txt"
+      )
+    ,
+      ( "GovernanceCmdUnexpectedKeyType"
+      , GovernanceCmdUnexpectedKeyType (TextEnvelopeType <$> ["env1", "env2"])
+      )
+    ,
+      ( "GovernanceCmdPollOutOfBoundAnswer"
+      , GovernanceCmdPollOutOfBoundAnswer 4
+      )
+    ,
+      ( "GovernanceCmdPollInvalidChoice"
+      , GovernanceCmdPollInvalidChoice
+      )
+    ,
+      ( "GovernanceCmdDecoderError"
+      , GovernanceCmdDecoderError $ DecoderErrorEmptyList "empty"
+      )
+    ,
+      ( "GovernanceCmdVerifyPollError"
+      , GovernanceCmdVerifyPollError ErrGovernancePollNoAnswer
+      )
+    ,
+      ( "GovernanceCmdWriteFileError"
+      , GovernanceCmdWriteFileError $ FileError "path/file.txt" ()
+      )
+    ,
+      ( "GovernanceCmdMIRCertNotSupportedInConway"
+      , GovernanceCmdMIRCertNotSupportedInConway
+      )
+    ,
+      ( "GovernanceCmdGenesisDelegationNotSupportedInConway"
+      , GovernanceCmdGenesisDelegationNotSupportedInConway
+      )
     ]
 
 test_DelegationError :: TestTree
 test_DelegationError =
-  testErrorMessagesRendering "Cardano.CLI.Types.Errors.CmdError" "DelegationError"
-    [ ("DelegationReadError"
-      , DelegationReadError
-      $ FileError "path/file.txt" InputInvalidError)
-    , ("DelegationStakeCredentialError1"
-      , DelegationStakeCredentialError
-        $ StakeCredentialInputDecodeError
-        $ FileError "path/file.txt" InputInvalidError)
-    , ("DelegationStakeCredentialError2"
-      , DelegationStakeCredentialError
-        $ StakeCredentialScriptDecodeError
-        $ FileError "path/file.txt"
-        $ ScriptDecodeSimpleScriptError
-        $ JsonDecodeError "json decode error")
-    , ("DelegationStakeCredentialError3"
-      , DelegationStakeCredentialError
-        $ StakeCredentialInputDecodeError
-        $ FileError "path/file.txt" InputInvalidError)
-    , ("DelegationCertificateWriteFileError"
-      , DelegationCertificateWriteFileError
-        $ FileError "path/file.txt" ())
-    , ("DelegationDRepReadError"
-      , DelegationDRepReadError $ FileError "path/file.txt" InputInvalidError)
+  testErrorMessagesRendering
+    "Cardano.CLI.Types.Errors.CmdError"
+    "DelegationError"
+    [
+      ( "DelegationReadError"
+      , DelegationReadError $
+          FileError "path/file.txt" InputInvalidError
+      )
+    ,
+      ( "DelegationStakeCredentialError1"
+      , DelegationStakeCredentialError $
+          StakeCredentialInputDecodeError $
+            FileError "path/file.txt" InputInvalidError
+      )
+    ,
+      ( "DelegationStakeCredentialError2"
+      , DelegationStakeCredentialError $
+          StakeCredentialScriptDecodeError $
+            FileError "path/file.txt" $
+              ScriptDecodeSimpleScriptError $
+                JsonDecodeError "json decode error"
+      )
+    ,
+      ( "DelegationStakeCredentialError3"
+      , DelegationStakeCredentialError $
+          StakeCredentialInputDecodeError $
+            FileError "path/file.txt" InputInvalidError
+      )
+    ,
+      ( "DelegationCertificateWriteFileError"
+      , DelegationCertificateWriteFileError $
+          FileError "path/file.txt" ()
+      )
+    ,
+      ( "DelegationDRepReadError"
+      , DelegationDRepReadError $ FileError "path/file.txt" InputInvalidError
+      )
     ]
 
 test_RegistrationError :: TestTree
 test_RegistrationError =
-  testErrorMessagesRendering "Cardano.CLI.Types.Errors.CmdError" "RegistrationError"
-    [ ("RegistrationReadError"
-      , RegistrationReadError $ FileError "path/file.txt" InputInvalidError)
-    , ("RegistrationWriteFileError"
-      , RegistrationWriteFileError $ FileError "path/file.txt" ())
-    , ("RegistrationStakeCredReadError1"
-      , RegistrationStakeCredentialError
-        $ StakeCredentialInputDecodeError
-        $ FileError "path/file.txt" InputInvalidError)
-    , ("RegistrationStakeCredReadError2"
-      , RegistrationStakeCredentialError
-        $ StakeCredentialScriptDecodeError
-        $ FileError "path/file.txt"
-        $ ScriptDecodeSimpleScriptError
-        $ JsonDecodeError "json decode error")
-    , ("RegistrationStakeCredReadError3"
-      , RegistrationStakeCredentialError
-        $ StakeCredentialInputDecodeError
-        $ FileError "path/file.txt" InputInvalidError)
-    , ("RegistrationStakeError"
-      , RegistrationStakeError StakeAddressRegistrationDepositRequired)
+  testErrorMessagesRendering
+    "Cardano.CLI.Types.Errors.CmdError"
+    "RegistrationError"
+    [
+      ( "RegistrationReadError"
+      , RegistrationReadError $ FileError "path/file.txt" InputInvalidError
+      )
+    ,
+      ( "RegistrationWriteFileError"
+      , RegistrationWriteFileError $ FileError "path/file.txt" ()
+      )
+    ,
+      ( "RegistrationStakeCredReadError1"
+      , RegistrationStakeCredentialError $
+          StakeCredentialInputDecodeError $
+            FileError "path/file.txt" InputInvalidError
+      )
+    ,
+      ( "RegistrationStakeCredReadError2"
+      , RegistrationStakeCredentialError $
+          StakeCredentialScriptDecodeError $
+            FileError "path/file.txt" $
+              ScriptDecodeSimpleScriptError $
+                JsonDecodeError "json decode error"
+      )
+    ,
+      ( "RegistrationStakeCredReadError3"
+      , RegistrationStakeCredentialError $
+          StakeCredentialInputDecodeError $
+            FileError "path/file.txt" InputInvalidError
+      )
+    ,
+      ( "RegistrationStakeError"
+      , RegistrationStakeError StakeAddressRegistrationDepositRequired
+      )
     ]
 
 test_VoteReadError :: TestTree
 test_VoteReadError =
-  testErrorMessagesRendering "Cardano.CLI.Types.Errors.GovernanceVoteCmdError" "GovernanceVoteCmdError"
-    [ ("GovernanceVoteCmdCredentialDecodeError"
-      , GovernanceVoteCmdCredentialDecodeError
-        $ DecoderErrorCustom "<todecode>" "<decodeeerror>")
-    , ("GovernanceVoteCmdReadError"
-      , GovernanceVoteCmdReadError $ FileError "path/file.txt" InputInvalidError)
-    , ("GovernanceVoteCmdWriteError"
-      , GovernanceVoteCmdWriteError $ FileError "path/file.txt" ())
+  testErrorMessagesRendering
+    "Cardano.CLI.Types.Errors.GovernanceVoteCmdError"
+    "GovernanceVoteCmdError"
+    [
+      ( "GovernanceVoteCmdCredentialDecodeError"
+      , GovernanceVoteCmdCredentialDecodeError $
+          DecoderErrorCustom "<todecode>" "<decodeeerror>"
+      )
+    ,
+      ( "GovernanceVoteCmdReadError"
+      , GovernanceVoteCmdReadError $ FileError "path/file.txt" InputInvalidError
+      )
+    ,
+      ( "GovernanceVoteCmdWriteError"
+      , GovernanceVoteCmdWriteError $ FileError "path/file.txt" ()
+      )
     ]
 
 test_GovernanceComitteeError :: TestTree
 test_GovernanceComitteeError =
-  testErrorMessagesRendering "Cardano.CLI.EraBased.Run.Governance.Committee" "GovernanceCommitteeError"
-    [ ("GovernanceCommitteeCmdWriteFileError"
-      , GovernanceCommitteeCmdWriteFileError $ FileError "path/file.txt" ())
-    , ("GovernanceCommitteeCmdTextEnvReadFileError"
-      , GovernanceCommitteeCmdTextEnvReadFileError
-        $ FileError  "path/file.txt"
-        $ TextEnvelopeAesonDecodeError "cannot decode json")
+  testErrorMessagesRendering
+    "Cardano.CLI.EraBased.Run.Governance.Committee"
+    "GovernanceCommitteeError"
+    [
+      ( "GovernanceCommitteeCmdWriteFileError"
+      , GovernanceCommitteeCmdWriteFileError $ FileError "path/file.txt" ()
+      )
+    ,
+      ( "GovernanceCommitteeCmdTextEnvReadFileError"
+      , GovernanceCommitteeCmdTextEnvReadFileError $
+          FileError "path/file.txt" $
+            TextEnvelopeAesonDecodeError "cannot decode json"
+      )
     ]
 
 test_GovernanceActionsError :: TestTree
 test_GovernanceActionsError =
-  testErrorMessagesRendering "Cardano.CLI.EraBased.Run.Governance.Actions" "GovernanceActionsError"
-    [ ("GovernanceActionsCmdWriteFileError"
-      , GovernanceActionsCmdWriteFileError $ FileError "path/file.txt" ())
-    , ("GovernanceActionsCmdReadFileError"
-      , GovernanceActionsCmdReadFileError $ FileError "path/file.txt" InputInvalidError)
-    , ("GovernanceActionsCmdConstitutionError"
-      , GovernanceActionsCmdConstitutionError
-          $ ConstitutionNotUnicodeError
-          $ DecodeError "seq" Nothing)
+  testErrorMessagesRendering
+    "Cardano.CLI.EraBased.Run.Governance.Actions"
+    "GovernanceActionsError"
+    [
+      ( "GovernanceActionsCmdWriteFileError"
+      , GovernanceActionsCmdWriteFileError $ FileError "path/file.txt" ()
+      )
+    ,
+      ( "GovernanceActionsCmdReadFileError"
+      , GovernanceActionsCmdReadFileError $ FileError "path/file.txt" InputInvalidError
+      )
+    ,
+      ( "GovernanceActionsCmdConstitutionError"
+      , GovernanceActionsCmdConstitutionError $
+          ConstitutionNotUnicodeError $
+            DecodeError "seq" Nothing
+      )
     ]
-
 
 goldenFilesPath :: FilePath
 goldenFilesPath = "test/cardano-cli-golden/files/golden/errors"
 
-testErrorMessagesRendering :: forall a. ()
-  => HasCallStack
-  => Error a
-  => String -- ^ module name
-  -> String -- ^ type name
-  -> [(String, a)]  -- ^ list of constructor names and values
+testErrorMessagesRendering
+  :: forall a
+   . ( HasCallStack
+     , Error a
+     )
+  => String
+  -- ^ module name
+  -> String
+  -- ^ type name
+  -> [(String, a)]
+  -- ^ list of constructor names and values
   -> TestTree
 testErrorMessagesRendering = ErrorMessage.testAllErrorMessages_ goldenFilesPath
-

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/ErrorsSpec.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/ErrorsSpec.hs
@@ -27,7 +27,7 @@ import Cardano.CLI.Types.Errors.StakeCredentialError
 import Data.Text.Encoding.Error
 import GHC.Stack (HasCallStack)
 
-import qualified Test.Hedgehog.Golden.ErrorMessage as ErrorMessage
+import Test.Hedgehog.Golden.ErrorMessage qualified as ErrorMessage
 import Test.Tasty
 
 test_GovernanceCmdError :: TestTree

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Governance/Action.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Governance/Action.hs
@@ -2,12 +2,12 @@
 
 module Test.Golden.Governance.Action where
 
-import           Control.Monad (void)
+import Control.Monad (void)
 
+import Test.Cardano.CLI.Util
 import qualified Test.Cardano.CLI.Util as H
-import           Test.Cardano.CLI.Util
 
-import           Hedgehog (Property)
+import Hedgehog (Property)
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 import qualified Hedgehog.Extras.Test.Golden as H
@@ -18,28 +18,46 @@ hprop_golden_governanceActionCreateConstitution =
     stakeAddressVKeyFile <- noteTempFile tempDir "stake-address.vkey"
     stakeAddressSKeyFile <- noteTempFile tempDir "stake-address.skey"
 
-    void $ execCardanoCLI
-      [ "legacy", "stake-address", "key-gen"
-      , "--verification-key-file", stakeAddressVKeyFile
-      , "--signing-key-file", stakeAddressSKeyFile
-      ]
+    void $
+      execCardanoCLI
+        [ "legacy"
+        , "stake-address"
+        , "key-gen"
+        , "--verification-key-file"
+        , stakeAddressVKeyFile
+        , "--signing-key-file"
+        , stakeAddressSKeyFile
+        ]
 
     actionFile <- noteTempFile tempDir "create-constitution.action"
     redactedActionFile <- noteTempFile tempDir "create-constitution.action.redacted"
 
-    void $ execCardanoCLI
-      [ "conway", "governance", "action", "create-constitution"
-      , "--mainnet"
-      , "--proposal-text", "eda258650888d4a7f8ac1127cfa136962f527f341c99db49929c79ae"
-      , "--proposal-url", "proposal-dummy-url"
-      , "--governance-action-deposit", "10"
-      , "--stake-verification-key-file", stakeAddressVKeyFile
-      , "--out-file", actionFile
-      , "--constitution-url", "constitution-dummy-url"
-      , "--constitution-text", "This is a test constitution."
-      ]
+    void $
+      execCardanoCLI
+        [ "conway"
+        , "governance"
+        , "action"
+        , "create-constitution"
+        , "--mainnet"
+        , "--proposal-text"
+        , "eda258650888d4a7f8ac1127cfa136962f527f341c99db49929c79ae"
+        , "--proposal-url"
+        , "proposal-dummy-url"
+        , "--governance-action-deposit"
+        , "10"
+        , "--stake-verification-key-file"
+        , stakeAddressVKeyFile
+        , "--out-file"
+        , actionFile
+        , "--constitution-url"
+        , "constitution-dummy-url"
+        , "--constitution-text"
+        , "This is a test constitution."
+        ]
 
-    goldenActionFile <-  H.note "test/cardano-cli-golden/files/golden/governance/action/create-constitution-for-stake-address.action.golden"
+    goldenActionFile <-
+      H.note
+        "test/cardano-cli-golden/files/golden/governance/action/create-constitution-for-stake-address.action.golden"
 
     H.redactJsonField "cborHex" "<cborHex>" actionFile redactedActionFile
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Governance/Action.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Governance/Action.hs
@@ -5,12 +5,12 @@ module Test.Golden.Governance.Action where
 import Control.Monad (void)
 
 import Test.Cardano.CLI.Util
-import qualified Test.Cardano.CLI.Util as H
+import Test.Cardano.CLI.Util qualified as H
 
 import Hedgehog (Property)
-import qualified Hedgehog.Extras.Test.Base as H
-import qualified Hedgehog.Extras.Test.File as H
-import qualified Hedgehog.Extras.Test.Golden as H
+import Hedgehog.Extras.Test.Base qualified as H
+import Hedgehog.Extras.Test.File qualified as H
+import Hedgehog.Extras.Test.Golden qualified as H
 
 hprop_golden_governanceActionCreateConstitution :: Property
 hprop_golden_governanceActionCreateConstitution =

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Governance/Committee.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Governance/Committee.hs
@@ -10,9 +10,9 @@ import Text.Regex.TDFA ((=~))
 import Test.Cardano.CLI.Util
 
 import Hedgehog (Property)
-import qualified Hedgehog as H
-import qualified Hedgehog.Extras.Test.Base as H
-import qualified Hedgehog.Extras.Test.File as H
+import Hedgehog qualified as H
+import Hedgehog.Extras.Test.Base qualified as H
+import Hedgehog.Extras.Test.File qualified as H
 
 hprop_golden_governanceCommitteeKeyGenCold :: Property
 hprop_golden_governanceCommitteeKeyGenCold =

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Governance/Committee.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Governance/Committee.hs
@@ -4,12 +4,12 @@
 
 module Test.Golden.Governance.Committee where
 
-import           Control.Monad (void)
-import           Text.Regex.TDFA ((=~))
+import Control.Monad (void)
+import Text.Regex.TDFA ((=~))
 
-import           Test.Cardano.CLI.Util
+import Test.Cardano.CLI.Util
 
-import           Hedgehog (Property)
+import Hedgehog (Property)
 import qualified Hedgehog as H
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
@@ -20,11 +20,17 @@ hprop_golden_governanceCommitteeKeyGenCold =
     verificationKeyFile <- noteTempFile tempDir "key-gen.vkey"
     signingKeyFile <- noteTempFile tempDir "key-gen.skey"
 
-    void $ execCardanoCLI
-      [ "conway", "governance", "committee", "key-gen-cold"
-      , "--verification-key-file", verificationKeyFile
-      , "--signing-key-file", signingKeyFile
-      ]
+    void $
+      execCardanoCLI
+        [ "conway"
+        , "governance"
+        , "committee"
+        , "key-gen-cold"
+        , "--verification-key-file"
+        , verificationKeyFile
+        , "--signing-key-file"
+        , signingKeyFile
+        ]
 
     H.assertFileOccurences 1 "ConstitutionalCommitteeColdVerificationKey_ed25519" verificationKeyFile
     H.assertFileOccurences 1 "ConstitutionalCommitteeColdSigningKey_ed25519" signingKeyFile
@@ -38,11 +44,17 @@ hprop_golden_governanceCommitteeKeyGenHot =
     verificationKeyFile <- noteTempFile tempDir "key-gen.vkey"
     signingKeyFile <- noteTempFile tempDir "key-gen.skey"
 
-    void $ execCardanoCLI
-      [  "conway", "governance", "committee", "key-gen-hot"
-      , "--verification-key-file", verificationKeyFile
-      , "--signing-key-file", signingKeyFile
-      ]
+    void $
+      execCardanoCLI
+        [ "conway"
+        , "governance"
+        , "committee"
+        , "key-gen-hot"
+        , "--verification-key-file"
+        , verificationKeyFile
+        , "--signing-key-file"
+        , signingKeyFile
+        ]
 
     H.assertFileOccurences 1 "ConstitutionalCommitteeHotVerificationKey_ed25519" verificationKeyFile
     H.assertFileOccurences 1 "ConstitutionalCommitteeHotSigningKey_ed25519" signingKeyFile
@@ -59,16 +71,27 @@ hprop_golden_governanceCommitteeKeyHashCold =
     verificationKeyFile <- noteTempFile tempDir "key-gen.vkey"
     signingKeyFile <- noteTempFile tempDir "key-gen.skey"
 
-    void $ execCardanoCLI
-      [ "conway", "governance", "committee", "key-gen-cold"
-      , "--verification-key-file", verificationKeyFile
-      , "--signing-key-file", signingKeyFile
-      ]
+    void $
+      execCardanoCLI
+        [ "conway"
+        , "governance"
+        , "committee"
+        , "key-gen-cold"
+        , "--verification-key-file"
+        , verificationKeyFile
+        , "--signing-key-file"
+        , signingKeyFile
+        ]
 
-    result <- execCardanoCLI
-      [  "conway", "governance", "committee", "key-hash"
-      , "--verification-key-file", verificationKeyFile
-      ]
+    result <-
+      execCardanoCLI
+        [ "conway"
+        , "governance"
+        , "committee"
+        , "key-hash"
+        , "--verification-key-file"
+        , verificationKeyFile
+        ]
 
     H.assert $ result =~ id @String "^[a-f0-9]{56}$"
 
@@ -78,16 +101,27 @@ hprop_golden_governanceCommitteeKeyHashHot =
     verificationKeyFile <- noteTempFile tempDir "key-gen.vkey"
     signingKeyFile <- noteTempFile tempDir "key-gen.skey"
 
-    void $ execCardanoCLI
-      [  "conway", "governance", "committee", "key-gen-hot"
-      , "--verification-key-file", verificationKeyFile
-      , "--signing-key-file", signingKeyFile
-      ]
+    void $
+      execCardanoCLI
+        [ "conway"
+        , "governance"
+        , "committee"
+        , "key-gen-hot"
+        , "--verification-key-file"
+        , verificationKeyFile
+        , "--signing-key-file"
+        , signingKeyFile
+        ]
 
-    result <- execCardanoCLI
-      [  "conway", "governance", "committee", "key-hash"
-      , "--verification-key-file", verificationKeyFile
-      ]
+    result <-
+      execCardanoCLI
+        [ "conway"
+        , "governance"
+        , "committee"
+        , "key-hash"
+        , "--verification-key-file"
+        , verificationKeyFile
+        ]
 
     H.assert $ result =~ id @String "^[a-f0-9]{56}$"
 
@@ -101,24 +135,43 @@ hprop_golden_governanceCommitteeCreateHotKeyAuthorizationCertificate =
 
     certFile <- noteTempFile tempDir "hot-auth.cert"
 
-    void $ execCardanoCLI
-      [ "conway", "governance", "committee", "key-gen-cold"
-      , "--verification-key-file", ccColdVKey
-      , "--signing-key-file", ccColdSKey
-      ]
+    void $
+      execCardanoCLI
+        [ "conway"
+        , "governance"
+        , "committee"
+        , "key-gen-cold"
+        , "--verification-key-file"
+        , ccColdVKey
+        , "--signing-key-file"
+        , ccColdSKey
+        ]
 
-    void $ execCardanoCLI
-      [ "conway", "governance", "committee", "key-gen-hot"
-      , "--verification-key-file", ccHotVKey
-      , "--signing-key-file", ccHotSKey
-      ]
+    void $
+      execCardanoCLI
+        [ "conway"
+        , "governance"
+        , "committee"
+        , "key-gen-hot"
+        , "--verification-key-file"
+        , ccHotVKey
+        , "--signing-key-file"
+        , ccHotSKey
+        ]
 
-    void $ execCardanoCLI
-      [ "conway", "governance", "committee", "create-hot-key-authorization-certificate"
-      , "--cold-verification-key-file", ccColdVKey
-      , "--hot-key-file", ccHotVKey
-      , "--out-file", certFile
-      ]
+    void $
+      execCardanoCLI
+        [ "conway"
+        , "governance"
+        , "committee"
+        , "create-hot-key-authorization-certificate"
+        , "--cold-verification-key-file"
+        , ccColdVKey
+        , "--hot-key-file"
+        , ccHotVKey
+        , "--out-file"
+        , certFile
+        ]
 
     H.assertFileOccurences 1 "CertificateShelley" certFile
     H.assertFileOccurences 1 "Constitutional Committee Hot Key Registration Certificate" certFile
@@ -131,17 +184,29 @@ hprop_golden_governanceCommitteeCreateColdKeyResignationCertificate =
 
     certFile <- noteTempFile tempDir "hot-auth.cert"
 
-    void $ execCardanoCLI
-      [ "conway", "governance", "committee", "key-gen-cold"
-      , "--verification-key-file", ccColdVKey
-      , "--signing-key-file", ccColdSKey
-      ]
+    void $
+      execCardanoCLI
+        [ "conway"
+        , "governance"
+        , "committee"
+        , "key-gen-cold"
+        , "--verification-key-file"
+        , ccColdVKey
+        , "--signing-key-file"
+        , ccColdSKey
+        ]
 
-    void $ execCardanoCLI
-      [  "conway", "governance", "committee", "create-cold-key-resignation-certificate"
-      , "--cold-verification-key-file", ccColdVKey
-      , "--out-file", certFile
-      ]
+    void $
+      execCardanoCLI
+        [ "conway"
+        , "governance"
+        , "committee"
+        , "create-cold-key-resignation-certificate"
+        , "--cold-verification-key-file"
+        , ccColdVKey
+        , "--out-file"
+        , certFile
+        ]
 
     H.assertFileOccurences 1 "CertificateShelley" certFile
     H.assertFileOccurences 1 "Constitutional Committee Cold Key Resignation Certificate" certFile

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Governance/DRep.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Governance/DRep.hs
@@ -2,11 +2,11 @@
 
 module Test.Golden.Governance.DRep where
 
-import           Control.Monad (void)
+import Control.Monad (void)
 
-import           Test.Cardano.CLI.Util (execCardanoCLI, noteInputFile, propertyOnce)
+import Test.Cardano.CLI.Util (execCardanoCLI, noteInputFile, propertyOnce)
 
-import           Hedgehog
+import Hedgehog
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 import qualified Hedgehog.Extras.Test.Golden as H
@@ -17,11 +17,17 @@ hprop_golden_governanceDRepKeyGen =
     verificationKeyFile <- H.noteTempFile tempDir "key-gen.vkey"
     signingKeyFile <- H.noteTempFile tempDir "key-gen.skey"
 
-    void $ execCardanoCLI
-      [  "conway", "governance", "drep", "key-gen"
-      , "--verification-key-file", verificationKeyFile
-      , "--signing-key-file", signingKeyFile
-      ]
+    void $
+      execCardanoCLI
+        [ "conway"
+        , "governance"
+        , "drep"
+        , "key-gen"
+        , "--verification-key-file"
+        , verificationKeyFile
+        , "--signing-key-file"
+        , signingKeyFile
+        ]
 
     H.assertFileOccurences 1 "DRepVerificationKey_ed25519" verificationKeyFile
     H.assertFileOccurences 1 "DRepSigningKey_ed25519" signingKeyFile
@@ -36,12 +42,19 @@ hprop_golden_governance_drep_id_bech32 =
     idFile <- H.noteTempFile tempDir "drep.id.bech32"
     idGold <- H.note "test/cardano-cli-golden/files/golden/governance/drep/drep.id.bech32"
 
-    void $ execCardanoCLI
-      [  "conway", "governance", "drep", "id"
-      , "--drep-verification-key-file", vkeyFile
-      , "--output-format", "bech32"
-      , "--out-file", idFile
-      ]
+    void $
+      execCardanoCLI
+        [ "conway"
+        , "governance"
+        , "drep"
+        , "id"
+        , "--drep-verification-key-file"
+        , vkeyFile
+        , "--output-format"
+        , "bech32"
+        , "--out-file"
+        , idFile
+        ]
 
     H.diffFileVsGoldenFile idFile idGold
 
@@ -52,11 +65,18 @@ hprop_golden_governance_drep_id_hex =
     idFile <- H.noteTempFile tempDir "drep.id.hex"
     idGold <- H.note "test/cardano-cli-golden/files/golden/governance/drep/drep.id.hex"
 
-    void $ execCardanoCLI
-      [  "conway", "governance", "drep", "id"
-      , "--drep-verification-key-file", vkeyFile
-      , "--output-format", "hex"
-      , "--out-file", idFile
-      ]
+    void $
+      execCardanoCLI
+        [ "conway"
+        , "governance"
+        , "drep"
+        , "id"
+        , "--drep-verification-key-file"
+        , vkeyFile
+        , "--output-format"
+        , "hex"
+        , "--out-file"
+        , idFile
+        ]
 
     H.diffFileVsGoldenFile idFile idGold

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Governance/DRep.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Governance/DRep.hs
@@ -7,9 +7,9 @@ import Control.Monad (void)
 import Test.Cardano.CLI.Util (execCardanoCLI, noteInputFile, propertyOnce)
 
 import Hedgehog
-import qualified Hedgehog.Extras.Test.Base as H
-import qualified Hedgehog.Extras.Test.File as H
-import qualified Hedgehog.Extras.Test.Golden as H
+import Hedgehog.Extras.Test.Base qualified as H
+import Hedgehog.Extras.Test.File qualified as H
+import Hedgehog.Extras.Test.Golden qualified as H
 
 hprop_golden_governanceDRepKeyGen :: Property
 hprop_golden_governanceDRepKeyGen =

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Help.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Help.hs
@@ -10,21 +10,21 @@ module Test.Golden.Help
 import Prelude hiding (lines)
 
 import Control.Monad (forM_, unless, (<=<))
-import qualified Data.Char as Char
-import qualified Data.List as List
+import Data.Char qualified as Char
+import Data.List qualified as List
 import Data.Maybe (maybeToList)
 import Data.Text (Text)
-import qualified Data.Text as Text
+import Data.Text qualified as Text
 import System.FilePath ((</>))
 import Text.Regex (Regex, mkRegex, subRegex)
 
 import Test.Cardano.CLI.Util (execCardanoCLI, propertyOnce)
-import qualified Test.Cardano.CLI.Util as H
+import Test.Cardano.CLI.Util qualified as H
 
 import Hedgehog (Property)
 import Hedgehog.Extras.Stock.OS (isWin32)
-import qualified Hedgehog.Extras.Test.Base as H
-import qualified Hedgehog.Extras.Test.Golden as H
+import Hedgehog.Extras.Test.Base qualified as H
+import Hedgehog.Extras.Test.Golden qualified as H
 
 ansiRegex :: Regex
 ansiRegex = mkRegex "\\[[0-9]+m"

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Key/NonExtendedKey.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Key/NonExtendedKey.hs
@@ -8,9 +8,9 @@ import System.FilePath ((</>))
 import Test.Cardano.CLI.Util (execCardanoCLI, propertyOnce)
 
 import Hedgehog (Property)
-import qualified Hedgehog.Extras.Test.Base as H
-import qualified Hedgehog.Extras.Test.File as H
-import qualified Hedgehog.Extras.Test.Golden as H
+import Hedgehog.Extras.Test.Base qualified as H
+import Hedgehog.Extras.Test.File qualified as H
+import Hedgehog.Extras.Test.Golden qualified as H
 
 {- HLINT ignore "Use camelCase" -}
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Key/NonExtendedKey.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Key/NonExtendedKey.hs
@@ -2,12 +2,12 @@
 
 module Test.Golden.Key.NonExtendedKey where
 
-import           Control.Monad (void)
-import           System.FilePath ((</>))
+import Control.Monad (void)
+import System.FilePath ((</>))
 
-import           Test.Cardano.CLI.Util (execCardanoCLI, propertyOnce)
+import Test.Cardano.CLI.Util (execCardanoCLI, propertyOnce)
 
-import           Hedgehog (Property)
+import Hedgehog (Property)
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 import qualified Hedgehog.Extras.Test.Golden as H
@@ -19,18 +19,24 @@ import qualified Hedgehog.Extras.Test.Golden as H
 hprop_golden_KeyNonExtendedKey_GenesisExtendedVerificationKey :: Property
 hprop_golden_KeyNonExtendedKey_GenesisExtendedVerificationKey =
   propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
-    genesisVKeyFp <- H.note "test/cardano-cli-golden/files/golden/key/non-extended-keys/shelley.000.vkey"
-    nonExtendedFp <-  H.note "test/cardano-cli-golden/files/golden/key/non-extended-keys/non-extended-shelley.000.vkey"
+    genesisVKeyFp <-
+      H.note "test/cardano-cli-golden/files/golden/key/non-extended-keys/shelley.000.vkey"
+    nonExtendedFp <-
+      H.note "test/cardano-cli-golden/files/golden/key/non-extended-keys/non-extended-shelley.000.vkey"
     outFp <- H.note $ tempDir </> "non-extended-shelley.000.vkey"
 
     H.assertFilesExist [genesisVKeyFp]
 
     -- Convert the `cardano-address` signing key
-    void $ execCardanoCLI
-      [ "key", "non-extended-key"
-      , "--extended-verification-key-file", genesisVKeyFp
-      , "--verification-key-file", outFp
-      ]
+    void $
+      execCardanoCLI
+        [ "key"
+        , "non-extended-key"
+        , "--extended-verification-key-file"
+        , genesisVKeyFp
+        , "--verification-key-file"
+        , outFp
+        ]
 
     -- Check for existence of the converted signing key file
     H.assertFilesExist [outFp]
@@ -43,17 +49,22 @@ hprop_golden_KeyNonExtendedKey_StakeExtendedVerificationKeyShelley :: Property
 hprop_golden_KeyNonExtendedKey_StakeExtendedVerificationKeyShelley =
   propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     genesisVKeyFp <- H.note "test/cardano-cli-golden/files/golden/key/non-extended-keys/stake.000.vkey"
-    nonExtendedFp <-  H.note "test/cardano-cli-golden/files/golden/key/non-extended-keys/non-extended-stake.000.vkey"
+    nonExtendedFp <-
+      H.note "test/cardano-cli-golden/files/golden/key/non-extended-keys/non-extended-stake.000.vkey"
     outFp <- H.note $ tempDir </> "non-extended-stake.000.vkey"
 
     H.assertFilesExist [genesisVKeyFp]
 
     -- Convert the `cardano-address` signing key
-    void $ execCardanoCLI
-      [ "key", "non-extended-key"
-      , "--extended-verification-key-file", genesisVKeyFp
-      , "--verification-key-file", outFp
-      ]
+    void $
+      execCardanoCLI
+        [ "key"
+        , "non-extended-key"
+        , "--extended-verification-key-file"
+        , genesisVKeyFp
+        , "--verification-key-file"
+        , outFp
+        ]
 
     -- Check for existence of the converted signing key file
     H.assertFilesExist [outFp]

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Address/Build.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Address/Build.hs
@@ -7,8 +7,8 @@ import Control.Monad (void)
 import Test.Cardano.CLI.Util as OP
 
 import Hedgehog (Property)
-import qualified Hedgehog.Extras.Test.Base as H
-import qualified Hedgehog.Extras.Test.File as H
+import Hedgehog.Extras.Test.Base qualified as H
+import Hedgehog.Extras.Test.File qualified as H
 
 {- HLINT ignore "Use camelCase" -}
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Address/Build.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Address/Build.hs
@@ -2,11 +2,11 @@
 
 module Test.Golden.Shelley.Address.Build where
 
-import           Control.Monad (void)
+import Control.Monad (void)
 
-import           Test.Cardano.CLI.Util as OP
+import Test.Cardano.CLI.Util as OP
 
-import           Hedgehog (Property)
+import Hedgehog (Property)
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 
@@ -14,21 +14,30 @@ import qualified Hedgehog.Extras.Test.File as H
 
 hprop_golden_shelleyAddressBuild :: Property
 hprop_golden_shelleyAddressBuild = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
-  addressVKeyFile <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/payment_keys/verification_key"
-  addressSKeyFile <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/stake_keys/verification_key"
-  goldenStakingAddressHexFile <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/addresses/staking-address.hex"
-  goldenEnterpriseAddressHexFile <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/addresses/enterprise-address.hex"
+  addressVKeyFile <-
+    noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/payment_keys/verification_key"
+  addressSKeyFile <-
+    noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/stake_keys/verification_key"
+  goldenStakingAddressHexFile <-
+    noteInputFile "test/cardano-cli-golden/files/golden/shelley/addresses/staking-address.hex"
+  goldenEnterpriseAddressHexFile <-
+    noteInputFile "test/cardano-cli-golden/files/golden/shelley/addresses/enterprise-address.hex"
   stakingAddressHexFile <- noteTempFile tempDir "staking-address.hex"
   enterpriseAddressHexFile <- noteTempFile tempDir "enterprise-address.hex"
 
   void $ H.readFile addressVKeyFile
 
-  stakingAddressText <- execCardanoCLI
-    [ "address","build"
-    , "--testnet-magic", "14"
-    , "--payment-verification-key-file", addressVKeyFile
-    , "--staking-verification-key-file", addressSKeyFile
-    ]
+  stakingAddressText <-
+    execCardanoCLI
+      [ "address"
+      , "build"
+      , "--testnet-magic"
+      , "14"
+      , "--payment-verification-key-file"
+      , addressVKeyFile
+      , "--staking-verification-key-file"
+      , addressSKeyFile
+      ]
 
   goldenStakingAddressHex <- H.readFile goldenStakingAddressHexFile
 
@@ -38,12 +47,17 @@ hprop_golden_shelleyAddressBuild = propertyOnce . H.moduleWorkspace "tmp" $ \tem
 
   void $ H.readFile addressSKeyFile
 
-  enterpriseAddressText <- execCardanoCLI
-    [ "address","build"
-    , "--testnet-magic", "14"
-    , "--payment-verification-key-file", addressVKeyFile
-    , "--staking-verification-key-file", addressSKeyFile
-    ]
+  enterpriseAddressText <-
+    execCardanoCLI
+      [ "address"
+      , "build"
+      , "--testnet-magic"
+      , "14"
+      , "--payment-verification-key-file"
+      , addressVKeyFile
+      , "--staking-verification-key-file"
+      , addressSKeyFile
+      ]
 
   goldenEnterpriseAddressHex <- H.readFile goldenEnterpriseAddressHexFile
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Address/Info.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Address/Info.hs
@@ -2,12 +2,12 @@
 
 module Test.Golden.Shelley.Address.Info where
 
-import           Control.Monad (when)
+import Control.Monad (when)
 import qualified Data.List as L
 
-import           Test.Cardano.CLI.Util
+import Test.Cardano.CLI.Util
 
-import           Hedgehog (Property)
+import Hedgehog (Property)
 import qualified Hedgehog as H
 
 {- HLINT ignore "Use camelCase" -}
@@ -16,32 +16,43 @@ hprop_golden_shelleyAddressInfo :: Property
 hprop_golden_shelleyAddressInfo = propertyOnce $ do
   -- Disable as per commit: e69984d797fc3bdd5d71bdd99a0328110d71f6ad
   when False $ do
-    let byronBase58 = "DdzFFzCqrhsg9F1joqXWJdGKwn6MaNavCqPsrZcjADRjA4ifEtrBmREJZyCojtuexKjMKNFr6CoU7Gx6PPR7pq14JxvPZuuk2xVkzn8p"
+    let byronBase58 =
+          "DdzFFzCqrhsg9F1joqXWJdGKwn6MaNavCqPsrZcjADRjA4ifEtrBmREJZyCojtuexKjMKNFr6CoU7Gx6PPR7pq14JxvPZuuk2xVkzn8p"
 
-    infoText1 <- execCardanoCLI
-      [ "address","info"
-      , "--address", byronBase58
-      ]
+    infoText1 <-
+      execCardanoCLI
+        [ "address"
+        , "info"
+        , "--address"
+        , byronBase58
+        ]
 
     H.assert $ "Encoding: Base58" `L.isInfixOf` infoText1
     H.assert $ "Era: Byron" `L.isInfixOf` infoText1
 
-    let byronHex = "82d818584283581c120e97e4ca7b831373c1060853d4896314e17d567a5723879b9a20eaa101581e581c135a115dd5dba68c28fb7e9409729ffc0503219ff7f9c08e84d13319001a28d0b871"
+    let byronHex =
+          "82d818584283581c120e97e4ca7b831373c1060853d4896314e17d567a5723879b9a20eaa101581e581c135a115dd5dba68c28fb7e9409729ffc0503219ff7f9c08e84d13319001a28d0b871"
 
-    infoText2 <- execCardanoCLI
-      [ "address","info"
-      , "--address", byronHex
-      ]
+    infoText2 <-
+      execCardanoCLI
+        [ "address"
+        , "info"
+        , "--address"
+        , byronHex
+        ]
 
     H.assert $ "Encoding: Hex" `L.isInfixOf` infoText2
     H.assert $ "Era: Byron" `L.isInfixOf` infoText2
 
     let shelleyHex = "82065820d8b4a892f2f6f1820d350c207d17d4cd7e7a1f7e0a83059e2d698a65ab8f96ed"
 
-    infoText3 <- execCardanoCLI
-      [ "address","info"
-      , "--address", shelleyHex
-      ]
+    infoText3 <-
+      execCardanoCLI
+        [ "address"
+        , "info"
+        , "--address"
+        , shelleyHex
+        ]
 
     H.assert $ "Encoding: Hex" `L.isInfixOf` infoText3
     H.assert $ "Era: Shelley" `L.isInfixOf` infoText3

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Address/Info.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Address/Info.hs
@@ -3,12 +3,12 @@
 module Test.Golden.Shelley.Address.Info where
 
 import Control.Monad (when)
-import qualified Data.List as L
+import Data.List qualified as L
 
 import Test.Cardano.CLI.Util
 
 import Hedgehog (Property)
-import qualified Hedgehog as H
+import Hedgehog qualified as H
 
 {- HLINT ignore "Use camelCase" -}
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Address/KeyGen.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Address/KeyGen.hs
@@ -7,8 +7,8 @@ import Control.Monad (void)
 import Test.Cardano.CLI.Util
 
 import Hedgehog (Property)
-import qualified Hedgehog.Extras.Test.Base as H
-import qualified Hedgehog.Extras.Test.File as H
+import Hedgehog.Extras.Test.Base qualified as H
+import Hedgehog.Extras.Test.File qualified as H
 
 {- HLINT ignore "Use camelCase" -}
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Address/KeyGen.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Address/KeyGen.hs
@@ -2,11 +2,11 @@
 
 module Test.Golden.Shelley.Address.KeyGen where
 
-import           Control.Monad (void)
+import Control.Monad (void)
 
-import           Test.Cardano.CLI.Util
+import Test.Cardano.CLI.Util
 
-import           Hedgehog (Property)
+import Hedgehog (Property)
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 
@@ -17,11 +17,15 @@ hprop_golden_shelleyAddressKeyGen = propertyOnce . H.moduleWorkspace "tmp" $ \te
   addressVKeyFile <- noteTempFile tempDir "address.vkey"
   addressSKeyFile <- noteTempFile tempDir "address.skey"
 
-  void $ execCardanoCLI
-    [ "address","key-gen"
-    , "--verification-key-file", addressVKeyFile
-    , "--signing-key-file", addressSKeyFile
-    ]
+  void $
+    execCardanoCLI
+      [ "address"
+      , "key-gen"
+      , "--verification-key-file"
+      , addressVKeyFile
+      , "--signing-key-file"
+      , addressSKeyFile
+      ]
 
   void $ H.readFile addressVKeyFile
   void $ H.readFile addressSKeyFile
@@ -34,12 +38,16 @@ hprop_golden_shelleyAddressExtendedKeyGen = propertyOnce . H.moduleWorkspace "tm
   addressVKeyFile <- noteTempFile tempDir "address.vkey"
   addressSKeyFile <- noteTempFile tempDir "address.skey"
 
-  void $ execCardanoCLI
-    [ "address","key-gen"
-    , "--extended-key"
-    , "--verification-key-file", addressVKeyFile
-    , "--signing-key-file", addressSKeyFile
-    ]
+  void $
+    execCardanoCLI
+      [ "address"
+      , "key-gen"
+      , "--extended-key"
+      , "--verification-key-file"
+      , addressVKeyFile
+      , "--signing-key-file"
+      , addressSKeyFile
+      ]
 
   void $ H.readFile addressVKeyFile
   void $ H.readFile addressSKeyFile

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Genesis/Create.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Genesis/Create.hs
@@ -6,26 +6,26 @@ module Test.Golden.Shelley.Genesis.Create
   ) where
 
 import Control.Monad (void)
-import qualified Data.Aeson as J
-import qualified Data.Aeson.Key as J
-import qualified Data.Aeson.KeyMap as KeyMap
-import qualified Data.Aeson.Types as J
+import Data.Aeson qualified as J
+import Data.Aeson.Key qualified as J
+import Data.Aeson.KeyMap qualified as KeyMap
+import Data.Aeson.Types qualified as J
 import Data.Bifunctor (Bifunctor (..))
-import qualified Data.ByteString.Lazy as LBS
+import Data.ByteString.Lazy qualified as LBS
 import Data.Foldable (for_)
-import qualified Data.HashMap.Lazy as HM
-import qualified Data.Set as S
-import qualified Data.Time.Clock as DT
+import Data.HashMap.Lazy qualified as HM
+import Data.Set qualified as S
+import Data.Time.Clock qualified as DT
 
 import Test.Cardano.CLI.Util as OP
 
 import Hedgehog (Property, forAll, (===))
-import qualified Hedgehog as H
-import qualified Hedgehog.Extras.Stock.Time as H
-import qualified Hedgehog.Extras.Test.Base as H
-import qualified Hedgehog.Extras.Test.File as H
-import qualified Hedgehog.Gen as G
-import qualified Hedgehog.Range as R
+import Hedgehog qualified as H
+import Hedgehog.Extras.Stock.Time qualified as H
+import Hedgehog.Extras.Test.Base qualified as H
+import Hedgehog.Extras.Test.File qualified as H
+import Hedgehog.Gen qualified as G
+import Hedgehog.Range qualified as R
 
 {- HLINT ignore "Use <$>" -}
 {- HLINT ignore "Use camelCase" -}

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Genesis/Create.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Genesis/Create.hs
@@ -5,21 +5,21 @@ module Test.Golden.Shelley.Genesis.Create
   ( hprop_golden_shelleyGenesisCreate
   ) where
 
-import           Control.Monad (void)
+import Control.Monad (void)
 import qualified Data.Aeson as J
 import qualified Data.Aeson.Key as J
 import qualified Data.Aeson.KeyMap as KeyMap
 import qualified Data.Aeson.Types as J
-import           Data.Bifunctor (Bifunctor (..))
+import Data.Bifunctor (Bifunctor (..))
 import qualified Data.ByteString.Lazy as LBS
-import           Data.Foldable (for_)
+import Data.Foldable (for_)
 import qualified Data.HashMap.Lazy as HM
 import qualified Data.Set as S
 import qualified Data.Time.Clock as DT
 
-import           Test.Cardano.CLI.Util as OP
+import Test.Cardano.CLI.Util as OP
 
-import           Hedgehog (Property, forAll, (===))
+import Hedgehog (Property, forAll, (===))
 import qualified Hedgehog as H
 import qualified Hedgehog.Extras.Stock.Time as H
 import qualified Hedgehog.Extras.Test.Base as H
@@ -61,16 +61,19 @@ parseHashKeys = J.withObject "Object" $ \o -> do
   pure $ fmap fst (HM.toList delegates)
 
 parseTotalSupply :: J.Value -> J.Parser Int
-parseTotalSupply = J.withObject "Object" $ \ o -> do
+parseTotalSupply = J.withObject "Object" $ \o -> do
   initialFunds <- (o J..: "initialFunds") >>= parseHashMap
   fmap sum (sequence (fmap (J.parseJSON @Int . snd) (HM.toList initialFunds)))
 
 hprop_golden_shelleyGenesisCreate :: Property
 hprop_golden_shelleyGenesisCreate = propertyOnce $ do
   H.moduleWorkspace "tmp" $ \tempDir -> do
-    sourceGenesisSpecFile <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/genesis/genesis.spec.json"
-    sourceAlonzoGenesisSpecFile <- noteInputFile "test/cardano-cli-golden/files/golden/alonzo/genesis.alonzo.spec.json"
-    sourceConwayGenesisSpecFile <- noteInputFile "test/cardano-cli-golden/files/golden/conway/genesis.conway.spec.json"
+    sourceGenesisSpecFile <-
+      noteInputFile "test/cardano-cli-golden/files/golden/shelley/genesis/genesis.spec.json"
+    sourceAlonzoGenesisSpecFile <-
+      noteInputFile "test/cardano-cli-golden/files/golden/alonzo/genesis.alonzo.spec.json"
+    sourceConwayGenesisSpecFile <-
+      noteInputFile "test/cardano-cli-golden/files/golden/conway/genesis.conway.spec.json"
 
     genesisSpecFile <- noteTempFile tempDir "genesis.spec.json"
     alonzoSpecFile <- noteTempFile tempDir "genesis.alonzo.spec.json"
@@ -89,94 +92,22 @@ hprop_golden_shelleyGenesisCreate = propertyOnce $ do
     (utxoCount, fmtUtxoCount) <- fmap (OP.withSnd show) $ forAll $ G.int (R.linear 4 19)
 
     -- Create the genesis json file and required keys
-    void $ execCardanoCLI
-      [ "genesis","create"
-      , "--testnet-magic", "12"
-      , "--start-time", fmtStartTime
-      , "--supply", fmtSupply
-      , "--gen-genesis-keys", fmtDelegateCount
-      , "--gen-utxo-keys", fmtUtxoCount
-      , "--genesis-dir", tempDir
-      ]
-
-    H.assertFilesExist [genesisFile]
-
-    genesisContents <- H.evalIO $ LBS.readFile genesisFile
-
-    actualJson <- H.evalEither $ J.eitherDecode genesisContents
-    actualSupply <- H.evalEither $ J.parseEither parseMaxLovelaceSupply actualJson
-    actualStartTime <- H.evalEither $ J.parseEither parseSystemStart actualJson
-    actualDelegateCount <- H.evalEither $ J.parseEither parseDelegateCount actualJson
-    actualTotalSupply <- H.evalEither $ J.parseEither parseTotalSupply actualJson
-    actualHashKeys <- H.evalEither $ J.parseEither parseHashKeys actualJson
-    actualDelegateKeys <- H.evalEither $ J.parseEither parseDelegateKeys actualJson
-
-    actualSupply === supply
-    actualStartTime === fmtStartTime
-    actualDelegateCount === delegateCount
-    actualDelegateCount === utxoCount
-    actualTotalSupply === supply - 1000000  -- Check that the sum of the initial fund amounts matches the total supply
-                                            -- We don't use the entire supply so there is ada in the treasury. This is
-                                            -- required for stake pool rewards.
-
-    -- Check uniqueness and count of hash keys
-    S.size (S.fromList actualHashKeys) === length actualHashKeys -- This isn't strictly necessary because we use aeson which guarantees uniqueness of keys
-    S.size (S.fromList actualHashKeys) === delegateCount
-
-    -- Check uniqueness and count of hash keys
-    S.size (S.fromList actualDelegateKeys) === length actualDelegateKeys
-    S.size (S.fromList actualDelegateKeys) === delegateCount
-
-    for_ [1 .. delegateCount] $ \i -> do
-      -- Check Genesis keys
-      H.assertFileOccurences 1 "GenesisSigningKey_ed25519" $ tempDir <> "/genesis-keys/genesis" <> show i <> ".skey"
-      H.assertFileOccurences 1 "GenesisVerificationKey_ed25519" $ tempDir <> "/genesis-keys/genesis" <> show i <> ".vkey"
-
-      H.assertEndsWithSingleNewline $ tempDir <> "/genesis-keys/genesis" <> show i <> ".skey"
-      H.assertEndsWithSingleNewline $ tempDir <> "/genesis-keys/genesis" <> show i <> ".vkey"
-
-      -- Check delegate keys
-      H.assertFileOccurences 1 "GenesisDelegateSigningKey_ed25519" $ tempDir <> "/delegate-keys/delegate" <> show i <> ".skey"
-      H.assertFileOccurences 1 "GenesisDelegateVerificationKey_ed25519" $ tempDir <> "/delegate-keys/delegate" <> show i <> ".vkey"
-      H.assertFileOccurences 1 "NodeOperationalCertificateIssueCounter" $ tempDir <> "/delegate-keys/delegate" <> show i <> ".counter"
-
-      H.assertEndsWithSingleNewline $ tempDir <> "/delegate-keys/delegate" <> show i <> ".skey"
-      H.assertEndsWithSingleNewline $ tempDir <> "/delegate-keys/delegate" <> show i <> ".vkey"
-      H.assertEndsWithSingleNewline $ tempDir <> "/delegate-keys/delegate" <> show i <> ".counter"
-
-      -- Check utxo keys
-      H.assertFileOccurences 1 "GenesisUTxOSigningKey_ed25519" $ tempDir <> "/utxo-keys/utxo" <> show i <> ".skey"
-      H.assertFileOccurences 1 "GenesisUTxOVerificationKey_ed25519"  $ tempDir <> "/utxo-keys/utxo" <> show i <> ".vkey"
-
-      H.assertEndsWithSingleNewline $ tempDir <> "/utxo-keys/utxo" <> show i <> ".skey"
-      H.assertEndsWithSingleNewline $ tempDir <> "/utxo-keys/utxo" <> show i <> ".vkey"
-
-  H.moduleWorkspace "tmp" $ \tempDir -> do
-    let genesisFile = tempDir <> "/genesis.json"
-
-    fmtStartTime <- fmap H.formatIso8601 $ H.evalIO DT.getCurrentTime
-
-    (supply, fmtSupply) <- fmap (OP.withSnd show) $ forAll $ G.int (R.linear 10000000 4000000000)
-    (delegateCount, fmtDelegateCount) <- fmap (OP.withSnd show) $ forAll $ G.int (R.linear 4 19)
-    (utxoCount, fmtUtxoCount) <- fmap (OP.withSnd show) $ forAll $ G.int (R.linear 4 19)
-
-    sourceAlonzoGenesisSpecFile <- noteInputFile "test/cardano-cli-golden/files/golden/alonzo/genesis.alonzo.spec.json"
-    alonzoSpecFile <- noteTempFile tempDir "genesis.alonzo.spec.json"
-    H.copyFile sourceAlonzoGenesisSpecFile alonzoSpecFile
-
-    sourceConwayGenesisSpecFile <- noteInputFile "test/cardano-cli-golden/files/golden/conway/genesis.conway.spec.json"
-    conwaySpecFile <- noteTempFile tempDir "genesis.conway.spec.json"
-    H.copyFile sourceConwayGenesisSpecFile conwaySpecFile
-
-    -- Create the genesis json file and required keys
-    void $ execCardanoCLI
-        [ "genesis","create"
-        , "--testnet-magic", "12"
-        , "--start-time", fmtStartTime
-        , "--supply", fmtSupply
-        , "--gen-genesis-keys", fmtDelegateCount
-        , "--gen-utxo-keys", fmtUtxoCount
-        , "--genesis-dir", tempDir
+    void $
+      execCardanoCLI
+        [ "genesis"
+        , "create"
+        , "--testnet-magic"
+        , "12"
+        , "--start-time"
+        , fmtStartTime
+        , "--supply"
+        , fmtSupply
+        , "--gen-genesis-keys"
+        , fmtDelegateCount
+        , "--gen-utxo-keys"
+        , fmtUtxoCount
+        , "--genesis-dir"
+        , tempDir
         ]
 
     H.assertFilesExist [genesisFile]
@@ -195,9 +126,10 @@ hprop_golden_shelleyGenesisCreate = propertyOnce $ do
     actualStartTime === fmtStartTime
     actualDelegateCount === delegateCount
     actualDelegateCount === utxoCount
-    actualTotalSupply === supply - 1000000  -- Check that the sum of the initial fund amounts matches the total supply
-                                            -- We don't use the entire supply so there is ada in the treasury. This is
-                                            -- required for stake pool rewards.
+    actualTotalSupply === supply - 1000000 -- Check that the sum of the initial fund amounts matches the total supply
+    -- We don't use the entire supply so there is ada in the treasury. This is
+    -- required for stake pool rewards.
+
     -- Check uniqueness and count of hash keys
     S.size (S.fromList actualHashKeys) === length actualHashKeys -- This isn't strictly necessary because we use aeson which guarantees uniqueness of keys
     S.size (S.fromList actualHashKeys) === delegateCount
@@ -208,24 +140,127 @@ hprop_golden_shelleyGenesisCreate = propertyOnce $ do
 
     for_ [1 .. delegateCount] $ \i -> do
       -- Check Genesis keys
-      H.assertFileOccurences 1 "GenesisSigningKey_ed25519" $ tempDir <> "/genesis-keys/genesis" <> show i <> ".skey"
-      H.assertFileOccurences 1 "GenesisVerificationKey_ed25519" $ tempDir <> "/genesis-keys/genesis" <> show i <> ".vkey"
+      H.assertFileOccurences 1 "GenesisSigningKey_ed25519" $
+        tempDir <> "/genesis-keys/genesis" <> show i <> ".skey"
+      H.assertFileOccurences 1 "GenesisVerificationKey_ed25519" $
+        tempDir <> "/genesis-keys/genesis" <> show i <> ".vkey"
 
       H.assertEndsWithSingleNewline $ tempDir <> "/genesis-keys/genesis" <> show i <> ".skey"
       H.assertEndsWithSingleNewline $ tempDir <> "/genesis-keys/genesis" <> show i <> ".vkey"
 
       -- Check delegate keys
-      H.assertFileOccurences 1 "GenesisDelegateSigningKey_ed25519" $ tempDir <> "/delegate-keys/delegate" <> show i <> ".skey"
-      H.assertFileOccurences 1 "GenesisDelegateVerificationKey_ed25519" $ tempDir <> "/delegate-keys/delegate" <> show i <> ".vkey"
-      H.assertFileOccurences 1 "NodeOperationalCertificateIssueCounter" $ tempDir <> "/delegate-keys/delegate" <> show i <> ".counter"
+      H.assertFileOccurences 1 "GenesisDelegateSigningKey_ed25519" $
+        tempDir <> "/delegate-keys/delegate" <> show i <> ".skey"
+      H.assertFileOccurences 1 "GenesisDelegateVerificationKey_ed25519" $
+        tempDir <> "/delegate-keys/delegate" <> show i <> ".vkey"
+      H.assertFileOccurences 1 "NodeOperationalCertificateIssueCounter" $
+        tempDir <> "/delegate-keys/delegate" <> show i <> ".counter"
 
       H.assertEndsWithSingleNewline $ tempDir <> "/delegate-keys/delegate" <> show i <> ".skey"
       H.assertEndsWithSingleNewline $ tempDir <> "/delegate-keys/delegate" <> show i <> ".vkey"
       H.assertEndsWithSingleNewline $ tempDir <> "/delegate-keys/delegate" <> show i <> ".counter"
 
       -- Check utxo keys
-      H.assertFileOccurences 1 "GenesisUTxOSigningKey_ed25519" $ tempDir <> "/utxo-keys/utxo" <> show i <> ".skey"
-      H.assertFileOccurences 1 "GenesisUTxOVerificationKey_ed25519"  $ tempDir <> "/utxo-keys/utxo" <> show i <> ".vkey"
+      H.assertFileOccurences 1 "GenesisUTxOSigningKey_ed25519" $
+        tempDir <> "/utxo-keys/utxo" <> show i <> ".skey"
+      H.assertFileOccurences 1 "GenesisUTxOVerificationKey_ed25519" $
+        tempDir <> "/utxo-keys/utxo" <> show i <> ".vkey"
+
+      H.assertEndsWithSingleNewline $ tempDir <> "/utxo-keys/utxo" <> show i <> ".skey"
+      H.assertEndsWithSingleNewline $ tempDir <> "/utxo-keys/utxo" <> show i <> ".vkey"
+
+  H.moduleWorkspace "tmp" $ \tempDir -> do
+    let genesisFile = tempDir <> "/genesis.json"
+
+    fmtStartTime <- fmap H.formatIso8601 $ H.evalIO DT.getCurrentTime
+
+    (supply, fmtSupply) <- fmap (OP.withSnd show) $ forAll $ G.int (R.linear 10000000 4000000000)
+    (delegateCount, fmtDelegateCount) <- fmap (OP.withSnd show) $ forAll $ G.int (R.linear 4 19)
+    (utxoCount, fmtUtxoCount) <- fmap (OP.withSnd show) $ forAll $ G.int (R.linear 4 19)
+
+    sourceAlonzoGenesisSpecFile <-
+      noteInputFile "test/cardano-cli-golden/files/golden/alonzo/genesis.alonzo.spec.json"
+    alonzoSpecFile <- noteTempFile tempDir "genesis.alonzo.spec.json"
+    H.copyFile sourceAlonzoGenesisSpecFile alonzoSpecFile
+
+    sourceConwayGenesisSpecFile <-
+      noteInputFile "test/cardano-cli-golden/files/golden/conway/genesis.conway.spec.json"
+    conwaySpecFile <- noteTempFile tempDir "genesis.conway.spec.json"
+    H.copyFile sourceConwayGenesisSpecFile conwaySpecFile
+
+    -- Create the genesis json file and required keys
+    void $
+      execCardanoCLI
+        [ "genesis"
+        , "create"
+        , "--testnet-magic"
+        , "12"
+        , "--start-time"
+        , fmtStartTime
+        , "--supply"
+        , fmtSupply
+        , "--gen-genesis-keys"
+        , fmtDelegateCount
+        , "--gen-utxo-keys"
+        , fmtUtxoCount
+        , "--genesis-dir"
+        , tempDir
+        ]
+
+    H.assertFilesExist [genesisFile]
+
+    genesisContents <- H.evalIO $ LBS.readFile genesisFile
+
+    actualJson <- H.evalEither $ J.eitherDecode genesisContents
+    actualSupply <- H.evalEither $ J.parseEither parseMaxLovelaceSupply actualJson
+    actualStartTime <- H.evalEither $ J.parseEither parseSystemStart actualJson
+    actualDelegateCount <- H.evalEither $ J.parseEither parseDelegateCount actualJson
+    actualTotalSupply <- H.evalEither $ J.parseEither parseTotalSupply actualJson
+    actualHashKeys <- H.evalEither $ J.parseEither parseHashKeys actualJson
+    actualDelegateKeys <- H.evalEither $ J.parseEither parseDelegateKeys actualJson
+
+    actualSupply === supply
+    actualStartTime === fmtStartTime
+    actualDelegateCount === delegateCount
+    actualDelegateCount === utxoCount
+    actualTotalSupply === supply - 1000000 -- Check that the sum of the initial fund amounts matches the total supply
+    -- We don't use the entire supply so there is ada in the treasury. This is
+    -- required for stake pool rewards.
+    -- Check uniqueness and count of hash keys
+    S.size (S.fromList actualHashKeys) === length actualHashKeys -- This isn't strictly necessary because we use aeson which guarantees uniqueness of keys
+    S.size (S.fromList actualHashKeys) === delegateCount
+
+    -- Check uniqueness and count of hash keys
+    S.size (S.fromList actualDelegateKeys) === length actualDelegateKeys
+    S.size (S.fromList actualDelegateKeys) === delegateCount
+
+    for_ [1 .. delegateCount] $ \i -> do
+      -- Check Genesis keys
+      H.assertFileOccurences 1 "GenesisSigningKey_ed25519" $
+        tempDir <> "/genesis-keys/genesis" <> show i <> ".skey"
+      H.assertFileOccurences 1 "GenesisVerificationKey_ed25519" $
+        tempDir <> "/genesis-keys/genesis" <> show i <> ".vkey"
+
+      H.assertEndsWithSingleNewline $ tempDir <> "/genesis-keys/genesis" <> show i <> ".skey"
+      H.assertEndsWithSingleNewline $ tempDir <> "/genesis-keys/genesis" <> show i <> ".vkey"
+
+      -- Check delegate keys
+      H.assertFileOccurences 1 "GenesisDelegateSigningKey_ed25519" $
+        tempDir <> "/delegate-keys/delegate" <> show i <> ".skey"
+      H.assertFileOccurences 1 "GenesisDelegateVerificationKey_ed25519" $
+        tempDir <> "/delegate-keys/delegate" <> show i <> ".vkey"
+      H.assertFileOccurences 1 "NodeOperationalCertificateIssueCounter" $
+        tempDir <> "/delegate-keys/delegate" <> show i <> ".counter"
+
+      H.assertEndsWithSingleNewline $ tempDir <> "/delegate-keys/delegate" <> show i <> ".skey"
+      H.assertEndsWithSingleNewline $ tempDir <> "/delegate-keys/delegate" <> show i <> ".vkey"
+      H.assertEndsWithSingleNewline $ tempDir <> "/delegate-keys/delegate" <> show i <> ".counter"
+
+      -- Check utxo keys
+      H.assertFileOccurences 1 "GenesisUTxOSigningKey_ed25519" $
+        tempDir <> "/utxo-keys/utxo" <> show i <> ".skey"
+      H.assertFileOccurences 1 "GenesisUTxOVerificationKey_ed25519" $
+        tempDir <> "/utxo-keys/utxo" <> show i <> ".vkey"
 
       H.assertEndsWithSingleNewline $ tempDir <> "/utxo-keys/utxo" <> show i <> ".skey"
       H.assertEndsWithSingleNewline $ tempDir <> "/utxo-keys/utxo" <> show i <> ".vkey"

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Genesis/InitialTxIn.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Genesis/InitialTxIn.hs
@@ -2,9 +2,9 @@
 
 module Test.Golden.Shelley.Genesis.InitialTxIn where
 
-import           Test.Cardano.CLI.Util
+import Test.Cardano.CLI.Util
 
-import           Hedgehog (Property)
+import Hedgehog (Property)
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 
@@ -12,15 +12,22 @@ import qualified Hedgehog.Extras.Test.File as H
 
 hprop_golden_shelleyGenesisInitialTxIn :: Property
 hprop_golden_shelleyGenesisInitialTxIn = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
-  verificationKeyFile <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/genesis_verification_keys/genesis-utxo.vkey"
-  goldenUtxoHashFile <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/genesis_utxo_hashes/utxo_hash"
+  verificationKeyFile <-
+    noteInputFile
+      "test/cardano-cli-golden/files/golden/shelley/keys/genesis_verification_keys/genesis-utxo.vkey"
+  goldenUtxoHashFile <-
+    noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/genesis_utxo_hashes/utxo_hash"
   utxoHashFile <- noteTempFile tempDir "utxo_hash"
 
-  utxoHash <- execCardanoCLI
-    [ "genesis","initial-txin"
-    , "--testnet-magic", "16"
-    , "--verification-key-file", verificationKeyFile
-    ]
+  utxoHash <-
+    execCardanoCLI
+      [ "genesis"
+      , "initial-txin"
+      , "--testnet-magic"
+      , "16"
+      , "--verification-key-file"
+      , verificationKeyFile
+      ]
 
   H.writeFile utxoHashFile utxoHash
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Genesis/InitialTxIn.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Genesis/InitialTxIn.hs
@@ -5,8 +5,8 @@ module Test.Golden.Shelley.Genesis.InitialTxIn where
 import Test.Cardano.CLI.Util
 
 import Hedgehog (Property)
-import qualified Hedgehog.Extras.Test.Base as H
-import qualified Hedgehog.Extras.Test.File as H
+import Hedgehog.Extras.Test.Base qualified as H
+import Hedgehog.Extras.Test.File qualified as H
 
 {- HLINT ignore "Use camelCase" -}
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Genesis/KeyGenDelegate.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Genesis/KeyGenDelegate.hs
@@ -2,11 +2,11 @@
 
 module Test.Golden.Shelley.Genesis.KeyGenDelegate where
 
-import           Control.Monad (void)
+import Control.Monad (void)
 
-import           Test.Cardano.CLI.Util
+import Test.Cardano.CLI.Util
 
-import           Hedgehog (Property)
+import Hedgehog (Property)
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 
@@ -18,16 +18,24 @@ hprop_golden_shelleyGenesisKeyGenDelegate = propertyOnce . H.moduleWorkspace "tm
   signingKeyFile <- noteTempFile tempDir "key-gen.skey"
   operationalCertificateIssueCounterFile <- noteTempFile tempDir "op-cert.counter"
 
-  void $ execCardanoCLI
-    [ "genesis","key-gen-delegate"
-    , "--verification-key-file", verificationKeyFile
-    , "--signing-key-file", signingKeyFile
-    , "--operational-certificate-issue-counter", operationalCertificateIssueCounterFile
-    ]
+  void $
+    execCardanoCLI
+      [ "genesis"
+      , "key-gen-delegate"
+      , "--verification-key-file"
+      , verificationKeyFile
+      , "--signing-key-file"
+      , signingKeyFile
+      , "--operational-certificate-issue-counter"
+      , operationalCertificateIssueCounterFile
+      ]
 
   H.assertFileOccurences 1 "GenesisDelegateVerificationKey_ed25519" verificationKeyFile
   H.assertFileOccurences 1 "GenesisDelegateSigningKey_ed25519" signingKeyFile
-  H.assertFileOccurences 1 "NodeOperationalCertificateIssueCounter" operationalCertificateIssueCounterFile
+  H.assertFileOccurences
+    1
+    "NodeOperationalCertificateIssueCounter"
+    operationalCertificateIssueCounterFile
 
   H.assertFileOccurences 1 "Genesis delegate operator key" verificationKeyFile
   H.assertFileOccurences 1 "Genesis delegate operator key" signingKeyFile

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Genesis/KeyGenDelegate.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Genesis/KeyGenDelegate.hs
@@ -7,8 +7,8 @@ import Control.Monad (void)
 import Test.Cardano.CLI.Util
 
 import Hedgehog (Property)
-import qualified Hedgehog.Extras.Test.Base as H
-import qualified Hedgehog.Extras.Test.File as H
+import Hedgehog.Extras.Test.Base qualified as H
+import Hedgehog.Extras.Test.File qualified as H
 
 {- HLINT ignore "Use camelCase" -}
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Genesis/KeyGenGenesis.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Genesis/KeyGenGenesis.hs
@@ -7,8 +7,8 @@ import Control.Monad (void)
 import Test.Cardano.CLI.Util
 
 import Hedgehog (Property)
-import qualified Hedgehog.Extras.Test.Base as H
-import qualified Hedgehog.Extras.Test.File as H
+import Hedgehog.Extras.Test.Base qualified as H
+import Hedgehog.Extras.Test.File qualified as H
 
 {- HLINT ignore "Use camelCase" -}
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Genesis/KeyGenGenesis.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Genesis/KeyGenGenesis.hs
@@ -2,11 +2,11 @@
 
 module Test.Golden.Shelley.Genesis.KeyGenGenesis where
 
-import           Control.Monad (void)
+import Control.Monad (void)
 
-import           Test.Cardano.CLI.Util
+import Test.Cardano.CLI.Util
 
-import           Hedgehog (Property)
+import Hedgehog (Property)
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 
@@ -17,11 +17,15 @@ hprop_golden_shelleyGenesisKeyGenGenesis = propertyOnce . H.moduleWorkspace "tmp
   verificationKeyFile <- noteTempFile tempDir "key-gen.vkey"
   signingKeyFile <- noteTempFile tempDir "key-gen.skey"
 
-  void $ execCardanoCLI
-    [ "genesis","key-gen-genesis"
-    , "--verification-key-file", verificationKeyFile
-    , "--signing-key-file", signingKeyFile
-    ]
+  void $
+    execCardanoCLI
+      [ "genesis"
+      , "key-gen-genesis"
+      , "--verification-key-file"
+      , verificationKeyFile
+      , "--signing-key-file"
+      , signingKeyFile
+      ]
 
   H.assertFileOccurences 1 "GenesisVerificationKey_ed25519" verificationKeyFile
   H.assertFileOccurences 1 "GenesisSigningKey_ed25519" signingKeyFile

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Genesis/KeyGenUtxo.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Genesis/KeyGenUtxo.hs
@@ -7,8 +7,8 @@ import Control.Monad (void)
 import Test.Cardano.CLI.Util
 
 import Hedgehog (Property)
-import qualified Hedgehog.Extras.Test.Base as H
-import qualified Hedgehog.Extras.Test.File as H
+import Hedgehog.Extras.Test.Base qualified as H
+import Hedgehog.Extras.Test.File qualified as H
 
 {- HLINT ignore "Use camelCase" -}
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Genesis/KeyGenUtxo.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Genesis/KeyGenUtxo.hs
@@ -2,11 +2,11 @@
 
 module Test.Golden.Shelley.Genesis.KeyGenUtxo where
 
-import           Control.Monad (void)
+import Control.Monad (void)
 
-import           Test.Cardano.CLI.Util
+import Test.Cardano.CLI.Util
 
-import           Hedgehog (Property)
+import Hedgehog (Property)
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 
@@ -17,11 +17,15 @@ hprop_golden_shelleyGenesisKeyGenUtxo = propertyOnce . H.moduleWorkspace "tmp" $
   utxoVerificationKeyFile <- noteTempFile tempDir "utxo.vkey"
   utxoSigningKeyFile <- noteTempFile tempDir "utxo.skey"
 
-  void $ execCardanoCLI
-    [ "genesis","key-gen-utxo"
-    , "--verification-key-file", utxoVerificationKeyFile
-    , "--signing-key-file", utxoSigningKeyFile
-    ]
+  void $
+    execCardanoCLI
+      [ "genesis"
+      , "key-gen-utxo"
+      , "--verification-key-file"
+      , utxoVerificationKeyFile
+      , "--signing-key-file"
+      , utxoSigningKeyFile
+      ]
 
   H.assertFileOccurences 1 "GenesisUTxOVerificationKey_ed25519" utxoVerificationKeyFile
   H.assertFileOccurences 1 "GenesisUTxOSigningKey_ed25519" utxoSigningKeyFile

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Genesis/KeyHash.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Genesis/KeyHash.hs
@@ -2,9 +2,9 @@
 
 module Test.Golden.Shelley.Genesis.KeyHash where
 
-import           Test.Cardano.CLI.Util as OP
+import Test.Cardano.CLI.Util as OP
 
-import           Hedgehog (Property, (===))
+import Hedgehog (Property, (===))
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 
@@ -12,14 +12,20 @@ import qualified Hedgehog.Extras.Test.File as H
 
 hprop_golden_shelleyGenesisKeyHash :: Property
 hprop_golden_shelleyGenesisKeyHash = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
-  referenceVerificationKey <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/genesis_keys/verification_key"
-  goldenGenesisVerificationKeyHashFile <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/genesis_keys/verification_key.key-hash"
+  referenceVerificationKey <-
+    noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/genesis_keys/verification_key"
+  goldenGenesisVerificationKeyHashFile <-
+    noteInputFile
+      "test/cardano-cli-golden/files/golden/shelley/keys/genesis_keys/verification_key.key-hash"
   genesisVerificationKeyHashFile <- noteTempFile tempDir "key-hash.hex"
 
-  genesisVerificationKeyHash <- execCardanoCLI
-    [ "genesis","key-hash"
-    , "--verification-key-file", referenceVerificationKey
-    ]
+  genesisVerificationKeyHash <-
+    execCardanoCLI
+      [ "genesis"
+      , "key-hash"
+      , "--verification-key-file"
+      , referenceVerificationKey
+      ]
 
   H.writeFile genesisVerificationKeyHashFile genesisVerificationKeyHash
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Genesis/KeyHash.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Genesis/KeyHash.hs
@@ -5,8 +5,8 @@ module Test.Golden.Shelley.Genesis.KeyHash where
 import Test.Cardano.CLI.Util as OP
 
 import Hedgehog (Property, (===))
-import qualified Hedgehog.Extras.Test.Base as H
-import qualified Hedgehog.Extras.Test.File as H
+import Hedgehog.Extras.Test.Base qualified as H
+import Hedgehog.Extras.Test.File qualified as H
 
 {- HLINT ignore "Use camelCase" -}
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Governance/AnswerPoll.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Governance/AnswerPoll.hs
@@ -2,11 +2,11 @@
 
 module Test.Golden.Shelley.Governance.AnswerPoll where
 
-import           Control.Monad (void)
+import Control.Monad (void)
 
-import           Test.Cardano.CLI.Util
+import Test.Cardano.CLI.Util
 
-import           Hedgehog (Property)
+import Hedgehog (Property)
 import qualified Hedgehog as H
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
@@ -19,12 +19,18 @@ hprop_golden_shelleyGovernanceAnswerPollNeg1Invalid = propertyOnce . H.moduleWor
   pollFile <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/governance/polls/basic.json"
   outFile <- H.noteTempFile tempDir "answer-file.json"
 
-  result <- tryExecCardanoCLI
-    [ "legacy", "governance", "answer-poll"
-    , "--poll-file", pollFile
-    , "--answer", "-1"
-    , "--out-file", outFile
-    ]
+  result <-
+    tryExecCardanoCLI
+      [ "legacy"
+      , "governance"
+      , "answer-poll"
+      , "--poll-file"
+      , pollFile
+      , "--answer"
+      , "-1"
+      , "--out-file"
+      , outFile
+      ]
 
   H.assertFileMissing outFile
 
@@ -33,30 +39,44 @@ hprop_golden_shelleyGovernanceAnswerPollNeg1Invalid = propertyOnce . H.moduleWor
 hprop_golden_shelleyGovernanceAnswerPoll0 :: Property
 hprop_golden_shelleyGovernanceAnswerPoll0 = propertyOnce . H.moduleWorkspace "governance-answer-poll" $ \tempDir -> do
   pollFile <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/governance/polls/basic.json"
-  expectedAnswerFile <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/governance/polls/basic.answer.0.json"
+  expectedAnswerFile <-
+    noteInputFile "test/cardano-cli-golden/files/golden/shelley/governance/polls/basic.answer.0.json"
   outFile <- H.noteTempFile tempDir "answer-file.json"
 
-  void $ execCardanoCLI
-    [ "legacy", "governance", "answer-poll"
-    , "--poll-file", pollFile
-    , "--answer", "0"
-    , "--out-file", outFile
-    ]
+  void $
+    execCardanoCLI
+      [ "legacy"
+      , "governance"
+      , "answer-poll"
+      , "--poll-file"
+      , pollFile
+      , "--answer"
+      , "0"
+      , "--out-file"
+      , outFile
+      ]
 
   H.diffFileVsGoldenFile outFile expectedAnswerFile
 
 hprop_golden_shelleyGovernanceAnswerPollPos1 :: Property
 hprop_golden_shelleyGovernanceAnswerPollPos1 = propertyOnce . H.moduleWorkspace "governance-answer-poll" $ \tempDir -> do
   pollFile <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/governance/polls/basic.json"
-  expectedAnswerFile <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/governance/polls/basic.answer.1.json"
+  expectedAnswerFile <-
+    noteInputFile "test/cardano-cli-golden/files/golden/shelley/governance/polls/basic.answer.1.json"
   outFile <- H.noteTempFile tempDir "answer-file.json"
 
-  void $ execCardanoCLI
-    [ "legacy", "governance", "answer-poll"
-    , "--poll-file", pollFile
-    , "--answer", "1"
-    , "--out-file", outFile
-    ]
+  void $
+    execCardanoCLI
+      [ "legacy"
+      , "governance"
+      , "answer-poll"
+      , "--poll-file"
+      , pollFile
+      , "--answer"
+      , "1"
+      , "--out-file"
+      , outFile
+      ]
 
   H.diffFileVsGoldenFile outFile expectedAnswerFile
 
@@ -65,12 +85,18 @@ hprop_golden_shelleyGovernanceAnswerPollPos2Invalid = propertyOnce . H.moduleWor
   pollFile <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/governance/polls/basic.json"
   outFile <- H.noteTempFile tempDir "answer-file.json"
 
-  result <- tryExecCardanoCLI
-    [ "legacy", "governance", "answer-poll"
-    , "--poll-file", pollFile
-    , "--answer", "2"
-    , "--out-file", outFile
-    ]
+  result <-
+    tryExecCardanoCLI
+      [ "legacy"
+      , "governance"
+      , "answer-poll"
+      , "--poll-file"
+      , pollFile
+      , "--answer"
+      , "2"
+      , "--out-file"
+      , outFile
+      ]
 
   H.assertFileMissing outFile
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Governance/AnswerPoll.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Governance/AnswerPoll.hs
@@ -7,10 +7,10 @@ import Control.Monad (void)
 import Test.Cardano.CLI.Util
 
 import Hedgehog (Property)
-import qualified Hedgehog as H
-import qualified Hedgehog.Extras.Test.Base as H
-import qualified Hedgehog.Extras.Test.File as H
-import qualified Hedgehog.Extras.Test.Golden as H
+import Hedgehog qualified as H
+import Hedgehog.Extras.Test.Base qualified as H
+import Hedgehog.Extras.Test.File qualified as H
+import Hedgehog.Extras.Test.Golden qualified as H
 
 {- HLINT ignore "Use camelCase" -}
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Governance/CreatePoll.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Governance/CreatePoll.hs
@@ -2,11 +2,11 @@
 
 module Test.Golden.Shelley.Governance.CreatePoll where
 
-import           Control.Monad (void)
+import Control.Monad (void)
 
-import           Test.Cardano.CLI.Util
+import Test.Cardano.CLI.Util
 
-import           Hedgehog (Property)
+import Hedgehog (Property)
 import qualified Hedgehog as H
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
@@ -18,13 +18,20 @@ hprop_golden_shelleyGovernanceCreatePoll =
   propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     pollFile <- noteTempFile tempDir "poll.json"
 
-    stdout <- execCardanoCLI
-      [ "legacy", "governance", "create-poll"
-      , "--question", "Pineapples on pizza?"
-      , "--answer", "yes"
-      , "--answer", "no"
-      , "--out-file", pollFile
-      ]
+    stdout <-
+      execCardanoCLI
+        [ "legacy"
+        , "governance"
+        , "create-poll"
+        , "--question"
+        , "Pineapples on pizza?"
+        , "--answer"
+        , "yes"
+        , "--answer"
+        , "no"
+        , "--out-file"
+        , pollFile
+        ]
 
     void $ H.readFile pollFile
     noteInputFile "test/cardano-cli-golden/files/golden/shelley/governance/create/basic.json"
@@ -38,13 +45,20 @@ hprop_golden_shelleyGovernanceCreateLongPoll =
   propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     pollFile <- noteTempFile tempDir "poll.json"
 
-    stdout <- execCardanoCLI
-      [ "legacy", "governance", "create-poll"
-      , "--question", "What is the most adequate topping to put on a pizza (please consider all possibilities and take time to answer)?"
-      , "--answer", "pineapples"
-      , "--answer", "only traditional topics should go on a pizza, this isn't room for jokes"
-      , "--out-file", pollFile
-      ]
+    stdout <-
+      execCardanoCLI
+        [ "legacy"
+        , "governance"
+        , "create-poll"
+        , "--question"
+        , "What is the most adequate topping to put on a pizza (please consider all possibilities and take time to answer)?"
+        , "--answer"
+        , "pineapples"
+        , "--answer"
+        , "only traditional topics should go on a pizza, this isn't room for jokes"
+        , "--out-file"
+        , pollFile
+        ]
 
     void $ H.readFile pollFile
     noteInputFile "test/cardano-cli-golden/files/golden/shelley/governance/create/long-text.json"

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Governance/CreatePoll.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Governance/CreatePoll.hs
@@ -7,9 +7,9 @@ import Control.Monad (void)
 import Test.Cardano.CLI.Util
 
 import Hedgehog (Property)
-import qualified Hedgehog as H
-import qualified Hedgehog.Extras.Test.Base as H
-import qualified Hedgehog.Extras.Test.File as H
+import Hedgehog qualified as H
+import Hedgehog.Extras.Test.Base qualified as H
+import Hedgehog.Extras.Test.File qualified as H
 
 {- HLINT ignore "Use camelCase" -}
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Governance/VerifyPoll.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Governance/VerifyPoll.hs
@@ -11,13 +11,13 @@ import Cardano.CLI.Types.Key
   )
 
 import Control.Monad.IO.Class (liftIO)
-import qualified Data.ByteString.Char8 as BSC
+import Data.ByteString.Char8 qualified as BSC
 
 import Test.Cardano.CLI.Util
 
 import Hedgehog (Property)
-import qualified Hedgehog as H
-import qualified Hedgehog.Internal.Property as H
+import Hedgehog qualified as H
+import Hedgehog.Internal.Property qualified as H
 
 {- HLINT ignore "Use camelCase" -}
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Governance/VerifyPoll.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Governance/VerifyPoll.hs
@@ -3,17 +3,19 @@
 
 module Test.Golden.Shelley.Governance.VerifyPoll where
 
-import           Cardano.Api
+import Cardano.Api
 
-import           Cardano.CLI.Types.Key (VerificationKeyOrFile (..),
-                   readVerificationKeyOrTextEnvFile)
+import Cardano.CLI.Types.Key
+  ( VerificationKeyOrFile (..)
+  , readVerificationKeyOrTextEnvFile
+  )
 
-import           Control.Monad.IO.Class (liftIO)
+import Control.Monad.IO.Class (liftIO)
 import qualified Data.ByteString.Char8 as BSC
 
-import           Test.Cardano.CLI.Util
+import Test.Cardano.CLI.Util
 
-import           Hedgehog (Property)
+import Hedgehog (Property)
 import qualified Hedgehog as H
 import qualified Hedgehog.Internal.Property as H
 
@@ -23,14 +25,21 @@ hprop_golden_shelleyGovernanceVerifyPoll :: Property
 hprop_golden_shelleyGovernanceVerifyPoll = propertyOnce $ do
   pollFile <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/governance/polls/basic.json"
   txFile <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/governance/verify/valid"
-  vkFile <- VerificationKeyFilePath . File <$>
-    noteInputFile "test/cardano-cli-golden/files/golden/shelley/governance/cold.vk"
+  vkFile <-
+    VerificationKeyFilePath . File
+      <$> noteInputFile "test/cardano-cli-golden/files/golden/shelley/governance/cold.vk"
 
-  stdout <- BSC.pack <$> execCardanoCLI
-    [ "legacy", "governance", "verify-poll"
-    , "--poll-file", pollFile
-    , "--tx-file", txFile
-    ]
+  stdout <-
+    BSC.pack
+      <$> execCardanoCLI
+        [ "legacy"
+        , "governance"
+        , "verify-poll"
+        , "--poll-file"
+        , pollFile
+        , "--tx-file"
+        , txFile
+        ]
 
   liftIO (readVerificationKeyOrTextEnvFile AsStakePoolKey vkFile) >>= \case
     Left e ->
@@ -44,11 +53,16 @@ hprop_golden_shelleyGovernanceVerifyPollMismatch = propertyOnce $ do
   pollFile <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/governance/polls/basic.json"
   txFile <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/governance/verify/mismatch"
 
-  result <- tryExecCardanoCLI
-    [ "legacy", "governance", "verify-poll"
-    , "--poll-file", pollFile
-    , "--tx-file", txFile
-    ]
+  result <-
+    tryExecCardanoCLI
+      [ "legacy"
+      , "governance"
+      , "verify-poll"
+      , "--poll-file"
+      , pollFile
+      , "--tx-file"
+      , txFile
+      ]
 
   either (const H.success) (H.failWith Nothing) result
 
@@ -57,11 +71,16 @@ hprop_golden_shelleyGovernanceVerifyPollNoAnswer = propertyOnce $ do
   pollFile <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/governance/polls/basic.json"
   txFile <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/governance/verify/none"
 
-  result <- tryExecCardanoCLI
-    [ "legacy", "governance", "verify-poll"
-    , "--poll-file", pollFile
-    , "--tx-file", txFile
-    ]
+  result <-
+    tryExecCardanoCLI
+      [ "legacy"
+      , "governance"
+      , "verify-poll"
+      , "--poll-file"
+      , pollFile
+      , "--tx-file"
+      , txFile
+      ]
 
   either (const H.success) (H.failWith Nothing) result
 
@@ -70,11 +89,16 @@ hprop_golden_shelleyGovernanceVerifyPollMalformedAnswer = propertyOnce $ do
   pollFile <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/governance/polls/basic.json"
   txFile <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/governance/verify/malformed"
 
-  result <- tryExecCardanoCLI
-    [ "legacy", "governance", "verify-poll"
-    , "--poll-file", pollFile
-    , "--tx-file", txFile
-    ]
+  result <-
+    tryExecCardanoCLI
+      [ "legacy"
+      , "governance"
+      , "verify-poll"
+      , "--poll-file"
+      , pollFile
+      , "--tx-file"
+      , txFile
+      ]
 
   either (const H.success) (H.failWith Nothing) result
 
@@ -83,10 +107,15 @@ hprop_golden_shelleyGovernanceVerifyPollInvalidAnswer = propertyOnce $ do
   pollFile <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/governance/polls/basic.json"
   txFile <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/governance/verify/invalid"
 
-  result <- tryExecCardanoCLI
-    [ "legacy", "governance", "verify-poll"
-    , "--poll-file", pollFile
-    , "--tx-file", txFile
-    ]
+  result <-
+    tryExecCardanoCLI
+      [ "legacy"
+      , "governance"
+      , "verify-poll"
+      , "--poll-file"
+      , pollFile
+      , "--tx-file"
+      , txFile
+      ]
 
   either (const H.success) (H.failWith Nothing) result

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Key/ConvertCardanoAddressKey.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Key/ConvertCardanoAddressKey.hs
@@ -2,12 +2,12 @@
 
 module Test.Golden.Shelley.Key.ConvertCardanoAddressKey where
 
-import           Control.Monad (void)
-import           Data.Text (Text)
+import Control.Monad (void)
+import Data.Text (Text)
 
-import           Test.Cardano.CLI.Util
+import Test.Cardano.CLI.Util
 
-import           Hedgehog (Property, (===))
+import Hedgehog (Property, (===))
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 
@@ -42,7 +42,6 @@ exampleShelleySigningKey =
 hprop_golden_convertCardanoAddressByronSigningKey :: Property
 hprop_golden_convertCardanoAddressByronSigningKey =
   propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
-
     -- `cardano-address` signing key filepath
     signingKeyFp <- noteTempFile tempDir "cardano-address-byron.skey"
 
@@ -55,12 +54,16 @@ hprop_golden_convertCardanoAddressByronSigningKey =
     H.assertFilesExist [signingKeyFp]
 
     -- Convert the `cardano-address` signing key
-    void $ execCardanoCLI
-      [ "key","convert-cardano-address-key"
-      , "--byron-payment-key"
-      , "--signing-key-file", signingKeyFp
-      , "--out-file", convertedSigningKeyFp
-      ]
+    void $
+      execCardanoCLI
+        [ "key"
+        , "convert-cardano-address-key"
+        , "--byron-payment-key"
+        , "--signing-key-file"
+        , signingKeyFp
+        , "--out-file"
+        , convertedSigningKeyFp
+        ]
 
     -- Check for existence of the converted signing key file
     H.assertFilesExist [convertedSigningKeyFp]
@@ -79,7 +82,6 @@ hprop_golden_convertCardanoAddressByronSigningKey =
 hprop_golden_convertCardanoAddressIcarusSigningKey :: Property
 hprop_golden_convertCardanoAddressIcarusSigningKey =
   propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
-
     -- `cardano-address` signing key filepath
     signingKeyFp <- H.noteTempFile tempDir "cardano-address-icarus.skey"
 
@@ -92,12 +94,16 @@ hprop_golden_convertCardanoAddressIcarusSigningKey =
     H.assertFilesExist [signingKeyFp]
 
     -- Convert the `cardano-address` signing key
-    void $ execCardanoCLI
-      [ "key","convert-cardano-address-key"
-      , "--icarus-payment-key"
-      , "--signing-key-file", signingKeyFp
-      , "--out-file", convertedSigningKeyFp
-      ]
+    void $
+      execCardanoCLI
+        [ "key"
+        , "convert-cardano-address-key"
+        , "--icarus-payment-key"
+        , "--signing-key-file"
+        , signingKeyFp
+        , "--out-file"
+        , convertedSigningKeyFp
+        ]
 
     -- Check for existence of the converted signing key file
     H.assertFilesExist [convertedSigningKeyFp]
@@ -116,7 +122,6 @@ hprop_golden_convertCardanoAddressIcarusSigningKey =
 hprop_golden_convertCardanoAddressShelleyPaymentSigningKey :: Property
 hprop_golden_convertCardanoAddressShelleyPaymentSigningKey =
   propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
-
     -- `cardano-address` signing key filepath
     signingKeyFp <-
       noteTempFile tempDir "cardano-address-shelley-payment.skey"
@@ -130,12 +135,16 @@ hprop_golden_convertCardanoAddressShelleyPaymentSigningKey =
     H.assertFilesExist [signingKeyFp]
 
     -- Convert the `cardano-address` signing key
-    void $ execCardanoCLI
-      [ "key","convert-cardano-address-key"
-      , "--shelley-payment-key"
-      , "--signing-key-file", signingKeyFp
-      , "--out-file", convertedSigningKeyFp
-      ]
+    void $
+      execCardanoCLI
+        [ "key"
+        , "convert-cardano-address-key"
+        , "--shelley-payment-key"
+        , "--signing-key-file"
+        , signingKeyFp
+        , "--out-file"
+        , convertedSigningKeyFp
+        ]
 
     -- Check for existence of the converted signing key file
     H.assertFilesExist [convertedSigningKeyFp]
@@ -154,7 +163,6 @@ hprop_golden_convertCardanoAddressShelleyPaymentSigningKey =
 hprop_golden_convertCardanoAddressShelleyStakeSigningKey :: Property
 hprop_golden_convertCardanoAddressShelleyStakeSigningKey =
   propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
-
     -- `cardano-address` signing key filepath
     signingKeyFp <-
       noteTempFile tempDir "cardano-address-shelley-stake.skey"
@@ -168,12 +176,16 @@ hprop_golden_convertCardanoAddressShelleyStakeSigningKey =
     H.assertFilesExist [signingKeyFp]
 
     -- Convert the `cardano-address` signing key
-    void $ execCardanoCLI
-      [ "key","convert-cardano-address-key"
-      , "--shelley-stake-key"
-      , "--signing-key-file", signingKeyFp
-      , "--out-file", convertedSigningKeyFp
-      ]
+    void $
+      execCardanoCLI
+        [ "key"
+        , "convert-cardano-address-key"
+        , "--shelley-stake-key"
+        , "--signing-key-file"
+        , signingKeyFp
+        , "--out-file"
+        , convertedSigningKeyFp
+        ]
 
     -- Check for existence of the converted signing key file
     H.assertFilesExist [convertedSigningKeyFp]

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Key/ConvertCardanoAddressKey.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Key/ConvertCardanoAddressKey.hs
@@ -8,8 +8,8 @@ import Data.Text (Text)
 import Test.Cardano.CLI.Util
 
 import Hedgehog (Property, (===))
-import qualified Hedgehog.Extras.Test.Base as H
-import qualified Hedgehog.Extras.Test.File as H
+import Hedgehog.Extras.Test.Base qualified as H
+import Hedgehog.Extras.Test.File qualified as H
 
 {- HLINT ignore "Use camelCase" -}
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Metadata/StakePoolMetadata.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Metadata/StakePoolMetadata.hs
@@ -2,13 +2,13 @@
 
 module Test.Golden.Shelley.Metadata.StakePoolMetadata where
 
-import           Control.Monad (void)
-import           Data.Text (Text)
+import Control.Monad (void)
+import Data.Text (Text)
 import qualified Data.Text.IO as Text
 
-import           Test.Cardano.CLI.Util as OP
+import Test.Cardano.CLI.Util as OP
 
-import           Hedgehog (Property)
+import Hedgehog (Property)
 import qualified Hedgehog as H
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
@@ -17,7 +17,8 @@ import qualified Hedgehog.Extras.Test.File as H
 
 hprop_golden_stakePoolMetadataHash :: Property
 hprop_golden_stakePoolMetadataHash = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
-  referenceStakePoolMetadata <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/metadata/stake_pool_metadata_hash"
+  referenceStakePoolMetadata <-
+    noteInputFile "test/cardano-cli-golden/files/golden/shelley/metadata/stake_pool_metadata_hash"
 
   stakePoolMetadataFile <- noteTempFile tempDir "stake-pool-metadata.json"
   outputStakePoolMetadataHashFp <- noteTempFile tempDir "stake-pool-metadata-hash.txt"
@@ -26,17 +27,22 @@ hprop_golden_stakePoolMetadataHash = propertyOnce . H.moduleWorkspace "tmp" $ \t
   H.evalIO $ Text.writeFile stakePoolMetadataFile exampleStakePoolMetadata
 
   -- Hash the stake pool metadata
-  void $ execCardanoCLI
-    [ "stake-pool","metadata-hash"
-    , "--pool-metadata-file", stakePoolMetadataFile
-    , "--out-file", outputStakePoolMetadataHashFp
-    ]
+  void $
+    execCardanoCLI
+      [ "stake-pool"
+      , "metadata-hash"
+      , "--pool-metadata-file"
+      , stakePoolMetadataFile
+      , "--out-file"
+      , outputStakePoolMetadataHashFp
+      ]
 
   -- Check that the stake pool metadata hash file content is correct.
   expectedStakePoolMetadataHash <- H.readFile referenceStakePoolMetadata
   actualStakePoolMetadataHash <- H.readFile outputStakePoolMetadataHashFp
 
   equivalence expectedStakePoolMetadataHash actualStakePoolMetadataHash
-  where
-    exampleStakePoolMetadata :: Text
-    exampleStakePoolMetadata = "{\"homepage\":\"https://iohk.io\",\"name\":\"Genesis Pool C\",\"ticker\":\"GPC\",\"description\":\"Lorem Ipsum Dolor Sit Amet.\"}"
+ where
+  exampleStakePoolMetadata :: Text
+  exampleStakePoolMetadata =
+    "{\"homepage\":\"https://iohk.io\",\"name\":\"Genesis Pool C\",\"ticker\":\"GPC\",\"description\":\"Lorem Ipsum Dolor Sit Amet.\"}"

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Metadata/StakePoolMetadata.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Metadata/StakePoolMetadata.hs
@@ -4,14 +4,14 @@ module Test.Golden.Shelley.Metadata.StakePoolMetadata where
 
 import Control.Monad (void)
 import Data.Text (Text)
-import qualified Data.Text.IO as Text
+import Data.Text.IO qualified as Text
 
 import Test.Cardano.CLI.Util as OP
 
 import Hedgehog (Property)
-import qualified Hedgehog as H
-import qualified Hedgehog.Extras.Test.Base as H
-import qualified Hedgehog.Extras.Test.File as H
+import Hedgehog qualified as H
+import Hedgehog.Extras.Test.Base qualified as H
+import Hedgehog.Extras.Test.File qualified as H
 
 {- HLINT ignore "Use camelCase" -}
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/MultiSig/Address.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/MultiSig/Address.hs
@@ -5,8 +5,8 @@ module Test.Golden.Shelley.MultiSig.Address where
 import Test.Cardano.CLI.Util as OP
 
 import Hedgehog (Property)
-import qualified Hedgehog.Extras.Test.Base as H
-import qualified Hedgehog.Extras.Test.File as H
+import Hedgehog.Extras.Test.Base qualified as H
+import Hedgehog.Extras.Test.File qualified as H
 
 {- HLINT ignore "Use camelCase" -}
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/MultiSig/Address.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/MultiSig/Address.hs
@@ -2,9 +2,9 @@
 
 module Test.Golden.Shelley.MultiSig.Address where
 
-import           Test.Cardano.CLI.Util as OP
+import Test.Cardano.CLI.Util as OP
 
-import           Hedgehog (Property)
+import Hedgehog (Property)
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 
@@ -14,13 +14,17 @@ hprop_golden_shelleyAllMultiSigAddressBuild :: Property
 hprop_golden_shelleyAllMultiSigAddressBuild = propertyOnce . H.moduleWorkspace "tmp" $ \_ -> do
   allMultiSigFp <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/multisig/scripts/all"
 
-  allMultiSigAddress <- execCardanoCLI
-    [ "address", "build"
-    , "--payment-script-file", allMultiSigFp
-    , "--mainnet"
-    ]
+  allMultiSigAddress <-
+    execCardanoCLI
+      [ "address"
+      , "build"
+      , "--payment-script-file"
+      , allMultiSigFp
+      , "--mainnet"
+      ]
 
-  goldenAllMultiSigAddrFp <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/multisig/addresses/all"
+  goldenAllMultiSigAddrFp <-
+    noteInputFile "test/cardano-cli-golden/files/golden/shelley/multisig/addresses/all"
 
   goldenAllMs <- H.readFile goldenAllMultiSigAddrFp
 
@@ -30,13 +34,17 @@ hprop_golden_shelleyAnyMultiSigAddressBuild :: Property
 hprop_golden_shelleyAnyMultiSigAddressBuild = propertyOnce . H.moduleWorkspace "tmp" $ \_ -> do
   anyMultiSigFp <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/multisig/scripts/any"
 
-  anyMultiSigAddress <- execCardanoCLI
-    [ "address", "build"
-    , "--payment-script-file", anyMultiSigFp
-    , "--mainnet"
-    ]
+  anyMultiSigAddress <-
+    execCardanoCLI
+      [ "address"
+      , "build"
+      , "--payment-script-file"
+      , anyMultiSigFp
+      , "--mainnet"
+      ]
 
-  goldenAnyMultiSigAddrFp <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/multisig/addresses/any"
+  goldenAnyMultiSigAddrFp <-
+    noteInputFile "test/cardano-cli-golden/files/golden/shelley/multisig/addresses/any"
 
   goldenAnyMs <- H.readFile goldenAnyMultiSigAddrFp
 
@@ -44,15 +52,20 @@ hprop_golden_shelleyAnyMultiSigAddressBuild = propertyOnce . H.moduleWorkspace "
 
 hprop_golden_shelleyAtLeastMultiSigAddressBuild :: Property
 hprop_golden_shelleyAtLeastMultiSigAddressBuild = propertyOnce . H.moduleWorkspace "tmp" $ \_ -> do
-  atLeastMultiSigFp <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/multisig/scripts/atleast"
+  atLeastMultiSigFp <-
+    noteInputFile "test/cardano-cli-golden/files/golden/shelley/multisig/scripts/atleast"
 
-  atLeastMultiSigAddress <- execCardanoCLI
-    [ "address", "build"
-    , "--payment-script-file", atLeastMultiSigFp
-    , "--mainnet"
-    ]
+  atLeastMultiSigAddress <-
+    execCardanoCLI
+      [ "address"
+      , "build"
+      , "--payment-script-file"
+      , atLeastMultiSigFp
+      , "--mainnet"
+      ]
 
-  goldenAtLeastMultiSigAddrFp <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/multisig/addresses/atleast"
+  goldenAtLeastMultiSigAddrFp <-
+    noteInputFile "test/cardano-cli-golden/files/golden/shelley/multisig/addresses/atleast"
 
   goldenAtLeastMs <- H.readFile goldenAtLeastMultiSigAddrFp
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Node/IssueOpCert.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Node/IssueOpCert.hs
@@ -7,8 +7,8 @@ import Control.Monad (void)
 import Test.Cardano.CLI.Util
 
 import Hedgehog (Property)
-import qualified Hedgehog.Extras.Test.Base as H
-import qualified Hedgehog.Extras.Test.File as H
+import Hedgehog.Extras.Test.Base qualified as H
+import Hedgehog.Extras.Test.File qualified as H
 
 {- HLINT ignore "Use camelCase" -}
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Node/IssueOpCert.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Node/IssueOpCert.hs
@@ -2,11 +2,11 @@
 
 module Test.Golden.Shelley.Node.IssueOpCert where
 
-import           Control.Monad (void)
+import Control.Monad (void)
 
-import           Test.Cardano.CLI.Util
+import Test.Cardano.CLI.Util
 
-import           Hedgehog (Property)
+import Hedgehog (Property)
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 
@@ -14,9 +14,13 @@ import qualified Hedgehog.Extras.Test.File as H
 
 hprop_golden_shelleyNodeIssueOpCert :: Property
 hprop_golden_shelleyNodeIssueOpCert = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
-  hotKesVerificationKeyFile <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/kes_keys/verification_key"
-  coldSigningKeyFile <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/genesis_delegate_keys/signing_key"
-  originalOperationalCertificateIssueCounterFile <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/genesis_delegate_keys/operational_certificate_counter"
+  hotKesVerificationKeyFile <-
+    noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/kes_keys/verification_key"
+  coldSigningKeyFile <-
+    noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/genesis_delegate_keys/signing_key"
+  originalOperationalCertificateIssueCounterFile <-
+    noteInputFile
+      "test/cardano-cli-golden/files/golden/shelley/keys/genesis_delegate_keys/operational_certificate_counter"
   operationalCertificateIssueCounterFile <- noteTempFile tempDir "delegate-op-cert.counter"
   operationalCertFile <- noteTempFile tempDir "operational.cert"
 
@@ -28,14 +32,21 @@ hprop_golden_shelleyNodeIssueOpCert = propertyOnce . H.moduleWorkspace "tmp" $ \
   --    cabal run cardano-cli:cardano-cli -- shelley node key-gen-KES \
   --        --verification-key-file cardano-cli/test/cli/node-issue-op-cert/data/node-kes.vkey \
   --        --signing-key-file /dev/null
-  void $ execCardanoCLI
-    [ "node","issue-op-cert"
-    , "--hot-kes-verification-key-file", hotKesVerificationKeyFile
-    , "--cold-signing-key-file", coldSigningKeyFile
-    , "--operational-certificate-issue-counter", operationalCertificateIssueCounterFile
-    , "--kes-period", "0"
-    , "--out-file", operationalCertFile
-    ]
+  void $
+    execCardanoCLI
+      [ "node"
+      , "issue-op-cert"
+      , "--hot-kes-verification-key-file"
+      , hotKesVerificationKeyFile
+      , "--cold-signing-key-file"
+      , coldSigningKeyFile
+      , "--operational-certificate-issue-counter"
+      , operationalCertificateIssueCounterFile
+      , "--kes-period"
+      , "0"
+      , "--out-file"
+      , operationalCertFile
+      ]
 
   H.assertFileOccurences 1 "NodeOperationalCertificate" operationalCertFile
   H.assertFileOccurences 1 "Next certificate issue number: 1" operationalCertificateIssueCounterFile

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Node/KeyGen.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Node/KeyGen.hs
@@ -1,13 +1,13 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 module Test.Golden.Shelley.Node.KeyGen
-   where
+where
 
-import           Control.Monad (void)
+import Control.Monad (void)
 
-import           Test.Cardano.CLI.Util
+import Test.Cardano.CLI.Util
 
-import           Hedgehog (Property)
+import Hedgehog (Property)
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 
@@ -19,12 +19,17 @@ hprop_golden_shelleyNodeKeyGen = propertyOnce . H.moduleWorkspace "tmp" $ \tempD
   signingKeyFile <- noteTempFile tempDir "key-gen.skey"
   opCertCounterFile <- noteTempFile tempDir "op-cert.counter"
 
-  void $ execCardanoCLI
-    [ "node","key-gen"
-    , "--verification-key-file", verificationKeyFile
-    , "--signing-key-file", signingKeyFile
-    , "--operational-certificate-issue-counter", opCertCounterFile
-    ]
+  void $
+    execCardanoCLI
+      [ "node"
+      , "key-gen"
+      , "--verification-key-file"
+      , verificationKeyFile
+      , "--signing-key-file"
+      , signingKeyFile
+      , "--operational-certificate-issue-counter"
+      , opCertCounterFile
+      ]
 
   H.assertFileOccurences 1 "StakePoolVerificationKey_ed25519" verificationKeyFile
   H.assertFileOccurences 1 "StakePoolSigningKey_ed25519" signingKeyFile
@@ -40,12 +45,17 @@ hprop_golden_shelleyNodeKeyGen_te = propertyOnce . H.moduleWorkspace "tmp" $ \te
   signingKeyFile <- noteTempFile tempDir "key-gen.skey"
   opCertCounterFile <- noteTempFile tempDir "op-cert.counter"
 
-  void $ execCardanoCLI
-    [ "node","key-gen"
-    , "--verification-key-file", verificationKeyFile
-    , "--signing-key-file", signingKeyFile
-    , "--operational-certificate-issue-counter", opCertCounterFile
-    ]
+  void $
+    execCardanoCLI
+      [ "node"
+      , "key-gen"
+      , "--verification-key-file"
+      , verificationKeyFile
+      , "--signing-key-file"
+      , signingKeyFile
+      , "--operational-certificate-issue-counter"
+      , opCertCounterFile
+      ]
 
   H.assertFileOccurences 1 "StakePoolVerificationKey_ed25519" verificationKeyFile
   H.assertFileOccurences 1 "StakePoolSigningKey_ed25519" signingKeyFile
@@ -61,13 +71,19 @@ hprop_golden_shelleyNodeKeyGen_bech32 = propertyOnce . H.moduleWorkspace "tmp" $
   signingKeyFile <- noteTempFile tempDir "key-gen.skey"
   opCertCounterFile <- noteTempFile tempDir "op-cert.counter"
 
-  void $ execCardanoCLI
-    [ "node","key-gen"
-    , "--key-output-format", "bech32"
-    , "--verification-key-file", verificationKeyFile
-    , "--signing-key-file", signingKeyFile
-    , "--operational-certificate-issue-counter", opCertCounterFile
-    ]
+  void $
+    execCardanoCLI
+      [ "node"
+      , "key-gen"
+      , "--key-output-format"
+      , "bech32"
+      , "--verification-key-file"
+      , verificationKeyFile
+      , "--signing-key-file"
+      , signingKeyFile
+      , "--operational-certificate-issue-counter"
+      , opCertCounterFile
+      ]
 
   H.assertFileOccurences 1 "pool_vk" verificationKeyFile
   H.assertFileOccurences 1 "pool_sk" signingKeyFile

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Node/KeyGen.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Node/KeyGen.hs
@@ -8,8 +8,8 @@ import Control.Monad (void)
 import Test.Cardano.CLI.Util
 
 import Hedgehog (Property)
-import qualified Hedgehog.Extras.Test.Base as H
-import qualified Hedgehog.Extras.Test.File as H
+import Hedgehog.Extras.Test.Base qualified as H
+import Hedgehog.Extras.Test.File qualified as H
 
 {- HLINT ignore "Use camelCase" -}
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Node/KeyGenKes.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Node/KeyGenKes.hs
@@ -7,8 +7,8 @@ import Control.Monad (void)
 import Test.Cardano.CLI.Util
 
 import Hedgehog (Property)
-import qualified Hedgehog.Extras.Test.Base as H
-import qualified Hedgehog.Extras.Test.File as H
+import Hedgehog.Extras.Test.Base qualified as H
+import Hedgehog.Extras.Test.File qualified as H
 
 {- HLINT ignore "Use camelCase" -}
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Node/KeyGenKes.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Node/KeyGenKes.hs
@@ -2,11 +2,11 @@
 
 module Test.Golden.Shelley.Node.KeyGenKes where
 
-import           Control.Monad (void)
+import Control.Monad (void)
 
-import           Test.Cardano.CLI.Util
+import Test.Cardano.CLI.Util
 
-import           Hedgehog (Property)
+import Hedgehog (Property)
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 
@@ -17,11 +17,15 @@ hprop_golden_shelleyNodeKeyGenKes = propertyOnce . H.moduleWorkspace "tmp" $ \te
   verificationKey <- noteTempFile tempDir "kes.vkey"
   signingKey <- noteTempFile tempDir "kes.skey"
 
-  void $ execCardanoCLI
-    [ "node","key-gen-KES"
-    , "--verification-key-file", verificationKey
-    , "--signing-key-file", signingKey
-    ]
+  void $
+    execCardanoCLI
+      [ "node"
+      , "key-gen-KES"
+      , "--verification-key-file"
+      , verificationKey
+      , "--signing-key-file"
+      , signingKey
+      ]
 
   H.assertFileOccurences 1 "KesVerificationKey_ed25519_kes_2^6" verificationKey
   H.assertFileOccurences 1 "KesSigningKey_ed25519_kes_2^6" signingKey
@@ -34,12 +38,17 @@ hprop_golden_shelleyNodeKeyGenKes_te = propertyOnce . H.moduleWorkspace "tmp" $ 
   verificationKey <- noteTempFile tempDir "kes.vkey"
   signingKey <- noteTempFile tempDir "kes.skey"
 
-  void $ execCardanoCLI
-    [ "node","key-gen-KES"
-    , "--key-output-format", "text-envelope"
-    , "--verification-key-file", verificationKey
-    , "--signing-key-file", signingKey
-    ]
+  void $
+    execCardanoCLI
+      [ "node"
+      , "key-gen-KES"
+      , "--key-output-format"
+      , "text-envelope"
+      , "--verification-key-file"
+      , verificationKey
+      , "--signing-key-file"
+      , signingKey
+      ]
 
   H.assertFileOccurences 1 "KesVerificationKey_ed25519_kes_2^6" verificationKey
   H.assertFileOccurences 1 "KesSigningKey_ed25519_kes_2^6" signingKey
@@ -52,12 +61,17 @@ hprop_golden_shelleyNodeKeyGenKes_bech32 = propertyOnce . H.moduleWorkspace "tmp
   verificationKey <- noteTempFile tempDir "kes.vkey"
   signingKey <- noteTempFile tempDir "kes.skey"
 
-  void $ execCardanoCLI
-    [ "node","key-gen-KES"
-    , "--key-output-format", "bech32"
-    , "--verification-key-file", verificationKey
-    , "--signing-key-file", signingKey
-    ]
+  void $
+    execCardanoCLI
+      [ "node"
+      , "key-gen-KES"
+      , "--key-output-format"
+      , "bech32"
+      , "--verification-key-file"
+      , verificationKey
+      , "--signing-key-file"
+      , signingKey
+      ]
 
   H.assertFileOccurences 1 "kes_vk" verificationKey
   H.assertFileOccurences 1 "kes_sk" signingKey

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Node/KeyGenVrf.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Node/KeyGenVrf.hs
@@ -7,8 +7,8 @@ import Control.Monad (void)
 import Test.Cardano.CLI.Util
 
 import Hedgehog (Property)
-import qualified Hedgehog.Extras.Test.Base as H
-import qualified Hedgehog.Extras.Test.File as H
+import Hedgehog.Extras.Test.Base qualified as H
+import Hedgehog.Extras.Test.File qualified as H
 
 {- HLINT ignore "Use camelCase" -}
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Node/KeyGenVrf.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Node/KeyGenVrf.hs
@@ -2,11 +2,11 @@
 
 module Test.Golden.Shelley.Node.KeyGenVrf where
 
-import           Control.Monad (void)
+import Control.Monad (void)
 
-import           Test.Cardano.CLI.Util
+import Test.Cardano.CLI.Util
 
-import           Hedgehog (Property)
+import Hedgehog (Property)
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 
@@ -17,11 +17,15 @@ hprop_golden_shelleyNodeKeyGenVrf = propertyOnce . H.moduleWorkspace "tmp" $ \te
   verificationKey <- noteTempFile tempDir "kes.vkey"
   signingKey <- noteTempFile tempDir "kes.skey"
 
-  void $ execCardanoCLI
-    [ "node","key-gen-VRF"
-    , "--verification-key-file", verificationKey
-    , "--signing-key-file", signingKey
-    ]
+  void $
+    execCardanoCLI
+      [ "node"
+      , "key-gen-VRF"
+      , "--verification-key-file"
+      , verificationKey
+      , "--signing-key-file"
+      , signingKey
+      ]
 
   H.assertFileOccurences 1 "VRF Verification Key" verificationKey
   H.assertFileOccurences 1 "VRF Signing Key" signingKey
@@ -34,12 +38,17 @@ hprop_golden_shelleyNodeKeyGenVrf_te = propertyOnce . H.moduleWorkspace "tmp" $ 
   verificationKey <- noteTempFile tempDir "kes.vkey"
   signingKey <- noteTempFile tempDir "kes.skey"
 
-  void $ execCardanoCLI
-    [ "node","key-gen-VRF"
-    , "--key-output-format", "text-envelope"
-    , "--verification-key-file", verificationKey
-    , "--signing-key-file", signingKey
-    ]
+  void $
+    execCardanoCLI
+      [ "node"
+      , "key-gen-VRF"
+      , "--key-output-format"
+      , "text-envelope"
+      , "--verification-key-file"
+      , verificationKey
+      , "--signing-key-file"
+      , signingKey
+      ]
 
   H.assertFileOccurences 1 "VRF Verification Key" verificationKey
   H.assertFileOccurences 1 "VRF Signing Key" signingKey
@@ -52,12 +61,17 @@ hprop_golden_shelleyNodeKeyGenVrf_bech32 = propertyOnce . H.moduleWorkspace "tmp
   verificationKey <- noteTempFile tempDir "kes.vkey"
   signingKey <- noteTempFile tempDir "kes.skey"
 
-  void $ execCardanoCLI
-    [ "node","key-gen-VRF"
-    , "--key-output-format", "bech32"
-    , "--verification-key-file", verificationKey
-    , "--signing-key-file", signingKey
-    ]
+  void $
+    execCardanoCLI
+      [ "node"
+      , "key-gen-VRF"
+      , "--key-output-format"
+      , "bech32"
+      , "--verification-key-file"
+      , verificationKey
+      , "--signing-key-file"
+      , signingKey
+      ]
 
   H.assertFileOccurences 1 "vrf_vk" verificationKey
   H.assertFileOccurences 1 "vrf_sk" signingKey

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/StakeAddress/Build.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/StakeAddress/Build.hs
@@ -5,8 +5,8 @@ module Test.Golden.Shelley.StakeAddress.Build where
 import Test.Cardano.CLI.Util as OP
 
 import Hedgehog (Property)
-import qualified Hedgehog.Extras.Test.Base as H
-import qualified Hedgehog.Extras.Test.File as H
+import Hedgehog.Extras.Test.Base qualified as H
+import Hedgehog.Extras.Test.File qualified as H
 
 {- HLINT ignore "Use camelCase" -}
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/StakeAddress/Build.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/StakeAddress/Build.hs
@@ -2,9 +2,9 @@
 
 module Test.Golden.Shelley.StakeAddress.Build where
 
-import           Test.Cardano.CLI.Util as OP
+import Test.Cardano.CLI.Util as OP
 
-import           Hedgehog (Property)
+import Hedgehog (Property)
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 
@@ -12,14 +12,19 @@ import qualified Hedgehog.Extras.Test.File as H
 
 hprop_golden_shelleyStakeAddressBuild :: Property
 hprop_golden_shelleyStakeAddressBuild = propertyOnce . H.moduleWorkspace "tmp" $ \_ -> do
-  verificationKeyFile <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/stake_keys/verification_key"
-  goldenRewardAddressFile <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/stake_keys/reward_address"
+  verificationKeyFile <-
+    noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/stake_keys/verification_key"
+  goldenRewardAddressFile <-
+    noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/stake_keys/reward_address"
 
-  rewardAddress <- execCardanoCLI
-    [ "stake-address","build"
-    , "--mainnet"
-    , "--staking-verification-key-file", verificationKeyFile
-    ]
+  rewardAddress <-
+    execCardanoCLI
+      [ "stake-address"
+      , "build"
+      , "--mainnet"
+      , "--staking-verification-key-file"
+      , verificationKeyFile
+      ]
 
   goldenRewardsAddress <- H.readFile goldenRewardAddressFile
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/StakeAddress/DeregistrationCertificate.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/StakeAddress/DeregistrationCertificate.hs
@@ -2,12 +2,12 @@
 
 module Test.Golden.Shelley.StakeAddress.DeregistrationCertificate where
 
-import           Control.Monad (void)
-import           System.FilePath ((</>))
+import Control.Monad (void)
+import System.FilePath ((</>))
 
-import           Test.Cardano.CLI.Util
+import Test.Cardano.CLI.Util
 
-import           Hedgehog (Property)
+import Hedgehog (Property)
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 import qualified Hedgehog.Extras.Test.Process as H
@@ -18,24 +18,36 @@ hprop_golden_shelleyStakeAddressDeregistrationCertificate :: Property
 hprop_golden_shelleyStakeAddressDeregistrationCertificate = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
   base <- H.getProjectBase
 
-  verificationKeyFile <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/stake_keys/verification_key"
+  verificationKeyFile <-
+    noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/stake_keys/verification_key"
   deregistrationCertFile <- noteTempFile tempDir "deregistrationCertFile"
   scriptDeregistrationCertFile <- noteTempFile tempDir "scripDeregistrationCertFile"
-  exampleScript <- noteInputFile $ base </> "scripts/plutus/scripts/v1/custom-guess-42-datum-42.plutus"
+  exampleScript <-
+    noteInputFile $ base </> "scripts/plutus/scripts/v1/custom-guess-42-datum-42.plutus"
 
-  void $ execCardanoCLI
-    [ "babbage", "stake-address","deregistration-certificate"
-    , "--staking-verification-key-file", verificationKeyFile
-    , "--out-file", deregistrationCertFile
-    ]
+  void $
+    execCardanoCLI
+      [ "babbage"
+      , "stake-address"
+      , "deregistration-certificate"
+      , "--staking-verification-key-file"
+      , verificationKeyFile
+      , "--out-file"
+      , deregistrationCertFile
+      ]
 
   H.assertFileOccurences 1 "Stake Address Deregistration Certificate" deregistrationCertFile
 
-  void $ execCardanoCLI
-    [ "babbage", "stake-address","deregistration-certificate"
-    , "--stake-script-file", exampleScript
-    , "--out-file", scriptDeregistrationCertFile
-    ]
+  void $
+    execCardanoCLI
+      [ "babbage"
+      , "stake-address"
+      , "deregistration-certificate"
+      , "--stake-script-file"
+      , exampleScript
+      , "--out-file"
+      , scriptDeregistrationCertFile
+      ]
 
   H.assertFileOccurences 1 "Stake Address Deregistration Certificate" scriptDeregistrationCertFile
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/StakeAddress/DeregistrationCertificate.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/StakeAddress/DeregistrationCertificate.hs
@@ -8,9 +8,9 @@ import System.FilePath ((</>))
 import Test.Cardano.CLI.Util
 
 import Hedgehog (Property)
-import qualified Hedgehog.Extras.Test.Base as H
-import qualified Hedgehog.Extras.Test.File as H
-import qualified Hedgehog.Extras.Test.Process as H
+import Hedgehog.Extras.Test.Base qualified as H
+import Hedgehog.Extras.Test.File qualified as H
+import Hedgehog.Extras.Test.Process qualified as H
 
 {- HLINT ignore "Use camelCase" -}
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/StakeAddress/KeyGen.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/StakeAddress/KeyGen.hs
@@ -7,8 +7,8 @@ import Control.Monad (void)
 import Test.Cardano.CLI.Util
 
 import Hedgehog (Property)
-import qualified Hedgehog.Extras.Test.Base as H
-import qualified Hedgehog.Extras.Test.File as H
+import Hedgehog.Extras.Test.Base qualified as H
+import Hedgehog.Extras.Test.File qualified as H
 
 {- HLINT ignore "Use camelCase" -}
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/StakeAddress/KeyGen.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/StakeAddress/KeyGen.hs
@@ -2,11 +2,11 @@
 
 module Test.Golden.Shelley.StakeAddress.KeyGen where
 
-import           Control.Monad (void)
+import Control.Monad (void)
 
-import           Test.Cardano.CLI.Util
+import Test.Cardano.CLI.Util
 
-import           Hedgehog (Property)
+import Hedgehog (Property)
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 
@@ -17,11 +17,15 @@ hprop_golden_shelleyStakeAddressKeyGen = propertyOnce . H.moduleWorkspace "tmp" 
   verificationKeyFile <- noteTempFile tempDir "kes.vkey"
   signingKeyFile <- noteTempFile tempDir "kes.skey"
 
-  void $ execCardanoCLI
-    [ "stake-address","key-gen"
-    , "--verification-key-file", verificationKeyFile
-    , "--signing-key-file", signingKeyFile
-    ]
+  void $
+    execCardanoCLI
+      [ "stake-address"
+      , "key-gen"
+      , "--verification-key-file"
+      , verificationKeyFile
+      , "--signing-key-file"
+      , signingKeyFile
+      ]
 
   H.assertFileOccurences 1 "StakeVerificationKeyShelley_ed25519" verificationKeyFile
   H.assertFileOccurences 1 "StakeSigningKeyShelley_ed25519" signingKeyFile

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/StakeAddress/RegistrationCertificate.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/StakeAddress/RegistrationCertificate.hs
@@ -2,12 +2,12 @@
 
 module Test.Golden.Shelley.StakeAddress.RegistrationCertificate where
 
-import           Control.Monad (void)
-import           System.FilePath ((</>))
+import Control.Monad (void)
+import System.FilePath ((</>))
 
-import           Test.Cardano.CLI.Util
+import Test.Cardano.CLI.Util
 
-import           Hedgehog
+import Hedgehog
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 import qualified Hedgehog.Extras.Test.Process as H
@@ -18,24 +18,36 @@ hprop_golden_shelleyStakeAddressRegistrationCertificate :: Property
 hprop_golden_shelleyStakeAddressRegistrationCertificate = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
   base <- H.getProjectBase
 
-  keyGenStakingVerificationKeyFile <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/stake_keys/verification_key"
+  keyGenStakingVerificationKeyFile <-
+    noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/stake_keys/verification_key"
   registrationCertFile <- noteTempFile tempDir "registration.cert"
   scriptRegistrationCertFile <- noteTempFile tempDir "script-registration.cert"
-  exampleScript <- noteInputFile $ base </> "scripts/plutus/scripts/v1/custom-guess-42-datum-42.plutus"
+  exampleScript <-
+    noteInputFile $ base </> "scripts/plutus/scripts/v1/custom-guess-42-datum-42.plutus"
 
-  void $ execCardanoCLI
-    [ "babbage", "stake-address", "registration-certificate"
-    , "--staking-verification-key-file", keyGenStakingVerificationKeyFile
-    , "--out-file", registrationCertFile
-    ]
+  void $
+    execCardanoCLI
+      [ "babbage"
+      , "stake-address"
+      , "registration-certificate"
+      , "--staking-verification-key-file"
+      , keyGenStakingVerificationKeyFile
+      , "--out-file"
+      , registrationCertFile
+      ]
 
   H.assertFileOccurences 1 "Stake Address Registration Certificate" registrationCertFile
 
-  void $ execCardanoCLI
-    [ "babbage", "stake-address", "registration-certificate"
-    , "--stake-script-file", exampleScript
-    , "--out-file", scriptRegistrationCertFile
-    ]
+  void $
+    execCardanoCLI
+      [ "babbage"
+      , "stake-address"
+      , "registration-certificate"
+      , "--stake-script-file"
+      , exampleScript
+      , "--out-file"
+      , scriptRegistrationCertFile
+      ]
 
   H.assertFileOccurences 1 "Stake Address Registration Certificate" scriptRegistrationCertFile
 
@@ -43,23 +55,37 @@ hprop_golden_shelleyStakeAddressRegistrationCertificate = propertyOnce . H.modul
 
 hprop_golden_shelleyStakeAddressRegistrationCertificateWithBuildRaw :: Property
 hprop_golden_shelleyStakeAddressRegistrationCertificateWithBuildRaw = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
-  keyGenStakingVerificationKeyFile <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/stake_keys/verification_key"
+  keyGenStakingVerificationKeyFile <-
+    noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/stake_keys/verification_key"
   registrationCertFile <- noteTempFile tempDir "registration.cert"
   txRawFile <- noteTempFile tempDir "tx.raw"
 
-  void $ execCardanoCLI
-    [ "conway", "stake-address", "registration-certificate"
-    , "--staking-verification-key-file", keyGenStakingVerificationKeyFile
-    , "--key-reg-deposit-amt", "2000000"
-    , "--out-file", registrationCertFile
-    ]
+  void $
+    execCardanoCLI
+      [ "conway"
+      , "stake-address"
+      , "registration-certificate"
+      , "--staking-verification-key-file"
+      , keyGenStakingVerificationKeyFile
+      , "--key-reg-deposit-amt"
+      , "2000000"
+      , "--out-file"
+      , registrationCertFile
+      ]
 
   H.assertFileOccurences 1 "Stake Address Registration Certificate" registrationCertFile
 
-  void $ execCardanoCLI
-    [ "conway", "transaction", "build-raw"
-    , "--tx-in", "bdfa7d91a29ffe071c028c0143c5d278c0a7ddb829c1e95f54a1676915fd82c2#0"
-    , "--fee", "1"
-    , "--certificate-file", registrationCertFile
-    , "--out-file", txRawFile
-    ]
+  void $
+    execCardanoCLI
+      [ "conway"
+      , "transaction"
+      , "build-raw"
+      , "--tx-in"
+      , "bdfa7d91a29ffe071c028c0143c5d278c0a7ddb829c1e95f54a1676915fd82c2#0"
+      , "--fee"
+      , "1"
+      , "--certificate-file"
+      , registrationCertFile
+      , "--out-file"
+      , txRawFile
+      ]

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/StakeAddress/RegistrationCertificate.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/StakeAddress/RegistrationCertificate.hs
@@ -8,9 +8,9 @@ import System.FilePath ((</>))
 import Test.Cardano.CLI.Util
 
 import Hedgehog
-import qualified Hedgehog.Extras.Test.Base as H
-import qualified Hedgehog.Extras.Test.File as H
-import qualified Hedgehog.Extras.Test.Process as H
+import Hedgehog.Extras.Test.Base qualified as H
+import Hedgehog.Extras.Test.File qualified as H
+import Hedgehog.Extras.Test.Process qualified as H
 
 {- HLINT ignore "Use camelCase" -}
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/StakePool/RegistrationCertificate.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/StakePool/RegistrationCertificate.hs
@@ -7,8 +7,8 @@ import Control.Monad (void)
 import Test.Cardano.CLI.Util
 
 import Hedgehog (Property)
-import qualified Hedgehog.Extras.Test.Base as H
-import qualified Hedgehog.Extras.Test.File as H
+import Hedgehog.Extras.Test.Base qualified as H
+import Hedgehog.Extras.Test.File qualified as H
 
 {- HLINT ignore "Use camelCase" -}
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/StakePool/RegistrationCertificate.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/StakePool/RegistrationCertificate.hs
@@ -2,11 +2,11 @@
 
 module Test.Golden.Shelley.StakePool.RegistrationCertificate where
 
-import           Control.Monad (void)
+import Control.Monad (void)
 
-import           Test.Cardano.CLI.Util
+import Test.Cardano.CLI.Util
 
-import           Hedgehog (Property)
+import Hedgehog (Property)
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 
@@ -14,23 +14,38 @@ import qualified Hedgehog.Extras.Test.File as H
 
 hprop_golden_shelleyStakePoolRegistrationCertificate :: Property
 hprop_golden_shelleyStakePoolRegistrationCertificate = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
-  operatorVerificationKeyFile <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/node-pool/operator.vkey"
-  vrfVerificationKeyFile <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/node-pool/vrf.vkey"
-  ownerVerificationKeyFile <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/node-pool/owner.vkey"
+  operatorVerificationKeyFile <-
+    noteInputFile "test/cardano-cli-golden/files/golden/shelley/node-pool/operator.vkey"
+  vrfVerificationKeyFile <-
+    noteInputFile "test/cardano-cli-golden/files/golden/shelley/node-pool/vrf.vkey"
+  ownerVerificationKeyFile <-
+    noteInputFile "test/cardano-cli-golden/files/golden/shelley/node-pool/owner.vkey"
   registrationCertFile <- noteTempFile tempDir "registration.cert"
 
-  void $ execCardanoCLI
-    [ "babbage", "stake-pool", "registration-certificate"
-    , "--testnet-magic", "42"
-    , "--pool-pledge", "0"
-    , "--pool-cost", "0"
-    , "--pool-margin", "0"
-    , "--cold-verification-key-file", operatorVerificationKeyFile
-    , "--vrf-verification-key-file", vrfVerificationKeyFile
-    , "--reward-account-verification-key-file", ownerVerificationKeyFile
-    , "--pool-owner-stake-verification-key-file", ownerVerificationKeyFile
-    , "--out-file", registrationCertFile
-    ]
+  void $
+    execCardanoCLI
+      [ "babbage"
+      , "stake-pool"
+      , "registration-certificate"
+      , "--testnet-magic"
+      , "42"
+      , "--pool-pledge"
+      , "0"
+      , "--pool-cost"
+      , "0"
+      , "--pool-margin"
+      , "0"
+      , "--cold-verification-key-file"
+      , operatorVerificationKeyFile
+      , "--vrf-verification-key-file"
+      , vrfVerificationKeyFile
+      , "--reward-account-verification-key-file"
+      , ownerVerificationKeyFile
+      , "--pool-owner-stake-verification-key-file"
+      , ownerVerificationKeyFile
+      , "--out-file"
+      , registrationCertFile
+      ]
 
   H.assertFileOccurences 1 "Stake Pool Registration Certificate" registrationCertFile
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Certificates/GenesisKeyDelegation.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Certificates/GenesisKeyDelegation.hs
@@ -14,8 +14,8 @@ import Control.Monad (void)
 import Test.Cardano.CLI.Util
 
 import Hedgehog (Property)
-import qualified Hedgehog.Extras.Test.Base as H
-import qualified Hedgehog.Extras.Test.File as H
+import Hedgehog.Extras.Test.Base qualified as H
+import Hedgehog.Extras.Test.File qualified as H
 
 {- HLINT ignore "Use camelCase" -}
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Certificates/GenesisKeyDelegation.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Certificates/GenesisKeyDelegation.hs
@@ -2,14 +2,18 @@
 
 module Test.Golden.Shelley.TextEnvelope.Certificates.GenesisKeyDelegation where
 
-import           Cardano.Api (AsType (..), CardanoEra (..), cardanoEraConstraints,
-                   textEnvelopeTypeInEra)
+import Cardano.Api
+  ( AsType (..)
+  , CardanoEra (..)
+  , cardanoEraConstraints
+  , textEnvelopeTypeInEra
+  )
 
-import           Control.Monad (void)
+import Control.Monad (void)
 
-import           Test.Cardano.CLI.Util
+import Test.Cardano.CLI.Util
 
-import           Hedgehog (Property)
+import Hedgehog (Property)
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 
@@ -42,29 +46,40 @@ hprop_golden_shelleyGenesisKeyDelegationCertificate =
 
     genesisDelegOpCertCounterFilePath <- noteTempFile tempDir "genesis-delegate-opcert-counter"
 
-
     -- Generate genesis key pair
-    void $ execCardanoCLI
-      [ "genesis","key-gen-genesis"
-      , "--verification-key-file", genesisVerKeyFilePath
-      , "--signing-key-file", genesisSignKeyFilePath
-      ]
+    void $
+      execCardanoCLI
+        [ "genesis"
+        , "key-gen-genesis"
+        , "--verification-key-file"
+        , genesisVerKeyFilePath
+        , "--signing-key-file"
+        , genesisSignKeyFilePath
+        ]
 
     -- Generate genesis delegate key pair
-    void $ execCardanoCLI
-      [ "genesis","key-gen-delegate"
-      , "--verification-key-file", genesisDelegVerKeyFilePath
-      , "--signing-key-file", genesisDelegSignKeyFilePath
-      , "--operational-certificate-issue-counter-file"
-      , genesisDelegOpCertCounterFilePath
-      ]
+    void $
+      execCardanoCLI
+        [ "genesis"
+        , "key-gen-delegate"
+        , "--verification-key-file"
+        , genesisDelegVerKeyFilePath
+        , "--signing-key-file"
+        , genesisDelegSignKeyFilePath
+        , "--operational-certificate-issue-counter-file"
+        , genesisDelegOpCertCounterFilePath
+        ]
 
     -- Generate VRF key pair
-    void $ execCardanoCLI
-      [ "node","key-gen-VRF"
-      , "--verification-key-file", vrfVerKeyFilePath
-      , "--signing-key-file", vrfSignKeyFilePath
-      ]
+    void $
+      execCardanoCLI
+        [ "node"
+        , "key-gen-VRF"
+        , "--verification-key-file"
+        , vrfVerKeyFilePath
+        , "--signing-key-file"
+        , vrfSignKeyFilePath
+        ]
 
     H.assertFilesExist
       [ genesisVerKeyFilePath
@@ -73,14 +88,21 @@ hprop_golden_shelleyGenesisKeyDelegationCertificate =
       ]
 
     -- Create genesis key delegation certificate
-    void $ execCardanoCLI
-      [ "legacy", "governance", "create-genesis-key-delegation-certificate"
-      , "--babbage-era"
-      , "--genesis-verification-key-file", genesisVerKeyFilePath
-      , "--genesis-delegate-verification-key-file", genesisDelegVerKeyFilePath
-      , "--vrf-verification-key-file", vrfVerKeyFilePath
-      , "--out-file", genesisKeyDelegCertFilePath
-      ]
+    void $
+      execCardanoCLI
+        [ "legacy"
+        , "governance"
+        , "create-genesis-key-delegation-certificate"
+        , "--babbage-era"
+        , "--genesis-verification-key-file"
+        , genesisVerKeyFilePath
+        , "--genesis-delegate-verification-key-file"
+        , genesisDelegVerKeyFilePath
+        , "--vrf-verification-key-file"
+        , vrfVerKeyFilePath
+        , "--out-file"
+        , genesisKeyDelegCertFilePath
+        ]
 
     H.assertFilesExist [genesisKeyDelegCertFilePath]
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Certificates/MIR.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Certificates/MIR.hs
@@ -9,8 +9,8 @@ import Control.Monad (void)
 import Test.Cardano.CLI.Util
 
 import Hedgehog (Property)
-import qualified Hedgehog.Extras.Test.Base as H
-import qualified Hedgehog.Extras.Test.File as H
+import Hedgehog.Extras.Test.Base qualified as H
+import Hedgehog.Extras.Test.File qualified as H
 
 {- HLINT ignore "Use camelCase" -}
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Certificates/MIR.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Certificates/MIR.hs
@@ -2,13 +2,13 @@
 
 module Test.Golden.Shelley.TextEnvelope.Certificates.MIR where
 
-import           Cardano.Api (AsType (..), CardanoEra (..), textEnvelopeTypeInEra)
+import Cardano.Api (AsType (..), CardanoEra (..), textEnvelopeTypeInEra)
 
-import           Control.Monad (void)
+import Control.Monad (void)
 
-import           Test.Cardano.CLI.Util
+import Test.Cardano.CLI.Util
 
-import           Hedgehog (Property)
+import Hedgehog (Property)
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 
@@ -22,7 +22,8 @@ hprop_golden_shelleyMIRCertificate = propertyOnce . H.moduleWorkspace "tmp" $ \t
   let era = BabbageEra
 
   -- Reference keys
-  referenceMIRCertificate <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/certificates/mir_certificate"
+  referenceMIRCertificate <-
+    noteInputFile "test/cardano-cli-golden/files/golden/shelley/certificates/mir_certificate"
 
   -- Key filepaths
   verKey <- noteTempFile tempDir "stake-verification-key-file"
@@ -30,23 +31,33 @@ hprop_golden_shelleyMIRCertificate = propertyOnce . H.moduleWorkspace "tmp" $ \t
   mirCertificate <- noteTempFile tempDir "mir-certificate-file"
 
   -- Generate stake key pair
-  void $ execCardanoCLI
-    [ "stake-address","key-gen"
-    , "--verification-key-file", verKey
-    , "--signing-key-file", signKey
-    ]
+  void $
+    execCardanoCLI
+      [ "stake-address"
+      , "key-gen"
+      , "--verification-key-file"
+      , verKey
+      , "--signing-key-file"
+      , signKey
+      ]
 
   H.assertFilesExist [verKey, signKey]
 
   let testAddr = "stake1u9j6axhcpd0exvrthn5dqzqt54g85akqvkn4uqmccm70qsc5hpv9w"
   -- Create MIR certificate
-  void $ execCardanoCLI
-    [ "babbage", "governance", "create-mir-certificate"
-    , "--reserves" --TODO: Should also do "--reserves"
-    , "--stake-address", testAddr
-    , "--reward", "1000"
-    , "--out-file", mirCertificate
-    ]
+  void $
+    execCardanoCLI
+      [ "babbage"
+      , "governance"
+      , "create-mir-certificate"
+      , "--reserves" -- TODO: Should also do "--reserves"
+      , "--stake-address"
+      , testAddr
+      , "--reward"
+      , "1000"
+      , "--out-file"
+      , mirCertificate
+      ]
 
   H.assertFilesExist [mirCertificate]
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Certificates/Operational.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Certificates/Operational.hs
@@ -2,13 +2,13 @@
 
 module Test.Golden.Shelley.TextEnvelope.Certificates.Operational where
 
-import           Cardano.Api (AsType (..), HasTextEnvelope (..))
+import Cardano.Api (AsType (..), HasTextEnvelope (..))
 
-import           Control.Monad (void)
+import Control.Monad (void)
 
-import           Test.Cardano.CLI.Util
+import Test.Cardano.CLI.Util
 
-import           Hedgehog (Property)
+import Hedgehog (Property)
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 
@@ -21,7 +21,8 @@ import qualified Hedgehog.Extras.Test.File as H
 hprop_golden_shelleyOperationalCertificate :: Property
 hprop_golden_shelleyOperationalCertificate = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
   -- Reference keys
-  referenceOperationalCertificate <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/certificates/operational_certificate"
+  referenceOperationalCertificate <-
+    noteInputFile "test/cardano-cli-golden/files/golden/shelley/certificates/operational_certificate"
 
   -- Key filepaths
   kesVerKey <- noteTempFile tempDir "KES-verification-key-file"
@@ -32,33 +33,49 @@ hprop_golden_shelleyOperationalCertificate = propertyOnce . H.moduleWorkspace "t
   operationalCert <- noteTempFile tempDir "operational-certificate-file"
 
   -- Create KES key pair
-  void $ execCardanoCLI
-    [ "node","key-gen-KES"
-    , "--verification-key-file", kesVerKey
-    , "--signing-key-file", kesSignKey
-    ]
+  void $
+    execCardanoCLI
+      [ "node"
+      , "key-gen-KES"
+      , "--verification-key-file"
+      , kesVerKey
+      , "--signing-key-file"
+      , kesSignKey
+      ]
 
   H.assertFilesExist [kesSignKey, kesVerKey]
 
   -- Create cold key pair
-  void $ execCardanoCLI
-    [ "node","key-gen"
-    , "--cold-verification-key-file", coldVerKey
-    , "--cold-signing-key-file", coldSignKey
-    , "--operational-certificate-issue-counter", operationalCertCounter
-    ]
+  void $
+    execCardanoCLI
+      [ "node"
+      , "key-gen"
+      , "--cold-verification-key-file"
+      , coldVerKey
+      , "--cold-signing-key-file"
+      , coldSignKey
+      , "--operational-certificate-issue-counter"
+      , operationalCertCounter
+      ]
 
   H.assertFilesExist [coldVerKey, coldSignKey, operationalCertCounter]
 
   -- Create operational certificate
-  void $ execCardanoCLI
-    [ "node","issue-op-cert"
-    , "--kes-verification-key-file", kesVerKey
-    , "--cold-signing-key-file", coldSignKey
-    , "--operational-certificate-issue-counter", operationalCertCounter
-    , "--kes-period", "1000"
-    , "--out-file", operationalCert
-    ]
+  void $
+    execCardanoCLI
+      [ "node"
+      , "issue-op-cert"
+      , "--kes-verification-key-file"
+      , kesVerKey
+      , "--cold-signing-key-file"
+      , coldSignKey
+      , "--operational-certificate-issue-counter"
+      , operationalCertCounter
+      , "--kes-period"
+      , "1000"
+      , "--out-file"
+      , operationalCert
+      ]
 
   let operationalCertificateType = textEnvelopeType AsOperationalCertificate
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Certificates/Operational.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Certificates/Operational.hs
@@ -9,8 +9,8 @@ import Control.Monad (void)
 import Test.Cardano.CLI.Util
 
 import Hedgehog (Property)
-import qualified Hedgehog.Extras.Test.Base as H
-import qualified Hedgehog.Extras.Test.File as H
+import Hedgehog.Extras.Test.Base qualified as H
+import Hedgehog.Extras.Test.File qualified as H
 
 {- HLINT ignore "Use camelCase" -}
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Certificates/StakeAddress.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Certificates/StakeAddress.hs
@@ -2,13 +2,13 @@
 
 module Test.Golden.Shelley.TextEnvelope.Certificates.StakeAddress where
 
-import           Cardano.Api (AsType (..), CardanoEra (..), textEnvelopeTypeInEra)
+import Cardano.Api (AsType (..), CardanoEra (..), textEnvelopeTypeInEra)
 
-import           Control.Monad (void)
+import Control.Monad (void)
 
-import           Test.Cardano.CLI.Util
+import Test.Cardano.CLI.Util
 
-import           Hedgehog (Property)
+import Hedgehog (Property)
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 
@@ -22,8 +22,12 @@ hprop_golden_shelleyStakeAddressCertificates = propertyOnce . H.moduleWorkspace 
   let era = BabbageEra
 
   -- Reference files
-  referenceRegistrationCertificate <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/certificates/stake_address_registration_certificate"
-  referenceDeregistrationCertificate <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/certificates/stake_address_deregistration_certificate"
+  referenceRegistrationCertificate <-
+    noteInputFile
+      "test/cardano-cli-golden/files/golden/shelley/certificates/stake_address_registration_certificate"
+  referenceDeregistrationCertificate <-
+    noteInputFile
+      "test/cardano-cli-golden/files/golden/shelley/certificates/stake_address_deregistration_certificate"
 
   -- Key filepaths
   verKey <- noteTempFile tempDir "stake-verification-key-file"
@@ -32,37 +36,57 @@ hprop_golden_shelleyStakeAddressCertificates = propertyOnce . H.moduleWorkspace 
   registrationCertificate <- noteTempFile tempDir "stake-address-registration-certificate"
 
   -- Generate stake verification key
-  void $ execCardanoCLI
-    [ "stake-address", "key-gen"
-    , "--verification-key-file", verKey
-    , "--signing-key-file", signKey
-    ]
+  void $
+    execCardanoCLI
+      [ "stake-address"
+      , "key-gen"
+      , "--verification-key-file"
+      , verKey
+      , "--signing-key-file"
+      , signKey
+      ]
 
   H.assertFilesExist [verKey, signKey]
 
   -- Create stake address registration certificate
-  void $ execCardanoCLI
-    [ "babbage", "stake-address", "registration-certificate"
-    , "--stake-verification-key-file", verKey
-    , "--out-file", registrationCertificate
-    ]
+  void $
+    execCardanoCLI
+      [ "babbage"
+      , "stake-address"
+      , "registration-certificate"
+      , "--stake-verification-key-file"
+      , verKey
+      , "--out-file"
+      , registrationCertificate
+      ]
 
   let registrationCertificateType = textEnvelopeTypeInEra era AsCertificate
 
   -- Check the newly created files have not deviated from the
   -- golden files
-  checkTextEnvelopeFormat registrationCertificateType referenceRegistrationCertificate registrationCertificate
+  checkTextEnvelopeFormat
+    registrationCertificateType
+    referenceRegistrationCertificate
+    registrationCertificate
 
   -- Create stake address deregistration certificate
-  void $ execCardanoCLI
-    [ "babbage", "stake-address", "deregistration-certificate"
-    , "--stake-verification-key-file", verKey
-    , "--out-file", deregistrationCertificate
-    ]
+  void $
+    execCardanoCLI
+      [ "babbage"
+      , "stake-address"
+      , "deregistration-certificate"
+      , "--stake-verification-key-file"
+      , verKey
+      , "--out-file"
+      , deregistrationCertificate
+      ]
 
   -- Check the newly created files have not deviated from the
   -- golden files
-  checkTextEnvelopeFormat registrationCertificateType referenceDeregistrationCertificate deregistrationCertificate
+  checkTextEnvelopeFormat
+    registrationCertificateType
+    referenceDeregistrationCertificate
+    deregistrationCertificate
 
 -- TODO: After delegation-certificate command is fixed to take a hash instead of a verification key
 {-

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Certificates/StakeAddress.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Certificates/StakeAddress.hs
@@ -9,8 +9,8 @@ import Control.Monad (void)
 import Test.Cardano.CLI.Util
 
 import Hedgehog (Property)
-import qualified Hedgehog.Extras.Test.Base as H
-import qualified Hedgehog.Extras.Test.File as H
+import Hedgehog.Extras.Test.Base qualified as H
+import Hedgehog.Extras.Test.File qualified as H
 
 {- HLINT ignore "Use camelCase" -}
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Certificates/StakePool.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Certificates/StakePool.hs
@@ -2,14 +2,18 @@
 
 module Test.Golden.Shelley.TextEnvelope.Certificates.StakePool where
 
-import           Cardano.Api (AsType (..), CardanoEra (..), cardanoEraConstraints,
-                   textEnvelopeTypeInEra)
+import Cardano.Api
+  ( AsType (..)
+  , CardanoEra (..)
+  , cardanoEraConstraints
+  , textEnvelopeTypeInEra
+  )
 
-import           Control.Monad (void)
+import Control.Monad (void)
 
-import           Test.Cardano.CLI.Util
+import Test.Cardano.CLI.Util
 
-import           Hedgehog (Property)
+import Hedgehog (Property)
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 
@@ -26,8 +30,12 @@ hprop_golden_shelleyStakePoolCertificates = propertyOnce . H.moduleWorkspace "tm
   let era = BabbageEra -- TODO generate for all eras
 
   -- Reference files
-  referenceRegistrationCertificate <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/certificates/stake_pool_registration_certificate"
-  referenceDeregistrationCertificate <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/certificates/stake_pool_deregistration_certificate"
+  referenceRegistrationCertificate <-
+    noteInputFile
+      "test/cardano-cli-golden/files/golden/shelley/certificates/stake_pool_registration_certificate"
+  referenceDeregistrationCertificate <-
+    noteInputFile
+      "test/cardano-cli-golden/files/golden/shelley/certificates/stake_pool_deregistration_certificate"
 
   -- Key filepaths
   coldVerKey <- noteTempFile tempDir "cold-verification-key-file"
@@ -41,47 +49,70 @@ hprop_golden_shelleyStakePoolCertificates = propertyOnce . H.moduleWorkspace "tm
   deregistrationCertificate <- noteTempFile tempDir "stake-pool-deregistration-certificate"
 
   -- Create cold key pair
-  void $ execCardanoCLI
-    [ "node", "key-gen"
-    , "--cold-verification-key-file", coldVerKey
-    , "--cold-signing-key-file", coldSignKey
-    , "--operational-certificate-issue-counter", operationalCertCounter
-    ]
+  void $
+    execCardanoCLI
+      [ "node"
+      , "key-gen"
+      , "--cold-verification-key-file"
+      , coldVerKey
+      , "--cold-signing-key-file"
+      , coldSignKey
+      , "--operational-certificate-issue-counter"
+      , operationalCertCounter
+      ]
 
   H.assertFilesExist [coldSignKey, coldVerKey, operationalCertCounter]
 
   -- Generate stake key pair
-  void $ execCardanoCLI
-    [ "stake-address", "key-gen"
-    , "--verification-key-file", poolRewardAccountAndOwnerVerKey
-    , "--signing-key-file", poolRewardAccountSignKey
-    ]
+  void $
+    execCardanoCLI
+      [ "stake-address"
+      , "key-gen"
+      , "--verification-key-file"
+      , poolRewardAccountAndOwnerVerKey
+      , "--signing-key-file"
+      , poolRewardAccountSignKey
+      ]
 
   H.assertFilesExist [poolRewardAccountAndOwnerVerKey, poolRewardAccountSignKey]
 
   -- Generate vrf verification key
-  void $ execCardanoCLI
-    [ "node", "key-gen-VRF"
-    , "--verification-key-file", vrfVerKey
-    , "--signing-key-file", vrfSignKey
-    ]
-
+  void $
+    execCardanoCLI
+      [ "node"
+      , "key-gen-VRF"
+      , "--verification-key-file"
+      , vrfVerKey
+      , "--signing-key-file"
+      , vrfSignKey
+      ]
 
   H.assertFilesExist [vrfSignKey, vrfVerKey]
 
   -- Create stake pool registration certificate
-  void $ execCardanoCLI
-    [ "babbage", "stake-pool", "registration-certificate"
-    , "--cold-verification-key-file", coldVerKey
-    , "--vrf-verification-key-file", vrfVerKey
-    , "--mainnet"
-    , "--pool-cost", "1000"
-    , "--pool-pledge", "5000"
-    , "--pool-margin", "0.1"
-    , "--pool-reward-account-verification-key-file", poolRewardAccountAndOwnerVerKey
-    , "--pool-owner-stake-verification-key-file", poolRewardAccountAndOwnerVerKey
-    , "--out-file", registrationCertificate
-    ]
+  void $
+    execCardanoCLI
+      [ "babbage"
+      , "stake-pool"
+      , "registration-certificate"
+      , "--cold-verification-key-file"
+      , coldVerKey
+      , "--vrf-verification-key-file"
+      , vrfVerKey
+      , "--mainnet"
+      , "--pool-cost"
+      , "1000"
+      , "--pool-pledge"
+      , "5000"
+      , "--pool-margin"
+      , "0.1"
+      , "--pool-reward-account-verification-key-file"
+      , poolRewardAccountAndOwnerVerKey
+      , "--pool-owner-stake-verification-key-file"
+      , poolRewardAccountAndOwnerVerKey
+      , "--out-file"
+      , registrationCertificate
+      ]
 
   H.assertFilesExist [registrationCertificate]
 
@@ -89,18 +120,30 @@ hprop_golden_shelleyStakePoolCertificates = propertyOnce . H.moduleWorkspace "tm
 
   -- Check the newly created files have not deviated from the
   -- golden files
-  checkTextEnvelopeFormat registrationCertificateType referenceRegistrationCertificate registrationCertificate
+  checkTextEnvelopeFormat
+    registrationCertificateType
+    referenceRegistrationCertificate
+    registrationCertificate
 
   -- Create stake pool deregistration certificate
-  void $ execCardanoCLI
-    [ "babbage", "stake-pool", "deregistration-certificate"
-    , "--cold-verification-key-file", coldVerKey
-    , "--epoch", "42"
-    , "--out-file", deregistrationCertificate
-    ]
+  void $
+    execCardanoCLI
+      [ "babbage"
+      , "stake-pool"
+      , "deregistration-certificate"
+      , "--cold-verification-key-file"
+      , coldVerKey
+      , "--epoch"
+      , "42"
+      , "--out-file"
+      , deregistrationCertificate
+      ]
 
   H.assertFilesExist [deregistrationCertificate]
 
   -- Check the newly created files have not deviated from the
   -- golden files
-  checkTextEnvelopeFormat registrationCertificateType referenceDeregistrationCertificate deregistrationCertificate
+  checkTextEnvelopeFormat
+    registrationCertificateType
+    referenceDeregistrationCertificate
+    deregistrationCertificate

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Certificates/StakePool.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Certificates/StakePool.hs
@@ -14,8 +14,8 @@ import Control.Monad (void)
 import Test.Cardano.CLI.Util
 
 import Hedgehog (Property)
-import qualified Hedgehog.Extras.Test.Base as H
-import qualified Hedgehog.Extras.Test.File as H
+import Hedgehog.Extras.Test.Base qualified as H
+import Hedgehog.Extras.Test.File qualified as H
 
 {- HLINT ignore "Use camelCase" -}
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/ExtendedPaymentKeys.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/ExtendedPaymentKeys.hs
@@ -3,14 +3,14 @@
 
 module Test.Golden.Shelley.TextEnvelope.Keys.ExtendedPaymentKeys where
 
-import           Cardano.Api (AsType (..), HasTextEnvelope (..))
+import Cardano.Api (AsType (..), HasTextEnvelope (..))
 
-import           Control.Monad (void)
-import           Text.Regex.TDFA ((=~))
+import Control.Monad (void)
+import Text.Regex.TDFA ((=~))
 
-import           Test.Cardano.CLI.Util
+import Test.Cardano.CLI.Util
 
-import           Hedgehog (Property)
+import Hedgehog (Property)
 import qualified Hedgehog as H
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
@@ -23,20 +23,27 @@ import qualified Hedgehog.Extras.Test.File as H
 hprop_golden_shelleyExtendedPaymentKeys :: Property
 hprop_golden_shelleyExtendedPaymentKeys = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
   -- Reference keys
-  referenceVerKey <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/extended_payment_keys/verification_key"
-  referenceSignKey <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/extended_payment_keys/signing_key"
+  referenceVerKey <-
+    noteInputFile
+      "test/cardano-cli-golden/files/golden/shelley/keys/extended_payment_keys/verification_key"
+  referenceSignKey <-
+    noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/extended_payment_keys/signing_key"
 
   -- Key filepaths
   verKey <- noteTempFile tempDir "extended-payment-verification-key-file"
   signKey <- noteTempFile tempDir "extended-payment-signing-key-file"
 
   -- Generate payment verification key
-  void $ execCardanoCLI
-    [ "address","key-gen"
-    , "--extended-key"
-    , "--verification-key-file", verKey
-    , "--signing-key-file", signKey
-    ]
+  void $
+    execCardanoCLI
+      [ "address"
+      , "key-gen"
+      , "--extended-key"
+      , "--verification-key-file"
+      , verKey
+      , "--signing-key-file"
+      , signKey
+      ]
 
   let signingKeyType = textEnvelopeType (AsSigningKey AsPaymentExtendedKey)
       verificationKeyType = textEnvelopeType (AsVerificationKey AsPaymentExtendedKey)
@@ -52,21 +59,29 @@ hprop_golden_shelleyExtendedPaymentKeys = propertyOnce . H.moduleWorkspace "tmp"
 hprop_golden_shelleyExtendedPaymentKeys_te :: Property
 hprop_golden_shelleyExtendedPaymentKeys_te = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
   -- Reference keys
-  referenceVerKey <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/extended_payment_keys/verification_key"
-  referenceSignKey <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/extended_payment_keys/signing_key"
+  referenceVerKey <-
+    noteInputFile
+      "test/cardano-cli-golden/files/golden/shelley/keys/extended_payment_keys/verification_key"
+  referenceSignKey <-
+    noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/extended_payment_keys/signing_key"
 
   -- Key filepaths
   verKey <- noteTempFile tempDir "extended-payment-verification-key-file"
   signKey <- noteTempFile tempDir "extended-payment-signing-key-file"
 
   -- Generate payment verification key
-  void $ execCardanoCLI
-    [ "address","key-gen"
-    , "--key-output-format", "text-envelope"
-    , "--extended-key"
-    , "--verification-key-file", verKey
-    , "--signing-key-file", signKey
-    ]
+  void $
+    execCardanoCLI
+      [ "address"
+      , "key-gen"
+      , "--key-output-format"
+      , "text-envelope"
+      , "--extended-key"
+      , "--verification-key-file"
+      , verKey
+      , "--signing-key-file"
+      , signKey
+      ]
 
   let signingKeyType = textEnvelopeType (AsSigningKey AsPaymentExtendedKey)
       verificationKeyType = textEnvelopeType (AsVerificationKey AsPaymentExtendedKey)
@@ -88,13 +103,18 @@ hprop_golden_shelleyExtendedPaymentKeys_bech32 = propertyOnce . H.moduleWorkspac
   signKeyFile <- noteTempFile tempDir "payment-signing-key-file"
 
   -- Generate payment verification key
-  void $ execCardanoCLI
-    [ "address","key-gen"
-    , "--key-output-format", "bech32"
-    , "--extended-key"
-    , "--verification-key-file", verKeyFile
-    , "--signing-key-file", signKeyFile
-    ]
+  void $
+    execCardanoCLI
+      [ "address"
+      , "key-gen"
+      , "--key-output-format"
+      , "bech32"
+      , "--extended-key"
+      , "--verification-key-file"
+      , verKeyFile
+      , "--signing-key-file"
+      , signKeyFile
+      ]
 
   verKey <- H.readFile verKeyFile
   H.assert $ verKey =~ id @String "^addr_xvk[a-z0-9]{110}$"

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/ExtendedPaymentKeys.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/ExtendedPaymentKeys.hs
@@ -11,9 +11,9 @@ import Text.Regex.TDFA ((=~))
 import Test.Cardano.CLI.Util
 
 import Hedgehog (Property)
-import qualified Hedgehog as H
-import qualified Hedgehog.Extras.Test.Base as H
-import qualified Hedgehog.Extras.Test.File as H
+import Hedgehog qualified as H
+import Hedgehog.Extras.Test.Base qualified as H
+import Hedgehog.Extras.Test.File qualified as H
 
 {- HLINT ignore "Use camelCase" -}
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/GenesisDelegateKeys.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/GenesisDelegateKeys.hs
@@ -9,7 +9,7 @@ import Control.Monad (void)
 import Test.Cardano.CLI.Util
 
 import Hedgehog (Property)
-import qualified Hedgehog.Extras.Test.Base as H
+import Hedgehog.Extras.Test.Base qualified as H
 
 {- HLINT ignore "Use camelCase" -}
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/GenesisDelegateKeys.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/GenesisDelegateKeys.hs
@@ -2,13 +2,13 @@
 
 module Test.Golden.Shelley.TextEnvelope.Keys.GenesisDelegateKeys where
 
-import           Cardano.Api (AsType (..), HasTextEnvelope (..))
+import Cardano.Api (AsType (..), HasTextEnvelope (..))
 
-import           Control.Monad (void)
+import Control.Monad (void)
 
-import           Test.Cardano.CLI.Util
+import Test.Cardano.CLI.Util
 
-import           Hedgehog (Property)
+import Hedgehog (Property)
 import qualified Hedgehog.Extras.Test.Base as H
 
 {- HLINT ignore "Use camelCase" -}
@@ -19,9 +19,14 @@ import qualified Hedgehog.Extras.Test.Base as H
 hprop_golden_shelleyGenesisDelegateKeys :: Property
 hprop_golden_shelleyGenesisDelegateKeys = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
   -- Reference keys
-  referenceVerKey <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/genesis_delegate_keys/verification_key"
-  referenceSignKey <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/genesis_delegate_keys/signing_key"
-  referenceOpCertCounter <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/genesis_delegate_keys/operational_certificate_counter"
+  referenceVerKey <-
+    noteInputFile
+      "test/cardano-cli-golden/files/golden/shelley/keys/genesis_delegate_keys/verification_key"
+  referenceSignKey <-
+    noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/genesis_delegate_keys/signing_key"
+  referenceOpCertCounter <-
+    noteInputFile
+      "test/cardano-cli-golden/files/golden/shelley/keys/genesis_delegate_keys/operational_certificate_counter"
 
   -- Key filepaths
   verKey <- noteTempFile tempDir "genesis-delegate-verification-key-file"
@@ -29,12 +34,17 @@ hprop_golden_shelleyGenesisDelegateKeys = propertyOnce . H.moduleWorkspace "tmp"
   opCertCounter <- noteTempFile tempDir "delegate-operational-cert-counter-file"
 
   -- Generate payment verification key
-  void $ execCardanoCLI
-    [ "genesis","key-gen-delegate"
-    , "--verification-key-file", verKey
-    , "--signing-key-file", signKey
-    , "--operational-certificate-issue-counter-file", opCertCounter
-    ]
+  void $
+    execCardanoCLI
+      [ "genesis"
+      , "key-gen-delegate"
+      , "--verification-key-file"
+      , verKey
+      , "--signing-key-file"
+      , signKey
+      , "--operational-certificate-issue-counter-file"
+      , opCertCounter
+      ]
 
   let signingKeyType = textEnvelopeType (AsSigningKey AsGenesisDelegateKey)
       verificationKeyType = textEnvelopeType (AsVerificationKey AsGenesisDelegateKey)

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/GenesisKeys.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/GenesisKeys.hs
@@ -9,7 +9,7 @@ import Control.Monad (void)
 import Test.Cardano.CLI.Util
 
 import Hedgehog (Property)
-import qualified Hedgehog.Extras.Test.Base as H
+import Hedgehog.Extras.Test.Base qualified as H
 
 {- HLINT ignore "Use camelCase" -}
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/GenesisKeys.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/GenesisKeys.hs
@@ -2,13 +2,13 @@
 
 module Test.Golden.Shelley.TextEnvelope.Keys.GenesisKeys where
 
-import           Cardano.Api (AsType (..), HasTextEnvelope (..))
+import Cardano.Api (AsType (..), HasTextEnvelope (..))
 
-import           Control.Monad (void)
+import Control.Monad (void)
 
-import           Test.Cardano.CLI.Util
+import Test.Cardano.CLI.Util
 
-import           Hedgehog (Property)
+import Hedgehog (Property)
 import qualified Hedgehog.Extras.Test.Base as H
 
 {- HLINT ignore "Use camelCase" -}
@@ -19,19 +19,25 @@ import qualified Hedgehog.Extras.Test.Base as H
 hprop_golden_shelleyGenesisKeys :: Property
 hprop_golden_shelleyGenesisKeys = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
   -- Reference keys
-  referenceVerKey <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/genesis_keys/verification_key"
-  referenceSignKey <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/genesis_keys/signing_key"
+  referenceVerKey <-
+    noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/genesis_keys/verification_key"
+  referenceSignKey <-
+    noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/genesis_keys/signing_key"
 
   -- Key filepaths
   verKey <- noteTempFile tempDir "genesis-verification-key-file"
   signKey <- noteTempFile tempDir "genesis-signing-key-file"
 
   -- Generate payment verification key
-  void $ execCardanoCLI
-    [ "genesis","key-gen-genesis"
-    , "--verification-key-file", verKey
-    , "--signing-key-file", signKey
-    ]
+  void $
+    execCardanoCLI
+      [ "genesis"
+      , "key-gen-genesis"
+      , "--verification-key-file"
+      , verKey
+      , "--signing-key-file"
+      , signKey
+      ]
 
   let signingKeyType = textEnvelopeType (AsSigningKey AsGenesisKey)
       verificationKeyType = textEnvelopeType (AsVerificationKey AsGenesisKey)

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/GenesisUTxOKeys.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/GenesisUTxOKeys.hs
@@ -2,13 +2,13 @@
 
 module Test.Golden.Shelley.TextEnvelope.Keys.GenesisUTxOKeys where
 
-import           Cardano.Api (AsType (..), HasTextEnvelope (..))
+import Cardano.Api (AsType (..), HasTextEnvelope (..))
 
-import           Control.Monad (void)
+import Control.Monad (void)
 
-import           Test.Cardano.CLI.Util
+import Test.Cardano.CLI.Util
 
-import           Hedgehog (Property)
+import Hedgehog (Property)
 import qualified Hedgehog.Extras.Test.Base as H
 
 {- HLINT ignore "Use camelCase" -}
@@ -19,19 +19,25 @@ import qualified Hedgehog.Extras.Test.Base as H
 hprop_golden_shelleyGenesisUTxOKeys :: Property
 hprop_golden_shelleyGenesisUTxOKeys = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
   -- Reference keys
-  referenceVerKey <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/genesis_utxo_keys/verification_key"
-  referenceSignKey <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/genesis_utxo_keys/signing_key"
+  referenceVerKey <-
+    noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/genesis_utxo_keys/verification_key"
+  referenceSignKey <-
+    noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/genesis_utxo_keys/signing_key"
 
   -- Key filepaths
   verKey <- noteTempFile tempDir "genesis-utxo-verification-key-file"
   signKey <- noteTempFile tempDir "genesis-utxo-signing-key-file"
 
   -- Generate payment verification key
-  void $ execCardanoCLI
-    [ "genesis","key-gen-utxo"
-    , "--verification-key-file", verKey
-    , "--signing-key-file", signKey
-    ]
+  void $
+    execCardanoCLI
+      [ "genesis"
+      , "key-gen-utxo"
+      , "--verification-key-file"
+      , verKey
+      , "--signing-key-file"
+      , signKey
+      ]
 
   let signingKeyType = textEnvelopeType (AsSigningKey AsGenesisUTxOKey)
       verificationKeyType = textEnvelopeType (AsVerificationKey AsGenesisUTxOKey)

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/GenesisUTxOKeys.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/GenesisUTxOKeys.hs
@@ -9,7 +9,7 @@ import Control.Monad (void)
 import Test.Cardano.CLI.Util
 
 import Hedgehog (Property)
-import qualified Hedgehog.Extras.Test.Base as H
+import Hedgehog.Extras.Test.Base qualified as H
 
 {- HLINT ignore "Use camelCase" -}
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/KESKeys.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/KESKeys.hs
@@ -11,9 +11,9 @@ import Text.Regex.TDFA ((=~))
 import Test.Cardano.CLI.Util
 
 import Hedgehog (Property)
-import qualified Hedgehog as H
-import qualified Hedgehog.Extras.Test.Base as H
-import qualified Hedgehog.Extras.Test.File as H
+import Hedgehog qualified as H
+import Hedgehog.Extras.Test.Base qualified as H
+import Hedgehog.Extras.Test.File qualified as H
 
 {- HLINT ignore "Use camelCase" -}
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/KESKeys.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/KESKeys.hs
@@ -3,14 +3,14 @@
 
 module Test.Golden.Shelley.TextEnvelope.Keys.KESKeys where
 
-import           Cardano.Api (AsType (..), HasTextEnvelope (..))
+import Cardano.Api (AsType (..), HasTextEnvelope (..))
 
-import           Control.Monad (void)
-import           Text.Regex.TDFA ((=~))
+import Control.Monad (void)
+import Text.Regex.TDFA ((=~))
 
-import           Test.Cardano.CLI.Util
+import Test.Cardano.CLI.Util
 
-import           Hedgehog (Property)
+import Hedgehog (Property)
 import qualified Hedgehog as H
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
@@ -23,19 +23,25 @@ import qualified Hedgehog.Extras.Test.File as H
 hprop_golden_shelleyKESKeys :: Property
 hprop_golden_shelleyKESKeys = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
   -- Reference keys
-  referenceVerKey <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/kes_keys/verification_key"
-  referenceSignKey <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/kes_keys/signing_key"
+  referenceVerKey <-
+    noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/kes_keys/verification_key"
+  referenceSignKey <-
+    noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/kes_keys/signing_key"
 
   -- Key filepaths
   verKey <- noteTempFile tempDir "kes-verification-key-file"
   signKey <- noteTempFile tempDir "kes-signing-key-file"
 
   -- Generate payment verification key
-  void $ execCardanoCLI
-    [ "node","key-gen-KES"
-    , "--verification-key-file", verKey
-    , "--signing-key-file", signKey
-    ]
+  void $
+    execCardanoCLI
+      [ "node"
+      , "key-gen-KES"
+      , "--verification-key-file"
+      , verKey
+      , "--signing-key-file"
+      , signKey
+      ]
 
   let signingKeyType = textEnvelopeType (AsSigningKey AsKesKey)
       verificationKeyType = textEnvelopeType (AsVerificationKey AsKesKey)
@@ -51,20 +57,27 @@ hprop_golden_shelleyKESKeys = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir 
 hprop_golden_shelleyKESKeys_te :: Property
 hprop_golden_shelleyKESKeys_te = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
   -- Reference keys
-  referenceVerKey <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/kes_keys/verification_key"
-  referenceSignKey <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/kes_keys/signing_key"
+  referenceVerKey <-
+    noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/kes_keys/verification_key"
+  referenceSignKey <-
+    noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/kes_keys/signing_key"
 
   -- Key filepaths
   verKey <- noteTempFile tempDir "kes-verification-key-file"
   signKey <- noteTempFile tempDir "kes-signing-key-file"
 
   -- Generate payment verification key
-  void $ execCardanoCLI
-    [ "node","key-gen-KES"
-    , "--key-output-format", "text-envelope"
-    , "--verification-key-file", verKey
-    , "--signing-key-file", signKey
-    ]
+  void $
+    execCardanoCLI
+      [ "node"
+      , "key-gen-KES"
+      , "--key-output-format"
+      , "text-envelope"
+      , "--verification-key-file"
+      , verKey
+      , "--signing-key-file"
+      , signKey
+      ]
 
   let signingKeyType = textEnvelopeType (AsSigningKey AsKesKey)
       verificationKeyType = textEnvelopeType (AsVerificationKey AsKesKey)
@@ -84,12 +97,17 @@ hprop_golden_shelleyKESKeys_bech32 = propertyOnce . H.moduleWorkspace "tmp" $ \t
   signKeyFile <- noteTempFile tempDir "kes-signing-key-file"
 
   -- Generate payment verification key
-  void $ execCardanoCLI
-    [ "node","key-gen-KES"
-    , "--key-output-format", "bech32"
-    , "--verification-key-file", verKeyFile
-    , "--signing-key-file", signKeyFile
-    ]
+  void $
+    execCardanoCLI
+      [ "node"
+      , "key-gen-KES"
+      , "--key-output-format"
+      , "bech32"
+      , "--verification-key-file"
+      , verKeyFile
+      , "--signing-key-file"
+      , signKeyFile
+      ]
 
   -- Check the newly created files have not deviated from the
   -- golden files

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/PaymentKeys.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/PaymentKeys.hs
@@ -3,14 +3,14 @@
 
 module Test.Golden.Shelley.TextEnvelope.Keys.PaymentKeys where
 
-import           Cardano.Api (AsType (..), HasTextEnvelope (..))
+import Cardano.Api (AsType (..), HasTextEnvelope (..))
 
-import           Control.Monad (void)
-import           Text.Regex.TDFA ((=~))
+import Control.Monad (void)
+import Text.Regex.TDFA ((=~))
 
-import           Test.Cardano.CLI.Util
+import Test.Cardano.CLI.Util
 
-import           Hedgehog (Property)
+import Hedgehog (Property)
 import qualified Hedgehog as H
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
@@ -23,19 +23,25 @@ import qualified Hedgehog.Extras.Test.File as H
 hprop_golden_shelleyPaymentKeys :: Property
 hprop_golden_shelleyPaymentKeys = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
   -- Reference keys
-  referenceVerKey <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/payment_keys/verification_key"
-  referenceSignKey <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/payment_keys/signing_key"
+  referenceVerKey <-
+    noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/payment_keys/verification_key"
+  referenceSignKey <-
+    noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/payment_keys/signing_key"
 
   -- Key filepaths
   verKey <- noteTempFile tempDir "payment-verification-key-file"
   signKey <- noteTempFile tempDir "payment-signing-key-file"
 
   -- Generate payment verification key
-  void $ execCardanoCLI
-    [ "address","key-gen"
-    , "--verification-key-file", verKey
-    , "--signing-key-file", signKey
-    ]
+  void $
+    execCardanoCLI
+      [ "address"
+      , "key-gen"
+      , "--verification-key-file"
+      , verKey
+      , "--signing-key-file"
+      , signKey
+      ]
 
   let signingKeyType = textEnvelopeType (AsSigningKey AsPaymentKey)
       verificationKeyType = textEnvelopeType (AsVerificationKey AsPaymentKey)
@@ -51,20 +57,27 @@ hprop_golden_shelleyPaymentKeys = propertyOnce . H.moduleWorkspace "tmp" $ \temp
 hprop_golden_shelleyPaymentKeys_te :: Property
 hprop_golden_shelleyPaymentKeys_te = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
   -- Reference keys
-  referenceVerKey <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/payment_keys/verification_key"
-  referenceSignKey <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/payment_keys/signing_key"
+  referenceVerKey <-
+    noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/payment_keys/verification_key"
+  referenceSignKey <-
+    noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/payment_keys/signing_key"
 
   -- Key filepaths
   verKey <- noteTempFile tempDir "payment-verification-key-file"
   signKey <- noteTempFile tempDir "payment-signing-key-file"
 
   -- Generate payment verification key
-  void $ execCardanoCLI
-    [ "address","key-gen"
-    , "--key-output-format", "text-envelope"
-    , "--verification-key-file", verKey
-    , "--signing-key-file", signKey
-    ]
+  void $
+    execCardanoCLI
+      [ "address"
+      , "key-gen"
+      , "--key-output-format"
+      , "text-envelope"
+      , "--verification-key-file"
+      , verKey
+      , "--signing-key-file"
+      , signKey
+      ]
 
   let signingKeyType = textEnvelopeType (AsSigningKey AsPaymentKey)
       verificationKeyType = textEnvelopeType (AsVerificationKey AsPaymentKey)
@@ -86,12 +99,17 @@ hprop_golden_shelleyPaymentKeys_bech32 = propertyOnce . H.moduleWorkspace "tmp" 
   signKeyFile <- noteTempFile tempDir "payment-signing-key-file"
 
   -- Generate payment verification key
-  void $ execCardanoCLI
-    [ "address","key-gen"
-    , "--key-output-format", "bech32"
-    , "--verification-key-file", verKeyFile
-    , "--signing-key-file", signKeyFile
-    ]
+  void $
+    execCardanoCLI
+      [ "address"
+      , "key-gen"
+      , "--key-output-format"
+      , "bech32"
+      , "--verification-key-file"
+      , verKeyFile
+      , "--signing-key-file"
+      , signKeyFile
+      ]
 
   verKey <- H.readFile verKeyFile
   H.assert $ verKey =~ id @String "^addr_vk[a-z0-9]{59}$"

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/PaymentKeys.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/PaymentKeys.hs
@@ -11,9 +11,9 @@ import Text.Regex.TDFA ((=~))
 import Test.Cardano.CLI.Util
 
 import Hedgehog (Property)
-import qualified Hedgehog as H
-import qualified Hedgehog.Extras.Test.Base as H
-import qualified Hedgehog.Extras.Test.File as H
+import Hedgehog qualified as H
+import Hedgehog.Extras.Test.Base qualified as H
+import Hedgehog.Extras.Test.File qualified as H
 
 {- HLINT ignore "Use camelCase" -}
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/StakeKeys.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/StakeKeys.hs
@@ -11,9 +11,9 @@ import Text.Regex.TDFA ((=~))
 import Test.Cardano.CLI.Util
 
 import Hedgehog (Property)
-import qualified Hedgehog as H
-import qualified Hedgehog.Extras.Test.Base as H
-import qualified Hedgehog.Extras.Test.File as H
+import Hedgehog qualified as H
+import Hedgehog.Extras.Test.Base qualified as H
+import Hedgehog.Extras.Test.File qualified as H
 
 {- HLINT ignore "Use camelCase" -}
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/StakeKeys.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/StakeKeys.hs
@@ -3,14 +3,14 @@
 
 module Test.Golden.Shelley.TextEnvelope.Keys.StakeKeys where
 
-import           Cardano.Api (AsType (..), HasTextEnvelope (..))
+import Cardano.Api (AsType (..), HasTextEnvelope (..))
 
-import           Control.Monad (void)
-import           Text.Regex.TDFA ((=~))
+import Control.Monad (void)
+import Text.Regex.TDFA ((=~))
 
-import           Test.Cardano.CLI.Util
+import Test.Cardano.CLI.Util
 
-import           Hedgehog (Property)
+import Hedgehog (Property)
 import qualified Hedgehog as H
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
@@ -23,19 +23,25 @@ import qualified Hedgehog.Extras.Test.File as H
 hprop_golden_shelleyStakeKeys :: Property
 hprop_golden_shelleyStakeKeys = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
   -- Reference keys
-  referenceVerKey <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/stake_keys/verification_key"
-  referenceSignKey <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/stake_keys/signing_key"
+  referenceVerKey <-
+    noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/stake_keys/verification_key"
+  referenceSignKey <-
+    noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/stake_keys/signing_key"
 
   -- Key filepaths
   verKey <- noteTempFile tempDir "stake-verification-key-file"
   signKey <- noteTempFile tempDir "stake-signing-key-file"
 
   -- Generate stake key pair
-  void $ execCardanoCLI
-    [ "stake-address","key-gen"
-    , "--verification-key-file", verKey
-    , "--signing-key-file", signKey
-    ]
+  void $
+    execCardanoCLI
+      [ "stake-address"
+      , "key-gen"
+      , "--verification-key-file"
+      , verKey
+      , "--signing-key-file"
+      , signKey
+      ]
 
   let signingKeyType = textEnvelopeType (AsSigningKey AsStakeKey)
       verificationKeyType = textEnvelopeType (AsVerificationKey AsStakeKey)
@@ -51,20 +57,27 @@ hprop_golden_shelleyStakeKeys = propertyOnce . H.moduleWorkspace "tmp" $ \tempDi
 hprop_golden_shelleyStakeKeys_te :: Property
 hprop_golden_shelleyStakeKeys_te = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
   -- Reference keys
-  referenceVerKey <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/stake_keys/verification_key"
-  referenceSignKey <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/stake_keys/signing_key"
+  referenceVerKey <-
+    noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/stake_keys/verification_key"
+  referenceSignKey <-
+    noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/stake_keys/signing_key"
 
   -- Key filepaths
   verKey <- noteTempFile tempDir "stake-verification-key-file"
   signKey <- noteTempFile tempDir "stake-signing-key-file"
 
   -- Generate stake key pair
-  void $ execCardanoCLI
-    [ "stake-address","key-gen"
-    , "--key-output-format", "text-envelope"
-    , "--verification-key-file", verKey
-    , "--signing-key-file", signKey
-    ]
+  void $
+    execCardanoCLI
+      [ "stake-address"
+      , "key-gen"
+      , "--key-output-format"
+      , "text-envelope"
+      , "--verification-key-file"
+      , verKey
+      , "--signing-key-file"
+      , signKey
+      ]
 
   let signingKeyType = textEnvelopeType (AsSigningKey AsStakeKey)
       verificationKeyType = textEnvelopeType (AsVerificationKey AsStakeKey)
@@ -86,12 +99,17 @@ hprop_golden_shelleyStakeKeys_bech32 = propertyOnce . H.moduleWorkspace "tmp" $ 
   signKeyFile <- noteTempFile tempDir "stake-signing-key-file"
 
   -- Generate stake key pair
-  void $ execCardanoCLI
-    [ "stake-address","key-gen"
-    , "--key-output-format", "bech32"
-    , "--verification-key-file", verKeyFile
-    , "--signing-key-file", signKeyFile
-    ]
+  void $
+    execCardanoCLI
+      [ "stake-address"
+      , "key-gen"
+      , "--key-output-format"
+      , "bech32"
+      , "--verification-key-file"
+      , verKeyFile
+      , "--signing-key-file"
+      , signKeyFile
+      ]
 
   verKey <- H.readFile verKeyFile
   H.assert $ verKey =~ id @String "stake_vk[a-z0-9]{59}"

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/VRFKeys.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/VRFKeys.hs
@@ -3,14 +3,14 @@
 
 module Test.Golden.Shelley.TextEnvelope.Keys.VRFKeys where
 
-import           Cardano.Api (AsType (..), HasTextEnvelope (..))
+import Cardano.Api (AsType (..), HasTextEnvelope (..))
 
-import           Control.Monad (void)
-import           Text.Regex.TDFA ((=~))
+import Control.Monad (void)
+import Text.Regex.TDFA ((=~))
 
-import           Test.Cardano.CLI.Util
+import Test.Cardano.CLI.Util
 
-import           Hedgehog (Property)
+import Hedgehog (Property)
 import qualified Hedgehog as H
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
@@ -25,19 +25,25 @@ hprop_golden_shelleyVRFKeys = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir 
   H.note_ tempDir
 
   -- Reference keys
-  referenceVerKey <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/vrf_keys/verification_key"
-  referenceSignKey <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/vrf_keys/signing_key"
+  referenceVerKey <-
+    noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/vrf_keys/verification_key"
+  referenceSignKey <-
+    noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/vrf_keys/signing_key"
 
   -- Key filepaths
   verKey <- noteTempFile tempDir "vrf-verification-key-file"
   signKey <- noteTempFile tempDir "vrf-signing-key-file"
 
   -- Generate vrf verification key
-  void $ execCardanoCLI
-    [ "node","key-gen-VRF"
-    , "--verification-key-file", verKey
-    , "--signing-key-file", signKey
-    ]
+  void $
+    execCardanoCLI
+      [ "node"
+      , "key-gen-VRF"
+      , "--verification-key-file"
+      , verKey
+      , "--signing-key-file"
+      , signKey
+      ]
 
   let signingKeyType = textEnvelopeType (AsSigningKey AsVrfKey)
       verificationKeyType = textEnvelopeType (AsVerificationKey AsVrfKey)
@@ -55,20 +61,27 @@ hprop_golden_shelleyVRFKeys_te = propertyOnce . H.moduleWorkspace "tmp" $ \tempD
   H.note_ tempDir
 
   -- Reference keys
-  referenceVerKey <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/vrf_keys/verification_key"
-  referenceSignKey <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/vrf_keys/signing_key"
+  referenceVerKey <-
+    noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/vrf_keys/verification_key"
+  referenceSignKey <-
+    noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/vrf_keys/signing_key"
 
   -- Key filepaths
   verKey <- noteTempFile tempDir "vrf-verification-key-file"
   signKey <- noteTempFile tempDir "vrf-signing-key-file"
 
   -- Generate vrf verification key
-  void $ execCardanoCLI
-    [ "node","key-gen-VRF"
-    , "--key-output-format", "text-envelope"
-    , "--verification-key-file", verKey
-    , "--signing-key-file", signKey
-    ]
+  void $
+    execCardanoCLI
+      [ "node"
+      , "key-gen-VRF"
+      , "--key-output-format"
+      , "text-envelope"
+      , "--verification-key-file"
+      , verKey
+      , "--signing-key-file"
+      , signKey
+      ]
 
   let signingKeyType = textEnvelopeType (AsSigningKey AsVrfKey)
       verificationKeyType = textEnvelopeType (AsVerificationKey AsVrfKey)
@@ -90,12 +103,17 @@ hprop_golden_shelleyVRFKeys_bech32 = propertyOnce . H.moduleWorkspace "tmp" $ \t
   signKeyFile <- noteTempFile tempDir "vrf-signing-key-file"
 
   -- Generate vrf verification key
-  void $ execCardanoCLI
-    [ "node","key-gen-VRF"
-    , "--key-output-format", "bech32"
-    , "--verification-key-file", verKeyFile
-    , "--signing-key-file", signKeyFile
-    ]
+  void $
+    execCardanoCLI
+      [ "node"
+      , "key-gen-VRF"
+      , "--key-output-format"
+      , "bech32"
+      , "--verification-key-file"
+      , verKeyFile
+      , "--signing-key-file"
+      , signKeyFile
+      ]
 
   verKey <- H.readFile verKeyFile
   H.assert $ verKey =~ id @String "vrf_vk[a-z0-9]{59}"

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/VRFKeys.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Keys/VRFKeys.hs
@@ -11,9 +11,9 @@ import Text.Regex.TDFA ((=~))
 import Test.Cardano.CLI.Util
 
 import Hedgehog (Property)
-import qualified Hedgehog as H
-import qualified Hedgehog.Extras.Test.Base as H
-import qualified Hedgehog.Extras.Test.File as H
+import Hedgehog qualified as H
+import Hedgehog.Extras.Test.Base qualified as H
+import Hedgehog.Extras.Test.File qualified as H
 
 {- HLINT ignore "Use camelCase" -}
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Tx/Tx.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Tx/Tx.hs
@@ -2,11 +2,11 @@
 
 module Test.Golden.Shelley.TextEnvelope.Tx.Tx where
 
-import           Control.Monad (void)
+import Control.Monad (void)
 
-import           Test.Cardano.CLI.Util
+import Test.Cardano.CLI.Util
 
-import           Hedgehog (Property)
+import Hedgehog (Property)
 import qualified Hedgehog.Extras.Test.Base as H
 
 {- HLINT ignore "Use camelCase" -}
@@ -21,28 +21,43 @@ hprop_golden_shelleyTx = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
   let referenceTx = "test/cardano-cli-golden/files/golden/alonzo/tx"
 
   -- Key filepaths
-  paymentSignKey <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/transaction-sign/utxo.skey"
+  paymentSignKey <-
+    noteInputFile "test/cardano-cli-golden/files/golden/shelley/transaction-sign/utxo.skey"
   transactionFile <- noteTempFile tempDir "tx-file"
   transactionBodyFile <- noteTempFile tempDir "tx-body-file"
 
   -- Create transaction body
-  void $ execCardanoCLI
-    [ "alonzo", "transaction", "build-raw"
-    , "--tx-in", "f62cd7bc15d8c6d2c8519fb8d13c57c0157ab6bab50af62bc63706feb966393d#0"
-    , "--tx-out", "addr_test1qpmxr8d8jcl25kyz2tz9a9sxv7jxglhddyf475045y8j3zxjcg9vquzkljyfn3rasfwwlkwu7hhm59gzxmsyxf3w9dps8832xh+1199989833223"
-    , "--tx-out", "addr_test1vpqgspvmh6m2m5pwangvdg499srfzre2dd96qq57nlnw6yctpasy4+10000000"
-    , "--fee", "166777"
-    , "--out-file", transactionBodyFile
-    ]
+  void $
+    execCardanoCLI
+      [ "alonzo"
+      , "transaction"
+      , "build-raw"
+      , "--tx-in"
+      , "f62cd7bc15d8c6d2c8519fb8d13c57c0157ab6bab50af62bc63706feb966393d#0"
+      , "--tx-out"
+      , "addr_test1qpmxr8d8jcl25kyz2tz9a9sxv7jxglhddyf475045y8j3zxjcg9vquzkljyfn3rasfwwlkwu7hhm59gzxmsyxf3w9dps8832xh+1199989833223"
+      , "--tx-out"
+      , "addr_test1vpqgspvmh6m2m5pwangvdg499srfzre2dd96qq57nlnw6yctpasy4+10000000"
+      , "--fee"
+      , "166777"
+      , "--out-file"
+      , transactionBodyFile
+      ]
 
   -- Sign transaction
-  void $ execCardanoCLI
-    [ "transaction", "sign"
-    , "--tx-body-file", transactionBodyFile
-    , "--signing-key-file", paymentSignKey
-    , "--testnet-magic", "42"
-    , "--out-file", transactionFile
-    ]
+  void $
+    execCardanoCLI
+      [ "transaction"
+      , "sign"
+      , "--tx-body-file"
+      , transactionBodyFile
+      , "--signing-key-file"
+      , paymentSignKey
+      , "--testnet-magic"
+      , "42"
+      , "--out-file"
+      , transactionFile
+      ]
 
   -- Check the newly created files have not deviated from the
   -- golden files

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Tx/Tx.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Tx/Tx.hs
@@ -7,7 +7,7 @@ import Control.Monad (void)
 import Test.Cardano.CLI.Util
 
 import Hedgehog (Property)
-import qualified Hedgehog.Extras.Test.Base as H
+import Hedgehog.Extras.Test.Base qualified as H
 
 {- HLINT ignore "Use camelCase" -}
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Tx/TxBody.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Tx/TxBody.hs
@@ -2,11 +2,11 @@
 
 module Test.Golden.Shelley.TextEnvelope.Tx.TxBody where
 
-import           Control.Monad (void)
+import Control.Monad (void)
 
-import           Test.Cardano.CLI.Util
+import Test.Cardano.CLI.Util
 
-import           Hedgehog (Property)
+import Hedgehog (Property)
 import qualified Hedgehog.Extras.Test.Base as H
 
 {- HLINT ignore "Use camelCase" -}
@@ -22,15 +22,22 @@ hprop_golden_shelleyTxBody = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -
   transactionBodyFile <- noteTempFile tempDir "transaction-body-file"
 
   -- Create transaction body
-  void $ execCardanoCLI
-    [ "mary", "transaction", "build-raw"
-    , "--tx-in", "91999ea21177b33ebe6b8690724a0c026d410a11ad7521caa350abdafa5394c3#0"
-    , "--tx-out", "addr1v9wmu83pzajplrtpsq6tsqdgwr98x888trpmah2u0ezznsge7del3+100000000"
-    , "--fee", "1000000"
-    , "--invalid-hereafter", "500000"
-    , "--out-file", transactionBodyFile
-    ]
-
+  void $
+    execCardanoCLI
+      [ "mary"
+      , "transaction"
+      , "build-raw"
+      , "--tx-in"
+      , "91999ea21177b33ebe6b8690724a0c026d410a11ad7521caa350abdafa5394c3#0"
+      , "--tx-out"
+      , "addr1v9wmu83pzajplrtpsq6tsqdgwr98x888trpmah2u0ezznsge7del3+100000000"
+      , "--fee"
+      , "1000000"
+      , "--invalid-hereafter"
+      , "500000"
+      , "--out-file"
+      , transactionBodyFile
+      ]
 
   -- Check the newly created files have not deviated from the
   -- golden files

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Tx/TxBody.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Tx/TxBody.hs
@@ -7,7 +7,7 @@ import Control.Monad (void)
 import Test.Cardano.CLI.Util
 
 import Hedgehog (Property)
-import qualified Hedgehog.Extras.Test.Base as H
+import Hedgehog.Extras.Test.Base qualified as H
 
 {- HLINT ignore "Use camelCase" -}
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Tx/Witness.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextEnvelope/Tx/Witness.hs
@@ -1,7 +1,6 @@
-
 module Test.Golden.Shelley.TextEnvelope.Tx.Witness where
 
-import           Hedgehog (Property, property, success)
+import Hedgehog (Property, property, success)
 
 {- HLINT ignore "Use camelCase" -}
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextView/DecodeCbor.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextView/DecodeCbor.hs
@@ -2,9 +2,9 @@
 
 module Test.Golden.Shelley.TextView.DecodeCbor where
 
-import           Test.Cardano.CLI.Util
+import Test.Cardano.CLI.Util
 
-import           Hedgehog (Property)
+import Hedgehog (Property)
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 
@@ -17,10 +17,13 @@ hprop_golden_shelleyTextViewDecodeCbor = propertyOnce $ H.moduleWorkspace "tmp" 
 
   -- Defaults to signing a Mainnet transaction.
 
-  decodedTxt <- execCardanoCLI
-    [ "text-view","decode-cbor"
-    , "--file", unsignedTxFile
-    ]
+  decodedTxt <-
+    execCardanoCLI
+      [ "text-view"
+      , "decode-cbor"
+      , "--file"
+      , unsignedTxFile
+      ]
 
   H.writeFile decodedTxtFile decodedTxt
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextView/DecodeCbor.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/TextView/DecodeCbor.hs
@@ -5,8 +5,8 @@ module Test.Golden.Shelley.TextView.DecodeCbor where
 import Test.Cardano.CLI.Util
 
 import Hedgehog (Property)
-import qualified Hedgehog.Extras.Test.Base as H
-import qualified Hedgehog.Extras.Test.File as H
+import Hedgehog.Extras.Test.Base qualified as H
+import Hedgehog.Extras.Test.File qualified as H
 
 {- HLINT ignore "Use camelCase" -}
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Transaction/Assemble.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Transaction/Assemble.hs
@@ -7,8 +7,8 @@ import Control.Monad (void)
 import Test.Cardano.CLI.Util
 
 import Hedgehog (Property)
-import qualified Hedgehog.Extras.Test.Base as H
-import qualified Hedgehog.Extras.Test.File as H
+import Hedgehog.Extras.Test.Base qualified as H
+import Hedgehog.Extras.Test.File qualified as H
 
 {- HLINT ignore "Use camelCase" -}
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Transaction/Assemble.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Transaction/Assemble.hs
@@ -2,11 +2,11 @@
 
 module Test.Golden.Shelley.Transaction.Assemble where
 
-import           Control.Monad (void)
+import Control.Monad (void)
 
-import           Test.Cardano.CLI.Util
+import Test.Cardano.CLI.Util
 
-import           Hedgehog (Property)
+import Hedgehog (Property)
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 
@@ -18,13 +18,20 @@ hprop_golden_shelleyTransactionAssembleWitness_SigningKey :: Property
 hprop_golden_shelleyTransactionAssembleWitness_SigningKey = propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir -> do
   witnessTx <- noteTempFile tempDir "single-signing-key-witness-tx"
   txBodyFile <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/tx/txbody"
-  signingKeyWitnessFile <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/witnesses/singleSigningKeyWitness"
-  void $ execCardanoCLI
-    [ "transaction","sign-witness"
-    , "--tx-body-file", txBodyFile
-    , "--witness-file", signingKeyWitnessFile
-    , "--witness-file", signingKeyWitnessFile
-    , "--out-file", witnessTx
-    ]
+  signingKeyWitnessFile <-
+    noteInputFile "test/cardano-cli-golden/files/golden/shelley/witnesses/singleSigningKeyWitness"
+  void $
+    execCardanoCLI
+      [ "transaction"
+      , "sign-witness"
+      , "--tx-body-file"
+      , txBodyFile
+      , "--witness-file"
+      , signingKeyWitnessFile
+      , "--witness-file"
+      , signingKeyWitnessFile
+      , "--out-file"
+      , witnessTx
+      ]
 
   H.assertFileOccurences 1 "Tx MaryEra" witnessTx

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Transaction/Build.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Transaction/Build.hs
@@ -1,22 +1,23 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 module Test.Golden.Shelley.Transaction.Build
-   where
+where
 
-import           Control.Monad (void)
+import Control.Monad (void)
 import qualified Data.ByteString.Base16 as Base16
 import qualified Data.ByteString.Char8 as BSC
 
-import           Test.Cardano.CLI.Util
+import Test.Cardano.CLI.Util
 
-import           Hedgehog (Property)
+import Hedgehog (Property)
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 
 {- HLINT ignore "Use camelCase" -}
 
 txOut :: String
-txOut = "addr1q94cxl99qvtwunsqqv6g9mgj3zrawtpt4edsgwxkjtwpy5dsezcht90tmwfur7t5hc9fk8hjd3r5vjwec2h8vmk3xh8s7er7t3+100"
+txOut =
+  "addr1q94cxl99qvtwunsqqv6g9mgj3zrawtpt4edsgwxkjtwpy5dsezcht90tmwfur7t5hc9fk8hjd3r5vjwec2h8vmk3xh8s7er7t3+100"
 
 txIn :: String
 txIn = "2392d2b1200b5139fe555c81261697b29a8ccf561c5c783d46e78a479d977053#0"
@@ -26,35 +27,52 @@ hprop_golden_shelleyTransactionBuild =
   propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir -> do
     txBodyOutFile <- noteTempFile tempDir "tx-body-out"
 
-    void $ execCardanoCLI
-      [ "mary", "transaction", "build-raw"
-      , "--tx-in", txIn
-      , "--tx-out", txOut
-      , "--fee", "12"
-      , "--tx-body-file", txBodyOutFile
-      ]
+    void $
+      execCardanoCLI
+        [ "mary"
+        , "transaction"
+        , "build-raw"
+        , "--tx-in"
+        , txIn
+        , "--tx-out"
+        , txOut
+        , "--fee"
+        , "12"
+        , "--tx-body-file"
+        , txBodyOutFile
+        ]
 
     H.assertFileOccurences 1 "Tx MaryEra" txBodyOutFile
 
     H.assertEndsWithSingleNewline txBodyOutFile
 
-
 hprop_golden_shelleyTransactionBuild_CertificateScriptWitnessed :: Property
 hprop_golden_shelleyTransactionBuild_CertificateScriptWitnessed =
   propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir -> do
-    let deregcert = "test/cardano-cli-golden/files/golden/shelley/certificates/stake_address_deregistration_certificate"
+    let deregcert =
+          "test/cardano-cli-golden/files/golden/shelley/certificates/stake_address_deregistration_certificate"
         scriptWit = "test/cardano-cli-golden/files/golden/shelley/multisig/scripts/any"
 
     txBodyOutFile <- noteTempFile tempDir "tx-body-out"
 
-    void $ execCardanoCLI
-      [ "mary", "transaction", "build-raw"
-      , "--tx-in", txIn
-      , "--tx-out", txOut
-      , "--certificate-file", deregcert, "--certificate-script-file", scriptWit
-      , "--fee", "12"
-      , "--tx-body-file", txBodyOutFile
-      ]
+    void $
+      execCardanoCLI
+        [ "mary"
+        , "transaction"
+        , "build-raw"
+        , "--tx-in"
+        , txIn
+        , "--tx-out"
+        , txOut
+        , "--certificate-file"
+        , deregcert
+        , "--certificate-script-file"
+        , scriptWit
+        , "--fee"
+        , "12"
+        , "--tx-body-file"
+        , txBodyOutFile
+        ]
 
     H.assertFileOccurences 1 "Tx MaryEra" txBodyOutFile
 
@@ -65,27 +83,38 @@ hprop_golden_shelleyTransactionBuild_Minting =
   propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir -> do
     let scriptWit = "test/cardano-cli-golden/files/golden/shelley/multisig/scripts/any"
 
-    polid <- execCardanoCLI
-               [ "transaction"
-               , "policyid"
-               , "--script-file"
-               , scriptWit
-               ]
+    polid <-
+      execCardanoCLI
+        [ "transaction"
+        , "policyid"
+        , "--script-file"
+        , scriptWit
+        ]
 
     let dummyMA =
           filter (/= '\n') $
-          "50 " ++ polid ++ "." ++ BSC.unpack (Base16.encode "ethereum")
+            "50 " ++ polid ++ "." ++ BSC.unpack (Base16.encode "ethereum")
 
     txBodyOutFile <- noteTempFile tempDir "tx-body-out"
 
-    void $ execCardanoCLI
-      [ "mary", "transaction", "build-raw"
-      , "--tx-in", txIn
-      , "--tx-out", txOut ++ "+" ++ dummyMA, "--mint-script-file", scriptWit
-      , "--mint", dummyMA
-      , "--fee", "12"
-      , "--tx-body-file", txBodyOutFile
-      ]
+    void $
+      execCardanoCLI
+        [ "mary"
+        , "transaction"
+        , "build-raw"
+        , "--tx-in"
+        , txIn
+        , "--tx-out"
+        , txOut ++ "+" ++ dummyMA
+        , "--mint-script-file"
+        , scriptWit
+        , "--mint"
+        , dummyMA
+        , "--fee"
+        , "12"
+        , "--tx-body-file"
+        , txBodyOutFile
+        ]
 
     H.assertFileOccurences 1 "Tx MaryEra" txBodyOutFile
 
@@ -96,19 +125,30 @@ hprop_golden_shelleyTransactionBuild_WithdrawalScriptWitnessed =
   propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir -> do
     txBodyOutFile <- noteTempFile tempDir "tx-body-out"
 
-    stakeAddress <- H.readFile "test/cardano-cli-golden/files/golden/shelley/keys/stake_keys/reward_address"
+    stakeAddress <-
+      H.readFile "test/cardano-cli-golden/files/golden/shelley/keys/stake_keys/reward_address"
 
     let withdrawal = filter (/= '\n') $ stakeAddress <> "+100"
         scriptWit = "test/cardano-cli-golden/files/golden/shelley/multisig/scripts/any"
 
-    void $ execCardanoCLI
-      [ "mary", "transaction", "build-raw"
-      , "--tx-in", txIn
-      , "--tx-out", txOut
-      , "--withdrawal", withdrawal, "--withdrawal-script-file", scriptWit
-      , "--fee", "12"
-      , "--tx-body-file", txBodyOutFile
-      ]
+    void $
+      execCardanoCLI
+        [ "mary"
+        , "transaction"
+        , "build-raw"
+        , "--tx-in"
+        , txIn
+        , "--tx-out"
+        , txOut
+        , "--withdrawal"
+        , withdrawal
+        , "--withdrawal-script-file"
+        , scriptWit
+        , "--fee"
+        , "12"
+        , "--tx-body-file"
+        , txBodyOutFile
+        ]
 
     H.assertFileOccurences 1 "Tx MaryEra" txBodyOutFile
 
@@ -121,13 +161,22 @@ hprop_golden_shelleyTransactionBuild_TxInScriptWitnessed =
 
     txBodyOutFile <- noteTempFile tempDir "tx-body-out"
 
-    void $ execCardanoCLI
-      [ "mary", "transaction", "build-raw"
-      , "--tx-in", txIn, "--txin-script-file", scriptWit
-      , "--tx-out", txOut
-      , "--fee", "12"
-      , "--tx-body-file", txBodyOutFile
-      ]
+    void $
+      execCardanoCLI
+        [ "mary"
+        , "transaction"
+        , "build-raw"
+        , "--tx-in"
+        , txIn
+        , "--txin-script-file"
+        , scriptWit
+        , "--tx-out"
+        , txOut
+        , "--fee"
+        , "12"
+        , "--tx-body-file"
+        , txBodyOutFile
+        ]
 
     H.assertFileOccurences 1 "Tx MaryEra" txBodyOutFile
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Transaction/Build.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Transaction/Build.hs
@@ -4,14 +4,14 @@ module Test.Golden.Shelley.Transaction.Build
 where
 
 import Control.Monad (void)
-import qualified Data.ByteString.Base16 as Base16
-import qualified Data.ByteString.Char8 as BSC
+import Data.ByteString.Base16 qualified as Base16
+import Data.ByteString.Char8 qualified as BSC
 
 import Test.Cardano.CLI.Util
 
 import Hedgehog (Property)
-import qualified Hedgehog.Extras.Test.Base as H
-import qualified Hedgehog.Extras.Test.File as H
+import Hedgehog.Extras.Test.Base qualified as H
+import Hedgehog.Extras.Test.File qualified as H
 
 {- HLINT ignore "Use camelCase" -}
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Transaction/CalculateMinFee.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Transaction/CalculateMinFee.hs
@@ -6,8 +6,8 @@ where
 import Test.Cardano.CLI.Util
 
 import Hedgehog (Property)
-import qualified Hedgehog.Extras.Test.Base as H
-import qualified Hedgehog.Extras.Test.File as H
+import Hedgehog.Extras.Test.Base qualified as H
+import Hedgehog.Extras.Test.File qualified as H
 
 {- HLINT ignore "Use camelCase" -}
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Transaction/CalculateMinFee.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Transaction/CalculateMinFee.hs
@@ -1,11 +1,11 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 module Test.Golden.Shelley.Transaction.CalculateMinFee
-   where
+where
 
-import           Test.Cardano.CLI.Util
+import Test.Cardano.CLI.Util
 
-import           Hedgehog (Property)
+import Hedgehog (Property)
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 
@@ -13,20 +13,31 @@ import qualified Hedgehog.Extras.Test.File as H
 
 hprop_golden_shelleyTransactionCalculateMinFee :: Property
 hprop_golden_shelleyTransactionCalculateMinFee = propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir -> do
-  protocolParamsJsonFile <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/transaction-calculate-min-fee/protocol-params.json"
+  protocolParamsJsonFile <-
+    noteInputFile
+      "test/cardano-cli-golden/files/golden/shelley/transaction-calculate-min-fee/protocol-params.json"
   txBodyFile <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/tx/txbody"
   minFeeTxtFile <- noteTempFile tempDir "min-fee.txt"
 
-  minFeeTxt <- execCardanoCLI
-    [ "transaction","calculate-min-fee"
-    , "--tx-in-count", "32"
-    , "--tx-out-count", "27"
-    , "--byron-witness-count", "5"
-    , "--witness-count", "10"
-    , "--testnet-magic", "4036000900"
-    , "--protocol-params-file", protocolParamsJsonFile
-    , "--tx-body-file", txBodyFile
-    ]
+  minFeeTxt <-
+    execCardanoCLI
+      [ "transaction"
+      , "calculate-min-fee"
+      , "--tx-in-count"
+      , "32"
+      , "--tx-out-count"
+      , "27"
+      , "--byron-witness-count"
+      , "5"
+      , "--witness-count"
+      , "10"
+      , "--testnet-magic"
+      , "4036000900"
+      , "--protocol-params-file"
+      , protocolParamsJsonFile
+      , "--tx-body-file"
+      , txBodyFile
+      ]
 
   H.writeFile minFeeTxtFile minFeeTxt
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Transaction/CreateWitness.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Transaction/CreateWitness.hs
@@ -2,11 +2,11 @@
 
 module Test.Golden.Shelley.Transaction.CreateWitness where
 
-import           Control.Monad (void)
+import Control.Monad (void)
 
-import           Test.Cardano.CLI.Util
+import Test.Cardano.CLI.Util
 
-import           Hedgehog (Property)
+import Hedgehog (Property)
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 
@@ -16,32 +16,47 @@ txIn :: String
 txIn = "2392d2b1200b5139fe555c81261697b29a8ccf561c5c783d46e78a479d977053#0"
 
 txOut :: String
-txOut = "addr1q94cxl99qvtwunsqqv6g9mgj3zrawtpt4edsgwxkjtwpy5dsezcht90tmwfur7t5hc9fk8hjd3r5vjwec2h8vmk3xh8s7er7t3+100"
+txOut =
+  "addr1q94cxl99qvtwunsqqv6g9mgj3zrawtpt4edsgwxkjtwpy5dsezcht90tmwfur7t5hc9fk8hjd3r5vjwec2h8vmk3xh8s7er7t3+100"
 
 hprop_golden_shelleyTransactionSigningKeyWitness :: Property
 hprop_golden_shelleyTransactionSigningKeyWitness = propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir -> do
   txBodyOutFile <- noteTempFile tempDir "tx-body-out"
 
   -- Create tx body file
-  void $ execCardanoCLI
-    [ "shelley", "transaction", "build-raw"
-    , "--tx-in", txIn
-    , "--tx-out", txOut
-    , "--invalid-hereafter", "60"
-    , "--fee", "12"
-    , "--tx-body-file", txBodyOutFile
-    ]
+  void $
+    execCardanoCLI
+      [ "shelley"
+      , "transaction"
+      , "build-raw"
+      , "--tx-in"
+      , txIn
+      , "--tx-out"
+      , txOut
+      , "--invalid-hereafter"
+      , "60"
+      , "--fee"
+      , "12"
+      , "--tx-body-file"
+      , txBodyOutFile
+      ]
 
   -- Create all multisig witness
   witnessOutFile <- noteTempFile tempDir "signingkey-witness"
-  signingKeyFile <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/payment_keys/signing_key"
-  void $ execCardanoCLI
-    [ "transaction","witness"
-    , "--tx-body-file", txBodyOutFile
-    , "--signing-key-file", signingKeyFile
-    , "--mainnet"
-    , "--out-file", witnessOutFile
-    ]
+  signingKeyFile <-
+    noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/payment_keys/signing_key"
+  void $
+    execCardanoCLI
+      [ "transaction"
+      , "witness"
+      , "--tx-body-file"
+      , txBodyOutFile
+      , "--signing-key-file"
+      , signingKeyFile
+      , "--mainnet"
+      , "--out-file"
+      , witnessOutFile
+      ]
 
   H.assertFileOccurences 1 "TxWitness ShelleyEra" witnessOutFile
   H.assertEndsWithSingleNewline txBodyOutFile

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Transaction/CreateWitness.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Transaction/CreateWitness.hs
@@ -7,8 +7,8 @@ import Control.Monad (void)
 import Test.Cardano.CLI.Util
 
 import Hedgehog (Property)
-import qualified Hedgehog.Extras.Test.Base as H
-import qualified Hedgehog.Extras.Test.File as H
+import Hedgehog.Extras.Test.Base qualified as H
+import Hedgehog.Extras.Test.File qualified as H
 
 {- HLINT ignore "Use camelCase" -}
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Transaction/Sign.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Transaction/Sign.hs
@@ -7,8 +7,8 @@ import Control.Monad (void)
 import Test.Cardano.CLI.Util
 
 import Hedgehog (Property)
-import qualified Hedgehog.Extras.Test.Base as H
-import qualified Hedgehog.Extras.Test.File as H
+import Hedgehog.Extras.Test.Base qualified as H
+import Hedgehog.Extras.Test.File qualified as H
 
 {- HLINT ignore "Use camelCase" -}
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Transaction/Sign.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Transaction/Sign.hs
@@ -2,11 +2,11 @@
 
 module Test.Golden.Shelley.Transaction.Sign where
 
-import           Control.Monad (void)
+import Control.Monad (void)
 
-import           Test.Cardano.CLI.Util
+import Test.Cardano.CLI.Util
 
-import           Hedgehog (Property)
+import Hedgehog (Property)
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 
@@ -15,36 +15,51 @@ import qualified Hedgehog.Extras.Test.File as H
 hprop_golden_shelleyTransactionSign :: Property
 hprop_golden_shelleyTransactionSign = propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir -> do
   txBodyFile <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/tx/txbody"
-  initialUtxo1SigningKeyFile <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/payment_keys/signing_key"
-  utxoSigningKeyFile <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/transaction-sign/utxo.skey"
-  stakeSigningKeyFile <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/transaction-sign/stake.skey"
-  nodeColdSigningKeyFile <- noteInputFile "test/cardano-cli-golden/files/golden/shelley/transaction-sign/node-cold.skey"
+  initialUtxo1SigningKeyFile <-
+    noteInputFile "test/cardano-cli-golden/files/golden/shelley/keys/payment_keys/signing_key"
+  utxoSigningKeyFile <-
+    noteInputFile "test/cardano-cli-golden/files/golden/shelley/transaction-sign/utxo.skey"
+  stakeSigningKeyFile <-
+    noteInputFile "test/cardano-cli-golden/files/golden/shelley/transaction-sign/stake.skey"
+  nodeColdSigningKeyFile <-
+    noteInputFile "test/cardano-cli-golden/files/golden/shelley/transaction-sign/node-cold.skey"
   signedTransactionFile <- noteTempFile tempDir "signed.tx"
   transactionPoolRegSignedFile <- noteTempFile tempDir "tx-pool-reg.signed"
 
   -- Defaults to signing a Mainnet transaction
 
-  void $ execCardanoCLI
-    [ "transaction","sign"
-    , "--mainnet"
-    , "--tx-body-file", txBodyFile
-    , "--signing-key-file", initialUtxo1SigningKeyFile
-    , "--tx-file", signedTransactionFile
-    ]
+  void $
+    execCardanoCLI
+      [ "transaction"
+      , "sign"
+      , "--mainnet"
+      , "--tx-body-file"
+      , txBodyFile
+      , "--signing-key-file"
+      , initialUtxo1SigningKeyFile
+      , "--tx-file"
+      , signedTransactionFile
+      ]
 
   H.assertFileOccurences 1 "Tx MaryEra" signedTransactionFile
   H.assertEndsWithSingleNewline signedTransactionFile
 
   -- Sign for a testnet with a testnet network magic of 11, but use two signing keys
 
-  void $ execCardanoCLI
-    [ "transaction","sign"
-    , "--mainnet"
-    , "--tx-body-file", txBodyFile
-    , "--signing-key-file", initialUtxo1SigningKeyFile
-    , "--signing-key-file", initialUtxo1SigningKeyFile
-    , "--tx-file", signedTransactionFile
-    ]
+  void $
+    execCardanoCLI
+      [ "transaction"
+      , "sign"
+      , "--mainnet"
+      , "--tx-body-file"
+      , txBodyFile
+      , "--signing-key-file"
+      , initialUtxo1SigningKeyFile
+      , "--signing-key-file"
+      , initialUtxo1SigningKeyFile
+      , "--tx-file"
+      , signedTransactionFile
+      ]
 
   H.assertFileOccurences 1 "Tx MaryEra" signedTransactionFile
   H.assertEndsWithSingleNewline signedTransactionFile
@@ -52,15 +67,22 @@ hprop_golden_shelleyTransactionSign = propertyOnce $ H.moduleWorkspace "tmp" $ \
   -- Sign a pool registration transaction.
   -- TODO: This needs to use an unsigned tx with a registration certificate
 
-  void $ execCardanoCLI
-    [ "transaction","sign"
-    , "--mainnet"
-    , "--tx-body-file", txBodyFile
-    , "--signing-key-file", utxoSigningKeyFile
-    , "--signing-key-file", stakeSigningKeyFile
-    , "--signing-key-file", nodeColdSigningKeyFile
-    , "--tx-file", transactionPoolRegSignedFile
-    ]
+  void $
+    execCardanoCLI
+      [ "transaction"
+      , "sign"
+      , "--mainnet"
+      , "--tx-body-file"
+      , txBodyFile
+      , "--signing-key-file"
+      , utxoSigningKeyFile
+      , "--signing-key-file"
+      , stakeSigningKeyFile
+      , "--signing-key-file"
+      , nodeColdSigningKeyFile
+      , "--tx-file"
+      , transactionPoolRegSignedFile
+      ]
 
   H.assertFileOccurences 1 "Tx MaryEra" transactionPoolRegSignedFile
   H.assertEndsWithSingleNewline transactionPoolRegSignedFile

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/TxView.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/TxView.hs
@@ -16,7 +16,7 @@ import Test.Cardano.CLI.Util (execCardanoCLI, noteTempFile)
 
 import Hedgehog (Property)
 import Hedgehog.Extras (Integration, moduleWorkspace, note_, propertyOnce)
-import qualified Hedgehog.Extras.Test.Golden as H
+import Hedgehog.Extras.Test.Golden qualified as H
 
 {- HLINT ignore "Use camelCase" -}
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/TxView.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/TxView.hs
@@ -9,13 +9,13 @@ module Test.Golden.TxView
   , hprop_golden_view_alonzo_signed
   ) where
 
-import           Control.Monad (void)
-import           System.FilePath ((</>))
+import Control.Monad (void)
+import System.FilePath ((</>))
 
-import           Test.Cardano.CLI.Util (execCardanoCLI, noteTempFile)
+import Test.Cardano.CLI.Util (execCardanoCLI, noteTempFile)
 
-import           Hedgehog (Property)
-import           Hedgehog.Extras (Integration, moduleWorkspace, note_, propertyOnce)
+import Hedgehog (Property)
+import Hedgehog.Extras (Integration, moduleWorkspace, note_, propertyOnce)
 import qualified Hedgehog.Extras.Test.Golden as H
 
 {- HLINT ignore "Use camelCase" -}
@@ -23,225 +23,273 @@ import qualified Hedgehog.Extras.Test.Golden as H
 hprop_golden_view_byron :: Property
 hprop_golden_view_byron =
   propertyOnce $
-  moduleWorkspace "tmp" $ \tempDir -> do
-    transactionBodyFile <- noteTempFile tempDir "transaction-body-file"
+    moduleWorkspace "tmp" $ \tempDir -> do
+      transactionBodyFile <- noteTempFile tempDir "transaction-body-file"
 
-    -- Create transaction body
-    void $
-      execCardanoCLI
-        [ "transaction", "build-raw"
-        , "--byron-era"
-        , "--tx-in"
-        ,   "F8EC302D19E3C8251C30B1434349BF2E949A1DBF14A4EBC3D512918D2D4D5C56#88"
-        , "--tx-out"
-        ,   "5oP9ib6ym3XfwXuy3ksXZzgtBzXSArXAACQVXKqcPhiLnHVYjXJNu2T6Zomh8LAWLV+68"
-        , "--out-file", transactionBodyFile
-        ]
+      -- Create transaction body
+      void $
+        execCardanoCLI
+          [ "transaction"
+          , "build-raw"
+          , "--byron-era"
+          , "--tx-in"
+          , "F8EC302D19E3C8251C30B1434349BF2E949A1DBF14A4EBC3D512918D2D4D5C56#88"
+          , "--tx-out"
+          , "5oP9ib6ym3XfwXuy3ksXZzgtBzXSArXAACQVXKqcPhiLnHVYjXJNu2T6Zomh8LAWLV+68"
+          , "--out-file"
+          , transactionBodyFile
+          ]
 
-    -- View transaction body
-    result <-
-      execCardanoCLI
-        ["transaction", "view", "--tx-body-file", transactionBodyFile]
-    H.diffVsGoldenFile result "test/cardano-cli-golden/files/golden/byron/transaction-view.out"
+      -- View transaction body
+      result <-
+        execCardanoCLI
+          ["transaction", "view", "--tx-body-file", transactionBodyFile]
+      H.diffVsGoldenFile result "test/cardano-cli-golden/files/golden/byron/transaction-view.out"
 
 hprop_golden_view_shelley :: Property
-hprop_golden_view_shelley = let
-  certDir = "test/cardano-cli-golden/files/golden/shelley/certificates"
-  certs =
-    (certDir </>) <$>
-    [ "genesis_key_delegation_certificate"
-    , "mir_certificate"
-    , "stake_address_deregistration_certificate"
-    , "stake_address_registration_certificate"
-    , "stake_pool_deregistration_certificate"
-    , "stake_pool_registration_certificate"
-    ]
-  in
-  propertyOnce $
-  moduleWorkspace "tmp" $ \tempDir -> do
-    updateProposalFile <- noteTempFile tempDir "update-proposal"
-    transactionBodyFile <- noteTempFile tempDir "transaction-body"
+hprop_golden_view_shelley =
+  let
+    certDir = "test/cardano-cli-golden/files/golden/shelley/certificates"
+    certs =
+      (certDir </>)
+        <$> [ "genesis_key_delegation_certificate"
+            , "mir_certificate"
+            , "stake_address_deregistration_certificate"
+            , "stake_address_registration_certificate"
+            , "stake_pool_deregistration_certificate"
+            , "stake_pool_registration_certificate"
+            ]
+   in
+    propertyOnce $
+      moduleWorkspace "tmp" $ \tempDir -> do
+        updateProposalFile <- noteTempFile tempDir "update-proposal"
+        transactionBodyFile <- noteTempFile tempDir "transaction-body"
 
-    let extraEntropySeed = "c0ffee"
-    note_ $ "extra entropy seed: " ++ extraEntropySeed
-    note_ $ mconcat
-      [ "extra entropy hash:"
-      , " 88f04f011dcded879039ae4b9b20219d9448e5c7b42c2d1f638fb8740e0ab8be"
-      ]
+        let extraEntropySeed = "c0ffee"
+        note_ $ "extra entropy seed: " ++ extraEntropySeed
+        note_ $
+          mconcat
+            [ "extra entropy hash:"
+            , " 88f04f011dcded879039ae4b9b20219d9448e5c7b42c2d1f638fb8740e0ab8be"
+            ]
 
-    note_ $ mconcat
-      [ "genesis-verification-key-file hash:"
-      , " 81cb0bc5b6fbba391e6f7ec3d9271cbea25bcbf907181b7c4d5f8c2f"
-      ]
+        note_ $
+          mconcat
+            [ "genesis-verification-key-file hash:"
+            , " 81cb0bc5b6fbba391e6f7ec3d9271cbea25bcbf907181b7c4d5f8c2f"
+            ]
 
-    -- Create update proposal
-    void $
-      execCardanoCLI
-        [ "legacy", "governance", "create-update-proposal"
-        , "--decentralization-parameter", "63/64"
-        , "--epoch", "64"
-        , "--extra-entropy", extraEntropySeed
-        , "--genesis-verification-key-file"
-        ,   "test/cardano-cli-golden/files/golden/shelley/keys/genesis_keys/verification_key"
-        , "--key-reg-deposit-amt", "71"
-        , "--max-block-body-size", "72"
-        , "--max-block-header-size", "73"
-        , "--max-tx-size", "74"
-        , "--min-fee-constant", "75"
-        , "--min-fee-linear", "76"
-        , "--min-pool-cost", "77"
-        , "--min-utxo-value", "78"
-        , "--monetary-expansion", "79/80"
-        , "--number-of-pools", "80"
-        , "--out-file", updateProposalFile
-        , "--pool-influence", "82/83"
-        , "--pool-reg-deposit", "83"
-        , "--pool-retirement-epoch-boundary", "84"
-        , "--protocol-major-version", "8"
-        , "--protocol-minor-version", "86"
-        , "--treasury-expansion", "87/88"
-        ]
+        -- Create update proposal
+        void $
+          execCardanoCLI
+            [ "legacy"
+            , "governance"
+            , "create-update-proposal"
+            , "--decentralization-parameter"
+            , "63/64"
+            , "--epoch"
+            , "64"
+            , "--extra-entropy"
+            , extraEntropySeed
+            , "--genesis-verification-key-file"
+            , "test/cardano-cli-golden/files/golden/shelley/keys/genesis_keys/verification_key"
+            , "--key-reg-deposit-amt"
+            , "71"
+            , "--max-block-body-size"
+            , "72"
+            , "--max-block-header-size"
+            , "73"
+            , "--max-tx-size"
+            , "74"
+            , "--min-fee-constant"
+            , "75"
+            , "--min-fee-linear"
+            , "76"
+            , "--min-pool-cost"
+            , "77"
+            , "--min-utxo-value"
+            , "78"
+            , "--monetary-expansion"
+            , "79/80"
+            , "--number-of-pools"
+            , "80"
+            , "--out-file"
+            , updateProposalFile
+            , "--pool-influence"
+            , "82/83"
+            , "--pool-reg-deposit"
+            , "83"
+            , "--pool-retirement-epoch-boundary"
+            , "84"
+            , "--protocol-major-version"
+            , "8"
+            , "--protocol-minor-version"
+            , "86"
+            , "--treasury-expansion"
+            , "87/88"
+            ]
 
-    -- Create transaction body
-    void $
-      execCardanoCLI $
-        [ "shelley", "transaction", "build-raw"
-        , "--tx-in"
-        ,   "fe5dd07fb576bff960d6e066eade5b26cdb5afebe29f76ea58d0a098bce5d891#29"
-        , "--tx-out"
-        ,   "addr_test1vz7w0r9epak6nmnh3mc8e2ypkjyu8zsc3xf7dpct6k577acxmcfyv+31"
-        , "--fee", "32"
-        , "--invalid-hereafter", "33"
-        , "--withdrawal"
-        ,   "stake_test1up00fz9lyqs5sjks82k22eqz7a9srym9vysjgp3h2ua2v2cm522kg+42"
-        , "--update-proposal-file", updateProposalFile
-        , "--out-file", transactionBodyFile
-        ]
-        ++
-        ["--certificate-file=" <> cert | cert <- certs]
+        -- Create transaction body
+        void $
+          execCardanoCLI $
+            [ "shelley"
+            , "transaction"
+            , "build-raw"
+            , "--tx-in"
+            , "fe5dd07fb576bff960d6e066eade5b26cdb5afebe29f76ea58d0a098bce5d891#29"
+            , "--tx-out"
+            , "addr_test1vz7w0r9epak6nmnh3mc8e2ypkjyu8zsc3xf7dpct6k577acxmcfyv+31"
+            , "--fee"
+            , "32"
+            , "--invalid-hereafter"
+            , "33"
+            , "--withdrawal"
+            , "stake_test1up00fz9lyqs5sjks82k22eqz7a9srym9vysjgp3h2ua2v2cm522kg+42"
+            , "--update-proposal-file"
+            , updateProposalFile
+            , "--out-file"
+            , transactionBodyFile
+            ]
+              ++ ["--certificate-file=" <> cert | cert <- certs]
 
-    -- View transaction body
-    result <-
-      execCardanoCLI
-        ["transaction", "view", "--tx-body-file", transactionBodyFile]
-    H.diffVsGoldenFile result "test/cardano-cli-golden/files/golden/shelley/transaction-view.out"
+        -- View transaction body
+        result <-
+          execCardanoCLI
+            ["transaction", "view", "--tx-body-file", transactionBodyFile]
+        H.diffVsGoldenFile result "test/cardano-cli-golden/files/golden/shelley/transaction-view.out"
 
 hprop_golden_view_allegra :: Property
 hprop_golden_view_allegra =
   propertyOnce $
-  moduleWorkspace "tmp" $ \tempDir -> do
-    transactionBodyFile <- noteTempFile tempDir "transaction-body-file"
+    moduleWorkspace "tmp" $ \tempDir -> do
+      transactionBodyFile <- noteTempFile tempDir "transaction-body-file"
 
-    -- Create transaction body
-    void $
-      execCardanoCLI
-        [ "allegra", "transaction", "build-raw"
-        , "--tx-in"
-        ,   "fe5dd07fb576bff960d6e066eade5b26cdb5afebe29f76ea58d0a098bce5d891#94"
-        , "--tx-out"
-        , mconcat
-          [ "addr_test1"
-          , "qrefnr4k09pvge6dq83v6s67ruter8sftmky8qrmkqqsxy7q5psgn8tgqmupq4r7"
-          , "9jmxlyk4eqt6z6hj5g8jd8393msqaw47f4"
-          , "+99"
+      -- Create transaction body
+      void $
+        execCardanoCLI
+          [ "allegra"
+          , "transaction"
+          , "build-raw"
+          , "--tx-in"
+          , "fe5dd07fb576bff960d6e066eade5b26cdb5afebe29f76ea58d0a098bce5d891#94"
+          , "--tx-out"
+          , mconcat
+              [ "addr_test1"
+              , "qrefnr4k09pvge6dq83v6s67ruter8sftmky8qrmkqqsxy7q5psgn8tgqmupq4r7"
+              , "9jmxlyk4eqt6z6hj5g8jd8393msqaw47f4"
+              , "+99"
+              ]
+          , "--fee"
+          , "100"
+          , "--invalid-hereafter"
+          , "101"
+          , "--out-file"
+          , transactionBodyFile
           ]
-        , "--fee", "100"
-        , "--invalid-hereafter", "101"
-        , "--out-file", transactionBodyFile
-        ]
 
-    -- View transaction body
-    result <-
-      execCardanoCLI
-        ["transaction", "view", "--tx-body-file", transactionBodyFile]
-    H.diffVsGoldenFile result "test/cardano-cli-golden/files/golden/allegra/transaction-view.out"
+      -- View transaction body
+      result <-
+        execCardanoCLI
+          ["transaction", "view", "--tx-body-file", transactionBodyFile]
+      H.diffVsGoldenFile result "test/cardano-cli-golden/files/golden/allegra/transaction-view.out"
 
 hprop_golden_view_mary :: Property
 hprop_golden_view_mary =
   propertyOnce $
-  moduleWorkspace "tmp" $ \tempDir -> do
-    transactionBodyFile <- noteTempFile tempDir "transaction-body-file"
+    moduleWorkspace "tmp" $ \tempDir -> do
+      transactionBodyFile <- noteTempFile tempDir "transaction-body-file"
 
-    -- Create transaction body
-    void $
-      execCardanoCLI
-        [ "mary", "transaction", "build-raw"
-        , "--tx-in"
-        ,   "fe5dd07fb576bff960d6e066eade5b26cdb5afebe29f76ea58d0a098bce5d891#135"
-        , "--tx-out"
-        ,   mconcat
-            [ "addr_test1"
-            , "qrefnr4k09pvge6dq83v6s67ruter8sftmky8qrmkqqsxy7q5psgn8tgqmupq4r7"
-            , "9jmxlyk4eqt6z6hj5g8jd8393msqaw47f4"
-            , " + "
-            , "138"
-            , " + "
-            , "130 d441227553a0f1a965fee7d60a0f724b368dd1bddbc208730fccebcf"
-            , " + "
-            , "132 a06ee5ffdd7f9b5bd992eb9543f44418323f81229526b77b0e4be067.cafe"
-            , " + "
-            , "134 d441227553a0f1a965fee7d60a0f724b368dd1bddbc208730fccebcf.f00d"
-            , " + "
-            , "136 a06ee5ffdd7f9b5bd992eb9543f44418323f81229526b77b0e4be067.dead"
-            , " + "
-            , "138"
-            ,   " d441227553a0f1a965fee7d60a0f724b368dd1bddbc208730fccebcf"
-            ,   ".736e6f77"
-            , " + "
-            , "142"
-            ,   " a06ee5ffdd7f9b5bd992eb9543f44418323f81229526b77b0e4be067"
-            ,   ".736b79"
-            ]
-        , "--fee", "139"
-        , "--invalid-before", "140"
-        , "--mint"
-        ,   mconcat
-            [ "130 d441227553a0f1a965fee7d60a0f724b368dd1bddbc208730fccebcf"
-            , " + "
-            , "132 a06ee5ffdd7f9b5bd992eb9543f44418323f81229526b77b0e4be067.cafe"
-            , " + "
-            , "134 d441227553a0f1a965fee7d60a0f724b368dd1bddbc208730fccebcf.f00d"
-            , " + "
-            , "136 a06ee5ffdd7f9b5bd992eb9543f44418323f81229526b77b0e4be067.dead"
-            , " + "
-            , "138"
-            ,   " d441227553a0f1a965fee7d60a0f724b368dd1bddbc208730fccebcf"
-            ,   ".736e6f77"
-            , " + "
-            , "142"
-            ,   " a06ee5ffdd7f9b5bd992eb9543f44418323f81229526b77b0e4be067"
-            ,   ".736b79"
-            ]
-        , "--mint-script-file", "test/cardano-cli-golden/files/golden/mary/scripts/mint.all"
-        , "--mint-script-file", "test/cardano-cli-golden/files/golden/mary/scripts/mint.sig"
-        , "--out-file", transactionBodyFile
-        ]
+      -- Create transaction body
+      void $
+        execCardanoCLI
+          [ "mary"
+          , "transaction"
+          , "build-raw"
+          , "--tx-in"
+          , "fe5dd07fb576bff960d6e066eade5b26cdb5afebe29f76ea58d0a098bce5d891#135"
+          , "--tx-out"
+          , mconcat
+              [ "addr_test1"
+              , "qrefnr4k09pvge6dq83v6s67ruter8sftmky8qrmkqqsxy7q5psgn8tgqmupq4r7"
+              , "9jmxlyk4eqt6z6hj5g8jd8393msqaw47f4"
+              , " + "
+              , "138"
+              , " + "
+              , "130 d441227553a0f1a965fee7d60a0f724b368dd1bddbc208730fccebcf"
+              , " + "
+              , "132 a06ee5ffdd7f9b5bd992eb9543f44418323f81229526b77b0e4be067.cafe"
+              , " + "
+              , "134 d441227553a0f1a965fee7d60a0f724b368dd1bddbc208730fccebcf.f00d"
+              , " + "
+              , "136 a06ee5ffdd7f9b5bd992eb9543f44418323f81229526b77b0e4be067.dead"
+              , " + "
+              , "138"
+              , " d441227553a0f1a965fee7d60a0f724b368dd1bddbc208730fccebcf"
+              , ".736e6f77"
+              , " + "
+              , "142"
+              , " a06ee5ffdd7f9b5bd992eb9543f44418323f81229526b77b0e4be067"
+              , ".736b79"
+              ]
+          , "--fee"
+          , "139"
+          , "--invalid-before"
+          , "140"
+          , "--mint"
+          , mconcat
+              [ "130 d441227553a0f1a965fee7d60a0f724b368dd1bddbc208730fccebcf"
+              , " + "
+              , "132 a06ee5ffdd7f9b5bd992eb9543f44418323f81229526b77b0e4be067.cafe"
+              , " + "
+              , "134 d441227553a0f1a965fee7d60a0f724b368dd1bddbc208730fccebcf.f00d"
+              , " + "
+              , "136 a06ee5ffdd7f9b5bd992eb9543f44418323f81229526b77b0e4be067.dead"
+              , " + "
+              , "138"
+              , " d441227553a0f1a965fee7d60a0f724b368dd1bddbc208730fccebcf"
+              , ".736e6f77"
+              , " + "
+              , "142"
+              , " a06ee5ffdd7f9b5bd992eb9543f44418323f81229526b77b0e4be067"
+              , ".736b79"
+              ]
+          , "--mint-script-file"
+          , "test/cardano-cli-golden/files/golden/mary/scripts/mint.all"
+          , "--mint-script-file"
+          , "test/cardano-cli-golden/files/golden/mary/scripts/mint.sig"
+          , "--out-file"
+          , transactionBodyFile
+          ]
 
-    -- View transaction body
-    result <-
-      execCardanoCLI
-        ["transaction", "view", "--tx-body-file", transactionBodyFile]
-    H.diffVsGoldenFile result "test/cardano-cli-golden/files/golden/mary/transaction-view.out"
+      -- View transaction body
+      result <-
+        execCardanoCLI
+          ["transaction", "view", "--tx-body-file", transactionBodyFile]
+      H.diffVsGoldenFile result "test/cardano-cli-golden/files/golden/mary/transaction-view.out"
 
 createAlonzoTxBody :: Maybe FilePath -> FilePath -> Integration ()
 createAlonzoTxBody mUpdateProposalFile transactionBodyFile = do
   void $
     execCardanoCLI
-      (   [ "alonzo", "transaction", "build-raw"
-          , "--tx-in"
-          ,   "ed7c8f68c194cc763ee65ad22ef0973e26481be058c65005fd39fb93f9c43a20#212"
-          , "--tx-in-collateral"
-          ,   "c9765d7d0e3955be8920e6d7a38e1f3f2032eac48c7c59b0b9193caa87727e7e#256"
-          , "--fee", "213"
-          , "--required-signer-hash"
-          ,   "98717eaba8105a50a2a71831267552e337dfdc893bef5e40b8676d27"
-          , "--required-signer-hash"
-          ,   "fafaaac8681b5050a8987f95bce4a7f99362f189879258fdbf733fa4"
-          , "--out-file", transactionBodyFile
-          ]
-      ++  [ "--update-proposal-file=" <> updateProposalFile
-          | Just updateProposalFile <- [mUpdateProposalFile]
-          ]
+      ( [ "alonzo"
+        , "transaction"
+        , "build-raw"
+        , "--tx-in"
+        , "ed7c8f68c194cc763ee65ad22ef0973e26481be058c65005fd39fb93f9c43a20#212"
+        , "--tx-in-collateral"
+        , "c9765d7d0e3955be8920e6d7a38e1f3f2032eac48c7c59b0b9193caa87727e7e#256"
+        , "--fee"
+        , "213"
+        , "--required-signer-hash"
+        , "98717eaba8105a50a2a71831267552e337dfdc893bef5e40b8676d27"
+        , "--required-signer-hash"
+        , "fafaaac8681b5050a8987f95bce4a7f99362f189879258fdbf733fa4"
+        , "--out-file"
+        , transactionBodyFile
+        ]
+          ++ [ "--update-proposal-file=" <> updateProposalFile
+             | Just updateProposalFile <- [mUpdateProposalFile]
+             ]
       )
 
 hprop_golden_view_alonzo :: Property
@@ -251,27 +299,40 @@ hprop_golden_view_alonzo =
       updateProposalFile <- noteTempFile tempDir "update-proposal"
       transactionBodyFile <- noteTempFile tempDir "transaction-body"
 
-      note_ $ mconcat
-        [ "genesis-verification-key-file hash:"
-        , " 1bafa294233a5a7ffbf539ae798da0943aa83d2a19398c2d0e5af114"
-        ]
+      note_ $
+        mconcat
+          [ "genesis-verification-key-file hash:"
+          , " 1bafa294233a5a7ffbf539ae798da0943aa83d2a19398c2d0e5af114"
+          ]
 
       -- Create update proposal
       void $
         execCardanoCLI
-          [ "legacy", "governance", "create-update-proposal"
-          , "--epoch", "190"
+          [ "legacy"
+          , "governance"
+          , "create-update-proposal"
+          , "--epoch"
+          , "190"
           , "--genesis-verification-key-file"
-          ,   "test/cardano-cli-golden/files/golden/shelley/keys/genesis_keys/verification_key"
-          , "--utxo-cost-per-word", "194"
-          , "--price-execution-steps", "195/196"
-          , "--price-execution-memory", "196/197"
-          , "--max-tx-execution-units", "(197, 198)"
-          , "--max-block-execution-units", "(198, 199)"
-          , "--max-value-size", "199"
-          , "--collateral-percent", "200"
-          , "--max-collateral-inputs", "201"
-          , "--out-file", updateProposalFile
+          , "test/cardano-cli-golden/files/golden/shelley/keys/genesis_keys/verification_key"
+          , "--utxo-cost-per-word"
+          , "194"
+          , "--price-execution-steps"
+          , "195/196"
+          , "--price-execution-memory"
+          , "196/197"
+          , "--max-tx-execution-units"
+          , "(197, 198)"
+          , "--max-block-execution-units"
+          , "(198, 199)"
+          , "--max-value-size"
+          , "199"
+          , "--collateral-percent"
+          , "200"
+          , "--max-collateral-inputs"
+          , "201"
+          , "--out-file"
+          , updateProposalFile
           ]
 
       createAlonzoTxBody (Just updateProposalFile) transactionBodyFile
@@ -285,25 +346,28 @@ hprop_golden_view_alonzo =
 hprop_golden_view_alonzo_signed :: Property
 hprop_golden_view_alonzo_signed =
   let testData = "test/cardano-cli-golden/files/golden/alonzo"
-  in
-  propertyOnce $
-    moduleWorkspace "tmp" $ \tempDir -> do
-      transactionBodyFile <- noteTempFile tempDir "transaction-body"
-      transactionFile <- noteTempFile tempDir "transaction"
+   in propertyOnce $
+        moduleWorkspace "tmp" $ \tempDir -> do
+          transactionBodyFile <- noteTempFile tempDir "transaction-body"
+          transactionFile <- noteTempFile tempDir "transaction"
 
-      createAlonzoTxBody Nothing transactionBodyFile
+          createAlonzoTxBody Nothing transactionBodyFile
 
-      -- Sign
-      void $
-        execCardanoCLI
-          [ "transaction", "sign"
-          , "--tx-body-file", transactionBodyFile
-          , "--signing-key-file", testData </> "signing.key"
-          , "--out-file", transactionFile
-          ]
+          -- Sign
+          void $
+            execCardanoCLI
+              [ "transaction"
+              , "sign"
+              , "--tx-body-file"
+              , transactionBodyFile
+              , "--signing-key-file"
+              , testData </> "signing.key"
+              , "--out-file"
+              , transactionFile
+              ]
 
-      -- View transaction body
-      result <-
-        execCardanoCLI
-          ["transaction", "view", "--tx-file", transactionFile]
-      H.diffVsGoldenFile result (testData </> "signed-transaction-view.out")
+          -- View transaction body
+          result <-
+            execCardanoCLI
+              ["transaction", "view", "--tx-file", transactionFile]
+          H.diffVsGoldenFile result (testData </> "signed-transaction-view.out")

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Version.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Version.hs
@@ -4,16 +4,17 @@ module Test.Golden.Version
   ( hprop_golden_version
   ) where
 
-import           Control.Monad (void)
+import Control.Monad (void)
 
-import           Test.Cardano.CLI.Util
+import Test.Cardano.CLI.Util
 
-import           Hedgehog (Property)
+import Hedgehog (Property)
 
 {- HLINT ignore "Use camelCase" -}
 
 hprop_golden_version :: Property
 hprop_golden_version = propertyOnce $ do
-  void $ execCardanoCLI
-    [ "version"
-    ]
+  void $
+    execCardanoCLI
+      [ "version"
+      ]

--- a/cardano-cli/test/cardano-cli-test-lib/Test/Cardano/CLI/Util.hs
+++ b/cardano-cli/test/cardano-cli-test-lib/Test/Cardano/CLI/Util.hs
@@ -20,27 +20,27 @@ import Control.Monad.Catch
 import Control.Monad.IO.Class (MonadIO (..))
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.Except (runExceptT)
-import qualified Data.Aeson as Aeson
-import qualified Data.Aeson.Encode.Pretty as Aeson
-import qualified Data.Aeson.Key as Aeson
-import qualified Data.Aeson.KeyMap as Aeson
-import qualified Data.ByteString.Lazy as LBS
+import Data.Aeson qualified as Aeson
+import Data.Aeson.Encode.Pretty qualified as Aeson
+import Data.Aeson.Key qualified as Aeson
+import Data.Aeson.KeyMap qualified as Aeson
+import Data.ByteString.Lazy qualified as LBS
 import Data.Function ((&))
-import qualified Data.List as List
+import Data.List qualified as List
 import Data.Monoid (Last (..))
 import Data.Text (Text)
 import GHC.Stack (CallStack, HasCallStack)
-import qualified GHC.Stack as GHC
-import qualified System.Exit as IO
+import GHC.Stack qualified as GHC
+import System.Exit qualified as IO
 import System.Process (CreateProcess)
-import qualified System.Process as IO
+import System.Process qualified as IO
 
-import qualified Hedgehog as H
+import Hedgehog qualified as H
 import Hedgehog.Extras (ExecConfig)
-import qualified Hedgehog.Extras as H
+import Hedgehog.Extras qualified as H
 import Hedgehog.Extras.Test (ExecConfig (..))
 import Hedgehog.Internal.Property (Diff, MonadTest, liftTest, mkTest)
-import qualified Hedgehog.Internal.Property as H
+import Hedgehog.Internal.Property qualified as H
 import Hedgehog.Internal.Show (ValueDiff (ValueSame), mkValue, showPretty, valueDiff)
 import Hedgehog.Internal.Source (getCaller)
 

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/CliIntermediateFormat.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/CliIntermediateFormat.hs
@@ -4,11 +4,11 @@ module Test.Cli.CliIntermediateFormat
   ( hprop_backwardsCompatibleCliFormat
   ) where
 
-import           Control.Monad (void)
+import Control.Monad (void)
 
-import           Test.Cardano.CLI.Util
+import Test.Cardano.CLI.Util
 
-import           Hedgehog (Property)
+import Hedgehog (Property)
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 
@@ -19,27 +19,37 @@ hprop_backwardsCompatibleCliFormat :: Property
 hprop_backwardsCompatibleCliFormat = propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir -> do
   txBodyFile <- noteInputFile "test/cardano-cli-test/files/golden/babbage/deprecated-cli-format.body"
   witness <- noteInputFile "test/cardano-cli-test/files/golden/babbage/tx-key-witness"
-  initialUtxo1SigningKeyFile <- noteInputFile "test/cardano-cli-test/files/golden/shelley/keys/payment_keys/signing_key"
+  initialUtxo1SigningKeyFile <-
+    noteInputFile "test/cardano-cli-test/files/golden/shelley/keys/payment_keys/signing_key"
   signedTransactionFile <- noteTempFile tempDir "signed.tx"
 
-
-  void $ execCardanoCLI
-    [ "transaction","sign"
-    , "--mainnet"
-    , "--tx-body-file", txBodyFile
-    , "--signing-key-file", initialUtxo1SigningKeyFile
-    , "--tx-file", signedTransactionFile
-    ]
+  void $
+    execCardanoCLI
+      [ "transaction"
+      , "sign"
+      , "--mainnet"
+      , "--tx-body-file"
+      , txBodyFile
+      , "--signing-key-file"
+      , initialUtxo1SigningKeyFile
+      , "--tx-file"
+      , signedTransactionFile
+      ]
 
   H.assertFileOccurences 1 "Tx BabbageEra" signedTransactionFile
   H.assertEndsWithSingleNewline signedTransactionFile
 
-  void $ execCardanoCLI
-    [ "transaction","assemble"
-    , "--tx-body-file", txBodyFile
-    , "--witness-file", witness
-    , "--out-file", signedTransactionFile
-    ]
+  void $
+    execCardanoCLI
+      [ "transaction"
+      , "assemble"
+      , "--tx-body-file"
+      , txBodyFile
+      , "--witness-file"
+      , witness
+      , "--out-file"
+      , signedTransactionFile
+      ]
 
   H.assertFileOccurences 1 "Tx BabbageEra" signedTransactionFile
   H.assertEndsWithSingleNewline signedTransactionFile

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/CliIntermediateFormat.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/CliIntermediateFormat.hs
@@ -9,8 +9,8 @@ import Control.Monad (void)
 import Test.Cardano.CLI.Util
 
 import Hedgehog (Property)
-import qualified Hedgehog.Extras.Test.Base as H
-import qualified Hedgehog.Extras.Test.File as H
+import Hedgehog.Extras.Test.Base qualified as H
+import Hedgehog.Extras.Test.File qualified as H
 
 {- HLINT ignore "Use camelCase" -}
 

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/FilePermissions.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/FilePermissions.hs
@@ -4,18 +4,18 @@ module Test.Cli.FilePermissions
   ( hprop_createVRFSigningKeyFilePermissions
   ) where
 
-import           Cardano.Api
-import           Cardano.Api.IO (checkVrfFilePermissions)
+import Cardano.Api
+import Cardano.Api.IO (checkVrfFilePermissions)
 
-import           Control.Monad (void)
-import           Control.Monad.IO.Class (MonadIO (..))
-import           Control.Monad.Trans.Except (runExceptT)
+import Control.Monad (void)
+import Control.Monad.IO.Class (MonadIO (..))
+import Control.Monad.Trans.Except (runExceptT)
 
-import           Test.Cardano.CLI.Util (execCardanoCLI)
+import Test.Cardano.CLI.Util (execCardanoCLI)
 
-import           Hedgehog (Property, success)
+import Hedgehog (Property, success)
 import qualified Hedgehog.Extras.Test.Base as H
-import           Hedgehog.Internal.Property (failWith)
+import Hedgehog.Internal.Property (failWith)
 
 -- | This property ensures that the VRF signing key file is created only with owner permissions
 hprop_createVRFSigningKeyFilePermissions :: Property
@@ -27,16 +27,21 @@ hprop_createVRFSigningKeyFilePermissions =
     vrfSignKey <- H.noteTempFile tempDir "VRF-signing-key-file"
 
     -- Create VRF key pair
-    void $ execCardanoCLI
-      [ "node", "key-gen-VRF"
-      , "--verification-key-file", vrfVerKey
-      , "--signing-key-file", vrfSignKey
-      ]
+    void $
+      execCardanoCLI
+        [ "node"
+        , "key-gen-VRF"
+        , "--verification-key-file"
+        , vrfVerKey
+        , "--signing-key-file"
+        , vrfSignKey
+        ]
 
     result <- liftIO . runExceptT $ checkVrfFilePermissions (File vrfSignKey)
     case result of
       Left err ->
-        failWith Nothing
-          $ "key-gen-VRF cli command created a VRF signing key \
-            \file with the wrong permissions: " <> show err
+        failWith Nothing $
+          "key-gen-VRF cli command created a VRF signing key \
+          \file with the wrong permissions: "
+            <> show err
       Right () -> success

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/FilePermissions.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/FilePermissions.hs
@@ -14,7 +14,7 @@ import Control.Monad.Trans.Except (runExceptT)
 import Test.Cardano.CLI.Util (execCardanoCLI)
 
 import Hedgehog (Property, success)
-import qualified Hedgehog.Extras.Test.Base as H
+import Hedgehog.Extras.Test.Base qualified as H
 import Hedgehog.Internal.Property (failWith)
 
 -- | This property ensures that the VRF signing key file is created only with owner permissions

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/ITN.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/ITN.hs
@@ -9,19 +9,19 @@ module Test.Cli.ITN
 
 import Cardano.CLI.EraBased.Run.Key (decodeBech32)
 
-import qualified Codec.Binary.Bech32 as Bech32
+import Codec.Binary.Bech32 qualified as Bech32
 import Control.Monad (void)
 import Data.ByteString (ByteString)
-import qualified Data.ByteString.Base16 as Base16
+import Data.ByteString.Base16 qualified as Base16
 import Data.Text (Text)
-import qualified Data.Text.IO as Text
+import Data.Text.IO qualified as Text
 
 import Test.Cardano.CLI.Util
 
 import Hedgehog (Property, (===))
-import qualified Hedgehog as H
-import qualified Hedgehog.Extras.Test.Base as H
-import qualified Hedgehog.Extras.Test.File as H
+import Hedgehog qualified as H
+import Hedgehog.Extras.Test.Base qualified as H
+import Hedgehog.Extras.Test.File qualified as H
 
 {- HLINT ignore "Reduce duplication" -}
 

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/ITN.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/ITN.hs
@@ -7,18 +7,18 @@ module Test.Cli.ITN
   , hprop_golden_bech32Decode
   ) where
 
-import           Cardano.CLI.EraBased.Run.Key (decodeBech32)
+import Cardano.CLI.EraBased.Run.Key (decodeBech32)
 
 import qualified Codec.Binary.Bech32 as Bech32
-import           Control.Monad (void)
-import           Data.ByteString (ByteString)
+import Control.Monad (void)
+import Data.ByteString (ByteString)
 import qualified Data.ByteString.Base16 as Base16
-import           Data.Text (Text)
+import Data.Text (Text)
 import qualified Data.Text.IO as Text
 
-import           Test.Cardano.CLI.Util
+import Test.Cardano.CLI.Util
 
-import           Hedgehog (Property, (===))
+import Hedgehog (Property, (===))
 import qualified Hedgehog as H
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
@@ -51,17 +51,25 @@ hprop_convertITNKeys = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
   H.assertFilesExist [itnVerKeyFp, itnSignKeyFp]
 
   -- Generate haskell stake verification key
-  void $ execCardanoCLI
-    [ "key","convert-itn-key"
-    , "--itn-verification-key-file", itnVerKeyFp
-    , "--out-file", outputHaskellVerKeyFp
-    ]
+  void $
+    execCardanoCLI
+      [ "key"
+      , "convert-itn-key"
+      , "--itn-verification-key-file"
+      , itnVerKeyFp
+      , "--out-file"
+      , outputHaskellVerKeyFp
+      ]
   -- Generate haskell signing key
-  void $ execCardanoCLI
-    [ "key","convert-itn-key"
-    , "--itn-signing-key-file", itnSignKeyFp
-    , "--out-file", outputHaskellSignKeyFp
-    ]
+  void $
+    execCardanoCLI
+      [ "key"
+      , "convert-itn-key"
+      , "--itn-signing-key-file"
+      , itnSignKeyFp
+      , "--out-file"
+      , outputHaskellSignKeyFp
+      ]
 
   -- Check for existence of the converted ITN keys
   H.assertFilesExist [outputHaskellVerKeyFp, outputHaskellSignKeyFp]
@@ -69,10 +77,11 @@ hprop_convertITNKeys = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
 -- | 1. Convert a bech32 ITN extended signing key to a haskell stake signing key
 hprop_convertITNExtendedSigningKey :: Property
 hprop_convertITNExtendedSigningKey = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
-  let itnExtendedSignKey = mconcat
-        [ "ed25519e_sk1qpcplz38tg4fusw0fkqljzspe9qmj06ldu9lgcve99v4fphuk9a535kwj"
-        , "f38hkyn0shcycyaha4k9tmjy6xgvzaz7stw5t7rqjadyjcwfyx6k"
-        ]
+  let itnExtendedSignKey =
+        mconcat
+          [ "ed25519e_sk1qpcplz38tg4fusw0fkqljzspe9qmj06ldu9lgcve99v4fphuk9a535kwj"
+          , "f38hkyn0shcycyaha4k9tmjy6xgvzaz7stw5t7rqjadyjcwfyx6k"
+          ]
 
   -- ITN input file paths
   itnSignKeyFp <- noteTempFile tempDir "itnExtendedSignKey.key"
@@ -85,11 +94,15 @@ hprop_convertITNExtendedSigningKey = propertyOnce . H.moduleWorkspace "tmp" $ \t
   H.assertFilesExist [itnSignKeyFp]
 
   -- Generate haskell signing key
-  void $ execCardanoCLI
-    [ "key","convert-itn-extended-key"
-    , "--itn-signing-key-file", itnSignKeyFp
-    , "--out-file", outputHaskellSignKeyFp
-    ]
+  void $
+    execCardanoCLI
+      [ "key"
+      , "convert-itn-extended-key"
+      , "--itn-signing-key-file"
+      , itnSignKeyFp
+      , "--out-file"
+      , outputHaskellSignKeyFp
+      ]
 
   -- Check for existence of the converted ITN keys
   H.assertFilesExist [outputHaskellSignKeyFp]
@@ -97,11 +110,12 @@ hprop_convertITNExtendedSigningKey = propertyOnce . H.moduleWorkspace "tmp" $ \t
 -- | 1. Convert a bech32 ITN BIP32 signing key to a haskell stake signing key
 hprop_convertITNBIP32SigningKey :: Property
 hprop_convertITNBIP32SigningKey = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
-  let itnExtendedSignKey = mconcat
-        [ "xprv1spkw5suj39723c40mr55gwh7j3vryjv2zdm4e47xs0deka"
-        , "jcza9ud848ckdqf48md9njzc5pkujfxwu2j8wdvtxkx02n3s2qa"
-        , "euhqnfx6zu9dyccpua6vf5x3kur9hsganq2kl0yw7y9hpunts0e9kc5xv3pz0yj"
-        ]
+  let itnExtendedSignKey =
+        mconcat
+          [ "xprv1spkw5suj39723c40mr55gwh7j3vryjv2zdm4e47xs0deka"
+          , "jcza9ud848ckdqf48md9njzc5pkujfxwu2j8wdvtxkx02n3s2qa"
+          , "euhqnfx6zu9dyccpua6vf5x3kur9hsganq2kl0yw7y9hpunts0e9kc5xv3pz0yj"
+          ]
 
   -- ITN input file paths
   itnSignKeyFp <- noteTempFile tempDir "itnBIP32SignKey.key"
@@ -115,11 +129,15 @@ hprop_convertITNBIP32SigningKey = propertyOnce . H.moduleWorkspace "tmp" $ \temp
   H.assertFilesExist [itnSignKeyFp]
 
   -- Generate haskell signing key
-  void $ execCardanoCLI
-    [ "key","convert-itn-bip32-key"
-    , "--itn-signing-key-file", itnSignKeyFp
-    , "--out-file", outputHaskellSignKeyFp
-    ]
+  void $
+    execCardanoCLI
+      [ "key"
+      , "convert-itn-bip32-key"
+      , "--itn-signing-key-file"
+      , itnSignKeyFp
+      , "--out-file"
+      , outputHaskellSignKeyFp
+      ]
 
   -- Check for existence of the converted ITN keys
   H.assertFilesExist [outputHaskellSignKeyFp]
@@ -128,10 +146,10 @@ hprop_convertITNBIP32SigningKey = propertyOnce . H.moduleWorkspace "tmp" $ \temp
 -- using 'itnVerKey' & 'itnSignKey' as inputs.
 hprop_golden_bech32Decode :: Property
 hprop_golden_bech32Decode = propertyOnce $ do
-  (vHumReadPart, vDataPart , _) <- H.evalEither $ decodeBech32 itnVerKey
+  (vHumReadPart, vDataPart, _) <- H.evalEither $ decodeBech32 itnVerKey
   Just vDataPartBase16 <- pure (dataPartToBase16 vDataPart)
 
-  (sHumReadPart, sDataPart , _) <- H.evalEither $ decodeBech32 itnSignKey
+  (sHumReadPart, sDataPart, _) <- H.evalEither $ decodeBech32 itnSignKey
   Just sDataPartBase16 <- pure (dataPartToBase16 sDataPart)
 
   -- Based on https://slowli.github.io/bech32-buffer/ which are in Base16
@@ -142,13 +160,11 @@ hprop_golden_bech32Decode = propertyOnce $ do
 
   -- ITN Verification key decode check
   expectedHumanReadPartVerificationKey === Bech32.humanReadablePartToText vHumReadPart
-  expectedDataPartVerificationKey ===  vDataPartBase16
-
+  expectedDataPartVerificationKey === vDataPartBase16
 
   -- ITN Signing key decode check
   expectedHumanReadPartSigningKey === Bech32.humanReadablePartToText sHumReadPart
   expectedDataPartSigningKey === sDataPartBase16
-
-  where
-    dataPartToBase16 :: Bech32.DataPart -> Maybe ByteString
-    dataPartToBase16 = fmap Base16.encode . Bech32.dataPartToBytes
+ where
+  dataPartToBase16 :: Bech32.DataPart -> Maybe ByteString
+  dataPartToBase16 = fmap Base16.encode . Bech32.dataPartToBytes

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/JSON.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/JSON.hs
@@ -1,28 +1,31 @@
 {-# LANGUAGE NumericUnderscores #-}
-{-# LANGUAGE OverloadedStrings #-}
 
 module Test.Cli.JSON
   ( hprop_json_roundtrip_delegations_and_rewards
   , hprop_roundtrip_kes_period_info_output_JSON
   ) where
 
-import           Cardano.Api.Shelley
+import Cardano.Api.Shelley
 
-import           Cardano.CLI.Types.Common
-import           Cardano.CLI.Types.Output (QueryKesPeriodInfoOutput (..), createOpCertIntervalInfo)
+import Cardano.CLI.Types.Common
+import Cardano.CLI.Types.Output (QueryKesPeriodInfoOutput (..), createOpCertIntervalInfo)
 
-import           Data.Aeson
+import Data.Aeson
 import qualified Data.Map.Strict as Map
-import           Data.Time
-import           Data.Time.Clock.POSIX (posixSecondsToUTCTime)
-import           Data.Word (Word64)
+import Data.Time
+import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
+import Data.Word (Word64)
 
-import           Test.Gen.Cardano.Api.Typed (genLovelace, genSlotNo, genStakeAddress,
-                   genVerificationKeyHash)
+import Test.Gen.Cardano.Api.Typed
+  ( genLovelace
+  , genSlotNo
+  , genStakeAddress
+  , genVerificationKeyHash
+  )
 
-import           Hedgehog (Gen, Property, forAll, property, tripping)
-import           Hedgehog.Gen as Gen
-import           Hedgehog.Range as Range
+import Hedgehog (Gen, Property, forAll, property, tripping)
+import Hedgehog.Gen as Gen
+import Hedgehog.Range as Range
 
 -- TODO: Move to cardano-api
 hprop_json_roundtrip_delegations_and_rewards :: Property

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/JSON.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/JSON.hs
@@ -11,7 +11,7 @@ import Cardano.CLI.Types.Common
 import Cardano.CLI.Types.Output (QueryKesPeriodInfoOutput (..), createOpCertIntervalInfo)
 
 import Data.Aeson
-import qualified Data.Map.Strict as Map
+import Data.Map.Strict qualified as Map
 import Data.Time
 import Data.Time.Clock.POSIX (posixSecondsToUTCTime)
 import Data.Word (Word64)

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/MultiAssetParsing.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/MultiAssetParsing.hs
@@ -7,13 +7,13 @@ module Test.Cli.MultiAssetParsing
 
 import Cardano.Api (parseValue, renderValue, renderValuePretty, valueToList)
 
-import qualified Data.Text as Text
-import qualified Text.Parsec as Parsec (parse)
+import Data.Text qualified as Text
+import Text.Parsec qualified as Parsec (parse)
 
 import Test.Gen.Cardano.Api.Typed (genValueDefault)
 
 import Hedgehog (Property, forAll, property, tripping)
-import qualified Hedgehog.Gen as Gen
+import Hedgehog.Gen qualified as Gen
 
 hprop_roundtrip_Value_parse_render :: Property
 hprop_roundtrip_Value_parse_render =

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/MultiAssetParsing.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/MultiAssetParsing.hs
@@ -5,14 +5,14 @@ module Test.Cli.MultiAssetParsing
   , hprop_roundtrip_Value_parse_renderPretty
   ) where
 
-import           Cardano.Api (parseValue, renderValue, renderValuePretty, valueToList)
+import Cardano.Api (parseValue, renderValue, renderValuePretty, valueToList)
 
 import qualified Data.Text as Text
 import qualified Text.Parsec as Parsec (parse)
 
-import           Test.Gen.Cardano.Api.Typed (genValueDefault)
+import Test.Gen.Cardano.Api.Typed (genValueDefault)
 
-import           Hedgehog (Property, forAll, property, tripping)
+import Hedgehog (Property, forAll, property, tripping)
 import qualified Hedgehog.Gen as Gen
 
 hprop_roundtrip_Value_parse_render :: Property

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/Pioneers/Exercise1.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/Pioneers/Exercise1.hs
@@ -5,11 +5,11 @@ module Test.Cli.Pioneers.Exercise1
   , hprop_buildShelleyStakeAddress
   ) where
 
-import           Control.Monad (void)
+import Control.Monad (void)
 
-import           Test.Cardano.CLI.Util
+import Test.Cardano.CLI.Util
 
-import           Hedgehog (Property)
+import Hedgehog (Property)
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 
@@ -23,20 +23,27 @@ hprop_buildShelleyPaymentAddress = propertyOnce . H.moduleWorkspace "tmp" $ \tem
   signKey <- noteTempFile tempDir "payment-signing-key-file"
 
   -- Generate payment verification key
-  void $ execCardanoCLI
-    [ "address","key-gen"
-    , "--verification-key-file", verKey
-    , "--signing-key-file", signKey
-    ]
+  void $
+    execCardanoCLI
+      [ "address"
+      , "key-gen"
+      , "--verification-key-file"
+      , verKey
+      , "--signing-key-file"
+      , signKey
+      ]
 
   H.assertFilesExist [verKey, signKey]
 
   -- Build shelley payment address
-  void $ execCardanoCLI
-    [ "address", "build"
-    , "--payment-verification-key-file", verKey
-    , "--mainnet"
-    ]
+  void $
+    execCardanoCLI
+      [ "address"
+      , "build"
+      , "--payment-verification-key-file"
+      , verKey
+      , "--mainnet"
+      ]
 
 -- | 1. We generate a key payment pair
 --   2. We generate a staking key pair
@@ -52,25 +59,37 @@ hprop_buildShelleyStakeAddress = propertyOnce . H.moduleWorkspace "tmp" $ \tempD
   paymentSignKey <- noteTempFile tempDir "payment-signing-key-file"
 
   -- Generate payment verification key
-  void $ execCardanoCLI
-    [ "address","key-gen"
-    , "--verification-key-file", paymentVerKey
-    , "--signing-key-file", paymentSignKey
-    ]
+  void $
+    execCardanoCLI
+      [ "address"
+      , "key-gen"
+      , "--verification-key-file"
+      , paymentVerKey
+      , "--signing-key-file"
+      , paymentSignKey
+      ]
 
   -- Generate stake verification key
-  void $ execCardanoCLI
-    [ "stake-address","key-gen"
-    , "--verification-key-file", stakeVerKey
-    , "--signing-key-file", stakeSignKey
-    ]
+  void $
+    execCardanoCLI
+      [ "stake-address"
+      , "key-gen"
+      , "--verification-key-file"
+      , stakeVerKey
+      , "--signing-key-file"
+      , stakeSignKey
+      ]
 
   H.assertFilesExist [stakeVerKey, stakeSignKey, paymentVerKey, paymentSignKey]
 
   -- Build shelley stake address
-  void $ execCardanoCLI
-    [ "address", "build"
-    , "--payment-verification-key-file", paymentVerKey
-    , "--stake-verification-key-file", stakeVerKey
-    , "--mainnet"
-    ]
+  void $
+    execCardanoCLI
+      [ "address"
+      , "build"
+      , "--payment-verification-key-file"
+      , paymentVerKey
+      , "--stake-verification-key-file"
+      , stakeVerKey
+      , "--mainnet"
+      ]

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/Pioneers/Exercise1.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/Pioneers/Exercise1.hs
@@ -10,8 +10,8 @@ import Control.Monad (void)
 import Test.Cardano.CLI.Util
 
 import Hedgehog (Property)
-import qualified Hedgehog.Extras.Test.Base as H
-import qualified Hedgehog.Extras.Test.File as H
+import Hedgehog.Extras.Test.Base qualified as H
+import Hedgehog.Extras.Test.File qualified as H
 
 -- | 1. Generate a key pair
 --   2. Check for the existence of the key pair

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/Pioneers/Exercise2.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/Pioneers/Exercise2.hs
@@ -9,8 +9,8 @@ import Control.Monad (void)
 import Test.Cardano.CLI.Util
 
 import Hedgehog (Property)
-import qualified Hedgehog.Extras.Test.Base as H
-import qualified Hedgehog.Extras.Test.File as H
+import Hedgehog.Extras.Test.Base qualified as H
+import Hedgehog.Extras.Test.File qualified as H
 
 -- | 1. We generate a payment signing key
 --   2. We create a tx body

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/Pioneers/Exercise2.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/Pioneers/Exercise2.hs
@@ -4,11 +4,11 @@ module Test.Cli.Pioneers.Exercise2
   ( hprop_createTransaction
   ) where
 
-import           Control.Monad (void)
+import Control.Monad (void)
 
-import           Test.Cardano.CLI.Util
+import Test.Cardano.CLI.Util
 
-import           Hedgehog (Property)
+import Hedgehog (Property)
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 
@@ -24,36 +24,55 @@ hprop_createTransaction = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> d
   transactionFile <- noteTempFile tempDir "transaction-file"
 
   -- Generate payment signing key to sign transaction
-  void $ execCardanoCLI
-    [ "address","key-gen"
-    , "--verification-key-file", paymentVerKey
-    , "--signing-key-file", paymentSignKey
-    ]
+  void $
+    execCardanoCLI
+      [ "address"
+      , "key-gen"
+      , "--verification-key-file"
+      , paymentVerKey
+      , "--signing-key-file"
+      , paymentSignKey
+      ]
 
   H.assertFilesExist [paymentVerKey, paymentSignKey]
 
   -- Create transaction body
-  void $ execCardanoCLI
-    [ "transaction", "build-raw"
-    , "--tx-in", "91999ea21177b33ebe6b8690724a0c026d410a11ad7521caa350abdafa5394c3#0"
-    , "--auxiliary-script-file", "test/cardano-cli-test/files/golden/shelley/multisig/scripts/all"
-    , "--tx-in", "91999ea21177b33ebe6b8690724a0c026d410a11ad7521caa350abdafa5394c3#0"
-    , "--auxiliary-script-file", "test/cardano-cli-test/files/golden/shelley/multisig/scripts/all"
-    , "--tx-out", "addr1v9wmu83pzajplrtpsq6tsqdgwr98x888trpmah2u0ezznsge7del3+100000000"
-    , "--fee", "1000000"
-    , "--invalid-hereafter", "500000"
-    , "--out-file", transactionBodyFile
-    ]
+  void $
+    execCardanoCLI
+      [ "transaction"
+      , "build-raw"
+      , "--tx-in"
+      , "91999ea21177b33ebe6b8690724a0c026d410a11ad7521caa350abdafa5394c3#0"
+      , "--auxiliary-script-file"
+      , "test/cardano-cli-test/files/golden/shelley/multisig/scripts/all"
+      , "--tx-in"
+      , "91999ea21177b33ebe6b8690724a0c026d410a11ad7521caa350abdafa5394c3#0"
+      , "--auxiliary-script-file"
+      , "test/cardano-cli-test/files/golden/shelley/multisig/scripts/all"
+      , "--tx-out"
+      , "addr1v9wmu83pzajplrtpsq6tsqdgwr98x888trpmah2u0ezznsge7del3+100000000"
+      , "--fee"
+      , "1000000"
+      , "--invalid-hereafter"
+      , "500000"
+      , "--out-file"
+      , transactionBodyFile
+      ]
 
   H.assertFilesExist [transactionBodyFile]
 
   -- Sign transaction
-  void $ execCardanoCLI
-    [ "transaction", "sign"
-    , "--tx-body-file", transactionBodyFile
-    , "--signing-key-file", paymentSignKey
-    , "--mainnet"
-    , "--out-file", transactionFile
-    ]
+  void $
+    execCardanoCLI
+      [ "transaction"
+      , "sign"
+      , "--tx-body-file"
+      , transactionBodyFile
+      , "--signing-key-file"
+      , paymentSignKey
+      , "--mainnet"
+      , "--out-file"
+      , transactionFile
+      ]
 
   H.assertFilesExist [paymentVerKey, paymentSignKey, transactionBodyFile, transactionFile]

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/Pioneers/Exercise3.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/Pioneers/Exercise3.hs
@@ -9,8 +9,8 @@ import Control.Monad (void)
 import Test.Cardano.CLI.Util
 
 import Hedgehog (Property)
-import qualified Hedgehog.Extras.Test.Base as H
-import qualified Hedgehog.Extras.Test.File as H
+import Hedgehog.Extras.Test.Base qualified as H
+import Hedgehog.Extras.Test.File qualified as H
 
 -- | 1. Create KES key pair.
 --   2. Create cold keys.

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/Pioneers/Exercise3.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/Pioneers/Exercise3.hs
@@ -4,11 +4,11 @@ module Test.Cli.Pioneers.Exercise3
   ( hprop_createOperationalCertificate
   ) where
 
-import           Control.Monad (void)
+import Control.Monad (void)
 
-import           Test.Cardano.CLI.Util
+import Test.Cardano.CLI.Util
 
-import           Hedgehog (Property)
+import Hedgehog (Property)
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 
@@ -27,32 +27,49 @@ hprop_createOperationalCertificate = propertyOnce . H.moduleWorkspace "tmp" $ \t
   operationalCert <- noteTempFile tempDir "operational-certificate-file"
 
   -- Create KES key pair
-  void $ execCardanoCLI
-    [ "node","key-gen-KES"
-    , "--verification-key-file", kesVerKey
-    , "--signing-key-file", kesSignKey
-    ]
+  void $
+    execCardanoCLI
+      [ "node"
+      , "key-gen-KES"
+      , "--verification-key-file"
+      , kesVerKey
+      , "--signing-key-file"
+      , kesSignKey
+      ]
 
   H.assertFilesExist [kesSignKey, kesVerKey]
 
   -- Create cold key pair
-  void $ execCardanoCLI
-    [ "node","key-gen"
-    , "--cold-verification-key-file", coldVerKey
-    , "--cold-signing-key-file", coldSignKey
-    , "--operational-certificate-issue-counter", operationalCertCounter
-    ]
+  void $
+    execCardanoCLI
+      [ "node"
+      , "key-gen"
+      , "--cold-verification-key-file"
+      , coldVerKey
+      , "--cold-signing-key-file"
+      , coldSignKey
+      , "--operational-certificate-issue-counter"
+      , operationalCertCounter
+      ]
 
   H.assertFilesExist [coldVerKey, coldSignKey, operationalCertCounter]
 
   -- Create operational certificate
-  void $ execCardanoCLI
-    [ "node","issue-op-cert"
-    , "--kes-verification-key-file", kesVerKey
-    , "--cold-signing-key-file", coldSignKey
-    , "--operational-certificate-issue-counter", operationalCertCounter
-    , "--kes-period", "1000"
-    , "--out-file", operationalCert
-    ]
+  void $
+    execCardanoCLI
+      [ "node"
+      , "issue-op-cert"
+      , "--kes-verification-key-file"
+      , kesVerKey
+      , "--cold-signing-key-file"
+      , coldSignKey
+      , "--operational-certificate-issue-counter"
+      , operationalCertCounter
+      , "--kes-period"
+      , "1000"
+      , "--out-file"
+      , operationalCert
+      ]
 
-  H.assertFilesExist [kesVerKey, kesSignKey, coldVerKey, coldSignKey, operationalCertCounter, operationalCert]
+  H.assertFilesExist
+    [kesVerKey, kesSignKey, coldVerKey, coldSignKey, operationalCertCounter, operationalCert]

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/Pioneers/Exercise4.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/Pioneers/Exercise4.hs
@@ -9,8 +9,8 @@ import Control.Monad (void)
 import Test.Cardano.CLI.Util
 
 import Hedgehog (Property)
-import qualified Hedgehog.Extras.Test.Base as H
-import qualified Hedgehog.Extras.Test.File as H
+import Hedgehog.Extras.Test.Base qualified as H
+import Hedgehog.Extras.Test.File qualified as H
 
 -- | 1. Generate a stake verification key
 --   2. Create a stake address registration certificate

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/Pioneers/Exercise4.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/Pioneers/Exercise4.hs
@@ -4,11 +4,11 @@ module Test.Cli.Pioneers.Exercise4
   ( hprop_createStakeAddressRegistrationCertificate
   ) where
 
-import           Control.Monad (void)
+import Control.Monad (void)
 
-import           Test.Cardano.CLI.Util
+import Test.Cardano.CLI.Util
 
-import           Hedgehog (Property)
+import Hedgehog (Property)
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 
@@ -22,18 +22,27 @@ hprop_createStakeAddressRegistrationCertificate = propertyOnce . H.moduleWorkspa
   stakeRegCert <- noteTempFile tempDir "stake-registration-certificate-file"
 
   -- Generate stake verification key
-  void $ execCardanoCLI
-    [ "stake-address", "key-gen"
-    , "--verification-key-file", verKey
-    , "--signing-key-file", signKey
-    ]
+  void $
+    execCardanoCLI
+      [ "stake-address"
+      , "key-gen"
+      , "--verification-key-file"
+      , verKey
+      , "--signing-key-file"
+      , signKey
+      ]
   H.assertFilesExist [verKey, signKey]
 
   -- Create stake address registration certificate
-  void $ execCardanoCLI
-    [ "babbage", "stake-address", "registration-certificate"
-    , "--stake-verification-key-file", verKey
-    , "--out-file", stakeRegCert
-    ]
+  void $
+    execCardanoCLI
+      [ "babbage"
+      , "stake-address"
+      , "registration-certificate"
+      , "--stake-verification-key-file"
+      , verKey
+      , "--out-file"
+      , stakeRegCert
+      ]
 
   H.assertFilesExist [verKey, signKey, stakeRegCert]

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/Pioneers/Exercise5.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/Pioneers/Exercise5.hs
@@ -4,11 +4,11 @@ module Test.Cli.Pioneers.Exercise5
   ( hprop_createLegacyZeroTxOutTransaction
   ) where
 
-import           Control.Monad (void)
+import Control.Monad (void)
 
-import           Test.Cardano.CLI.Util
+import Test.Cardano.CLI.Util
 
-import           Hedgehog (Property)
+import Hedgehog (Property)
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 
@@ -24,33 +24,49 @@ hprop_createLegacyZeroTxOutTransaction = propertyOnce . H.moduleWorkspace "tmp" 
   transactionFile <- noteTempFile tempDir "transaction-file"
 
   -- Generate payment signing key to sign transaction
-  void $ execCardanoCLI
-    [ "address","key-gen"
-    , "--verification-key-file", paymentVerKey
-    , "--signing-key-file", paymentSignKey
-    ]
+  void $
+    execCardanoCLI
+      [ "address"
+      , "key-gen"
+      , "--verification-key-file"
+      , paymentVerKey
+      , "--signing-key-file"
+      , paymentSignKey
+      ]
 
   H.assertFilesExist [paymentVerKey, paymentSignKey]
 
   -- Create transaction body
-  void $ execCardanoCLI
-    [ "transaction", "build-raw"
-    , "--tx-in", "91999ea21177b33ebe6b8690724a0c026d410a11ad7521caa350abdafa5394c3#0"
-    , "--tx-out", "addr1v9wmu83pzajplrtpsq6tsqdgwr98x888trpmah2u0ezznsge7del3+0"
-    , "--fee", "1000000"
-    , "--invalid-hereafter", "500000"
-    , "--out-file", transactionBodyFile
-    ]
+  void $
+    execCardanoCLI
+      [ "transaction"
+      , "build-raw"
+      , "--tx-in"
+      , "91999ea21177b33ebe6b8690724a0c026d410a11ad7521caa350abdafa5394c3#0"
+      , "--tx-out"
+      , "addr1v9wmu83pzajplrtpsq6tsqdgwr98x888trpmah2u0ezznsge7del3+0"
+      , "--fee"
+      , "1000000"
+      , "--invalid-hereafter"
+      , "500000"
+      , "--out-file"
+      , transactionBodyFile
+      ]
 
   H.assertFilesExist [transactionBodyFile]
 
   -- Sign transaction
-  void $ execCardanoCLI
-    [ "transaction", "sign"
-    , "--tx-body-file", transactionBodyFile
-    , "--signing-key-file", paymentSignKey
-    , "--mainnet"
-    , "--out-file", transactionFile
-    ]
+  void $
+    execCardanoCLI
+      [ "transaction"
+      , "sign"
+      , "--tx-body-file"
+      , transactionBodyFile
+      , "--signing-key-file"
+      , paymentSignKey
+      , "--mainnet"
+      , "--out-file"
+      , transactionFile
+      ]
 
   H.assertFilesExist [paymentVerKey, paymentSignKey, transactionBodyFile, transactionFile]

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/Pioneers/Exercise5.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/Pioneers/Exercise5.hs
@@ -9,8 +9,8 @@ import Control.Monad (void)
 import Test.Cardano.CLI.Util
 
 import Hedgehog (Property)
-import qualified Hedgehog.Extras.Test.Base as H
-import qualified Hedgehog.Extras.Test.File as H
+import Hedgehog.Extras.Test.Base qualified as H
+import Hedgehog.Extras.Test.File qualified as H
 
 -- | 1. We generate a payment signing key
 --   2. We create a tx body

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/Pioneers/Exercise6.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/Pioneers/Exercise6.hs
@@ -4,11 +4,11 @@ module Test.Cli.Pioneers.Exercise6
   ( hprop_createZeroLovelaceTxOutTransaction
   ) where
 
-import           Control.Monad (void)
+import Control.Monad (void)
 
-import           Test.Cardano.CLI.Util
+import Test.Cardano.CLI.Util
 
-import           Hedgehog (Property)
+import Hedgehog (Property)
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 
@@ -24,33 +24,49 @@ hprop_createZeroLovelaceTxOutTransaction = propertyOnce . H.moduleWorkspace "tmp
   transactionFile <- noteTempFile tempDir "transaction-file"
 
   -- Generate payment signing key to sign transaction
-  void $ execCardanoCLI
-    [ "address","key-gen"
-    , "--verification-key-file", paymentVerKey
-    , "--signing-key-file", paymentSignKey
-    ]
+  void $
+    execCardanoCLI
+      [ "address"
+      , "key-gen"
+      , "--verification-key-file"
+      , paymentVerKey
+      , "--signing-key-file"
+      , paymentSignKey
+      ]
 
   H.assertFilesExist [paymentVerKey, paymentSignKey]
 
   -- Create transaction body
-  void $ execCardanoCLI
-    [ "transaction", "build-raw"
-    , "--tx-in", "91999ea21177b33ebe6b8690724a0c026d410a11ad7521caa350abdafa5394c3#0"
-    , "--tx-out", "addr1v9wmu83pzajplrtpsq6tsqdgwr98x888trpmah2u0ezznsge7del3 0 lovelace"
-    , "--fee", "1000000"
-    , "--invalid-hereafter", "500000"
-    , "--out-file", transactionBodyFile
-    ]
+  void $
+    execCardanoCLI
+      [ "transaction"
+      , "build-raw"
+      , "--tx-in"
+      , "91999ea21177b33ebe6b8690724a0c026d410a11ad7521caa350abdafa5394c3#0"
+      , "--tx-out"
+      , "addr1v9wmu83pzajplrtpsq6tsqdgwr98x888trpmah2u0ezznsge7del3 0 lovelace"
+      , "--fee"
+      , "1000000"
+      , "--invalid-hereafter"
+      , "500000"
+      , "--out-file"
+      , transactionBodyFile
+      ]
 
   H.assertFilesExist [transactionBodyFile]
 
   -- Sign transaction
-  void $ execCardanoCLI
-    [ "transaction", "sign"
-    , "--tx-body-file", transactionBodyFile
-    , "--signing-key-file", paymentSignKey
-    , "--mainnet"
-    , "--out-file", transactionFile
-    ]
+  void $
+    execCardanoCLI
+      [ "transaction"
+      , "sign"
+      , "--tx-body-file"
+      , transactionBodyFile
+      , "--signing-key-file"
+      , paymentSignKey
+      , "--mainnet"
+      , "--out-file"
+      , transactionFile
+      ]
 
   H.assertFilesExist [paymentVerKey, paymentSignKey, transactionBodyFile, transactionFile]

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/Pioneers/Exercise6.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/Pioneers/Exercise6.hs
@@ -9,8 +9,8 @@ import Control.Monad (void)
 import Test.Cardano.CLI.Util
 
 import Hedgehog (Property)
-import qualified Hedgehog.Extras.Test.Base as H
-import qualified Hedgehog.Extras.Test.File as H
+import Hedgehog.Extras.Test.Base qualified as H
+import Hedgehog.Extras.Test.File qualified as H
 
 -- | 1. We generate a payment signing key
 --   2. We create a tx body

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/Shelley/Run/Query.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/Shelley/Run/Query.hs
@@ -2,11 +2,11 @@ module Test.Cli.Shelley.Run.Query
   ( hprop_percentage
   ) where
 
-import qualified Cardano.CLI.EraBased.Run.Query as Q
+import Cardano.CLI.EraBased.Run.Query qualified as Q
 import Cardano.Slotting.Time (RelativeTime (..))
 
 import Hedgehog (Property, (===))
-import qualified Hedgehog.Extras.Test.Base as H
+import Hedgehog.Extras.Test.Base qualified as H
 
 hprop_percentage :: Property
 hprop_percentage = H.propertyOnce $ do

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/Shelley/Run/Query.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/Shelley/Run/Query.hs
@@ -3,9 +3,9 @@ module Test.Cli.Shelley.Run.Query
   ) where
 
 import qualified Cardano.CLI.EraBased.Run.Query as Q
-import           Cardano.Slotting.Time (RelativeTime (..))
+import Cardano.Slotting.Time (RelativeTime (..))
 
-import           Hedgehog (Property, (===))
+import Hedgehog (Property, (===))
 import qualified Hedgehog.Extras.Test.Base as H
 
 hprop_percentage :: Property

--- a/flake.lock
+++ b/flake.lock
@@ -134,6 +134,22 @@
         "type": "github"
       }
     },
+    "flake-compat_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -149,6 +165,24 @@
       "original": {
         "owner": "hamishmack",
         "ref": "hkm/nested-hydraJobs",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1685518550,
+        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
         "repo": "flake-utils",
         "type": "github"
       }
@@ -205,6 +239,27 @@
         "submodules": true,
         "type": "git",
         "url": "https://gitlab.haskell.org/ghc/ghc"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "pre-commit-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1660459072,
+        "narHash": "sha256-8DFJjXG8zqoONA1vXtgeKXy68KdJL5UaXR8NtVMUbx8=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "a20de23b925fd8264fd7fad6454652e142fd7f73",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
       }
     },
     "hackage": {
@@ -595,6 +650,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-stable": {
+      "locked": {
+        "lastModified": 1685801374,
+        "narHash": "sha256-otaSUoFEMM+LjBI1XL/xGB5ao6IwnZOXc47qhIgJe8U=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c37ca420157f4abc31e26f436c1145f8951ff373",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-23.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs-unstable": {
       "locked": {
         "lastModified": 1690720142,
@@ -644,6 +715,31 @@
         "type": "github"
       }
     },
+    "pre-commit-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat_2",
+        "flake-utils": "flake-utils_2",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "haskellNix",
+          "nixpkgs-unstable"
+        ],
+        "nixpkgs-stable": "nixpkgs-stable"
+      },
+      "locked": {
+        "lastModified": 1695576016,
+        "narHash": "sha256-71KxwRhTfVuh7kNrg3/edNjYVg9DCyKZl2QIKbhRggg=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "cb770e93516a1609652fa8e945a0f310e98f10c0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "CHaP": "CHaP",
@@ -654,7 +750,8 @@
         "nixpkgs": [
           "haskellNix",
           "nixpkgs-unstable"
-        ]
+        ],
+        "pre-commit-hooks": "pre-commit-hooks"
       }
     },
     "secp256k1": {
@@ -708,6 +805,21 @@
       }
     },
     "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -49,7 +49,7 @@
           src = ./.;
           hooks = {
             alejandra.enable = true;
-            ormolu.enable = true;
+            fourmolu.enable = true;
             hlint.enable = true;
           };
           # make sure the tools are exactly the ones from the cabalProject.shell below.
@@ -61,7 +61,7 @@
               cabalProject.shell.nativeBuildInputs;
           in {
             hlint = findToolHack "hlint";
-            ormolu = findToolHack "ormolu";
+            fourmolu = findToolHack "fourmolu";
           };
         };
 
@@ -95,7 +95,7 @@
             }
             // lib.optionalAttrs (config.compiler-nix-name == defaultCompiler) {
               # tools that work only with default compiler
-              ormolu = "0.7.1.0";
+              fourmolu = "0.13.0.0";
               hlint = "3.5";
               haskell-language-server = "2.0.0.0";
             };

--- a/fourmolu.yaml
+++ b/fourmolu.yaml
@@ -1,0 +1,16 @@
+indentation: 2
+column-limit: 100
+function-arrows: leading
+comma-style: leading
+import-export-style: leading
+indent-wheres: false
+record-brace-space: true
+newlines-between-decls: 1
+haddock-style: single-line
+haddock-style-module: null
+let-style: auto
+single-constraint-parens: always
+unicode: never
+respectful: true
+fixities: []
+reexports: []


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    <insert-changelog-description-here>
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

We were discussing formatting recently. Let's use this PR to discuss
- whether we want a completely automatically enforced style, and
- what that style should be.

As a first approximation, I tried to set `fourmolu` up in such a way as to closely match the [style guide](https://github.com/input-output-hk/cardano-node-wiki/wiki/Style-guide) (or something reasonably close to it).

Since I'm in the camp that is _for_ automation, I'm also proposing in this PR to add pre-commit hooks that run `hlint`, `fourmolu`, and `alejandra`.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
