### PR TITLE
Command argument types for `transaction` commands

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Transaction.hs
@@ -27,128 +27,18 @@ import           Cardano.CLI.Types.Governance
 import           Data.Text (Text)
 
 data TransactionCmds era
-  = TransactionBuildRawCmd
-      (CardanoEra era)
-      (Maybe ScriptValidity)
-      -- ^ Mark script as expected to pass or fail validation
-      [(TxIn, Maybe (ScriptWitnessFiles WitCtxTxIn))]
-      -- ^ Transaction inputs with optional spending scripts
-      [TxIn]
-      -- ^ Read only reference inputs
-      [TxIn]
-      -- ^ Transaction inputs for collateral, only key witnesses, no scripts.
-      (Maybe TxOutAnyEra)
-      -- ^ Return collateral
-      (Maybe Lovelace)
-      -- ^ Total collateral
-      [RequiredSigner]
-      -- ^ Required signers
-      [TxOutAnyEra]
-      (Maybe (Value, [ScriptWitnessFiles WitCtxMint]))
-      -- ^ Multi-Asset value with script witness
-      (Maybe SlotNo)
-      -- ^ Transaction lower bound
-      (Maybe SlotNo)
-      -- ^ Transaction upper bound
-      (Maybe Lovelace)
-      -- ^ Transaction feeCmd
-      [(CertificateFile, Maybe (ScriptWitnessFiles WitCtxStake))]
-      -- ^ Certificates with potential script witness
-      [(StakeAddress, Lovelace, Maybe (ScriptWitnessFiles WitCtxStake))]
-      TxMetadataJsonSchema
-      [ScriptFile]
-      -- ^ Auxiliary scripts
-      [MetadataFile]
-      (Maybe ProtocolParamsFile)
-      (Maybe UpdateProposalFile)
-      [VoteFile In]
-      [ProposalFile In]
-      (TxBodyFile Out)
-
-    -- | Like 'TransactionBuildRaw' but without the fee, and with a change output.
-  | TransactionBuildCmd
-      (CardanoEra era)
-      SocketPath
-      AnyConsensusModeParams
-      NetworkId
-      (Maybe ScriptValidity) -- ^ Mark script as expected to pass or fail validation
-      (Maybe Word)
-      -- ^ Override the required number of tx witnesses
-      [(TxIn, Maybe (ScriptWitnessFiles WitCtxTxIn))]
-      -- ^ Transaction inputs with optional spending scripts
-      [TxIn]
-      -- ^ Read only reference inputs
-      [RequiredSigner]
-      -- ^ Required signers
-      [TxIn]
-      -- ^ Transaction inputs for collateral, only key witnesses, no scripts.
-      (Maybe TxOutAnyEra)
-      -- ^ Return collateral
-      (Maybe Lovelace)
-      -- ^ Total collateral
-      [TxOutAnyEra]
-      -- ^ Normal outputs
-      TxOutChangeAddress
-      -- ^ A change output
-      (Maybe (Value, [ScriptWitnessFiles WitCtxMint]))
-      -- ^ Multi-Asset value with script witness
-      (Maybe SlotNo)
-      -- ^ Transaction lower bound
-      (Maybe SlotNo)
-      -- ^ Transaction upper bound
-      [(CertificateFile, Maybe (ScriptWitnessFiles WitCtxStake))]
-      -- ^ Certificates with potential script witness
-      [(StakeAddress, Lovelace, Maybe (ScriptWitnessFiles WitCtxStake))]
-      -- ^ Withdrawals with potential script witness
-      TxMetadataJsonSchema
-      [ScriptFile]
-      -- ^ Auxiliary scripts
-      [MetadataFile]
-      (Maybe UpdateProposalFile)
-      [VoteFile In]
-      [ProposalFile In]
-      TxBuildOutputOptions
-  | TransactionSignCmd
-      InputTxBodyOrTxFile
-      [WitnessSigningData]
-      (Maybe NetworkId)
-      (TxFile Out)
-  | TransactionWitnessCmd
-      (TxBodyFile In)
-      WitnessSigningData
-      (Maybe NetworkId)
-      (File () Out)
-  | TransactionSignWitnessCmd
-      (TxBodyFile In)
-      [WitnessFile]
-      (File () Out)
-  | TransactionSubmitCmd
-      SocketPath
-      AnyConsensusModeParams
-      NetworkId
-      FilePath
-  | TransactionPolicyIdCmd
-      ScriptFile
-  | TransactionCalculateMinFeeCmd
-      (TxBodyFile In)
-      NetworkId
-      ProtocolParamsFile
-      TxInCount
-      TxOutCount
-      TxShelleyWitnessCount
-      TxByronWitnessCount
-  | TransactionCalculateMinValueCmd
-      (CardanoEra era)
-      ProtocolParamsFile
-      TxOutAnyEra
-  | TransactionHashScriptDataCmd
-      ScriptDataOrFile
-  | TransactionTxIdCmd
-      InputTxBodyOrTxFile
-  | TransactionViewCmd
-      TxViewOutputFormat
-      (Maybe (File () Out))
-      InputTxBodyOrTxFile
+  = TransactionBuildRawCmd            !(TransactionBuildRawCmdArgs era)
+  | TransactionBuildCmd               !(TransactionBuildCmdArgs era)
+  | TransactionSignCmd                !TransactionSignCmdArgs
+  | TransactionWitnessCmd             !TransactionWitnessCmdArgs
+  | TransactionSignWitnessCmd         !TransactionSignWitnessCmdArgs
+  | TransactionSubmitCmd              !TransactionSubmitCmdArgs
+  | TransactionPolicyIdCmd            !TransactionPolicyIdCmdArgs
+  | TransactionCalculateMinFeeCmd     !TransactionCalculateMinFeeCmdArgs
+  | TransactionCalculateMinValueCmd   !(TransactionCalculateMinValueCmdArgs era)
+  | TransactionHashScriptDataCmd      !TransactionHashScriptDataCmdArgs
+  | TransactionTxIdCmd                !TransactionTxIdCmdArgs
+  | TransactionViewCmd                !TransactionViewCmdArgs
 
 data TransactionBuildRawCmdArgs era = TransactionBuildRawCmdArgs
   (CardanoEra era)
@@ -170,11 +60,11 @@ data TransactionBuildRawCmdArgs era = TransactionBuildRawCmdArgs
   (Maybe (Value, [ScriptWitnessFiles WitCtxMint]))
   -- ^ Multi-Asset value with script witness
   (Maybe SlotNo)
-  -- ^ Transaction lower bound
+  -- ^ Transaction validity lower bound
   (Maybe SlotNo)
-  -- ^ Transaction upper bound
+  -- ^ Transaction validity upper bound
   (Maybe Lovelace)
-  -- ^ Transaction feeCmd
+  -- ^ Transaction fee
   [(CertificateFile, Maybe (ScriptWitnessFiles WitCtxStake))]
   -- ^ Certificates with potential script witness
   [(StakeAddress, Lovelace, Maybe (ScriptWitnessFiles WitCtxStake))]
@@ -216,9 +106,9 @@ data TransactionBuildCmdArgs era = TransactionBuildCmdArgs
   (Maybe (Value, [ScriptWitnessFiles WitCtxMint]))
   -- ^ Multi-Asset value with script witness
   (Maybe SlotNo)
-  -- ^ Transaction lower bound
+  -- ^ Transaction validity lower bound
   (Maybe SlotNo)
-  -- ^ Transaction upper bound
+  -- ^ Transaction validity upper bound
   [(CertificateFile, Maybe (ScriptWitnessFiles WitCtxStake))]
   -- ^ Certificates with potential script witness
   [(StakeAddress, Lovelace, Maybe (ScriptWitnessFiles WitCtxStake))]

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Transaction.hs
@@ -77,7 +77,7 @@ data TransactionBuildRawCmdArgs era = TransactionBuildRawCmdArgs
   , mUpdateProprosalFile  :: !(Maybe UpdateProposalFile)
   , voteFiles             :: ![VoteFile In]
   , proposalFiles         :: ![ProposalFile In]
-  , out                   :: !(TxBodyFile Out)
+  , txBodyOutFile         :: !(TxBodyFile Out)
   } deriving Show
 
 -- | Like 'TransactionBuildRaw' but without the fee, and with a change output.

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Transaction.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE LambdaCase #-}
 
 module Cardano.CLI.EraBased.Commands.Transaction
@@ -41,137 +42,150 @@ data TransactionCmds era
   | TransactionViewCmd                !TransactionViewCmdArgs
 
 data TransactionBuildRawCmdArgs era = TransactionBuildRawCmdArgs
-  (CardanoEra era)
-  (Maybe ScriptValidity)
-  -- ^ Mark script as expected to pass or fail validation
-  [(TxIn, Maybe (ScriptWitnessFiles WitCtxTxIn))]
-  -- ^ Transaction inputs with optional spending scripts
-  [TxIn]
-  -- ^ Read only reference inputs
-  [TxIn]
-  -- ^ Transaction inputs for collateral, only key witnesses, no scripts.
-  (Maybe TxOutAnyEra)
-  -- ^ Return collateral
-  (Maybe Lovelace)
-  -- ^ Total collateral
-  [RequiredSigner]
-  -- ^ Required signers
-  [TxOutAnyEra]
-  (Maybe (Value, [ScriptWitnessFiles WitCtxMint]))
-  -- ^ Multi-Asset value with script witness
-  (Maybe SlotNo)
-  -- ^ Transaction validity lower bound
-  (Maybe SlotNo)
-  -- ^ Transaction validity upper bound
-  (Maybe Lovelace)
-  -- ^ Transaction fee
-  [(CertificateFile, Maybe (ScriptWitnessFiles WitCtxStake))]
-  -- ^ Certificates with potential script witness
-  [(StakeAddress, Lovelace, Maybe (ScriptWitnessFiles WitCtxStake))]
-  TxMetadataJsonSchema
-  [ScriptFile]
-  -- ^ Auxiliary scripts
-  [MetadataFile]
-  (Maybe ProtocolParamsFile)
-  (Maybe UpdateProposalFile)
-  [VoteFile In]
-  [ProposalFile In]
-  (TxBodyFile Out)
+  { eon                   :: !(CardanoEra era)
+  , mScriptValidity       :: !(Maybe ScriptValidity)
+    -- ^ Mark script as expected to pass or fail validation
+  , txIns                 :: ![(TxIn, Maybe (ScriptWitnessFiles WitCtxTxIn))]
+    -- ^ Transaction inputs with optional spending scripts
+  , readOnlyRefIns        :: ![TxIn]
+    -- ^ Read only reference inputs
+  , txInsCollateral       :: ![TxIn]
+    -- ^ Transaction inputs for collateral, only key witnesses, no scripts.
+  , mReturnCollateral     :: !(Maybe TxOutAnyEra)
+    -- ^ Return collateral
+  , mTotalCollateral      :: !(Maybe Lovelace)
+    -- ^ Total collateral
+  , requiredSigners       :: ![RequiredSigner]
+    -- ^ Required signers
+  , txouts                :: ![TxOutAnyEra]
+  , mValue                :: !(Maybe (Value, [ScriptWitnessFiles WitCtxMint]))
+    -- ^ Multi-Asset value with script witness
+  , mValidityLowerBound   :: !(Maybe SlotNo)
+    -- ^ Transaction validity lower bound
+  , mValidityUpperBound   :: !(Maybe SlotNo)
+    -- ^ Transaction validity upper bound
+  , fee                   :: !(Maybe Lovelace)
+    -- ^ Transaction fee
+  , certificates          :: ![(CertificateFile, Maybe (ScriptWitnessFiles WitCtxStake))]
+    -- ^ Certificates with potential script witness
+  , withdrawals           :: ![(StakeAddress, Lovelace, Maybe (ScriptWitnessFiles WitCtxStake))]
+  , metadataSchema        :: !TxMetadataJsonSchema
+  , scriptFiles           :: ![ScriptFile]
+    -- ^ Auxiliary scripts
+  , metadataFiles         :: ![MetadataFile]
+  , mProtocolParamsFile   :: !(Maybe ProtocolParamsFile)
+  , mUpdateProprosalFile  :: !(Maybe UpdateProposalFile)
+  , voteFiles             :: ![VoteFile In]
+  , proposalFiles         :: ![ProposalFile In]
+  , out                   :: !(TxBodyFile Out)
+  } deriving Show
 
 -- | Like 'TransactionBuildRaw' but without the fee, and with a change output.
 data TransactionBuildCmdArgs era = TransactionBuildCmdArgs
