### PR TITLE
Ch/clearer anchor flags

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
@@ -3176,7 +3176,7 @@ pDRepVerificationKeyFile =
 pProposalUrl :: Parser ProposalUrl
 pProposalUrl =
   ProposalUrl
-    <$> pUrl "proposal-url" "Proposal anchor URL"
+    <$> pUrl "proposal-anchor-url" "Proposal anchor URL"
 
 pProposalHashSource :: Parser ProposalHashSource
 pProposalHashSource =
@@ -3184,13 +3184,13 @@ pProposalHashSource =
     [ ProposalHashSourceText
         <$> Opt.strOption
             ( mconcat
-                [ Opt.long "proposal-text"
+                [ Opt.long "proposal-anchor-metadata"
                 , Opt.metavar "TEXT"
-                , Opt.help "Input proposal as UTF-8 encoded text."
+                , Opt.help "Proposal anchor contents as UTF-8 encoded text."
                 ]
             )
     , ProposalHashSourceFile
-        <$> pFileInDirection "proposal-file" "Input proposal as a text file."
+        <$> pFileInDirection "proposal-anchor-metadata-file" "Proposal anchor contents as a text file."
     , ProposalHashSourceHash
         <$> pProposalHash
     ]
@@ -3198,9 +3198,9 @@ pProposalHashSource =
 pProposalHash :: Parser (L.SafeHash Crypto.StandardCrypto L.AnchorData)
 pProposalHash =
   Opt.option readSafeHash $ mconcat
-    [ Opt.long "proposal-hash"
+    [ Opt.long "proposal-anchor-metadata-hash"
     , Opt.metavar "HASH"
-    , Opt.help "Proposal anchor data hash."
+    , Opt.help "Hash of the proposal anchor contents."
     ]
 
 pPreviousGovernanceAction :: Parser (Maybe (TxId, Word32))

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
@@ -921,7 +921,7 @@ pConstitutionHash =
   Opt.option readSafeHash $ mconcat
     [ Opt.long "constitution-anchor-metadata-hash"
     , Opt.metavar "HASH"
-    , Opt.help "Hash of the constitution anchor contents."
+    , Opt.help "Hash of the constitution anchor data."
     ]
 
 pUrl :: String -> String -> Parser Ledger.Url
@@ -3060,7 +3060,7 @@ pVoteHash =
   Opt.option readSafeHash $ mconcat
     [ Opt.long "vote-anchor-metadata-hash"
     , Opt.metavar "HASH"
-    , Opt.help "Hash of the vote anchor contents."
+    , Opt.help "Hash of the vote anchor data."
     ]
 
 pAlwaysNoConfidence :: Parser ()

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
@@ -3035,7 +3035,7 @@ pAlwaysAbstain =
 
 pVoteAnchor :: Parser (VoteUrl, VoteHashSource)
 pVoteAnchor = (,)
-  <$> (VoteUrl <$> pUrl "vote-url" "Vote anchor URL")
+  <$> (VoteUrl <$> pUrl "vote-anchor-url" "Vote anchor URL")
   <*> pVoteHashSource
 
 pVoteHashSource :: Parser VoteHashSource
@@ -3044,13 +3044,13 @@ pVoteHashSource =
     [ VoteHashSourceText
         <$> Opt.strOption
             ( mconcat
-                [ Opt.long "vote-text"
+                [ Opt.long "vote-anchor-metadata"
                 , Opt.metavar "TEXT"
-                , Opt.help "Input vote as UTF-8 encoded text."
+                , Opt.help "Vote anchor contents as UTF-8 encoded text."
                 ]
             )
     , VoteHashSourceFile
-        <$> pFileInDirection "vote-file" "Input vote as a text file."
+        <$> pFileInDirection "vote-anchor-metadata-file" "Vote anchor contents as a text file."
     , VoteHashSourceHash
         <$> pVoteHash
     ]
@@ -3058,9 +3058,9 @@ pVoteHashSource =
 pVoteHash :: Parser (L.SafeHash Crypto.StandardCrypto L.AnchorData)
 pVoteHash =
   Opt.option readSafeHash $ mconcat
-    [ Opt.long "vote-hash"
+    [ Opt.long "vote-anchor-metadata-hash"
     , Opt.metavar "HASH"
-    , Opt.help "Vote anchor data hash."
+    , Opt.help "Hash of the vote anchor contents."
     ]
 
 pAlwaysNoConfidence :: Parser ()

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
@@ -897,7 +897,7 @@ catCommands = \case
 pConstitutionUrl :: Parser ConstitutionUrl
 pConstitutionUrl =
   ConstitutionUrl
-    <$> pUrl "constitution-url" "Constitution URL."
+    <$> pUrl "constitution-anchor-url" "Constitution anchor URL."
 
 pConstitutionHashSource :: Parser ConstitutionHashSource
 pConstitutionHashSource =
@@ -905,13 +905,13 @@ pConstitutionHashSource =
     [ ConstitutionHashSourceText
         <$> Opt.strOption
             ( mconcat
-                [ Opt.long "constitution-text"
+                [ Opt.long "constitution-anchor-metadata"
                 , Opt.metavar "TEXT"
-                , Opt.help "Input constitution as UTF-8 encoded text."
+                , Opt.help "Constitution anchor contents as UTF-8 encoded text."
                 ]
             )
     , ConstitutionHashSourceFile
-        <$> pFileInDirection "constitution-file" "Input constitution as a text file."
+        <$> pFileInDirection "constitution-anchor-metadata-file" "Constitution anchor contents as a text file."
     , ConstitutionHashSourceHash
         <$> pConstitutionHash
     ]
@@ -919,9 +919,9 @@ pConstitutionHashSource =
 pConstitutionHash :: Parser (L.SafeHash Crypto.StandardCrypto L.AnchorData)
 pConstitutionHash =
   Opt.option readSafeHash $ mconcat
-    [ Opt.long "constitution-hash"
+    [ Opt.long "constitution-anchor-metadata-hash"
     , Opt.metavar "HASH"
-    , Opt.help "Constitution anchor data hash."
+    , Opt.help "Hash of the constitution anchor contents."
     ]
 
 pUrl :: String -> String -> Parser Ledger.Url
@@ -3200,7 +3200,7 @@ pProposalHash =
   Opt.option readSafeHash $ mconcat
     [ Opt.long "proposal-anchor-metadata-hash"
     , Opt.metavar "HASH"
-    , Opt.help "Hash of the proposal anchor contents."
+    , Opt.help "Proposal anchor data hash."
     ]
 
 pPreviousGovernanceAction :: Parser (Maybe (TxId, Word32))

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Governance/Action.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Governance/Action.hs
@@ -30,8 +30,8 @@ hprop_golden_governanceActionCreateConstitution =
     void $ execCardanoCLI
       [ "conway", "governance", "action", "create-constitution"
       , "--mainnet"
-      , "--proposal-text", "eda258650888d4a7f8ac1127cfa136962f527f341c99db49929c79ae"
-      , "--proposal-url", "proposal-dummy-url"
+      , "--proposal-anchor-metadata", "eda258650888d4a7f8ac1127cfa136962f527f341c99db49929c79ae"
+      , "--proposal-anchor-url", "proposal-dummy-url"
       , "--governance-action-deposit", "10"
       , "--stake-verification-key-file", stakeAddressVKeyFile
       , "--out-file", actionFile

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Governance/Action.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Governance/Action.hs
@@ -35,8 +35,8 @@ hprop_golden_governanceActionCreateConstitution =
       , "--governance-action-deposit", "10"
       , "--stake-verification-key-file", stakeAddressVKeyFile
       , "--out-file", actionFile
-      , "--constitution-url", "constitution-dummy-url"
-      , "--constitution-text", "This is a test constitution."
+      , "--constitution-anchor-url", "constitution-dummy-url"
+      , "--constitution-anchor-metadata", "This is a test constitution."
       ]
 
     goldenActionFile <-  H.note "test/cardano-cli-golden/files/golden/governance/action/create-constitution-for-stake-address.action.golden"

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Governance/Vote.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Governance/Vote.hs
@@ -24,8 +24,8 @@ hprop_golden_governance_governance_vote_create =
       , "--governance-action-index", "5"
       , "--drep-verification-key-file", vkeyFile
       , "--out-file", voteFile
-      , "--vote-url", "https://example.com/vote"
-      , "--vote-text", "I don't like this proposal, because it's bad. I'm not going to tell you why I voted yes nonetheless."
+      , "--vote-anchor-url", "https://example.com/vote"
+      , "--vote-anchor-metadata", "I don't like this proposal, because it's bad. I'm not going to tell you why I voted yes nonetheless."
       ]
 
     H.diffFileVsGoldenFile voteFile voteGold

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -6351,10 +6351,10 @@ Usage: cardano-cli conway governance vote create (--yes | --no | --abstain)
                                                    | --cc-hot-key-hash STRING
                                                    )
                                                    --out-file FILE
-                                                   [--vote-url TEXT
-                                                     ( --vote-text TEXT
-                                                     | --vote-file FILE
-                                                     | --vote-hash HASH
+                                                   [--vote-anchor-url TEXT
+                                                     ( --vote-anchor-metadata TEXT
+                                                     | --vote-anchor-metadata-file FILE
+                                                     | --vote-anchor-metadata-hash HASH
                                                      )]
 
   Vote creation.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -6065,10 +6065,10 @@ Usage: cardano-cli conway governance action create-constitution
                                                                   )
                                                                   [--governance-action-tx-id TXID
                                                                     --governance-action-index WORD32]
-                                                                  --proposal-url TEXT
-                                                                  ( --proposal-text TEXT
-                                                                  | --proposal-file FILE
-                                                                  | --proposal-hash HASH
+                                                                  --proposal-anchor-url TEXT
+                                                                  ( --proposal-anchor-metadata TEXT
+                                                                  | --proposal-anchor-metadata-file FILE
+                                                                  | --proposal-anchor-metadata-hash HASH
                                                                   )
                                                                   --constitution-url TEXT
                                                                   ( --constitution-text TEXT
@@ -6091,10 +6091,10 @@ Usage: cardano-cli conway governance action update-committee
                                                                | --stake-verification-key-file FILE
                                                                | --stake-key-hash HASH
                                                                )
-                                                               --proposal-url TEXT
-                                                               ( --proposal-text TEXT
-                                                               | --proposal-file FILE
-                                                               | --proposal-hash HASH
+                                                               --proposal-anchor-url TEXT
+                                                               ( --proposal-anchor-metadata TEXT
+                                                               | --proposal-anchor-metadata-file FILE
+                                                               | --proposal-anchor-metadata-hash HASH
                                                                )
                                                                [ --remove-cc-cold-verification-key STRING
                                                                | --remove-cc-cold-verification-key-file FILE
@@ -6122,10 +6122,10 @@ Usage: cardano-cli conway governance action create-info (--mainnet | --testnet)
                                                           | --stake-verification-key-file FILE
                                                           | --stake-key-hash HASH
                                                           )
-                                                          --proposal-url TEXT
-                                                          ( --proposal-text TEXT
-                                                          | --proposal-file FILE
-                                                          | --proposal-hash HASH
+                                                          --proposal-anchor-url TEXT
+                                                          ( --proposal-anchor-metadata TEXT
+                                                          | --proposal-anchor-metadata-file FILE
+                                                          | --proposal-anchor-metadata-hash HASH
                                                           )
                                                           --out-file FILE
 
@@ -6143,10 +6143,10 @@ Usage: cardano-cli conway governance action create-no-confidence
                                                                    | --stake-verification-key-file FILE
                                                                    | --stake-key-hash HASH
                                                                    )
-                                                                   --proposal-url TEXT
-                                                                   ( --proposal-text TEXT
-                                                                   | --proposal-file FILE
-                                                                   | --proposal-hash HASH
+                                                                   --proposal-anchor-url TEXT
+                                                                   ( --proposal-anchor-metadata TEXT
+                                                                   | --proposal-anchor-metadata-file FILE
+                                                                   | --proposal-anchor-metadata-hash HASH
                                                                    )
                                                                    --governance-action-tx-id TXID
                                                                    --governance-action-index WORD32
@@ -6214,10 +6214,10 @@ Usage: cardano-cli conway governance action create-treasury-withdrawal
                                                                          | --stake-verification-key-file FILE
                                                                          | --stake-key-hash HASH
                                                                          )
-                                                                         --proposal-url TEXT
-                                                                         ( --proposal-text TEXT
-                                                                         | --proposal-file FILE
-                                                                         | --proposal-hash HASH
+                                                                         --proposal-anchor-url TEXT
+                                                                         ( --proposal-anchor-metadata TEXT
+                                                                         | --proposal-anchor-metadata-file FILE
+                                                                         | --proposal-anchor-metadata-hash HASH
                                                                          )
                                                                          [
                                                                            ( --stake-pool-verification-key STRING

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -6070,10 +6070,10 @@ Usage: cardano-cli conway governance action create-constitution
                                                                   | --proposal-anchor-metadata-file FILE
                                                                   | --proposal-anchor-metadata-hash HASH
                                                                   )
-                                                                  --constitution-url TEXT
-                                                                  ( --constitution-text TEXT
-                                                                  | --constitution-file FILE
-                                                                  | --constitution-hash HASH
+                                                                  --constitution-anchor-url TEXT
+                                                                  ( --constitution-anchor-metadata TEXT
+                                                                  | --constitution-anchor-metadata-file FILE
+                                                                  | --constitution-anchor-metadata-hash HASH
                                                                   )
                                                                   --out-file FILE
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_create-constitution.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_create-constitution.cli
@@ -17,10 +17,10 @@ Usage: cardano-cli conway governance action create-constitution
                                                                   | --proposal-anchor-metadata-file FILE
                                                                   | --proposal-anchor-metadata-hash HASH
                                                                   )
-                                                                  --constitution-url TEXT
-                                                                  ( --constitution-text TEXT
-                                                                  | --constitution-file FILE
-                                                                  | --constitution-hash HASH
+                                                                  --constitution-anchor-url TEXT
+                                                                  ( --constitution-anchor-metadata TEXT
+                                                                  | --constitution-anchor-metadata-file FILE
+                                                                  | --constitution-anchor-metadata-hash HASH
                                                                   )
                                                                   --out-file FILE
 
@@ -55,10 +55,14 @@ Available options:
   --proposal-anchor-metadata-file FILE
                            Proposal anchor contents as a text file.
   --proposal-anchor-metadata-hash HASH
-                           Hash of the proposal anchor contents.
-  --constitution-url TEXT  Constitution URL.
-  --constitution-text TEXT Input constitution as UTF-8 encoded text.
-  --constitution-file FILE Input constitution as a text file.
-  --constitution-hash HASH Constitution anchor data hash.
+                           Proposal anchor data hash.
+  --constitution-anchor-url TEXT
+                           Constitution anchor URL.
+  --constitution-anchor-metadata TEXT
+                           Constitution anchor contents as UTF-8 encoded text.
+  --constitution-anchor-metadata-file FILE
+                           Constitution anchor contents as a text file.
+  --constitution-anchor-metadata-hash HASH
+                           Hash of the constitution anchor contents.
   --out-file FILE          Output filepath of the constitution.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_create-constitution.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_create-constitution.cli
@@ -63,6 +63,6 @@ Available options:
   --constitution-anchor-metadata-file FILE
                            Constitution anchor contents as a text file.
   --constitution-anchor-metadata-hash HASH
-                           Hash of the constitution anchor contents.
+                           Hash of the constitution anchor data.
   --out-file FILE          Output filepath of the constitution.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_create-constitution.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_create-constitution.cli
@@ -12,10 +12,10 @@ Usage: cardano-cli conway governance action create-constitution
                                                                   )
                                                                   [--governance-action-tx-id TXID
                                                                     --governance-action-index WORD32]
-                                                                  --proposal-url TEXT
-                                                                  ( --proposal-text TEXT
-                                                                  | --proposal-file FILE
-                                                                  | --proposal-hash HASH
+                                                                  --proposal-anchor-url TEXT
+                                                                  ( --proposal-anchor-metadata TEXT
+                                                                  | --proposal-anchor-metadata-file FILE
+                                                                  | --proposal-anchor-metadata-hash HASH
                                                                   )
                                                                   --constitution-url TEXT
                                                                   ( --constitution-text TEXT
@@ -48,10 +48,14 @@ Available options:
                            Previous txid of the governance action.
   --governance-action-index WORD32
                            Previous tx's governance action index.
-  --proposal-url TEXT      Proposal anchor URL
-  --proposal-text TEXT     Input proposal as UTF-8 encoded text.
-  --proposal-file FILE     Input proposal as a text file.
-  --proposal-hash HASH     Proposal anchor data hash.
+  --proposal-anchor-url TEXT
+                           Proposal anchor URL
+  --proposal-anchor-metadata TEXT
+                           Proposal anchor contents as UTF-8 encoded text.
+  --proposal-anchor-metadata-file FILE
+                           Proposal anchor contents as a text file.
+  --proposal-anchor-metadata-hash HASH
+                           Hash of the proposal anchor contents.
   --constitution-url TEXT  Constitution URL.
   --constitution-text TEXT Input constitution as UTF-8 encoded text.
   --constitution-file FILE Input constitution as a text file.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_create-info.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_create-info.cli
@@ -7,10 +7,10 @@ Usage: cardano-cli conway governance action create-info (--mainnet | --testnet)
                                                           | --stake-verification-key-file FILE
                                                           | --stake-key-hash HASH
                                                           )
-                                                          --proposal-url TEXT
-                                                          ( --proposal-text TEXT
-                                                          | --proposal-file FILE
-                                                          | --proposal-hash HASH
+                                                          --proposal-anchor-url TEXT
+                                                          ( --proposal-anchor-metadata TEXT
+                                                          | --proposal-anchor-metadata-file FILE
+                                                          | --proposal-anchor-metadata-hash HASH
                                                           )
                                                           --out-file FILE
 
@@ -34,10 +34,14 @@ Available options:
   --stake-verification-key-file FILE
                            Filepath of the staking verification key.
   --stake-key-hash HASH    Stake verification key hash (hex-encoded).
-  --proposal-url TEXT      Proposal anchor URL
-  --proposal-text TEXT     Input proposal as UTF-8 encoded text.
-  --proposal-file FILE     Input proposal as a text file.
-  --proposal-hash HASH     Proposal anchor data hash.
+  --proposal-anchor-url TEXT
+                           Proposal anchor URL
+  --proposal-anchor-metadata TEXT
+                           Proposal anchor contents as UTF-8 encoded text.
+  --proposal-anchor-metadata-file FILE
+                           Proposal anchor contents as a text file.
+  --proposal-anchor-metadata-hash HASH
+                           Hash of the proposal anchor contents.
   --out-file FILE          Path to action file to be used later on with build or
                            build-raw
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_create-info.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_create-info.cli
@@ -41,7 +41,7 @@ Available options:
   --proposal-anchor-metadata-file FILE
                            Proposal anchor contents as a text file.
   --proposal-anchor-metadata-hash HASH
-                           Hash of the proposal anchor contents.
+                           Proposal anchor data hash.
   --out-file FILE          Path to action file to be used later on with build or
                            build-raw
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_create-no-confidence.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_create-no-confidence.cli
@@ -10,10 +10,10 @@ Usage: cardano-cli conway governance action create-no-confidence
                                                                    | --stake-verification-key-file FILE
                                                                    | --stake-key-hash HASH
                                                                    )
-                                                                   --proposal-url TEXT
-                                                                   ( --proposal-text TEXT
-                                                                   | --proposal-file FILE
-                                                                   | --proposal-hash HASH
+                                                                   --proposal-anchor-url TEXT
+                                                                   ( --proposal-anchor-metadata TEXT
+                                                                   | --proposal-anchor-metadata-file FILE
+                                                                   | --proposal-anchor-metadata-hash HASH
                                                                    )
                                                                    --governance-action-tx-id TXID
                                                                    --governance-action-index WORD32
@@ -39,10 +39,14 @@ Available options:
   --stake-verification-key-file FILE
                            Filepath of the staking verification key.
   --stake-key-hash HASH    Stake verification key hash (hex-encoded).
-  --proposal-url TEXT      Proposal anchor URL
-  --proposal-text TEXT     Input proposal as UTF-8 encoded text.
-  --proposal-file FILE     Input proposal as a text file.
-  --proposal-hash HASH     Proposal anchor data hash.
+  --proposal-anchor-url TEXT
+                           Proposal anchor URL
+  --proposal-anchor-metadata TEXT
+                           Proposal anchor contents as UTF-8 encoded text.
+  --proposal-anchor-metadata-file FILE
+                           Proposal anchor contents as a text file.
+  --proposal-anchor-metadata-hash HASH
+                           Hash of the proposal anchor contents.
   --governance-action-tx-id TXID
                            Previous txid of `NoConfidence` or `NewCommittee`
                            governance action.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_create-no-confidence.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_create-no-confidence.cli
@@ -46,7 +46,7 @@ Available options:
   --proposal-anchor-metadata-file FILE
                            Proposal anchor contents as a text file.
   --proposal-anchor-metadata-hash HASH
-                           Hash of the proposal anchor contents.
+                           Proposal anchor data hash.
   --governance-action-tx-id TXID
                            Previous txid of `NoConfidence` or `NewCommittee`
                            governance action.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_create-treasury-withdrawal.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_create-treasury-withdrawal.cli
@@ -10,10 +10,10 @@ Usage: cardano-cli conway governance action create-treasury-withdrawal
                                                                          | --stake-verification-key-file FILE
                                                                          | --stake-key-hash HASH
                                                                          )
-                                                                         --proposal-url TEXT
-                                                                         ( --proposal-text TEXT
-                                                                         | --proposal-file FILE
-                                                                         | --proposal-hash HASH
+                                                                         --proposal-anchor-url TEXT
+                                                                         ( --proposal-anchor-metadata TEXT
+                                                                         | --proposal-anchor-metadata-file FILE
+                                                                         | --proposal-anchor-metadata-hash HASH
                                                                          )
                                                                          [
                                                                            ( --stake-pool-verification-key STRING
@@ -46,10 +46,14 @@ Available options:
   --stake-verification-key-file FILE
                            Filepath of the staking verification key.
   --stake-key-hash HASH    Stake verification key hash (hex-encoded).
-  --proposal-url TEXT      Proposal anchor URL
-  --proposal-text TEXT     Input proposal as UTF-8 encoded text.
-  --proposal-file FILE     Input proposal as a text file.
-  --proposal-hash HASH     Proposal anchor data hash.
+  --proposal-anchor-url TEXT
+                           Proposal anchor URL
+  --proposal-anchor-metadata TEXT
+                           Proposal anchor contents as UTF-8 encoded text.
+  --proposal-anchor-metadata-file FILE
+                           Proposal anchor contents as a text file.
+  --proposal-anchor-metadata-hash HASH
+                           Hash of the proposal anchor contents.
   --stake-pool-verification-key STRING
                            Stake pool verification key (Bech32 or hex-encoded).
   --cold-verification-key-file FILE

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_create-treasury-withdrawal.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_create-treasury-withdrawal.cli
@@ -53,7 +53,7 @@ Available options:
   --proposal-anchor-metadata-file FILE
                            Proposal anchor contents as a text file.
   --proposal-anchor-metadata-hash HASH
-                           Hash of the proposal anchor contents.
+                           Proposal anchor data hash.
   --stake-pool-verification-key STRING
                            Stake pool verification key (Bech32 or hex-encoded).
   --cold-verification-key-file FILE

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_update-committee.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_update-committee.cli
@@ -10,10 +10,10 @@ Usage: cardano-cli conway governance action update-committee
                                                                | --stake-verification-key-file FILE
                                                                | --stake-key-hash HASH
                                                                )
-                                                               --proposal-url TEXT
-                                                               ( --proposal-text TEXT
-                                                               | --proposal-file FILE
-                                                               | --proposal-hash HASH
+                                                               --proposal-anchor-url TEXT
+                                                               ( --proposal-anchor-metadata TEXT
+                                                               | --proposal-anchor-metadata-file FILE
+                                                               | --proposal-anchor-metadata-hash HASH
                                                                )
                                                                [ --remove-cc-cold-verification-key STRING
                                                                | --remove-cc-cold-verification-key-file FILE
@@ -50,10 +50,14 @@ Available options:
   --stake-verification-key-file FILE
                            Filepath of the staking verification key.
   --stake-key-hash HASH    Stake verification key hash (hex-encoded).
-  --proposal-url TEXT      Proposal anchor URL
-  --proposal-text TEXT     Input proposal as UTF-8 encoded text.
-  --proposal-file FILE     Input proposal as a text file.
-  --proposal-hash HASH     Proposal anchor data hash.
+  --proposal-anchor-url TEXT
+                           Proposal anchor URL
+  --proposal-anchor-metadata TEXT
+                           Proposal anchor contents as UTF-8 encoded text.
+  --proposal-anchor-metadata-file FILE
+                           Proposal anchor contents as a text file.
+  --proposal-anchor-metadata-hash HASH
+                           Hash of the proposal anchor contents.
   --remove-cc-cold-verification-key STRING
                            Constitutional Committee cold key (hex-encoded).
   --remove-cc-cold-verification-key-file FILE

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_update-committee.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_update-committee.cli
@@ -57,7 +57,7 @@ Available options:
   --proposal-anchor-metadata-file FILE
                            Proposal anchor contents as a text file.
   --proposal-anchor-metadata-hash HASH
-                           Hash of the proposal anchor contents.
+                           Proposal anchor data hash.
   --remove-cc-cold-verification-key STRING
                            Constitutional Committee cold key (hex-encoded).
   --remove-cc-cold-verification-key-file FILE

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_vote_create.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_vote_create.cli
@@ -52,5 +52,5 @@ Available options:
   --vote-anchor-metadata-file FILE
                            Vote anchor contents as a text file.
   --vote-anchor-metadata-hash HASH
-                           Hash of the vote anchor contents.
+                           Hash of the vote anchor data.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_vote_create.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_vote_create.cli
@@ -12,10 +12,10 @@ Usage: cardano-cli conway governance vote create (--yes | --no | --abstain)
                                                    | --cc-hot-key-hash STRING
                                                    )
                                                    --out-file FILE
-                                                   [--vote-url TEXT
-                                                     ( --vote-text TEXT
-                                                     | --vote-file FILE
-                                                     | --vote-hash HASH
+                                                   [--vote-anchor-url TEXT
+                                                     ( --vote-anchor-metadata TEXT
+                                                     | --vote-anchor-metadata-file FILE
+                                                     | --vote-anchor-metadata-hash HASH
                                                      )]
 
   Vote creation.
@@ -46,8 +46,11 @@ Available options:
                            Filepath of the Consitutional Committee hot key.
   --cc-hot-key-hash STRING Constitutional Committee key hash (hex-encoded).
   --out-file FILE          Output filepath of the vote.
-  --vote-url TEXT          Vote anchor URL
-  --vote-text TEXT         Input vote as UTF-8 encoded text.
-  --vote-file FILE         Input vote as a text file.
-  --vote-hash HASH         Vote anchor data hash.
+  --vote-anchor-url TEXT   Vote anchor URL
+  --vote-anchor-metadata TEXT
+                           Vote anchor contents as UTF-8 encoded text.
+  --vote-anchor-metadata-file FILE
+                           Vote anchor contents as a text file.
+  --vote-anchor-metadata-hash HASH
+                           Hash of the vote anchor contents.
   -h,--help                Show this help text


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Clearer command line flags for vote, proposal, and constitution anchors
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

On #362, we started a discussion about how the various anchor-related flags could be named in a less confusing manner. This PR implements an idea that we settled upon after a short discussion: Anchors for an `x` are given by an `--x-anchor-url` together with one of the following three: 
- `--x-anchor-metadata` for the literal data behind the URL,
- `--x-anchor-metadata-file` for a file containing the same data, or
- `--x-anchor-metadata-hash` for the hash of the data.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
