### PR TITLE
Command argument types for `key` commands

### DIFF
--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -133,6 +133,7 @@ library
                         Cardano.CLI.Legacy.Commands.TextView
                         Cardano.CLI.Legacy.Commands.Transaction
                         Cardano.CLI.Legacy.Options
+                        Cardano.CLI.Legacy.Options.Key
                         Cardano.CLI.Legacy.Run
                         Cardano.CLI.Legacy.Run.Address
                         Cardano.CLI.Legacy.Run.Genesis

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Key.hs
@@ -1,8 +1,17 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE LambdaCase #-}
 
 module Cardano.CLI.EraBased.Commands.Key
   ( KeyCmds (..)
+  , KeyVerificationKeyCmdArgs(..)
+  , KeyNonExtendedKeyCmdArgs(..)
+  , KeyConvertByronKeyCmdArgs(..)
+  , KeyConvertByronGenesisKeyCmdArgs(..)
+  , KeyConvertITNKeyCmdArgs(..)
+  , KeyConvertITNExtendedKeyCmdArgs(..)
+  , KeyConvertITNBip32KeyCmdArgs(..)
+  , KeyConvertCardanoAddressKeyCmdArgs(..)
   , renderKeyCmds
   ) where
 
@@ -13,34 +22,58 @@ import           Cardano.CLI.Types.Common
 import           Data.Text (Text)
 
 data KeyCmds era
-  = KeyVerificationKeyCmd
-      (SigningKeyFile In)
-      (VerificationKeyFile Out)
-  | KeyNonExtendedKeyCmd
-      (VerificationKeyFile In)
-      (VerificationKeyFile Out)
-  | KeyConvertByronKeyCmd
-      (Maybe Text)
-      ByronKeyType
-      (SomeKeyFile In)
-      (File () Out)
-  | KeyConvertByronGenesisKeyCmd
-      VerificationKeyBase64
-      (File () Out)
-  | KeyConvertITNKeyCmd
-      (SomeKeyFile In)
-      (File () Out)
-  | KeyConvertITNExtendedKeyCmd
-      (SomeKeyFile In)
-      (File () Out)
-  | KeyConvertITNBip32KeyCmd
-      (SomeKeyFile In)
-      (File () Out)
-  | KeyConvertCardanoAddressKeyCmd
-      CardanoAddressKeyType
-      (SigningKeyFile In)
-      (File () Out)
+  = KeyVerificationKeyCmd           !KeyVerificationKeyCmdArgs
+  | KeyNonExtendedKeyCmd            !KeyNonExtendedKeyCmdArgs
+  | KeyConvertByronKeyCmd           !KeyConvertByronKeyCmdArgs
+  | KeyConvertByronGenesisKeyCmd    !KeyConvertByronGenesisKeyCmdArgs
+  | KeyConvertITNKeyCmd             !KeyConvertITNKeyCmdArgs
+  | KeyConvertITNExtendedKeyCmd     !KeyConvertITNExtendedKeyCmdArgs
+  | KeyConvertITNBip32KeyCmd        !KeyConvertITNBip32KeyCmdArgs
+  | KeyConvertCardanoAddressKeyCmd  !KeyConvertCardanoAddressKeyCmdArgs
   deriving Show
+
+data KeyVerificationKeyCmdArgs = KeyVerificationKeyCmdArgs
+  { skeyFile  :: !(SigningKeyFile In)
+  , vkeyFile  :: !(VerificationKeyFile Out)
+  } deriving Show
+
+data KeyNonExtendedKeyCmdArgs = KeyNonExtendedKeyCmdArgs
+  { extendedVkeyFileIn      :: !(VerificationKeyFile In)
+  , nonExtendedVkeyFileOut  :: !(VerificationKeyFile Out)
+  } deriving Show
+
+data KeyConvertByronKeyCmdArgs = KeyConvertByronKeyCmdArgs
+  { mPassword       :: !(Maybe Text)      -- ^ Password (if applicable)
+  , byronKeyType    :: !ByronKeyType
+  , someKeyFileIn   :: !(SomeKeyFile In)  -- ^ Input file: old format
+  , someKeyFileOut  :: !(File () Out)     -- ^ Output file: new format
+  } deriving Show
+
+data KeyConvertByronGenesisKeyCmdArgs = KeyConvertByronGenesisKeyCmdArgs
+  { vkey        :: VerificationKeyBase64  -- ^ Input key raw old format
+  , vkeyFileOut :: !(File () Out)         -- ^ Output file: new format
+  } deriving Show
+
+data KeyConvertITNKeyCmdArgs = KeyConvertITNKeyCmdArgs
+  { itnKeyFile  :: !(SomeKeyFile In)
+  , outFile     :: !(File () Out)
+  } deriving Show
+
+data KeyConvertITNExtendedKeyCmdArgs = KeyConvertITNExtendedKeyCmdArgs
+  { itnPrivKeyFile  :: !(SomeKeyFile In)
+  , outFile         :: !(File () Out)
+  } deriving Show
+
+data KeyConvertITNBip32KeyCmdArgs = KeyConvertITNBip32KeyCmdArgs
+  { itnPrivKeyFile  :: !(SomeKeyFile In)
+  , outFile         :: !(File () Out)
+  } deriving Show
+
+data KeyConvertCardanoAddressKeyCmdArgs = KeyConvertCardanoAddressKeyCmdArgs
+  { cardanoAddressKeyType :: !CardanoAddressKeyType
+  , skeyFileIn            :: !(SigningKeyFile In)
+  , skeyFileOut           :: !(File () Out)
+  } deriving Show
 
 renderKeyCmds :: KeyCmds era -> Text
 renderKeyCmds = \case

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Key.hs
@@ -13,30 +13,30 @@ import           Cardano.CLI.Types.Common
 import           Data.Text (Text)
 
 data KeyCmds era
-  = KeyGetVerificationKey
+  = KeyVerificationKeyCmd
       (SigningKeyFile In)
       (VerificationKeyFile Out)
-  | KeyNonExtendedKey
+  | KeyNonExtendedKeyCmd
       (VerificationKeyFile In)
       (VerificationKeyFile Out)
-  | KeyConvertByronKey
+  | KeyConvertByronKeyCmd
       (Maybe Text)
       ByronKeyType
       (SomeKeyFile In)
       (File () Out)
-  | KeyConvertByronGenesisVKey
+  | KeyConvertByronGenesisKeyCmd
       VerificationKeyBase64
       (File () Out)
-  | KeyConvertITNStakeKey
+  | KeyConvertITNKeyCmd
       (SomeKeyFile In)
       (File () Out)
-  | KeyConvertITNExtendedToStakeKey
+  | KeyConvertITNExtendedKeyCmd
       (SomeKeyFile In)
       (File () Out)
-  | KeyConvertITNBip32ToStakeKey
+  | KeyConvertITNBip32KeyCmd
       (SomeKeyFile In)
       (File () Out)
-  | KeyConvertCardanoAddressSigningKey
+  | KeyConvertCardanoAddressKeyCmd
       CardanoAddressKeyType
       (SigningKeyFile In)
       (File () Out)
@@ -44,19 +44,19 @@ data KeyCmds era
 
 renderKeyCmds :: KeyCmds era -> Text
 renderKeyCmds = \case
-  KeyGetVerificationKey {} ->
+  KeyVerificationKeyCmd {} ->
     "key verification-key"
-  KeyNonExtendedKey {} ->
+  KeyNonExtendedKeyCmd {} ->
     "key non-extended-key"
-  KeyConvertByronKey {} ->
+  KeyConvertByronKeyCmd {} ->
     "key convert-byron-key"
-  KeyConvertByronGenesisVKey {} ->
+  KeyConvertByronGenesisKeyCmd {} ->
     "key convert-byron-genesis-key"
-  KeyConvertITNStakeKey {} ->
+  KeyConvertITNKeyCmd {} ->
     "key convert-itn-key"
-  KeyConvertITNExtendedToStakeKey {} ->
+  KeyConvertITNExtendedKeyCmd {} ->
     "key convert-itn-extended-key"
-  KeyConvertITNBip32ToStakeKey {} ->
+  KeyConvertITNBip32KeyCmd {} ->
     "key convert-itn-bip32-key"
-  KeyConvertCardanoAddressSigningKey {} ->
-    "key convert-cardano-address-signing-key"
+  KeyConvertCardanoAddressKeyCmd {} ->
+    "key convert-cardano-address-key"

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Key.hs
@@ -7,7 +7,7 @@ module Cardano.CLI.EraBased.Commands.Key
   , KeyVerificationKeyCmdArgs(..)
   , KeyNonExtendedKeyCmdArgs(..)
   , KeyConvertByronKeyCmdArgs(..)
-  , KeyConvertByronGenesisKeyCmdArgs(..)
+  , KeyConvertByronGenesisVKeyCmdArgs(..)
   , KeyConvertITNKeyCmdArgs(..)
   , KeyConvertITNExtendedKeyCmdArgs(..)
   , KeyConvertITNBip32KeyCmdArgs(..)
@@ -25,54 +25,69 @@ data KeyCmds era
   = KeyVerificationKeyCmd           !KeyVerificationKeyCmdArgs
   | KeyNonExtendedKeyCmd            !KeyNonExtendedKeyCmdArgs
   | KeyConvertByronKeyCmd           !KeyConvertByronKeyCmdArgs
-  | KeyConvertByronGenesisKeyCmd    !KeyConvertByronGenesisKeyCmdArgs
+  | KeyConvertByronGenesisVKeyCmd   !KeyConvertByronGenesisVKeyCmdArgs
   | KeyConvertITNKeyCmd             !KeyConvertITNKeyCmdArgs
   | KeyConvertITNExtendedKeyCmd     !KeyConvertITNExtendedKeyCmdArgs
   | KeyConvertITNBip32KeyCmd        !KeyConvertITNBip32KeyCmdArgs
   | KeyConvertCardanoAddressKeyCmd  !KeyConvertCardanoAddressKeyCmdArgs
   deriving Show
 
