### PR TITLE
Add `conway governance action view`

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/Actions.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/Actions.hs
@@ -9,6 +9,7 @@ module Cardano.CLI.EraBased.Commands.Governance.Actions
   , GovernanceActionCreateConstitutionCmdArgs(..)
   , GovernanceActionCreateNoConfidenceCmdArgs(..)
   , GovernanceActionInfoCmdArgs(..)
+  , GovernanceActionViewCmdArgs(..)
   , GovernanceActionProtocolParametersUpdateCmdArgs(..)
   , GovernanceActionTreasuryWithdrawalCmdArgs(..)
   , renderGovernanceActionCmds
@@ -33,6 +34,7 @@ data GovernanceActionCmds era
   | GovernanceActionProtocolParametersUpdateCmd   !(GovernanceActionProtocolParametersUpdateCmdArgs era)
   | GovernanceActionTreasuryWithdrawalCmd         !(GovernanceActionTreasuryWithdrawalCmdArgs era)
   | GovernanceActionInfoCmd                       !(GovernanceActionInfoCmdArgs era)
+  | GovernanceActionViewCmd                       !(GovernanceActionViewCmdArgs era)
   deriving Show
 
 data GoveranceActionUpdateCommitteeCmdArgs era
@@ -110,6 +112,14 @@ data GovernanceActionTreasuryWithdrawalCmdArgs era
       , outFile             :: !(File () Out)
       } deriving Show
 
+data GovernanceActionViewCmdArgs era
+  = GovernanceActionViewCmdArgs
+      { eon        :: !(ConwayEraOnwards era)
+      , actionFile :: !(ProposalFile In)
+      , outFormat  :: !GovernanceActionViewOutputFormat
+      , mOutFile   :: !(Maybe (File () Out))
+      } deriving Show
+
 renderGovernanceActionCmds :: GovernanceActionCmds era -> Text
 renderGovernanceActionCmds = ("governance action " <>) . \case
   GovernanceActionCreateConstitutionCmd {} ->
@@ -129,6 +139,9 @@ renderGovernanceActionCmds = ("governance action " <>) . \case
 
   GovernanceActionInfoCmd {} ->
     "create-info"
+
+  GovernanceActionViewCmd {} ->
+    "view"
 
 data AnyStakeIdentifier
   = AnyStakeKey (VerificationKeyOrHashOrFile StakeKey)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
@@ -1606,6 +1606,18 @@ pTxViewOutputFormat =
     , Opt.value TxViewOutputFormatJson
     ]
 
+pGovernanceActionViewOutputFormat :: Parser GovernanceActionViewOutputFormat
+pGovernanceActionViewOutputFormat =
+  Opt.option readGovernanceActionViewOutputFormat $ mconcat
+    [ Opt.long "output-format"
+    , Opt.metavar "STRING"
+    , Opt.help $ mconcat
+      [ "Optional governance action view output format. Accepted output formats are \"json\" "
+      , "and \"yaml\" (default is \"json\")."
+      ]
+    , Opt.value GovernanceActionViewOutputFormatJson
+    ]
+
 pMaybeOutputFile :: Parser (Maybe (File content Out))
 pMaybeOutputFile =
   optional $ fmap File $ Opt.strOption $ mconcat

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Actions.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Actions.hs
@@ -37,7 +37,24 @@ pGovernanceActionCmds era =
     , pGovernanceActionNoConfidenceCmd era
     , pGovernanceActionProtocolParametersUpdateCmd era
     , pGovernanceActionTreasuryWithdrawalCmd era
+    , pGovernanceActionViewCmd era
     ]
+
+pGovernanceActionViewCmd
+  :: CardanoEra era
+  -> Maybe (Parser (Cmd.GovernanceActionCmds era))
+pGovernanceActionViewCmd era = do
+  eon <- forEraMaybeEon era
+  return
+    $ subParser "view"
+    $ Opt.info
+        ( fmap Cmd.GovernanceActionViewCmd
+            $ Cmd.GovernanceActionViewCmdArgs eon
+                <$> pFileInDirection "action-file" "Path to action file."
+                <*> pGovernanceActionViewOutputFormat
+                <*> pMaybeOutputFile
+        )
+    $ Opt.progDesc "View a governance action."
 
 pGovernanceActionNewInfoCmd
   :: CardanoEra era

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Actions.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Actions.hs
@@ -18,6 +18,7 @@ import           Cardano.Api.Shelley
 
 import           Cardano.CLI.EraBased.Commands.Governance.Actions
 import qualified Cardano.CLI.EraBased.Commands.Governance.Actions as Cmd
