### PR TITLE
Drep certification registration: add parameters for anchor

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/DRep.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/DRep.hs
@@ -7,6 +7,8 @@ module Cardano.CLI.EraBased.Commands.Governance.DRep
   ) where
 
 import           Cardano.Api
+import qualified Cardano.Api.Ledger as Ledger
+import           Cardano.Api.Shelley
 
 import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Key
@@ -27,6 +29,7 @@ data GovernanceDRepCmds era
       (ConwayEraOnwards era)
       (VerificationKeyOrHashOrFile DRepKey)
       Lovelace
+      (Maybe (Ledger.Anchor (Ledger.EraCrypto (ShelleyLedgerEra era))))
       (File () Out)
 
 renderGovernanceDRepCmds :: ()

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/DRep.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/DRep.hs
@@ -14,8 +14,12 @@ import           Cardano.CLI.Environment
 import           Cardano.CLI.EraBased.Commands.Governance.DRep
 import           Cardano.CLI.EraBased.Options.Common
 import           Cardano.CLI.Parser
+import           Cardano.CLI.Read
 import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Key
+import qualified Cardano.Ledger.BaseTypes as L
+import qualified Cardano.Ledger.Crypto as Crypto
+import qualified Cardano.Ledger.SafeHash as L
 
 import           Control.Applicative
 import           Data.Foldable
@@ -88,13 +92,35 @@ pRegistrationCertificateCmd era = do
   w <- forEraMaybeEon era
   pure
     $ subParser "registration-certificate"
-    $ Opt.info (mkParser w)
+    $ Opt.info (conwayEraOnwardsConstraints w $ mkParser w)
     $ Opt.progDesc "Create a registration certificate."
  where
   mkParser w = GovernanceDRepRegistrationCertificateCmd w
         <$> pDRepVerificationKeyOrHashOrFile
         <*> pKeyRegistDeposit
+        <*> pDRepMetadata
         <*> pOutputFile
+
+pDRepMetadata :: Parser (Maybe (L.Anchor Crypto.StandardCrypto))
+pDRepMetadata =
+  optional $
+    L.Anchor
+      <$> fmap unAnchorUrl pDrepMetadataUrl
+      <*> pDrepMetadataHash
+
+pDrepMetadataUrl :: Parser AnchorUrl
+pDrepMetadataUrl =
+  AnchorUrl
+    <$> pUrl "drep-metadata-url" "DRep anchor URL"
+
+pDrepMetadataHash :: Parser (L.SafeHash Crypto.StandardCrypto L.AnchorData)
+pDrepMetadataHash =
+  Opt.option readSafeHash $ mconcat
+    [ Opt.long "drep-metadata-hash"
+    , Opt.metavar "HASH"
+    , Opt.help "DRep anchor data hash."
+    ]
+
 
 --------------------------------------------------------------------------------
 

--- a/cardano-cli/src/Cardano/CLI/Types/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Common.hs
@@ -6,7 +6,9 @@
 {-# LANGUAGE StandaloneDeriving #-}
 
 module Cardano.CLI.Types.Common
-  ( AllOrOnly(..)
+  ( AnchorDataHash(..)
+  , AnchorUrl(..)
+  , AllOrOnly(..)
   , AddressKeyType(..)
   , BalanceTxExecUnits (..)
   , BlockId(..)
@@ -126,6 +128,14 @@ data ProposalHashSource
   | ProposalHashSourceText Text
   | ProposalHashSourceHash (L.SafeHash Crypto.StandardCrypto L.AnchorData)
   deriving Show
+
+newtype AnchorUrl = AnchorUrl
+  { unAnchorUrl :: L.Url
+  } deriving (Eq, Show)
+
+newtype AnchorDataHash = AnchorDataHash
+  { unAnchorDataHash :: L.SafeHash Crypto.StandardCrypto L.AnchorData
+  } deriving (Eq, Show)
 
 -- | Specify whether to render the script cost as JSON
 -- in the cli's build command.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -6546,6 +6546,8 @@ Usage: cardano-cli conway governance drep registration-certificate
                                                                      | --drep-key-hash HASH
                                                                      )
                                                                      --key-reg-deposit-amt NATURAL
+                                                                     [--drep-metadata-url TEXT
+                                                                       --drep-metadata-hash HASH]
                                                                      --out-file FILE
 
   Create a registration certificate.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_drep_registration-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_drep_registration-certificate.cli
@@ -4,6 +4,8 @@ Usage: cardano-cli conway governance drep registration-certificate
                                                                      | --drep-key-hash HASH
                                                                      )
                                                                      --key-reg-deposit-amt NATURAL
+                                                                     [--drep-metadata-url TEXT
+                                                                       --drep-metadata-hash HASH]
                                                                      --out-file FILE
 
   Create a registration certificate.
@@ -18,5 +20,8 @@ Available options:
                            is allowed.
   --key-reg-deposit-amt NATURAL
                            Key registration deposit amount.
+  --drep-metadata-url TEXT DRep anchor URL
+  --drep-metadata-hash HASH
+                           DRep anchor data hash.
   --out-file FILE          The output file.
   -h,--help                Show this help text


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Add `--drep-metadata-url` and `--drep-metadata-hash` to the drep registration certificate command
# uncomment types applicable to the change:
  type:
  - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Closes https://github.com/input-output-hk/cardano-cli/issues/198

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- NA The version bounds in `.cabal` files are updated
- [X] CI passes. See note on CI.  The following CI checks are required:
  - [X] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [X] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [X] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [X] The changelog section in the PR is updated to describe the change
- [X] Self-reviewed the diff