### PR TITLE
Make drep query parser accept zero or more keys

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Query.hs
@@ -334,7 +334,7 @@ pQueryDRepStateCmd era envCli = do
         <$> pSocketPath envCli
         <*> pConsensusModeParams
         <*> pNetworkId envCli
-        <*> some pDRepVerificationKeyOrHashOrFile
+        <*> many pDRepVerificationKeyOrHashOrFile
         <*> optional pOutputFile
 
 pQueryDRepStakeDistributionCmd :: ()
@@ -353,7 +353,7 @@ pQueryDRepStakeDistributionCmd era envCli = do
       <$> pSocketPath envCli
       <*> pConsensusModeParams
       <*> pNetworkId envCli
-      <*> some pDRepVerificationKeyOrHashOrFile
+      <*> many pDRepVerificationKeyOrHashOrFile
       <*> optional pOutputFile
 
 pQueryGetCommitteeStateCmd :: ()

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -6880,10 +6880,10 @@ Usage: cardano-cli conway query drep-state --socket-path SOCKET_PATH
                                              ( --mainnet
                                              | --testnet-magic NATURAL
                                              )
-                                             ( --drep-verification-key STRING
+                                             [ --drep-verification-key STRING
                                              | --drep-verification-key-file FILE
                                              | --drep-key-hash HASH
-                                             )
+                                             ]
                                              [--out-file FILE]
 
   Get the DRep state. If no DRep credentials are provided, return states for all
@@ -6900,10 +6900,10 @@ Usage: cardano-cli conway query drep-stake-distribution
                                                           ( --mainnet
                                                           | --testnet-magic NATURAL
                                                           )
-                                                          ( --drep-verification-key STRING
+                                                          [ --drep-verification-key STRING
                                                           | --drep-verification-key-file FILE
                                                           | --drep-key-hash HASH
-                                                          )
+                                                          ]
                                                           [--out-file FILE]
 
   Get the DRep stake distribution. If no DRep credentials are provided, return

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_drep-stake-distribution.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_drep-stake-distribution.cli
@@ -9,10 +9,10 @@ Usage: cardano-cli conway query drep-stake-distribution
                                                           ( --mainnet
                                                           | --testnet-magic NATURAL
                                                           )
-                                                          ( --drep-verification-key STRING
+                                                          [ --drep-verification-key STRING
                                                           | --drep-verification-key-file FILE
                                                           | --drep-key-hash HASH
-                                                          )
+                                                          ]
                                                           [--out-file FILE]
 
   Get the DRep stake distribution. If no DRep credentials are provided, return

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_drep-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_drep-state.cli
@@ -8,10 +8,10 @@ Usage: cardano-cli conway query drep-state --socket-path SOCKET_PATH
                                              ( --mainnet
                                              | --testnet-magic NATURAL
                                              )
-                                             ( --drep-verification-key STRING
+                                             [ --drep-verification-key STRING
                                              | --drep-verification-key-file FILE
                                              | --drep-key-hash HASH
-                                             )
+                                             ]
                                              [--out-file FILE]
 
   Get the DRep state. If no DRep credentials are provided, return states for all


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    The `cardano-cli conway governance query drep-state` and `... drep-stake-distribution` now accept zero or more DRep verification keys, making the help messages correct.
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

This will close #346 .

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] The changelog section in the PR is updated to describe the change
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
