### PR TITLE
Add support for committee hot key witnesses

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -14,7 +14,7 @@ repository cardano-haskell-packages
 -- you need to run if you change them
 index-state:
   , hackage.haskell.org 2023-08-08T19:56:09Z
-  , cardano-haskell-packages 2023-10-03T23:50:17Z
+  , cardano-haskell-packages 2023-10-05T20:00:00Z
 
 packages:
   cardano-cli

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -203,7 +203,7 @@ library
                       , binary
                       , bytestring
                       , canonical-json
-                      , cardano-api ^>= 8.25
+                      , cardano-api ^>= 8.25.0.1
                       , cardano-binary
                       , cardano-crypto
                       , cardano-crypto-class ^>= 2.1.2

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -203,7 +203,7 @@ library
                       , binary
                       , bytestring
                       , canonical-json
-                      , cardano-api ^>= 8.25.0.1
+                      , cardano-api ^>= 8.25.2.0
                       , cardano-binary
                       , cardano-crypto
                       , cardano-crypto-class ^>= 2.1.2

--- a/cardano-cli/src/Cardano/CLI/Json/Friendly.hs
+++ b/cardano-cli/src/Cardano/CLI/Json/Friendly.hs
@@ -301,7 +301,7 @@ friendlyCertificates sbe = \case
   TxCertificates _ cs _ -> array $ map (friendlyCertificate sbe) cs
 
 friendlyCertificate :: ShelleyBasedEra era -> Certificate era -> Aeson.Value
-friendlyCertificate sbe = withShelleyBasedEraConstraintsForLedger sbe $
+friendlyCertificate sbe = shelleyBasedEraConstraints sbe $
   object . (: []) . renderCertificate sbe
 
 renderCertificate :: ShelleyBasedEra era -> Certificate era -> (Aeson.Key, Aeson.Value)

--- a/cardano-cli/src/Cardano/CLI/Read.hs
+++ b/cardano-cli/src/Cardano/CLI/Read.hs
@@ -620,7 +620,8 @@ data SomeSigningWitness
   | AGenesisDelegateExtendedSigningWitness  (SigningKey GenesisDelegateExtendedKey)
   | AGenesisUTxOSigningWitness              (SigningKey GenesisUTxOKey)
   | ADRepSigningWitness                     (SigningKey DRepKey)
-  | ACommitteeSigningWitness                (SigningKey CommitteeColdKey)
+  | ACommitteeColdSigningWitness            (SigningKey CommitteeColdKey)
+  | ACommitteeHotSigningWitness             (SigningKey CommitteeHotKey)
   deriving Show
 
 
@@ -655,7 +656,8 @@ categoriseSomeSigningWitness swsk =
     AGenesisDelegateExtendedSigningWitness  sk      -> AShelleyKeyWitness (WitnessGenesisDelegateExtendedKey      sk)
     AGenesisUTxOSigningWitness              sk      -> AShelleyKeyWitness (WitnessGenesisUTxOKey                  sk)
     ADRepSigningWitness                     sk      -> AShelleyKeyWitness (WitnessPaymentKey $ castDrep           sk)
-    ACommitteeSigningWitness                sk      -> AShelleyKeyWitness (WitnessCommitteeColdKey                sk)
+    ACommitteeColdSigningWitness            sk      -> AShelleyKeyWitness (WitnessCommitteeColdKey                sk)
+    ACommitteeHotSigningWitness             sk      -> AShelleyKeyWitness (WitnessCommitteeHotKey                 sk)
 
 -- TODO: Conway era - Add constrctor for SigningKey DrepKey to ShelleyWitnessSigningKey
 castDrep :: SigningKey DRepKey -> SigningKey PaymentKey
@@ -708,7 +710,8 @@ readWitnessSigningData (KeyWitnessSigningData skFile mbByronAddr) = do
       , FromSomeType (AsSigningKey AsGenesisDelegateExtendedKey ) AGenesisDelegateExtendedSigningWitness
       , FromSomeType (AsSigningKey AsGenesisUTxOKey             ) AGenesisUTxOSigningWitness
       , FromSomeType (AsSigningKey AsDRepKey                    ) ADRepSigningWitness
-      , FromSomeType (AsSigningKey AsCommitteeColdKey           ) ACommitteeSigningWitness
+      , FromSomeType (AsSigningKey AsCommitteeColdKey           ) ACommitteeColdSigningWitness
+      , FromSomeType (AsSigningKey AsCommitteeHotKey            ) ACommitteeHotSigningWitness
       ]
 
     bech32FileTypes =

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Transaction/Sign.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Transaction/Sign.hs
@@ -19,6 +19,7 @@ hprop_golden_shelleyTransactionSign = propertyOnce $ H.moduleWorkspace "tmp" $ \
   utxoSigningKeyFile <- noteInputFile "test/cardano-cli-golden/files/input/shelley/transaction-sign/utxo.skey"
   stakeSigningKeyFile <- noteInputFile "test/cardano-cli-golden/files/input/shelley/transaction-sign/stake.skey"
   nodeColdSigningKeyFile <- noteInputFile "test/cardano-cli-golden/files/input/shelley/transaction-sign/node-cold.skey"