+import           Cardano.CLI.Json.Friendly
 import           Cardano.CLI.Read
 import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Errors.GovernanceActionsError
@@ -51,6 +52,29 @@ runGovernanceActionCmds = \case
 
   GovernanceActionInfoCmd args ->
     runGovernanceActionInfoCmd args
+
+  GovernanceActionViewCmd args ->
+    runGovernanceActionViewCmd args
+
+runGovernanceActionViewCmd :: ()
+  => GovernanceActionViewCmdArgs era
+  -> ExceptT GovernanceActionsError IO ()
+runGovernanceActionViewCmd
+  Cmd.GovernanceActionViewCmdArgs
+    { Cmd.outFormat
+    , Cmd.actionFile
+    , Cmd.mOutFile
+    , Cmd.eon
+    } = do
+  proposal <- firstExceptT GovernanceActionsCmdReadTextEnvelopeFileError . newExceptT $ readProposal eon actionFile
+  firstExceptT GovernanceActionsCmdWriteFileError . newExceptT $
+    friendlyProposal
+      (case outFormat of
+        GovernanceActionViewOutputFormatJson -> FriendlyJson
+        GovernanceActionViewOutputFormatYaml -> FriendlyYaml)
+      mOutFile
+      eon
+      proposal
 
 runGovernanceActionInfoCmd :: ()
   => GovernanceActionInfoCmdArgs era

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Transaction.hs
@@ -34,7 +34,7 @@ import           Cardano.Api.Shelley
 
 import qualified Cardano.CLI.EraBased.Commands.Transaction as Cmd
 import           Cardano.CLI.EraBased.Run.Genesis
-import           Cardano.CLI.Json.Friendly (friendlyTxBody, friendlyTx, FriendlyFormat (..))
+import           Cardano.CLI.Json.Friendly (FriendlyFormat (..), friendlyTx, friendlyTxBody)
 import           Cardano.CLI.Read
 import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Errors.BootstrapWitnessError

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Transaction.hs
@@ -34,8 +34,7 @@ import           Cardano.Api.Shelley
 
 import qualified Cardano.CLI.EraBased.Commands.Transaction as Cmd
 import           Cardano.CLI.EraBased.Run.Genesis
-import           Cardano.CLI.Json.Friendly (friendlyTxBodyJson, friendlyTxBodyYaml, friendlyTxJson,
-                   friendlyTxYaml)
+import           Cardano.CLI.Json.Friendly (friendlyTxBody, friendlyTx, FriendlyFormat (..))
 import           Cardano.CLI.Read
 import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Errors.BootstrapWitnessError
@@ -1185,16 +1184,15 @@ runTransactionViewCmd
       -- is arguably not part of the transaction body.
       firstExceptT TxCmdWriteFileError . newExceptT $
         case outputFormat of
-          TxViewOutputFormatYaml -> friendlyTxBodyYaml mOutFile era txbody
-          TxViewOutputFormatJson -> friendlyTxBodyJson mOutFile era txbody
+          TxViewOutputFormatYaml -> friendlyTxBody FriendlyYaml mOutFile era txbody
+          TxViewOutputFormatJson -> friendlyTxBody FriendlyJson mOutFile era txbody
     InputTxFile (File txFilePath) -> do
       txFile <- liftIO $ fileOrPipe txFilePath
       InAnyCardanoEra era tx <- lift (readFileTx txFile) & onLeft (left . TxCmdCddlError)
       firstExceptT TxCmdWriteFileError . newExceptT $
         case outputFormat of
-          TxViewOutputFormatYaml -> friendlyTxYaml mOutFile era tx
-          TxViewOutputFormatJson -> friendlyTxJson mOutFile era tx
-
+          TxViewOutputFormatYaml -> friendlyTx FriendlyYaml mOutFile era tx
+          TxViewOutputFormatJson -> friendlyTx FriendlyJson mOutFile era tx
 
 -- ----------------------------------------------------------------------------
 -- Witness commands

