### PR TITLE
Anchors: remove cardano-cli's types

### DIFF
--- a/cardano-cli/src/Cardano/CLI/Types/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Common.hs
@@ -147,14 +147,6 @@ data VoteHashSource
   | VoteHashSourceHash (L.SafeHash Crypto.StandardCrypto L.AnchorData)
   deriving Show
 
-newtype AnchorUrl = AnchorUrl
-  { unAnchorUrl :: L.Url
-  } deriving (Eq, Show)
-
-newtype AnchorDataHash = AnchorDataHash
-  { unAnchorDataHash :: L.SafeHash Crypto.StandardCrypto L.AnchorData
-  } deriving (Eq, Show)
-
 -- | Specify whether to render the script cost as JSON
 -- in the cli's build command.
 data TxBuildOutputOptions = OutputScriptCostOnly (File () Out)


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Anchors: use cardano-api types, remove cardano-cli's ones
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Uses types introduced in cardano-api in https://github.com/input-output-hk/cardano-api/pull/305, delete the cardano-cli ones.

Fixes https://github.com/input-output-hk/cardano-api/issues/301

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] The change log section in the PR description has been filled in
- NA New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- NA The version bounds in `.cabal` files are updated
- [X] CI passes. See note on CI.  The following CI checks are required:
  - [X] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [X] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [X] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [X] Self-reviewed the diff