### PR TITLE
Add DRep Retirement Certificate command

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/DRep.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/DRep.hs
@@ -31,6 +31,11 @@ data GovernanceDRepCmds era
       Lovelace
       (Maybe (Ledger.Anchor (Ledger.EraCrypto (ShelleyLedgerEra era))))
       (File () Out)
+  | GovernanceDRepRetirementCertificateCmd
+      (ConwayEraOnwards era)
+      (VerificationKeyOrHashOrFile DRepKey)
+      EpochNo
+      (File () Out)
 
 renderGovernanceDRepCmds :: ()
   => GovernanceDRepCmds era
@@ -42,3 +47,5 @@ renderGovernanceDRepCmds = \case
     "governance drep id"
   GovernanceDRepRegistrationCertificateCmd {} ->
     "governance drep registration-certificate"
+  GovernanceDRepRetirementCertificateCmd {} ->
+    "governance drep retirement-certificate"

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/DRep.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/DRep.hs
@@ -34,7 +34,7 @@ data GovernanceDRepCmds era
   | GovernanceDRepRetirementCertificateCmd
       (ConwayEraOnwards era)
       (VerificationKeyOrHashOrFile DRepKey)
-      EpochNo
+      Lovelace
       (File () Out)
 
 renderGovernanceDRepCmds :: ()

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
@@ -2631,6 +2631,14 @@ pKeyRegistDeposit =
    , Opt.help "Key registration deposit amount."
    ]
 
+pDrepDeposit :: Parser Lovelace
+pDrepDeposit =
+  Opt.option (readerFromParsecParser parseLovelace) $ mconcat
+   [ Opt.long "deposit-amt"
+   , Opt.metavar "LOVELACE"
+   , Opt.help "DRep deposit amount (same at registration and retirement)."
+   ]
+
 pPoolDeposit :: Parser Lovelace
 pPoolDeposit =
   Opt.option (readerFromParsecParser parseLovelace) $ mconcat

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/DRep.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/DRep.hs
@@ -127,13 +127,13 @@ pRetirementCertificateCmd :: ()
   => CardanoEra era
   -> Maybe (Parser (GovernanceDRepCmds era))
 pRetirementCertificateCmd era = do
-  w <- maybeEonInEra era
+  w <- forEraMaybeEon era
   pure
     $ subParser "retirement-certificate"
     $ Opt.info
       ( GovernanceDRepRetirementCertificateCmd w
           <$> pDRepVerificationKeyOrHashOrFile
-          <*> pEpochNo "epoch after which the DRep will retire."
+          <*> pDrepDeposit
           <*> pOutputFile
       )
     $ Opt.progDesc "Create a DRep retirement certificate."

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/DRep.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/DRep.hs
@@ -40,6 +40,7 @@ pGovernanceDRepCmds era =
     [ pGovernanceDRepKeyGenCmd era
     , pGovernanceDRepKeyIdCmd era
     , pRegistrationCertificateCmd era
+    , pRetirementCertificateCmd era
     ]
 
 pGovernanceDRepKeyGenCmd :: ()
@@ -121,6 +122,21 @@ pDrepMetadataHash =
     , Opt.help "DRep anchor data hash."
     ]
 
+
+pRetirementCertificateCmd :: ()
+  => CardanoEra era
+  -> Maybe (Parser (GovernanceDRepCmds era))
+pRetirementCertificateCmd era = do
+  w <- maybeEonInEra era
+  pure
+    $ subParser "retirement-certificate"
+    $ Opt.info
+      ( GovernanceDRepRetirementCertificateCmd w
+          <$> pDRepVerificationKeyOrHashOrFile
+          <*> pEpochNo "epoch after which the DRep will retire."
+          <*> pOutputFile
+      )
+    $ Opt.progDesc "Create a DRep retirement certificate."
 
 --------------------------------------------------------------------------------
 

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/DRep.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/DRep.hs
@@ -46,6 +46,10 @@ runGovernanceDRepCmds = \case
       runGovernanceRegistrationCertificateCmd w vkey lovelace anchor outFp
         & firstExceptT CmdRegistrationError
 
+  GovernanceDRepRetirementCertificateCmd w vkeyOrHashOrFile epoch outFp ->
+    runGovernanceDrepRetirementCertificateCmd w vkeyOrHashOrFile epoch outFp
+      & firstExceptT CmdGovernanceCmdError
+
 runGovernanceDRepIdCmd :: ()
   => ConwayEraOnwards era
   -> VerificationKeyOrFile DRepKey
