### PR TITLE
Plug *-poll legacy commands back

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Poll.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Poll.hs
@@ -4,7 +4,10 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Cardano.CLI.EraBased.Run.Governance.Poll
-  ( runGovernancePollCmds
+  ( runGovernancePollCmds,
+    runGovernanceCreatePoll,
+    runGovernanceAnswerPoll,
+    runGovernanceVerifyPoll
   ) where
 
 import           Cardano.Api

--- a/cardano-cli/src/Cardano/CLI/Legacy/Commands/Governance.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Commands/Governance.hs
@@ -35,6 +35,19 @@ data LegacyGovernanceCmds
       [VerificationKeyFile In]
       ProtocolParametersUpdate
       (Maybe FilePath)
+  | GovernanceCreatePoll
+      Text -- ^ Prompt
+      [Text] -- ^ Choices
+      (Maybe Word) -- ^ Nonce
+      (File GovernancePoll Out)
+  | GovernanceAnswerPoll
+      (File GovernancePoll In) -- ^ Poll file
+      (Maybe Word) -- ^ Answer index
+      (Maybe (File () Out)) -- ^ Tx file
+  | GovernanceVerifyPoll
+      (File GovernancePoll In) -- ^ Poll file
+      (File (Tx ()) In) -- ^ Tx file
+      (Maybe (File () Out)) -- ^ Tx file
   deriving Show
 
 renderLegacyGovernanceCmds :: LegacyGovernanceCmds -> Text
@@ -44,4 +57,7 @@ renderLegacyGovernanceCmds = \case
   GovernanceMIRTransfer _ _ _ TransferToTreasury -> "governance create-mir-certificate transfer-to-treasury"
   GovernanceMIRTransfer _ _ _ TransferToReserves -> "governance create-mir-certificate transfer-to-reserves"
   GovernanceUpdateProposal {} -> "governance create-update-proposal"
+  GovernanceCreatePoll{} -> "governance create-poll"
+  GovernanceAnswerPoll{} -> "governance answer-poll"
+  GovernanceVerifyPoll{} -> "governance verify-poll"
 

--- a/cardano-cli/src/Cardano/CLI/Legacy/Options.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Options.hs
@@ -1032,6 +1032,15 @@ pGovernanceCmds envCli =
     , subParser "create-update-proposal"
         $ Opt.info pUpdateProposal
         $ Opt.progDesc "Create an update proposal"
+    , subParser "create-poll"
+        $ Opt.info pGovernanceCreatePoll
+        $ Opt.progDesc "Create an SPO poll"
+    , subParser "answer-poll"
+        $ Opt.info pGovernanceAnswerPoll
+        $ Opt.progDesc "Answer an SPO poll"
+    , subParser "verify-poll"
+        $ Opt.info pGovernanceVerifyPoll
+        $ Opt.progDesc "Verify an answer to a given SPO poll"
     ]
   where
     mirCertParsers :: Parser LegacyGovernanceCmds
@@ -1089,6 +1098,28 @@ pGovernanceCmds envCli =
         <*> some pGenesisVerificationKeyFile
         <*> pProtocolParametersUpdate
         <*> optional pCostModels
+
+    pGovernanceCreatePoll :: Parser LegacyGovernanceCmds
+    pGovernanceCreatePoll =
+      GovernanceCreatePoll
+        <$> pPollQuestion
+        <*> some pPollAnswer
+        <*> optional pPollNonce
+        <*> pOutputFile
+
+    pGovernanceAnswerPoll :: Parser LegacyGovernanceCmds
+    pGovernanceAnswerPoll =
+      GovernanceAnswerPoll
+        <$> pPollFile
+        <*> optional pPollAnswerIndex
+        <*> optional pOutputFile
+
+    pGovernanceVerifyPoll :: Parser LegacyGovernanceCmds
+    pGovernanceVerifyPoll =
+      GovernanceVerifyPoll
+        <$> pPollFile
+        <*> pPollTxFile
+        <*> optional pOutputFile
 
 pGenesisCmds :: EnvCli -> Parser LegacyGenesisCmds
 pGenesisCmds envCli =

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Governance.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Governance.hs
@@ -24,6 +24,7 @@ import           Data.Aeson (eitherDecode)
 import qualified Data.ByteString.Lazy as LB
 import           Data.Function ((&))
 import qualified Data.Text as Text
