### PR TITLE
Tidy up query command structure

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Query.hs
@@ -14,8 +14,8 @@ import           Cardano.CLI.Types.Key
 import           Data.Text (Text)
 import           Data.Time.Clock
 
-data QueryCmds era =
-    QueryLeadershipSchedule
+data QueryCmds era
+  = QueryLeadershipScheduleCmd
       SocketPath
       AnyConsensusModeParams
       NetworkId
@@ -24,78 +24,78 @@ data QueryCmds era =
       (SigningKeyFile In)
       EpochLeadershipSchedule
       (Maybe (File () Out))
-  | QueryProtocolParameters'
+  | QueryProtocolParametersCmd
       SocketPath
       AnyConsensusModeParams
       NetworkId
       (Maybe (File () Out))
-  | QueryConstitutionHash
+  | QueryConstitutionHashCmd
       SocketPath
       AnyConsensusModeParams
       NetworkId
       (Maybe (File () Out))
-  | QueryTip
+  | QueryTipCmd
       SocketPath
       AnyConsensusModeParams
       NetworkId
       (Maybe (File () Out))
-  | QueryStakePools'
+  | QueryStakePoolsCmd
       SocketPath
       AnyConsensusModeParams
       NetworkId
       (Maybe (File () Out))
-  | QueryStakeDistribution'
+  | QueryStakeDistributionCmd
       SocketPath
       AnyConsensusModeParams
       NetworkId
       (Maybe (File () Out))
-  | QueryStakeAddressInfo
+  | QueryStakeAddressInfoCmd
       SocketPath
       AnyConsensusModeParams
       StakeAddress
       NetworkId
       (Maybe (File () Out))
-  | QueryUTxO'
+  | QueryUTxOCmd
       SocketPath
       AnyConsensusModeParams
       QueryUTxOFilter
       NetworkId
       (Maybe (File () Out))
-  | QueryDebugLedgerState'
+  | QueryDebugLedgerStateCmd
       SocketPath
       AnyConsensusModeParams
       NetworkId
       (Maybe (File () Out))
-  | QueryProtocolState'
+  | QueryProtocolStateCmd
       SocketPath
       AnyConsensusModeParams
       NetworkId
       (Maybe (File () Out))
-  | QueryStakeSnapshot'
+  | QueryStakeSnapshotCmd
       SocketPath
       AnyConsensusModeParams
       NetworkId
       (AllOrOnly [Hash StakePoolKey])
       (Maybe (File () Out))
-  | QueryKesPeriodInfo
+  | QueryKesPeriodInfoCmd
       SocketPath
       AnyConsensusModeParams
       NetworkId
       (File () In)
       -- ^ Node operational certificate
       (Maybe (File () Out))
-  | QueryPoolState'
+  | QueryPoolStateCmd
       SocketPath
       AnyConsensusModeParams
       NetworkId
       [Hash StakePoolKey]
-  | QueryTxMempool
+  | QueryTxMempoolCmd
       SocketPath
       AnyConsensusModeParams
       NetworkId
       TxMempoolQuery
       (Maybe (File () Out))
-  | QuerySlotNumber
+  | QuerySlotNumberCmd
       SocketPath
       AnyConsensusModeParams
       NetworkId
@@ -104,35 +104,35 @@ data QueryCmds era =
 
 renderQueryCmds :: QueryCmds era -> Text
 renderQueryCmds = \case
-  QueryLeadershipSchedule {} ->
+  QueryLeadershipScheduleCmd {} ->
     "query leadership-schedule"
-  QueryProtocolParameters' {} ->
+  QueryProtocolParametersCmd {} ->
     "query protocol-parameters "
-  QueryConstitutionHash {} ->
+  QueryConstitutionHashCmd {} ->
     "query constitution-hash "
-  QueryTip {} ->
+  QueryTipCmd {} ->
     "query tip"
-  QueryStakePools' {} ->
+  QueryStakePoolsCmd {} ->
     "query stake-pools"
-  QueryStakeDistribution' {} ->
+  QueryStakeDistributionCmd {} ->
     "query stake-distribution"
-  QueryStakeAddressInfo {} ->
+  QueryStakeAddressInfoCmd {} ->
     "query stake-address-info"
-  QueryUTxO' {} ->
+  QueryUTxOCmd {} ->
     "query utxo"
-  QueryDebugLedgerState' {} ->
+  QueryDebugLedgerStateCmd {} ->
     "query ledger-state"
-  QueryProtocolState' {} ->
+  QueryProtocolStateCmd {} ->
     "query protocol-state"
-  QueryStakeSnapshot' {} ->
+  QueryStakeSnapshotCmd {} ->
     "query stake-snapshot"
-  QueryKesPeriodInfo {} ->
+  QueryKesPeriodInfoCmd {} ->
     "query kes-period-info"
-  QueryPoolState' {} ->
+  QueryPoolStateCmd {} ->
     "query pool-state"
-  QueryTxMempool _ _ _ query _ ->
+  QueryTxMempoolCmd _ _ _ query _ ->
     "query tx-mempool" <> renderTxMempoolQuery query
-  QuerySlotNumber {} ->
+  QuerySlotNumberCmd {} ->
     "query slot-number"
 
 renderTxMempoolQuery :: TxMempoolQuery -> Text

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Query.hs
@@ -1,8 +1,24 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE LambdaCase #-}
 
 module Cardano.CLI.EraBased.Commands.Query
   ( QueryCmds (..)
+  , QueryLeadershipScheduleCmdArgs(..)
+  , QueryProtocolParametersCmdArgs(..)
+  , QueryConstitutionHashCmdArgs(..)
+  , QueryTipCmdArgs(..)
+  , QueryStakePoolsCmdArgs(..)
+  , QueryStakeDistributionCmdArgs(..)
+  , QueryStakeAddressInfoCmdArgs(..)
+  , QueryUTxOCmdArgs(..)
+  , QueryDebugLedgerStateCmdArgs(..)
+  , QueryProtocolStateCmdArgs(..)
+  , QueryStakeSnapshotCmdArgs(..)
+  , QueryKesPeriodInfoCmdArgs(..)
+  , QueryPoolStateCmdArgs(..)
+  , QueryTxMempoolCmdArgs(..)
+  , QuerySlotNumberCmdArgs(..)
   , renderQueryCmds
   ) where
 
@@ -13,94 +29,140 @@ import           Cardano.CLI.Types.Key
 
 import           Data.Text (Text)
 import           Data.Time.Clock
+import           GHC.Generics
 
 data QueryCmds era
-  = QueryLeadershipScheduleCmd
-      SocketPath
-      AnyConsensusModeParams
-      NetworkId
-      GenesisFile
-      (VerificationKeyOrHashOrFile StakePoolKey)
-      (SigningKeyFile In)
-      EpochLeadershipSchedule
-      (Maybe (File () Out))
-  | QueryProtocolParametersCmd
-      SocketPath
-      AnyConsensusModeParams
-      NetworkId
-      (Maybe (File () Out))
-  | QueryConstitutionHashCmd
-      SocketPath
-      AnyConsensusModeParams
-      NetworkId
-      (Maybe (File () Out))
-  | QueryTipCmd
-      SocketPath
-      AnyConsensusModeParams
-      NetworkId
-      (Maybe (File () Out))
-  | QueryStakePoolsCmd
-      SocketPath
-      AnyConsensusModeParams
-      NetworkId
-      (Maybe (File () Out))
-  | QueryStakeDistributionCmd
-      SocketPath
-      AnyConsensusModeParams
-      NetworkId
-      (Maybe (File () Out))
-  | QueryStakeAddressInfoCmd
-      SocketPath
-      AnyConsensusModeParams
-      StakeAddress
-      NetworkId
-      (Maybe (File () Out))
-  | QueryUTxOCmd
-      SocketPath
-      AnyConsensusModeParams
-      QueryUTxOFilter
-      NetworkId
-      (Maybe (File () Out))
-  | QueryDebugLedgerStateCmd
-      SocketPath
-      AnyConsensusModeParams
-      NetworkId
-      (Maybe (File () Out))
-  | QueryProtocolStateCmd
-      SocketPath
-      AnyConsensusModeParams
-      NetworkId
-      (Maybe (File () Out))
-  | QueryStakeSnapshotCmd
-      SocketPath
-      AnyConsensusModeParams
-      NetworkId
-      (AllOrOnly [Hash StakePoolKey])
-      (Maybe (File () Out))
-  | QueryKesPeriodInfoCmd
-      SocketPath
-      AnyConsensusModeParams
-      NetworkId
-      (File () In)
-      -- ^ Node operational certificate
-      (Maybe (File () Out))
-  | QueryPoolStateCmd
-      SocketPath
-      AnyConsensusModeParams
-      NetworkId
-      [Hash StakePoolKey]
-  | QueryTxMempoolCmd
-      SocketPath
-      AnyConsensusModeParams
-      NetworkId
-      TxMempoolQuery
-      (Maybe (File () Out))
-  | QuerySlotNumberCmd
-      SocketPath
-      AnyConsensusModeParams
-      NetworkId
-      UTCTime
-  deriving Show
+  = QueryLeadershipScheduleCmd  !QueryLeadershipScheduleCmdArgs
+  | QueryProtocolParametersCmd  !QueryProtocolParametersCmdArgs
+  | QueryConstitutionHashCmd    !QueryConstitutionHashCmdArgs
+  | QueryTipCmd                 !QueryTipCmdArgs
+  | QueryStakePoolsCmd          !QueryStakePoolsCmdArgs
+  | QueryStakeDistributionCmd   !QueryStakeDistributionCmdArgs
+  | QueryStakeAddressInfoCmd    !QueryStakeAddressInfoCmdArgs
+  | QueryUTxOCmd                !QueryUTxOCmdArgs
+  | QueryDebugLedgerStateCmd    !QueryDebugLedgerStateCmdArgs
+  | QueryProtocolStateCmd       !QueryProtocolStateCmdArgs
+  | QueryStakeSnapshotCmd       !QueryStakeSnapshotCmdArgs
+  | QueryKesPeriodInfoCmd       !QueryKesPeriodInfoCmdArgs
+  | QueryPoolStateCmd           !QueryPoolStateCmdArgs
+  | QueryTxMempoolCmd           !QueryTxMempoolCmdArgs
+  | QuerySlotNumberCmd          !QuerySlotNumberCmdArgs
+  deriving (Generic, Show)
+
+data QueryLeadershipScheduleCmdArgs = QueryLeadershipScheduleCmdArgs
+  !SocketPath
+  !AnyConsensusModeParams
+  !NetworkId
+  !GenesisFile
+  !(VerificationKeyOrHashOrFile StakePoolKey)
+  !(SigningKeyFile In)
+  !EpochLeadershipSchedule
+  !(Maybe (File () Out))
+  deriving (Generic, Show)
+
+data QueryProtocolParametersCmdArgs = QueryProtocolParametersCmdArgs
+  !SocketPath
+  !AnyConsensusModeParams
+  !NetworkId
+  !(Maybe (File () Out))
+  deriving (Generic, Show)
+
+data QueryConstitutionHashCmdArgs = QueryConstitutionHashCmdArgs
+  !SocketPath
+  !AnyConsensusModeParams
+  !NetworkId
+  !(Maybe (File () Out))
+  deriving (Generic, Show)
+
+data QueryTipCmdArgs = QueryTipCmdArgs
+  !SocketPath
+  !AnyConsensusModeParams
+  !NetworkId
+  !(Maybe (File () Out))
+  deriving (Generic, Show)
+
+data QueryStakePoolsCmdArgs = QueryStakePoolsCmdArgs
+  !SocketPath
+  !AnyConsensusModeParams
+  !NetworkId
+  !(Maybe (File () Out))
+  deriving (Generic, Show)
+
+data QueryStakeDistributionCmdArgs = QueryStakeDistributionCmdArgs
+  !SocketPath
+  !AnyConsensusModeParams
+  !NetworkId
+  !(Maybe (File () Out))
+  deriving (Generic, Show)
+
+data QueryStakeAddressInfoCmdArgs = QueryStakeAddressInfoCmdArgs
+  !SocketPath
+  !AnyConsensusModeParams
+  !StakeAddress
+  !NetworkId
+  !(Maybe (File () Out))
+  deriving (Generic, Show)
+
+data QueryUTxOCmdArgs = QueryUTxOCmdArgs
+  !SocketPath
+  !AnyConsensusModeParams
+  !QueryUTxOFilter
+  !NetworkId
+  !(Maybe (File () Out))
+  deriving (Generic, Show)
+
+data QueryDebugLedgerStateCmdArgs = QueryDebugLedgerStateCmdArgs
+  !SocketPath
+  !AnyConsensusModeParams
+  !NetworkId
+  !(Maybe (File () Out))
+  deriving (Generic, Show)
+
+data QueryProtocolStateCmdArgs = QueryProtocolStateCmdArgs
+  !SocketPath
+  !AnyConsensusModeParams
+  !NetworkId
+  !(Maybe (File () Out))
+  deriving (Generic, Show)
+
+data QueryStakeSnapshotCmdArgs = QueryStakeSnapshotCmdArgs
+  !SocketPath
+  !AnyConsensusModeParams
+  !NetworkId
+  !(AllOrOnly [Hash StakePoolKey])
+  !(Maybe (File () Out))
+  deriving (Generic, Show)
+
+data QueryKesPeriodInfoCmdArgs = QueryKesPeriodInfoCmdArgs
+  !SocketPath
+  !AnyConsensusModeParams
+  !NetworkId
+  !(File () In)
+  -- ^ Node operational certificate
+  !(Maybe (File () Out))
+  deriving (Generic, Show)
+
+data QueryPoolStateCmdArgs = QueryPoolStateCmdArgs
+  !SocketPath
+  !AnyConsensusModeParams
+  !NetworkId
+  ![Hash StakePoolKey]
+  deriving (Generic, Show)
+
+data QueryTxMempoolCmdArgs = QueryTxMempoolCmdArgs
+  !SocketPath
+  !AnyConsensusModeParams
+  !NetworkId
+  !TxMempoolQuery
+  !(Maybe (File () Out))
+  deriving (Generic, Show)
+
+data QuerySlotNumberCmdArgs = QuerySlotNumberCmdArgs
+  !SocketPath
+  !AnyConsensusModeParams
+  !NetworkId
+  !UTCTime
+  deriving (Generic, Show)
 
 renderQueryCmds :: QueryCmds era -> Text
 renderQueryCmds = \case
@@ -130,7 +192,7 @@ renderQueryCmds = \case
     "query kes-period-info"
   QueryPoolStateCmd {} ->
     "query pool-state"
