### PR TITLE
Shelley to Alonzo: add create-genesis-key-delegation-certificate to governance

### DIFF
--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -108,6 +108,7 @@ library
                         Cardano.CLI.EraBased.Run.Governance.Actions
                         Cardano.CLI.EraBased.Run.Governance.Committee
                         Cardano.CLI.EraBased.Run.Governance.DRep
+                        Cardano.CLI.EraBased.Run.Governance.GenesisKeyDelegationCertificate
                         Cardano.CLI.EraBased.Run.Governance.Poll
                         Cardano.CLI.EraBased.Run.Governance.Vote
                         Cardano.CLI.EraBased.Run.Key

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance.hs
@@ -8,6 +8,7 @@ module Cardano.CLI.EraBased.Commands.Governance
   ) where
 
 import           Cardano.Api
+import           Cardano.Api.Shelley (VrfKey)
 
 import           Cardano.CLI.EraBased.Commands.Governance.Actions
 import           Cardano.CLI.EraBased.Commands.Governance.Committee
@@ -15,6 +16,7 @@ import           Cardano.CLI.EraBased.Commands.Governance.DRep
 import           Cardano.CLI.EraBased.Commands.Governance.Poll
 import           Cardano.CLI.EraBased.Commands.Governance.Vote
 import           Cardano.CLI.Types.Common
+import           Cardano.CLI.Types.Key (VerificationKeyOrHashOrFile)
 
 import           Data.Text (Text)
 
@@ -30,6 +32,12 @@ data GovernanceCmds era
       Lovelace
       (File () Out)
       TransferDirection
+  | GovernanceGenesisKeyDelegationCertificate
+      (ShelleyToAlonzoEra era)
+      (VerificationKeyOrHashOrFile GenesisKey)
+      (VerificationKeyOrHashOrFile GenesisDelegateKey)
+      (VerificationKeyOrHashOrFile VrfKey)
+      (File () Out)
   | GovernanceActionCmds
       (GovernanceActionCmds era)
   | GovernanceCommitteeCmds
@@ -49,6 +57,8 @@ renderGovernanceCmds = \case
     "governance create-mir-certificate transfer-to-treasury"
   GovernanceMIRTransfer _ _ _ TransferToReserves ->
     "governance create-mir-certificate transfer-to-reserves"