-  (CardanoEra era)
-  SocketPath
-  AnyConsensusModeParams
-  NetworkId
-  (Maybe ScriptValidity) -- ^ Mark script as expected to pass or fail validation
-  (Maybe Word)
-  -- ^ Override the required number of tx witnesses
-  [(TxIn, Maybe (ScriptWitnessFiles WitCtxTxIn))]
-  -- ^ Transaction inputs with optional spending scripts
-  [TxIn]
-  -- ^ Read only reference inputs
-  [RequiredSigner]
-  -- ^ Required signers
-  [TxIn]
-  -- ^ Transaction inputs for collateral, only key witnesses, no scripts.
-  (Maybe TxOutAnyEra)
-  -- ^ Return collateral
-  (Maybe Lovelace)
-  -- ^ Total collateral
-  [TxOutAnyEra]
-  -- ^ Normal outputs
-  TxOutChangeAddress
-  -- ^ A change output
-  (Maybe (Value, [ScriptWitnessFiles WitCtxMint]))
-  -- ^ Multi-Asset value with script witness
-  (Maybe SlotNo)
-  -- ^ Transaction validity lower bound
-  (Maybe SlotNo)
-  -- ^ Transaction validity upper bound
-  [(CertificateFile, Maybe (ScriptWitnessFiles WitCtxStake))]
-  -- ^ Certificates with potential script witness
-  [(StakeAddress, Lovelace, Maybe (ScriptWitnessFiles WitCtxStake))]
-  -- ^ Withdrawals with potential script witness
-  TxMetadataJsonSchema
-  [ScriptFile]
-  -- ^ Auxiliary scripts
-  [MetadataFile]
-  (Maybe UpdateProposalFile)
-  [VoteFile In]
-  [ProposalFile In]
-  TxBuildOutputOptions
+  { eon                     :: !(CardanoEra era)
+  , nodeSocketPath          :: !SocketPath
+  , consensusModeParams     :: !AnyConsensusModeParams
+  , networkId               :: !NetworkId
+  , mScriptValidity         :: !(Maybe ScriptValidity)
+    -- ^ Mark script as expected to pass or fail validation
+  , mOverrideWitnesses      :: !(Maybe Word)
+    -- ^ Override the required number of tx witnesses
+  , txins                   :: ![(TxIn, Maybe (ScriptWitnessFiles WitCtxTxIn))]
+    -- ^ Transaction inputs with optional spending scripts
+  , readOnlyReferenceInputs :: ![TxIn]
+    -- ^ Read only reference inputs
+  , requiredSigners         :: ![RequiredSigner]
+    -- ^ Required signers
+  , txinsc                  :: ![TxIn]
+    -- ^ Transaction inputs for collateral, only key witnesses, no scripts.
+  , mReturnCollateral       :: !(Maybe TxOutAnyEra)
+    -- ^ Return collateral
+  , mTotalCollateral        :: !(Maybe Lovelace)
+    -- ^ Total collateral
+  , txouts                  :: ![TxOutAnyEra]
+    -- ^ Normal outputs
+  , changeAddresses         :: !TxOutChangeAddress
+    -- ^ A change output
+  , mValue                  :: !(Maybe (Value, [ScriptWitnessFiles WitCtxMint]))
+    -- ^ Multi-Asset value with script witness
+  , mValidityLowerBound     :: !(Maybe SlotNo)
+    -- ^ Transaction validity lower bound
+  , mValidityUpperBound     :: !(Maybe SlotNo)
+    -- ^ Transaction validity upper bound
+  , certificates            :: ![(CertificateFile, Maybe (ScriptWitnessFiles WitCtxStake))]
+    -- ^ Certificates with potential script witness
+  , withdrawals             :: ![(StakeAddress, Lovelace, Maybe (ScriptWitnessFiles WitCtxStake))]
+    -- ^ Withdrawals with potential script witness
+  , metadataSchema          :: !TxMetadataJsonSchema
+  , scriptFiles             :: ![ScriptFile]
+    -- ^ Auxiliary scripts
+  , metadataFiles           :: ![MetadataFile]
+  , mUpdateProposalFile     :: !(Maybe UpdateProposalFile)
+  , voteFiles               :: ![VoteFile In]
+  , proposalFiles           :: ![ProposalFile In]
+  , buildOutputOptions      :: !TxBuildOutputOptions
+  } deriving Show
 
 data TransactionSignCmdArgs = TransactionSignCmdArgs
-  InputTxBodyOrTxFile
-  [WitnessSigningData]
-  (Maybe NetworkId)
-  (TxFile Out)
+  { txOrTxBodyFile      :: !InputTxBodyOrTxFile
+  , witnessSigningData  :: ![WitnessSigningData]
+  , mNetworkId          :: !(Maybe NetworkId)
+  , outTxFile           :: !(TxFile Out)
+  } deriving Show
 
 data TransactionWitnessCmdArgs = TransactionWitnessCmdArgs
-  (TxBodyFile In)
-  WitnessSigningData
-  (Maybe NetworkId)
-  (File () Out)
+  { txBodyFile          :: !(TxBodyFile In)
+  , witnessSigningData  :: !WitnessSigningData
+  , mNetworkId          :: !(Maybe NetworkId)
+  , outFile             :: !(File () Out)
+  } deriving Show
 
 data TransactionSignWitnessCmdArgs = TransactionSignWitnessCmdArgs
-  (TxBodyFile In)
-  [WitnessFile]
-  (File () Out)
+  { txBodyFile    :: !(TxBodyFile In)
+  , witnessFiles  :: ![WitnessFile]
+  , outFile       :: !(File () Out)
+  } deriving Show
 
 data TransactionSubmitCmdArgs = TransactionSubmitCmdArgs
-  SocketPath
-  AnyConsensusModeParams
-  NetworkId
-  FilePath
+  { nodeSocketPath          :: !SocketPath
+  , anyConsensusModeParams  :: !AnyConsensusModeParams
+  , networkId               :: !NetworkId
+  , txFile                  :: !FilePath
+  } deriving Show
 
 newtype TransactionPolicyIdCmdArgs = TransactionPolicyIdCmdArgs
-  ScriptFile
+  { scriptFile  :: ScriptFile
+  } deriving Show
 
 data TransactionCalculateMinFeeCmdArgs = TransactionCalculateMinFeeCmdArgs
-  (TxBodyFile In)
-  NetworkId
-  ProtocolParamsFile
-  TxInCount
-  TxOutCount
-  TxShelleyWitnessCount
-  TxByronWitnessCount
+  { txBodyFile            :: !(TxBodyFile In)
+  , networkId             :: !NetworkId
+  , protocolParamsFile    :: !ProtocolParamsFile
+  , txInCount             :: !TxInCount
+  , txOutCount            :: !TxOutCount
+  , txShelleyWitnessCount :: !TxShelleyWitnessCount
+  , txByronWitnessCount   :: !TxByronWitnessCount
+  } deriving Show
 
 data TransactionCalculateMinValueCmdArgs era = TransactionCalculateMinValueCmdArgs
-  (CardanoEra era)
-  ProtocolParamsFile
-  TxOutAnyEra
+  { eon                 :: !(CardanoEra era)
+  , protocolParamsFile  :: !ProtocolParamsFile
+  , txOut               :: !TxOutAnyEra
+  } deriving Show
 
 newtype TransactionHashScriptDataCmdArgs = TransactionHashScriptDataCmdArgs
-  ScriptDataOrFile
+  { scriptDataOrFile  :: ScriptDataOrFile
+  } deriving Show
 
 newtype TransactionTxIdCmdArgs = TransactionTxIdCmdArgs
-  InputTxBodyOrTxFile
+  { inputTxBodyOrTxFile :: InputTxBodyOrTxFile
+  } deriving Show
 
 data TransactionViewCmdArgs = TransactionViewCmdArgs
-  TxViewOutputFormat
-  (Maybe (File () Out))
-  InputTxBodyOrTxFile
+  { outputFormat        :: !TxViewOutputFormat
+  , mOutFile            :: !(Maybe (File () Out))
+  , inputTxBodyOrTxFile :: !InputTxBodyOrTxFile
+  } deriving Show
 
 renderTransactionCmds :: TransactionCmds era -> Text
 renderTransactionCmds = \case

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Transaction.hs
@@ -3,6 +3,19 @@
 
 module Cardano.CLI.EraBased.Commands.Transaction
   ( TransactionCmds (..)
+  , TransactionBuildRawCmdArgs(..)
+  , TransactionBuildCmdArgs(..)
+  , TransactionSignCmdArgs(..)
+  , TransactionWitnessCmdArgs(..)
+  , TransactionSignWitnessCmdArgs(..)
+  , TransactionSubmitCmdArgs(..)
+  , TransactionPolicyIdCmdArgs(..)
+  , TransactionCalculateMinFeeCmdArgs(..)
+  , TransactionCalculateMinValueCmdArgs(..)
+  , TransactionHashScriptDataCmdArgs(..)
+  , TransactionTxIdCmdArgs(..)
+  , TransactionViewCmdArgs(..)
+
   , renderTransactionCmds
   ) where
 
