### PR TITLE
Add a systemd cabal flag

### DIFF
--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -19,6 +19,11 @@ Flag unexpected_thunks
   Description:          Turn on unexpected thunks checks
   Default:              False
 
+flag systemd
+  description:          Enable systemd support
+  default:              True
+  manual:               False
+
 common project-config
   default-language:     Haskell2010
 
@@ -33,8 +38,6 @@ common project-config
                         -Wpartial-fields
                         -Wredundant-constraints
 
-  if impl(ghc >= 9.6)
-    ghc-options:        -Wunused-packages
 
 common maybe-unix
   if !os(windows)
@@ -47,6 +50,11 @@ common maybe-bytestring
 library
   import:               project-config
                       , maybe-unix
+
+  if os(linux) && flag(systemd)
+    cpp-options:        -DSYSTEMD
+    build-depends:      lobemo-scribe-systemd
+                      , systemd >= 2.3.0
 
   if flag(unexpected_thunks)
     cpp-options:        -DUNEXPECTED_THUNKS


### PR DESCRIPTION
This is needed because neither MacOS nor Windows have systemd but it is desirable on Linux.

# Changelog

```yaml
- description: |
   Add a systemd cabal flag
# uncomment types applicable to the change:
  type: feature        # introduces a new feature
```

# Context

Manual testing:
```
> cabal build all --dry-run --flag=-systemd 
Up to date
> jq < dist-newstyle/cache/plan.json | grep systemd
        "systemd": false,
        ....

> cabal build all --dry-run --flag=+systemd 
Resolving dependencies...
....

> jq < dist-newstyle/cache/plan.json | grep systemd
        "systemd": true,
         ....
> cabal build all --dry-run 
Resolving dependencies...
...
> jq < dist-newstyle/cache/plan.json | grep systemd
        "systemd": true,
         ...
```

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [x] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
