### PR TITLE
conway governance vote create: make it possible to use cc hot keys

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Vote.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Vote.hs
@@ -53,4 +53,5 @@ pAnyVotingStakeVerificationKeyOrHashOrFile :: Parser AnyVotingStakeVerificationK
 pAnyVotingStakeVerificationKeyOrHashOrFile =
   asum [ AnyDRepVerificationKeyOrHashOrFile <$> pDRepVerificationKeyOrHashOrFile
        , AnyStakePoolVerificationKeyOrHashOrFile <$> pStakePoolVerificationKeyOrHashOrFile Nothing
+       , AnyCommitteeHotVerificationKeyOrHashOrFile <$> pCommitteeHotVerificationKeyOrHashOrVerificationFile
        ]

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -6563,6 +6563,9 @@ Usage: cardano-cli conway governance vote create (--yes | --no | --abstain)
                                                    | --stake-pool-verification-key STRING
                                                    | --cold-verification-key-file FILE
                                                    | --stake-pool-id STAKE_POOL_ID
+                                                   | --cc-hot-verification-key STRING
+                                                   | --cc-hot-verification-key-file FILE
+                                                   | --cc-hot-key-hash STRING
                                                    )
                                                    --out-file FILE
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_vote_create.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_vote_create.cli
@@ -7,6 +7,9 @@ Usage: cardano-cli conway governance vote create (--yes | --no | --abstain)
                                                    | --stake-pool-verification-key STRING
                                                    | --cold-verification-key-file FILE
                                                    | --stake-pool-id STAKE_POOL_ID
+                                                   | --cc-hot-verification-key STRING
+                                                   | --cc-hot-verification-key-file FILE
+                                                   | --cc-hot-key-hash STRING
                                                    )
                                                    --out-file FILE
 
@@ -32,5 +35,10 @@ Available options:
                            Stake pool ID/verification key hash (either
                            Bech32-encoded or hex-encoded). Zero or more
                            occurences of this option is allowed.
+  --cc-hot-verification-key STRING
+                           Constitutional Committee hot key (hex-encoded).
+  --cc-hot-verification-key-file FILE
+                           Filepath of the Consitutional Committee hot key.
+  --cc-hot-key-hash STRING Constitutional Committee key hash (hex-encoded).
   --out-file FILE          Output filepath of the vote.
   -h,--help                Show this help text


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Make it possible to use cc hot keys for `conway governance vote create`
# uncomment types applicable to the change:
  type:
  - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Fix https://github.com/input-output-hk/cardano-cli/issues/333

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- NA The version bounds in `.cabal` files are updated
- [X] CI passes. See note on CI.  The following CI checks are required:
  - [X] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [X] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [X] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [X] Self-reviewed the diff