@@ -136,6 +149,139 @@ data TransactionCmds era
       TxViewOutputFormat
       (Maybe (File () Out))
       InputTxBodyOrTxFile
+
+data TransactionBuildRawCmdArgs era = TransactionBuildRawCmdArgs
+  (CardanoEra era)
+  (Maybe ScriptValidity)
+  -- ^ Mark script as expected to pass or fail validation
+  [(TxIn, Maybe (ScriptWitnessFiles WitCtxTxIn))]
+  -- ^ Transaction inputs with optional spending scripts
+  [TxIn]
+  -- ^ Read only reference inputs
+  [TxIn]
+  -- ^ Transaction inputs for collateral, only key witnesses, no scripts.
+  (Maybe TxOutAnyEra)
+  -- ^ Return collateral
+  (Maybe Lovelace)
+  -- ^ Total collateral
+  [RequiredSigner]
+  -- ^ Required signers
+  [TxOutAnyEra]
+  (Maybe (Value, [ScriptWitnessFiles WitCtxMint]))
+  -- ^ Multi-Asset value with script witness
+  (Maybe SlotNo)
+  -- ^ Transaction lower bound
+  (Maybe SlotNo)
+  -- ^ Transaction upper bound
+  (Maybe Lovelace)
+  -- ^ Transaction feeCmd
+  [(CertificateFile, Maybe (ScriptWitnessFiles WitCtxStake))]
+  -- ^ Certificates with potential script witness
+  [(StakeAddress, Lovelace, Maybe (ScriptWitnessFiles WitCtxStake))]
+  TxMetadataJsonSchema
+  [ScriptFile]
+  -- ^ Auxiliary scripts
+  [MetadataFile]
+  (Maybe ProtocolParamsFile)
+  (Maybe UpdateProposalFile)
+  [VoteFile In]
+  [ProposalFile In]
+  (TxBodyFile Out)
+
+-- | Like 'TransactionBuildRaw' but without the fee, and with a change output.
+data TransactionBuildCmdArgs era = TransactionBuildCmdArgs
+  (CardanoEra era)
+  SocketPath
+  AnyConsensusModeParams
+  NetworkId
+  (Maybe ScriptValidity) -- ^ Mark script as expected to pass or fail validation
+  (Maybe Word)
+  -- ^ Override the required number of tx witnesses
+  [(TxIn, Maybe (ScriptWitnessFiles WitCtxTxIn))]
+  -- ^ Transaction inputs with optional spending scripts
+  [TxIn]
+  -- ^ Read only reference inputs
+  [RequiredSigner]
+  -- ^ Required signers
+  [TxIn]
+  -- ^ Transaction inputs for collateral, only key witnesses, no scripts.
+  (Maybe TxOutAnyEra)
+  -- ^ Return collateral
+  (Maybe Lovelace)
+  -- ^ Total collateral
+  [TxOutAnyEra]
+  -- ^ Normal outputs
+  TxOutChangeAddress
+  -- ^ A change output
+  (Maybe (Value, [ScriptWitnessFiles WitCtxMint]))
+  -- ^ Multi-Asset value with script witness
+  (Maybe SlotNo)
+  -- ^ Transaction lower bound
+  (Maybe SlotNo)
+  -- ^ Transaction upper bound
+  [(CertificateFile, Maybe (ScriptWitnessFiles WitCtxStake))]
+  -- ^ Certificates with potential script witness
+  [(StakeAddress, Lovelace, Maybe (ScriptWitnessFiles WitCtxStake))]
+  -- ^ Withdrawals with potential script witness
+  TxMetadataJsonSchema
+  [ScriptFile]
+  -- ^ Auxiliary scripts
+  [MetadataFile]
+  (Maybe UpdateProposalFile)
+  [VoteFile In]
+  [ProposalFile In]
+  TxBuildOutputOptions
+
+data TransactionSignCmdArgs = TransactionSignCmdArgs
+  InputTxBodyOrTxFile
+  [WitnessSigningData]
+  (Maybe NetworkId)
+  (TxFile Out)
+
+data TransactionWitnessCmdArgs = TransactionWitnessCmdArgs
+  (TxBodyFile In)
+  WitnessSigningData
+  (Maybe NetworkId)
+  (File () Out)
+
+data TransactionSignWitnessCmdArgs = TransactionSignWitnessCmdArgs
+  (TxBodyFile In)
+  [WitnessFile]
+  (File () Out)
+
+data TransactionSubmitCmdArgs = TransactionSubmitCmdArgs
+  SocketPath
+  AnyConsensusModeParams
+  NetworkId
+  FilePath
+
+newtype TransactionPolicyIdCmdArgs = TransactionPolicyIdCmdArgs
+  ScriptFile
+
+data TransactionCalculateMinFeeCmdArgs = TransactionCalculateMinFeeCmdArgs
+  (TxBodyFile In)
+  NetworkId
+  ProtocolParamsFile
+  TxInCount
+  TxOutCount
+  TxShelleyWitnessCount
+  TxByronWitnessCount
+
+data TransactionCalculateMinValueCmdArgs era = TransactionCalculateMinValueCmdArgs
+  (CardanoEra era)
+  ProtocolParamsFile
+  TxOutAnyEra
+
+newtype TransactionHashScriptDataCmdArgs = TransactionHashScriptDataCmdArgs
+  ScriptDataOrFile
+
+newtype TransactionTxIdCmdArgs = TransactionTxIdCmdArgs
+  InputTxBodyOrTxFile
+
+data TransactionViewCmdArgs = TransactionViewCmdArgs
+  TxViewOutputFormat
+  (Maybe (File () Out))
+  InputTxBodyOrTxFile
 
 renderTransactionCmds :: TransactionCmds era -> Text
 renderTransactionCmds = \case

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Transaction.hs
@@ -14,7 +14,7 @@ import           Cardano.CLI.Types.Governance
 import           Data.Text (Text)
 
 data TransactionCmds era
-  = TxBuildRaw
+  = TransactionBuildRawCmd
       (CardanoEra era)
       (Maybe ScriptValidity)
       -- ^ Mark script as expected to pass or fail validation
@@ -38,7 +38,7 @@ data TransactionCmds era
       (Maybe SlotNo)
       -- ^ Transaction upper bound
       (Maybe Lovelace)
-      -- ^ Tx fee
+      -- ^ Transaction feeCmd
       [(CertificateFile, Maybe (ScriptWitnessFiles WitCtxStake))]
       -- ^ Certificates with potential script witness
       [(StakeAddress, Lovelace, Maybe (ScriptWitnessFiles WitCtxStake))]
@@ -52,8 +52,8 @@ data TransactionCmds era
       [ProposalFile In]
       (TxBodyFile Out)
 
-    -- | Like 'TxBuildRaw' but without the fee, and with a change output.
-  | TxBuild
+    -- | Like 'TransactionBuildRaw' but without the fee, and with a change output.
+  | TransactionBuildCmd
       (CardanoEra era)
       SocketPath
       AnyConsensusModeParams
@@ -95,28 +95,28 @@ data TransactionCmds era
       [VoteFile In]
       [ProposalFile In]
       TxBuildOutputOptions
-  | TxSign
+  | TransactionSignCmd
       InputTxBodyOrTxFile
       [WitnessSigningData]
       (Maybe NetworkId)
       (TxFile Out)
-  | TxCreateWitness
+  | TransactionWitnessCmd
       (TxBodyFile In)
       WitnessSigningData
       (Maybe NetworkId)
       (File () Out)
-  | TxAssembleTxBodyWitness
+  | TransactionSignWitnessCmd
       (TxBodyFile In)
       [WitnessFile]
       (File () Out)
-  | TxSubmit
+  | TransactionSubmitCmd
       SocketPath
       AnyConsensusModeParams
       NetworkId
       FilePath
-  | TxMintedPolicyId
+  | TransactionPolicyIdCmd
       ScriptFile
-  | TxCalculateMinFee
+  | TransactionCalculateMinFeeCmd
       (TxBodyFile In)
       NetworkId
       ProtocolParamsFile
@@ -124,30 +124,30 @@ data TransactionCmds era
       TxOutCount
       TxShelleyWitnessCount
       TxByronWitnessCount
-  | TxCalculateMinRequiredUTxO
+  | TransactionCalculateMinValueCmd
       (CardanoEra era)
       ProtocolParamsFile
       TxOutAnyEra
-  | TxHashScriptData
+  | TransactionHashScriptDataCmd
       ScriptDataOrFile
-  | TxGetTxId
+  | TransactionTxIdCmd
       InputTxBodyOrTxFile
-  | TxView
+  | TransactionViewCmd
       TxViewOutputFormat
       (Maybe (File () Out))
       InputTxBodyOrTxFile
 
 renderTransactionCmds :: TransactionCmds era -> Text
 renderTransactionCmds = \case
-  TxBuild {} -> "transaction build"
-  TxBuildRaw {} -> "transaction build-raw"
-  TxSign {} -> "transaction sign"
-  TxCreateWitness {} -> "transaction witness"
-  TxAssembleTxBodyWitness {} -> "transaction sign-witness"
-  TxSubmit {} -> "transaction submit"
-  TxMintedPolicyId {} -> "transaction policyid"
-  TxCalculateMinFee {} -> "transaction calculate-min-fee"
-  TxCalculateMinRequiredUTxO {} -> "transaction calculate-min-value"
-  TxHashScriptData {} -> "transaction hash-script-data"
-  TxGetTxId {} -> "transaction txid"
-  TxView {} -> "transaction view"
+  TransactionBuildCmd                     {} -> "transaction build"
+  TransactionBuildRawCmd                  {} -> "transaction build-raw"
+  TransactionSignCmd                      {} -> "transaction sign"
+  TransactionWitnessCmd                   {} -> "transaction witness"
+  TransactionSignWitnessCmd               {} -> "transaction sign-witness"
+  TransactionSubmitCmd                    {} -> "transaction submit"
+  TransactionPolicyIdCmd                  {} -> "transaction policyid"
+  TransactionCalculateMinFeeCmd           {} -> "transaction calculate-min-fee"
+  TransactionCalculateMinValueCmd         {} -> "transaction calculate-min-value"
+  TransactionHashScriptDataCmd            {} -> "transaction hash-script-data"
+  TransactionTxIdCmd                      {} -> "transaction txid"
+  TransactionViewCmd                      {} -> "transaction view"

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Transaction.hs
@@ -151,7 +151,7 @@ pScriptValidity = asum
 
 pTransactionBuild :: CardanoEra era -> EnvCli -> Parser (TransactionCmds era)
 pTransactionBuild era envCli =