--- a/cardano-cli/src/Cardano/CLI/Json/Friendly.hs
+++ b/cardano-cli/src/Cardano/CLI/Json/Friendly.hs
@@ -101,7 +101,7 @@ friendlyProposal format mOutFile era =
   conwayEraOnwardsConstraints era $
     friendly format mOutFile . object . friendlyProposalImpl era
 
-friendlyProposalImpl :: IsCardanoEra era => ConwayEraOnwards era -> Proposal era -> [Aeson.Pair]
+friendlyProposalImpl :: ConwayEraOnwards era -> Proposal era -> [Aeson.Pair]
 friendlyProposalImpl
   era
   (Proposal

--- a/cardano-cli/src/Cardano/CLI/Parser.hs
+++ b/cardano-cli/src/Cardano/CLI/Parser.hs
@@ -11,6 +11,7 @@ module Cardano.CLI.Parser
   , readStringOfMaxLength
   , readURIOfMaxLength
   , eDNSName
+  , readGovernanceActionViewOutputFormat
   ) where
 
 import           Cardano.CLI.Types.Common
@@ -59,6 +60,18 @@ readTxViewOutputFormat = do
     _ ->
       fail $ mconcat
         [ "Invalid transaction view output format: " <> show s
+        , ". Accepted output formats are \"json\" and \"yaml\"."
+        ]
+
+readGovernanceActionViewOutputFormat :: Opt.ReadM GovernanceActionViewOutputFormat
+readGovernanceActionViewOutputFormat = do
+  s <- Opt.str @String
+  case s of
+    "json" -> pure GovernanceActionViewOutputFormatJson
+    "yaml" -> pure GovernanceActionViewOutputFormatYaml
+    _ ->
+      fail $ mconcat
+        [ "Invalid governance action view output format: " <> show s
         , ". Accepted output formats are \"json\" and \"yaml\"."
         ]
 

--- a/cardano-cli/src/Cardano/CLI/Types/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Common.hs
@@ -27,6 +27,7 @@ module Cardano.CLI.Types.Common
   , GenesisDir(..)
   , GenesisFile (..)
   , GenesisKeyFile(..)
+  , GovernanceActionViewOutputFormat(..)
   , InputTxBodyOrTxFile (..)
   , KeyOutputFormat(..)
   , MetadataFile(..)
@@ -465,6 +466,10 @@ data TxViewOutputFormat
   | TxViewOutputFormatYaml
   deriving Show
 
+data GovernanceActionViewOutputFormat
+  = GovernanceActionViewOutputFormatJson
+  | GovernanceActionViewOutputFormatYaml
+  deriving Show
 --
 -- Shelley CLI flag/option data types
 --

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Governance/Action.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Governance/Action.hs
@@ -48,3 +48,81 @@ hprop_golden_governanceActionCreateConstitution =
     H.assertFileOccurences 1 "Governance proposal" actionFile
 
     H.assertEndsWithSingleNewline actionFile