+import Cardano.CLI.EraBased.Run.Governance.Poll
 
 runLegacyGovernanceCmds :: LegacyGovernanceCmds -> ExceptT GovernanceCmdError IO ()
 runLegacyGovernanceCmds = \case
@@ -35,6 +36,13 @@ runLegacyGovernanceCmds = \case
     runLegacyGovernanceGenesisKeyDelegationCertificate sbe genVk genDelegVk vrfVk out
   GovernanceUpdateProposal out eNo genVKeys ppUp mCostModelFp ->
     runLegacyGovernanceUpdateProposal out eNo genVKeys ppUp mCostModelFp
+  GovernanceCreatePoll prompt choices nonce out ->
+    runGovernanceCreatePoll BabbageEraOnwardsBabbage  prompt choices nonce out
+  GovernanceAnswerPoll poll ix mOutFile ->
+    runGovernanceAnswerPoll BabbageEraOnwardsBabbage poll ix mOutFile
+  GovernanceVerifyPoll poll metadata mOutFile ->
+    runGovernanceVerifyPoll BabbageEraOnwardsBabbage poll metadata mOutFile
+
 
 runLegacyGovernanceMIRCertificatePayStakeAddrs
   :: EraInEon ShelleyToBabbageEra

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -8722,6 +8722,9 @@ Usage: cardano-cli legacy governance
                                        ( create-mir-certificate
                                        | create-genesis-key-delegation-certificate
                                        | create-update-proposal
+                                       | create-poll
+                                       | answer-poll
+                                       | verify-poll
                                        )
 
   Governance commands
@@ -8847,6 +8850,25 @@ Usage: cardano-cli legacy governance create-update-proposal --out-file FILE
                                                               [--cost-model-file FILE]
 
   Create an update proposal