-  TxBuild era
+  TransactionBuildCmd era
     <$> pSocketPath envCli
     <*> pConsensusModeParams
     <*> pNetworkId envCli
@@ -191,7 +191,7 @@ pChangeAddress =
 
 pTransactionBuildRaw :: CardanoEra era -> Parser (TransactionCmds era)
 pTransactionBuildRaw era =
-  TxBuildRaw era
+  TransactionBuildRawCmd era
     <$> optional pScriptValidity
     <*> some (pTxIn ManualBalance)
     <*> many pReadOnlyReferenceTxIn
@@ -217,7 +217,7 @@ pTransactionBuildRaw era =
 
 pTransactionSign  :: EnvCli -> Parser (TransactionCmds era)
 pTransactionSign envCli =
-  TxSign
+  TransactionSignCmd
     <$> pInputTxOrTxBodyFile
     <*> many pWitnessSigningData
     <*> optional (pNetworkId envCli)
@@ -225,7 +225,7 @@ pTransactionSign envCli =
 
 pTransactionCreateWitness :: EnvCli -> Parser (TransactionCmds era)
 pTransactionCreateWitness envCli =
-  TxCreateWitness
+  TransactionWitnessCmd
     <$> pTxBodyFileIn
     <*> pWitnessSigningData
     <*> optional (pNetworkId envCli)
@@ -233,25 +233,27 @@ pTransactionCreateWitness envCli =
 
 pTransactionAssembleTxBodyWit :: Parser (TransactionCmds era)
 pTransactionAssembleTxBodyWit =
-  TxAssembleTxBodyWitness
+  TransactionSignWitnessCmd
     <$> pTxBodyFileIn
     <*> many pWitnessFile
     <*> pOutputFile
 
 pTransactionSubmit :: EnvCli -> Parser (TransactionCmds era)
 pTransactionSubmit envCli =
-  TxSubmit
+  TransactionSubmitCmd
     <$> pSocketPath envCli
     <*> pConsensusModeParams
     <*> pNetworkId envCli
     <*> pTxSubmitFile
 
 pTransactionPolicyId :: Parser (TransactionCmds era)
-pTransactionPolicyId = TxMintedPolicyId <$> pScript
+pTransactionPolicyId =
+  TransactionPolicyIdCmd
+    <$> pScript
 
 pTransactionCalculateMinFee :: EnvCli -> Parser (TransactionCmds era)
 pTransactionCalculateMinFee envCli  =
-  TxCalculateMinFee
+  TransactionCalculateMinFeeCmd
     <$> pTxBodyFileIn
     <*> pNetworkId envCli
     <*> pProtocolParamsFile
@@ -262,24 +264,26 @@ pTransactionCalculateMinFee envCli  =
 
 pTransactionCalculateMinReqUTxO :: CardanoEra era -> Parser (TransactionCmds era)
 pTransactionCalculateMinReqUTxO era =
-  TxCalculateMinRequiredUTxO era
+  TransactionCalculateMinValueCmd era
     <$> pProtocolParamsFile
     <*> pTxOut
 
 pTxHashScriptData :: Parser (TransactionCmds era)
 pTxHashScriptData =
-  fmap TxHashScriptData
+  fmap TransactionHashScriptDataCmd
     $ pScriptDataOrFile
         "script-data"
         "The script data, in JSON syntax."
         "The script data, in the given JSON file."
 
 pTransactionId  :: Parser (TransactionCmds era)
-pTransactionId = TxGetTxId <$> pInputTxOrTxBodyFile
+pTransactionId =
+  TransactionTxIdCmd
+    <$> pInputTxOrTxBodyFile
 
 pTransactionView :: Parser (TransactionCmds era)
 pTransactionView =
-  TxView
+  TransactionViewCmd
     <$> pTxViewOutputFormat
     <*> pMaybeOutputFile
     <*> pInputTxOrTxBodyFile

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Transaction.hs
@@ -151,35 +151,36 @@ pScriptValidity = asum
 
 pTransactionBuild :: CardanoEra era -> EnvCli -> Parser (TransactionCmds era)
 pTransactionBuild era envCli =
-  TransactionBuildCmd era
-    <$> pSocketPath envCli
-    <*> pConsensusModeParams
-    <*> pNetworkId envCli
-    <*> optional pScriptValidity
-    <*> optional pWitnessOverride
-    <*> some (pTxIn AutoBalance)
-    <*> many pReadOnlyReferenceTxIn
-    <*> many pRequiredSigner
-    <*> many pTxInCollateral
-    <*> optional pReturnCollateral
-    <*> optional pTotalCollateral
-    <*> many pTxOut
-    <*> pChangeAddress
-    <*> optional (pMintMultiAsset AutoBalance)
-    <*> optional pInvalidBefore
-    <*> optional pInvalidHereafter
-    <*> many (pCertificateFile AutoBalance)
-    <*> many (pWithdrawal AutoBalance)
-    <*> pTxMetadataJsonSchema
-    <*> many (pScriptFor
-                "auxiliary-script-file"
-                Nothing
-                "Filepath of auxiliary script(s)")
-    <*> many pMetadataFile
-    <*> optional pUpdateProposalFile
-    <*> many (pFileInDirection "vote-file" "Filepath of the vote.")
-    <*> many (pFileInDirection "proposal-file" "Filepath of the proposal.")
-    <*> (OutputTxBodyOnly <$> pTxBodyFileOut <|> pCalculatePlutusScriptCost)
+  fmap TransactionBuildCmd $
+    TransactionBuildCmdArgs era
+      <$> pSocketPath envCli
+      <*> pConsensusModeParams
+      <*> pNetworkId envCli
+      <*> optional pScriptValidity
+      <*> optional pWitnessOverride
+      <*> some (pTxIn AutoBalance)
+      <*> many pReadOnlyReferenceTxIn
+      <*> many pRequiredSigner
+      <*> many pTxInCollateral
+      <*> optional pReturnCollateral
+      <*> optional pTotalCollateral
+      <*> many pTxOut
+      <*> pChangeAddress
+      <*> optional (pMintMultiAsset AutoBalance)
+      <*> optional pInvalidBefore
+      <*> optional pInvalidHereafter
+      <*> many (pCertificateFile AutoBalance)
+      <*> many (pWithdrawal AutoBalance)
+      <*> pTxMetadataJsonSchema
+      <*> many (pScriptFor
+                  "auxiliary-script-file"
+                  Nothing
+                  "Filepath of auxiliary script(s)")
+      <*> many pMetadataFile
+      <*> optional pUpdateProposalFile
+      <*> many (pFileInDirection "vote-file" "Filepath of the vote.")
+      <*> many (pFileInDirection "proposal-file" "Filepath of the proposal.")
+      <*> (OutputTxBodyOnly <$> pTxBodyFileOut <|> pCalculatePlutusScriptCost)
 
 pChangeAddress :: Parser TxOutChangeAddress
 pChangeAddress =
@@ -191,99 +192,110 @@ pChangeAddress =
 
 pTransactionBuildRaw :: CardanoEra era -> Parser (TransactionCmds era)
 pTransactionBuildRaw era =
-  TransactionBuildRawCmd era
-    <$> optional pScriptValidity
-    <*> some (pTxIn ManualBalance)
-    <*> many pReadOnlyReferenceTxIn
-    <*> many pTxInCollateral
-    <*> optional pReturnCollateral
-    <*> optional pTotalCollateral
-    <*> many pRequiredSigner
-    <*> many pTxOut
-    <*> optional (pMintMultiAsset ManualBalance)
-    <*> optional pInvalidBefore
-    <*> optional pInvalidHereafter
-    <*> optional pTxFee
-    <*> many (pCertificateFile ManualBalance )
-    <*> many (pWithdrawal ManualBalance)
-    <*> pTxMetadataJsonSchema
-    <*> many (pScriptFor "auxiliary-script-file" Nothing "Filepath of auxiliary script(s)")
-    <*> many pMetadataFile
-    <*> optional pProtocolParamsFile
-    <*> optional pUpdateProposalFile
-    <*> many (pFileInDirection "vote-file" "Filepath of the vote.")
-    <*> many (pFileInDirection "proposal-file" "Filepath of the proposal.")
-    <*> pTxBodyFileOut
+  fmap TransactionBuildRawCmd $
+    TransactionBuildRawCmdArgs era
+      <$> optional pScriptValidity
+      <*> some (pTxIn ManualBalance)
+      <*> many pReadOnlyReferenceTxIn
+      <*> many pTxInCollateral
+      <*> optional pReturnCollateral
+      <*> optional pTotalCollateral
+      <*> many pRequiredSigner
+      <*> many pTxOut
+      <*> optional (pMintMultiAsset ManualBalance)
+      <*> optional pInvalidBefore
+      <*> optional pInvalidHereafter
+      <*> optional pTxFee
+      <*> many (pCertificateFile ManualBalance )
+      <*> many (pWithdrawal ManualBalance)
+      <*> pTxMetadataJsonSchema
+      <*> many (pScriptFor "auxiliary-script-file" Nothing "Filepath of auxiliary script(s)")
+      <*> many pMetadataFile
+      <*> optional pProtocolParamsFile
+      <*> optional pUpdateProposalFile
+      <*> many (pFileInDirection "vote-file" "Filepath of the vote.")
+      <*> many (pFileInDirection "proposal-file" "Filepath of the proposal.")
+      <*> pTxBodyFileOut
 
 pTransactionSign  :: EnvCli -> Parser (TransactionCmds era)
 pTransactionSign envCli =
-  TransactionSignCmd
-    <$> pInputTxOrTxBodyFile
-    <*> many pWitnessSigningData
-    <*> optional (pNetworkId envCli)
-    <*> pTxFileOut
+  fmap TransactionSignCmd $
+    TransactionSignCmdArgs
+      <$> pInputTxOrTxBodyFile
+      <*> many pWitnessSigningData
+      <*> optional (pNetworkId envCli)
+      <*> pTxFileOut
 
 pTransactionCreateWitness :: EnvCli -> Parser (TransactionCmds era)
 pTransactionCreateWitness envCli =
