### PR TITLE
Remove eras' constitution-hash

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Query.hs
@@ -39,10 +39,6 @@ pQueryCmds era envCli =
         $ Opt.info (pQueryProtocolParametersCmd envCli)
         $ Opt.progDesc "Get the node's current protocol parameters"
     , Just
-        $ subParser "constitution-hash"
-        $ Opt.info (pQueryConstitutionHashCmd envCli)
-        $ Opt.progDesc "Get the constitution hash"
-    , Just
         $ subParser "tip"
         $ Opt.info (pQueryTipCmd envCli)
         $ Opt.progDesc "Get the node's current tip (slot no, hash, block no)"
@@ -122,15 +118,6 @@ pQueryProtocolParametersCmd :: EnvCli -> Parser (QueryCmds era)
 pQueryProtocolParametersCmd envCli =
   fmap QueryProtocolParametersCmd $
     QueryProtocolParametersCmdArgs
-      <$> pSocketPath envCli
-      <*> pConsensusModeParams
-      <*> pNetworkId envCli
-      <*> pMaybeOutputFile
-
-pQueryConstitutionHashCmd :: EnvCli -> Parser (QueryCmds era)
-pQueryConstitutionHashCmd envCli =
-  fmap QueryConstitutionHashCmd $
-    QueryConstitutionHashCmdArgs
       <$> pSocketPath envCli
       <*> pConsensusModeParams
       <*> pNetworkId envCli

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -364,7 +364,6 @@ Usage: cardano-cli shelley node issue-op-cert
 
 Usage: cardano-cli shelley query 
                                    ( protocol-parameters
-                                   | constitution-hash
                                    | tip
                                    | stake-pools
                                    | stake-distribution
@@ -396,20 +395,6 @@ Usage: cardano-cli shelley query protocol-parameters --socket-path SOCKET_PATH
                                                        [--out-file FILE]
 
   Get the node's current protocol parameters
-
-Usage: cardano-cli shelley query constitution-hash --socket-path SOCKET_PATH
-                                                     [ --shelley-mode
-                                                     | --byron-mode
-                                                       [--epoch-slots SLOTS]
-                                                     | --cardano-mode
-                                                       [--epoch-slots SLOTS]
-                                                     ]
-                                                     ( --mainnet
-                                                     | --testnet-magic NATURAL
-                                                     )
-                                                     [--out-file FILE]
-
-  Get the constitution hash
 
 Usage: cardano-cli shelley query tip --socket-path SOCKET_PATH
                                        [ --shelley-mode
@@ -1520,7 +1505,6 @@ Usage: cardano-cli allegra node issue-op-cert
 
 Usage: cardano-cli allegra query 
                                    ( protocol-parameters
-                                   | constitution-hash
                                    | tip
                                    | stake-pools
                                    | stake-distribution
@@ -1552,20 +1536,6 @@ Usage: cardano-cli allegra query protocol-parameters --socket-path SOCKET_PATH
                                                        [--out-file FILE]
 
   Get the node's current protocol parameters
-
-Usage: cardano-cli allegra query constitution-hash --socket-path SOCKET_PATH
-                                                     [ --shelley-mode
-                                                     | --byron-mode
-                                                       [--epoch-slots SLOTS]
-                                                     | --cardano-mode
-                                                       [--epoch-slots SLOTS]
-                                                     ]
-                                                     ( --mainnet
-                                                     | --testnet-magic NATURAL
-                                                     )
-                                                     [--out-file FILE]
-
-  Get the constitution hash
 
 Usage: cardano-cli allegra query tip --socket-path SOCKET_PATH
                                        [ --shelley-mode
@@ -2674,7 +2644,6 @@ Usage: cardano-cli mary node issue-op-cert
 
 Usage: cardano-cli mary query 
                                 ( protocol-parameters
-                                | constitution-hash
                                 | tip
                                 | stake-pools
                                 | stake-distribution
@@ -2706,20 +2675,6 @@ Usage: cardano-cli mary query protocol-parameters --socket-path SOCKET_PATH
                                                     [--out-file FILE]
 
   Get the node's current protocol parameters
-
-Usage: cardano-cli mary query constitution-hash --socket-path SOCKET_PATH
-                                                  [ --shelley-mode
-                                                  | --byron-mode
-                                                    [--epoch-slots SLOTS]
-                                                  | --cardano-mode
-                                                    [--epoch-slots SLOTS]
-                                                  ]
-                                                  ( --mainnet
-                                                  | --testnet-magic NATURAL
-                                                  )
-                                                  [--out-file FILE]
-
-  Get the constitution hash
 
 Usage: cardano-cli mary query tip --socket-path SOCKET_PATH
                                     [ --shelley-mode
@@ -3805,7 +3760,6 @@ Usage: cardano-cli alonzo node issue-op-cert
 
 Usage: cardano-cli alonzo query 
                                   ( protocol-parameters
-                                  | constitution-hash
                                   | tip
                                   | stake-pools
                                   | stake-distribution
@@ -3837,20 +3791,6 @@ Usage: cardano-cli alonzo query protocol-parameters --socket-path SOCKET_PATH
                                                       [--out-file FILE]
 
   Get the node's current protocol parameters
-
-Usage: cardano-cli alonzo query constitution-hash --socket-path SOCKET_PATH
-                                                    [ --shelley-mode
-                                                    | --byron-mode
-                                                      [--epoch-slots SLOTS]
-                                                    | --cardano-mode
-                                                      [--epoch-slots SLOTS]
-                                                    ]
-                                                    ( --mainnet
-                                                    | --testnet-magic NATURAL
-                                                    )
-                                                    [--out-file FILE]
-
-  Get the constitution hash
 
 Usage: cardano-cli alonzo query tip --socket-path SOCKET_PATH
                                       [ --shelley-mode
@@ -4984,7 +4924,6 @@ Usage: cardano-cli babbage node issue-op-cert
 
 Usage: cardano-cli babbage query 
                                    ( protocol-parameters
-                                   | constitution-hash
                                    | tip
                                    | stake-pools
                                    | stake-distribution
@@ -5016,20 +4955,6 @@ Usage: cardano-cli babbage query protocol-parameters --socket-path SOCKET_PATH
                                                        [--out-file FILE]
 
   Get the node's current protocol parameters
-
-Usage: cardano-cli babbage query constitution-hash --socket-path SOCKET_PATH
-                                                     [ --shelley-mode
-                                                     | --byron-mode
-                                                       [--epoch-slots SLOTS]
-                                                     | --cardano-mode
-                                                       [--epoch-slots SLOTS]
-                                                     ]
-                                                     ( --mainnet
-                                                     | --testnet-magic NATURAL
-                                                     )
-                                                     [--out-file FILE]
-
-  Get the constitution hash
 
 Usage: cardano-cli babbage query tip --socket-path SOCKET_PATH
                                        [ --shelley-mode
@@ -6427,7 +6352,6 @@ Usage: cardano-cli conway node issue-op-cert
 
 Usage: cardano-cli conway query 
                                   ( protocol-parameters
-                                  | constitution-hash
                                   | tip
                                   | stake-pools
                                   | stake-distribution
@@ -6464,20 +6388,6 @@ Usage: cardano-cli conway query protocol-parameters --socket-path SOCKET_PATH
                                                       [--out-file FILE]
 
   Get the node's current protocol parameters
-
-Usage: cardano-cli conway query constitution-hash --socket-path SOCKET_PATH
-                                                    [ --shelley-mode
-                                                    | --byron-mode
-                                                      [--epoch-slots SLOTS]
-                                                    | --cardano-mode
-                                                      [--epoch-slots SLOTS]
-                                                    ]
-                                                    ( --mainnet
-                                                    | --testnet-magic NATURAL
-                                                    )
-                                                    [--out-file FILE]
-
-  Get the constitution hash
 
 Usage: cardano-cli conway query tip --socket-path SOCKET_PATH
                                       [ --shelley-mode
@@ -7731,7 +7641,6 @@ Usage: cardano-cli latest node issue-op-cert
 
 Usage: cardano-cli latest query 
                                   ( protocol-parameters
-                                  | constitution-hash
                                   | tip
                                   | stake-pools
                                   | stake-distribution
@@ -7763,20 +7672,6 @@ Usage: cardano-cli latest query protocol-parameters --socket-path SOCKET_PATH
                                                       [--out-file FILE]
 
   Get the node's current protocol parameters
-
-Usage: cardano-cli latest query constitution-hash --socket-path SOCKET_PATH
-                                                    [ --shelley-mode
-                                                    | --byron-mode
-                                                      [--epoch-slots SLOTS]
-                                                    | --cardano-mode
-                                                      [--epoch-slots SLOTS]
-                                                    ]
-                                                    ( --mainnet
-                                                    | --testnet-magic NATURAL
-                                                    )
-                                                    [--out-file FILE]
-
-  Get the constitution hash
 
 Usage: cardano-cli latest query tip --socket-path SOCKET_PATH
                                       [ --shelley-mode

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query.cli
@@ -1,6 +1,5 @@
 Usage: cardano-cli allegra query 
                                    ( protocol-parameters
-                                   | constitution-hash
                                    | tip
                                    | stake-pools
                                    | stake-distribution
@@ -24,7 +23,6 @@ Available options:
 
 Available commands:
   protocol-parameters      Get the node's current protocol parameters
-  constitution-hash        Get the constitution hash
   tip                      Get the node's current tip (slot no, hash, block no)
   stake-pools              Get the node's current set of stake pool ids
   stake-distribution       Get the node's current aggregated stake distribution

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query.cli
@@ -1,6 +1,5 @@
 Usage: cardano-cli alonzo query 
                                   ( protocol-parameters
-                                  | constitution-hash
                                   | tip
                                   | stake-pools
                                   | stake-distribution
@@ -24,7 +23,6 @@ Available options:
 
 Available commands:
   protocol-parameters      Get the node's current protocol parameters
-  constitution-hash        Get the constitution hash
   tip                      Get the node's current tip (slot no, hash, block no)
   stake-pools              Get the node's current set of stake pool ids
   stake-distribution       Get the node's current aggregated stake distribution

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query.cli
@@ -1,6 +1,5 @@
 Usage: cardano-cli babbage query 
                                    ( protocol-parameters
-                                   | constitution-hash
                                    | tip
                                    | stake-pools
                                    | stake-distribution
@@ -24,7 +23,6 @@ Available options:
 
 Available commands:
   protocol-parameters      Get the node's current protocol parameters
-  constitution-hash        Get the constitution hash
   tip                      Get the node's current tip (slot no, hash, block no)
   stake-pools              Get the node's current set of stake pool ids
   stake-distribution       Get the node's current aggregated stake distribution

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query.cli
@@ -1,6 +1,5 @@
 Usage: cardano-cli conway query 
                                   ( protocol-parameters
-                                  | constitution-hash
                                   | tip
                                   | stake-pools
                                   | stake-distribution
@@ -29,7 +28,6 @@ Available options:
 
 Available commands:
   protocol-parameters      Get the node's current protocol parameters
-  constitution-hash        Get the constitution hash
   tip                      Get the node's current tip (slot no, hash, block no)
   stake-pools              Get the node's current set of stake pool ids
   stake-distribution       Get the node's current aggregated stake distribution

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query.cli
@@ -1,6 +1,5 @@
 Usage: cardano-cli latest query 
                                   ( protocol-parameters
-                                  | constitution-hash
                                   | tip
                                   | stake-pools
                                   | stake-distribution
@@ -24,7 +23,6 @@ Available options:
 
 Available commands:
   protocol-parameters      Get the node's current protocol parameters
-  constitution-hash        Get the constitution hash
   tip                      Get the node's current tip (slot no, hash, block no)
   stake-pools              Get the node's current set of stake pool ids
   stake-distribution       Get the node's current aggregated stake distribution

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query.cli
@@ -1,6 +1,5 @@
 Usage: cardano-cli mary query 
                                 ( protocol-parameters
-                                | constitution-hash
                                 | tip
                                 | stake-pools
                                 | stake-distribution
@@ -24,7 +23,6 @@ Available options:
 
 Available commands:
   protocol-parameters      Get the node's current protocol parameters
-  constitution-hash        Get the constitution hash
   tip                      Get the node's current tip (slot no, hash, block no)
   stake-pools              Get the node's current set of stake pool ids
   stake-distribution       Get the node's current aggregated stake distribution

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query.cli
@@ -1,6 +1,5 @@
 Usage: cardano-cli shelley query 
                                    ( protocol-parameters
-                                   | constitution-hash
                                    | tip
                                    | stake-pools
                                    | stake-distribution
@@ -24,7 +23,6 @@ Available options:
 
 Available commands:
   protocol-parameters      Get the node's current protocol parameters
-  constitution-hash        Get the constitution hash
   tip                      Get the node's current tip (slot no, hash, block no)
   stake-pools              Get the node's current set of stake pool ids
   stake-distribution       Get the node's current aggregated stake distribution


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Remove the `constitution-hash` command from eras. Users can use the `constitution` query instead.
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Fixes https://github.com/input-output-hk/cardano-cli/issues/354

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] The change log section in the PR description has been filled in
- NA New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [X] The version bounds in `.cabal` files are updated
- [X] CI passes. See note on CI.  The following CI checks are required:
  - [X] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [X] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [X] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [X] Self-reviewed the diff