+  GovernanceGenesisKeyDelegationCertificate {} ->
+    "governance create-genesis-key-delegation-certificate"
   GovernanceActionCmds cmds ->
     renderGovernanceActionCmds cmds
   GovernanceCommitteeCmds cmds ->

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance.hs
@@ -33,6 +33,7 @@ pGovernanceCmds era =
           ]
     )
     [ pCreateMirCertificatesCmds era
+    , pGovernanceGenesisKeyDelegationCertificate era
     , fmap GovernanceActionCmds       <$> pGovernanceActionCmds era
     , fmap GovernanceCommitteeCmds    <$> pGovernanceCommitteeCmds era
     , fmap GovernanceDRepCmds         <$> pGovernanceDRepCmds era
@@ -91,3 +92,19 @@ pMIRTransferToReserves w =
     <$> pTransferAmt
     <*> pOutputFile
     <*> pure TransferToReserves
+
+pGovernanceGenesisKeyDelegationCertificate :: ()
+  => CardanoEra era
+  -> Maybe (Parser (GovernanceCmds era))
+pGovernanceGenesisKeyDelegationCertificate era = do
+  w <- forEraMaybeEon era
+  pure
+    $ subParser "create-genesis-key-delegation-certificate"
+    $ Opt.info (parser w)
+    $ Opt.progDesc "Create a genesis key delegation certificate"
+  where
+    parser w = GovernanceGenesisKeyDelegationCertificate w
+         <$> pGenesisVerificationKeyOrHashOrFile
+         <*> pGenesisDelegateVerificationKeyOrHashOrFile
+         <*> pVrfVerificationKeyOrHashOrFile
+         <*> pOutputFile

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run.hs
@@ -17,6 +17,8 @@ import           Cardano.CLI.EraBased.Run.Governance
 import           Cardano.CLI.EraBased.Run.Governance.Actions
 import           Cardano.CLI.EraBased.Run.Governance.Committee
 import           Cardano.CLI.EraBased.Run.Governance.DRep
+import           Cardano.CLI.EraBased.Run.Governance.GenesisKeyDelegationCertificate
+                   (runGovernanceGenesisKeyDelegationCertificate)
 import           Cardano.CLI.EraBased.Run.Governance.Poll (runGovernancePollCmds)
 import           Cardano.CLI.EraBased.Run.Governance.Vote
 import           Cardano.CLI.EraBased.Run.Key
@@ -82,6 +84,11 @@ runGovernanceCmds = \case
 
   GovernanceMIRTransfer w ll oFp direction ->
     runGovernanceMIRCertificateTransfer w ll oFp direction
+      & firstExceptT CmdGovernanceCmdError
+
+  GovernanceGenesisKeyDelegationCertificate sta genVk genDelegVk vrfVk out ->
+    let sbe = shelleyToAlonzoEraToShelleyBasedEra sta in
+    runGovernanceGenesisKeyDelegationCertificate sbe genVk genDelegVk vrfVk out
       & firstExceptT CmdGovernanceCmdError
 
   GovernanceCommitteeCmds cmds ->

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run.hs
@@ -74,6 +74,15 @@ runCmds = \case
     runTransactionCmds cmd
       & firstExceptT CmdTransactionError
 
+-- TODO smelc Move me to cardano-api. Or is there another way? I'd be surprised
+-- this is the first time we need this.
+shelleyToAlonzoEraToShelleyToBabbageEra :: ShelleyToAlonzoEra era -> ShelleyToBabbageEra era
+shelleyToAlonzoEraToShelleyToBabbageEra = \case
+  ShelleyToAlonzoEraShelley -> ShelleyToBabbageEraShelley
+  ShelleyToAlonzoEraAllegra -> ShelleyToBabbageEraAllegra
+  ShelleyToAlonzoEraMary -> ShelleyToBabbageEraMary
+  ShelleyToAlonzoEraAlonzo -> ShelleyToBabbageEraAlonzo
+
 runGovernanceCmds :: ()
   => GovernanceCmds era
   -> ExceptT CmdError IO ()
@@ -87,8 +96,8 @@ runGovernanceCmds = \case
       & firstExceptT CmdGovernanceCmdError
 
   GovernanceGenesisKeyDelegationCertificate sta genVk genDelegVk vrfVk out ->
-    let sbe = shelleyToAlonzoEraToShelleyBasedEra sta in
-    runGovernanceGenesisKeyDelegationCertificate sbe genVk genDelegVk vrfVk out
+    let stb = shelleyToAlonzoEraToShelleyToBabbageEra sta in
+    runGovernanceGenesisKeyDelegationCertificate stb genVk genDelegVk vrfVk out
       & firstExceptT CmdGovernanceCmdError
 
   GovernanceCommitteeCmds cmds ->

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/GenesisKeyDelegationCertificate.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/GenesisKeyDelegationCertificate.hs
@@ -1,0 +1,62 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+
+module Cardano.CLI.EraBased.Run.Governance.GenesisKeyDelegationCertificate
+  ( runGovernanceGenesisKeyDelegationCertificate
+  ) where
+
+
+import           Cardano.Api
+import           Cardano.Api.Shelley
+
+import           Cardano.CLI.Types.Errors.GovernanceCmdError
+import           Cardano.CLI.Types.Key
+
+import           Control.Monad.Trans.Except (ExceptT)
+import           Control.Monad.Trans.Except.Extra
+
+runGovernanceGenesisKeyDelegationCertificate
+  :: ShelleyBasedEra era
+  -> VerificationKeyOrHashOrFile GenesisKey
+  -> VerificationKeyOrHashOrFile GenesisDelegateKey
+  -> VerificationKeyOrHashOrFile VrfKey
+  -> File () Out
+  -> ExceptT GovernanceCmdError IO ()
+runGovernanceGenesisKeyDelegationCertificate sbe
+                                             genVkOrHashOrFp
+                                             genDelVkOrHashOrFp
+                                             vrfVkOrHashOrFp
+                                             oFp = do
+  genesisVkHash <- firstExceptT GovernanceCmdKeyReadError
+    . newExceptT
+    $ readVerificationKeyOrHashOrTextEnvFile AsGenesisKey genVkOrHashOrFp
+  genesisDelVkHash <-firstExceptT GovernanceCmdKeyReadError
+    . newExceptT
+    $ readVerificationKeyOrHashOrTextEnvFile AsGenesisDelegateKey genDelVkOrHashOrFp
+  vrfVkHash <- firstExceptT GovernanceCmdKeyReadError
+    . newExceptT
+    $ readVerificationKeyOrHashOrFile AsVrfKey vrfVkOrHashOrFp
+
+  req <- hoistEither $ createGenesisDelegationRequirements sbe genesisVkHash genesisDelVkHash vrfVkHash
+  let genKeyDelegCert = makeGenesisKeyDelegationCertificate req
+
+  firstExceptT GovernanceCmdTextEnvWriteError
+    . newExceptT
+    $ writeLazyByteStringFile oFp
+    $ shelleyBasedEraConstraints sbe
+    $ textEnvelopeToJSON (Just genKeyDelegCertDesc) genKeyDelegCert
+  where
+    genKeyDelegCertDesc :: TextEnvelopeDescr
+    genKeyDelegCertDesc = "Genesis Key Delegation Certificate"
+
+createGenesisDelegationRequirements
+  :: ShelleyBasedEra era
+  -> Hash GenesisKey
+  -> Hash GenesisDelegateKey
+  -> Hash VrfKey
+  -> Either GovernanceCmdError (GenesisKeyDelegationRequirements era)
+createGenesisDelegationRequirements sbe hGen hGenDeleg hVrf =
+  caseShelleyToBabbageOrConwayEraOnwards
+      (\eon -> return $ GenesisKeyDelegationRequirements eon hGen hGenDeleg hVrf)
+      (const $ Left GovernanceCmdGenesisDelegationNotSupportedInConway)
+      sbe

--- a/cardano-cli/src/Cardano/CLI/Legacy/Commands/Governance.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Commands/Governance.hs
@@ -25,7 +25,7 @@ data LegacyGovernanceCmds
       (File () Out)
       TransferDirection
   | GovernanceGenesisKeyDelegationCertificate
-      (EraInEon ShelleyBasedEra)
+      (EraInEon ShelleyToBabbageEra)
       (VerificationKeyOrHashOrFile GenesisKey)
       (VerificationKeyOrHashOrFile GenesisDelegateKey)
       (VerificationKeyOrHashOrFile VrfKey)

--- a/cardano-cli/src/Cardano/CLI/Legacy/Options.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Options.hs
@@ -854,7 +854,7 @@ pGovernanceCmds envCli =
     pGovernanceGenesisKeyDelegationCertificate :: Parser LegacyGovernanceCmds
     pGovernanceGenesisKeyDelegationCertificate =
       GovernanceGenesisKeyDelegationCertificate
-        <$> pAnyShelleyBasedEra envCli
+        <$> pAnyShelleyToBabbageEra envCli
         <*> pGenesisVerificationKeyOrHashOrFile
         <*> pGenesisDelegateVerificationKeyOrHashOrFile
         <*> pVrfVerificationKeyOrHashOrFile

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -262,7 +262,10 @@ Usage: cardano-cli shelley genesis hash --genesis FILE
 
   Compute the hash of a genesis file
 
-Usage: cardano-cli shelley governance create-mir-certificate
+Usage: cardano-cli shelley governance 
+                                        ( create-mir-certificate
+                                        | create-genesis-key-delegation-certificate
+                                        )
 
   Governance commands.
 
@@ -301,6 +304,23 @@ Usage: cardano-cli shelley governance create-mir-certificate transfer-to-rewards
 
   Create an MIR certificate to transfer from the treasury pot to the reserves
   pot
+
+Usage: cardano-cli shelley governance create-genesis-key-delegation-certificate 
+                                                                                  ( --genesis-verification-key STRING
+                                                                                  | --genesis-verification-key-file FILE
+                                                                                  | --genesis-verification-key-hash STRING
+                                                                                  )
+                                                                                  ( --genesis-delegate-verification-key STRING
+                                                                                  | --genesis-delegate-verification-key-file FILE
+                                                                                  | --genesis-delegate-verification-key-hash STRING
+                                                                                  )
+                                                                                  ( --vrf-verification-key STRING
+                                                                                  | --vrf-verification-key-file FILE
+                                                                                  | --vrf-verification-key-hash STRING
+                                                                                  )
+                                                                                  --out-file FILE
+
+  Create a genesis key delegation certificate
 
 Usage: cardano-cli shelley node 
                                   ( key-gen
@@ -1403,7 +1423,10 @@ Usage: cardano-cli allegra genesis hash --genesis FILE
 
   Compute the hash of a genesis file
 
-Usage: cardano-cli allegra governance create-mir-certificate
+Usage: cardano-cli allegra governance 
+                                        ( create-mir-certificate
+                                        | create-genesis-key-delegation-certificate
+                                        )
 
   Governance commands.
 
@@ -1442,6 +1465,23 @@ Usage: cardano-cli allegra governance create-mir-certificate transfer-to-rewards
 
   Create an MIR certificate to transfer from the treasury pot to the reserves
   pot
+
+Usage: cardano-cli allegra governance create-genesis-key-delegation-certificate 
+                                                                                  ( --genesis-verification-key STRING
+                                                                                  | --genesis-verification-key-file FILE
+                                                                                  | --genesis-verification-key-hash STRING
+                                                                                  )
+                                                                                  ( --genesis-delegate-verification-key STRING
+                                                                                  | --genesis-delegate-verification-key-file FILE
+                                                                                  | --genesis-delegate-verification-key-hash STRING
+                                                                                  )
+                                                                                  ( --vrf-verification-key STRING
+                                                                                  | --vrf-verification-key-file FILE
+                                                                                  | --vrf-verification-key-hash STRING
+                                                                                  )
+                                                                                  --out-file FILE
+
+  Create a genesis key delegation certificate
 
 Usage: cardano-cli allegra node 
                                   ( key-gen
@@ -2542,7 +2582,10 @@ Usage: cardano-cli mary genesis hash --genesis FILE
 
   Compute the hash of a genesis file
 
-Usage: cardano-cli mary governance create-mir-certificate
+Usage: cardano-cli mary governance 
+                                     ( create-mir-certificate
+                                     | create-genesis-key-delegation-certificate
+                                     )
 
   Governance commands.
 
@@ -2581,6 +2624,23 @@ Usage: cardano-cli mary governance create-mir-certificate transfer-to-rewards --
 
   Create an MIR certificate to transfer from the treasury pot to the reserves
   pot
+
+Usage: cardano-cli mary governance create-genesis-key-delegation-certificate 
+                                                                               ( --genesis-verification-key STRING
+                                                                               | --genesis-verification-key-file FILE
+                                                                               | --genesis-verification-key-hash STRING
+                                                                               )
+                                                                               ( --genesis-delegate-verification-key STRING
+                                                                               | --genesis-delegate-verification-key-file FILE
+                                                                               | --genesis-delegate-verification-key-hash STRING
+                                                                               )
+                                                                               ( --vrf-verification-key STRING
+                                                                               | --vrf-verification-key-file FILE
+                                                                               | --vrf-verification-key-hash STRING
+                                                                               )
+                                                                               --out-file FILE
+
+  Create a genesis key delegation certificate
 
 Usage: cardano-cli mary node 
                                ( key-gen
@@ -3658,7 +3718,10 @@ Usage: cardano-cli alonzo genesis hash --genesis FILE
 
   Compute the hash of a genesis file
 
-Usage: cardano-cli alonzo governance create-mir-certificate
+Usage: cardano-cli alonzo governance 
+                                       ( create-mir-certificate
+                                       | create-genesis-key-delegation-certificate
+                                       )
 
   Governance commands.
 
@@ -3697,6 +3760,23 @@ Usage: cardano-cli alonzo governance create-mir-certificate transfer-to-rewards 
 
   Create an MIR certificate to transfer from the treasury pot to the reserves
   pot
+
+Usage: cardano-cli alonzo governance create-genesis-key-delegation-certificate 
+                                                                                 ( --genesis-verification-key STRING
+                                                                                 | --genesis-verification-key-file FILE
+                                                                                 | --genesis-verification-key-hash STRING
+                                                                                 )
+                                                                                 ( --genesis-delegate-verification-key STRING
+                                                                                 | --genesis-delegate-verification-key-file FILE
+                                                                                 | --genesis-delegate-verification-key-hash STRING
+                                                                                 )
+                                                                                 ( --vrf-verification-key STRING
+                                                                                 | --vrf-verification-key-file FILE
+                                                                                 | --vrf-verification-key-hash STRING
+                                                                                 )
+                                                                                 --out-file FILE
+
+  Create a genesis key delegation certificate
 
 Usage: cardano-cli alonzo node 
                                  ( key-gen
@@ -8529,7 +8609,6 @@ Usage: cardano-cli legacy governance create-genesis-key-delegation-certificate
                                                                                  | --mary-era
                                                                                  | --alonzo-era
                                                                                  | --babbage-era
-                                                                                 | --conway-era
                                                                                  ]
                                                                                  ( --genesis-verification-key STRING
                                                                                  | --genesis-verification-key-file FILE
@@ -9841,7 +9920,6 @@ Usage: cardano-cli governance create-genesis-key-delegation-certificate
                                                                           | --mary-era
                                                                           | --alonzo-era
                                                                           | --babbage-era
-                                                                          | --conway-era
                                                                           ]
                                                                           ( --genesis-verification-key STRING
                                                                           | --genesis-verification-key-file FILE

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_governance.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_governance.cli
@@ -1,0 +1,15 @@
+Usage: cardano-cli allegra governance 
+                                        ( create-mir-certificate
+                                        | create-genesis-key-delegation-certificate
+                                        )
+
+  Governance commands.
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  create-mir-certificate   Create an MIR (Move Instantaneous Rewards)
+                           certificate
+  create-genesis-key-delegation-certificate
+                           Create a genesis key delegation certificate

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_governance_create-genesis-key-delegation-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_governance_create-genesis-key-delegation-certificate.cli
@@ -1,0 +1,38 @@
+Usage: cardano-cli allegra governance create-genesis-key-delegation-certificate 
+                                                                                  ( --genesis-verification-key STRING
+                                                                                  | --genesis-verification-key-file FILE
+                                                                                  | --genesis-verification-key-hash STRING
+                                                                                  )
+                                                                                  ( --genesis-delegate-verification-key STRING
+                                                                                  | --genesis-delegate-verification-key-file FILE
+                                                                                  | --genesis-delegate-verification-key-hash STRING
+                                                                                  )
+                                                                                  ( --vrf-verification-key STRING
+                                                                                  | --vrf-verification-key-file FILE
+                                                                                  | --vrf-verification-key-hash STRING
+                                                                                  )
+                                                                                  --out-file FILE
+
+  Create a genesis key delegation certificate
+
+Available options:
+  --genesis-verification-key STRING
+                           Genesis verification key (hex-encoded).
+  --genesis-verification-key-file FILE
+                           Filepath of the genesis verification key.
+  --genesis-verification-key-hash STRING
+                           Genesis verification key hash (hex-encoded).
+  --genesis-delegate-verification-key STRING
+                           Genesis delegate verification key (hex-encoded).
+  --genesis-delegate-verification-key-file FILE
+                           Filepath of the genesis delegate verification key.
+  --genesis-delegate-verification-key-hash STRING
+                           Genesis delegate verification key hash (hex-encoded).
+  --vrf-verification-key STRING
+                           VRF verification key (Bech32 or hex-encoded).
+  --vrf-verification-key-file FILE
+                           Filepath of the VRF verification key.
+  --vrf-verification-key-hash STRING
+                           VRF verification key hash (hex-encoded).
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_governance.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_governance.cli
@@ -1,0 +1,15 @@
+Usage: cardano-cli alonzo governance 
+                                       ( create-mir-certificate
+                                       | create-genesis-key-delegation-certificate
+                                       )
+
+  Governance commands.
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  create-mir-certificate   Create an MIR (Move Instantaneous Rewards)
+                           certificate
+  create-genesis-key-delegation-certificate
+                           Create a genesis key delegation certificate

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_governance_create-genesis-key-delegation-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_governance_create-genesis-key-delegation-certificate.cli
@@ -1,10 +1,4 @@
-Usage: cardano-cli legacy governance create-genesis-key-delegation-certificate 
-                                                                                 [ --shelley-era
-                                                                                 | --allegra-era
-                                                                                 | --mary-era
-                                                                                 | --alonzo-era
-                                                                                 | --babbage-era
-                                                                                 ]
+Usage: cardano-cli alonzo governance create-genesis-key-delegation-certificate 
                                                                                  ( --genesis-verification-key STRING
                                                                                  | --genesis-verification-key-file FILE
                                                                                  | --genesis-verification-key-hash STRING
@@ -22,11 +16,6 @@ Usage: cardano-cli legacy governance create-genesis-key-delegation-certificate
   Create a genesis key delegation certificate
 
 Available options:
-  --shelley-era            Specify the Shelley era
-  --allegra-era            Specify the Allegra era
-  --mary-era               Specify the Mary era
-  --alonzo-era             Specify the Alonzo era
-  --babbage-era            Specify the Babbage era (default)
   --genesis-verification-key STRING
                            Genesis verification key (hex-encoded).
   --genesis-verification-key-file FILE

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_create-genesis-key-delegation-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_create-genesis-key-delegation-certificate.cli
@@ -4,7 +4,6 @@ Usage: cardano-cli governance create-genesis-key-delegation-certificate
                                                                           | --mary-era
                                                                           | --alonzo-era
                                                                           | --babbage-era
-                                                                          | --conway-era
                                                                           ]
                                                                           ( --genesis-verification-key STRING
                                                                           | --genesis-verification-key-file FILE
@@ -28,7 +27,6 @@ Available options:
   --mary-era               Specify the Mary era
   --alonzo-era             Specify the Alonzo era
   --babbage-era            Specify the Babbage era (default)
-  --conway-era             Specify the Conway era
   --genesis-verification-key STRING
                            Genesis verification key (hex-encoded).
   --genesis-verification-key-file FILE

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_governance.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_governance.cli
@@ -1,0 +1,15 @@
+Usage: cardano-cli mary governance 
+                                     ( create-mir-certificate
+                                     | create-genesis-key-delegation-certificate
+                                     )
+
+  Governance commands.
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  create-mir-certificate   Create an MIR (Move Instantaneous Rewards)
+                           certificate
+  create-genesis-key-delegation-certificate
+                           Create a genesis key delegation certificate

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_governance_create-genesis-key-delegation-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_governance_create-genesis-key-delegation-certificate.cli
@@ -1,0 +1,38 @@
+Usage: cardano-cli mary governance create-genesis-key-delegation-certificate 
+                                                                               ( --genesis-verification-key STRING
+                                                                               | --genesis-verification-key-file FILE
+                                                                               | --genesis-verification-key-hash STRING
+                                                                               )
+                                                                               ( --genesis-delegate-verification-key STRING
+                                                                               | --genesis-delegate-verification-key-file FILE
+                                                                               | --genesis-delegate-verification-key-hash STRING
+                                                                               )
+                                                                               ( --vrf-verification-key STRING
+                                                                               | --vrf-verification-key-file FILE
+                                                                               | --vrf-verification-key-hash STRING
+                                                                               )
+                                                                               --out-file FILE
+
+  Create a genesis key delegation certificate
+
+Available options:
+  --genesis-verification-key STRING
+                           Genesis verification key (hex-encoded).
+  --genesis-verification-key-file FILE
+                           Filepath of the genesis verification key.
+  --genesis-verification-key-hash STRING
+                           Genesis verification key hash (hex-encoded).
+  --genesis-delegate-verification-key STRING
+                           Genesis delegate verification key (hex-encoded).
+  --genesis-delegate-verification-key-file FILE
+                           Filepath of the genesis delegate verification key.
+  --genesis-delegate-verification-key-hash STRING
+                           Genesis delegate verification key hash (hex-encoded).
+  --vrf-verification-key STRING
+                           VRF verification key (Bech32 or hex-encoded).
+  --vrf-verification-key-file FILE
+                           Filepath of the VRF verification key.
+  --vrf-verification-key-hash STRING
+                           VRF verification key hash (hex-encoded).
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_governance.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_governance.cli
@@ -1,0 +1,15 @@
+Usage: cardano-cli shelley governance 
+                                        ( create-mir-certificate
+                                        | create-genesis-key-delegation-certificate
+                                        )
+
+  Governance commands.
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  create-mir-certificate   Create an MIR (Move Instantaneous Rewards)
+                           certificate
+  create-genesis-key-delegation-certificate
+                           Create a genesis key delegation certificate

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_governance_create-genesis-key-delegation-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_governance_create-genesis-key-delegation-certificate.cli
@@ -1,0 +1,38 @@
+Usage: cardano-cli shelley governance create-genesis-key-delegation-certificate 
+                                                                                  ( --genesis-verification-key STRING
+                                                                                  | --genesis-verification-key-file FILE
+                                                                                  | --genesis-verification-key-hash STRING
+                                                                                  )
+                                                                                  ( --genesis-delegate-verification-key STRING
+                                                                                  | --genesis-delegate-verification-key-file FILE
+                                                                                  | --genesis-delegate-verification-key-hash STRING
+                                                                                  )
+                                                                                  ( --vrf-verification-key STRING
+                                                                                  | --vrf-verification-key-file FILE
+                                                                                  | --vrf-verification-key-hash STRING
+                                                                                  )
+                                                                                  --out-file FILE
+
+  Create a genesis key delegation certificate
+
+Available options:
+  --genesis-verification-key STRING
+                           Genesis verification key (hex-encoded).
+  --genesis-verification-key-file FILE
+                           Filepath of the genesis verification key.
+  --genesis-verification-key-hash STRING
+                           Genesis verification key hash (hex-encoded).
+  --genesis-delegate-verification-key STRING
+                           Genesis delegate verification key (hex-encoded).
+  --genesis-delegate-verification-key-file FILE
+                           Filepath of the genesis delegate verification key.
+  --genesis-delegate-verification-key-hash STRING
+                           Genesis delegate verification key hash (hex-encoded).
+  --vrf-verification-key STRING
+                           VRF verification key (Bech32 or hex-encoded).
+  --vrf-verification-key-file FILE
+                           Filepath of the VRF verification key.
+  --vrf-verification-key-hash STRING
+                           VRF verification key hash (hex-encoded).
+  --out-file FILE          The output file.
+  -h,--help                Show this help text


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Shelley to Alonzo: add create-genesis-key-delegation-certificate to governance
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Fixes https://github.com/input-output-hk/cardano-cli/issues/313

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] The change log section in the PR description has been filled in
- [X] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- NA The version bounds in `.cabal` files are updated
- [X] CI passes. See note on CI.  The following CI checks are required:
  - [X] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [X] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [X] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [X] Self-reviewed the diff