### PR TITLE
Command argument types for governance key commands

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/Committee.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/Committee.hs
@@ -22,8 +22,8 @@ import           Data.Text (Text)
 data GovernanceCommitteeCmds era
   = GovernanceCommitteeKeyGenColdCmd                            (GovernanceCommitteeKeyGenColdCmdArgs                           era)
   | GovernanceCommitteeKeyGenHotCmd                             (GovernanceCommitteeKeyGenHotCmdArgs                            era)
-  | GovernanceCommitteeKeyHashCmd                               (GovernanceCommitteeKeyHashCmdArgs                              era) -- TODO to be moved under the top-level command group "key"
-  | GovernanceCommitteeCreateHotKeyAuthorizationCertificateCmd  (GovernanceCommitteeCreateHotKeyAuthorizationCertificateCmdArgs era) -- TODO to be moved under the top-level command group "key"
+  | GovernanceCommitteeKeyHashCmd                               (GovernanceCommitteeKeyHashCmdArgs                              era)
+  | GovernanceCommitteeCreateHotKeyAuthorizationCertificateCmd  (GovernanceCommitteeCreateHotKeyAuthorizationCertificateCmdArgs era)
   | GovernanceCommitteeCreateColdKeyResignationCertificateCmd   (GovernanceCommitteeCreateColdKeyResignationCertificateCmdArgs  era)
   deriving Show
 
@@ -41,14 +41,12 @@ data GovernanceCommitteeKeyGenHotCmdArgs era =
     , skeyOutFile :: !(File (SigningKey ()) Out)
     } deriving Show
 
- -- TODO to be moved under the top-level command group "key"
 data GovernanceCommitteeKeyHashCmdArgs era =
   GovernanceCommitteeKeyHashCmdArgs
     { eon         :: !(ConwayEraOnwards era)
     , vkeySource  :: !AnyVerificationKeySource
     } deriving Show
 