-  QueryTxMempoolCmd _ _ _ query _ ->
+  QueryTxMempoolCmd (QueryTxMempoolCmdArgs _ _ _ query _) ->
     "query tx-mempool" <> renderTxMempoolQuery query
   QuerySlotNumberCmd {} ->
     "query slot-number"

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Query.hs
@@ -53,9 +53,9 @@ data QueryCmds era
 data QueryLeadershipScheduleCmdArgs = QueryLeadershipScheduleCmdArgs
   { nodeSocketPath      :: !SocketPath
   , consensusModeParams :: !AnyConsensusModeParams
-  , network             :: !NetworkId
+  , networkId           :: !NetworkId
   , genesisFp           :: !GenesisFile
-  , poolId              :: !(VerificationKeyOrHashOrFile StakePoolKey)
+  , poolColdVerKeyFile  :: !(VerificationKeyOrHashOrFile StakePoolKey)
   , vrkSkeyFp           :: !(SigningKeyFile In)
   , whichSchedule       :: !EpochLeadershipSchedule
   , mOutFile            :: !(Maybe (File () Out))
@@ -64,43 +64,43 @@ data QueryLeadershipScheduleCmdArgs = QueryLeadershipScheduleCmdArgs
 data QueryProtocolParametersCmdArgs = QueryProtocolParametersCmdArgs
   { nodeSocketPath      :: !SocketPath
   , consensusModeParams :: !AnyConsensusModeParams
-  , network             :: !NetworkId
+  , networkId           :: !NetworkId
   , mOutFile            :: !(Maybe (File () Out))
   } deriving (Generic, Show)
 
 data QueryConstitutionHashCmdArgs = QueryConstitutionHashCmdArgs
   { nodeSocketPath      :: !SocketPath
   , consensusModeParams :: !AnyConsensusModeParams
-  , network             :: !NetworkId
+  , networkId           :: !NetworkId
   , mOutFile            :: !(Maybe (File () Out))
   } deriving (Generic, Show)
 
 data QueryTipCmdArgs = QueryTipCmdArgs
   { nodeSocketPath      :: !SocketPath
   , consensusModeParams :: !AnyConsensusModeParams
-  , network             :: !NetworkId
+  , networkId           :: !NetworkId
   , mOutFile            :: !(Maybe (File () Out))
   } deriving (Generic, Show)
 
 data QueryStakePoolsCmdArgs = QueryStakePoolsCmdArgs
   { nodeSocketPath      :: !SocketPath
   , consensusModeParams :: !AnyConsensusModeParams
-  , network             :: !NetworkId
+  , networkId           :: !NetworkId
   , mOutFile            :: !(Maybe (File () Out))
   } deriving (Generic, Show)
 
 data QueryStakeDistributionCmdArgs = QueryStakeDistributionCmdArgs
   { nodeSocketPath      :: !SocketPath
   , consensusModeParams :: !AnyConsensusModeParams
-  , network             :: !NetworkId
+  , networkId           :: !NetworkId
   , mOutFile            :: !(Maybe (File () Out))
   } deriving (Generic, Show)
 
 data QueryStakeAddressInfoCmdArgs = QueryStakeAddressInfoCmdArgs
-  { mNodeSocketPath     :: !SocketPath
+  { nodeSocketPath      :: !SocketPath
   , consensusModeParams :: !AnyConsensusModeParams
   , addr                :: !StakeAddress
-  , network             :: !NetworkId
+  , networkId           :: !NetworkId
   , mOutFile            :: !(Maybe (File () Out))
   } deriving (Generic, Show)
 
@@ -115,21 +115,21 @@ data QueryUTxOCmdArgs = QueryUTxOCmdArgs
 data QueryLedgerStateCmdArgs = QueryLedgerStateCmdArgs
   { nodeSocketPath      :: !SocketPath
   , consensusModeParams :: !AnyConsensusModeParams
-  , network             :: !NetworkId
+  , networkId           :: !NetworkId
   , mOutFile            :: !(Maybe (File () Out))
   } deriving (Generic, Show)
 
 data QueryProtocolStateCmdArgs = QueryProtocolStateCmdArgs
   { nodeSocketPath      :: !SocketPath
   , consensusModeParams :: !AnyConsensusModeParams
-  , network             :: !NetworkId
+  , networkId           :: !NetworkId
   , mOutFile            :: !(Maybe (File () Out))
   } deriving (Generic, Show)
 
 data QueryStakeSnapshotCmdArgs = QueryStakeSnapshotCmdArgs
   { nodeSocketPath      :: !SocketPath
   , consensusModeParams :: !AnyConsensusModeParams
-  , network             :: !NetworkId
+  , networkId           :: !NetworkId
   , allOrOnlyPoolIds    :: !(AllOrOnly [Hash StakePoolKey])
   , mOutFile            :: !(Maybe (File () Out))
   } deriving (Generic, Show)
@@ -137,23 +137,23 @@ data QueryStakeSnapshotCmdArgs = QueryStakeSnapshotCmdArgs
 data QueryKesPeriodInfoCmdArgs = QueryKesPeriodInfoCmdArgs
   { nodeSocketPath      :: !SocketPath
   , consensusModeParams :: !AnyConsensusModeParams
-  , network             :: !NetworkId
-  , nodeOpCert          :: !(File () In) -- ^ Node operational certificate
+  , networkId           :: !NetworkId
+  , nodeOpCertFp        :: !(File () In) -- ^ Node operational certificate
   , mOutFile            :: !(Maybe (File () Out))
   } deriving (Generic, Show)
 
 data QueryPoolStateCmdArgs = QueryPoolStateCmdArgs
   { nodeSocketPath      :: !SocketPath
   , consensusModeParams :: !AnyConsensusModeParams
-  , network             :: !NetworkId
-  , poolid              :: ![Hash StakePoolKey]
+  , networkId           :: !NetworkId
+  , poolIds             :: ![Hash StakePoolKey]
   } deriving (Generic, Show)
 
 data QueryTxMempoolCmdArgs = QueryTxMempoolCmdArgs
   { nodeSocketPath      :: !SocketPath
   , consensusModeParams :: !AnyConsensusModeParams
-  , network             :: !NetworkId
-  , op                  :: !TxMempoolQuery
+  , networkId           :: !NetworkId
+  , query               :: !TxMempoolQuery
   , mOutFile            :: !(Maybe (File () Out))
   }
   deriving (Generic, Show)
@@ -161,7 +161,7 @@ data QueryTxMempoolCmdArgs = QueryTxMempoolCmdArgs
 data QuerySlotNumberCmdArgs = QuerySlotNumberCmdArgs
   { nodeSocketPath      :: !SocketPath
   , consensusModeParams :: !AnyConsensusModeParams
-  , network             :: !NetworkId
+  , networkId           :: !NetworkId
   , utcTime             :: !UTCTime
   } deriving (Generic, Show)
 
@@ -193,8 +193,8 @@ renderQueryCmds = \case
     "query kes-period-info"
   QueryPoolStateCmd {} ->
     "query pool-state"
-  QueryTxMempoolCmd (QueryTxMempoolCmdArgs _ _ _ query _) ->
-    "query tx-mempool" <> renderTxMempoolQuery query
+  QueryTxMempoolCmd (QueryTxMempoolCmdArgs _ _ _ q _) ->
+    "query tx-mempool" <> renderTxMempoolQuery q
   QuerySlotNumberCmd {} ->
     "query slot-number"
 

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Query.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE LambdaCase #-}
 
 module Cardano.CLI.EraBased.Commands.Query
@@ -12,7 +13,7 @@ module Cardano.CLI.EraBased.Commands.Query
   , QueryStakeDistributionCmdArgs(..)
   , QueryStakeAddressInfoCmdArgs(..)
   , QueryUTxOCmdArgs(..)
-  , QueryDebugLedgerStateCmdArgs(..)
+  , QueryLedgerStateCmdArgs(..)
   , QueryProtocolStateCmdArgs(..)
   , QueryStakeSnapshotCmdArgs(..)
   , QueryKesPeriodInfoCmdArgs(..)
@@ -40,7 +41,7 @@ data QueryCmds era
   | QueryStakeDistributionCmd   !QueryStakeDistributionCmdArgs
   | QueryStakeAddressInfoCmd    !QueryStakeAddressInfoCmdArgs
   | QueryUTxOCmd                !QueryUTxOCmdArgs
-  | QueryDebugLedgerStateCmd    !QueryDebugLedgerStateCmdArgs
+  | QueryLedgerStateCmd         !QueryLedgerStateCmdArgs
   | QueryProtocolStateCmd       !QueryProtocolStateCmdArgs
   | QueryStakeSnapshotCmd       !QueryStakeSnapshotCmdArgs
   | QueryKesPeriodInfoCmd       !QueryKesPeriodInfoCmdArgs
@@ -50,119 +51,119 @@ data QueryCmds era
   deriving (Generic, Show)
 
 data QueryLeadershipScheduleCmdArgs = QueryLeadershipScheduleCmdArgs
-  !SocketPath
-  !AnyConsensusModeParams
-  !NetworkId
-  !GenesisFile
-  !(VerificationKeyOrHashOrFile StakePoolKey)
-  !(SigningKeyFile In)
-  !EpochLeadershipSchedule
-  !(Maybe (File () Out))
-  deriving (Generic, Show)
+  { nodeSocketPath      :: !SocketPath
+  , consensusModeParams :: !AnyConsensusModeParams
+  , network             :: !NetworkId
+  , genesisFp           :: !GenesisFile
+  , poolId              :: !(VerificationKeyOrHashOrFile StakePoolKey)
+  , vrkSkeyFp           :: !(SigningKeyFile In)
+  , whichSchedule       :: !EpochLeadershipSchedule
+  , mOutFile            :: !(Maybe (File () Out))
+  } deriving (Generic, Show)
 
 data QueryProtocolParametersCmdArgs = QueryProtocolParametersCmdArgs
-  !SocketPath
-  !AnyConsensusModeParams
-  !NetworkId
-  !(Maybe (File () Out))
-  deriving (Generic, Show)
+  { nodeSocketPath      :: !SocketPath
+  , consensusModeParams :: !AnyConsensusModeParams
+  , network             :: !NetworkId
+  , mOutFile            :: !(Maybe (File () Out))
+  } deriving (Generic, Show)
 
 data QueryConstitutionHashCmdArgs = QueryConstitutionHashCmdArgs
-  !SocketPath
-  !AnyConsensusModeParams
-  !NetworkId
-  !(Maybe (File () Out))
-  deriving (Generic, Show)
+  { nodeSocketPath      :: !SocketPath
+  , consensusModeParams :: !AnyConsensusModeParams
+  , network             :: !NetworkId
+  , mOutFile            :: !(Maybe (File () Out))
+  } deriving (Generic, Show)
 
 data QueryTipCmdArgs = QueryTipCmdArgs
-  !SocketPath
-  !AnyConsensusModeParams
-  !NetworkId
-  !(Maybe (File () Out))
-  deriving (Generic, Show)
+  { nodeSocketPath      :: !SocketPath
+  , consensusModeParams :: !AnyConsensusModeParams
+  , network             :: !NetworkId
+  , mOutFile            :: !(Maybe (File () Out))
+  } deriving (Generic, Show)
 
 data QueryStakePoolsCmdArgs = QueryStakePoolsCmdArgs
-  !SocketPath
-  !AnyConsensusModeParams
-  !NetworkId
-  !(Maybe (File () Out))
-  deriving (Generic, Show)
+  { nodeSocketPath      :: !SocketPath
+  , consensusModeParams :: !AnyConsensusModeParams
+  , network             :: !NetworkId
+  , mOutFile            :: !(Maybe (File () Out))
+  } deriving (Generic, Show)
 
 data QueryStakeDistributionCmdArgs = QueryStakeDistributionCmdArgs
-  !SocketPath
-  !AnyConsensusModeParams
-  !NetworkId
-  !(Maybe (File () Out))
-  deriving (Generic, Show)
+  { nodeSocketPath      :: !SocketPath
+  , consensusModeParams :: !AnyConsensusModeParams
+  , network             :: !NetworkId
+  , mOutFile            :: !(Maybe (File () Out))
+  } deriving (Generic, Show)
 
 data QueryStakeAddressInfoCmdArgs = QueryStakeAddressInfoCmdArgs
-  !SocketPath
-  !AnyConsensusModeParams
-  !StakeAddress
-  !NetworkId
-  !(Maybe (File () Out))
-  deriving (Generic, Show)
+  { mNodeSocketPath     :: !SocketPath
+  , consensusModeParams :: !AnyConsensusModeParams
+  , addr                :: !StakeAddress
+  , network             :: !NetworkId
+  , mOutFile            :: !(Maybe (File () Out))
+  } deriving (Generic, Show)
 
 data QueryUTxOCmdArgs = QueryUTxOCmdArgs
-  !SocketPath
-  !AnyConsensusModeParams
-  !QueryUTxOFilter
-  !NetworkId
-  !(Maybe (File () Out))
-  deriving (Generic, Show)
+  { nodeSocketPath      :: !SocketPath
+  , consensusModeParams :: !AnyConsensusModeParams
+  , queryFilter         :: !QueryUTxOFilter
+  , networkId           :: !NetworkId
+  , mOutFile            :: !(Maybe (File () Out))
+  } deriving (Generic, Show)
 
-data QueryDebugLedgerStateCmdArgs = QueryDebugLedgerStateCmdArgs
-  !SocketPath
-  !AnyConsensusModeParams
-  !NetworkId
-  !(Maybe (File () Out))
-  deriving (Generic, Show)
+data QueryLedgerStateCmdArgs = QueryLedgerStateCmdArgs
+  { nodeSocketPath      :: !SocketPath
+  , consensusModeParams :: !AnyConsensusModeParams
+  , network             :: !NetworkId
+  , mOutFile            :: !(Maybe (File () Out))
+  } deriving (Generic, Show)
 
 data QueryProtocolStateCmdArgs = QueryProtocolStateCmdArgs
-  !SocketPath
-  !AnyConsensusModeParams
-  !NetworkId
-  !(Maybe (File () Out))
-  deriving (Generic, Show)
+  { nodeSocketPath      :: !SocketPath
+  , consensusModeParams :: !AnyConsensusModeParams
+  , network             :: !NetworkId
+  , mOutFile            :: !(Maybe (File () Out))
+  } deriving (Generic, Show)
 
 data QueryStakeSnapshotCmdArgs = QueryStakeSnapshotCmdArgs
-  !SocketPath
-  !AnyConsensusModeParams
-  !NetworkId
-  !(AllOrOnly [Hash StakePoolKey])
-  !(Maybe (File () Out))
-  deriving (Generic, Show)
+  { nodeSocketPath      :: !SocketPath
+  , consensusModeParams :: !AnyConsensusModeParams
+  , network             :: !NetworkId
+  , allOrOnlyPoolIds    :: !(AllOrOnly [Hash StakePoolKey])
+  , mOutFile            :: !(Maybe (File () Out))
+  } deriving (Generic, Show)
 
 data QueryKesPeriodInfoCmdArgs = QueryKesPeriodInfoCmdArgs
-  !SocketPath
-  !AnyConsensusModeParams
-  !NetworkId
-  !(File () In)
-  -- ^ Node operational certificate
-  !(Maybe (File () Out))
-  deriving (Generic, Show)
+  { nodeSocketPath      :: !SocketPath
+  , consensusModeParams :: !AnyConsensusModeParams
+  , network             :: !NetworkId
+  , nodeOpCert          :: !(File () In) -- ^ Node operational certificate
+  , mOutFile            :: !(Maybe (File () Out))
+  } deriving (Generic, Show)
 
 data QueryPoolStateCmdArgs = QueryPoolStateCmdArgs
-  !SocketPath
-  !AnyConsensusModeParams
-  !NetworkId
-  ![Hash StakePoolKey]
-  deriving (Generic, Show)
+  { nodeSocketPath      :: !SocketPath
+  , consensusModeParams :: !AnyConsensusModeParams
+  , network             :: !NetworkId
+  , poolid              :: ![Hash StakePoolKey]
+  } deriving (Generic, Show)
 
 data QueryTxMempoolCmdArgs = QueryTxMempoolCmdArgs
-  !SocketPath
-  !AnyConsensusModeParams
-  !NetworkId
-  !TxMempoolQuery
-  !(Maybe (File () Out))
+  { nodeSocketPath      :: !SocketPath
+  , consensusModeParams :: !AnyConsensusModeParams
+  , network             :: !NetworkId
+  , op                  :: !TxMempoolQuery
+  , mOutFile            :: !(Maybe (File () Out))
+  }
   deriving (Generic, Show)
 
 data QuerySlotNumberCmdArgs = QuerySlotNumberCmdArgs
-  !SocketPath
-  !AnyConsensusModeParams
-  !NetworkId
-  !UTCTime
-  deriving (Generic, Show)
+  { nodeSocketPath      :: !SocketPath
+  , consensusModeParams :: !AnyConsensusModeParams
+  , network             :: !NetworkId
+  , utcTime             :: !UTCTime
+  } deriving (Generic, Show)
 
 renderQueryCmds :: QueryCmds era -> Text
 renderQueryCmds = \case
@@ -182,7 +183,7 @@ renderQueryCmds = \case
     "query stake-address-info"
   QueryUTxOCmd {} ->
     "query utxo"
-  QueryDebugLedgerStateCmd {} ->
+  QueryLedgerStateCmd {} ->
     "query ledger-state"
   QueryProtocolStateCmd {} ->
     "query protocol-state"

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Query.hs
@@ -35,152 +35,152 @@ pQueryCmds envCli =
     )
     [ Just
         $ subParser "protocol-parameters"
-        $ Opt.info (pQueryProtocolParameters envCli)
+        $ Opt.info (pQueryProtocolParametersCmd envCli)
         $ Opt.progDesc "Get the node's current protocol parameters"
     , Just
         $ subParser "constitution-hash"
-        $ Opt.info (pQueryConstitutionHash envCli)
+        $ Opt.info (pQueryConstitutionHashCmd envCli)
         $ Opt.progDesc "Get the constitution hash"
     , Just
         $ subParser "tip"
-        $ Opt.info (pQueryTip envCli)
+        $ Opt.info (pQueryTipCmd envCli)
         $ Opt.progDesc "Get the node's current tip (slot no, hash, block no)"
     , Just
         $ subParser "stake-pools"
-        $ Opt.info (pQueryStakePools envCli)
+        $ Opt.info (pQueryStakePoolsCmd envCli)
         $ Opt.progDesc "Get the node's current set of stake pool ids"
     , Just
         $ subParser "stake-distribution"
-        $ Opt.info (pQueryStakeDistribution envCli)
+        $ Opt.info (pQueryStakeDistributionCmd envCli)
         $ Opt.progDesc "Get the node's current aggregated stake distribution"
     , Just
         $ subParser "stake-address-info"
-        $ Opt.info (pQueryStakeAddressInfo envCli)
+        $ Opt.info (pQueryStakeAddressInfoCmd envCli)
         $ Opt.progDesc $ mconcat
             [ "Get the current delegations and reward accounts filtered by stake address."
             ]
     , Just
         $ subParser "utxo"
-        $ Opt.info (pQueryUTxO envCli)
+        $ Opt.info (pQueryUTxOCmd envCli)
         $ Opt.progDesc $ mconcat
             [ "Get a portion of the current UTxO: by tx in, by address or the whole."
             ]
     , Just
         $ subParser "ledger-state"
-        $ Opt.info (pQueryLedgerState envCli)
+        $ Opt.info (pQueryLedgerStateCmd envCli)
         $ Opt.progDesc $ mconcat
             [ "Dump the current ledger state of the node (Ledger.NewEpochState -- advanced command)"
             ]
     , Just
         $ subParser "protocol-state"
-        $ Opt.info (pQueryProtocolState envCli)
+        $ Opt.info (pQueryProtocolStateCmd envCli)
         $ Opt.progDesc $ mconcat
             [ "Dump the current protocol state of the node (Ledger.ChainDepState -- advanced command)"
             ]
     , Just
         $ subParser "stake-snapshot"
-        $ Opt.info (pQueryStakeSnapshot envCli)
+        $ Opt.info (pQueryStakeSnapshotCmd envCli)
         $ Opt.progDesc $ mconcat
             [ "Obtain the three stake snapshots for a pool, plus the total active stake (advanced command)"
             ]
     , Just
         $ hiddenSubParser "pool-params"
-        $ Opt.info (pQueryPoolState envCli)
+        $ Opt.info (pQueryPoolStateCmd envCli)
         $ Opt.progDesc $ mconcat
             [ "DEPRECATED.  Use query pool-state instead.  Dump the pool parameters "
             , "(Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced command)"
             ]
     , Just
         $ subParser "leadership-schedule"
-        $ Opt.info (pLeadershipSchedule envCli)
+        $ Opt.info (pLeadershipScheduleCmd envCli)
         $ Opt.progDesc "Get the slots the node is expected to mint a block in (advanced command)"
     , Just
         $ subParser "kes-period-info"
-        $ Opt.info (pKesPeriodInfo envCli)
+        $ Opt.info (pKesPeriodInfoCmd envCli)
         $ Opt.progDesc "Get information about the current KES period and your node's operational certificate."
     , Just
         $ subParser "pool-state"
-        $ Opt.info (pQueryPoolState envCli)
+        $ Opt.info (pQueryPoolStateCmd envCli)
         $ Opt.progDesc "Dump the pool state"
     , Just
         $ subParser "tx-mempool"
-        $ Opt.info (pQueryTxMempool envCli)
+        $ Opt.info (pQueryTxMempoolCmd envCli)
         $ Opt.progDesc "Local Mempool info"
     , Just
         $ subParser "slot-number"
-        $ Opt.info (pQuerySlotNumber envCli)
+        $ Opt.info (pQuerySlotNumberCmd envCli)
         $ Opt.progDesc "Query slot number for UTC timestamp"
     ]
 
-pQueryProtocolParameters :: EnvCli -> Parser (QueryCmds era)
-pQueryProtocolParameters envCli =
-  QueryProtocolParameters'
+pQueryProtocolParametersCmd :: EnvCli -> Parser (QueryCmds era)
+pQueryProtocolParametersCmd envCli =
+  QueryProtocolParametersCmd
     <$> pSocketPath envCli
     <*> pConsensusModeParams
     <*> pNetworkId envCli
     <*> pMaybeOutputFile
 
-pQueryConstitutionHash :: EnvCli -> Parser (QueryCmds era)
-pQueryConstitutionHash envCli =
-  QueryConstitutionHash
+pQueryConstitutionHashCmd :: EnvCli -> Parser (QueryCmds era)
+pQueryConstitutionHashCmd envCli =
+  QueryConstitutionHashCmd
     <$> pSocketPath envCli
     <*> pConsensusModeParams
     <*> pNetworkId envCli
     <*> pMaybeOutputFile
 
-pQueryTip :: EnvCli -> Parser (QueryCmds era)
-pQueryTip envCli =
-  QueryTip
+pQueryTipCmd :: EnvCli -> Parser (QueryCmds era)
+pQueryTipCmd envCli =
+  QueryTipCmd
     <$> pSocketPath envCli
     <*> pConsensusModeParams
     <*> pNetworkId envCli
     <*> pMaybeOutputFile
 
-pQueryUTxO :: EnvCli -> Parser (QueryCmds era)
-pQueryUTxO envCli =
-  QueryUTxO'
+pQueryUTxOCmd :: EnvCli -> Parser (QueryCmds era)
+pQueryUTxOCmd envCli =
+  QueryUTxOCmd
     <$> pSocketPath envCli
     <*> pConsensusModeParams
     <*> pQueryUTxOFilter
     <*> pNetworkId envCli
     <*> pMaybeOutputFile
 
-pQueryStakePools :: EnvCli -> Parser (QueryCmds era)
-pQueryStakePools envCli =
-  QueryStakePools'
+pQueryStakePoolsCmd :: EnvCli -> Parser (QueryCmds era)
+pQueryStakePoolsCmd envCli =
+  QueryStakePoolsCmd
     <$> pSocketPath envCli
     <*> pConsensusModeParams
     <*> pNetworkId envCli
     <*> pMaybeOutputFile
 
-pQueryStakeDistribution :: EnvCli -> Parser (QueryCmds era)
-pQueryStakeDistribution envCli =
-  QueryStakeDistribution'
+pQueryStakeDistributionCmd :: EnvCli -> Parser (QueryCmds era)
+pQueryStakeDistributionCmd envCli =
+  QueryStakeDistributionCmd
     <$> pSocketPath envCli
     <*> pConsensusModeParams
     <*> pNetworkId envCli
     <*> pMaybeOutputFile
 
-pQueryStakeAddressInfo :: EnvCli -> Parser (QueryCmds era)
-pQueryStakeAddressInfo envCli =
-  QueryStakeAddressInfo
+pQueryStakeAddressInfoCmd :: EnvCli -> Parser (QueryCmds era)
+pQueryStakeAddressInfoCmd envCli =
+  QueryStakeAddressInfoCmd
     <$> pSocketPath envCli
     <*> pConsensusModeParams
     <*> pFilterByStakeAddress
     <*> pNetworkId envCli
     <*> pMaybeOutputFile
 
-pQueryLedgerState :: EnvCli -> Parser (QueryCmds era)
-pQueryLedgerState envCli =
-  QueryDebugLedgerState'
+pQueryLedgerStateCmd :: EnvCli -> Parser (QueryCmds era)
+pQueryLedgerStateCmd envCli =
+  QueryDebugLedgerStateCmd
     <$> pSocketPath envCli
     <*> pConsensusModeParams
     <*> pNetworkId envCli
     <*> pMaybeOutputFile
 
-pQueryProtocolState :: EnvCli -> Parser (QueryCmds era)
-pQueryProtocolState envCli =
-  QueryProtocolState'
+pQueryProtocolStateCmd :: EnvCli -> Parser (QueryCmds era)
+pQueryProtocolStateCmd envCli =
+  QueryProtocolStateCmd
     <$> pSocketPath envCli
     <*> pConsensusModeParams
     <*> pNetworkId envCli
@@ -196,26 +196,26 @@ pAllStakePoolsOrOnly = pAll <|> pOnly
         pOnly :: Parser (AllOrOnly [Hash StakePoolKey])
         pOnly = Only <$> many (pStakePoolVerificationKeyHash Nothing)
 
-pQueryStakeSnapshot :: EnvCli -> Parser (QueryCmds era)
-pQueryStakeSnapshot envCli =
-  QueryStakeSnapshot'
+pQueryStakeSnapshotCmd :: EnvCli -> Parser (QueryCmds era)
+pQueryStakeSnapshotCmd envCli =
+  QueryStakeSnapshotCmd
     <$> pSocketPath envCli
     <*> pConsensusModeParams
     <*> pNetworkId envCli
     <*> pAllStakePoolsOrOnly
     <*> pMaybeOutputFile
 
-pQueryPoolState :: EnvCli -> Parser (QueryCmds era)
-pQueryPoolState envCli =
-  QueryPoolState'
+pQueryPoolStateCmd :: EnvCli -> Parser (QueryCmds era)
+pQueryPoolStateCmd envCli =
+  QueryPoolStateCmd
     <$> pSocketPath envCli
     <*> pConsensusModeParams
     <*> pNetworkId envCli
     <*> many (pStakePoolVerificationKeyHash Nothing)
 
-pQueryTxMempool :: EnvCli -> Parser (QueryCmds era)
-pQueryTxMempool envCli =
-  QueryTxMempool
+pQueryTxMempoolCmd :: EnvCli -> Parser (QueryCmds era)
+pQueryTxMempoolCmd envCli =
+  QueryTxMempoolCmd
     <$> pSocketPath envCli
     <*> pConsensusModeParams
     <*> pNetworkId envCli
@@ -234,9 +234,9 @@ pQueryTxMempool envCli =
           $ Opt.info (TxMempoolQueryTxExists <$> argument Opt.str (metavar "TX_ID"))
           $ Opt.progDesc "Query if a particular transaction exists in the mempool"
       ]
-pLeadershipSchedule :: EnvCli -> Parser (QueryCmds era)
-pLeadershipSchedule envCli =
-  QueryLeadershipSchedule
+pLeadershipScheduleCmd :: EnvCli -> Parser (QueryCmds era)
+pLeadershipScheduleCmd envCli =
+  QueryLeadershipScheduleCmd
     <$> pSocketPath envCli
     <*> pConsensusModeParams
     <*> pNetworkId envCli
@@ -246,18 +246,18 @@ pLeadershipSchedule envCli =
     <*> pWhichLeadershipSchedule
     <*> pMaybeOutputFile
 
-pKesPeriodInfo :: EnvCli -> Parser (QueryCmds era)
-pKesPeriodInfo envCli =
-  QueryKesPeriodInfo
+pKesPeriodInfoCmd :: EnvCli -> Parser (QueryCmds era)
+pKesPeriodInfoCmd envCli =
+  QueryKesPeriodInfoCmd
     <$> pSocketPath envCli
     <*> pConsensusModeParams
     <*> pNetworkId envCli
     <*> pOperationalCertificateFile
     <*> pMaybeOutputFile
 