+-- | Get a verification key from a signing key. This supports all key types
 data KeyVerificationKeyCmdArgs = KeyVerificationKeyCmdArgs
-  { skeyFile  :: !(SigningKeyFile In)
-  , vkeyFile  :: !(VerificationKeyFile Out)
+  { skeyFile  :: !(SigningKeyFile In)       -- ^ Input filepath of the signing key
+  , vkeyFile  :: !(VerificationKeyFile Out) -- ^ Output filepath of the verification key
   } deriving Show
 
+-- | Get a non-extended verification key from an extended verification key. This
+-- supports all extended key types.
 data KeyNonExtendedKeyCmdArgs = KeyNonExtendedKeyCmdArgs
-  { extendedVkeyFileIn      :: !(VerificationKeyFile In)
-  , nonExtendedVkeyFileOut  :: !(VerificationKeyFile Out)
+  { extendedVkeyFileIn      :: !(VerificationKeyFile In)  -- ^ Input filepath of the ed25519-bip32 verification key
+  , nonExtendedVkeyFileOut  :: !(VerificationKeyFile Out) -- ^ Output filepath of the verification key
   } deriving Show
 
+-- | Convert a Byron payment, genesis or genesis delegate key (signing or
+-- verification) to a corresponding Shelley-format key.
 data KeyConvertByronKeyCmdArgs = KeyConvertByronKeyCmdArgs
-  { mPassword       :: !(Maybe Text)      -- ^ Password (if applicable)
-  , byronKeyType    :: !ByronKeyType
-  , someKeyFileIn   :: !(SomeKeyFile In)  -- ^ Input file: old format
-  , someKeyFileOut  :: !(File () Out)     -- ^ Output file: new format
+  { mPassword       :: !(Maybe Text)      -- ^ Password for signing key (if applicable)
+  , byronKeyType    :: !ByronKeyType      -- ^ The byron key type of the input file
+  , someKeyFileIn   :: !(SomeKeyFile In)  -- ^ Input file containing the byron key
+  , someKeyFileOut  :: !(File () Out)     -- ^ The output file to which the Shelley-format key will be written
   } deriving Show
 
-data KeyConvertByronGenesisKeyCmdArgs = KeyConvertByronGenesisKeyCmdArgs
-  { vkey        :: VerificationKeyBase64  -- ^ Input key raw old format
-  , vkeyFileOut :: !(File () Out)         -- ^ Output file: new format
+-- Convert a Base64-encoded Byron genesis verification key to a Shelley genesis
+-- verification key
+data KeyConvertByronGenesisVKeyCmdArgs = KeyConvertByronGenesisVKeyCmdArgs
+  { vkey        :: !VerificationKeyBase64 -- ^ Base64 string for the Byron genesis verification key
+  , vkeyFileOut :: !(File () Out)         -- ^ The output file
   } deriving Show
 
+-- | Convert an Incentivized Testnet (ITN) non-extended (Ed25519) signing or
+-- verification key to a corresponding Shelley stake key
 data KeyConvertITNKeyCmdArgs = KeyConvertITNKeyCmdArgs
-  { itnKeyFile  :: !(SomeKeyFile In)
-  , outFile     :: !(File () Out)
+  { itnKeyFile  :: !(SomeKeyFile In)      -- ^ Filepath of the ITN key (signing or verification)
+  , outFile     :: !(File () Out)         -- ^ The output file
   } deriving Show
 
+-- | Convert an Incentivized Testnet (ITN) extended (Ed25519Extended) signing key
+-- to a corresponding Shelley stake signing key
 data KeyConvertITNExtendedKeyCmdArgs = KeyConvertITNExtendedKeyCmdArgs
-  { itnPrivKeyFile  :: !(SomeKeyFile In)
-  , outFile         :: !(File () Out)
+  { itnPrivKeyFile  :: !(SomeKeyFile In)  -- ^ Filepath of the ITN signing key
+  , outFile         :: !(File () Out)     -- ^ The output file
   } deriving Show
 
+-- | Convert an Incentivized Testnet (ITN) BIP32 (Ed25519Bip32) signing key to a
+-- corresponding Shelley stake signing key
 data KeyConvertITNBip32KeyCmdArgs = KeyConvertITNBip32KeyCmdArgs
-  { itnPrivKeyFile  :: !(SomeKeyFile In)
-  , outFile         :: !(File () Out)
+  { itnPrivKeyFile  :: !(SomeKeyFile In)  -- ^ Filepath of the ITN signing key
+  , outFile         :: !(File () Out)     -- ^ The output file
   } deriving Show
 
+-- | Convert a cardano-address extended signing key to a corresponding
+-- Shelley-format key
 data KeyConvertCardanoAddressKeyCmdArgs = KeyConvertCardanoAddressKeyCmdArgs
-  { cardanoAddressKeyType :: !CardanoAddressKeyType
-  , skeyFileIn            :: !(SigningKeyFile In)
-  , skeyFileOut           :: !(File () Out)
+  { cardanoAddressKeyType :: !CardanoAddressKeyType -- ^ Address key type of th signing key input file
+  , skeyFileIn            :: !(SigningKeyFile In)   -- ^ Input filepath of the signing key
+  , skeyFileOut           :: !(File () Out)         -- ^ The output file
   } deriving Show
 
 renderKeyCmds :: KeyCmds era -> Text
@@ -83,8 +98,8 @@ renderKeyCmds = \case
     "key non-extended-key"
   KeyConvertByronKeyCmd {} ->
     "key convert-byron-key"
-  KeyConvertByronGenesisKeyCmd {} ->
-    "key convert-byron-genesis-key"
+  KeyConvertByronGenesisVKeyCmd {} ->
+    "key convert-byron-genesis-vkey"
   KeyConvertITNKeyCmd {} ->
     "key convert-itn-key"
   KeyConvertITNExtendedKeyCmd {} ->

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Key.hs
@@ -31,7 +31,7 @@ pKeyCmds =
     )
     [ Just
         $ subParser "verification-key"
-        $ Opt.info pKeyGetVerificationKey
+        $ Opt.info pKeyVerificationKeyCmd
         $ Opt.progDesc
         $ mconcat
             [ "Get a verification key from a signing key. This "
@@ -39,7 +39,7 @@ pKeyCmds =
             ]
     , Just
         $ subParser "non-extended-key"
-        $ Opt.info pKeyNonExtendedKey
+        $ Opt.info pKeyNonExtendedKeyCmd
         $ Opt.progDesc
         $ mconcat
             [ "Get a non-extended verification key from an "
@@ -48,7 +48,7 @@ pKeyCmds =
             ]
     , Just
         $ subParser "convert-byron-key"
-        $ Opt.info pKeyConvertByronKey
+        $ Opt.info pKeyConvertByronKeyCmd
         $ Opt.progDesc
         $ mconcat
             [ "Convert a Byron payment, genesis or genesis "
@@ -57,7 +57,7 @@ pKeyCmds =
             ]
     , Just
         $ subParser "convert-byron-genesis-vkey"
-        $ Opt.info pKeyConvertByronGenesisVKey
+        $ Opt.info pKeyConvertByronGenesisKeyCmd
         $ Opt.progDesc
         $ mconcat
             [ "Convert a Base64-encoded Byron genesis "
@@ -66,7 +66,7 @@ pKeyCmds =
             ]
     , Just
         $ subParser "convert-itn-key"
-        $ Opt.info pKeyConvertITNKey
+        $ Opt.info pKeyConvertITNKeyCmd
         $ Opt.progDesc
         $ mconcat
             [ "Convert an Incentivized Testnet (ITN) non-extended "
@@ -75,7 +75,7 @@ pKeyCmds =
             ]
     , Just
         $ subParser "convert-itn-extended-key"
-        $ Opt.info pKeyConvertITNExtendedKey
+        $ Opt.info pKeyConvertITNExtendedKeyCmd
         $ Opt.progDesc
         $ mconcat
             [ "Convert an Incentivized Testnet (ITN) extended "
@@ -84,7 +84,7 @@ pKeyCmds =
             ]
     , Just
         $ subParser "convert-itn-bip32-key"
-        $ Opt.info pKeyConvertITNBip32Key
+        $ Opt.info pKeyConvertITNBip32KeyCmd
         $ Opt.progDesc
         $ mconcat
             [ "Convert an Incentivized Testnet (ITN) BIP32 "
@@ -93,7 +93,7 @@ pKeyCmds =
             ]
     , Just
         $ subParser "convert-cardano-address-key"
-        $ Opt.info pKeyConvertCardanoAddressSigningKey
+        $ Opt.info pKeyConvertCardanoAddressKeyCmd
         $ Opt.progDesc
         $ mconcat
             [ "Convert a cardano-address extended signing key "
@@ -101,21 +101,21 @@ pKeyCmds =
             ]
     ]
 
-pKeyGetVerificationKey :: Parser (KeyCmds era)
-pKeyGetVerificationKey =
-  KeyGetVerificationKey
+pKeyVerificationKeyCmd :: Parser (KeyCmds era)
+pKeyVerificationKeyCmd =
+  KeyVerificationKeyCmd
     <$> pSigningKeyFileIn
     <*> pVerificationKeyFileOut
 
-pKeyNonExtendedKey :: Parser (KeyCmds era)
-pKeyNonExtendedKey =
-  KeyNonExtendedKey
+pKeyNonExtendedKeyCmd :: Parser (KeyCmds era)
+pKeyNonExtendedKeyCmd =
+  KeyNonExtendedKeyCmd
     <$> pExtendedVerificationKeyFileIn
     <*> pVerificationKeyFileOut
 
-pKeyConvertByronKey :: Parser (KeyCmds era)
-pKeyConvertByronKey =
-  KeyConvertByronKey
+pKeyConvertByronKeyCmd :: Parser (KeyCmds era)
+pKeyConvertByronKeyCmd =
+  KeyConvertByronKeyCmd
     <$> optional pPassword
     <*> pByronKeyType
     <*> pByronKeyFile
@@ -183,9 +183,9 @@ pByronVerificationKeyFile =
     , Opt.completer (Opt.bashCompleter "file")
     ]
 
-pKeyConvertByronGenesisVKey :: Parser (KeyCmds era)
-pKeyConvertByronGenesisVKey =
-  KeyConvertByronGenesisVKey
+pKeyConvertByronGenesisKeyCmd :: Parser (KeyCmds era)
+pKeyConvertByronGenesisKeyCmd =
+  KeyConvertByronGenesisKeyCmd
     <$> pByronGenesisVKeyBase64
     <*> pOutputFile
 
@@ -197,21 +197,21 @@ pByronGenesisVKeyBase64 =
     , Opt.help "Base64 string for the Byron genesis verification key."
     ]
 
-pKeyConvertITNKey :: Parser (KeyCmds era)
-pKeyConvertITNKey =
-  KeyConvertITNStakeKey
+pKeyConvertITNKeyCmd :: Parser (KeyCmds era)
+pKeyConvertITNKeyCmd =
+  KeyConvertITNKeyCmd
     <$> pITNKeyFIle
     <*> pOutputFile
 
-pKeyConvertITNExtendedKey :: Parser (KeyCmds era)
-pKeyConvertITNExtendedKey =
-  KeyConvertITNExtendedToStakeKey
+pKeyConvertITNExtendedKeyCmd :: Parser (KeyCmds era)
+pKeyConvertITNExtendedKeyCmd =
+  KeyConvertITNExtendedKeyCmd
     <$> pITNSigningKeyFile
     <*> pOutputFile
 
-pKeyConvertITNBip32Key :: Parser (KeyCmds era)
-pKeyConvertITNBip32Key =
-  KeyConvertITNBip32ToStakeKey
+pKeyConvertITNBip32KeyCmd :: Parser (KeyCmds era)
+pKeyConvertITNBip32KeyCmd =
+  KeyConvertITNBip32KeyCmd
     <$> pITNSigningKeyFile
     <*> pOutputFile
 
@@ -240,9 +240,9 @@ pITNVerificationKeyFile =
     , Opt.completer (Opt.bashCompleter "file")
     ]
 
-pKeyConvertCardanoAddressSigningKey :: Parser (KeyCmds era)
-pKeyConvertCardanoAddressSigningKey =
-  KeyConvertCardanoAddressSigningKey
+pKeyConvertCardanoAddressKeyCmd :: Parser (KeyCmds era)
+pKeyConvertCardanoAddressKeyCmd =
+  KeyConvertCardanoAddressKeyCmd
     <$> pCardanoAddressKeyType
     <*> pSigningKeyFileIn
     <*> pOutputFile

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Key.hs
@@ -188,8 +188,8 @@ pByronVerificationKeyFile =
 
 pKeyConvertByronGenesisKeyCmd :: Parser (KeyCmds era)
 pKeyConvertByronGenesisKeyCmd =
-  fmap KeyConvertByronGenesisKeyCmd $
-    KeyConvertByronGenesisKeyCmdArgs
+  fmap KeyConvertByronGenesisVKeyCmd $
+    KeyConvertByronGenesisVKeyCmdArgs
       <$> pByronGenesisVKeyBase64
       <*> pOutputFile
 

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Key.hs
@@ -103,23 +103,26 @@ pKeyCmds =
 
 pKeyVerificationKeyCmd :: Parser (KeyCmds era)
 pKeyVerificationKeyCmd =
-  KeyVerificationKeyCmd
-    <$> pSigningKeyFileIn
-    <*> pVerificationKeyFileOut
+  fmap KeyVerificationKeyCmd $
+    KeyVerificationKeyCmdArgs
+      <$> pSigningKeyFileIn
+      <*> pVerificationKeyFileOut
 
 pKeyNonExtendedKeyCmd :: Parser (KeyCmds era)
 pKeyNonExtendedKeyCmd =
-  KeyNonExtendedKeyCmd
-    <$> pExtendedVerificationKeyFileIn
-    <*> pVerificationKeyFileOut
+  fmap KeyNonExtendedKeyCmd $
+    KeyNonExtendedKeyCmdArgs
+      <$> pExtendedVerificationKeyFileIn
+      <*> pVerificationKeyFileOut
 
 pKeyConvertByronKeyCmd :: Parser (KeyCmds era)
 pKeyConvertByronKeyCmd =
-  KeyConvertByronKeyCmd
-    <$> optional pPassword
-    <*> pByronKeyType
-    <*> pByronKeyFile
-    <*> pOutputFile
+  fmap KeyConvertByronKeyCmd $
+    KeyConvertByronKeyCmdArgs
+      <$> optional pPassword
+      <*> pByronKeyType
+      <*> pByronKeyFile
+      <*> pOutputFile
 
 pPassword :: Parser Text
 pPassword =
@@ -185,9 +188,10 @@ pByronVerificationKeyFile =
 
 pKeyConvertByronGenesisKeyCmd :: Parser (KeyCmds era)
 pKeyConvertByronGenesisKeyCmd =
-  KeyConvertByronGenesisKeyCmd
-    <$> pByronGenesisVKeyBase64
-    <*> pOutputFile
+  fmap KeyConvertByronGenesisKeyCmd $
+    KeyConvertByronGenesisKeyCmdArgs
+      <$> pByronGenesisVKeyBase64
+      <*> pOutputFile
 
 pByronGenesisVKeyBase64 :: Parser VerificationKeyBase64
 pByronGenesisVKeyBase64 =
@@ -199,21 +203,24 @@ pByronGenesisVKeyBase64 =
 
 pKeyConvertITNKeyCmd :: Parser (KeyCmds era)
 pKeyConvertITNKeyCmd =
-  KeyConvertITNKeyCmd
-    <$> pITNKeyFIle
-    <*> pOutputFile
+  fmap KeyConvertITNKeyCmd $
+    KeyConvertITNKeyCmdArgs
+      <$> pITNKeyFIle
+      <*> pOutputFile
 
 pKeyConvertITNExtendedKeyCmd :: Parser (KeyCmds era)
 pKeyConvertITNExtendedKeyCmd =
-  KeyConvertITNExtendedKeyCmd
-    <$> pITNSigningKeyFile
-    <*> pOutputFile
+  fmap KeyConvertITNExtendedKeyCmd $
+    KeyConvertITNExtendedKeyCmdArgs
+      <$> pITNSigningKeyFile
+      <*> pOutputFile
 
 pKeyConvertITNBip32KeyCmd :: Parser (KeyCmds era)
 pKeyConvertITNBip32KeyCmd =
-  KeyConvertITNBip32KeyCmd
-    <$> pITNSigningKeyFile
-    <*> pOutputFile
+  fmap KeyConvertITNBip32KeyCmd $
+    KeyConvertITNBip32KeyCmdArgs
+      <$> pITNSigningKeyFile
+      <*> pOutputFile
 
 pITNKeyFIle :: Parser (SomeKeyFile direction)
 pITNKeyFIle =
@@ -242,10 +249,11 @@ pITNVerificationKeyFile =
 
 pKeyConvertCardanoAddressKeyCmd :: Parser (KeyCmds era)
 pKeyConvertCardanoAddressKeyCmd =
-  KeyConvertCardanoAddressKeyCmd
-    <$> pCardanoAddressKeyType
-    <*> pSigningKeyFileIn
-    <*> pOutputFile
+  fmap KeyConvertCardanoAddressKeyCmd $
+    KeyConvertCardanoAddressKeyCmdArgs
+      <$> pCardanoAddressKeyType
+      <*> pSigningKeyFileIn
+      <*> pOutputFile
 
 pCardanoAddressKeyType :: Parser CardanoAddressKeyType
 pCardanoAddressKeyType =

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Key.hs
@@ -9,7 +9,7 @@
 module Cardano.CLI.EraBased.Run.Key
   ( runKeyCmds
 
-  , runConvertByronGenesisKeyCmd
+  , runConvertByronGenesisVKeyCmd
   , runConvertByronKeyCmd
   , runConvertCardanoAddressKeyCmd
   , runConvertITNBip32KeyCmd
@@ -64,8 +64,8 @@ runKeyCmds = \case
     runNonExtendedKeyCmd cmd
   Cmd.KeyConvertByronKeyCmd cmd ->
     runConvertByronKeyCmd cmd
-  Cmd.KeyConvertByronGenesisKeyCmd cmd ->
-    runConvertByronGenesisKeyCmd cmd
+  Cmd.KeyConvertByronGenesisVKeyCmd cmd ->
+    runConvertByronGenesisVKeyCmd cmd
   Cmd.KeyConvertITNKeyCmd cmd ->
     runConvertITNKeyCmd cmd
   Cmd.KeyConvertITNExtendedKeyCmd cmd ->
@@ -260,11 +260,11 @@ convertByronVerificationKey convert vkeyPathOld vkeyPathNew = do
       writeLazyByteStringFile vkeyPathNew $ textEnvelopeToJSON Nothing vk'
 
 
-runConvertByronGenesisKeyCmd
-  :: Cmd.KeyConvertByronGenesisKeyCmdArgs
+runConvertByronGenesisVKeyCmd
+  :: Cmd.KeyConvertByronGenesisVKeyCmdArgs
   -> ExceptT KeyCmdError IO ()
-runConvertByronGenesisKeyCmd
-    Cmd.KeyConvertByronGenesisKeyCmdArgs
+runConvertByronGenesisVKeyCmd
+    Cmd.KeyConvertByronGenesisVKeyCmdArgs
       { Cmd.vkey        = VerificationKeyBase64 b64ByronVKey
       , Cmd.vkeyFileOut = vkeyPathNew
       } = do

--- a/cardano-cli/src/Cardano/CLI/Legacy/Commands/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Commands/Key.hs
@@ -13,23 +13,41 @@ import           Cardano.CLI.Types.Common
 import           Data.Text (Text)
 
 data LegacyKeyCmds
-  = KeyGetVerificationKey (SigningKeyFile In) (VerificationKeyFile Out)
-  | KeyNonExtendedKey  (VerificationKeyFile In) (VerificationKeyFile Out)
-  | KeyConvertByronKey (Maybe Text) ByronKeyType (SomeKeyFile In) (File () Out)
-  | KeyConvertByronGenesisVKey VerificationKeyBase64 (File () Out)
-  | KeyConvertITNStakeKey (SomeKeyFile In) (File () Out)
-  | KeyConvertITNExtendedToStakeKey (SomeKeyFile In) (File () Out)
-  | KeyConvertITNBip32ToStakeKey (SomeKeyFile In) (File () Out)
-  | KeyConvertCardanoAddressSigningKey CardanoAddressKeyType (SigningKeyFile In) (File () Out)
+  = KeyVerificationKeyCmd
+      (SigningKeyFile In)
+      (VerificationKeyFile Out)
+  | KeyNonExtendedKeyCmd
+      (VerificationKeyFile In)
+      (VerificationKeyFile Out)
+  | KeyConvertByronKeyCmd
+      (Maybe Text)
+      ByronKeyType
+      (SomeKeyFile In)
+      (File () Out)
+  | KeyConvertByronGenesisKeyCmd
+      VerificationKeyBase64
+      (File () Out)
+  | KeyConvertITNKeyCmd
+      (SomeKeyFile In)
+      (File () Out)
+  | KeyConvertITNExtendedKeyCmd
+      (SomeKeyFile In) (File () Out)
+  | KeyConvertITNBip32KeyCmd
+      (SomeKeyFile In)
+      (File () Out)
+  | KeyConvertCardanoAddressKeyCmd
+      CardanoAddressKeyType
+      (SigningKeyFile In)
+      (File () Out)
   deriving Show
 
 renderLegacyKeyCmds :: LegacyKeyCmds -> Text
 renderLegacyKeyCmds = \case
-  KeyGetVerificationKey {} -> "key verification-key"
-  KeyNonExtendedKey {} -> "key non-extended-key"
-  KeyConvertByronKey {} -> "key convert-byron-key"
-  KeyConvertByronGenesisVKey {} -> "key convert-byron-genesis-key"
-  KeyConvertITNStakeKey {} -> "key convert-itn-key"
-  KeyConvertITNExtendedToStakeKey {} -> "key convert-itn-extended-key"
-  KeyConvertITNBip32ToStakeKey {} -> "key convert-itn-bip32-key"
-  KeyConvertCardanoAddressSigningKey {} -> "key convert-cardano-address-signing-key"
+  KeyVerificationKeyCmd {} -> "key verification-key"
+  KeyNonExtendedKeyCmd {} -> "key non-extended-key"
+  KeyConvertByronKeyCmd {} -> "key convert-byron-key"
+  KeyConvertByronGenesisKeyCmd {} -> "key convert-byron-genesis-key"
+  KeyConvertITNKeyCmd {} -> "key convert-itn-key"
+  KeyConvertITNExtendedKeyCmd {} -> "key convert-itn-extended-key"
+  KeyConvertITNBip32KeyCmd {} -> "key convert-itn-bip32-key"
+  KeyConvertCardanoAddressKeyCmd {} -> "key convert-cardano-address-key"

--- a/cardano-cli/src/Cardano/CLI/Legacy/Commands/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Commands/Key.hs
@@ -24,7 +24,7 @@ data LegacyKeyCmds
       ByronKeyType
       (SomeKeyFile In)
       (File () Out)
-  | KeyConvertByronGenesisKeyCmd
+  | KeyConvertByronGenesisVKeyCmd
       VerificationKeyBase64
       (File () Out)
   | KeyConvertITNKeyCmd
@@ -46,7 +46,7 @@ renderLegacyKeyCmds = \case
   KeyVerificationKeyCmd {} -> "key verification-key"
   KeyNonExtendedKeyCmd {} -> "key non-extended-key"
   KeyConvertByronKeyCmd {} -> "key convert-byron-key"
-  KeyConvertByronGenesisKeyCmd {} -> "key convert-byron-genesis-key"
+  KeyConvertByronGenesisVKeyCmd {} -> "key convert-byron-genesis-vkey"
   KeyConvertITNKeyCmd {} -> "key convert-itn-key"
   KeyConvertITNExtendedKeyCmd {} -> "key convert-itn-extended-key"
   KeyConvertITNBip32KeyCmd {} -> "key convert-itn-bip32-key"

--- a/cardano-cli/src/Cardano/CLI/Legacy/Options.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Options.hs
@@ -217,14 +217,14 @@ pKeyCmds :: Parser LegacyKeyCmds
 pKeyCmds =
   asum
     [ subParser "verification-key"
-        $ Opt.info pKeyGetVerificationKey
+        $ Opt.info pKeyVerificationKeyCmd
         $ Opt.progDesc
         $ mconcat
             [ "Get a verification key from a signing key. This "
             , " supports all key types."
             ]
     , subParser "non-extended-key"
-        $ Opt.info pKeyNonExtendedKey
+        $ Opt.info pKeyNonExtendedKeyCmd
         $ Opt.progDesc
         $ mconcat
             [ "Get a non-extended verification key from an "
@@ -232,7 +232,7 @@ pKeyCmds =
             , "extended key types."
             ]
     , subParser "convert-byron-key"
-        $ Opt.info pKeyConvertByronKey
+        $ Opt.info pKeyConvertByronKeyCmd
         $ Opt.progDesc
         $ mconcat
             [ "Convert a Byron payment, genesis or genesis "
@@ -240,7 +240,7 @@ pKeyCmds =
             , "corresponding Shelley-format key."
             ]
     , subParser "convert-byron-genesis-vkey"
-        $ Opt.info pKeyConvertByronGenesisVKey
+        $ Opt.info pKeyConvertByronGenesisKeyCmd
         $ Opt.progDesc
         $ mconcat
             [ "Convert a Base64-encoded Byron genesis "
@@ -248,7 +248,7 @@ pKeyCmds =
             , "verification key"
             ]
     , subParser "convert-itn-key"
-        $ Opt.info pKeyConvertITNKey
+        $ Opt.info pKeyConvertITNKeyCmd
         $ Opt.progDesc
         $ mconcat
             [ "Convert an Incentivized Testnet (ITN) non-extended "
@@ -256,7 +256,7 @@ pKeyCmds =
             , "corresponding Shelley stake key"
             ]
     , subParser "convert-itn-extended-key"
-        $ Opt.info pKeyConvertITNExtendedKey
+        $ Opt.info pKeyConvertITNExtendedKeyCmd
         $ Opt.progDesc
         $ mconcat
             [ "Convert an Incentivized Testnet (ITN) extended "
@@ -264,7 +264,7 @@ pKeyCmds =
             , "Shelley stake signing key"
             ]
     , subParser "convert-itn-bip32-key"
-        $ Opt.info pKeyConvertITNBip32Key
+        $ Opt.info pKeyConvertITNBip32KeyCmd
         $ Opt.progDesc
         $ mconcat
             [ "Convert an Incentivized Testnet (ITN) BIP32 "
@@ -272,7 +272,7 @@ pKeyCmds =
             , "Shelley stake signing key"
             ]
     , subParser "convert-cardano-address-key"
-        $ Opt.info pKeyConvertCardanoAddressSigningKey
+        $ Opt.info pKeyConvertCardanoAddressKeyCmd
         $ Opt.progDesc
         $ mconcat
             [ "Convert a cardano-address extended signing key "
@@ -280,21 +280,21 @@ pKeyCmds =
             ]
     ]
   where
-    pKeyGetVerificationKey :: Parser LegacyKeyCmds
-    pKeyGetVerificationKey =
-      KeyGetVerificationKey
+    pKeyVerificationKeyCmd :: Parser LegacyKeyCmds
+    pKeyVerificationKeyCmd =
+      KeyVerificationKeyCmd
         <$> pSigningKeyFileIn
         <*> pVerificationKeyFileOut
 
-    pKeyNonExtendedKey :: Parser LegacyKeyCmds
-    pKeyNonExtendedKey =
-      KeyNonExtendedKey
+    pKeyNonExtendedKeyCmd :: Parser LegacyKeyCmds
+    pKeyNonExtendedKeyCmd =
+      KeyNonExtendedKeyCmd
         <$> pExtendedVerificationKeyFileIn
         <*> pVerificationKeyFileOut
 
-    pKeyConvertByronKey :: Parser LegacyKeyCmds
-    pKeyConvertByronKey =
-      KeyConvertByronKey
+    pKeyConvertByronKeyCmd :: Parser LegacyKeyCmds
+    pKeyConvertByronKeyCmd =
+      KeyConvertByronKeyCmd
         <$> optional pPassword
         <*> pByronKeyType
         <*> pByronKeyFile
@@ -362,9 +362,9 @@ pKeyCmds =
         , Opt.completer (Opt.bashCompleter "file")
         ]
 
-    pKeyConvertByronGenesisVKey :: Parser LegacyKeyCmds
-    pKeyConvertByronGenesisVKey =
-      KeyConvertByronGenesisVKey
+    pKeyConvertByronGenesisKeyCmd :: Parser LegacyKeyCmds
+    pKeyConvertByronGenesisKeyCmd =
+      KeyConvertByronGenesisKeyCmd
         <$> pByronGenesisVKeyBase64
         <*> pOutputFile
 
@@ -376,21 +376,21 @@ pKeyCmds =
         , Opt.help "Base64 string for the Byron genesis verification key."
         ]
 
-    pKeyConvertITNKey :: Parser LegacyKeyCmds
-    pKeyConvertITNKey =
-      KeyConvertITNStakeKey
+    pKeyConvertITNKeyCmd :: Parser LegacyKeyCmds
+    pKeyConvertITNKeyCmd =
+      KeyConvertITNKeyCmd
         <$> pITNKeyFIle
         <*> pOutputFile
 
-    pKeyConvertITNExtendedKey :: Parser LegacyKeyCmds
-    pKeyConvertITNExtendedKey =
-      KeyConvertITNExtendedToStakeKey
+    pKeyConvertITNExtendedKeyCmd :: Parser LegacyKeyCmds
+    pKeyConvertITNExtendedKeyCmd =
+      KeyConvertITNExtendedKeyCmd
         <$> pITNSigningKeyFile
         <*> pOutputFile
 
-    pKeyConvertITNBip32Key :: Parser LegacyKeyCmds
-    pKeyConvertITNBip32Key =
-      KeyConvertITNBip32ToStakeKey
+    pKeyConvertITNBip32KeyCmd :: Parser LegacyKeyCmds
+    pKeyConvertITNBip32KeyCmd =
+      KeyConvertITNBip32KeyCmd
         <$> pITNSigningKeyFile
         <*> pOutputFile
 
@@ -419,9 +419,9 @@ pKeyCmds =
         , Opt.completer (Opt.bashCompleter "file")
         ]
 
-    pKeyConvertCardanoAddressSigningKey :: Parser LegacyKeyCmds
-    pKeyConvertCardanoAddressSigningKey =
-      KeyConvertCardanoAddressSigningKey
+    pKeyConvertCardanoAddressKeyCmd :: Parser LegacyKeyCmds
+    pKeyConvertCardanoAddressKeyCmd =
+      KeyConvertCardanoAddressKeyCmd
         <$> pCardanoAddressKeyType
         <*> pSigningKeyFileIn
         <*> pOutputFile

--- a/cardano-cli/src/Cardano/CLI/Legacy/Options.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Options.hs
@@ -30,20 +30,19 @@ import           Cardano.CLI.Legacy.Commands
 import           Cardano.CLI.Legacy.Commands.Address
 import           Cardano.CLI.Legacy.Commands.Genesis
 import           Cardano.CLI.Legacy.Commands.Governance
-import           Cardano.CLI.Legacy.Commands.Key
 import           Cardano.CLI.Legacy.Commands.Node
 import           Cardano.CLI.Legacy.Commands.Query
 import           Cardano.CLI.Legacy.Commands.StakeAddress
 import           Cardano.CLI.Legacy.Commands.StakePool
 import           Cardano.CLI.Legacy.Commands.TextView
 import           Cardano.CLI.Legacy.Commands.Transaction
+import           Cardano.CLI.Legacy.Options.Key
 import           Cardano.CLI.Parser
 import           Cardano.CLI.Types.Common
 
 import           Data.Foldable
 import           Data.Function
 import           Data.Maybe (fromMaybe, maybeToList)
-import           Data.Text (Text)
 import           Data.Word (Word64)
 import           Options.Applicative hiding (help, str)
 import qualified Options.Applicative as Opt
@@ -212,240 +211,6 @@ pStakeAddressCmds envCli =
         <*> pStakeIdentifier
         <*> pStakePoolVerificationKeyOrHashOrFile Nothing
         <*> pOutputFile
-
-pKeyCmds :: Parser LegacyKeyCmds
-pKeyCmds =
-  asum
-    [ subParser "verification-key"
-        $ Opt.info pKeyVerificationKeyCmd
-        $ Opt.progDesc
-        $ mconcat
-            [ "Get a verification key from a signing key. This "
-            , " supports all key types."
-            ]
-    , subParser "non-extended-key"
-        $ Opt.info pKeyNonExtendedKeyCmd
-        $ Opt.progDesc
-        $ mconcat
-            [ "Get a non-extended verification key from an "
-            , "extended verification key. This supports all "
-            , "extended key types."
-            ]
-    , subParser "convert-byron-key"
-        $ Opt.info pKeyConvertByronKeyCmd
-        $ Opt.progDesc
-        $ mconcat
-            [ "Convert a Byron payment, genesis or genesis "
-            , "delegate key (signing or verification) to a "
-            , "corresponding Shelley-format key."
-            ]
-    , subParser "convert-byron-genesis-vkey"
-        $ Opt.info pKeyConvertByronGenesisKeyCmd
-        $ Opt.progDesc
-        $ mconcat
-            [ "Convert a Base64-encoded Byron genesis "
-            , "verification key to a Shelley genesis "
-            , "verification key"
-            ]
-    , subParser "convert-itn-key"
-        $ Opt.info pKeyConvertITNKeyCmd
-        $ Opt.progDesc
-        $ mconcat
-            [ "Convert an Incentivized Testnet (ITN) non-extended "
-            , "(Ed25519) signing or verification key to a "
-            , "corresponding Shelley stake key"
-            ]
-    , subParser "convert-itn-extended-key"
-        $ Opt.info pKeyConvertITNExtendedKeyCmd
-        $ Opt.progDesc
-        $ mconcat
-            [ "Convert an Incentivized Testnet (ITN) extended "
-            , "(Ed25519Extended) signing key to a corresponding "
-            , "Shelley stake signing key"
-            ]
-    , subParser "convert-itn-bip32-key"
-        $ Opt.info pKeyConvertITNBip32KeyCmd
-        $ Opt.progDesc
-        $ mconcat
-            [ "Convert an Incentivized Testnet (ITN) BIP32 "
-            , "(Ed25519Bip32) signing key to a corresponding "
-            , "Shelley stake signing key"
-            ]
-    , subParser "convert-cardano-address-key"
-        $ Opt.info pKeyConvertCardanoAddressKeyCmd
-        $ Opt.progDesc
-        $ mconcat
-            [ "Convert a cardano-address extended signing key "
-            , "to a corresponding Shelley-format key."
-            ]
-    ]
-  where
-    pKeyVerificationKeyCmd :: Parser LegacyKeyCmds
-    pKeyVerificationKeyCmd =
-      KeyVerificationKeyCmd
-        <$> pSigningKeyFileIn
-        <*> pVerificationKeyFileOut
-
-    pKeyNonExtendedKeyCmd :: Parser LegacyKeyCmds
-    pKeyNonExtendedKeyCmd =
-      KeyNonExtendedKeyCmd
-        <$> pExtendedVerificationKeyFileIn
-        <*> pVerificationKeyFileOut
-
-    pKeyConvertByronKeyCmd :: Parser LegacyKeyCmds
-    pKeyConvertByronKeyCmd =
-      KeyConvertByronKeyCmd
-        <$> optional pPassword
-        <*> pByronKeyType
-        <*> pByronKeyFile
-        <*> pOutputFile
-
-    pPassword :: Parser Text
-    pPassword =
-      Opt.strOption $ mconcat
-        [ Opt.long "password"
-        , Opt.metavar "TEXT"
-        , Opt.help "Password for signing key (if applicable)."
-        ]
-
-    pByronKeyType :: Parser ByronKeyType
-    pByronKeyType =
-      asum
-        [ Opt.flag' (ByronPaymentKey NonLegacyByronKeyFormat) $ mconcat
-            [ Opt.long "byron-payment-key-type"
-            , Opt.help "Use a Byron-era payment key."
-            ]
-        , Opt.flag' (ByronPaymentKey LegacyByronKeyFormat) $ mconcat
-            [ Opt.long "legacy-byron-payment-key-type"
-            , Opt.help "Use a Byron-era payment key, in legacy SL format."
-            ]
-        , Opt.flag' (ByronGenesisKey NonLegacyByronKeyFormat) $ mconcat
-            [ Opt.long "byron-genesis-key-type"
-            , Opt.help "Use a Byron-era genesis key."
-            ]
-        , Opt.flag' (ByronGenesisKey LegacyByronKeyFormat) $ mconcat
-            [ Opt.long "legacy-byron-genesis-key-type"
-            , Opt.help "Use a Byron-era genesis key, in legacy SL format."
-            ]
-        , Opt.flag' (ByronDelegateKey NonLegacyByronKeyFormat) $ mconcat
-            [ Opt.long "byron-genesis-delegate-key-type"
-            , Opt.help "Use a Byron-era genesis delegate key."
-            ]
-        , Opt.flag' (ByronDelegateKey LegacyByronKeyFormat) $ mconcat
-            [ Opt.long "legacy-byron-genesis-delegate-key-type"
-            , Opt.help "Use a Byron-era genesis delegate key, in legacy SL format."
-            ]
-        ]
-
-    pByronKeyFile :: Parser (SomeKeyFile In)
-    pByronKeyFile =
-      asum
-        [ ASigningKeyFile      <$> pByronSigningKeyFile
-        , AVerificationKeyFile <$> pByronVerificationKeyFile
-        ]
-
-    pByronSigningKeyFile :: Parser (SigningKeyFile In)
-    pByronSigningKeyFile =
-      fmap File $ Opt.strOption $ mconcat
-        [ Opt.long "byron-signing-key-file"
-        , Opt.metavar "FILE"
-        , Opt.help "Input filepath of the Byron-format signing key."
-        , Opt.completer (Opt.bashCompleter "file")
-        ]
-
-    pByronVerificationKeyFile :: Parser (VerificationKeyFile In)
-    pByronVerificationKeyFile =
-      fmap File $ Opt.strOption $ mconcat
-        [ Opt.long "byron-verification-key-file"
-        , Opt.metavar "FILE"
-        , Opt.help "Input filepath of the Byron-format verification key."
-        , Opt.completer (Opt.bashCompleter "file")
-        ]
-
-    pKeyConvertByronGenesisKeyCmd :: Parser LegacyKeyCmds
-    pKeyConvertByronGenesisKeyCmd =
-      KeyConvertByronGenesisKeyCmd
-        <$> pByronGenesisVKeyBase64
-        <*> pOutputFile
-
-    pByronGenesisVKeyBase64 :: Parser VerificationKeyBase64
-    pByronGenesisVKeyBase64 =
-      fmap VerificationKeyBase64 $ Opt.strOption $ mconcat
-        [ Opt.long "byron-genesis-verification-key"
-        , Opt.metavar "BASE64"
-        , Opt.help "Base64 string for the Byron genesis verification key."
-        ]
-
-    pKeyConvertITNKeyCmd :: Parser LegacyKeyCmds
-    pKeyConvertITNKeyCmd =
-      KeyConvertITNKeyCmd
-        <$> pITNKeyFIle
-        <*> pOutputFile
-
-    pKeyConvertITNExtendedKeyCmd :: Parser LegacyKeyCmds
-    pKeyConvertITNExtendedKeyCmd =
-      KeyConvertITNExtendedKeyCmd
-        <$> pITNSigningKeyFile
-        <*> pOutputFile
-
-    pKeyConvertITNBip32KeyCmd :: Parser LegacyKeyCmds
-    pKeyConvertITNBip32KeyCmd =
-      KeyConvertITNBip32KeyCmd
-        <$> pITNSigningKeyFile
-        <*> pOutputFile
-
-    pITNKeyFIle :: Parser (SomeKeyFile direction)
-    pITNKeyFIle =
-      asum
-        [ pITNSigningKeyFile
-        , pITNVerificationKeyFile
-        ]
-
-    pITNSigningKeyFile :: Parser (SomeKeyFile direction)
-    pITNSigningKeyFile =
-      fmap (ASigningKeyFile . File) $ Opt.strOption $ mconcat
-        [ Opt.long "itn-signing-key-file"
-        , Opt.metavar "FILE"
-        , Opt.help "Filepath of the ITN signing key."
-        , Opt.completer (Opt.bashCompleter "file")
-        ]
-
-    pITNVerificationKeyFile :: Parser (SomeKeyFile direction)
-    pITNVerificationKeyFile =
-      fmap (AVerificationKeyFile . File) $ Opt.strOption $ mconcat
-        [ Opt.long "itn-verification-key-file"
-        , Opt.metavar "FILE"
-        , Opt.help "Filepath of the ITN verification key."
-        , Opt.completer (Opt.bashCompleter "file")
-        ]
-
-    pKeyConvertCardanoAddressKeyCmd :: Parser LegacyKeyCmds
-    pKeyConvertCardanoAddressKeyCmd =
-      KeyConvertCardanoAddressKeyCmd
-        <$> pCardanoAddressKeyType
-        <*> pSigningKeyFileIn
-        <*> pOutputFile
-
-    pCardanoAddressKeyType :: Parser CardanoAddressKeyType
-    pCardanoAddressKeyType =
-      asum
-        [ Opt.flag' CardanoAddressShelleyPaymentKey $ mconcat
-            [ Opt.long "shelley-payment-key"
-            , Opt.help "Use a Shelley-era extended payment key."
-            ]
-        , Opt.flag' CardanoAddressShelleyStakeKey $ mconcat
-            [ Opt.long "shelley-stake-key"
-            , Opt.help "Use a Shelley-era extended stake key."
-            ]
-        , Opt.flag' CardanoAddressIcarusPaymentKey $ mconcat
-            [ Opt.long "icarus-payment-key"
-            , Opt.help "Use a Byron-era extended payment key formatted in the Icarus style."
-            ]
-        , Opt.flag' CardanoAddressByronPaymentKey $ mconcat
-            [ Opt.long "byron-payment-key"
-            , Opt.help "Use a Byron-era extended payment key formatted in the deprecated Byron style."
-            ]
-        ]
 
 pTransaction :: EnvCli -> Parser LegacyTransactionCmds
 pTransaction envCli =

--- a/cardano-cli/src/Cardano/CLI/Legacy/Options/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Options/Key.hs
@@ -1,0 +1,253 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Cardano.CLI.Legacy.Options.Key
+  ( pKeyCmds
+  ) where
+
+import           Cardano.Api hiding (QueryInShelleyBasedEra (..))
+
+import           Cardano.CLI.EraBased.Options.Common
+import           Cardano.CLI.Legacy.Commands.Key
+import           Cardano.CLI.Types.Common
+
+import           Data.Foldable
+import           Data.Text (Text)
+import           Options.Applicative hiding (help, str)
+import qualified Options.Applicative as Opt
+
+pKeyCmds :: Parser LegacyKeyCmds
+pKeyCmds =
+  asum
+    [ subParser "verification-key"
+        $ Opt.info pKeyVerificationKeyCmd
+        $ Opt.progDesc
+        $ mconcat
+            [ "Get a verification key from a signing key. This "
+            , " supports all key types."
+            ]
+    , subParser "non-extended-key"
+        $ Opt.info pKeyNonExtendedKeyCmd
+        $ Opt.progDesc
+        $ mconcat
+            [ "Get a non-extended verification key from an "
+            , "extended verification key. This supports all "
+            , "extended key types."
+            ]
+    , subParser "convert-byron-key"
+        $ Opt.info pKeyConvertByronKeyCmd
+        $ Opt.progDesc
+        $ mconcat
+            [ "Convert a Byron payment, genesis or genesis "
+            , "delegate key (signing or verification) to a "
+            , "corresponding Shelley-format key."
+            ]
+    , subParser "convert-byron-genesis-vkey"
+        $ Opt.info pKeyConvertByronGenesisKeyCmd
+        $ Opt.progDesc
+        $ mconcat
+            [ "Convert a Base64-encoded Byron genesis "
+            , "verification key to a Shelley genesis "
+            , "verification key"
+            ]
+    , subParser "convert-itn-key"
+        $ Opt.info pKeyConvertITNKeyCmd
+        $ Opt.progDesc
+        $ mconcat
+            [ "Convert an Incentivized Testnet (ITN) non-extended "
+            , "(Ed25519) signing or verification key to a "
+            , "corresponding Shelley stake key"
+            ]
+    , subParser "convert-itn-extended-key"
+        $ Opt.info pKeyConvertITNExtendedKeyCmd
+        $ Opt.progDesc
+        $ mconcat
+            [ "Convert an Incentivized Testnet (ITN) extended "
+            , "(Ed25519Extended) signing key to a corresponding "
+            , "Shelley stake signing key"
+            ]
+    , subParser "convert-itn-bip32-key"
+        $ Opt.info pKeyConvertITNBip32KeyCmd
+        $ Opt.progDesc
+        $ mconcat
+            [ "Convert an Incentivized Testnet (ITN) BIP32 "
+            , "(Ed25519Bip32) signing key to a corresponding "
+            , "Shelley stake signing key"
+            ]
+    , subParser "convert-cardano-address-key"
+        $ Opt.info pKeyConvertCardanoAddressKeyCmd
+        $ Opt.progDesc
+        $ mconcat
+            [ "Convert a cardano-address extended signing key "
+            , "to a corresponding Shelley-format key."
+            ]
+    ]
+
+pKeyVerificationKeyCmd :: Parser LegacyKeyCmds
+pKeyVerificationKeyCmd =
+  KeyVerificationKeyCmd
+    <$> pSigningKeyFileIn
+    <*> pVerificationKeyFileOut
+
+pKeyNonExtendedKeyCmd :: Parser LegacyKeyCmds
+pKeyNonExtendedKeyCmd =
+  KeyNonExtendedKeyCmd
+    <$> pExtendedVerificationKeyFileIn
+    <*> pVerificationKeyFileOut
+
+pKeyConvertByronKeyCmd :: Parser LegacyKeyCmds
+pKeyConvertByronKeyCmd =
+  KeyConvertByronKeyCmd
+    <$> optional pPassword
+    <*> pByronKeyType
+    <*> pByronKeyFile
+    <*> pOutputFile
+
+pPassword :: Parser Text
+pPassword =
+  Opt.strOption $ mconcat
+    [ Opt.long "password"
+    , Opt.metavar "TEXT"
+    , Opt.help "Password for signing key (if applicable)."
+    ]
+
+pByronKeyType :: Parser ByronKeyType
+pByronKeyType =
+  asum
+    [ Opt.flag' (ByronPaymentKey NonLegacyByronKeyFormat) $ mconcat
+        [ Opt.long "byron-payment-key-type"
+        , Opt.help "Use a Byron-era payment key."
+        ]
+    , Opt.flag' (ByronPaymentKey LegacyByronKeyFormat) $ mconcat
+        [ Opt.long "legacy-byron-payment-key-type"
+        , Opt.help "Use a Byron-era payment key, in legacy SL format."
+        ]
+    , Opt.flag' (ByronGenesisKey NonLegacyByronKeyFormat) $ mconcat
+        [ Opt.long "byron-genesis-key-type"
+        , Opt.help "Use a Byron-era genesis key."
+        ]
+    , Opt.flag' (ByronGenesisKey LegacyByronKeyFormat) $ mconcat
+        [ Opt.long "legacy-byron-genesis-key-type"
+        , Opt.help "Use a Byron-era genesis key, in legacy SL format."
+        ]
+    , Opt.flag' (ByronDelegateKey NonLegacyByronKeyFormat) $ mconcat
+        [ Opt.long "byron-genesis-delegate-key-type"
+        , Opt.help "Use a Byron-era genesis delegate key."
+        ]
+    , Opt.flag' (ByronDelegateKey LegacyByronKeyFormat) $ mconcat
+        [ Opt.long "legacy-byron-genesis-delegate-key-type"
+        , Opt.help "Use a Byron-era genesis delegate key, in legacy SL format."
+        ]
+    ]
+
+pByronKeyFile :: Parser (SomeKeyFile In)
+pByronKeyFile =
+  asum
+    [ ASigningKeyFile      <$> pByronSigningKeyFile
+    , AVerificationKeyFile <$> pByronVerificationKeyFile
+    ]
+
+pByronSigningKeyFile :: Parser (SigningKeyFile In)
+pByronSigningKeyFile =
+  fmap File $ Opt.strOption $ mconcat
+    [ Opt.long "byron-signing-key-file"
+    , Opt.metavar "FILE"
+    , Opt.help "Input filepath of the Byron-format signing key."
+    , Opt.completer (Opt.bashCompleter "file")
+    ]
+
+pByronVerificationKeyFile :: Parser (VerificationKeyFile In)
+pByronVerificationKeyFile =
+  fmap File $ Opt.strOption $ mconcat
+    [ Opt.long "byron-verification-key-file"
+    , Opt.metavar "FILE"
+    , Opt.help "Input filepath of the Byron-format verification key."
+    , Opt.completer (Opt.bashCompleter "file")
+    ]
+
+pKeyConvertByronGenesisKeyCmd :: Parser LegacyKeyCmds
+pKeyConvertByronGenesisKeyCmd =
+  KeyConvertByronGenesisKeyCmd
+    <$> pByronGenesisVKeyBase64
+    <*> pOutputFile
+
+pByronGenesisVKeyBase64 :: Parser VerificationKeyBase64
+pByronGenesisVKeyBase64 =
+  fmap VerificationKeyBase64 $ Opt.strOption $ mconcat
+    [ Opt.long "byron-genesis-verification-key"
+    , Opt.metavar "BASE64"
+    , Opt.help "Base64 string for the Byron genesis verification key."
+    ]
+
+pKeyConvertITNKeyCmd :: Parser LegacyKeyCmds
+pKeyConvertITNKeyCmd =
+  KeyConvertITNKeyCmd
+    <$> pITNKeyFIle
+    <*> pOutputFile
+
+pKeyConvertITNExtendedKeyCmd :: Parser LegacyKeyCmds
+pKeyConvertITNExtendedKeyCmd =
+  KeyConvertITNExtendedKeyCmd
+    <$> pITNSigningKeyFile
+    <*> pOutputFile
+
+pKeyConvertITNBip32KeyCmd :: Parser LegacyKeyCmds
+pKeyConvertITNBip32KeyCmd =
+  KeyConvertITNBip32KeyCmd
+    <$> pITNSigningKeyFile
+    <*> pOutputFile
+
+pITNKeyFIle :: Parser (SomeKeyFile direction)
+pITNKeyFIle =
+  asum
+    [ pITNSigningKeyFile
+    , pITNVerificationKeyFile
+    ]
+
+pITNSigningKeyFile :: Parser (SomeKeyFile direction)
+pITNSigningKeyFile =
+  fmap (ASigningKeyFile . File) $ Opt.strOption $ mconcat
+    [ Opt.long "itn-signing-key-file"
+    , Opt.metavar "FILE"
+    , Opt.help "Filepath of the ITN signing key."
+    , Opt.completer (Opt.bashCompleter "file")
+    ]
+
+pITNVerificationKeyFile :: Parser (SomeKeyFile direction)
+pITNVerificationKeyFile =
+  fmap (AVerificationKeyFile . File) $ Opt.strOption $ mconcat
+    [ Opt.long "itn-verification-key-file"
+    , Opt.metavar "FILE"
+    , Opt.help "Filepath of the ITN verification key."
+    , Opt.completer (Opt.bashCompleter "file")
+    ]
+
+pKeyConvertCardanoAddressKeyCmd :: Parser LegacyKeyCmds
+pKeyConvertCardanoAddressKeyCmd =
+  KeyConvertCardanoAddressKeyCmd
+    <$> pCardanoAddressKeyType
+    <*> pSigningKeyFileIn
+    <*> pOutputFile
+
+pCardanoAddressKeyType :: Parser CardanoAddressKeyType
+pCardanoAddressKeyType =
+  asum
+    [ Opt.flag' CardanoAddressShelleyPaymentKey $ mconcat
+        [ Opt.long "shelley-payment-key"
+        , Opt.help "Use a Shelley-era extended payment key."
+        ]
+    , Opt.flag' CardanoAddressShelleyStakeKey $ mconcat
+        [ Opt.long "shelley-stake-key"
+        , Opt.help "Use a Shelley-era extended stake key."
+        ]
+    , Opt.flag' CardanoAddressIcarusPaymentKey $ mconcat
+        [ Opt.long "icarus-payment-key"
+        , Opt.help "Use a Byron-era extended payment key formatted in the Icarus style."
+        ]
+    , Opt.flag' CardanoAddressByronPaymentKey $ mconcat
+        [ Opt.long "byron-payment-key"
+        , Opt.help "Use a Byron-era extended payment key formatted in the deprecated Byron style."
+        ]
+    ]

--- a/cardano-cli/src/Cardano/CLI/Legacy/Options/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Options/Key.hs
@@ -45,7 +45,7 @@ pKeyCmds =
             , "corresponding Shelley-format key."
             ]
     , subParser "convert-byron-genesis-vkey"
-        $ Opt.info pKeyConvertByronGenesisKeyCmd
+        $ Opt.info pKeyConvertByronGenesisVKeyCmd
         $ Opt.progDesc
         $ mconcat
             [ "Convert a Base64-encoded Byron genesis "
@@ -167,9 +167,9 @@ pByronVerificationKeyFile =
     , Opt.completer (Opt.bashCompleter "file")
     ]
 
-pKeyConvertByronGenesisKeyCmd :: Parser LegacyKeyCmds
-pKeyConvertByronGenesisKeyCmd =
-  KeyConvertByronGenesisKeyCmd
+pKeyConvertByronGenesisVKeyCmd :: Parser LegacyKeyCmds
+pKeyConvertByronGenesisVKeyCmd =
+  KeyConvertByronGenesisVKeyCmd
     <$> pByronGenesisVKeyBase64
     <*> pOutputFile
 

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Key.hs
@@ -26,8 +26,8 @@ runLegacyKeyCmds = \case
     runLegacyNonExtendedKeyCmd evkf vkf
   KeyConvertByronKeyCmd mPassword keytype skfOld skfNew ->
     runLegacyConvertByronKeyCmd mPassword keytype skfOld skfNew
-  KeyConvertByronGenesisKeyCmd oldVk newVkf ->
-    runLegacyConvertByronGenesisKeyCmd oldVk newVkf
+  KeyConvertByronGenesisVKeyCmd oldVk newVkf ->
+    runLegacyConvertByronGenesisVKeyCmd oldVk newVkf
   KeyConvertITNKeyCmd itnKeyFile outFile ->
     runLegacyConvertITNStakeKeyCmd itnKeyFile outFile
   KeyConvertITNExtendedKeyCmd itnPrivKeyFile outFile ->
@@ -63,13 +63,13 @@ runLegacyConvertByronKeyCmd mPassword keytype skfOld skfNew =
   runConvertByronKeyCmd $
     Cmd.KeyConvertByronKeyCmdArgs mPassword keytype skfOld skfNew
 
-runLegacyConvertByronGenesisKeyCmd :: ()
+runLegacyConvertByronGenesisVKeyCmd :: ()
   => VerificationKeyBase64  -- ^ Input key raw old format
   -> File () Out            -- ^ Output file: new format
   -> ExceptT KeyCmdError IO ()
-runLegacyConvertByronGenesisKeyCmd oldVk newVkf =
-  runConvertByronGenesisKeyCmd $
-    Cmd.KeyConvertByronGenesisKeyCmdArgs oldVk newVkf
+runLegacyConvertByronGenesisVKeyCmd oldVk newVkf =
+  runConvertByronGenesisVKeyCmd $
+    Cmd.KeyConvertByronGenesisVKeyCmdArgs oldVk newVkf
 
 --------------------------------------------------------------------------------
 -- ITN verification/signing key conversion to Haskell verficiation/signing keys

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Key.hs
@@ -19,34 +19,34 @@ runLegacyKeyCmds :: ()
   => LegacyKeyCmds
   -> ExceptT KeyCmdError IO ()
 runLegacyKeyCmds = \case
-  KeyGetVerificationKey skf vkf ->
-    runLegacyGetVerificationKeyCmd skf vkf
-  KeyNonExtendedKey evkf vkf ->
-    runLegacyConvertToNonExtendedKeyCmd evkf vkf
-  KeyConvertByronKey mPassword keytype skfOld skfNew ->
+  KeyVerificationKeyCmd skf vkf ->
+    runLegacyVerificationKeyCmd skf vkf
+  KeyNonExtendedKeyCmd evkf vkf ->
+    runLegacyNonExtendedKeyCmd evkf vkf
+  KeyConvertByronKeyCmd mPassword keytype skfOld skfNew ->
     runLegacyConvertByronKeyCmd mPassword keytype skfOld skfNew
-  KeyConvertByronGenesisVKey oldVk newVkf ->
-    runLegacyConvertByronGenesisVerificationKeyCmd oldVk newVkf
-  KeyConvertITNStakeKey itnKeyFile outFile ->
+  KeyConvertByronGenesisKeyCmd oldVk newVkf ->
+    runLegacyConvertByronGenesisKeyCmd oldVk newVkf
+  KeyConvertITNKeyCmd itnKeyFile outFile ->
     runLegacyConvertITNStakeKeyCmd itnKeyFile outFile
-  KeyConvertITNExtendedToStakeKey itnPrivKeyFile outFile ->
-    runLegacyConvertITNExtendedToStakeKeyCmd itnPrivKeyFile outFile
-  KeyConvertITNBip32ToStakeKey itnPrivKeyFile outFile ->
-    runLegacyConvertITNBip32ToStakeKeyCmd itnPrivKeyFile outFile
-  KeyConvertCardanoAddressSigningKey keyType skfOld skfNew ->
-    runLegacyConvertCardanoAddressSigningKeyCmd keyType skfOld skfNew
+  KeyConvertITNExtendedKeyCmd itnPrivKeyFile outFile ->
+    runLegacyConvertITNExtendedKeyCmd itnPrivKeyFile outFile
+  KeyConvertITNBip32KeyCmd itnPrivKeyFile outFile ->
+    runLegacyConvertITNBip32KeyCmd itnPrivKeyFile outFile
+  KeyConvertCardanoAddressKeyCmd keyType skfOld skfNew ->
+    runLegacyConvertCardanoAddressKeyCmd keyType skfOld skfNew
 
-runLegacyGetVerificationKeyCmd :: ()
+runLegacyVerificationKeyCmd :: ()
   => SigningKeyFile In
   -> VerificationKeyFile Out
   -> ExceptT KeyCmdError IO ()
-runLegacyGetVerificationKeyCmd = runGetVerificationKeyCmd
+runLegacyVerificationKeyCmd = runVerificationKeyCmd
 
-runLegacyConvertToNonExtendedKeyCmd :: ()
+runLegacyNonExtendedKeyCmd :: ()
   => VerificationKeyFile In
   -> VerificationKeyFile Out
   -> ExceptT KeyCmdError IO ()
-runLegacyConvertToNonExtendedKeyCmd = runConvertToNonExtendedKeyCmd
+runLegacyNonExtendedKeyCmd = runNonExtendedKeyCmd
 
 runLegacyConvertByronKeyCmd :: ()
   => Maybe Text      -- ^ Password (if applicable)
@@ -56,11 +56,11 @@ runLegacyConvertByronKeyCmd :: ()
   -> ExceptT KeyCmdError IO ()
 runLegacyConvertByronKeyCmd = runConvertByronKeyCmd
 
-runLegacyConvertByronGenesisVerificationKeyCmd :: ()
+runLegacyConvertByronGenesisKeyCmd :: ()
   => VerificationKeyBase64  -- ^ Input key raw old format
   -> File () Out            -- ^ Output file: new format
   -> ExceptT KeyCmdError IO ()
-runLegacyConvertByronGenesisVerificationKeyCmd = runConvertByronGenesisVerificationKeyCmd
+runLegacyConvertByronGenesisKeyCmd = runConvertByronGenesisKeyCmd
 
 --------------------------------------------------------------------------------
 -- ITN verification/signing key conversion to Haskell verficiation/signing keys
@@ -70,23 +70,23 @@ runLegacyConvertITNStakeKeyCmd :: ()
   => SomeKeyFile In
   -> File () Out
   -> ExceptT KeyCmdError IO ()
-runLegacyConvertITNStakeKeyCmd = runConvertITNStakeKeyCmd
+runLegacyConvertITNStakeKeyCmd = runConvertITNKeyCmd
 
-runLegacyConvertITNExtendedToStakeKeyCmd :: ()
+runLegacyConvertITNExtendedKeyCmd :: ()
   => SomeKeyFile In
   -> File () Out
   -> ExceptT KeyCmdError IO ()
-runLegacyConvertITNExtendedToStakeKeyCmd = runConvertITNExtendedToStakeKeyCmd
+runLegacyConvertITNExtendedKeyCmd = runConvertITNExtendedKeyCmd
 
-runLegacyConvertITNBip32ToStakeKeyCmd :: ()
+runLegacyConvertITNBip32KeyCmd :: ()
   => SomeKeyFile In
   -> File () Out
   -> ExceptT KeyCmdError IO ()
-runLegacyConvertITNBip32ToStakeKeyCmd = runConvertITNBip32ToStakeKeyCmd
+runLegacyConvertITNBip32KeyCmd = runConvertITNBip32KeyCmd
 
-runLegacyConvertCardanoAddressSigningKeyCmd :: ()
+runLegacyConvertCardanoAddressKeyCmd :: ()
   => CardanoAddressKeyType
   -> SigningKeyFile In
   -> File () Out
   -> ExceptT KeyCmdError IO ()
-runLegacyConvertCardanoAddressSigningKeyCmd = runConvertCardanoAddressSigningKeyCmd
+runLegacyConvertCardanoAddressKeyCmd = runConvertCardanoAddressKeyCmd

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Key.hs
@@ -7,6 +7,7 @@ module Cardano.CLI.Legacy.Run.Key
 
 import           Cardano.Api
 
+import qualified Cardano.CLI.EraBased.Commands.Key as Cmd
 import           Cardano.CLI.EraBased.Run.Key
 import           Cardano.CLI.Legacy.Commands.Key
 import           Cardano.CLI.Types.Common
@@ -40,13 +41,17 @@ runLegacyVerificationKeyCmd :: ()
   => SigningKeyFile In
   -> VerificationKeyFile Out
   -> ExceptT KeyCmdError IO ()
-runLegacyVerificationKeyCmd = runVerificationKeyCmd
+runLegacyVerificationKeyCmd skf vkf =
+  runVerificationKeyCmd $
+    Cmd.KeyVerificationKeyCmdArgs skf vkf
 
 runLegacyNonExtendedKeyCmd :: ()
   => VerificationKeyFile In
   -> VerificationKeyFile Out
   -> ExceptT KeyCmdError IO ()
-runLegacyNonExtendedKeyCmd = runNonExtendedKeyCmd
+runLegacyNonExtendedKeyCmd evkf vkf =
+  runNonExtendedKeyCmd $
+    Cmd.KeyNonExtendedKeyCmdArgs evkf vkf
 
 runLegacyConvertByronKeyCmd :: ()
   => Maybe Text      -- ^ Password (if applicable)
@@ -54,13 +59,17 @@ runLegacyConvertByronKeyCmd :: ()
   -> SomeKeyFile In  -- ^ Input file: old format
   -> File () Out     -- ^ Output file: new format
   -> ExceptT KeyCmdError IO ()
-runLegacyConvertByronKeyCmd = runConvertByronKeyCmd
+runLegacyConvertByronKeyCmd mPassword keytype skfOld skfNew =
+  runConvertByronKeyCmd $
+    Cmd.KeyConvertByronKeyCmdArgs mPassword keytype skfOld skfNew
 
 runLegacyConvertByronGenesisKeyCmd :: ()
   => VerificationKeyBase64  -- ^ Input key raw old format
   -> File () Out            -- ^ Output file: new format
   -> ExceptT KeyCmdError IO ()
-runLegacyConvertByronGenesisKeyCmd = runConvertByronGenesisKeyCmd
+runLegacyConvertByronGenesisKeyCmd oldVk newVkf =
+  runConvertByronGenesisKeyCmd $
+    Cmd.KeyConvertByronGenesisKeyCmdArgs oldVk newVkf
 
 --------------------------------------------------------------------------------
 -- ITN verification/signing key conversion to Haskell verficiation/signing keys
@@ -70,23 +79,31 @@ runLegacyConvertITNStakeKeyCmd :: ()
   => SomeKeyFile In
   -> File () Out
   -> ExceptT KeyCmdError IO ()
-runLegacyConvertITNStakeKeyCmd = runConvertITNKeyCmd
+runLegacyConvertITNStakeKeyCmd itnKeyFile outFile =
+  runConvertITNKeyCmd $
+    Cmd.KeyConvertITNKeyCmdArgs itnKeyFile outFile
 
 runLegacyConvertITNExtendedKeyCmd :: ()
   => SomeKeyFile In
   -> File () Out
   -> ExceptT KeyCmdError IO ()
-runLegacyConvertITNExtendedKeyCmd = runConvertITNExtendedKeyCmd
+runLegacyConvertITNExtendedKeyCmd itnPrivKeyFile outFile =
+  runConvertITNExtendedKeyCmd $
+    Cmd.KeyConvertITNExtendedKeyCmdArgs itnPrivKeyFile outFile
 
 runLegacyConvertITNBip32KeyCmd :: ()
   => SomeKeyFile In
   -> File () Out
   -> ExceptT KeyCmdError IO ()
-runLegacyConvertITNBip32KeyCmd = runConvertITNBip32KeyCmd
+runLegacyConvertITNBip32KeyCmd itnPrivKeyFile outFile =
+  runConvertITNBip32KeyCmd $
+    Cmd.KeyConvertITNBip32KeyCmdArgs itnPrivKeyFile outFile
 
 runLegacyConvertCardanoAddressKeyCmd :: ()
   => CardanoAddressKeyType
   -> SigningKeyFile In
   -> File () Out
   -> ExceptT KeyCmdError IO ()
-runLegacyConvertCardanoAddressKeyCmd = runConvertCardanoAddressKeyCmd
+runLegacyConvertCardanoAddressKeyCmd keyType skfOld skfNew =
+  runConvertCardanoAddressKeyCmd $
+    Cmd.KeyConvertCardanoAddressKeyCmdArgs keyType skfOld skfNew


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Command argument types for `key` commands
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

We are standardising on having a separate type to describe each command.

This PR refactors all the era-based key commands to this style in preparation for the next step which is to move some governance key commands into this command group.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