+
+hprop_golden_conway_governance_action_view_constitution_json :: Property
+hprop_golden_conway_governance_action_view_constitution_json =
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+    stakeAddressVKeyFile <- H.note "test/cardano-cli-golden/files/input/governance/stake-address.vkey"
+
+    actionFile <- noteTempFile tempDir "action"
+
+    void $ execCardanoCLI
+      [ "conway", "governance", "action", "create-constitution"
+      , "--mainnet"
+      , "--proposal-anchor-metadata", "eda258650888d4a7f8ac1127cfa136962f527f341c99db49929c79ae"
+      , "--proposal-anchor-url", "proposal-dummy-url"
+      , "--governance-action-deposit", "10"
+      , "--stake-verification-key-file", stakeAddressVKeyFile
+      , "--out-file", actionFile
+      , "--constitution-anchor-url", "constitution-dummy-url"
+      , "--constitution-anchor-metadata", "This is a test constitution."
+      ]
+
+    goldenActionViewFile <- H.note "test/cardano-cli-golden/files/golden/governance/action/view/create-constitution.action.view"
+    actionView <- execCardanoCLI
+      [ "conway", "governance", "action", "view"
+      , "--action-file", actionFile
+      ]
+    H.diffVsGoldenFile actionView goldenActionViewFile
+
+hprop_golden_conway_governance_action_view_update_committee_yaml :: Property
+hprop_golden_conway_governance_action_view_update_committee_yaml =
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+    stakeAddressVKeyFile <- H.note "test/cardano-cli-golden/files/input/governance/stake-address.vkey"
+
+    actionFile <- noteTempFile tempDir "action"
+
+    void $ execCardanoCLI
+      [ "conway", "governance", "action", "update-committee"
+      , "--mainnet"
+      , "--governance-action-deposit", "10"
+      , "--stake-verification-key-file", stakeAddressVKeyFile
+      , "--proposal-anchor-url", "proposal-dummy-url"
+      , "--proposal-anchor-metadata", "eda258650888d4a7f8ac1127cfa136962f527f341c99db49929c79ae"
+      , "--quorum", "0.61"
+      , "--out-file", actionFile
+      ]
+
+    goldenActionViewFile <- H.note "test/cardano-cli-golden/files/golden/governance/action/view/update-committee.action.view"
+    actionView <- execCardanoCLI
+      [ "conway", "governance", "action", "view"
+      , "--action-file", actionFile
+      , "--output-format", "yaml"
+      ]
+    H.diffVsGoldenFile actionView goldenActionViewFile
+
+hprop_golden_conway_governance_action_view_create_info_json_outfile :: Property
+hprop_golden_conway_governance_action_view_create_info_json_outfile =
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+    stakeAddressVKeyFile <- H.note "test/cardano-cli-golden/files/input/governance/stake-address.vkey"
+
+    actionFile <- noteTempFile tempDir "action"
+
+    void $ execCardanoCLI
+      [ "conway", "governance", "action", "create-info"
+      , "--testnet"
+      , "--governance-action-deposit", "10"
+      , "--stake-verification-key-file", stakeAddressVKeyFile
+      , "--proposal-anchor-url", "proposal-dummy-url"
+      , "--proposal-anchor-metadata", "eda258650888d4a7f8ac1127cfa136962f527f341c99db49929c79ae"
+      , "--out-file", actionFile
+      ]
+
+    actionViewFile <- noteTempFile tempDir "action-view"
+    goldenActionViewFile <- H.note "test/cardano-cli-golden/files/golden/governance/action/view/create-info.action.view"
+    void $ execCardanoCLI
+      [ "conway", "governance", "action", "view"
+      , "--action-file", actionFile
+      , "--out-file", actionViewFile
+      ]
+    H.diffFileVsGoldenFile actionViewFile goldenActionViewFile

--- a/cardano-cli/test/cardano-cli-golden/files/golden/governance/action/view/create-constitution.action.view
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/governance/action/view/create-constitution.action.view
@@ -1,0 +1,25 @@
+{
+    "anchor": {
+        "dataHash": "04c36ab926c8d0e6b37d03c781bdf0214b67f65af6eb1241459d17209a0bf784",
+        "url": "proposal-dummy-url"
+    },
+    "deposit": 10,
+    "governance action": {
+        "contents": [
+            null,
+            {
+                "anchor": {
+                    "dataHash": "42cb2e410023679943d26c23ce2b5046eb7dfc5883c69fb91cc8a3c9c9a99a99",
+                    "url": "constitution-dummy-url"
+                }
+            }
+        ],
+        "tag": "NewConstitution"
+    },
+    "return address": {
+        "credential": {
+            "keyHash": "8f4a3466a404c11eb410313015b88e447d81b60089e25f611600e605"
+        },
+        "network": "Mainnet"
+    }
+}

--- a/cardano-cli/test/cardano-cli-golden/files/golden/governance/action/view/create-info.action.view
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/governance/action/view/create-info.action.view
@@ -1,0 +1,16 @@
+{
+    "anchor": {
+        "dataHash": "04c36ab926c8d0e6b37d03c781bdf0214b67f65af6eb1241459d17209a0bf784",
+        "url": "proposal-dummy-url"
+    },
+    "deposit": 10,
+    "governance action": {
+        "tag": "InfoAction"
+    },
+    "return address": {
+        "credential": {
+            "keyHash": "8f4a3466a404c11eb410313015b88e447d81b60089e25f611600e605"
+        },
+        "network": "Testnet"
+    }
+}