@@ -91,3 +95,18 @@ runGovernanceRegistrationCertificateCmd cOnwards drepKOrHOrF deposit anchor outf
       . writeLazyByteStringFile outfp
       $ conwayEraOnwardsConstraints cOnwards
       $ textEnvelopeToJSON description registrationCert
+
+runGovernanceDrepRetirementCertificateCmd
+  :: ConwayEraOnwards era
+  -> VerificationKeyOrHashOrFile DRepKey
+  -> EpochNo
+  -> File () 'Out
+  -> ExceptT GovernanceCmdError IO ()
+runGovernanceDrepRetirementCertificateCmd = undefined
+-- w vKeyOrHashOrFile outFile =
+--   conwayEraOnwardsConstraints w $ do
+--     DRepKeyHash drepKeyHash <- firstExceptT GovernanceCmdKeyReadError
+--       . newExceptT
+--       $ readVerificationKeyOrHashOrFile AsDRepKey vKeyOrHashOrFile
+--     undefined
+--

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Governance/DRep.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Governance/DRep.hs
@@ -60,3 +60,19 @@ hprop_golden_governance_drep_id_hex =
       ]
 
     H.diffFileVsGoldenFile idFile idGold
+
+hprop_golden_governance_drep_retirement_certificate :: Property
+hprop_golden_governance_drep_retirement_certificate =
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+    drepVKeyFile <- noteInputFile "test/cardano-cli-golden/files/input/drep.vkey"
+    certFile <- H.noteTempFile tempDir "drep.retirement.cert"
+
+    void $ execCardanoCLI
+      [  "conway", "governance", "drep", "retirement-certificate"
+      , "--drep-verification-key-file", drepVKeyFile
+      , "--deposit-amt", "1000000"
+      , "--out-file", certFile
+      ]
+
+    H.assertFileOccurences 1 "CertificateShelley" certFile
+    H.assertFileOccurences 1 "DRep Retirement Certificate" certFile

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -6530,6 +6530,7 @@ Usage: cardano-cli conway governance drep
                                             ( key-gen
                                             | id
                                             | registration-certificate
+                                            | retirement-certificate
                                             )
 
   DRep member commands.
@@ -6559,6 +6560,16 @@ Usage: cardano-cli conway governance drep registration-certificate
                                                                      --out-file FILE
 
   Create a registration certificate.
+
+Usage: cardano-cli conway governance drep retirement-certificate 
+                                                                   ( --drep-verification-key STRING
+                                                                   | --drep-verification-key-file FILE
+                                                                   | --drep-key-hash HASH
+                                                                   )
+                                                                   --deposit-amt LOVELACE
+                                                                   --out-file FILE
+
+  Create a DRep retirement certificate.
 
 Usage: cardano-cli conway governance vote (create | view)
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_drep.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_drep.cli
@@ -2,6 +2,7 @@ Usage: cardano-cli conway governance drep
                                             ( key-gen
                                             | id
                                             | registration-certificate
+                                            | retirement-certificate
                                             )
 
   DRep member commands.
@@ -14,3 +15,4 @@ Available commands:
                            signing keys.
   id                       Generate a drep id.
   registration-certificate Create a registration certificate.
+  retirement-certificate   Create a DRep retirement certificate.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_drep_retirement-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_drep_retirement-certificate.cli
@@ -1,0 +1,22 @@
+Usage: cardano-cli conway governance drep retirement-certificate 
+                                                                   ( --drep-verification-key STRING
+                                                                   | --drep-verification-key-file FILE
+                                                                   | --drep-key-hash HASH
+                                                                   )
+                                                                   --deposit-amt LOVELACE
+                                                                   --out-file FILE
+
+  Create a DRep retirement certificate.
+
+Available options:
+  --drep-verification-key STRING
+                           DRep verification key (Bech32 or hex-encoded).
+  --drep-verification-key-file FILE
+                           Filepath of the DRep verification key.
+  --drep-key-hash HASH     DRep verification key hash (either Bech32-encoded or
+                           hex-encoded). Zero or more occurences of this option
+                           is allowed.
+  --deposit-amt LOVELACE   DRep deposit amount (same at registration and
+                           retirement).
+  --out-file FILE          The output file.
+  -h,--help                Show this help text


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Added a command to create DRep retirement certificates
# uncomment types applicable to the change:
  type:
  - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context
 
This PR closes #132 (and #291, I assume?)

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [x] The change log section in the PR description has been filled in
- [x] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [x] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