-pQuerySlotNumber :: EnvCli -> Parser (QueryCmds era)
-pQuerySlotNumber envCli =
-  QuerySlotNumber
+pQuerySlotNumberCmd :: EnvCli -> Parser (QueryCmds era)
+pQuerySlotNumberCmd envCli =
+  QuerySlotNumberCmd
     <$> pSocketPath envCli
     <*> pConsensusModeParams
     <*> pNetworkId envCli

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Query.hs
@@ -179,8 +179,8 @@ pQueryStakeAddressInfoCmd envCli =
 
 pQueryLedgerStateCmd :: EnvCli -> Parser (QueryCmds era)
 pQueryLedgerStateCmd envCli =
-  fmap QueryDebugLedgerStateCmd $
-    QueryDebugLedgerStateCmdArgs
+  fmap QueryLedgerStateCmd $
+    QueryLedgerStateCmdArgs
       <$> pSocketPath envCli
       <*> pConsensusModeParams
       <*> pNetworkId envCli

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Query.hs
@@ -114,77 +114,86 @@ pQueryCmds envCli =
 
 pQueryProtocolParametersCmd :: EnvCli -> Parser (QueryCmds era)
 pQueryProtocolParametersCmd envCli =
-  QueryProtocolParametersCmd
-    <$> pSocketPath envCli
-    <*> pConsensusModeParams
-    <*> pNetworkId envCli
-    <*> pMaybeOutputFile
+  fmap QueryProtocolParametersCmd $
+    QueryProtocolParametersCmdArgs
+      <$> pSocketPath envCli
+      <*> pConsensusModeParams
+      <*> pNetworkId envCli
+      <*> pMaybeOutputFile
 
 pQueryConstitutionHashCmd :: EnvCli -> Parser (QueryCmds era)
 pQueryConstitutionHashCmd envCli =
-  QueryConstitutionHashCmd
-    <$> pSocketPath envCli
-    <*> pConsensusModeParams
-    <*> pNetworkId envCli
-    <*> pMaybeOutputFile
+  fmap QueryConstitutionHashCmd $
+    QueryConstitutionHashCmdArgs
+      <$> pSocketPath envCli
+      <*> pConsensusModeParams
+      <*> pNetworkId envCli
+      <*> pMaybeOutputFile
 
 pQueryTipCmd :: EnvCli -> Parser (QueryCmds era)
 pQueryTipCmd envCli =
-  QueryTipCmd
-    <$> pSocketPath envCli
-    <*> pConsensusModeParams
-    <*> pNetworkId envCli
-    <*> pMaybeOutputFile
+  fmap QueryTipCmd $
+    QueryTipCmdArgs
+      <$> pSocketPath envCli
+      <*> pConsensusModeParams
+      <*> pNetworkId envCli
+      <*> pMaybeOutputFile
 
 pQueryUTxOCmd :: EnvCli -> Parser (QueryCmds era)
 pQueryUTxOCmd envCli =
-  QueryUTxOCmd
-    <$> pSocketPath envCli
-    <*> pConsensusModeParams
-    <*> pQueryUTxOFilter
-    <*> pNetworkId envCli
-    <*> pMaybeOutputFile
+  fmap QueryUTxOCmd $
+    QueryUTxOCmdArgs
+      <$> pSocketPath envCli
+      <*> pConsensusModeParams
+      <*> pQueryUTxOFilter
+      <*> pNetworkId envCli
+      <*> pMaybeOutputFile
 
 pQueryStakePoolsCmd :: EnvCli -> Parser (QueryCmds era)
 pQueryStakePoolsCmd envCli =
-  QueryStakePoolsCmd
-    <$> pSocketPath envCli
-    <*> pConsensusModeParams
-    <*> pNetworkId envCli
-    <*> pMaybeOutputFile
+  fmap QueryStakePoolsCmd $
+    QueryStakePoolsCmdArgs
+      <$> pSocketPath envCli
+      <*> pConsensusModeParams
+      <*> pNetworkId envCli
+      <*> pMaybeOutputFile
 
 pQueryStakeDistributionCmd :: EnvCli -> Parser (QueryCmds era)
 pQueryStakeDistributionCmd envCli =
-  QueryStakeDistributionCmd
-    <$> pSocketPath envCli
-    <*> pConsensusModeParams
-    <*> pNetworkId envCli
-    <*> pMaybeOutputFile
+  fmap QueryStakeDistributionCmd $
+    QueryStakeDistributionCmdArgs
+      <$> pSocketPath envCli
+      <*> pConsensusModeParams
+      <*> pNetworkId envCli
+      <*> pMaybeOutputFile
 
 pQueryStakeAddressInfoCmd :: EnvCli -> Parser (QueryCmds era)
 pQueryStakeAddressInfoCmd envCli =
-  QueryStakeAddressInfoCmd
-    <$> pSocketPath envCli
-    <*> pConsensusModeParams
-    <*> pFilterByStakeAddress
-    <*> pNetworkId envCli
-    <*> pMaybeOutputFile
+  fmap QueryStakeAddressInfoCmd $
+    QueryStakeAddressInfoCmdArgs
+      <$> pSocketPath envCli
+      <*> pConsensusModeParams
+      <*> pFilterByStakeAddress
+      <*> pNetworkId envCli
+      <*> pMaybeOutputFile
 
 pQueryLedgerStateCmd :: EnvCli -> Parser (QueryCmds era)
 pQueryLedgerStateCmd envCli =
-  QueryDebugLedgerStateCmd
-    <$> pSocketPath envCli
-    <*> pConsensusModeParams
-    <*> pNetworkId envCli
-    <*> pMaybeOutputFile
+  fmap QueryDebugLedgerStateCmd $
+    QueryDebugLedgerStateCmdArgs
+      <$> pSocketPath envCli
+      <*> pConsensusModeParams
+      <*> pNetworkId envCli
+      <*> pMaybeOutputFile
 
 pQueryProtocolStateCmd :: EnvCli -> Parser (QueryCmds era)
 pQueryProtocolStateCmd envCli =
-  QueryProtocolStateCmd
-    <$> pSocketPath envCli
-    <*> pConsensusModeParams
-    <*> pNetworkId envCli
-    <*> pMaybeOutputFile
+  fmap QueryProtocolStateCmd $
+    QueryProtocolStateCmdArgs
+      <$> pSocketPath envCli
+      <*> pConsensusModeParams
+      <*> pNetworkId envCli
+      <*> pMaybeOutputFile
 
 pAllStakePoolsOrOnly :: Parser (AllOrOnly [Hash StakePoolKey])
 pAllStakePoolsOrOnly = pAll <|> pOnly
@@ -198,29 +207,32 @@ pAllStakePoolsOrOnly = pAll <|> pOnly
 
 pQueryStakeSnapshotCmd :: EnvCli -> Parser (QueryCmds era)
 pQueryStakeSnapshotCmd envCli =
-  QueryStakeSnapshotCmd
-    <$> pSocketPath envCli
-    <*> pConsensusModeParams
-    <*> pNetworkId envCli
-    <*> pAllStakePoolsOrOnly
-    <*> pMaybeOutputFile
+  fmap QueryStakeSnapshotCmd $
+    QueryStakeSnapshotCmdArgs
+      <$> pSocketPath envCli
+      <*> pConsensusModeParams
+      <*> pNetworkId envCli
+      <*> pAllStakePoolsOrOnly
+      <*> pMaybeOutputFile
 
 pQueryPoolStateCmd :: EnvCli -> Parser (QueryCmds era)
 pQueryPoolStateCmd envCli =
-  QueryPoolStateCmd
-    <$> pSocketPath envCli
-    <*> pConsensusModeParams
-    <*> pNetworkId envCli
-    <*> many (pStakePoolVerificationKeyHash Nothing)
+  fmap QueryPoolStateCmd $
+    QueryPoolStateCmdArgs
+      <$> pSocketPath envCli
+      <*> pConsensusModeParams
+      <*> pNetworkId envCli
+      <*> many (pStakePoolVerificationKeyHash Nothing)
 
 pQueryTxMempoolCmd :: EnvCli -> Parser (QueryCmds era)
 pQueryTxMempoolCmd envCli =
-  QueryTxMempoolCmd
-    <$> pSocketPath envCli
-    <*> pConsensusModeParams
-    <*> pNetworkId envCli
-    <*> pTxMempoolQuery
-    <*> pMaybeOutputFile
+  fmap QueryTxMempoolCmd $
+    QueryTxMempoolCmdArgs
+      <$> pSocketPath envCli
+      <*> pConsensusModeParams
+      <*> pNetworkId envCli
+      <*> pTxMempoolQuery
+      <*> pMaybeOutputFile
   where
     pTxMempoolQuery :: Parser TxMempoolQuery
     pTxMempoolQuery = asum
@@ -236,35 +248,38 @@ pQueryTxMempoolCmd envCli =
       ]
 pLeadershipScheduleCmd :: EnvCli -> Parser (QueryCmds era)
 pLeadershipScheduleCmd envCli =
-  QueryLeadershipScheduleCmd
-    <$> pSocketPath envCli
-    <*> pConsensusModeParams
-    <*> pNetworkId envCli
-    <*> pGenesisFile "Shelley genesis filepath"
-    <*> pStakePoolVerificationKeyOrHashOrFile Nothing
-    <*> pVrfSigningKeyFile
-    <*> pWhichLeadershipSchedule
-    <*> pMaybeOutputFile
+  fmap QueryLeadershipScheduleCmd $
+    QueryLeadershipScheduleCmdArgs
+      <$> pSocketPath envCli
+      <*> pConsensusModeParams
+      <*> pNetworkId envCli
+      <*> pGenesisFile "Shelley genesis filepath"
+      <*> pStakePoolVerificationKeyOrHashOrFile Nothing
+      <*> pVrfSigningKeyFile
+      <*> pWhichLeadershipSchedule
+      <*> pMaybeOutputFile
 
 pKesPeriodInfoCmd :: EnvCli -> Parser (QueryCmds era)
 pKesPeriodInfoCmd envCli =
-  QueryKesPeriodInfoCmd
-    <$> pSocketPath envCli
-    <*> pConsensusModeParams
-    <*> pNetworkId envCli
-    <*> pOperationalCertificateFile
-    <*> pMaybeOutputFile
+  fmap QueryKesPeriodInfoCmd $
+    QueryKesPeriodInfoCmdArgs
+      <$> pSocketPath envCli
+      <*> pConsensusModeParams
+      <*> pNetworkId envCli
+      <*> pOperationalCertificateFile
+      <*> pMaybeOutputFile
 
 pQuerySlotNumberCmd :: EnvCli -> Parser (QueryCmds era)
 pQuerySlotNumberCmd envCli =
-  QuerySlotNumberCmd
-    <$> pSocketPath envCli
-    <*> pConsensusModeParams
-    <*> pNetworkId envCli
-    <*> pUtcTimestamp
-      where
-        pUtcTimestamp =
-          convertTime <$> (Opt.strArgument . mconcat)
-            [ Opt.metavar "TIMESTAMP"
-            , Opt.help "UTC timestamp in YYYY-MM-DDThh:mm:ssZ format"
-            ]
+  fmap QuerySlotNumberCmd $
+    QuerySlotNumberCmdArgs
+      <$> pSocketPath envCli
+      <*> pConsensusModeParams
+      <*> pNetworkId envCli
+      <*> pUtcTimestamp
+  where
+    pUtcTimestamp =
+      convertTime <$> (Opt.strArgument . mconcat)
+        [ Opt.metavar "TIMESTAMP"
+        , Opt.help "UTC timestamp in YYYY-MM-DDThh:mm:ssZ format"
+        ]

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Query.hs
@@ -106,35 +106,35 @@ import           Text.Printf (printf)
 
 runQueryCmds :: QueryCmds era -> ExceptT QueryCmdError IO ()
 runQueryCmds = \case
-  QueryLeadershipScheduleCmd mNodeSocketPath consensusModeParams network shelleyGenFp poolid vrkSkeyFp whichSchedule outputAs ->
+  QueryLeadershipScheduleCmd (QueryLeadershipScheduleCmdArgs mNodeSocketPath consensusModeParams network shelleyGenFp poolid vrkSkeyFp whichSchedule outputAs) ->
     runQueryLeadershipScheduleCmd mNodeSocketPath consensusModeParams network shelleyGenFp poolid vrkSkeyFp whichSchedule outputAs
-  QueryProtocolParametersCmd mNodeSocketPath consensusModeParams network mOutFile ->
+  QueryProtocolParametersCmd (QueryProtocolParametersCmdArgs mNodeSocketPath consensusModeParams network mOutFile) ->
     runQueryProtocolParametersCmd mNodeSocketPath consensusModeParams network mOutFile
-  QueryConstitutionHashCmd mNodeSocketPath consensusModeParams network mOutFile ->
+  QueryConstitutionHashCmd (QueryConstitutionHashCmdArgs mNodeSocketPath consensusModeParams network mOutFile) ->
     runQueryConstitutionHashCmd mNodeSocketPath consensusModeParams network mOutFile
-  QueryTipCmd mNodeSocketPath consensusModeParams network mOutFile ->
+  QueryTipCmd (QueryTipCmdArgs mNodeSocketPath consensusModeParams network mOutFile) ->
     runQueryTipCmd mNodeSocketPath consensusModeParams network mOutFile
-  QueryStakePoolsCmd mNodeSocketPath consensusModeParams network mOutFile ->
+  QueryStakePoolsCmd (QueryStakePoolsCmdArgs mNodeSocketPath consensusModeParams network mOutFile) ->
     runQueryStakePoolsCmd mNodeSocketPath consensusModeParams network mOutFile
-  QueryStakeDistributionCmd mNodeSocketPath consensusModeParams network mOutFile ->
+  QueryStakeDistributionCmd (QueryStakeDistributionCmdArgs mNodeSocketPath consensusModeParams network mOutFile) ->
     runQueryStakeDistributionCmd mNodeSocketPath consensusModeParams network mOutFile
-  QueryStakeAddressInfoCmd mNodeSocketPath consensusModeParams addr network mOutFile ->
+  QueryStakeAddressInfoCmd (QueryStakeAddressInfoCmdArgs mNodeSocketPath consensusModeParams addr network mOutFile) ->
     runQueryStakeAddressInfoCmd mNodeSocketPath consensusModeParams addr network mOutFile
-  QueryDebugLedgerStateCmd mNodeSocketPath consensusModeParams network mOutFile ->
+  QueryDebugLedgerStateCmd (QueryDebugLedgerStateCmdArgs mNodeSocketPath consensusModeParams network mOutFile) ->
     runQueryLedgerStateCmd mNodeSocketPath consensusModeParams network mOutFile
-  QueryStakeSnapshotCmd mNodeSocketPath consensusModeParams network allOrOnlyPoolIds mOutFile ->
+  QueryStakeSnapshotCmd (QueryStakeSnapshotCmdArgs mNodeSocketPath consensusModeParams network allOrOnlyPoolIds mOutFile) ->
     runQueryStakeSnapshotCmd mNodeSocketPath consensusModeParams network allOrOnlyPoolIds mOutFile
-  QueryProtocolStateCmd mNodeSocketPath consensusModeParams network mOutFile ->
+  QueryProtocolStateCmd (QueryProtocolStateCmdArgs mNodeSocketPath consensusModeParams network mOutFile) ->
     runQueryProtocolStateCmd mNodeSocketPath consensusModeParams network mOutFile
-  QueryUTxOCmd mNodeSocketPath consensusModeParams qFilter networkId mOutFile ->
+  QueryUTxOCmd (QueryUTxOCmdArgs mNodeSocketPath consensusModeParams qFilter networkId mOutFile) ->
     runQueryUTxOCmd mNodeSocketPath consensusModeParams qFilter networkId mOutFile
-  QueryKesPeriodInfoCmd mNodeSocketPath consensusModeParams network nodeOpCert mOutFile ->
+  QueryKesPeriodInfoCmd (QueryKesPeriodInfoCmdArgs mNodeSocketPath consensusModeParams network nodeOpCert mOutFile) ->
     runQueryKesPeriodInfoCmd mNodeSocketPath consensusModeParams network nodeOpCert mOutFile
-  QueryPoolStateCmd mNodeSocketPath consensusModeParams network poolid ->
+  QueryPoolStateCmd (QueryPoolStateCmdArgs mNodeSocketPath consensusModeParams network poolid) ->
     runQueryPoolStateCmd mNodeSocketPath consensusModeParams network poolid
-  QueryTxMempoolCmd mNodeSocketPath consensusModeParams network op mOutFile ->
+  QueryTxMempoolCmd (QueryTxMempoolCmdArgs mNodeSocketPath consensusModeParams network op mOutFile) ->
     runQueryTxMempoolCmd mNodeSocketPath consensusModeParams network op mOutFile
-  QuerySlotNumberCmd mNodeSocketPath consensusModeParams network utcTime ->
+  QuerySlotNumberCmd (QuerySlotNumberCmdArgs mNodeSocketPath consensusModeParams network utcTime) ->
     runQuerySlotNumberCmd mNodeSocketPath consensusModeParams network utcTime
 
 runQueryConstitutionHashCmd

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Query.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
@@ -49,8 +50,7 @@ import           Cardano.CLI.Pretty
 import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Errors.QueryCmdError
 import           Cardano.CLI.Types.Errors.QueryCmdLocalStateQueryError
-import           Cardano.CLI.Types.Key (VerificationKeyOrHashOrFile,
-                   readVerificationKeyOrHashOrFile)
+import           Cardano.CLI.Types.Key
 import qualified Cardano.CLI.Types.Output as O
 import           Cardano.Crypto.Hash (hashToBytesAsHex)
 import qualified Cardano.Crypto.Hash.Blake2b as Blake2b
@@ -106,45 +106,33 @@ import           Text.Printf (printf)
 
 runQueryCmds :: Cmd.QueryCmds era -> ExceptT QueryCmdError IO ()
 runQueryCmds = \case
-  Cmd.QueryLeadershipScheduleCmd (Cmd.QueryLeadershipScheduleCmdArgs mNodeSocketPath consensusModeParams network shelleyGenFp poolid vrkSkeyFp whichSchedule outputAs) ->
-    runQueryLeadershipScheduleCmd mNodeSocketPath consensusModeParams network shelleyGenFp poolid vrkSkeyFp whichSchedule outputAs
-  Cmd.QueryProtocolParametersCmd (Cmd.QueryProtocolParametersCmdArgs mNodeSocketPath consensusModeParams network mOutFile) ->
-    runQueryProtocolParametersCmd mNodeSocketPath consensusModeParams network mOutFile
-  Cmd.QueryConstitutionHashCmd (Cmd.QueryConstitutionHashCmdArgs mNodeSocketPath consensusModeParams network mOutFile) ->
-    runQueryConstitutionHashCmd mNodeSocketPath consensusModeParams network mOutFile
-  Cmd.QueryTipCmd (Cmd.QueryTipCmdArgs mNodeSocketPath consensusModeParams network mOutFile) ->
-    runQueryTipCmd mNodeSocketPath consensusModeParams network mOutFile
-  Cmd.QueryStakePoolsCmd (Cmd.QueryStakePoolsCmdArgs mNodeSocketPath consensusModeParams network mOutFile) ->
-    runQueryStakePoolsCmd mNodeSocketPath consensusModeParams network mOutFile
-  Cmd.QueryStakeDistributionCmd (Cmd.QueryStakeDistributionCmdArgs mNodeSocketPath consensusModeParams network mOutFile) ->
-    runQueryStakeDistributionCmd mNodeSocketPath consensusModeParams network mOutFile
-  Cmd.QueryStakeAddressInfoCmd (Cmd.QueryStakeAddressInfoCmdArgs mNodeSocketPath consensusModeParams addr network mOutFile) ->
-    runQueryStakeAddressInfoCmd mNodeSocketPath consensusModeParams addr network mOutFile
-  Cmd.QueryLedgerStateCmd (Cmd.QueryLedgerStateCmdArgs mNodeSocketPath consensusModeParams network mOutFile) ->
-    runQueryLedgerStateCmd mNodeSocketPath consensusModeParams network mOutFile
-  Cmd.QueryStakeSnapshotCmd (Cmd.QueryStakeSnapshotCmdArgs mNodeSocketPath consensusModeParams network allOrOnlyPoolIds mOutFile) ->
-    runQueryStakeSnapshotCmd mNodeSocketPath consensusModeParams network allOrOnlyPoolIds mOutFile
-  Cmd.QueryProtocolStateCmd (Cmd.QueryProtocolStateCmdArgs mNodeSocketPath consensusModeParams network mOutFile) ->
-    runQueryProtocolStateCmd mNodeSocketPath consensusModeParams network mOutFile
-  Cmd.QueryUTxOCmd (Cmd.QueryUTxOCmdArgs mNodeSocketPath consensusModeParams qFilter networkId mOutFile) ->
-    runQueryUTxOCmd mNodeSocketPath consensusModeParams qFilter networkId mOutFile
-  Cmd.QueryKesPeriodInfoCmd (Cmd.QueryKesPeriodInfoCmdArgs mNodeSocketPath consensusModeParams network nodeOpCert mOutFile) ->
-    runQueryKesPeriodInfoCmd mNodeSocketPath consensusModeParams network nodeOpCert mOutFile
-  Cmd.QueryPoolStateCmd (Cmd.QueryPoolStateCmdArgs mNodeSocketPath consensusModeParams network poolid) ->
-    runQueryPoolStateCmd mNodeSocketPath consensusModeParams network poolid
-  Cmd.QueryTxMempoolCmd (Cmd.QueryTxMempoolCmdArgs mNodeSocketPath consensusModeParams network op mOutFile) ->
-    runQueryTxMempoolCmd mNodeSocketPath consensusModeParams network op mOutFile
-  Cmd.QuerySlotNumberCmd (Cmd.QuerySlotNumberCmdArgs mNodeSocketPath consensusModeParams network utcTime) ->
-    runQuerySlotNumberCmd mNodeSocketPath consensusModeParams network utcTime
+  Cmd.QueryLeadershipScheduleCmd  args -> runQueryLeadershipScheduleCmd args
+  Cmd.QueryProtocolParametersCmd  args -> runQueryProtocolParametersCmd args
+  Cmd.QueryConstitutionHashCmd    args -> runQueryConstitutionHashCmd args
+  Cmd.QueryTipCmd                 args -> runQueryTipCmd args
+  Cmd.QueryStakePoolsCmd          args -> runQueryStakePoolsCmd args
+  Cmd.QueryStakeDistributionCmd   args -> runQueryStakeDistributionCmd args
+  Cmd.QueryStakeAddressInfoCmd    args -> runQueryStakeAddressInfoCmd args
+  Cmd.QueryLedgerStateCmd         args -> runQueryLedgerStateCmd args
+  Cmd.QueryStakeSnapshotCmd       args -> runQueryStakeSnapshotCmd args
+  Cmd.QueryProtocolStateCmd       args -> runQueryProtocolStateCmd args
+  Cmd.QueryUTxOCmd                args -> runQueryUTxOCmd args
+  Cmd.QueryKesPeriodInfoCmd       args -> runQueryKesPeriodInfoCmd args
+  Cmd.QueryPoolStateCmd           args -> runQueryPoolStateCmd args
+  Cmd.QueryTxMempoolCmd           args -> runQueryTxMempoolCmd args
+  Cmd.QuerySlotNumberCmd          args -> runQuerySlotNumberCmd args
 