-  TransactionWitnessCmd
-    <$> pTxBodyFileIn
-    <*> pWitnessSigningData
-    <*> optional (pNetworkId envCli)
-    <*> pOutputFile
+  fmap TransactionWitnessCmd $
+    TransactionWitnessCmdArgs
+      <$> pTxBodyFileIn
+      <*> pWitnessSigningData
+      <*> optional (pNetworkId envCli)
+      <*> pOutputFile
 
 pTransactionAssembleTxBodyWit :: Parser (TransactionCmds era)
 pTransactionAssembleTxBodyWit =
-  TransactionSignWitnessCmd
-    <$> pTxBodyFileIn
-    <*> many pWitnessFile
-    <*> pOutputFile
+  fmap TransactionSignWitnessCmd $
+    TransactionSignWitnessCmdArgs
+      <$> pTxBodyFileIn
+      <*> many pWitnessFile
+      <*> pOutputFile
 
 pTransactionSubmit :: EnvCli -> Parser (TransactionCmds era)
 pTransactionSubmit envCli =
-  TransactionSubmitCmd
-    <$> pSocketPath envCli
-    <*> pConsensusModeParams
-    <*> pNetworkId envCli
-    <*> pTxSubmitFile
+  fmap TransactionSubmitCmd $
+    TransactionSubmitCmdArgs
+      <$> pSocketPath envCli
+      <*> pConsensusModeParams
+      <*> pNetworkId envCli
+      <*> pTxSubmitFile
 
 pTransactionPolicyId :: Parser (TransactionCmds era)
 pTransactionPolicyId =
-  TransactionPolicyIdCmd
-    <$> pScript
+  fmap TransactionPolicyIdCmd $
+    TransactionPolicyIdCmdArgs
+      <$> pScript
 
 pTransactionCalculateMinFee :: EnvCli -> Parser (TransactionCmds era)
 pTransactionCalculateMinFee envCli  =
-  TransactionCalculateMinFeeCmd
-    <$> pTxBodyFileIn
-    <*> pNetworkId envCli
-    <*> pProtocolParamsFile
-    <*> pTxInCount
-    <*> pTxOutCount
-    <*> pTxShelleyWitnessCount
-    <*> pTxByronWitnessCount
+  fmap TransactionCalculateMinFeeCmd $
+    TransactionCalculateMinFeeCmdArgs
+      <$> pTxBodyFileIn
+      <*> pNetworkId envCli
+      <*> pProtocolParamsFile
+      <*> pTxInCount
+      <*> pTxOutCount
+      <*> pTxShelleyWitnessCount
+      <*> pTxByronWitnessCount
 
 pTransactionCalculateMinReqUTxO :: CardanoEra era -> Parser (TransactionCmds era)
 pTransactionCalculateMinReqUTxO era =
-  TransactionCalculateMinValueCmd era
-    <$> pProtocolParamsFile
-    <*> pTxOut
+  fmap TransactionCalculateMinValueCmd $
+    TransactionCalculateMinValueCmdArgs era
+      <$> pProtocolParamsFile
+      <*> pTxOut
 
 pTxHashScriptData :: Parser (TransactionCmds era)
 pTxHashScriptData =
-  fmap TransactionHashScriptDataCmd
-    $ pScriptDataOrFile
-        "script-data"
-        "The script data, in JSON syntax."
-        "The script data, in the given JSON file."
+  fmap TransactionHashScriptDataCmd $
+    TransactionHashScriptDataCmdArgs
+      <$> pScriptDataOrFile
+            "script-data"
+            "The script data, in JSON syntax."
+            "The script data, in the given JSON file."
 
 pTransactionId  :: Parser (TransactionCmds era)
 pTransactionId =
-  TransactionTxIdCmd
-    <$> pInputTxOrTxBodyFile
+  fmap TransactionTxIdCmd $
+    TransactionTxIdCmdArgs
+      <$> pInputTxOrTxBodyFile
 
 pTransactionView :: Parser (TransactionCmds era)
 pTransactionView =
-  TransactionViewCmd
-    <$> pTxViewOutputFormat
-    <*> pMaybeOutputFile
-    <*> pInputTxOrTxBodyFile
+  fmap TransactionViewCmd $
+    TransactionViewCmdArgs
+      <$> pTxViewOutputFormat
+      <*> pMaybeOutputFile
+      <*> pInputTxOrTxBodyFile

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Transaction.hs
@@ -75,9 +75,8 @@ import qualified System.IO as IO
 
 
 runTransactionCmds :: TransactionCmds era -> ExceptT TxCmdError IO ()
-runTransactionCmds cmd =
-  case cmd of
-    TxBuild
+runTransactionCmds = \case
+  TransactionBuildCmd
         era mNodeSocketPath consensusModeParams nid mScriptValidity mOverrideWits txins readOnlyRefIns
         reqSigners txinsc mReturnColl mTotCollateral txouts changeAddr mValue mLowBound
         mUpperBound certs wdrls metadataSchema scriptFiles metadataFiles mUpProp voteFiles
@@ -87,7 +86,7 @@ runTransactionCmds cmd =
         reqSigners txinsc mReturnColl mTotCollateral txouts changeAddr mValue mLowBound
         mUpperBound certs wdrls metadataSchema scriptFiles metadataFiles mUpProp voteFiles
         proposalFiles outputOptions
-    TxBuildRaw
+  TransactionBuildRawCmd
         era mScriptValidity txins readOnlyRefIns txinsc mReturnColl
         mTotColl reqSigners txouts mValue mLowBound mUpperBound fee certs wdrls
         metadataSchema scriptFiles metadataFiles mProtocolParamsFile mUpProp
@@ -98,25 +97,25 @@ runTransactionCmds cmd =
         metadataSchema scriptFiles metadataFiles mProtocolParamsFile mUpProp
         voteFiles proposalFiles
         out
-    TxSign txinfile skfiles network txoutfile ->
+  TransactionSignCmd txinfile skfiles network txoutfile ->
       runTxSignCmd txinfile skfiles network txoutfile
-    TxSubmit mNodeSocketPath anyConsensusModeParams network txFp ->
+  TransactionSubmitCmd mNodeSocketPath anyConsensusModeParams network txFp ->
       runTxSubmitCmd mNodeSocketPath anyConsensusModeParams network txFp
-    TxCalculateMinFee txbody nw pParamsFile nInputs nOutputs nShelleyKeyWitnesses nByronKeyWitnesses ->
+  TransactionCalculateMinFeeCmd txbody nw pParamsFile nInputs nOutputs nShelleyKeyWitnesses nByronKeyWitnesses ->
       runTxCalculateMinFeeCmd txbody nw pParamsFile nInputs nOutputs nShelleyKeyWitnesses nByronKeyWitnesses
-    TxCalculateMinRequiredUTxO era pParamsFile txOuts ->
+  TransactionCalculateMinValueCmd era pParamsFile txOuts ->
       runTxCalculateMinRequiredUTxOCmd era pParamsFile txOuts
-    TxHashScriptData scriptDataOrFile ->
+  TransactionHashScriptDataCmd scriptDataOrFile ->
       runTxHashScriptDataCmd scriptDataOrFile
-    TxGetTxId txinfile ->
+  TransactionTxIdCmd txinfile ->
       runTxGetTxIdCmd txinfile
-    TxView outFormat mOutFile txinfile ->
+  TransactionViewCmd outFormat mOutFile txinfile ->
       runTxViewCmd outFormat mOutFile txinfile
-    TxMintedPolicyId sFile ->
+  TransactionPolicyIdCmd sFile ->
       runTxCreatePolicyIdCmd sFile
-    TxCreateWitness txBodyfile witSignData mbNw outFile ->
+  TransactionWitnessCmd txBodyfile witSignData mbNw outFile ->
       runTxCreateWitnessCmd txBodyfile witSignData mbNw outFile
-    TxAssembleTxBodyWitness txBodyFile witnessFile outFile ->
+  TransactionSignWitnessCmd txBodyFile witnessFile outFile ->
       runTxSignWitnessCmd txBodyFile witnessFile outFile
 
 -- ----------------------------------------------------------------------------

--- a/cardano-cli/src/Cardano/CLI/Legacy/Commands/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Commands/Transaction.hs
@@ -14,7 +14,7 @@ import           Cardano.CLI.Types.Governance
 import           Data.Text (Text)
 
 data LegacyTransactionCmds
-  = TxBuildRaw
+  = TransactionBuildRawCmd
       AnyCardanoEra
       (Maybe ScriptValidity)
       -- ^ Mark script as expected to pass or fail validation
@@ -50,8 +50,8 @@ data LegacyTransactionCmds
       (Maybe UpdateProposalFile)
       (TxBodyFile Out)
 
-    -- | Like 'TxBuildRaw' but without the fee, and with a change output.
-  | TxBuild
+    -- | Like 'TransactionBuildRaw' but without the fee, and with a change output.
+  | TransactionBuildCmd
       SocketPath
       AnyCardanoEra
       AnyConsensusModeParams
@@ -93,28 +93,28 @@ data LegacyTransactionCmds
       [VoteFile In]
       [ProposalFile In]
       TxBuildOutputOptions
-  | TxSign
+  | TransactionSignCmd
       InputTxBodyOrTxFile
       [WitnessSigningData]
       (Maybe NetworkId)
       (TxFile Out)
-  | TxCreateWitness
+  | TransactionWitnessCmd
       (TxBodyFile In)
       WitnessSigningData
       (Maybe NetworkId)
       (File () Out)
-  | TxAssembleTxBodyWitness
+  | TransactionSignWitnessCmd
       (TxBodyFile In)
       [WitnessFile]
       (File () Out)
-  | TxSubmit
+  | TransactionSubmitCmd
       SocketPath
       AnyConsensusModeParams
       NetworkId
       FilePath
-  | TxMintedPolicyId
+  | TransactionPolicyIdCmd
       ScriptFile
-  | TxCalculateMinFee
+  | TransactionCalculateMinFeeCmd
       (TxBodyFile In)
       NetworkId
       ProtocolParamsFile
@@ -122,30 +122,30 @@ data LegacyTransactionCmds
       TxOutCount
       TxShelleyWitnessCount
       TxByronWitnessCount
-  | TxCalculateMinRequiredUTxO
+  | TransactionCalculateMinValueCmd
       AnyCardanoEra
       ProtocolParamsFile
       TxOutAnyEra
-  | TxHashScriptData
+  | TransactionHashScriptDataCmd
       ScriptDataOrFile
-  | TxGetTxId
+  | TransactionTxIdCmd
       InputTxBodyOrTxFile