--- a/cardano-cli/test/cardano-cli-golden/files/golden/governance/action/view/update-committee.action.view
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/governance/action/view/update-committee.action.view
@@ -1,0 +1,15 @@
+anchor:
+  dataHash: 04c36ab926c8d0e6b37d03c781bdf0214b67f65af6eb1241459d17209a0bf784
+  url: proposal-dummy-url
+deposit: 10
+governance action:
+  contents:
+  - null
+  - []
+  - {}
+  - 0.61
+  tag: UpdateCommittee
+return address:
+  credential:
+    keyHash: 8f4a3466a404c11eb410313015b88e447d81b60089e25f611600e605
+  network: Mainnet

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -5972,6 +5972,7 @@ Usage: cardano-cli conway governance action
                                               | create-no-confidence
                                               | create-protocol-parameters-update
                                               | create-treasury-withdrawal
+                                              | view
                                               )
 
   Governance action commands.
@@ -6156,6 +6157,12 @@ Usage: cardano-cli conway governance action create-treasury-withdrawal
                                                                          --out-file FILE
 
   Create a treasury withdrawal.
+
+Usage: cardano-cli conway governance action view --action-file FILE
+                                                   [--output-format STRING]
+                                                   [--out-file FILE]
+
+  View a governance action.
 
 Usage: cardano-cli conway governance committee 
                                                  ( key-gen-cold

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action.cli
@@ -5,6 +5,7 @@ Usage: cardano-cli conway governance action
                                               | create-no-confidence
                                               | create-protocol-parameters-update
                                               | create-treasury-withdrawal
+                                              | view
                                               )
 
   Governance action commands.
@@ -21,3 +22,4 @@ Available commands:
                            Create a protocol parameters update.
   create-treasury-withdrawal
                            Create a treasury withdrawal.
+  view                     View a governance action.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_view.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_view.cli
@@ -1,0 +1,13 @@
+Usage: cardano-cli conway governance action view --action-file FILE
+                                                   [--output-format STRING]
+                                                   [--out-file FILE]
+
+  View a governance action.
+
+Available options:
+  --action-file FILE       Path to action file.
+  --output-format STRING   Optional governance action view output format.
+                           Accepted output formats are "json" and "yaml"
+                           (default is "json").
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/input/governance/stake-address.skey
+++ b/cardano-cli/test/cardano-cli-golden/files/input/governance/stake-address.skey
@@ -1,0 +1,5 @@
+{
+    "type": "StakeSigningKeyShelley_ed25519",
+    "description": "Stake Signing Key",
+    "cborHex": "5820226ac6cf686bdd3e9d5934b2ac8ae8fc7c19c0b2910ac6b808359207fab68599"
+}

--- a/cardano-cli/test/cardano-cli-golden/files/input/governance/stake-address.vkey
+++ b/cardano-cli/test/cardano-cli-golden/files/input/governance/stake-address.vkey
@@ -1,0 +1,5 @@
+{
+    "type": "StakeVerificationKeyShelley_ed25519",
+    "description": "Stake Verification Key",
+    "cborHex": "5820a593d821195a27907841d73bd7ddca8777da9dd0bf34c7168b1eff75af8c2881"
+}


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Add a command to view governance action files
# uncomment types applicable to the change:
  type:
  - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

This will close #8, which asks for a command to inspect governance action files. I've implemented with this interface:
```
Usage: cardano-cli conway governance action view --action-file FILE
                                                   [--output-format STRING]
                                                   [--out-file FILE]

  View a governance action.

Available options:
  --action-file FILE       Path to action file.
  --output-format STRING   Optional governance action view output format.
                           Accepted output formats are "json" and "yaml"
                           (default is "json").
  --out-file FILE          Optional output file. Default is to write to stdout.
  -h,--help                Show this help text
```
Every action file produced by any `conway governance action *` command should be understood as a possible `--action-file`. (I'm not testing all of them, only three...)

I've also slightly refactored the API of `Cardano.CLI.Json.Friendly`, because this was leading to a profusion of very similar functions.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