-runQueryConstitutionHashCmd
-  :: SocketPath
-  -> AnyConsensusModeParams
-  -> NetworkId
-  -> Maybe (File () Out)
+runQueryConstitutionHashCmd :: ()
+  => Cmd.QueryConstitutionHashCmdArgs
   -> ExceptT QueryCmdError IO ()
-runQueryConstitutionHashCmd socketPath (AnyConsensusModeParams cModeParams) network mOutFile = do
-  let localNodeConnInfo = LocalNodeConnectInfo cModeParams network socketPath
+runQueryConstitutionHashCmd
+    Cmd.QueryConstitutionHashCmdArgs
+    { Cmd.nodeSocketPath
+    , Cmd.consensusModeParams = AnyConsensusModeParams cModeParams
+    , Cmd.networkId
+    , Cmd.mOutFile
+    } = do
+  let localNodeConnInfo = LocalNodeConnectInfo cModeParams networkId nodeSocketPath
 
   result <- liftIO $ executeLocalStateQueryExpr localNodeConnInfo Nothing $ runExceptT $ do
     anyE@(AnyCardanoEra era) <- lift (determineEraExpr cModeParams)
@@ -175,14 +163,17 @@ runQueryConstitutionHashCmd socketPath (AnyConsensusModeParams cModeParams) netw
           handleIOExceptT (QueryCmdWriteFileError . FileIOError fpath) $
             LBS.writeFile fpath (encodePretty cHash)
 
-runQueryProtocolParametersCmd
-  :: SocketPath
-  -> AnyConsensusModeParams
-  -> NetworkId
-  -> Maybe (File () Out)
+runQueryProtocolParametersCmd :: ()
+  => Cmd.QueryProtocolParametersCmdArgs
   -> ExceptT QueryCmdError IO ()
-runQueryProtocolParametersCmd socketPath (AnyConsensusModeParams cModeParams) network mOutFile = do
-  let localNodeConnInfo = LocalNodeConnectInfo cModeParams network socketPath
+runQueryProtocolParametersCmd
+    Cmd.QueryProtocolParametersCmdArgs
+    { Cmd.nodeSocketPath
+    , Cmd.consensusModeParams = AnyConsensusModeParams cModeParams
+    , Cmd.networkId
+    , Cmd.mOutFile
+    } = do
+  let localNodeConnInfo = LocalNodeConnectInfo cModeParams networkId nodeSocketPath
   anyE@(AnyCardanoEra era) <- firstExceptT QueryCmdAcquireFailure $ newExceptT $ determineEra cModeParams localNodeConnInfo
   sbe <- case cardanoEraStyle era of
             LegacyByronEra -> left QueryCmdByronEra
@@ -244,16 +235,19 @@ queryChainTipViaChainSync localNodeConnInfo = do
     "Warning: Local header state query unavailable. Falling back to chain sync query"
   liftIO $ getLocalChainTip localNodeConnInfo
 
-runQueryTipCmd
-  :: SocketPath
-  -> AnyConsensusModeParams
-  -> NetworkId
-  -> Maybe (File () Out)
+runQueryTipCmd :: ()
+  => Cmd.QueryTipCmdArgs
   -> ExceptT QueryCmdError IO ()
-runQueryTipCmd socketPath (AnyConsensusModeParams cModeParams) network mOutFile = do
+runQueryTipCmd
+    Cmd.QueryTipCmdArgs
+    { Cmd.nodeSocketPath
+    , Cmd.consensusModeParams = AnyConsensusModeParams cModeParams
+    , Cmd.networkId
+    , Cmd.mOutFile
+    } = do
   case consensusModeOnly cModeParams of
     CardanoMode -> do
-      let localNodeConnInfo = LocalNodeConnectInfo cModeParams network socketPath
+      let localNodeConnInfo = LocalNodeConnectInfo cModeParams networkId nodeSocketPath
 
       eLocalState <- ExceptT $ fmap sequence $
         executeLocalStateQueryExpr localNodeConnInfo Nothing $ runExceptT $ do
@@ -328,16 +322,18 @@ runQueryTipCmd socketPath (AnyConsensusModeParams cModeParams) network mOutFile 
 
 -- | Query the UTxO, filtered by a given set of addresses, from a Shelley node
 -- via the local state query protocol.
-runQueryUTxOCmd
-  :: SocketPath
-  -> AnyConsensusModeParams
-  -> QueryUTxOFilter
-  -> NetworkId
-  -> Maybe (File () Out)
+runQueryUTxOCmd :: ()
+  => Cmd.QueryUTxOCmdArgs
   -> ExceptT QueryCmdError IO ()