-  | TxView
+  | TransactionViewCmd
       TxViewOutputFormat
       (Maybe (File () Out))
       InputTxBodyOrTxFile
 
 renderLegacyTransactionCmds :: LegacyTransactionCmds -> Text
 renderLegacyTransactionCmds = \case
-  TxBuild {} -> "transaction build"
-  TxBuildRaw {} -> "transaction build-raw"
-  TxSign {} -> "transaction sign"
-  TxCreateWitness {} -> "transaction witness"
-  TxAssembleTxBodyWitness {} -> "transaction sign-witness"
-  TxSubmit {} -> "transaction submit"
-  TxMintedPolicyId {} -> "transaction policyid"
-  TxCalculateMinFee {} -> "transaction calculate-min-fee"
-  TxCalculateMinRequiredUTxO {} -> "transaction calculate-min-value"
-  TxHashScriptData {} -> "transaction hash-script-data"
-  TxGetTxId {} -> "transaction txid"
-  TxView {} -> "transaction view"
+  TransactionBuildCmd                     {} -> "transaction build"
+  TransactionBuildRawCmd                  {} -> "transaction build-raw"
+  TransactionSignCmd                      {} -> "transaction sign"
+  TransactionWitnessCmd                   {} -> "transaction witness"
+  TransactionSignWitnessCmd               {} -> "transaction sign-witness"
+  TransactionSubmitCmd                    {} -> "transaction submit"
+  TransactionPolicyIdCmd                  {} -> "transaction policyid"
+  TransactionCalculateMinFeeCmd           {} -> "transaction calculate-min-fee"
+  TransactionCalculateMinValueCmd         {} -> "transaction calculate-min-value"
+  TransactionHashScriptDataCmd            {} -> "transaction hash-script-data"
+  TransactionTxIdCmd                      {} -> "transaction txid"
+  TransactionViewCmd                      {} -> "transaction view"

--- a/cardano-cli/src/Cardano/CLI/Legacy/Options.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Options.hs
@@ -306,7 +306,7 @@ pTransaction envCli =
 
   pTransactionBuild :: Parser LegacyTransactionCmds
   pTransactionBuild =
-    TxBuild
+    TransactionBuildCmd
       <$> pSocketPath envCli
       <*> pLegacyCardanoEra envCli
       <*> pConsensusModeParams
@@ -347,7 +347,7 @@ pTransaction envCli =
 
   pTransactionBuildRaw :: Parser LegacyTransactionCmds
   pTransactionBuildRaw =
-    TxBuildRaw
+    TransactionBuildRawCmd
       <$> pLegacyCardanoEra envCli
       <*> optional pScriptValidity
       <*> some (pTxIn ManualBalance)
@@ -372,7 +372,7 @@ pTransaction envCli =
 
   pTransactionSign  :: Parser LegacyTransactionCmds
   pTransactionSign =
-    TxSign
+    TransactionSignCmd
       <$> pInputTxOrTxBodyFile
       <*> many pWitnessSigningData
       <*> optional (pNetworkId envCli)
@@ -380,7 +380,7 @@ pTransaction envCli =
 
   pTransactionCreateWitness :: Parser LegacyTransactionCmds
   pTransactionCreateWitness =
-    TxCreateWitness
+    TransactionWitnessCmd
       <$> pTxBodyFileIn
       <*> pWitnessSigningData
       <*> optional (pNetworkId envCli)
@@ -388,25 +388,27 @@ pTransaction envCli =
 
   pTransactionAssembleTxBodyWit :: Parser LegacyTransactionCmds
   pTransactionAssembleTxBodyWit =
-    TxAssembleTxBodyWitness
+    TransactionSignWitnessCmd
       <$> pTxBodyFileIn
       <*> many pWitnessFile
       <*> pOutputFile
 
   pTransactionSubmit :: Parser LegacyTransactionCmds
   pTransactionSubmit =
-    TxSubmit
+    TransactionSubmitCmd
       <$> pSocketPath envCli
       <*> pConsensusModeParams
       <*> pNetworkId envCli
       <*> pTxSubmitFile
 
   pTransactionPolicyId :: Parser LegacyTransactionCmds
-  pTransactionPolicyId = TxMintedPolicyId <$> pScript
+  pTransactionPolicyId =
+    TransactionPolicyIdCmd
+      <$> pScript
 
   pTransactionCalculateMinFee :: Parser LegacyTransactionCmds
   pTransactionCalculateMinFee =
-    TxCalculateMinFee
+    TransactionCalculateMinFeeCmd
       <$> pTxBodyFileIn
       <*> pNetworkId envCli
       <*> pProtocolParamsFile
@@ -416,25 +418,28 @@ pTransaction envCli =
       <*> pTxByronWitnessCount
 
   pTransactionCalculateMinReqUTxO :: Parser LegacyTransactionCmds
-  pTransactionCalculateMinReqUTxO = TxCalculateMinRequiredUTxO
-    <$> pLegacyCardanoEra envCli
-    <*> pProtocolParamsFile
-    <*> pTxOut
+  pTransactionCalculateMinReqUTxO =
+    TransactionCalculateMinValueCmd
+      <$> pLegacyCardanoEra envCli
+      <*> pProtocolParamsFile
+      <*> pTxOut
 
   pTxHashScriptData :: Parser LegacyTransactionCmds
   pTxHashScriptData =
-    fmap TxHashScriptData
+    fmap TransactionHashScriptDataCmd
       $ pScriptDataOrFile
           "script-data"
           "The script data, in JSON syntax."
           "The script data, in the given JSON file."
 
   pTransactionId  :: Parser LegacyTransactionCmds
-  pTransactionId = TxGetTxId <$> pInputTxOrTxBodyFile
+  pTransactionId =
+    TransactionTxIdCmd
+      <$> pInputTxOrTxBodyFile
 
   pTransactionView :: Parser LegacyTransactionCmds
   pTransactionView =
-    TxView
+    TransactionViewCmd
       <$> pTxViewOutputFormat
       <*> pMaybeOutputFile
       <*> pInputTxOrTxBodyFile

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Transaction.hs
@@ -89,7 +89,7 @@ runLegacyTransactionBuildCmd :: ()
   -> [ProposalFile In]
   -> TxBuildOutputOptions
   -> ExceptT TxCmdError IO ()
-runLegacyTransactionBuildCmd socketPath (AnyCardanoEra era) = runTxBuildCmd era socketPath
+runLegacyTransactionBuildCmd socketPath (AnyCardanoEra era) = runTransactionBuildCmd era socketPath
 
 runLegacyTransactionBuildRawCmd :: ()
   => AnyCardanoEra
@@ -118,7 +118,7 @@ runLegacyTransactionBuildRawCmd
     (AnyCardanoEra era) mScriptValidity txins readOnlyRefIns txinsc mReturnColl
     mTotColl reqSigners txouts mValue mLowBound mUpperBound fee certs wdrls
     metadataSchema scriptFiles metadataFiles mProtocolParamsFile mUpProp =
-  runTxBuildRawCmd era mScriptValidity txins readOnlyRefIns txinsc mReturnColl
+  runTransactionBuildRawCmd era mScriptValidity txins readOnlyRefIns txinsc mReturnColl
     mTotColl reqSigners txouts mValue mLowBound mUpperBound fee certs wdrls
     metadataSchema scriptFiles metadataFiles mProtocolParamsFile mUpProp [] []
 
@@ -127,7 +127,7 @@ runLegacyTransactionSignCmd :: InputTxBodyOrTxFile
           -> Maybe NetworkId
           -> TxFile Out
           -> ExceptT TxCmdError IO ()
-runLegacyTransactionSignCmd = runTxSignCmd
+runLegacyTransactionSignCmd = runTransactionSignCmd
 
 runLegacyTransactionSubmitCmd :: ()
   => SocketPath
@@ -135,7 +135,7 @@ runLegacyTransactionSubmitCmd :: ()
   -> NetworkId
   -> FilePath
   -> ExceptT TxCmdError IO ()
-runLegacyTransactionSubmitCmd = runTxSubmitCmd
+runLegacyTransactionSubmitCmd = runTransactionSubmitCmd
 
 runLegacyTransactionCalculateMinFeeCmd :: ()
   => TxBodyFile In
@@ -146,26 +146,26 @@ runLegacyTransactionCalculateMinFeeCmd :: ()
   -> TxShelleyWitnessCount
   -> TxByronWitnessCount
   -> ExceptT TxCmdError IO ()
-runLegacyTransactionCalculateMinFeeCmd = runTxCalculateMinFeeCmd
+runLegacyTransactionCalculateMinFeeCmd = runTransactionCalculateMinFeeCmd
 
 runLegacyTransactionCalculateMinValueCmd :: ()
   => AnyCardanoEra
   -> ProtocolParamsFile
   -> TxOutAnyEra
   -> ExceptT TxCmdError IO ()
-runLegacyTransactionCalculateMinValueCmd (AnyCardanoEra era) = runTxCalculateMinRequiredUTxOCmd era
+runLegacyTransactionCalculateMinValueCmd (AnyCardanoEra era) = runTransactionCalculateMinValueCmd era
 
 runLegacyTransactionPolicyIdCmd :: ScriptFile -> ExceptT TxCmdError IO ()
-runLegacyTransactionPolicyIdCmd = runTxCreatePolicyIdCmd
+runLegacyTransactionPolicyIdCmd = runTransactionPolicyIdCmd
 
 runLegacyTransactionHashScriptDataCmd :: ScriptDataOrFile -> ExceptT TxCmdError IO ()
-runLegacyTransactionHashScriptDataCmd = runTxHashScriptDataCmd
+runLegacyTransactionHashScriptDataCmd = runTransactionHashScriptDataCmd
 
 runLegacyTransactionTxIdCmd :: InputTxBodyOrTxFile -> ExceptT TxCmdError IO ()
-runLegacyTransactionTxIdCmd = runTxGetTxIdCmd
+runLegacyTransactionTxIdCmd = runTransactionTxIdCmd
 
 runLegacyTransactionViewCmd :: TxViewOutputFormat -> Maybe (File () Out) -> InputTxBodyOrTxFile -> ExceptT TxCmdError IO ()
-runLegacyTransactionViewCmd = runTxViewCmd
+runLegacyTransactionViewCmd = runTransactionViewCmd
 
 runLegacyTransactionWitnessCmd :: ()
   => TxBodyFile In
@@ -173,11 +173,11 @@ runLegacyTransactionWitnessCmd :: ()
   -> Maybe NetworkId
   -> File () Out
   -> ExceptT TxCmdError IO ()