--- TODO to be moved under the top-level command group "key"
 data GovernanceCommitteeCreateHotKeyAuthorizationCertificateCmdArgs era =
   GovernanceCommitteeCreateHotKeyAuthorizationCertificateCmdArgs
     { eon               :: !(ConwayEraOnwards era)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/Committee.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/Committee.hs
@@ -1,8 +1,14 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE LambdaCase #-}
 
 module Cardano.CLI.EraBased.Commands.Governance.Committee
   ( GovernanceCommitteeCmds(..)
+  , GovernanceCommitteeKeyGenColdCmdArgs(..)
+  , GovernanceCommitteeKeyGenHotCmdArgs(..)
+  , GovernanceCommitteeKeyHashCmdArgs(..)
+  , GovernanceCommitteeCreateHotKeyAuthorizationCertificateCmdArgs(..)
+  , GovernanceCommitteeCreateColdKeyResignationCertificateCmdArgs(..)
   , renderGovernanceCommitteeCmds
   ) where
 
@@ -14,27 +20,49 @@ import           Cardano.CLI.Types.Key.VerificationKey
 import           Data.Text (Text)
 
 data GovernanceCommitteeCmds era
-  = GovernanceCommitteeKeyGenColdCmd
-      (ConwayEraOnwards era)
-      (File (VerificationKey ()) Out)
-      (File (SigningKey ()) Out)
-  | GovernanceCommitteeKeyGenHotCmd
-      (ConwayEraOnwards era)
-      (File (VerificationKey ()) Out)
-      (File (SigningKey ()) Out)
-  | GovernanceCommitteeKeyHashCmd -- TODO to be moved under the top-level command group "key"
-      (ConwayEraOnwards era)
-      AnyVerificationKeySource
-  | GovernanceCommitteeCreateHotKeyAuthorizationCertificateCmd -- TODO to be moved under the top-level command group "key"
-      (ConwayEraOnwards era)
-      (VerificationKeyOrHashOrFile CommitteeColdKey)
-      (VerificationKeyOrHashOrFile CommitteeHotKey)
-      (File () Out)
-  | GovernanceCommitteeCreateColdKeyResignationCertificateCmd
-      (ConwayEraOnwards era)
-      (VerificationKeyOrHashOrFile CommitteeColdKey)
-      (File () Out)
+  = GovernanceCommitteeKeyGenColdCmd                            (GovernanceCommitteeKeyGenColdCmdArgs                           era)
+  | GovernanceCommitteeKeyGenHotCmd                             (GovernanceCommitteeKeyGenHotCmdArgs                            era)
+  | GovernanceCommitteeKeyHashCmd                               (GovernanceCommitteeKeyHashCmdArgs                              era) -- TODO to be moved under the top-level command group "key"
+  | GovernanceCommitteeCreateHotKeyAuthorizationCertificateCmd  (GovernanceCommitteeCreateHotKeyAuthorizationCertificateCmdArgs era) -- TODO to be moved under the top-level command group "key"
+  | GovernanceCommitteeCreateColdKeyResignationCertificateCmd   (GovernanceCommitteeCreateColdKeyResignationCertificateCmdArgs  era)
   deriving Show
+
+data GovernanceCommitteeKeyGenColdCmdArgs era =
+  GovernanceCommitteeKeyGenColdCmdArgs
+    { eon         :: !(ConwayEraOnwards era)
+    , vkeyOutFile :: !(File (VerificationKey ()) Out)
+    , skeyOutFile :: !(File (SigningKey ()) Out)
+    } deriving Show
+
+data GovernanceCommitteeKeyGenHotCmdArgs era =
+  GovernanceCommitteeKeyGenHotCmdArgs
+    { eon         :: !(ConwayEraOnwards era)
+    , vkeyOutFile :: !(File (VerificationKey ()) Out)
+    , skeyOutFile :: !(File (SigningKey ()) Out)
+    } deriving Show
+
+ -- TODO to be moved under the top-level command group "key"
+data GovernanceCommitteeKeyHashCmdArgs era =
+  GovernanceCommitteeKeyHashCmdArgs
+    { eon         :: !(ConwayEraOnwards era)
+    , vkeySource  :: !AnyVerificationKeySource
+    } deriving Show
+
+-- TODO to be moved under the top-level command group "key"
+data GovernanceCommitteeCreateHotKeyAuthorizationCertificateCmdArgs era =
+  GovernanceCommitteeCreateHotKeyAuthorizationCertificateCmdArgs
+    { eon               :: !(ConwayEraOnwards era)
+    , vkeyColdKeySource :: !(VerificationKeyOrHashOrFile CommitteeColdKey)
+    , vkeyHotKeySource  :: !(VerificationKeyOrHashOrFile CommitteeHotKey)
+    , outFile           :: !(File () Out)
+    } deriving Show
+
+data GovernanceCommitteeCreateColdKeyResignationCertificateCmdArgs era =
+  GovernanceCommitteeCreateColdKeyResignationCertificateCmdArgs
+    { eon               :: !(ConwayEraOnwards era)
+    , vkeyColdKeySource :: !(VerificationKeyOrHashOrFile CommitteeColdKey)
+    , outFile           :: !(File () Out)
+    } deriving Show
 
 renderGovernanceCommitteeCmds :: GovernanceCommitteeCmds era -> Text
 renderGovernanceCommitteeCmds = \case

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Committee.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Committee.hs
@@ -46,9 +46,10 @@ pGovernanceCommitteeKeyGenColdCmd era = do
       => ConwayEraOnwards era
       -> Parser (GovernanceCommitteeCmds era)
     pCmd w =
-      GovernanceCommitteeKeyGenColdCmd w
-        <$> pColdVerificationKeyFile
-        <*> pColdSigningKeyFile
+      fmap GovernanceCommitteeKeyGenColdCmd $
+        GovernanceCommitteeKeyGenColdCmdArgs w
+          <$> pColdVerificationKeyFile
+          <*> pColdSigningKeyFile
 
 pGovernanceCommitteeKeyGenHotCmd :: ()
   => CardanoEra era
@@ -67,9 +68,10 @@ pGovernanceCommitteeKeyGenHotCmd era = do
       => ConwayEraOnwards era
       -> Parser (GovernanceCommitteeCmds era)
     pCmd w =
-      GovernanceCommitteeKeyGenHotCmd w
-        <$> pVerificationKeyFileOut
-        <*> pSigningKeyFileOut
+      fmap GovernanceCommitteeKeyGenHotCmd $
+        GovernanceCommitteeKeyGenHotCmdArgs w
+          <$> pVerificationKeyFileOut
+          <*> pSigningKeyFileOut
 
 pGovernanceCommitteeKeyHashCmd :: ()
   => CardanoEra era
@@ -79,8 +81,9 @@ pGovernanceCommitteeKeyHashCmd era = do
   pure
     $ subParser "key-hash"
     $ Opt.info
-        ( GovernanceCommitteeKeyHashCmd w
-            <$> pAnyVerificationKeySource "Constitutional Committee Member key (hot or cold)"
+        ( fmap GovernanceCommitteeKeyHashCmd $
+            GovernanceCommitteeKeyHashCmdArgs w
+              <$> pAnyVerificationKeySource "Constitutional Committee Member key (hot or cold)"
         )
     $ Opt.progDesc
     $ mconcat
@@ -95,10 +98,11 @@ pGovernanceCommitteeCreateHotKeyAuthorizationCertificateCmd era = do
   pure
     $ subParser "create-hot-key-authorization-certificate"
     $ Opt.info
-        ( GovernanceCommitteeCreateHotKeyAuthorizationCertificateCmd w
-            <$> pCommitteeColdVerificationKeyOrHashOrFile
-            <*> pCommitteeHotKeyOrHashOrFile
-            <*> pOutputFile
+        ( fmap GovernanceCommitteeCreateHotKeyAuthorizationCertificateCmd $
+            GovernanceCommitteeCreateHotKeyAuthorizationCertificateCmdArgs w
+              <$> pCommitteeColdVerificationKeyOrHashOrFile
+              <*> pCommitteeHotKeyOrHashOrFile
+              <*> pOutputFile
         )
     $ Opt.progDesc
     $ mconcat
@@ -113,9 +117,10 @@ pGovernanceCommitteeCreateColdKeyResignationCertificateCmd era = do
   pure
     $ subParser "create-cold-key-resignation-certificate"
     $ Opt.info
-        ( GovernanceCommitteeCreateColdKeyResignationCertificateCmd w
-            <$> pCommitteeColdVerificationKeyOrHashOrFile
-            <*> pOutputFile
+        ( fmap GovernanceCommitteeCreateColdKeyResignationCertificateCmd $
+            GovernanceCommitteeCreateColdKeyResignationCertificateCmdArgs w
+              <$> pCommitteeColdVerificationKeyOrHashOrFile
+              <*> pOutputFile
         )
     $ Opt.progDesc
     $ mconcat


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Command argument types for `governance key` commands
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context


# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
