### PR TITLE
PR template: remove that changelog extension is requested twice

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -40,7 +40,6 @@ to the issue.
   - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
   - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
   - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
-- [ ] The changelog section in the PR is updated to describe the change
 - [ ] Self-reviewed the diff
 
 <!-- 


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Remove doublon in PR template
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Like https://github.com/input-output-hk/cardano-api/pull/285, but for cardano-cli this time

As visible in this PR, the Checklist section has a doublon regarding checking that the PR changelog is specified, it contains both:

> The change log section in the PR description has been filled in

and

> The changelog section in the PR is updated to describe the change

This PR removes the second entry.

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] The change log section in the PR description has been filled in
- NA New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- NA The version bounds in `.cabal` files are updated
- [X] CI passes. See note on CI.  The following CI checks are required:`ghc-9.2.7`
- [X] The changelog section in the PR is updated to describe the change
- [X] Self-reviewed the diff