-runLegacyTransactionWitnessCmd = runTxCreateWitnessCmd
+runLegacyTransactionWitnessCmd = runTransactionWitnessCmd
 
 runLegacyTransactionSignWitnessCmd :: ()
   => TxBodyFile In
   -> [WitnessFile]
   -> File () Out
   -> ExceptT TxCmdError IO ()
-runLegacyTransactionSignWitnessCmd = runTxSignWitnessCmd
+runLegacyTransactionSignWitnessCmd = runTransactionSignWitnessCmd

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Transaction.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
@@ -20,48 +21,47 @@ import           Control.Monad.Trans.Except
 
 
 runLegacyTransactionCmds :: LegacyTransactionCmds -> ExceptT TxCmdError IO ()
-runLegacyTransactionCmds cmd =
-  case cmd of
-    TxBuild mNodeSocketPath era consensusModeParams nid mScriptValidity mOverrideWits txins readOnlyRefIns
+runLegacyTransactionCmds = \case
+  TransactionBuildCmd mNodeSocketPath era consensusModeParams nid mScriptValidity mOverrideWits txins readOnlyRefIns
             reqSigners txinsc mReturnColl mTotCollateral txouts changeAddr mValue mLowBound
             mUpperBound certs wdrls metadataSchema scriptFiles metadataFiles mUpProp mconwayVote
             mNewConstitution outputOptions -> do
-      runLegacyTxBuildCmd mNodeSocketPath era consensusModeParams nid mScriptValidity mOverrideWits txins readOnlyRefIns
+      runLegacyTransactionBuildCmd mNodeSocketPath era consensusModeParams nid mScriptValidity mOverrideWits txins readOnlyRefIns
             reqSigners txinsc mReturnColl mTotCollateral txouts changeAddr mValue mLowBound
             mUpperBound certs wdrls metadataSchema scriptFiles metadataFiles mUpProp mconwayVote
             mNewConstitution outputOptions
-    TxBuildRaw era mScriptValidity txins readOnlyRefIns txinsc mReturnColl
+  TransactionBuildRawCmd era mScriptValidity txins readOnlyRefIns txinsc mReturnColl
                mTotColl reqSigners txouts mValue mLowBound mUpperBound fee certs wdrls
                metadataSchema scriptFiles metadataFiles mProtocolParamsFile mUpProp out -> do
-      runLegacyTxBuildRawCmd era mScriptValidity txins readOnlyRefIns txinsc mReturnColl
+      runLegacyTransactionBuildRawCmd era mScriptValidity txins readOnlyRefIns txinsc mReturnColl
                mTotColl reqSigners txouts mValue mLowBound mUpperBound fee certs wdrls
                metadataSchema scriptFiles metadataFiles mProtocolParamsFile mUpProp out
-    TxSign txinfile skfiles network txoutfile ->
-      runLegacyTxSignCmd txinfile skfiles network txoutfile
-    TxSubmit mNodeSocketPath anyConsensusModeParams network txFp ->
-      runLegacyTxSubmitCmd mNodeSocketPath anyConsensusModeParams network txFp
-    TxCalculateMinFee txbody nw pParamsFile nInputs nOutputs nShelleyKeyWitnesses nByronKeyWitnesses ->
-      runLegacyTxCalculateMinFeeCmd txbody nw pParamsFile nInputs nOutputs nShelleyKeyWitnesses nByronKeyWitnesses
-    TxCalculateMinRequiredUTxO era pParamsFile txOuts' ->
-      runLegacyTxCalculateMinRequiredUTxOCmd era pParamsFile txOuts'
-    TxHashScriptData scriptDataOrFile ->
-      runLegacyTxHashScriptDataCmd scriptDataOrFile
-    TxGetTxId txinfile ->
-      runLegacyTxGetTxIdCmd txinfile
-    TxView yamlOrJson mOutFile txinfile ->
-      runLegacyTxViewCmd yamlOrJson mOutFile txinfile
-    TxMintedPolicyId sFile ->
-      runLegacyTxCreatePolicyIdCmd sFile
-    TxCreateWitness txBodyfile witSignData mbNw outFile ->
-      runLegacyTxCreateWitnessCmd txBodyfile witSignData mbNw outFile
-    TxAssembleTxBodyWitness txBodyFile witnessFile outFile ->
-      runLegacyTxSignWitnessCmd txBodyFile witnessFile outFile
+  TransactionSignCmd txinfile skfiles network txoutfile ->
+      runLegacyTransactionSignCmd txinfile skfiles network txoutfile
+  TransactionSubmitCmd mNodeSocketPath anyConsensusModeParams network txFp ->
+      runLegacyTransactionSubmitCmd mNodeSocketPath anyConsensusModeParams network txFp
+  TransactionCalculateMinFeeCmd txbody nw pParamsFile nInputs nOutputs nShelleyKeyWitnesses nByronKeyWitnesses ->
+      runLegacyTransactionCalculateMinFeeCmd txbody nw pParamsFile nInputs nOutputs nShelleyKeyWitnesses nByronKeyWitnesses
+  TransactionCalculateMinValueCmd era pParamsFile txOuts' ->
+      runLegacyTransactionCalculateMinValueCmd era pParamsFile txOuts'
+  TransactionHashScriptDataCmd scriptDataOrFile ->
+      runLegacyTransactionHashScriptDataCmd scriptDataOrFile
+  TransactionTxIdCmd txinfile ->
+      runLegacyTransactionTxIdCmd txinfile
+  TransactionViewCmd yamlOrJson mOutFile txinfile ->
+      runLegacyTransactionViewCmd yamlOrJson mOutFile txinfile
+  TransactionPolicyIdCmd sFile ->
+      runLegacyTransactionPolicyIdCmd sFile
+  TransactionWitnessCmd txBodyfile witSignData mbNw outFile ->
+      runLegacyTransactionWitnessCmd txBodyfile witSignData mbNw outFile
+  TransactionSignWitnessCmd txBodyFile witnessFile outFile ->
+      runLegacyTransactionSignWitnessCmd txBodyFile witnessFile outFile
 
 -- ----------------------------------------------------------------------------
 -- Building transactions
 --
 
-runLegacyTxBuildCmd :: ()
+runLegacyTransactionBuildCmd :: ()
   => SocketPath
   -> AnyCardanoEra
   -> AnyConsensusModeParams
@@ -89,9 +89,9 @@ runLegacyTxBuildCmd :: ()
   -> [ProposalFile In]
   -> TxBuildOutputOptions
   -> ExceptT TxCmdError IO ()
-runLegacyTxBuildCmd socketPath (AnyCardanoEra era) = runTxBuildCmd era socketPath
+runLegacyTransactionBuildCmd socketPath (AnyCardanoEra era) = runTxBuildCmd era socketPath
 
-runLegacyTxBuildRawCmd :: ()
+runLegacyTransactionBuildRawCmd :: ()
   => AnyCardanoEra
   -> Maybe ScriptValidity
   -> [(TxIn, Maybe (ScriptWitnessFiles WitCtxTxIn))]
@@ -114,7 +114,7 @@ runLegacyTxBuildRawCmd :: ()
   -> Maybe UpdateProposalFile
   -> TxBodyFile Out
   -> ExceptT TxCmdError IO ()
-runLegacyTxBuildRawCmd
+runLegacyTransactionBuildRawCmd
     (AnyCardanoEra era) mScriptValidity txins readOnlyRefIns txinsc mReturnColl
     mTotColl reqSigners txouts mValue mLowBound mUpperBound fee certs wdrls
     metadataSchema scriptFiles metadataFiles mProtocolParamsFile mUpProp =
@@ -122,22 +122,22 @@ runLegacyTxBuildRawCmd
     mTotColl reqSigners txouts mValue mLowBound mUpperBound fee certs wdrls
     metadataSchema scriptFiles metadataFiles mProtocolParamsFile mUpProp [] []
 
-runLegacyTxSignCmd :: InputTxBodyOrTxFile
+runLegacyTransactionSignCmd :: InputTxBodyOrTxFile
           -> [WitnessSigningData]
           -> Maybe NetworkId
           -> TxFile Out
           -> ExceptT TxCmdError IO ()
-runLegacyTxSignCmd = runTxSignCmd
+runLegacyTransactionSignCmd = runTxSignCmd
 
-runLegacyTxSubmitCmd :: ()
+runLegacyTransactionSubmitCmd :: ()
   => SocketPath
   -> AnyConsensusModeParams
   -> NetworkId
   -> FilePath
   -> ExceptT TxCmdError IO ()
-runLegacyTxSubmitCmd = runTxSubmitCmd
+runLegacyTransactionSubmitCmd = runTxSubmitCmd
 
-runLegacyTxCalculateMinFeeCmd :: ()
+runLegacyTransactionCalculateMinFeeCmd :: ()
   => TxBodyFile In
   -> NetworkId
   -> ProtocolParamsFile
@@ -146,38 +146,38 @@ runLegacyTxCalculateMinFeeCmd :: ()
   -> TxShelleyWitnessCount
   -> TxByronWitnessCount
   -> ExceptT TxCmdError IO ()
-runLegacyTxCalculateMinFeeCmd = runTxCalculateMinFeeCmd
+runLegacyTransactionCalculateMinFeeCmd = runTxCalculateMinFeeCmd
 
-runLegacyTxCalculateMinRequiredUTxOCmd :: ()
+runLegacyTransactionCalculateMinValueCmd :: ()
   => AnyCardanoEra
   -> ProtocolParamsFile
   -> TxOutAnyEra
   -> ExceptT TxCmdError IO ()
-runLegacyTxCalculateMinRequiredUTxOCmd (AnyCardanoEra era) = runTxCalculateMinRequiredUTxOCmd era
+runLegacyTransactionCalculateMinValueCmd (AnyCardanoEra era) = runTxCalculateMinRequiredUTxOCmd era
 
-runLegacyTxCreatePolicyIdCmd :: ScriptFile -> ExceptT TxCmdError IO ()
-runLegacyTxCreatePolicyIdCmd = runTxCreatePolicyIdCmd
+runLegacyTransactionPolicyIdCmd :: ScriptFile -> ExceptT TxCmdError IO ()
+runLegacyTransactionPolicyIdCmd = runTxCreatePolicyIdCmd
 
-runLegacyTxHashScriptDataCmd :: ScriptDataOrFile -> ExceptT TxCmdError IO ()
-runLegacyTxHashScriptDataCmd = runTxHashScriptDataCmd
+runLegacyTransactionHashScriptDataCmd :: ScriptDataOrFile -> ExceptT TxCmdError IO ()
+runLegacyTransactionHashScriptDataCmd = runTxHashScriptDataCmd
 