-runQueryUTxOCmd socketPath (AnyConsensusModeParams cModeParams)
-             qfilter network mOutFile = do
-  let localNodeConnInfo = LocalNodeConnectInfo cModeParams network socketPath
+runQueryUTxOCmd
+    Cmd.QueryUTxOCmdArgs
+    { Cmd.nodeSocketPath
+    , Cmd.consensusModeParams = AnyConsensusModeParams cModeParams
+    , Cmd.queryFilter
+    , Cmd.networkId
+    , Cmd.mOutFile
+    } = do
+  let localNodeConnInfo = LocalNodeConnectInfo cModeParams networkId nodeSocketPath
 
   join $ lift
     ( executeLocalStateQueryExpr localNodeConnInfo Nothing $ runExceptT $ do
@@ -356,7 +352,7 @@ runQueryUTxOCmd socketPath (AnyConsensusModeParams cModeParams)
 
         requireNotByronEraInByronMode eraInMode
 
-        utxo <- lift (queryUtxo eInMode sbe qfilter)
+        utxo <- lift (queryUtxo eInMode sbe queryFilter)
           & onLeft (left . QueryCmdUnsupportedNtcVersion)
           & onLeft (left . QueryCmdLocalStateQueryError . EraMismatchError)
 
@@ -366,18 +362,21 @@ runQueryUTxOCmd socketPath (AnyConsensusModeParams cModeParams)
     & onLeft (left . QueryCmdAcquireFailure)
     & onLeft left
 
-runQueryKesPeriodInfoCmd
-  :: SocketPath
-  -> AnyConsensusModeParams
-  -> NetworkId
-  -> File () In
-  -> Maybe (File () Out)
+runQueryKesPeriodInfoCmd :: ()
+  => Cmd.QueryKesPeriodInfoCmdArgs
   -> ExceptT QueryCmdError IO ()
-runQueryKesPeriodInfoCmd socketPath (AnyConsensusModeParams cModeParams) network nodeOpCertFile mOutFile = do
-  opCert <- lift (readFileTextEnvelope AsOperationalCertificate nodeOpCertFile)
+runQueryKesPeriodInfoCmd
+    Cmd.QueryKesPeriodInfoCmdArgs
+    { Cmd.nodeSocketPath
+    , Cmd.consensusModeParams = AnyConsensusModeParams cModeParams
+    , Cmd.networkId
+    , Cmd.nodeOpCertFp
+    , Cmd.mOutFile
+    } = do
+  opCert <- lift (readFileTextEnvelope AsOperationalCertificate nodeOpCertFp)
     & onLeft (left . QueryCmdOpCertCounterReadError)
 
-  let localNodeConnInfo = LocalNodeConnectInfo cModeParams network socketPath
+  let localNodeConnInfo = LocalNodeConnectInfo cModeParams networkId nodeSocketPath
 
   let cMode = consensusModeOnly cModeParams
 
@@ -428,8 +427,8 @@ runQueryKesPeriodInfoCmd socketPath (AnyConsensusModeParams cModeParams) network
               let counterInformation = opCertNodeAndOnDiskCounters onDiskC stateC
 
               -- Always render diagnostic information
-              liftIO . putStrLn $ renderOpCertIntervalInformation (unFile nodeOpCertFile) opCertIntervalInformation
-              liftIO . putStrLn $ renderOpCertNodeAndOnDiskCounterInformation (unFile nodeOpCertFile) counterInformation
+              liftIO . putStrLn $ renderOpCertIntervalInformation (unFile nodeOpCertFp) opCertIntervalInformation
+              liftIO . putStrLn $ renderOpCertNodeAndOnDiskCounterInformation (unFile nodeOpCertFp) counterInformation
 
               let qKesInfoOutput = createQueryKesPeriodInfoOutput opCertIntervalInformation counterInformation eInfo gParams
                   kesPeriodInfoJSON = encodePretty qKesInfoOutput
@@ -647,14 +646,17 @@ renderOpCertIntervalInformation opCertFile opCertInfo = case opCertInfo of
 -- | Query the current and future parameters for a stake pool, including the retirement date.
 -- Any of these may be empty (in which case a null will be displayed).
 --
-runQueryPoolStateCmd
-  :: SocketPath
-  -> AnyConsensusModeParams
-  -> NetworkId
-  -> [Hash StakePoolKey]
+runQueryPoolStateCmd :: ()
+  => Cmd.QueryPoolStateCmdArgs
   -> ExceptT QueryCmdError IO ()
-runQueryPoolStateCmd socketPath (AnyConsensusModeParams cModeParams) network poolIds = do
-  let localNodeConnInfo = LocalNodeConnectInfo cModeParams network socketPath
+runQueryPoolStateCmd
+    Cmd.QueryPoolStateCmdArgs
+    { Cmd.nodeSocketPath
+    , Cmd.consensusModeParams = AnyConsensusModeParams cModeParams
+    , Cmd.networkId
+    , Cmd.poolIds
+    } = do
+  let localNodeConnInfo = LocalNodeConnectInfo cModeParams networkId nodeSocketPath
 
   join $ lift
     ( executeLocalStateQueryExpr localNodeConnInfo Nothing $ runExceptT $ do
@@ -684,15 +686,18 @@ runQueryPoolStateCmd socketPath (AnyConsensusModeParams cModeParams) network poo
     & onLeft left
 
 -- | Query the local mempool state
-runQueryTxMempoolCmd
-  :: SocketPath
-  -> AnyConsensusModeParams
-  -> NetworkId
-  -> TxMempoolQuery
-  -> Maybe (File () Out)
+runQueryTxMempoolCmd :: ()
+  => Cmd.QueryTxMempoolCmdArgs
   -> ExceptT QueryCmdError IO ()
-runQueryTxMempoolCmd socketPath (AnyConsensusModeParams cModeParams) network query mOutFile = do
-  let localNodeConnInfo = LocalNodeConnectInfo cModeParams network socketPath
+runQueryTxMempoolCmd
+    Cmd.QueryTxMempoolCmdArgs
+    { Cmd.nodeSocketPath
+    , Cmd.consensusModeParams = AnyConsensusModeParams cModeParams
+    , Cmd.networkId
+    , Cmd.query
+    , Cmd.mOutFile
+    } = do
+  let localNodeConnInfo = LocalNodeConnectInfo cModeParams networkId nodeSocketPath
 
   localQuery <- case query of
       TxMempoolQueryTxExists tx -> do
@@ -713,28 +718,34 @@ runQueryTxMempoolCmd socketPath (AnyConsensusModeParams cModeParams) network que
     Just (File oFp) -> handleIOExceptT (QueryCmdWriteFileError . FileIOError oFp)
         $ LBS.writeFile oFp renderedResult
 
-runQuerySlotNumberCmd
-  :: SocketPath
-  -> AnyConsensusModeParams
-  -> NetworkId
-  -> UTCTime
+runQuerySlotNumberCmd :: ()
+  => Cmd.QuerySlotNumberCmdArgs
   -> ExceptT QueryCmdError IO ()
-runQuerySlotNumberCmd sockPath aCmp network utcTime = do
-  SlotNo slotNo <- utcTimeToSlotNo sockPath aCmp network utcTime
+runQuerySlotNumberCmd
+    Cmd.QuerySlotNumberCmdArgs
+    { Cmd.nodeSocketPath
+    , Cmd.consensusModeParams
+    , Cmd.networkId
+    , Cmd.utcTime
+    } = do
+  SlotNo slotNo <- utcTimeToSlotNo nodeSocketPath consensusModeParams networkId utcTime
   liftIO . putStr $ show slotNo
 
 -- | Obtain stake snapshot information for a pool, plus information about the total active stake.
 -- This information can be used for leader slot calculation, for example, and has been requested by SPOs.
 -- Obtaining the information directly is significantly more time and memory efficient than using a full ledger state dump.
-runQueryStakeSnapshotCmd
-  :: SocketPath
-  -> AnyConsensusModeParams
-  -> NetworkId
-  -> AllOrOnly [Hash StakePoolKey]
-  -> Maybe (File () Out)
+runQueryStakeSnapshotCmd :: ()
+  => Cmd.QueryStakeSnapshotCmdArgs
   -> ExceptT QueryCmdError IO ()
-runQueryStakeSnapshotCmd socketPath (AnyConsensusModeParams cModeParams) network allOrOnlyPoolIds mOutFile = do
-  let localNodeConnInfo = LocalNodeConnectInfo cModeParams network socketPath
+runQueryStakeSnapshotCmd
+    Cmd.QueryStakeSnapshotCmdArgs
+    { Cmd.nodeSocketPath
+    , Cmd.consensusModeParams = AnyConsensusModeParams cModeParams
+    , Cmd.networkId
+    , Cmd.allOrOnlyPoolIds
+    , Cmd.mOutFile
+    } = do
+  let localNodeConnInfo = LocalNodeConnectInfo cModeParams networkId nodeSocketPath
 
   join $ lift
     ( executeLocalStateQueryExpr localNodeConnInfo Nothing $ runExceptT $ do
@@ -767,14 +778,17 @@ runQueryStakeSnapshotCmd socketPath (AnyConsensusModeParams cModeParams) network
     & onLeft (left . QueryCmdAcquireFailure)
     & onLeft left
 
-runQueryLedgerStateCmd
-  :: SocketPath
-  -> AnyConsensusModeParams
-  -> NetworkId
-  -> Maybe (File () Out)
+runQueryLedgerStateCmd :: ()
+  => Cmd.QueryLedgerStateCmdArgs
   -> ExceptT QueryCmdError IO ()
-runQueryLedgerStateCmd socketPath (AnyConsensusModeParams cModeParams) network mOutFile = do
-  let localNodeConnInfo = LocalNodeConnectInfo cModeParams network socketPath
+runQueryLedgerStateCmd
+    Cmd.QueryLedgerStateCmdArgs
+    { Cmd.nodeSocketPath
+    , Cmd.consensusModeParams = AnyConsensusModeParams cModeParams
+    , Cmd.networkId
+    , Cmd.mOutFile
+     } = do
+  let localNodeConnInfo = LocalNodeConnectInfo cModeParams networkId nodeSocketPath
 
   join $ lift
     ( executeLocalStateQueryExpr localNodeConnInfo Nothing $ runExceptT $ do
@@ -803,14 +817,17 @@ runQueryLedgerStateCmd socketPath (AnyConsensusModeParams cModeParams) network m
     & onLeft (left . QueryCmdAcquireFailure)
     & onLeft left
 
-runQueryProtocolStateCmd
-  :: SocketPath
-  -> AnyConsensusModeParams
-  -> NetworkId
-  -> Maybe (File () Out)
+runQueryProtocolStateCmd :: ()
+  => Cmd.QueryProtocolStateCmdArgs
   -> ExceptT QueryCmdError IO ()
-runQueryProtocolStateCmd socketPath (AnyConsensusModeParams cModeParams) network mOutFile = do
-  let localNodeConnInfo = LocalNodeConnectInfo cModeParams network socketPath
+runQueryProtocolStateCmd
+    Cmd.QueryProtocolStateCmdArgs
+    { Cmd.nodeSocketPath
+    , Cmd.consensusModeParams = AnyConsensusModeParams cModeParams
+    , Cmd.networkId
+    , Cmd.mOutFile
+     } = do
+  let localNodeConnInfo = LocalNodeConnectInfo cModeParams networkId nodeSocketPath
 
   join $ lift
     ( executeLocalStateQueryExpr localNodeConnInfo Nothing $ runExceptT $ do
@@ -844,15 +861,18 @@ runQueryProtocolStateCmd socketPath (AnyConsensusModeParams cModeParams) network
 -- | Query the current delegations and reward accounts, filtered by a given
 -- set of addresses, from a Shelley node via the local state query protocol.
 
-runQueryStakeAddressInfoCmd
-  :: SocketPath
-  -> AnyConsensusModeParams
-  -> StakeAddress
-  -> NetworkId
-  -> Maybe (File () Out)
+runQueryStakeAddressInfoCmd :: ()
+  => Cmd.QueryStakeAddressInfoCmdArgs
   -> ExceptT QueryCmdError IO ()
-runQueryStakeAddressInfoCmd socketPath (AnyConsensusModeParams cModeParams) (StakeAddress _ addr) network mOutFile = do
-  let localNodeConnInfo = LocalNodeConnectInfo cModeParams network socketPath
+runQueryStakeAddressInfoCmd
+    Cmd.QueryStakeAddressInfoCmdArgs
+    { Cmd.nodeSocketPath
+    , Cmd.consensusModeParams = AnyConsensusModeParams cModeParams
+    , Cmd.addr = StakeAddress _ addr
+    , Cmd.networkId
+    , Cmd.mOutFile
+    } = do
+  let localNodeConnInfo = LocalNodeConnectInfo cModeParams networkId nodeSocketPath
 
   join $ lift
     ( executeLocalStateQueryExpr localNodeConnInfo Nothing $ runExceptT $ do
@@ -873,7 +893,7 @@ runQueryStakeAddressInfoCmd socketPath (AnyConsensusModeParams cModeParams) (Sta
 
         requireNotByronEraInByronMode eraInMode
 
-        result <- lift (queryStakeAddresses eInMode sbe stakeAddr network)
+        result <- lift (queryStakeAddresses eInMode sbe stakeAddr networkId)
           & onLeft (left . QueryCmdUnsupportedNtcVersion)
           & onLeft (left . QueryCmdLocalStateQueryError . EraMismatchError)
 
@@ -1080,14 +1100,17 @@ printUtxo sbe txInOutTuple =
   printableValue (TxOutValue _ val) = renderValue val
   printableValue (TxOutAdaOnly _ (Lovelace i)) = Text.pack $ show i
 
-runQueryStakePoolsCmd
-  :: SocketPath
-  -> AnyConsensusModeParams
-  -> NetworkId
-  -> Maybe (File () Out)
+runQueryStakePoolsCmd :: ()
+  => Cmd.QueryStakePoolsCmdArgs
   -> ExceptT QueryCmdError IO ()
-runQueryStakePoolsCmd socketPath (AnyConsensusModeParams cModeParams) network mOutFile = do
-  let localNodeConnInfo = LocalNodeConnectInfo cModeParams network socketPath
+runQueryStakePoolsCmd
+    Cmd.QueryStakePoolsCmdArgs
+    { Cmd.nodeSocketPath
+    , Cmd.consensusModeParams = AnyConsensusModeParams cModeParams
+    , Cmd.networkId
+    , Cmd.mOutFile
+    } = do
+  let localNodeConnInfo = LocalNodeConnectInfo cModeParams networkId nodeSocketPath
 
   join $ lift
     ( executeLocalStateQueryExpr localNodeConnInfo Nothing $ runExceptT @QueryCmdError $ do
@@ -1125,14 +1148,17 @@ writeStakePools Nothing stakePools =
   forM_ (Set.toList stakePools) $ \poolId ->
     liftIO . putStrLn $ Text.unpack (serialiseToBech32 poolId)
 
-runQueryStakeDistributionCmd
-  :: SocketPath
-  -> AnyConsensusModeParams
-  -> NetworkId
-  -> Maybe (File () Out)
+runQueryStakeDistributionCmd :: ()
+  => Cmd.QueryStakeDistributionCmdArgs
   -> ExceptT QueryCmdError IO ()
-runQueryStakeDistributionCmd socketPath (AnyConsensusModeParams cModeParams) network mOutFile = do
-  let localNodeConnInfo = LocalNodeConnectInfo cModeParams network socketPath
+runQueryStakeDistributionCmd
+    Cmd.QueryStakeDistributionCmdArgs
+    { Cmd.nodeSocketPath
+    , Cmd.consensusModeParams = AnyConsensusModeParams cModeParams
+    , Cmd.networkId
+    , Cmd.mOutFile
+    } = do
+  let localNodeConnInfo = LocalNodeConnectInfo cModeParams networkId nodeSocketPath
 
   join $ lift
     ( executeLocalStateQueryExpr localNodeConnInfo Nothing $ runExceptT $ do
@@ -1197,25 +1223,25 @@ printStakeDistribution stakeDistrib = do
        ]
 
 runQueryLeadershipScheduleCmd
-  :: SocketPath
-  -> AnyConsensusModeParams
-  -> NetworkId
-  -> GenesisFile -- ^ Shelley genesis
-  -> VerificationKeyOrHashOrFile StakePoolKey
-  -> SigningKeyFile In -- ^ VRF signing key
-  -> EpochLeadershipSchedule
-  -> Maybe (File () Out)
+  :: Cmd.QueryLeadershipScheduleCmdArgs
   -> ExceptT QueryCmdError IO ()
 runQueryLeadershipScheduleCmd
-    socketPath (AnyConsensusModeParams cModeParams) network
-    (GenesisFile genFile) coldVerKeyFile vrfSkeyFp
-    whichSchedule mJsonOutputFile = do
-  let localNodeConnInfo = LocalNodeConnectInfo cModeParams network socketPath
+    Cmd.QueryLeadershipScheduleCmdArgs
+    { Cmd.nodeSocketPath
+    , Cmd.consensusModeParams = AnyConsensusModeParams cModeParams
+    , Cmd.networkId
+    , Cmd.genesisFp = GenesisFile genFile
+    , Cmd.poolColdVerKeyFile
+    , Cmd.vrkSkeyFp
+    , Cmd.whichSchedule
+    , Cmd.mOutFile
+    } = do
+  let localNodeConnInfo = LocalNodeConnectInfo cModeParams networkId nodeSocketPath
 
-  poolid <- lift (readVerificationKeyOrHashOrFile AsStakePoolKey coldVerKeyFile)
+  poolid <- lift (readVerificationKeyOrHashOrFile AsStakePoolKey poolColdVerKeyFile)
     & onLeft (left . QueryCmdTextReadError)
 
-  vrkSkey <- lift (readFileTextEnvelope (AsSigningKey AsVrfKey) vrfSkeyFp)
+  vrkSkey <- lift (readFileTextEnvelope (AsSigningKey AsVrfKey) vrkSkeyFp)
     & onLeft (left . QueryCmdTextEnvelopeReadError)
 
   shelleyGenesis <- lift (readAndDecodeShelleyGenesis genFile)
@@ -1277,7 +1303,7 @@ runQueryLeadershipScheduleCmd
                       serCurrentEpochState
                       curentEpoch
 
-                  writeSchedule mJsonOutputFile eInfo shelleyGenesis schedule
+                  writeSchedule mOutFile eInfo shelleyGenesis schedule
 
               NextEpoch -> do
                 serCurrentEpochState <- lift (queryCurrentEpochState eInMode sbe)
@@ -1293,7 +1319,7 @@ runQueryLeadershipScheduleCmd
                       serCurrentEpochState ptclState poolid vrkSkey pparams
                       eInfo (tip, curentEpoch)
 
-                  writeSchedule mJsonOutputFile eInfo shelleyGenesis schedule
+                  writeSchedule mOutFile eInfo shelleyGenesis schedule
           mode ->
             pure $ do
               left . QueryCmdUnsupportedMode $ AnyConsensusMode mode
@@ -1301,8 +1327,8 @@ runQueryLeadershipScheduleCmd
     & onLeft (left . QueryCmdAcquireFailure)
     & onLeft left
   where
-    writeSchedule mOutFile eInfo shelleyGenesis schedule =
-      case mOutFile of
+    writeSchedule mOutFile' eInfo shelleyGenesis schedule =
+      case mOutFile' of
         Nothing -> liftIO $ printLeadershipScheduleAsText schedule eInfo (SystemStart $ sgSystemStart shelleyGenesis)
         Just (File jsonOutputFile) ->
           liftIO $ LBS.writeFile jsonOutputFile $
@@ -1416,8 +1442,8 @@ utcTimeToSlotNo
   -> NetworkId
   -> UTCTime
   -> ExceptT QueryCmdError IO SlotNo
-utcTimeToSlotNo socketPath (AnyConsensusModeParams cModeParams) network utcTime = do
-  let localNodeConnInfo = LocalNodeConnectInfo cModeParams network socketPath
+utcTimeToSlotNo nodeSocketPath (AnyConsensusModeParams cModeParams) networkId utcTime = do
+  let localNodeConnInfo = LocalNodeConnectInfo cModeParams networkId nodeSocketPath
   case consensusModeOnly cModeParams of
     CardanoMode -> do
       lift

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Query.hs
@@ -42,7 +42,7 @@ import           Cardano.Api.Byron hiding (QueryInShelleyBasedEra (..))
 import qualified Cardano.Api.Ledger as Ledger
 import           Cardano.Api.Shelley hiding (QueryInShelleyBasedEra (..))
 
-import           Cardano.CLI.EraBased.Commands.Query
+import qualified Cardano.CLI.EraBased.Commands.Query as Cmd
 import           Cardano.CLI.EraBased.Run.Genesis (readAndDecodeShelleyGenesis)
 import           Cardano.CLI.Helpers (pPrintCBOR)
 import           Cardano.CLI.Pretty
@@ -104,37 +104,37 @@ import           Text.Printf (printf)
 {- HLINT ignore "Move brackets to avoid $" -}
 {- HLINT ignore "Redundant flip" -}
 
-runQueryCmds :: QueryCmds era -> ExceptT QueryCmdError IO ()
+runQueryCmds :: Cmd.QueryCmds era -> ExceptT QueryCmdError IO ()
 runQueryCmds = \case
-  QueryLeadershipScheduleCmd (QueryLeadershipScheduleCmdArgs mNodeSocketPath consensusModeParams network shelleyGenFp poolid vrkSkeyFp whichSchedule outputAs) ->
+  Cmd.QueryLeadershipScheduleCmd (Cmd.QueryLeadershipScheduleCmdArgs mNodeSocketPath consensusModeParams network shelleyGenFp poolid vrkSkeyFp whichSchedule outputAs) ->
     runQueryLeadershipScheduleCmd mNodeSocketPath consensusModeParams network shelleyGenFp poolid vrkSkeyFp whichSchedule outputAs
-  QueryProtocolParametersCmd (QueryProtocolParametersCmdArgs mNodeSocketPath consensusModeParams network mOutFile) ->
+  Cmd.QueryProtocolParametersCmd (Cmd.QueryProtocolParametersCmdArgs mNodeSocketPath consensusModeParams network mOutFile) ->
     runQueryProtocolParametersCmd mNodeSocketPath consensusModeParams network mOutFile
-  QueryConstitutionHashCmd (QueryConstitutionHashCmdArgs mNodeSocketPath consensusModeParams network mOutFile) ->
+  Cmd.QueryConstitutionHashCmd (Cmd.QueryConstitutionHashCmdArgs mNodeSocketPath consensusModeParams network mOutFile) ->
     runQueryConstitutionHashCmd mNodeSocketPath consensusModeParams network mOutFile
-  QueryTipCmd (QueryTipCmdArgs mNodeSocketPath consensusModeParams network mOutFile) ->
+  Cmd.QueryTipCmd (Cmd.QueryTipCmdArgs mNodeSocketPath consensusModeParams network mOutFile) ->
     runQueryTipCmd mNodeSocketPath consensusModeParams network mOutFile
-  QueryStakePoolsCmd (QueryStakePoolsCmdArgs mNodeSocketPath consensusModeParams network mOutFile) ->
+  Cmd.QueryStakePoolsCmd (Cmd.QueryStakePoolsCmdArgs mNodeSocketPath consensusModeParams network mOutFile) ->
     runQueryStakePoolsCmd mNodeSocketPath consensusModeParams network mOutFile
-  QueryStakeDistributionCmd (QueryStakeDistributionCmdArgs mNodeSocketPath consensusModeParams network mOutFile) ->
+  Cmd.QueryStakeDistributionCmd (Cmd.QueryStakeDistributionCmdArgs mNodeSocketPath consensusModeParams network mOutFile) ->
     runQueryStakeDistributionCmd mNodeSocketPath consensusModeParams network mOutFile
-  QueryStakeAddressInfoCmd (QueryStakeAddressInfoCmdArgs mNodeSocketPath consensusModeParams addr network mOutFile) ->
+  Cmd.QueryStakeAddressInfoCmd (Cmd.QueryStakeAddressInfoCmdArgs mNodeSocketPath consensusModeParams addr network mOutFile) ->
     runQueryStakeAddressInfoCmd mNodeSocketPath consensusModeParams addr network mOutFile
-  QueryDebugLedgerStateCmd (QueryDebugLedgerStateCmdArgs mNodeSocketPath consensusModeParams network mOutFile) ->
+  Cmd.QueryLedgerStateCmd (Cmd.QueryLedgerStateCmdArgs mNodeSocketPath consensusModeParams network mOutFile) ->
     runQueryLedgerStateCmd mNodeSocketPath consensusModeParams network mOutFile
-  QueryStakeSnapshotCmd (QueryStakeSnapshotCmdArgs mNodeSocketPath consensusModeParams network allOrOnlyPoolIds mOutFile) ->
+  Cmd.QueryStakeSnapshotCmd (Cmd.QueryStakeSnapshotCmdArgs mNodeSocketPath consensusModeParams network allOrOnlyPoolIds mOutFile) ->
     runQueryStakeSnapshotCmd mNodeSocketPath consensusModeParams network allOrOnlyPoolIds mOutFile
-  QueryProtocolStateCmd (QueryProtocolStateCmdArgs mNodeSocketPath consensusModeParams network mOutFile) ->
+  Cmd.QueryProtocolStateCmd (Cmd.QueryProtocolStateCmdArgs mNodeSocketPath consensusModeParams network mOutFile) ->
     runQueryProtocolStateCmd mNodeSocketPath consensusModeParams network mOutFile
-  QueryUTxOCmd (QueryUTxOCmdArgs mNodeSocketPath consensusModeParams qFilter networkId mOutFile) ->
+  Cmd.QueryUTxOCmd (Cmd.QueryUTxOCmdArgs mNodeSocketPath consensusModeParams qFilter networkId mOutFile) ->
     runQueryUTxOCmd mNodeSocketPath consensusModeParams qFilter networkId mOutFile
-  QueryKesPeriodInfoCmd (QueryKesPeriodInfoCmdArgs mNodeSocketPath consensusModeParams network nodeOpCert mOutFile) ->
+  Cmd.QueryKesPeriodInfoCmd (Cmd.QueryKesPeriodInfoCmdArgs mNodeSocketPath consensusModeParams network nodeOpCert mOutFile) ->
     runQueryKesPeriodInfoCmd mNodeSocketPath consensusModeParams network nodeOpCert mOutFile
-  QueryPoolStateCmd (QueryPoolStateCmdArgs mNodeSocketPath consensusModeParams network poolid) ->
+  Cmd.QueryPoolStateCmd (Cmd.QueryPoolStateCmdArgs mNodeSocketPath consensusModeParams network poolid) ->
     runQueryPoolStateCmd mNodeSocketPath consensusModeParams network poolid
-  QueryTxMempoolCmd (QueryTxMempoolCmdArgs mNodeSocketPath consensusModeParams network op mOutFile) ->
+  Cmd.QueryTxMempoolCmd (Cmd.QueryTxMempoolCmdArgs mNodeSocketPath consensusModeParams network op mOutFile) ->
     runQueryTxMempoolCmd mNodeSocketPath consensusModeParams network op mOutFile
-  QuerySlotNumberCmd (QuerySlotNumberCmdArgs mNodeSocketPath consensusModeParams network utcTime) ->
+  Cmd.QuerySlotNumberCmd (Cmd.QuerySlotNumberCmdArgs mNodeSocketPath consensusModeParams network utcTime) ->
     runQuerySlotNumberCmd mNodeSocketPath consensusModeParams network utcTime
 
 runQueryConstitutionHashCmd

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Query.hs
@@ -106,35 +106,35 @@ import           Text.Printf (printf)
 
 runQueryCmds :: QueryCmds era -> ExceptT QueryCmdError IO ()
 runQueryCmds = \case
-  QueryLeadershipSchedule mNodeSocketPath consensusModeParams network shelleyGenFp poolid vrkSkeyFp whichSchedule outputAs ->
+  QueryLeadershipScheduleCmd mNodeSocketPath consensusModeParams network shelleyGenFp poolid vrkSkeyFp whichSchedule outputAs ->
     runQueryLeadershipScheduleCmd mNodeSocketPath consensusModeParams network shelleyGenFp poolid vrkSkeyFp whichSchedule outputAs
-  QueryProtocolParameters' mNodeSocketPath consensusModeParams network mOutFile ->
+  QueryProtocolParametersCmd mNodeSocketPath consensusModeParams network mOutFile ->
     runQueryProtocolParametersCmd mNodeSocketPath consensusModeParams network mOutFile
-  QueryConstitutionHash mNodeSocketPath consensusModeParams network mOutFile ->
+  QueryConstitutionHashCmd mNodeSocketPath consensusModeParams network mOutFile ->
     runQueryConstitutionHashCmd mNodeSocketPath consensusModeParams network mOutFile
-  QueryTip mNodeSocketPath consensusModeParams network mOutFile ->
+  QueryTipCmd mNodeSocketPath consensusModeParams network mOutFile ->
     runQueryTipCmd mNodeSocketPath consensusModeParams network mOutFile
-  QueryStakePools' mNodeSocketPath consensusModeParams network mOutFile ->
+  QueryStakePoolsCmd mNodeSocketPath consensusModeParams network mOutFile ->
     runQueryStakePoolsCmd mNodeSocketPath consensusModeParams network mOutFile
-  QueryStakeDistribution' mNodeSocketPath consensusModeParams network mOutFile ->
+  QueryStakeDistributionCmd mNodeSocketPath consensusModeParams network mOutFile ->
     runQueryStakeDistributionCmd mNodeSocketPath consensusModeParams network mOutFile
-  QueryStakeAddressInfo mNodeSocketPath consensusModeParams addr network mOutFile ->
+  QueryStakeAddressInfoCmd mNodeSocketPath consensusModeParams addr network mOutFile ->
     runQueryStakeAddressInfoCmd mNodeSocketPath consensusModeParams addr network mOutFile
-  QueryDebugLedgerState' mNodeSocketPath consensusModeParams network mOutFile ->
+  QueryDebugLedgerStateCmd mNodeSocketPath consensusModeParams network mOutFile ->
     runQueryLedgerStateCmd mNodeSocketPath consensusModeParams network mOutFile
-  QueryStakeSnapshot' mNodeSocketPath consensusModeParams network allOrOnlyPoolIds mOutFile ->
+  QueryStakeSnapshotCmd mNodeSocketPath consensusModeParams network allOrOnlyPoolIds mOutFile ->
     runQueryStakeSnapshotCmd mNodeSocketPath consensusModeParams network allOrOnlyPoolIds mOutFile
-  QueryProtocolState' mNodeSocketPath consensusModeParams network mOutFile ->
+  QueryProtocolStateCmd mNodeSocketPath consensusModeParams network mOutFile ->
     runQueryProtocolStateCmd mNodeSocketPath consensusModeParams network mOutFile
-  QueryUTxO' mNodeSocketPath consensusModeParams qFilter networkId mOutFile ->
+  QueryUTxOCmd mNodeSocketPath consensusModeParams qFilter networkId mOutFile ->
     runQueryUTxOCmd mNodeSocketPath consensusModeParams qFilter networkId mOutFile
-  QueryKesPeriodInfo mNodeSocketPath consensusModeParams network nodeOpCert mOutFile ->
+  QueryKesPeriodInfoCmd mNodeSocketPath consensusModeParams network nodeOpCert mOutFile ->
     runQueryKesPeriodInfoCmd mNodeSocketPath consensusModeParams network nodeOpCert mOutFile
-  QueryPoolState' mNodeSocketPath consensusModeParams network poolid ->
+  QueryPoolStateCmd mNodeSocketPath consensusModeParams network poolid ->
     runQueryPoolStateCmd mNodeSocketPath consensusModeParams network poolid
-  QueryTxMempool mNodeSocketPath consensusModeParams network op mOutFile ->
+  QueryTxMempoolCmd mNodeSocketPath consensusModeParams network op mOutFile ->
     runQueryTxMempoolCmd mNodeSocketPath consensusModeParams network op mOutFile
-  QuerySlotNumber mNodeSocketPath consensusModeParams network utcTime ->
+  QuerySlotNumberCmd mNodeSocketPath consensusModeParams network utcTime ->
     runQuerySlotNumberCmd mNodeSocketPath consensusModeParams network utcTime
 
 runQueryConstitutionHashCmd

--- a/cardano-cli/src/Cardano/CLI/Legacy/Commands/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Commands/Query.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE LambdaCase #-}
 
 module Cardano.CLI.Legacy.Commands.Query
@@ -50,119 +51,119 @@ data LegacyQueryCmds
   deriving (Generic, Show)
 
 data LegacyQueryLeadershipScheduleCmdArgs = LegacyQueryLeadershipScheduleCmdArgs
-  !SocketPath
-  !AnyConsensusModeParams
-  !NetworkId
-  !GenesisFile
-  !(VerificationKeyOrHashOrFile StakePoolKey)
-  !(SigningKeyFile In)
-  !EpochLeadershipSchedule
-  !(Maybe (File () Out))
-  deriving (Generic, Show)
+  { nodeSocketPath      :: !SocketPath
+  , consensusModeParams :: !AnyConsensusModeParams
+  , network             :: !NetworkId
+  , genesisFp           :: !GenesisFile
+  , poolId              :: !(VerificationKeyOrHashOrFile StakePoolKey)
+  , vrkSkeyFp           :: !(SigningKeyFile In)
+  , whichSchedule       :: !EpochLeadershipSchedule
+  , mOutFile            :: !(Maybe (File () Out))
+  } deriving (Generic, Show)
 
 data LegacyQueryProtocolParametersCmdArgs = LegacyQueryProtocolParametersCmdArgs
-  !SocketPath
-  !AnyConsensusModeParams
-  !NetworkId
-  !(Maybe (File () Out))
-  deriving (Generic, Show)
+  { nodeSocketPath      :: !SocketPath
+  , consensusModeParams :: !AnyConsensusModeParams
+  , network             :: !NetworkId
+  , mOutFile            :: !(Maybe (File () Out))
+  } deriving (Generic, Show)
 
 data LegacyQueryConstitutionHashCmdArgs = LegacyQueryConstitutionHashCmdArgs
-  !SocketPath
-  !AnyConsensusModeParams
-  !NetworkId
-  !(Maybe (File () Out))
-  deriving (Generic, Show)
+  { nodeSocketPath      :: !SocketPath
+  , consensusModeParams :: !AnyConsensusModeParams
+  , network             :: !NetworkId
+  , mOutFile            :: !(Maybe (File () Out))
+  } deriving (Generic, Show)
 
 data LegacyQueryTipCmdArgs = LegacyQueryTipCmdArgs
-  !SocketPath
-  !AnyConsensusModeParams
-  !NetworkId
-  !(Maybe (File () Out))
-  deriving (Generic, Show)
+  { nodeSocketPath      :: !SocketPath
+  , consensusModeParams :: !AnyConsensusModeParams
+  , network             :: !NetworkId
+  , mOutFile            :: !(Maybe (File () Out))
+  } deriving (Generic, Show)
 
 data LegacyQueryStakePoolsCmdArgs = LegacyQueryStakePoolsCmdArgs
-  !SocketPath
-  !AnyConsensusModeParams
-  !NetworkId
-  !(Maybe (File () Out))
-  deriving (Generic, Show)
+  { nodeSocketPath      :: !SocketPath
+  , consensusModeParams :: !AnyConsensusModeParams
+  , network             :: !NetworkId
+  , mOutFile            :: !(Maybe (File () Out))
+  } deriving (Generic, Show)
 
 data LegacyQueryStakeDistributionCmdArgs = LegacyQueryStakeDistributionCmdArgs
-  !SocketPath
-  !AnyConsensusModeParams
-  !NetworkId
-  !(Maybe (File () Out))
-  deriving (Generic, Show)
+  { nodeSocketPath      :: !SocketPath
+  , consensusModeParams :: !AnyConsensusModeParams
+  , network             :: !NetworkId
+  , mOutFile            :: !(Maybe (File () Out))
+  } deriving (Generic, Show)
 
 data LegacyQueryStakeAddressInfoCmdArgs = LegacyQueryStakeAddressInfoCmdArgs
-  !SocketPath
-  !AnyConsensusModeParams
-  !StakeAddress
-  !NetworkId
-  !(Maybe (File () Out))
-  deriving (Generic, Show)
+  { mNodeSocketPath     :: !SocketPath
+  , consensusModeParams :: !AnyConsensusModeParams
+  , addr                :: !StakeAddress
+  , network             :: !NetworkId
+  , mOutFile            :: !(Maybe (File () Out))
+  } deriving (Generic, Show)
 
 data LegacyQueryUTxOCmdArgs = LegacyQueryUTxOCmdArgs
-  !SocketPath
-  !AnyConsensusModeParams
-  !QueryUTxOFilter
-  !NetworkId
-  !(Maybe (File () Out))
-  deriving (Generic, Show)
+  { nodeSocketPath      :: !SocketPath
+  , consensusModeParams :: !AnyConsensusModeParams
+  , queryFilter         :: !QueryUTxOFilter
+  , networkId           :: !NetworkId
+  , mOutFile            :: !(Maybe (File () Out))
+  } deriving (Generic, Show)
 
 data LegacyQueryLedgerStateCmdArgs = LegacyQueryLedgerStateCmdArgs
-  !SocketPath
-  !AnyConsensusModeParams
-  !NetworkId
-  !(Maybe (File () Out))
-  deriving (Generic, Show)
+  { nodeSocketPath      :: !SocketPath
+  , consensusModeParams :: !AnyConsensusModeParams
+  , network             :: !NetworkId
+  , mOutFile            :: !(Maybe (File () Out))
+  } deriving (Generic, Show)
 
 data LegacyQueryProtocolStateCmdArgs = LegacyQueryProtocolStateCmdArgs
-  !SocketPath
-  !AnyConsensusModeParams
-  !NetworkId
-  !(Maybe (File () Out))
-  deriving (Generic, Show)
+  { nodeSocketPath      :: !SocketPath
+  , consensusModeParams :: !AnyConsensusModeParams
+  , network             :: !NetworkId
+  , mOutFile            :: !(Maybe (File () Out))
+  } deriving (Generic, Show)
 
 data LegacyQueryStakeSnapshotCmdArgs = LegacyQueryStakeSnapshotCmdArgs
-  !SocketPath
-  !AnyConsensusModeParams
-  !NetworkId
-  !(AllOrOnly [Hash StakePoolKey])
-  !(Maybe (File () Out))
-  deriving (Generic, Show)
+  { nodeSocketPath      :: !SocketPath
+  , consensusModeParams :: !AnyConsensusModeParams
+  , network             :: !NetworkId
+  , allOrOnlyPoolIds    :: !(AllOrOnly [Hash StakePoolKey])
+  , mOutFile            :: !(Maybe (File () Out))
+  } deriving (Generic, Show)
 
 data LegacyQueryKesPeriodInfoCmdArgs = LegacyQueryKesPeriodInfoCmdArgs
-  !SocketPath
-  !AnyConsensusModeParams
-  !NetworkId
-  !(File () In)
-  -- ^ Node operational certificate
-  !(Maybe (File () Out))
-  deriving (Generic, Show)
+  { nodeSocketPath      :: !SocketPath
+  , consensusModeParams :: !AnyConsensusModeParams
+  , network             :: !NetworkId
+  , nodeOpCert          :: !(File () In) -- ^ Node operational certificate
+  , mOutFile            :: !(Maybe (File () Out))
+  } deriving (Generic, Show)
 
 data LegacyQueryPoolStateCmdArgs = LegacyQueryPoolStateCmdArgs
-  !SocketPath
-  !AnyConsensusModeParams
-  !NetworkId
-  ![Hash StakePoolKey]
-  deriving (Generic, Show)
+  { nodeSocketPath      :: !SocketPath
+  , consensusModeParams :: !AnyConsensusModeParams
+  , network             :: !NetworkId
+  , poolid              :: ![Hash StakePoolKey]
+  } deriving (Generic, Show)
 
 data LegacyQueryTxMempoolCmdArgs = LegacyQueryTxMempoolCmdArgs
-  !SocketPath
-  !AnyConsensusModeParams
-  !NetworkId
-  !TxMempoolQuery
-  !(Maybe (File () Out))
+  { nodeSocketPath      :: !SocketPath
+  , consensusModeParams :: !AnyConsensusModeParams
+  , network             :: !NetworkId
+  , op                  :: !TxMempoolQuery
+  , mOutFile            :: !(Maybe (File () Out))
+  }
   deriving (Generic, Show)
 
 data LegacyQuerySlotNumberCmdArgs = LegacyQuerySlotNumberCmdArgs
-  !SocketPath
-  !AnyConsensusModeParams
-  !NetworkId
-  !UTCTime
-  deriving (Generic, Show)
+  { nodeSocketPath      :: !SocketPath
+  , consensusModeParams :: !AnyConsensusModeParams
+  , network             :: !NetworkId
+  , utcTime             :: !UTCTime
+  } deriving (Generic, Show)
 
 renderLegacyQueryCmds :: LegacyQueryCmds -> Text
 renderLegacyQueryCmds = \case

--- a/cardano-cli/src/Cardano/CLI/Legacy/Commands/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Commands/Query.hs
@@ -53,9 +53,9 @@ data LegacyQueryCmds
 data LegacyQueryLeadershipScheduleCmdArgs = LegacyQueryLeadershipScheduleCmdArgs
   { nodeSocketPath      :: !SocketPath
   , consensusModeParams :: !AnyConsensusModeParams
-  , network             :: !NetworkId
+  , networkId           :: !NetworkId
   , genesisFp           :: !GenesisFile
-  , poolId              :: !(VerificationKeyOrHashOrFile StakePoolKey)
+  , poolColdVerKeyFile  :: !(VerificationKeyOrHashOrFile StakePoolKey)
   , vrkSkeyFp           :: !(SigningKeyFile In)
   , whichSchedule       :: !EpochLeadershipSchedule
   , mOutFile            :: !(Maybe (File () Out))
@@ -64,43 +64,43 @@ data LegacyQueryLeadershipScheduleCmdArgs = LegacyQueryLeadershipScheduleCmdArgs
 data LegacyQueryProtocolParametersCmdArgs = LegacyQueryProtocolParametersCmdArgs
   { nodeSocketPath      :: !SocketPath
   , consensusModeParams :: !AnyConsensusModeParams
-  , network             :: !NetworkId
+  , networkId           :: !NetworkId
   , mOutFile            :: !(Maybe (File () Out))
   } deriving (Generic, Show)
 
 data LegacyQueryConstitutionHashCmdArgs = LegacyQueryConstitutionHashCmdArgs
   { nodeSocketPath      :: !SocketPath
   , consensusModeParams :: !AnyConsensusModeParams
-  , network             :: !NetworkId
+  , networkId           :: !NetworkId
   , mOutFile            :: !(Maybe (File () Out))
   } deriving (Generic, Show)
 
 data LegacyQueryTipCmdArgs = LegacyQueryTipCmdArgs
   { nodeSocketPath      :: !SocketPath
   , consensusModeParams :: !AnyConsensusModeParams
-  , network             :: !NetworkId
+  , networkId           :: !NetworkId
   , mOutFile            :: !(Maybe (File () Out))
   } deriving (Generic, Show)
 
 data LegacyQueryStakePoolsCmdArgs = LegacyQueryStakePoolsCmdArgs
   { nodeSocketPath      :: !SocketPath
   , consensusModeParams :: !AnyConsensusModeParams
-  , network             :: !NetworkId
+  , networkId           :: !NetworkId
   , mOutFile            :: !(Maybe (File () Out))
   } deriving (Generic, Show)
 
 data LegacyQueryStakeDistributionCmdArgs = LegacyQueryStakeDistributionCmdArgs
   { nodeSocketPath      :: !SocketPath
   , consensusModeParams :: !AnyConsensusModeParams
-  , network             :: !NetworkId
+  , networkId           :: !NetworkId
   , mOutFile            :: !(Maybe (File () Out))
   } deriving (Generic, Show)
 
 data LegacyQueryStakeAddressInfoCmdArgs = LegacyQueryStakeAddressInfoCmdArgs
-  { mNodeSocketPath     :: !SocketPath
+  { nodeSocketPath      :: !SocketPath
   , consensusModeParams :: !AnyConsensusModeParams
   , addr                :: !StakeAddress
-  , network             :: !NetworkId
+  , networkId           :: !NetworkId
   , mOutFile            :: !(Maybe (File () Out))
   } deriving (Generic, Show)
 
@@ -115,21 +115,21 @@ data LegacyQueryUTxOCmdArgs = LegacyQueryUTxOCmdArgs
 data LegacyQueryLedgerStateCmdArgs = LegacyQueryLedgerStateCmdArgs
   { nodeSocketPath      :: !SocketPath
   , consensusModeParams :: !AnyConsensusModeParams
-  , network             :: !NetworkId
+  , networkId           :: !NetworkId
   , mOutFile            :: !(Maybe (File () Out))
   } deriving (Generic, Show)
 
 data LegacyQueryProtocolStateCmdArgs = LegacyQueryProtocolStateCmdArgs
   { nodeSocketPath      :: !SocketPath
   , consensusModeParams :: !AnyConsensusModeParams
-  , network             :: !NetworkId
+  , networkId           :: !NetworkId
   , mOutFile            :: !(Maybe (File () Out))
   } deriving (Generic, Show)
 
 data LegacyQueryStakeSnapshotCmdArgs = LegacyQueryStakeSnapshotCmdArgs
   { nodeSocketPath      :: !SocketPath
   , consensusModeParams :: !AnyConsensusModeParams
-  , network             :: !NetworkId
+  , networkId           :: !NetworkId
   , allOrOnlyPoolIds    :: !(AllOrOnly [Hash StakePoolKey])
   , mOutFile            :: !(Maybe (File () Out))
   } deriving (Generic, Show)
@@ -137,23 +137,23 @@ data LegacyQueryStakeSnapshotCmdArgs = LegacyQueryStakeSnapshotCmdArgs
 data LegacyQueryKesPeriodInfoCmdArgs = LegacyQueryKesPeriodInfoCmdArgs
   { nodeSocketPath      :: !SocketPath
   , consensusModeParams :: !AnyConsensusModeParams
-  , network             :: !NetworkId
-  , nodeOpCert          :: !(File () In) -- ^ Node operational certificate
+  , networkId           :: !NetworkId
+  , nodeOpCertFp        :: !(File () In) -- ^ Node operational certificate
   , mOutFile            :: !(Maybe (File () Out))
   } deriving (Generic, Show)
 
 data LegacyQueryPoolStateCmdArgs = LegacyQueryPoolStateCmdArgs
   { nodeSocketPath      :: !SocketPath
   , consensusModeParams :: !AnyConsensusModeParams
-  , network             :: !NetworkId
-  , poolid              :: ![Hash StakePoolKey]
+  , networkId           :: !NetworkId
+  , poolIds             :: ![Hash StakePoolKey]
   } deriving (Generic, Show)
 
 data LegacyQueryTxMempoolCmdArgs = LegacyQueryTxMempoolCmdArgs
   { nodeSocketPath      :: !SocketPath
   , consensusModeParams :: !AnyConsensusModeParams
-  , network             :: !NetworkId
-  , op                  :: !TxMempoolQuery
+  , networkId           :: !NetworkId
+  , query               :: !TxMempoolQuery
   , mOutFile            :: !(Maybe (File () Out))
   }
   deriving (Generic, Show)
@@ -161,7 +161,7 @@ data LegacyQueryTxMempoolCmdArgs = LegacyQueryTxMempoolCmdArgs
 data LegacyQuerySlotNumberCmdArgs = LegacyQuerySlotNumberCmdArgs
   { nodeSocketPath      :: !SocketPath
   , consensusModeParams :: !AnyConsensusModeParams
-  , network             :: !NetworkId
+  , networkId           :: !NetworkId
   , utcTime             :: !UTCTime
   } deriving (Generic, Show)
 
@@ -180,11 +180,10 @@ renderLegacyQueryCmds = \case
   QueryStakeSnapshotCmd {} -> "query stake-snapshot"
   QueryKesPeriodInfoCmd {} -> "query kes-period-info"
   QueryPoolStateCmd {} -> "query pool-state"
-  QueryTxMempoolCmd (LegacyQueryTxMempoolCmdArgs _ _ _ query _) -> "query tx-mempool" <> renderTxMempoolQuery query
+  QueryTxMempoolCmd (LegacyQueryTxMempoolCmdArgs _ _ _ txMempoolQuery _) -> "query tx-mempool" <> renderTxMempoolQuery txMempoolQuery
   QuerySlotNumberCmd {} -> "query slot-number"
   where
-    renderTxMempoolQuery query =
-      case query of
-        TxMempoolQueryTxExists tx -> "tx-exists " <> serialiseToRawBytesHexText tx
-        TxMempoolQueryNextTx -> "next-tx"
-        TxMempoolQueryInfo -> "info"
+    renderTxMempoolQuery = \case
+      TxMempoolQueryTxExists tx -> "tx-exists " <> serialiseToRawBytesHexText tx
+      TxMempoolQueryNextTx -> "next-tx"
+      TxMempoolQueryInfo -> "info"

--- a/cardano-cli/src/Cardano/CLI/Legacy/Commands/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Commands/Query.hs
@@ -1,8 +1,24 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE LambdaCase #-}
 
 module Cardano.CLI.Legacy.Commands.Query
   ( LegacyQueryCmds (..)
+  , LegacyQueryLeadershipScheduleCmdArgs (..)
+  , LegacyQueryProtocolParametersCmdArgs (..)
+  , LegacyQueryConstitutionHashCmdArgs (..)
+  , LegacyQueryTipCmdArgs (..)
+  , LegacyQueryStakePoolsCmdArgs (..)
+  , LegacyQueryStakeDistributionCmdArgs (..)
+  , LegacyQueryStakeAddressInfoCmdArgs (..)
+  , LegacyQueryUTxOCmdArgs (..)
+  , LegacyQueryLedgerStateCmdArgs (..)
+  , LegacyQueryProtocolStateCmdArgs (..)
+  , LegacyQueryStakeSnapshotCmdArgs (..)
+  , LegacyQueryKesPeriodInfoCmdArgs (..)
+  , LegacyQueryPoolStateCmdArgs (..)
+  , LegacyQueryTxMempoolCmdArgs (..)
+  , LegacyQuerySlotNumberCmdArgs (..)
   , renderLegacyQueryCmds
   ) where
 
@@ -13,112 +29,158 @@ import           Cardano.CLI.Types.Key
 
 import           Data.Text (Text)
 import           Data.Time.Clock
+import           GHC.Generics
 
-data LegacyQueryCmds =
-    QueryLeadershipSchedule
-      SocketPath
-      AnyConsensusModeParams
-      NetworkId
-      GenesisFile
-      (VerificationKeyOrHashOrFile StakePoolKey)
-      (SigningKeyFile In)
-      EpochLeadershipSchedule
-      (Maybe (File () Out))
-  | QueryProtocolParameters'
-      SocketPath
-      AnyConsensusModeParams
-      NetworkId
-      (Maybe (File () Out))
-  | QueryConstitutionHash
-      SocketPath
-      AnyConsensusModeParams
-      NetworkId
-      (Maybe (File () Out))
-  | QueryTip
-      SocketPath
-      AnyConsensusModeParams
-      NetworkId
-      (Maybe (File () Out))
-  | QueryStakePools'
-      SocketPath
-      AnyConsensusModeParams
-      NetworkId
-      (Maybe (File () Out))
-  | QueryStakeDistribution'
-      SocketPath
-      AnyConsensusModeParams
-      NetworkId
-      (Maybe (File () Out))
-  | QueryStakeAddressInfo
-      SocketPath
-      AnyConsensusModeParams
-      StakeAddress
-      NetworkId
-      (Maybe (File () Out))
-  | QueryUTxO'
-      SocketPath
-      AnyConsensusModeParams
-      QueryUTxOFilter
-      NetworkId
-      (Maybe (File () Out))
-  | QueryDebugLedgerState'
-      SocketPath
-      AnyConsensusModeParams
-      NetworkId
-      (Maybe (File () Out))
-  | QueryProtocolState'
-      SocketPath
-      AnyConsensusModeParams
-      NetworkId
-      (Maybe (File () Out))
-  | QueryStakeSnapshot'
-      SocketPath
-      AnyConsensusModeParams
-      NetworkId
-      (AllOrOnly [Hash StakePoolKey])
-      (Maybe (File () Out))
-  | QueryKesPeriodInfo
-      SocketPath
-      AnyConsensusModeParams
-      NetworkId
-      (File () In)
-      -- ^ Node operational certificate
-      (Maybe (File () Out))
-  | QueryPoolState'
-      SocketPath
-      AnyConsensusModeParams
-      NetworkId
-      [Hash StakePoolKey]
-  | QueryTxMempool
-      SocketPath
-      AnyConsensusModeParams
-      NetworkId
-      TxMempoolQuery
-      (Maybe (File () Out))
-  | QuerySlotNumber
-      SocketPath
-      AnyConsensusModeParams
-      NetworkId
-      UTCTime
-  deriving Show
+data LegacyQueryCmds
+  = QueryLeadershipScheduleCmd  !LegacyQueryLeadershipScheduleCmdArgs
+  | QueryProtocolParametersCmd  !LegacyQueryProtocolParametersCmdArgs
+  | QueryConstitutionHashCmd    !LegacyQueryConstitutionHashCmdArgs
+  | QueryTipCmd                 !LegacyQueryTipCmdArgs
+  | QueryStakePoolsCmd          !LegacyQueryStakePoolsCmdArgs
+  | QueryStakeDistributionCmd   !LegacyQueryStakeDistributionCmdArgs
+  | QueryStakeAddressInfoCmd    !LegacyQueryStakeAddressInfoCmdArgs
+  | QueryUTxOCmd                !LegacyQueryUTxOCmdArgs
+  | QueryLedgerStateCmd         !LegacyQueryLedgerStateCmdArgs
+  | QueryProtocolStateCmd       !LegacyQueryProtocolStateCmdArgs
+  | QueryStakeSnapshotCmd       !LegacyQueryStakeSnapshotCmdArgs
+  | QueryKesPeriodInfoCmd       !LegacyQueryKesPeriodInfoCmdArgs
+  | QueryPoolStateCmd           !LegacyQueryPoolStateCmdArgs
+  | QueryTxMempoolCmd           !LegacyQueryTxMempoolCmdArgs
+  | QuerySlotNumberCmd          !LegacyQuerySlotNumberCmdArgs
+  deriving (Generic, Show)
+
+data LegacyQueryLeadershipScheduleCmdArgs = LegacyQueryLeadershipScheduleCmdArgs
+  !SocketPath
+  !AnyConsensusModeParams
+  !NetworkId
+  !GenesisFile
+  !(VerificationKeyOrHashOrFile StakePoolKey)
+  !(SigningKeyFile In)
+  !EpochLeadershipSchedule
+  !(Maybe (File () Out))
+  deriving (Generic, Show)
+
+data LegacyQueryProtocolParametersCmdArgs = LegacyQueryProtocolParametersCmdArgs
+  !SocketPath
+  !AnyConsensusModeParams
+  !NetworkId
+  !(Maybe (File () Out))
+  deriving (Generic, Show)
+
+data LegacyQueryConstitutionHashCmdArgs = LegacyQueryConstitutionHashCmdArgs
+  !SocketPath
+  !AnyConsensusModeParams
+  !NetworkId
+  !(Maybe (File () Out))
+  deriving (Generic, Show)
+
+data LegacyQueryTipCmdArgs = LegacyQueryTipCmdArgs
+  !SocketPath
+  !AnyConsensusModeParams
+  !NetworkId
+  !(Maybe (File () Out))
+  deriving (Generic, Show)
+
+data LegacyQueryStakePoolsCmdArgs = LegacyQueryStakePoolsCmdArgs
+  !SocketPath
+  !AnyConsensusModeParams
+  !NetworkId
+  !(Maybe (File () Out))
+  deriving (Generic, Show)
+
+data LegacyQueryStakeDistributionCmdArgs = LegacyQueryStakeDistributionCmdArgs
+  !SocketPath
+  !AnyConsensusModeParams
+  !NetworkId
+  !(Maybe (File () Out))
+  deriving (Generic, Show)
+
+data LegacyQueryStakeAddressInfoCmdArgs = LegacyQueryStakeAddressInfoCmdArgs
+  !SocketPath
+  !AnyConsensusModeParams
+  !StakeAddress
+  !NetworkId
+  !(Maybe (File () Out))
+  deriving (Generic, Show)
+
+data LegacyQueryUTxOCmdArgs = LegacyQueryUTxOCmdArgs
+  !SocketPath
+  !AnyConsensusModeParams
+  !QueryUTxOFilter
+  !NetworkId
+  !(Maybe (File () Out))
+  deriving (Generic, Show)
+
+data LegacyQueryLedgerStateCmdArgs = LegacyQueryLedgerStateCmdArgs
+  !SocketPath
+  !AnyConsensusModeParams
+  !NetworkId
+  !(Maybe (File () Out))
+  deriving (Generic, Show)
+
+data LegacyQueryProtocolStateCmdArgs = LegacyQueryProtocolStateCmdArgs
+  !SocketPath
+  !AnyConsensusModeParams
+  !NetworkId
+  !(Maybe (File () Out))
+  deriving (Generic, Show)
+
+data LegacyQueryStakeSnapshotCmdArgs = LegacyQueryStakeSnapshotCmdArgs
+  !SocketPath
+  !AnyConsensusModeParams
+  !NetworkId
+  !(AllOrOnly [Hash StakePoolKey])
+  !(Maybe (File () Out))
+  deriving (Generic, Show)
+
+data LegacyQueryKesPeriodInfoCmdArgs = LegacyQueryKesPeriodInfoCmdArgs
+  !SocketPath
+  !AnyConsensusModeParams
+  !NetworkId
+  !(File () In)
+  -- ^ Node operational certificate
+  !(Maybe (File () Out))
+  deriving (Generic, Show)
+
+data LegacyQueryPoolStateCmdArgs = LegacyQueryPoolStateCmdArgs
+  !SocketPath
+  !AnyConsensusModeParams
+  !NetworkId
+  ![Hash StakePoolKey]
+  deriving (Generic, Show)
+
+data LegacyQueryTxMempoolCmdArgs = LegacyQueryTxMempoolCmdArgs
+  !SocketPath
+  !AnyConsensusModeParams
+  !NetworkId
+  !TxMempoolQuery
+  !(Maybe (File () Out))
+  deriving (Generic, Show)
+
+data LegacyQuerySlotNumberCmdArgs = LegacyQuerySlotNumberCmdArgs
+  !SocketPath
+  !AnyConsensusModeParams
+  !NetworkId
+  !UTCTime
+  deriving (Generic, Show)
 
 renderLegacyQueryCmds :: LegacyQueryCmds -> Text
 renderLegacyQueryCmds = \case
-  QueryLeadershipSchedule {} -> "query leadership-schedule"
-  QueryProtocolParameters' {} -> "query protocol-parameters "
-  QueryConstitutionHash {} -> "query constitution-hash "
-  QueryTip {} -> "query tip"
-  QueryStakePools' {} -> "query stake-pools"
-  QueryStakeDistribution' {} -> "query stake-distribution"
-  QueryStakeAddressInfo {} -> "query stake-address-info"
-  QueryUTxO' {} -> "query utxo"
-  QueryDebugLedgerState' {} -> "query ledger-state"
-  QueryProtocolState' {} -> "query protocol-state"
-  QueryStakeSnapshot' {} -> "query stake-snapshot"
-  QueryKesPeriodInfo {} -> "query kes-period-info"
-  QueryPoolState' {} -> "query pool-state"
-  QueryTxMempool _ _ _ query _ -> "query tx-mempool" <> renderTxMempoolQuery query
-  QuerySlotNumber {} -> "query slot-number"
+  QueryLeadershipScheduleCmd {} -> "query leadership-schedule"
+  QueryProtocolParametersCmd {} -> "query protocol-parameters "
+  QueryConstitutionHashCmd {} -> "query constitution-hash "
+  QueryTipCmd {} -> "query tip"
+  QueryStakePoolsCmd {} -> "query stake-pools"
+  QueryStakeDistributionCmd {} -> "query stake-distribution"
+  QueryStakeAddressInfoCmd {} -> "query stake-address-info"
+  QueryUTxOCmd {} -> "query utxo"
+  QueryLedgerStateCmd {} -> "query ledger-state"
+  QueryProtocolStateCmd {} -> "query protocol-state"
+  QueryStakeSnapshotCmd {} -> "query stake-snapshot"
+  QueryKesPeriodInfoCmd {} -> "query kes-period-info"
+  QueryPoolStateCmd {} -> "query pool-state"
+  QueryTxMempoolCmd (LegacyQueryTxMempoolCmdArgs _ _ _ query _) -> "query tx-mempool" <> renderTxMempoolQuery query
+  QuerySlotNumberCmd {} -> "query slot-number"
   where
     renderTxMempoolQuery query =
       case query of

--- a/cardano-cli/src/Cardano/CLI/Legacy/Options.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Options.hs
@@ -844,48 +844,54 @@ pQueryCmds envCli =
   where
     pQueryProtocolParameters :: Parser LegacyQueryCmds
     pQueryProtocolParameters =
-      QueryProtocolParameters'
-        <$> pSocketPath envCli
-        <*> pConsensusModeParams
-        <*> pNetworkId envCli
-        <*> pMaybeOutputFile
+      fmap QueryProtocolParametersCmd $
+        LegacyQueryProtocolParametersCmdArgs
+          <$> pSocketPath envCli
+          <*> pConsensusModeParams
+          <*> pNetworkId envCli
+          <*> pMaybeOutputFile
 
     pQueryConstitutionHash :: Parser LegacyQueryCmds
     pQueryConstitutionHash =
-      QueryConstitutionHash
-        <$> pSocketPath envCli
-        <*> pConsensusModeParams
-        <*> pNetworkId envCli
-        <*> pMaybeOutputFile
+      fmap QueryConstitutionHashCmd $
+        LegacyQueryConstitutionHashCmdArgs
+          <$> pSocketPath envCli
+          <*> pConsensusModeParams
+          <*> pNetworkId envCli
+          <*> pMaybeOutputFile
 
     pQueryTip :: Parser LegacyQueryCmds
     pQueryTip =
-      QueryTip
-        <$> pSocketPath envCli
-        <*> pConsensusModeParams
-        <*> pNetworkId envCli
-        <*> pMaybeOutputFile
+      fmap QueryTipCmd $
+        LegacyQueryTipCmdArgs
+          <$> pSocketPath envCli
+          <*> pConsensusModeParams
+          <*> pNetworkId envCli
+          <*> pMaybeOutputFile
 
     pQueryUTxO :: Parser LegacyQueryCmds
     pQueryUTxO =
-      QueryUTxO'
-        <$> pSocketPath envCli
-        <*> pConsensusModeParams
-        <*> pQueryUTxOFilter
-        <*> pNetworkId envCli
-        <*> pMaybeOutputFile
+      fmap QueryUTxOCmd $
+        LegacyQueryUTxOCmdArgs
+          <$> pSocketPath envCli
+          <*> pConsensusModeParams
+          <*> pQueryUTxOFilter
+          <*> pNetworkId envCli
+          <*> pMaybeOutputFile
 
     pQueryStakePools :: Parser LegacyQueryCmds
     pQueryStakePools =
-      QueryStakePools'
-        <$> pSocketPath envCli
-        <*> pConsensusModeParams
-        <*> pNetworkId envCli
-        <*> pMaybeOutputFile
+      fmap QueryStakePoolsCmd $
+        LegacyQueryStakePoolsCmdArgs
+          <$> pSocketPath envCli
+          <*> pConsensusModeParams
+          <*> pNetworkId envCli
+          <*> pMaybeOutputFile
 
     pQueryStakeDistribution :: Parser LegacyQueryCmds
     pQueryStakeDistribution =
-      QueryStakeDistribution'
+      fmap QueryStakeDistributionCmd $
+        LegacyQueryStakeDistributionCmdArgs
         <$> pSocketPath envCli
         <*> pConsensusModeParams
         <*> pNetworkId envCli
@@ -893,7 +899,8 @@ pQueryCmds envCli =
 
     pQueryStakeAddressInfo :: Parser LegacyQueryCmds
     pQueryStakeAddressInfo =
-      QueryStakeAddressInfo
+      fmap QueryStakeAddressInfoCmd $
+        LegacyQueryStakeAddressInfoCmdArgs
         <$> pSocketPath envCli
         <*> pConsensusModeParams
         <*> pFilterByStakeAddress
@@ -902,7 +909,8 @@ pQueryCmds envCli =
 
     pQueryLedgerState :: Parser LegacyQueryCmds
     pQueryLedgerState =
-      QueryDebugLedgerState'
+      fmap QueryLedgerStateCmd $
+        LegacyQueryLedgerStateCmdArgs
         <$> pSocketPath envCli
         <*> pConsensusModeParams
         <*> pNetworkId envCli
@@ -910,11 +918,12 @@ pQueryCmds envCli =
 
     pQueryProtocolState :: Parser LegacyQueryCmds
     pQueryProtocolState =
-      QueryProtocolState'
-        <$> pSocketPath envCli
-        <*> pConsensusModeParams
-        <*> pNetworkId envCli
-        <*> pMaybeOutputFile
+      fmap QueryProtocolStateCmd $
+        LegacyQueryProtocolStateCmdArgs
+          <$> pSocketPath envCli
+          <*> pConsensusModeParams
+          <*> pNetworkId envCli
+          <*> pMaybeOutputFile
 
     pAllStakePoolsOrOnly :: Parser (AllOrOnly [Hash StakePoolKey])
     pAllStakePoolsOrOnly = pAll <|> pOnly
@@ -928,29 +937,32 @@ pQueryCmds envCli =
 
     pQueryStakeSnapshot :: Parser LegacyQueryCmds
     pQueryStakeSnapshot =
-      QueryStakeSnapshot'
-        <$> pSocketPath envCli
-        <*> pConsensusModeParams
-        <*> pNetworkId envCli
-        <*> pAllStakePoolsOrOnly
-        <*> pMaybeOutputFile
+      fmap QueryStakeSnapshotCmd $
+        LegacyQueryStakeSnapshotCmdArgs
+          <$> pSocketPath envCli
+          <*> pConsensusModeParams
+          <*> pNetworkId envCli
+          <*> pAllStakePoolsOrOnly
+          <*> pMaybeOutputFile
 
     pQueryPoolState :: Parser LegacyQueryCmds
     pQueryPoolState =
-      QueryPoolState'
-        <$> pSocketPath envCli
-        <*> pConsensusModeParams
-        <*> pNetworkId envCli
-        <*> many (pStakePoolVerificationKeyHash Nothing)
+      fmap QueryPoolStateCmd $
+        LegacyQueryPoolStateCmdArgs
+          <$> pSocketPath envCli
+          <*> pConsensusModeParams
+          <*> pNetworkId envCli
+          <*> many (pStakePoolVerificationKeyHash Nothing)
 
     pQueryTxMempool :: Parser LegacyQueryCmds
     pQueryTxMempool =
-      QueryTxMempool
-        <$> pSocketPath envCli
-        <*> pConsensusModeParams
-        <*> pNetworkId envCli
-        <*> pTxMempoolQuery
-        <*> pMaybeOutputFile
+      fmap QueryTxMempoolCmd $
+        LegacyQueryTxMempoolCmdArgs
+          <$> pSocketPath envCli
+          <*> pConsensusModeParams
+          <*> pNetworkId envCli
+          <*> pTxMempoolQuery
+          <*> pMaybeOutputFile
       where
         pTxMempoolQuery :: Parser TxMempoolQuery
         pTxMempoolQuery = asum
@@ -966,38 +978,41 @@ pQueryCmds envCli =
           ]
     pLeadershipSchedule :: Parser LegacyQueryCmds
     pLeadershipSchedule =
-      QueryLeadershipSchedule
-        <$> pSocketPath envCli
-        <*> pConsensusModeParams
-        <*> pNetworkId envCli
-        <*> pGenesisFile "Shelley genesis filepath"
-        <*> pStakePoolVerificationKeyOrHashOrFile Nothing
-        <*> pVrfSigningKeyFile
-        <*> pWhichLeadershipSchedule
-        <*> pMaybeOutputFile
+      fmap QueryLeadershipScheduleCmd $
+        LegacyQueryLeadershipScheduleCmdArgs
+          <$> pSocketPath envCli
+          <*> pConsensusModeParams
+          <*> pNetworkId envCli
+          <*> pGenesisFile "Shelley genesis filepath"
+          <*> pStakePoolVerificationKeyOrHashOrFile Nothing
+          <*> pVrfSigningKeyFile
+          <*> pWhichLeadershipSchedule
+          <*> pMaybeOutputFile
 
     pKesPeriodInfo :: Parser LegacyQueryCmds
     pKesPeriodInfo =
-      QueryKesPeriodInfo
-        <$> pSocketPath envCli
-        <*> pConsensusModeParams
-        <*> pNetworkId envCli
-        <*> pOperationalCertificateFile
-        <*> pMaybeOutputFile
+      fmap QueryKesPeriodInfoCmd $
+        LegacyQueryKesPeriodInfoCmdArgs
+          <$> pSocketPath envCli
+          <*> pConsensusModeParams
+          <*> pNetworkId envCli
+          <*> pOperationalCertificateFile
+          <*> pMaybeOutputFile
 
     pQuerySlotNumber :: Parser LegacyQueryCmds
     pQuerySlotNumber =
-      QuerySlotNumber
-        <$> pSocketPath envCli
-        <*> pConsensusModeParams
-        <*> pNetworkId envCli
-        <*> pUtcTimestamp
-          where
-            pUtcTimestamp =
-              convertTime <$> (Opt.strArgument . mconcat)
-                [ Opt.metavar "TIMESTAMP"
-                , Opt.help "UTC timestamp in YYYY-MM-DDThh:mm:ssZ format"
-                ]
+      fmap QuerySlotNumberCmd $
+        LegacyQuerySlotNumberCmdArgs
+          <$> pSocketPath envCli
+          <*> pConsensusModeParams
+          <*> pNetworkId envCli
+          <*> pUtcTimestamp
+            where
+              pUtcTimestamp =
+                convertTime <$> (Opt.strArgument . mconcat)
+                  [ Opt.metavar "TIMESTAMP"
+                  , Opt.help "UTC timestamp in YYYY-MM-DDThh:mm:ssZ format"
+                  ]
 
 
 -- TODO: Conway era - move to Cardano.CLI.Conway.Parsers

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Query.hs
@@ -1,210 +1,137 @@
+{-# OPTIONS_GHC -Wno-unticked-promoted-constructors #-}
+
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
-
-{-# OPTIONS_GHC -Wno-unticked-promoted-constructors #-}
+{-# LANGUAGE RecordWildCards #-}
 
 module Cardano.CLI.Legacy.Run.Query
   ( runLegacyQueryCmds
   ) where
 
-import           Cardano.Api hiding (QueryInShelleyBasedEra (..))
-import           Cardano.Api.Shelley hiding (QueryInShelleyBasedEra (..))
-
+import qualified Cardano.CLI.EraBased.Commands.Query as EraBased
 import qualified Cardano.CLI.EraBased.Run.Query as EraBased
 import qualified Cardano.CLI.Legacy.Commands.Query as Cmd
-import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Errors.QueryCmdError
-import           Cardano.CLI.Types.Key (VerificationKeyOrHashOrFile)
 
 import           Control.Monad.Trans.Except
-import           Data.Time.Clock
 
 runLegacyQueryCmds :: Cmd.LegacyQueryCmds -> ExceptT QueryCmdError IO ()
 runLegacyQueryCmds = \case
-  Cmd.QueryLeadershipScheduleCmd
-      (Cmd.LegacyQueryLeadershipScheduleCmdArgs mNodeSocketPath consensusModeParams network shelleyGenFp poolid vrkSkeyFp whichSchedule outputAs) ->
-    runLegacyQueryLeadershipScheduleCmd mNodeSocketPath consensusModeParams network shelleyGenFp poolid vrkSkeyFp whichSchedule outputAs
-  Cmd.QueryProtocolParametersCmd
-      (Cmd.LegacyQueryProtocolParametersCmdArgs mNodeSocketPath consensusModeParams network mOutFile) ->
-    runLegacyQueryProtocolParametersCmd mNodeSocketPath consensusModeParams network mOutFile
-  Cmd.QueryConstitutionHashCmd
-      (Cmd.LegacyQueryConstitutionHashCmdArgs mNodeSocketPath consensusModeParams network mOutFile) ->
-    runLegacyQueryConstitutionHashCmd mNodeSocketPath consensusModeParams network mOutFile
-  Cmd.QueryTipCmd
-      (Cmd.LegacyQueryTipCmdArgs mNodeSocketPath consensusModeParams network mOutFile) ->
-    runLegacyQueryTipCmd mNodeSocketPath consensusModeParams network mOutFile
-  Cmd.QueryStakePoolsCmd
-      (Cmd.LegacyQueryStakePoolsCmdArgs mNodeSocketPath consensusModeParams network mOutFile) ->
-    runLegacyQueryStakePoolsCmd mNodeSocketPath consensusModeParams network mOutFile
-  Cmd.QueryStakeDistributionCmd
-      (Cmd.LegacyQueryStakeDistributionCmdArgs mNodeSocketPath consensusModeParams network mOutFile) ->
-    runLegacyQueryStakeDistributionCmd mNodeSocketPath consensusModeParams network mOutFile
-  Cmd.QueryStakeAddressInfoCmd
-      (Cmd.LegacyQueryStakeAddressInfoCmdArgs mNodeSocketPath consensusModeParams addr network mOutFile) ->
-    runLegacyQueryStakeAddressInfoCmd mNodeSocketPath consensusModeParams addr network mOutFile
-  Cmd.QueryLedgerStateCmd
-      (Cmd.LegacyQueryLedgerStateCmdArgs mNodeSocketPath consensusModeParams network mOutFile) ->
-    runLegacyQueryLedgerStateCmd mNodeSocketPath consensusModeParams network mOutFile
-  Cmd.QueryStakeSnapshotCmd
-      (Cmd.LegacyQueryStakeSnapshotCmdArgs mNodeSocketPath consensusModeParams network allOrOnlyPoolIds mOutFile) ->
-    runLegacyQueryStakeSnapshotCmd mNodeSocketPath consensusModeParams network allOrOnlyPoolIds mOutFile
-  Cmd.QueryProtocolStateCmd
-      (Cmd.LegacyQueryProtocolStateCmdArgs mNodeSocketPath consensusModeParams network mOutFile) ->
-    runLegacyQueryProtocolStateCmd mNodeSocketPath consensusModeParams network mOutFile
-  Cmd.QueryUTxOCmd
-      (Cmd.LegacyQueryUTxOCmdArgs mNodeSocketPath consensusModeParams qFilter networkId mOutFile) ->
-    runLegacyQueryUTxOCmd mNodeSocketPath consensusModeParams qFilter networkId mOutFile
-  Cmd.QueryKesPeriodInfoCmd
-      (Cmd.LegacyQueryKesPeriodInfoCmdArgs mNodeSocketPath consensusModeParams network nodeOpCert mOutFile) ->
-    runLegacyQueryKesPeriodInfoCmd mNodeSocketPath consensusModeParams network nodeOpCert mOutFile
-  Cmd.QueryPoolStateCmd
-      (Cmd.LegacyQueryPoolStateCmdArgs mNodeSocketPath consensusModeParams network poolid) ->
-    runLegacyQueryPoolStateCmd mNodeSocketPath consensusModeParams network poolid
-  Cmd.QueryTxMempoolCmd
-      (Cmd.LegacyQueryTxMempoolCmdArgs mNodeSocketPath consensusModeParams network op mOutFile) ->
-    runLegacyQueryTxMempoolCmd mNodeSocketPath consensusModeParams network op mOutFile
-  Cmd.QuerySlotNumberCmd
-      (Cmd.LegacyQuerySlotNumberCmdArgs mNodeSocketPath consensusModeParams network utcTime) ->
-    runLegacyQuerySlotNumberCmd mNodeSocketPath consensusModeParams network utcTime
+  Cmd.QueryLeadershipScheduleCmd  args -> runLegacyQueryLeadershipScheduleCmd args
+  Cmd.QueryProtocolParametersCmd  args -> runLegacyQueryProtocolParametersCmd args
+  Cmd.QueryConstitutionHashCmd    args -> runLegacyQueryConstitutionHashCmd args
+  Cmd.QueryTipCmd                 args -> runLegacyQueryTipCmd args
+  Cmd.QueryStakePoolsCmd          args -> runLegacyQueryStakePoolsCmd args
+  Cmd.QueryStakeDistributionCmd   args -> runLegacyQueryStakeDistributionCmd args
+  Cmd.QueryStakeAddressInfoCmd    args -> runLegacyQueryStakeAddressInfoCmd args
+  Cmd.QueryLedgerStateCmd         args -> runLegacyQueryLedgerStateCmd args
+  Cmd.QueryStakeSnapshotCmd       args -> runLegacyQueryStakeSnapshotCmd args
+  Cmd.QueryProtocolStateCmd       args -> runLegacyQueryProtocolStateCmd args
+  Cmd.QueryUTxOCmd                args -> runLegacyQueryUTxOCmd args
+  Cmd.QueryKesPeriodInfoCmd       args -> runLegacyQueryKesPeriodInfoCmd args
+  Cmd.QueryPoolStateCmd           args -> runLegacyQueryPoolStateCmd args
+  Cmd.QueryTxMempoolCmd           args -> runLegacyQueryTxMempoolCmd args
+  Cmd.QuerySlotNumberCmd          args -> runLegacyQuerySlotNumberCmd args
 
 runLegacyQueryConstitutionHashCmd :: ()
-  => SocketPath
-  -> AnyConsensusModeParams
-  -> NetworkId
-  -> Maybe (File () Out)
+  => Cmd.LegacyQueryConstitutionHashCmdArgs
   -> ExceptT QueryCmdError IO ()
-runLegacyQueryConstitutionHashCmd = EraBased.runQueryConstitutionHashCmd
+runLegacyQueryConstitutionHashCmd Cmd.LegacyQueryConstitutionHashCmdArgs {..} =
+  EraBased.runQueryConstitutionHashCmd EraBased.QueryConstitutionHashCmdArgs {..}
 
 runLegacyQueryProtocolParametersCmd :: ()
-  => SocketPath
-  -> AnyConsensusModeParams
-  -> NetworkId
-  -> Maybe (File () Out)
+  => Cmd.LegacyQueryProtocolParametersCmdArgs
   -> ExceptT QueryCmdError IO ()
-runLegacyQueryProtocolParametersCmd = EraBased.runQueryProtocolParametersCmd
+runLegacyQueryProtocolParametersCmd Cmd.LegacyQueryProtocolParametersCmdArgs {..} =
+  EraBased.runQueryProtocolParametersCmd EraBased.QueryProtocolParametersCmdArgs {..}
 
 runLegacyQueryTipCmd :: ()
-  => SocketPath
-  -> AnyConsensusModeParams
-  -> NetworkId
-  -> Maybe (File () Out)
+  => Cmd.LegacyQueryTipCmdArgs
   -> ExceptT QueryCmdError IO ()
-runLegacyQueryTipCmd = EraBased.runQueryTipCmd
+runLegacyQueryTipCmd Cmd.LegacyQueryTipCmdArgs {..} =
+  EraBased.runQueryTipCmd EraBased.QueryTipCmdArgs {..}
 
 -- | Query the UTxO, filtered by a given set of addresses, from a Shelley node
 -- via the local state query protocol.
 runLegacyQueryUTxOCmd :: ()
-  => SocketPath
-  -> AnyConsensusModeParams
-  -> QueryUTxOFilter
-  -> NetworkId
-  -> Maybe (File () Out)
+  => Cmd.LegacyQueryUTxOCmdArgs
   -> ExceptT QueryCmdError IO ()
-runLegacyQueryUTxOCmd = EraBased.runQueryUTxOCmd
+runLegacyQueryUTxOCmd Cmd.LegacyQueryUTxOCmdArgs {..} =
+  EraBased.runQueryUTxOCmd EraBased.QueryUTxOCmdArgs {..}
 
 runLegacyQueryKesPeriodInfoCmd :: ()
-  => SocketPath
-  -> AnyConsensusModeParams
-  -> NetworkId
-  -> File () In
-  -> Maybe (File () Out)
+  => Cmd.LegacyQueryKesPeriodInfoCmdArgs
   -> ExceptT QueryCmdError IO ()
-runLegacyQueryKesPeriodInfoCmd = EraBased.runQueryKesPeriodInfoCmd
+runLegacyQueryKesPeriodInfoCmd Cmd.LegacyQueryKesPeriodInfoCmdArgs {..} =
+  EraBased.runQueryKesPeriodInfoCmd EraBased.QueryKesPeriodInfoCmdArgs {..}
 
 -- | Query the current and future parameters for a stake pool, including the retirement date.
 -- Any of these may be empty (in which case a null will be displayed).
 --
 runLegacyQueryPoolStateCmd :: ()
-  => SocketPath
-  -> AnyConsensusModeParams
-  -> NetworkId
-  -> [Hash StakePoolKey]
+  => Cmd.LegacyQueryPoolStateCmdArgs
   -> ExceptT QueryCmdError IO ()
-runLegacyQueryPoolStateCmd = EraBased.runQueryPoolStateCmd
+runLegacyQueryPoolStateCmd Cmd.LegacyQueryPoolStateCmdArgs {..} =
+  EraBased.runQueryPoolStateCmd EraBased.QueryPoolStateCmdArgs {..}
 
 -- | Query the local mempool state
 runLegacyQueryTxMempoolCmd :: ()
-  => SocketPath
-  -> AnyConsensusModeParams
-  -> NetworkId
-  -> TxMempoolQuery
-  -> Maybe (File () Out)
+  => Cmd.LegacyQueryTxMempoolCmdArgs
   -> ExceptT QueryCmdError IO ()
-runLegacyQueryTxMempoolCmd = EraBased.runQueryTxMempoolCmd
+runLegacyQueryTxMempoolCmd Cmd.LegacyQueryTxMempoolCmdArgs {..} =
+  EraBased.runQueryTxMempoolCmd EraBased.QueryTxMempoolCmdArgs {..}
 
 runLegacyQuerySlotNumberCmd :: ()
-  => SocketPath
-  -> AnyConsensusModeParams
-  -> NetworkId
-  -> UTCTime
+  => Cmd.LegacyQuerySlotNumberCmdArgs
   -> ExceptT QueryCmdError IO ()
-runLegacyQuerySlotNumberCmd = EraBased.runQuerySlotNumberCmd
+runLegacyQuerySlotNumberCmd Cmd.LegacyQuerySlotNumberCmdArgs {..} =
+  EraBased.runQuerySlotNumberCmd EraBased.QuerySlotNumberCmdArgs {..}
 
 -- | Obtain stake snapshot information for a pool, plus information about the total active stake.
 -- This information can be used for leader slot calculation, for example, and has been requested by SPOs.
 -- Obtaining the information directly is significantly more time and memory efficient than using a full ledger state dump.
 runLegacyQueryStakeSnapshotCmd :: ()
-  => SocketPath
-  -> AnyConsensusModeParams
-  -> NetworkId
-  -> AllOrOnly [Hash StakePoolKey]
-  -> Maybe (File () Out)
+  => Cmd.LegacyQueryStakeSnapshotCmdArgs
   -> ExceptT QueryCmdError IO ()
-runLegacyQueryStakeSnapshotCmd = EraBased.runQueryStakeSnapshotCmd
+runLegacyQueryStakeSnapshotCmd Cmd.LegacyQueryStakeSnapshotCmdArgs {..} =
+  EraBased.runQueryStakeSnapshotCmd EraBased.QueryStakeSnapshotCmdArgs {..}
 
 runLegacyQueryLedgerStateCmd :: ()
-  => SocketPath
-  -> AnyConsensusModeParams
-  -> NetworkId
-  -> Maybe (File () Out)
+  => Cmd.LegacyQueryLedgerStateCmdArgs
   -> ExceptT QueryCmdError IO ()
-runLegacyQueryLedgerStateCmd = EraBased.runQueryLedgerStateCmd
+runLegacyQueryLedgerStateCmd Cmd.LegacyQueryLedgerStateCmdArgs {..} =
+  EraBased.runQueryLedgerStateCmd EraBased.QueryLedgerStateCmdArgs {..}
 
 runLegacyQueryProtocolStateCmd :: ()
-  => SocketPath
-  -> AnyConsensusModeParams
-  -> NetworkId
-  -> Maybe (File () Out)
+  => Cmd.LegacyQueryProtocolStateCmdArgs
   -> ExceptT QueryCmdError IO ()
-runLegacyQueryProtocolStateCmd = EraBased.runQueryProtocolStateCmd
+runLegacyQueryProtocolStateCmd Cmd.LegacyQueryProtocolStateCmdArgs {..} =
+  EraBased.runQueryProtocolStateCmd EraBased.QueryProtocolStateCmdArgs {..}
 
 -- | Query the current delegations and reward accounts, filtered by a given
 -- set of addresses, from a Shelley node via the local state query protocol.
 
 runLegacyQueryStakeAddressInfoCmd :: ()
-  => SocketPath
-  -> AnyConsensusModeParams
-  -> StakeAddress
-  -> NetworkId
-  -> Maybe (File () Out)
+  => Cmd.LegacyQueryStakeAddressInfoCmdArgs
   -> ExceptT QueryCmdError IO ()
-runLegacyQueryStakeAddressInfoCmd = EraBased.runQueryStakeAddressInfoCmd
+runLegacyQueryStakeAddressInfoCmd Cmd.LegacyQueryStakeAddressInfoCmdArgs {..} =
+  EraBased.runQueryStakeAddressInfoCmd EraBased.QueryStakeAddressInfoCmdArgs {..}
 
 runLegacyQueryStakePoolsCmd :: ()
-  => SocketPath
-  -> AnyConsensusModeParams
-  -> NetworkId
-  -> Maybe (File () Out)
+  => Cmd.LegacyQueryStakePoolsCmdArgs
   -> ExceptT QueryCmdError IO ()
-runLegacyQueryStakePoolsCmd = EraBased.runQueryStakePoolsCmd
+runLegacyQueryStakePoolsCmd Cmd.LegacyQueryStakePoolsCmdArgs {..} =
+  EraBased.runQueryStakePoolsCmd EraBased.QueryStakePoolsCmdArgs {..}
 
 runLegacyQueryStakeDistributionCmd :: ()
-  => SocketPath
-  -> AnyConsensusModeParams
-  -> NetworkId
-  -> Maybe (File () Out)
+  => Cmd.LegacyQueryStakeDistributionCmdArgs
   -> ExceptT QueryCmdError IO ()
-runLegacyQueryStakeDistributionCmd = EraBased.runQueryStakeDistributionCmd
+runLegacyQueryStakeDistributionCmd Cmd.LegacyQueryStakeDistributionCmdArgs {..} =
+  EraBased.runQueryStakeDistributionCmd EraBased.QueryStakeDistributionCmdArgs {..}
 
 runLegacyQueryLeadershipScheduleCmd :: ()
-  => SocketPath
-  -> AnyConsensusModeParams
-  -> NetworkId
-  -> GenesisFile -- ^ Shelley genesis
-  -> VerificationKeyOrHashOrFile StakePoolKey
-  -> SigningKeyFile In -- ^ VRF signing key
-  -> EpochLeadershipSchedule
-  -> Maybe (File () Out)
+  => Cmd.LegacyQueryLeadershipScheduleCmdArgs
   -> ExceptT QueryCmdError IO ()
-runLegacyQueryLeadershipScheduleCmd = EraBased.runQueryLeadershipScheduleCmd
+runLegacyQueryLeadershipScheduleCmd Cmd.LegacyQueryLeadershipScheduleCmdArgs {..} =
+  EraBased.runQueryLeadershipScheduleCmd EraBased.QueryLeadershipScheduleCmdArgs {..}

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Query.hs
@@ -12,7 +12,7 @@ import           Cardano.Api hiding (QueryInShelleyBasedEra (..))
 import           Cardano.Api.Shelley hiding (QueryInShelleyBasedEra (..))
 
 import qualified Cardano.CLI.EraBased.Run.Query as EraBased
-import           Cardano.CLI.Legacy.Commands.Query
+import qualified Cardano.CLI.Legacy.Commands.Query as Cmd
 import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Errors.QueryCmdError
 import           Cardano.CLI.Types.Key (VerificationKeyOrHashOrFile)
@@ -20,52 +20,52 @@ import           Cardano.CLI.Types.Key (VerificationKeyOrHashOrFile)
 import           Control.Monad.Trans.Except
 import           Data.Time.Clock
 
-runLegacyQueryCmds :: LegacyQueryCmds -> ExceptT QueryCmdError IO ()
+runLegacyQueryCmds :: Cmd.LegacyQueryCmds -> ExceptT QueryCmdError IO ()
 runLegacyQueryCmds = \case
-  QueryLeadershipScheduleCmd
-      (LegacyQueryLeadershipScheduleCmdArgs mNodeSocketPath consensusModeParams network shelleyGenFp poolid vrkSkeyFp whichSchedule outputAs) ->
+  Cmd.QueryLeadershipScheduleCmd
+      (Cmd.LegacyQueryLeadershipScheduleCmdArgs mNodeSocketPath consensusModeParams network shelleyGenFp poolid vrkSkeyFp whichSchedule outputAs) ->
     runLegacyQueryLeadershipScheduleCmd mNodeSocketPath consensusModeParams network shelleyGenFp poolid vrkSkeyFp whichSchedule outputAs
-  QueryProtocolParametersCmd
-      (LegacyQueryProtocolParametersCmdArgs mNodeSocketPath consensusModeParams network mOutFile) ->
+  Cmd.QueryProtocolParametersCmd
+      (Cmd.LegacyQueryProtocolParametersCmdArgs mNodeSocketPath consensusModeParams network mOutFile) ->
     runLegacyQueryProtocolParametersCmd mNodeSocketPath consensusModeParams network mOutFile
-  QueryConstitutionHashCmd
-      (LegacyQueryConstitutionHashCmdArgs mNodeSocketPath consensusModeParams network mOutFile) ->
+  Cmd.QueryConstitutionHashCmd
+      (Cmd.LegacyQueryConstitutionHashCmdArgs mNodeSocketPath consensusModeParams network mOutFile) ->
     runLegacyQueryConstitutionHashCmd mNodeSocketPath consensusModeParams network mOutFile
-  QueryTipCmd
-      (LegacyQueryTipCmdArgs mNodeSocketPath consensusModeParams network mOutFile) ->
+  Cmd.QueryTipCmd
+      (Cmd.LegacyQueryTipCmdArgs mNodeSocketPath consensusModeParams network mOutFile) ->
     runLegacyQueryTipCmd mNodeSocketPath consensusModeParams network mOutFile
-  QueryStakePoolsCmd
-      (LegacyQueryStakePoolsCmdArgs mNodeSocketPath consensusModeParams network mOutFile) ->
+  Cmd.QueryStakePoolsCmd
+      (Cmd.LegacyQueryStakePoolsCmdArgs mNodeSocketPath consensusModeParams network mOutFile) ->
     runLegacyQueryStakePoolsCmd mNodeSocketPath consensusModeParams network mOutFile
-  QueryStakeDistributionCmd
-      (LegacyQueryStakeDistributionCmdArgs mNodeSocketPath consensusModeParams network mOutFile) ->
+  Cmd.QueryStakeDistributionCmd
+      (Cmd.LegacyQueryStakeDistributionCmdArgs mNodeSocketPath consensusModeParams network mOutFile) ->
     runLegacyQueryStakeDistributionCmd mNodeSocketPath consensusModeParams network mOutFile
-  QueryStakeAddressInfoCmd
-      (LegacyQueryStakeAddressInfoCmdArgs mNodeSocketPath consensusModeParams addr network mOutFile) ->
+  Cmd.QueryStakeAddressInfoCmd
+      (Cmd.LegacyQueryStakeAddressInfoCmdArgs mNodeSocketPath consensusModeParams addr network mOutFile) ->
     runLegacyQueryStakeAddressInfoCmd mNodeSocketPath consensusModeParams addr network mOutFile
-  QueryLedgerStateCmd
-      (LegacyQueryLedgerStateCmdArgs mNodeSocketPath consensusModeParams network mOutFile) ->
+  Cmd.QueryLedgerStateCmd
+      (Cmd.LegacyQueryLedgerStateCmdArgs mNodeSocketPath consensusModeParams network mOutFile) ->
     runLegacyQueryLedgerStateCmd mNodeSocketPath consensusModeParams network mOutFile
-  QueryStakeSnapshotCmd
-      (LegacyQueryStakeSnapshotCmdArgs mNodeSocketPath consensusModeParams network allOrOnlyPoolIds mOutFile) ->
+  Cmd.QueryStakeSnapshotCmd
+      (Cmd.LegacyQueryStakeSnapshotCmdArgs mNodeSocketPath consensusModeParams network allOrOnlyPoolIds mOutFile) ->
     runLegacyQueryStakeSnapshotCmd mNodeSocketPath consensusModeParams network allOrOnlyPoolIds mOutFile
-  QueryProtocolStateCmd
-      (LegacyQueryProtocolStateCmdArgs mNodeSocketPath consensusModeParams network mOutFile) ->
+  Cmd.QueryProtocolStateCmd
+      (Cmd.LegacyQueryProtocolStateCmdArgs mNodeSocketPath consensusModeParams network mOutFile) ->
     runLegacyQueryProtocolStateCmd mNodeSocketPath consensusModeParams network mOutFile
-  QueryUTxOCmd
-      (LegacyQueryUTxOCmdArgs mNodeSocketPath consensusModeParams qFilter networkId mOutFile) ->
+  Cmd.QueryUTxOCmd
+      (Cmd.LegacyQueryUTxOCmdArgs mNodeSocketPath consensusModeParams qFilter networkId mOutFile) ->
     runLegacyQueryUTxOCmd mNodeSocketPath consensusModeParams qFilter networkId mOutFile
-  QueryKesPeriodInfoCmd
-      (LegacyQueryKesPeriodInfoCmdArgs mNodeSocketPath consensusModeParams network nodeOpCert mOutFile) ->
+  Cmd.QueryKesPeriodInfoCmd
+      (Cmd.LegacyQueryKesPeriodInfoCmdArgs mNodeSocketPath consensusModeParams network nodeOpCert mOutFile) ->
     runLegacyQueryKesPeriodInfoCmd mNodeSocketPath consensusModeParams network nodeOpCert mOutFile
-  QueryPoolStateCmd
-      (LegacyQueryPoolStateCmdArgs mNodeSocketPath consensusModeParams network poolid) ->
+  Cmd.QueryPoolStateCmd
+      (Cmd.LegacyQueryPoolStateCmdArgs mNodeSocketPath consensusModeParams network poolid) ->
     runLegacyQueryPoolStateCmd mNodeSocketPath consensusModeParams network poolid
-  QueryTxMempoolCmd
-      (LegacyQueryTxMempoolCmdArgs mNodeSocketPath consensusModeParams network op mOutFile) ->
+  Cmd.QueryTxMempoolCmd
+      (Cmd.LegacyQueryTxMempoolCmdArgs mNodeSocketPath consensusModeParams network op mOutFile) ->
     runLegacyQueryTxMempoolCmd mNodeSocketPath consensusModeParams network op mOutFile
-  QuerySlotNumberCmd
-      (LegacyQuerySlotNumberCmdArgs mNodeSocketPath consensusModeParams network utcTime) ->
+  Cmd.QuerySlotNumberCmd
+      (Cmd.LegacyQuerySlotNumberCmdArgs mNodeSocketPath consensusModeParams network utcTime) ->
     runLegacyQuerySlotNumberCmd mNodeSocketPath consensusModeParams network utcTime
 
 runLegacyQueryConstitutionHashCmd :: ()

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Query.hs
@@ -22,35 +22,50 @@ import           Data.Time.Clock
 
 runLegacyQueryCmds :: LegacyQueryCmds -> ExceptT QueryCmdError IO ()
 runLegacyQueryCmds = \case
-  QueryLeadershipSchedule mNodeSocketPath consensusModeParams network shelleyGenFp poolid vrkSkeyFp whichSchedule outputAs ->
+  QueryLeadershipScheduleCmd
+      (LegacyQueryLeadershipScheduleCmdArgs mNodeSocketPath consensusModeParams network shelleyGenFp poolid vrkSkeyFp whichSchedule outputAs) ->
     runLegacyQueryLeadershipScheduleCmd mNodeSocketPath consensusModeParams network shelleyGenFp poolid vrkSkeyFp whichSchedule outputAs
-  QueryProtocolParameters' mNodeSocketPath consensusModeParams network mOutFile ->
+  QueryProtocolParametersCmd
+      (LegacyQueryProtocolParametersCmdArgs mNodeSocketPath consensusModeParams network mOutFile) ->
     runLegacyQueryProtocolParametersCmd mNodeSocketPath consensusModeParams network mOutFile
-  QueryConstitutionHash mNodeSocketPath consensusModeParams network mOutFile ->
+  QueryConstitutionHashCmd
+      (LegacyQueryConstitutionHashCmdArgs mNodeSocketPath consensusModeParams network mOutFile) ->
     runLegacyQueryConstitutionHashCmd mNodeSocketPath consensusModeParams network mOutFile
-  QueryTip mNodeSocketPath consensusModeParams network mOutFile ->
+  QueryTipCmd
+      (LegacyQueryTipCmdArgs mNodeSocketPath consensusModeParams network mOutFile) ->
     runLegacyQueryTipCmd mNodeSocketPath consensusModeParams network mOutFile
-  QueryStakePools' mNodeSocketPath consensusModeParams network mOutFile ->
+  QueryStakePoolsCmd
+      (LegacyQueryStakePoolsCmdArgs mNodeSocketPath consensusModeParams network mOutFile) ->
     runLegacyQueryStakePoolsCmd mNodeSocketPath consensusModeParams network mOutFile
-  QueryStakeDistribution' mNodeSocketPath consensusModeParams network mOutFile ->
+  QueryStakeDistributionCmd
+      (LegacyQueryStakeDistributionCmdArgs mNodeSocketPath consensusModeParams network mOutFile) ->
     runLegacyQueryStakeDistributionCmd mNodeSocketPath consensusModeParams network mOutFile
-  QueryStakeAddressInfo mNodeSocketPath consensusModeParams addr network mOutFile ->
+  QueryStakeAddressInfoCmd
+      (LegacyQueryStakeAddressInfoCmdArgs mNodeSocketPath consensusModeParams addr network mOutFile) ->
     runLegacyQueryStakeAddressInfoCmd mNodeSocketPath consensusModeParams addr network mOutFile
-  QueryDebugLedgerState' mNodeSocketPath consensusModeParams network mOutFile ->
+  QueryLedgerStateCmd
+      (LegacyQueryLedgerStateCmdArgs mNodeSocketPath consensusModeParams network mOutFile) ->
     runLegacyQueryLedgerStateCmd mNodeSocketPath consensusModeParams network mOutFile
-  QueryStakeSnapshot' mNodeSocketPath consensusModeParams network allOrOnlyPoolIds mOutFile ->
+  QueryStakeSnapshotCmd
+      (LegacyQueryStakeSnapshotCmdArgs mNodeSocketPath consensusModeParams network allOrOnlyPoolIds mOutFile) ->
     runLegacyQueryStakeSnapshotCmd mNodeSocketPath consensusModeParams network allOrOnlyPoolIds mOutFile
-  QueryProtocolState' mNodeSocketPath consensusModeParams network mOutFile ->
+  QueryProtocolStateCmd
+      (LegacyQueryProtocolStateCmdArgs mNodeSocketPath consensusModeParams network mOutFile) ->
     runLegacyQueryProtocolStateCmd mNodeSocketPath consensusModeParams network mOutFile
-  QueryUTxO' mNodeSocketPath consensusModeParams qFilter networkId mOutFile ->
+  QueryUTxOCmd
+      (LegacyQueryUTxOCmdArgs mNodeSocketPath consensusModeParams qFilter networkId mOutFile) ->
     runLegacyQueryUTxOCmd mNodeSocketPath consensusModeParams qFilter networkId mOutFile
-  QueryKesPeriodInfo mNodeSocketPath consensusModeParams network nodeOpCert mOutFile ->
+  QueryKesPeriodInfoCmd
+      (LegacyQueryKesPeriodInfoCmdArgs mNodeSocketPath consensusModeParams network nodeOpCert mOutFile) ->
     runLegacyQueryKesPeriodInfoCmd mNodeSocketPath consensusModeParams network nodeOpCert mOutFile
-  QueryPoolState' mNodeSocketPath consensusModeParams network poolid ->
+  QueryPoolStateCmd
+      (LegacyQueryPoolStateCmdArgs mNodeSocketPath consensusModeParams network poolid) ->
     runLegacyQueryPoolStateCmd mNodeSocketPath consensusModeParams network poolid
-  QueryTxMempool mNodeSocketPath consensusModeParams network op mOutFile ->
+  QueryTxMempoolCmd
+      (LegacyQueryTxMempoolCmdArgs mNodeSocketPath consensusModeParams network op mOutFile) ->
     runLegacyQueryTxMempoolCmd mNodeSocketPath consensusModeParams network op mOutFile
-  QuerySlotNumber mNodeSocketPath consensusModeParams network utcTime ->
+  QuerySlotNumberCmd
+      (LegacyQuerySlotNumberCmdArgs mNodeSocketPath consensusModeParams network utcTime) ->
     runLegacyQuerySlotNumberCmd mNodeSocketPath consensusModeParams network utcTime
 
 runLegacyQueryConstitutionHashCmd :: ()


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Tidy up query command structure
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Governance query commands will move into here, so first tidying up the existing query command group in preparation.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
