### PR TITLE
Use `caseShelleyToBabbageOrConwayEraOnwards` from `cardano-api`

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/StakeAddress.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/StakeAddress.hs
@@ -192,20 +192,6 @@ runStakeAddressStakeDelegationCertificateCmd sbe stakeVerifier poolVKeyOrHashOrF
       $ writeLazyByteStringFile outFp
       $ textEnvelopeToJSON (Just @TextEnvelopeDescr "Stake Address Delegation Certificate") certificate
 
--- TODO use the version in cardano-api
-caseShelleyToBabbageAndConwayEraOnwards :: forall a era. ()
-  => (ShelleyToBabbageEra era -> a)
-  -> (ConwayEraOnwards era -> a)
-  -> ShelleyBasedEra era
-  -> a
-caseShelleyToBabbageAndConwayEraOnwards l r = \case
-  ShelleyBasedEraShelley -> l ShelleyToBabbageEraShelley
-  ShelleyBasedEraAllegra -> l ShelleyToBabbageEraAllegra
-  ShelleyBasedEraMary    -> l ShelleyToBabbageEraMary
-  ShelleyBasedEraAlonzo  -> l ShelleyToBabbageEraAlonzo
-  ShelleyBasedEraBabbage -> l ShelleyToBabbageEraBabbage
-  ShelleyBasedEraConway  -> r ConwayEraOnwardsConway
-
 runStakeAddressStakeAndVoteDelegationCertificateCmd :: ()
   => ConwayEraOnwards era
   -> StakeIdentifier
@@ -276,7 +262,7 @@ createStakeDelegationCertificate :: forall era. ()
   -> ShelleyBasedEra era
   -> Certificate era
 createStakeDelegationCertificate stakeCredential (StakePoolKeyHash poolStakeVKeyHash) = do
-  caseShelleyToBabbageAndConwayEraOnwards
+  caseShelleyToBabbageOrConwayEraOnwards
     (\w ->
       shelleyToBabbageEraConstraints w
         $ ShelleyRelatedCertificate w


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Use `caseShelleyToBabbageOrConwayEraOnwards` from `cardano-api`
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