-runLegacyTxGetTxIdCmd :: InputTxBodyOrTxFile -> ExceptT TxCmdError IO ()
-runLegacyTxGetTxIdCmd = runTxGetTxIdCmd
+runLegacyTransactionTxIdCmd :: InputTxBodyOrTxFile -> ExceptT TxCmdError IO ()
+runLegacyTransactionTxIdCmd = runTxGetTxIdCmd
 
-runLegacyTxViewCmd :: TxViewOutputFormat -> Maybe (File () Out) -> InputTxBodyOrTxFile -> ExceptT TxCmdError IO ()
-runLegacyTxViewCmd = runTxViewCmd
+runLegacyTransactionViewCmd :: TxViewOutputFormat -> Maybe (File () Out) -> InputTxBodyOrTxFile -> ExceptT TxCmdError IO ()
+runLegacyTransactionViewCmd = runTxViewCmd
 
-runLegacyTxCreateWitnessCmd :: ()
+runLegacyTransactionWitnessCmd :: ()
   => TxBodyFile In
   -> WitnessSigningData
   -> Maybe NetworkId
   -> File () Out
   -> ExceptT TxCmdError IO ()
-runLegacyTxCreateWitnessCmd = runTxCreateWitnessCmd
+runLegacyTransactionWitnessCmd = runTxCreateWitnessCmd
 
-runLegacyTxSignWitnessCmd :: ()
+runLegacyTransactionSignWitnessCmd :: ()
   => TxBodyFile In
   -> [WitnessFile]
   -> File () Out
   -> ExceptT TxCmdError IO ()
-runLegacyTxSignWitnessCmd = runTxSignWitnessCmd
+runLegacyTransactionSignWitnessCmd = runTxSignWitnessCmd

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Transaction.hs
@@ -11,6 +11,7 @@ module Cardano.CLI.Legacy.Run.Transaction
 
 import           Cardano.Api
 
+import qualified Cardano.CLI.EraBased.Commands.Transaction as Cmd
 import           Cardano.CLI.EraBased.Run.Transaction
 import           Cardano.CLI.Legacy.Commands.Transaction
 import           Cardano.CLI.Types.Common
@@ -89,7 +90,19 @@ runLegacyTransactionBuildCmd :: ()
   -> [ProposalFile In]
   -> TxBuildOutputOptions
   -> ExceptT TxCmdError IO ()
-runLegacyTransactionBuildCmd socketPath (AnyCardanoEra era) = runTransactionBuildCmd era socketPath
+runLegacyTransactionBuildCmd
+    socketPath (AnyCardanoEra era)
+    consensusModeParams nid mScriptValidity mOverrideWits txins readOnlyRefIns
+    reqSigners txinsc mReturnColl mTotCollateral txouts changeAddr mValue mLowBound
+    mUpperBound certs wdrls metadataSchema scriptFiles metadataFiles mUpProp voteFiles
+    proposalFiles outputOptions =
+  runTransactionBuildCmd
+    ( Cmd.TransactionBuildCmdArgs era socketPath
+        consensusModeParams nid mScriptValidity mOverrideWits txins readOnlyRefIns
+        reqSigners txinsc mReturnColl mTotCollateral txouts changeAddr mValue mLowBound
+        mUpperBound certs wdrls metadataSchema scriptFiles metadataFiles mUpProp voteFiles
+        proposalFiles outputOptions
+    )
 
 runLegacyTransactionBuildRawCmd :: ()
   => AnyCardanoEra
@@ -117,17 +130,32 @@ runLegacyTransactionBuildRawCmd :: ()
 runLegacyTransactionBuildRawCmd
     (AnyCardanoEra era) mScriptValidity txins readOnlyRefIns txinsc mReturnColl
     mTotColl reqSigners txouts mValue mLowBound mUpperBound fee certs wdrls
-    metadataSchema scriptFiles metadataFiles mProtocolParamsFile mUpProp =
-  runTransactionBuildRawCmd era mScriptValidity txins readOnlyRefIns txinsc mReturnColl
-    mTotColl reqSigners txouts mValue mLowBound mUpperBound fee certs wdrls
-    metadataSchema scriptFiles metadataFiles mProtocolParamsFile mUpProp [] []
+    metadataSchema scriptFiles metadataFiles mProtocolParamsFile mUpProp outFile =
+  runTransactionBuildRawCmd
+    ( Cmd.TransactionBuildRawCmdArgs
+        era mScriptValidity txins readOnlyRefIns txinsc mReturnColl
+        mTotColl reqSigners txouts mValue mLowBound mUpperBound fee certs wdrls
+        metadataSchema scriptFiles metadataFiles mProtocolParamsFile mUpProp [] []
+        outFile
+    )
 
 runLegacyTransactionSignCmd :: InputTxBodyOrTxFile
           -> [WitnessSigningData]
           -> Maybe NetworkId
           -> TxFile Out
           -> ExceptT TxCmdError IO ()
-runLegacyTransactionSignCmd = runTransactionSignCmd
+runLegacyTransactionSignCmd
+    txOrTxBody
+    witSigningData
+    mnw
+    outTxFile =
+  runTransactionSignCmd
+    ( Cmd.TransactionSignCmdArgs
+       txOrTxBody
+       witSigningData
+       mnw
+       outTxFile
+    )
 
 runLegacyTransactionSubmitCmd :: ()
   => SocketPath
@@ -135,7 +163,18 @@ runLegacyTransactionSubmitCmd :: ()
   -> NetworkId
   -> FilePath
   -> ExceptT TxCmdError IO ()
-runLegacyTransactionSubmitCmd = runTransactionSubmitCmd
+runLegacyTransactionSubmitCmd
+    socketPath
+    anyConsensusModeParams
+    network
+    txFilePath =
+  runTransactionSubmitCmd
+    ( Cmd.TransactionSubmitCmdArgs
+        socketPath
+        anyConsensusModeParams
+        network
+        txFilePath
+     )
 
 runLegacyTransactionCalculateMinFeeCmd :: ()
   => TxBodyFile In
@@ -146,26 +185,73 @@ runLegacyTransactionCalculateMinFeeCmd :: ()
   -> TxShelleyWitnessCount
   -> TxByronWitnessCount
   -> ExceptT TxCmdError IO ()
-runLegacyTransactionCalculateMinFeeCmd = runTransactionCalculateMinFeeCmd
+runLegacyTransactionCalculateMinFeeCmd
+    txbodyFile
+    nw
+    pParamsFile
+    txInCount
+    txOutCount
+    txShelleyWitnessCount
+    txByronWitnessCount =
+  runTransactionCalculateMinFeeCmd
+    ( Cmd.TransactionCalculateMinFeeCmdArgs
+        txbodyFile
+        nw
+        pParamsFile
+        txInCount
+        txOutCount
+        txShelleyWitnessCount
+        txByronWitnessCount
+    )
 
 runLegacyTransactionCalculateMinValueCmd :: ()
   => AnyCardanoEra
   -> ProtocolParamsFile
   -> TxOutAnyEra
   -> ExceptT TxCmdError IO ()
-runLegacyTransactionCalculateMinValueCmd (AnyCardanoEra era) = runTransactionCalculateMinValueCmd era
+runLegacyTransactionCalculateMinValueCmd
+    (AnyCardanoEra era)
+    pParamsFile
+    txOut =
+  runTransactionCalculateMinValueCmd
+    ( Cmd.TransactionCalculateMinValueCmdArgs
+        era
+        pParamsFile
+        txOut
+    )
 
-runLegacyTransactionPolicyIdCmd :: ScriptFile -> ExceptT TxCmdError IO ()
-runLegacyTransactionPolicyIdCmd = runTransactionPolicyIdCmd
+runLegacyTransactionPolicyIdCmd ::  ScriptFile -> ExceptT TxCmdError IO ()
+runLegacyTransactionPolicyIdCmd scriptFile =
+  runTransactionPolicyIdCmd
+    ( Cmd.TransactionPolicyIdCmdArgs
+        scriptFile
+    )
 
 runLegacyTransactionHashScriptDataCmd :: ScriptDataOrFile -> ExceptT TxCmdError IO ()
-runLegacyTransactionHashScriptDataCmd = runTransactionHashScriptDataCmd
+runLegacyTransactionHashScriptDataCmd scriptDataOrFile =
+  runTransactionHashScriptDataCmd
+    ( Cmd.TransactionHashScriptDataCmdArgs
+        scriptDataOrFile
+    )
 
 runLegacyTransactionTxIdCmd :: InputTxBodyOrTxFile -> ExceptT TxCmdError IO ()
-runLegacyTransactionTxIdCmd = runTransactionTxIdCmd
+runLegacyTransactionTxIdCmd txfile =
+  runTransactionTxIdCmd
+    ( Cmd.TransactionTxIdCmdArgs
+        txfile
+    )
 
 runLegacyTransactionViewCmd :: TxViewOutputFormat -> Maybe (File () Out) -> InputTxBodyOrTxFile -> ExceptT TxCmdError IO ()
-runLegacyTransactionViewCmd = runTransactionViewCmd
+runLegacyTransactionViewCmd
+    yamlOrJson
+    mOutFile
+    inputTxBodyOrTxFile =
+  runTransactionViewCmd
+    ( Cmd.TransactionViewCmdArgs
+        yamlOrJson
+        mOutFile
+        inputTxBodyOrTxFile
+    )
 
 runLegacyTransactionWitnessCmd :: ()
   => TxBodyFile In
@@ -173,11 +259,31 @@ runLegacyTransactionWitnessCmd :: ()
   -> Maybe NetworkId
   -> File () Out
   -> ExceptT TxCmdError IO ()
-runLegacyTransactionWitnessCmd = runTransactionWitnessCmd
+runLegacyTransactionWitnessCmd
+    txbodyFile
+    witSignData
+    mbNw
+    outFile =
+  runTransactionWitnessCmd
+    ( Cmd.TransactionWitnessCmdArgs
+        txbodyFile
+        witSignData
+        mbNw
+        outFile
+     )
 
 runLegacyTransactionSignWitnessCmd :: ()
   => TxBodyFile In
   -> [WitnessFile]
   -> File () Out
   -> ExceptT TxCmdError IO ()
-runLegacyTransactionSignWitnessCmd = runTransactionSignWitnessCmd
+runLegacyTransactionSignWitnessCmd
+    txbodyFile
+    witnessFiles
+    outFile =
+  runTransactionSignWitnessCmd
+    ( Cmd.TransactionSignWitnessCmdArgs
+        txbodyFile
+        witnessFiles
+        outFile
+    )


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Command argument types for `transaction` commands
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

The next step would be to make the new arguments appear only in conway onwards.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