+
+Usage: cardano-cli legacy governance create-poll --question STRING
+                                                   (--answer STRING)
+                                                   [--nonce UINT]
+                                                   --out-file FILE
+
+  Create an SPO poll
+
+Usage: cardano-cli legacy governance answer-poll --poll-file FILE
+                                                   [--answer INT]
+                                                   [--out-file FILE]
+
+  Answer an SPO poll
+
+Usage: cardano-cli legacy governance verify-poll --poll-file FILE
+                                                   --tx-file FILE
+                                                   [--out-file FILE]
+
+  Verify an answer to a given SPO poll
 
 Usage: cardano-cli legacy genesis 
                                     ( key-gen-genesis
@@ -10012,6 +10034,9 @@ Usage: cardano-cli governance
                                 ( create-mir-certificate
                                 | create-genesis-key-delegation-certificate
                                 | create-update-proposal
+                                | create-poll
+                                | answer-poll
+                                | verify-poll
                                 )
 
   Governance commands
@@ -10137,6 +10162,25 @@ Usage: cardano-cli governance create-update-proposal --out-file FILE
                                                        [--cost-model-file FILE]
 
   Create an update proposal
+
+Usage: cardano-cli governance create-poll --question STRING
+                                            (--answer STRING)
+                                            [--nonce UINT]
+                                            --out-file FILE
+
+  Create an SPO poll
+
+Usage: cardano-cli governance answer-poll --poll-file FILE
+                                            [--answer INT]
+                                            [--out-file FILE]
+
+  Answer an SPO poll
+
+Usage: cardano-cli governance verify-poll --poll-file FILE
+                                            --tx-file FILE
+                                            [--out-file FILE]
+
+  Verify an answer to a given SPO poll
 
 Usage: cardano-cli genesis 
                              ( key-gen-genesis

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/governance.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/governance.cli
@@ -2,6 +2,9 @@ Usage: cardano-cli governance
                                 ( create-mir-certificate
                                 | create-genesis-key-delegation-certificate
                                 | create-update-proposal
+                                | create-poll
+                                | answer-poll
+                                | verify-poll
                                 )
 
   Governance commands
@@ -15,3 +18,6 @@ Available commands:
   create-genesis-key-delegation-certificate
                            Create a genesis key delegation certificate
   create-update-proposal   Create an update proposal
+  create-poll              Create an SPO poll
+  answer-poll              Answer an SPO poll
+  verify-poll              Verify an answer to a given SPO poll

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_answer-poll.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_answer-poll.cli
@@ -1,0 +1,12 @@
+Usage: cardano-cli governance answer-poll --poll-file FILE
+                                            [--answer INT]
+                                            [--out-file FILE]
+
+  Answer an SPO poll
+
+Available options:
+  --poll-file FILE         Filepath to the ongoing poll.
+  --answer INT             The index of the chosen answer in the poll. Optional.
+                           Asked interactively if omitted.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_create-poll.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_create-poll.cli
@@ -1,0 +1,14 @@
+Usage: cardano-cli governance create-poll --question STRING
+                                            (--answer STRING)
+                                            [--nonce UINT]
+                                            --out-file FILE
+
+  Create an SPO poll
+
+Available options:
+  --question STRING        The question for the poll.
+  --answer STRING          A possible choice for the poll. The option is
+                           repeatable.
+  --nonce UINT             An (optional) nonce for non-replayability.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_verify-poll.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_verify-poll.cli
@@ -1,0 +1,12 @@
+Usage: cardano-cli governance verify-poll --poll-file FILE
+                                            --tx-file FILE
+                                            [--out-file FILE]
+
+  Verify an answer to a given SPO poll
+
+Available options:
+  --poll-file FILE         Filepath to the ongoing poll.
+  --tx-file FILE           Filepath to the JSON TxBody or JSON Tx carrying a
+                           valid poll answer.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_governance.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_governance.cli
@@ -2,6 +2,9 @@ Usage: cardano-cli legacy governance
                                        ( create-mir-certificate
                                        | create-genesis-key-delegation-certificate
                                        | create-update-proposal
+                                       | create-poll
+                                       | answer-poll
+                                       | verify-poll
                                        )
 
   Governance commands
@@ -15,3 +18,6 @@ Available commands:
   create-genesis-key-delegation-certificate
                            Create a genesis key delegation certificate
   create-update-proposal   Create an update proposal
+  create-poll              Create an SPO poll
+  answer-poll              Answer an SPO poll
+  verify-poll              Verify an answer to a given SPO poll

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_governance_answer-poll.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_governance_answer-poll.cli
@@ -1,0 +1,12 @@
+Usage: cardano-cli legacy governance answer-poll --poll-file FILE
+                                                   [--answer INT]
+                                                   [--out-file FILE]
+
+  Answer an SPO poll
+
+Available options:
+  --poll-file FILE         Filepath to the ongoing poll.
+  --answer INT             The index of the chosen answer in the poll. Optional.
+                           Asked interactively if omitted.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_governance_create-poll.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_governance_create-poll.cli
@@ -1,0 +1,14 @@
+Usage: cardano-cli legacy governance create-poll --question STRING
+                                                   (--answer STRING)
+                                                   [--nonce UINT]
+                                                   --out-file FILE
+
+  Create an SPO poll
+
+Available options:
+  --question STRING        The question for the poll.
+  --answer STRING          A possible choice for the poll. The option is
+                           repeatable.
+  --nonce UINT             An (optional) nonce for non-replayability.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_governance_verify-poll.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_governance_verify-poll.cli
@@ -1,0 +1,12 @@
+Usage: cardano-cli legacy governance verify-poll --poll-file FILE
+                                                   --tx-file FILE
+                                                   [--out-file FILE]
+
+  Verify an answer to a given SPO poll
+
+Available options:
+  --poll-file FILE         Filepath to the ongoing poll.
+  --tx-file FILE           Filepath to the JSON TxBody or JSON Tx carrying a
+                           valid poll answer.
+  --out-file FILE          The output file.
+  -h,--help                Show this help text


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Bring back legacy *-poll commands
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

@newhoggy witnessed after https://github.com/input-output-hk/cardano-cli/pull/322's merge that it was removing two many cmomands: the `legacy` voting commands should have been kept.

This PR brings back the `legacy` poll commands.

Fix https://github.com/input-output-hk/cardano-cli/issues/340

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] The change log section in the PR description has been filled in
- NA New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- NA The version bounds in `.cabal` files are updated
- [X] CI passes. See note on CI.  The following CI checks are required:
  - [X] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [X] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [X] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [X] Self-reviewed the diff