+  ccHotSigningKeyFile <- noteInputFile "test/cardano-cli-golden/files/input/governance/cc-hot.skey"
   signedTransactionFile <- noteTempFile tempDir "signed.tx"
   transactionPoolRegSignedFile <- noteTempFile tempDir "tx-pool-reg.signed"
 
@@ -59,6 +60,17 @@ hprop_golden_shelleyTransactionSign = propertyOnce $ H.moduleWorkspace "tmp" $ \
     , "--signing-key-file", utxoSigningKeyFile
     , "--signing-key-file", stakeSigningKeyFile
     , "--signing-key-file", nodeColdSigningKeyFile
+    , "--tx-file", transactionPoolRegSignedFile
+    ]
+
+  H.assertFileOccurences 1 "Tx MaryEra" transactionPoolRegSignedFile
+  H.assertEndsWithSingleNewline transactionPoolRegSignedFile
+
+  void $ execCardanoCLI
+    [ "transaction","sign"
+    , "--mainnet"
+    , "--tx-body-file", txBodyFile
+    , "--signing-key-file", ccHotSigningKeyFile
     , "--tx-file", transactionPoolRegSignedFile
     ]
 

--- a/cardano-cli/test/cardano-cli-golden/files/input/governance/cc-cold.skey
+++ b/cardano-cli/test/cardano-cli-golden/files/input/governance/cc-cold.skey
@@ -1,0 +1,5 @@
+{
+    "type": "ConstitutionalCommitteeColdSigningKey_ed25519",
+    "description": "Constitutional Committee Cold Signing Key",
+    "cborHex": "5820ef19a7c87cf4979232da72647fe91f633facd4d1fa817712d6d978ddd68cde33"
+}

--- a/cardano-cli/test/cardano-cli-golden/files/input/governance/cc-cold.vkey
+++ b/cardano-cli/test/cardano-cli-golden/files/input/governance/cc-cold.vkey
@@ -1,0 +1,5 @@
+{
+    "type": "ConstitutionalCommitteeColdVerificationKey_ed25519",
+    "description": "Constitutional Committee Cold Verification Key",
+    "cborHex": "582017c7526f7cd307a361f959b6ab2e7fa339852c9a08309b968023a0df9b84c47a"
+}

--- a/cardano-cli/test/cardano-cli-golden/files/input/governance/cc-hot.skey
+++ b/cardano-cli/test/cardano-cli-golden/files/input/governance/cc-hot.skey
@@ -1,0 +1,5 @@
+{
+    "type": "ConstitutionalCommitteeHotSigningKey_ed25519",
+    "description": "Constitutional Committee Hot Signing Key",
+    "cborHex": "5820d2039207db7cff9dad95b0f98bfe2aea192e9d159e7c0e9a1f31bd2dc8cd4b47"
+}

--- a/cardano-cli/test/cardano-cli-golden/files/input/governance/cc-hot.vkey
+++ b/cardano-cli/test/cardano-cli-golden/files/input/governance/cc-hot.vkey
@@ -1,0 +1,5 @@
+{
+    "type": "ConstitutionalCommitteeHotVerificationKey_ed25519",
+    "description": "Constitutional Committee Hot Verification Key",
+    "cborHex": "58202b35e914764560fcf7655523d303d8cf27fc8306b6e86891802feedcfa087715"
+}

--- a/cardano-cli/test/cardano-cli-golden/files/input/governance/hot-auth.cert
+++ b/cardano-cli/test/cardano-cli-golden/files/input/governance/hot-auth.cert
@@ -1,0 +1,5 @@
+{
+    "type": "CertificateShelley",
+    "description": "Constitutional Committee Hot Key Registration Certificate",
+    "cborHex": "830e8200581c9c0682d5a71b1496ccbe4a79c332fcbc7cb317ec3b8faf6d45723e408200581cbb0fe4aca8548f6fd2050e5bd1b419d12bac166f3719b4959f323908"
+}

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1696413619,
-        "narHash": "sha256-M0+sdwZ2uAf7P73sUys2BBSeOrvdAnews3AEgQuquw8=",
+        "lastModified": 1696532530,
+        "narHash": "sha256-Tabp1I371941jDRh+5X7/zp4cxKACt3H4hrXR5TdA8Y=",
         "owner": "input-output-hk",
         "repo": "cardano-haskell-packages",
-        "rev": "843760eb244f402d48f8e907c33af2148a557fa9",
+        "rev": "6d33ceace68c32707cb6a5d08483dd7c35059f31",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Add support for committee hot key witnesses
# uncomment types applicable to the change:
  type:
  - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Depends on https://github.com/input-output-hk/cardano-api/pull/300

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
