### PR TITLE
key non-extended-key: support drep extended keys

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance.hs
@@ -16,6 +16,7 @@ import           Cardano.Api
 import qualified Cardano.Api.Ledger as Ledger
 import           Cardano.Api.Shelley
 
+import qualified Cardano.CLI.EraBased.Run.Key as Key
 import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Errors.GovernanceCmdError
 import qualified Cardano.Ledger.Shelley.TxBody as Shelley
@@ -90,10 +91,8 @@ runGovernanceDRepKeyGen _w vkeyPath skeyPath = firstExceptT GovernanceCmdWriteFi
   skey <- liftIO $ generateSigningKey AsDRepKey
   let vkey = getVerificationKey skey
   newExceptT $ writeLazyByteStringFile skeyPath (textEnvelopeToJSON (Just skeyDesc) skey)
-  newExceptT $ writeLazyByteStringFile vkeyPath (textEnvelopeToJSON (Just vkeyDesc) vkey)
+  newExceptT $ writeLazyByteStringFile vkeyPath (textEnvelopeToJSON (Just Key.drepKeyEnvelopeDescr) vkey)
   where
     skeyDesc :: TextEnvelopeDescr
     skeyDesc = "Delegate Representative Signing Key"
-    vkeyDesc :: TextEnvelopeDescr
-    vkeyDesc = "Delegate Representative Verification Key"
 

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Key.hs
@@ -111,6 +111,8 @@ runNonExtendedKeyCmd
     case ssk of
       APaymentExtendedVerificationKey vk ->
         writeToDisk vkf (castVerificationKey vk :: VerificationKey PaymentKey)
+      ADRepExtendedVerificationKey vk ->
+        writeToDisk vkf (castVerificationKey vk :: VerificationKey DRepKey)
       AStakeExtendedVerificationKey vk ->
         writeToDisk vkf (castVerificationKey vk :: VerificationKey StakeKey)
       AGenesisExtendedVerificationKey vk ->
@@ -139,6 +141,7 @@ readExtendedVerificationKeyFile evkfile = do
                          $ VktofVerificationKeyFile evkfile
   case vKey of
       k@APaymentExtendedVerificationKey{} -> return k
+      k@ADRepExtendedVerificationKey{} -> return k
       k@AStakeExtendedVerificationKey{} -> return k
       k@AGenesisExtendedVerificationKey{} -> return k
       k@AGenesisDelegateExtendedVerificationKey{} -> return k

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Key.hs
@@ -18,6 +18,8 @@ module Cardano.CLI.EraBased.Run.Key
   , runNonExtendedKeyCmd
   , runVerificationKeyCmd
 
+  , drepKeyEnvelopeDescr
+
     -- * Exports for testing
   , decodeBech32
   ) where
@@ -53,6 +55,9 @@ import           Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import           System.Exit (exitFailure)
+
+drepKeyEnvelopeDescr :: TextEnvelopeDescr
+drepKeyEnvelopeDescr = "Delegate Representative Verification Key"
 
 runKeyCmds :: ()
   => Cmd.KeyCmds era
@@ -110,26 +115,27 @@ runNonExtendedKeyCmd
   writeVerificationKey ssk =
     case ssk of
       APaymentExtendedVerificationKey vk ->
-        writeToDisk vkf (castVerificationKey vk :: VerificationKey PaymentKey)
+        writeToDisk vkf Nothing (castVerificationKey vk :: VerificationKey PaymentKey)
       ADRepExtendedVerificationKey vk ->
-        writeToDisk vkf (castVerificationKey vk :: VerificationKey DRepKey)
+        writeToDisk vkf (Just drepKeyEnvelopeDescr) (castVerificationKey vk :: VerificationKey DRepKey)
       AStakeExtendedVerificationKey vk ->
-        writeToDisk vkf (castVerificationKey vk :: VerificationKey StakeKey)
+        writeToDisk vkf Nothing (castVerificationKey vk :: VerificationKey StakeKey)
       AGenesisExtendedVerificationKey vk ->
-        writeToDisk vkf (castVerificationKey vk :: VerificationKey GenesisKey)
+        writeToDisk vkf Nothing (castVerificationKey vk :: VerificationKey GenesisKey)
       AGenesisDelegateExtendedVerificationKey vk ->
-        writeToDisk vkf (castVerificationKey vk :: VerificationKey GenesisDelegateKey)
+        writeToDisk vkf Nothing (castVerificationKey vk :: VerificationKey GenesisDelegateKey)
       nonExtendedKey -> left $ KeyCmdExpectedExtendedVerificationKey nonExtendedKey
 
 
   writeToDisk
    :: Key keyrole
    => File content Out
+   -> Maybe TextEnvelopeDescr
    -> VerificationKey keyrole
    -> ExceptT KeyCmdError IO ()
-  writeToDisk vkf' vk =
+  writeToDisk vkf' descr vk =
     firstExceptT KeyCmdWriteFileError . newExceptT
-      $ writeLazyByteStringFile vkf' $ textEnvelopeToJSON Nothing vk
+      $ writeLazyByteStringFile vkf' $ textEnvelopeToJSON descr vk
 
 
 readExtendedVerificationKeyFile

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Key/NonExtendedKey.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Key/NonExtendedKey.hs
@@ -60,3 +60,25 @@ hprop_golden_KeyNonExtendedKey_StakeExtendedVerificationKeyShelley =
     H.assertFilesExist [outFp]
 
     H.diffFileVsGoldenFile outFp nonExtendedFp
+
+-- | Test that converting a drep extended verification key yields the
+-- expected result.
+hprop_golden_KeyNonExtendedKey_DRepExtendedVerificationKey :: Property
+hprop_golden_KeyNonExtendedKey_DRepExtendedVerificationKey =
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+    extendedKeyFile <- H.noteInputFile "test/cardano-cli-golden/files/input/key/non-extended-keys/extended-drep.vkey"
+    goldenFile <-  H.note "test/cardano-cli-golden/files/golden/key/non-extended-keys/non-extended-drep.vkey"
+    outFp <- H.note $ tempDir </> "non-extended-drep.vkey"
+
+    H.assertFilesExist [extendedKeyFile]
+
+    void $ execCardanoCLI
+      [ "conway", "key", "non-extended-key"
+      , "--extended-verification-key-file", extendedKeyFile
+      , "--verification-key-file", outFp
+      ]
+
+    -- Check for existence of the converted signing key file
+    H.assertFilesExist [outFp]
+
+    H.diffFileVsGoldenFile outFp goldenFile

--- a/cardano-cli/test/cardano-cli-golden/files/golden/key/non-extended-keys/non-extended-drep.vkey
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/key/non-extended-keys/non-extended-drep.vkey
@@ -1,5 +1,5 @@
 {
     "type": "DRepVerificationKey_ed25519",
-    "description": "",
+    "description": "Delegate Representative Verification Key",
     "cborHex": "5820b0cd9e6e3e274f4f38f55ef274af123cf4600ac0c58294399b7e076175262553"
 }

--- a/cardano-cli/test/cardano-cli-golden/files/golden/key/non-extended-keys/non-extended-drep.vkey
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/key/non-extended-keys/non-extended-drep.vkey
@@ -1,0 +1,5 @@
+{
+    "type": "DRepVerificationKey_ed25519",
+    "description": "",
+    "cborHex": "5820b0cd9e6e3e274f4f38f55ef274af123cf4600ac0c58294399b7e076175262553"
+}

--- a/cardano-cli/test/cardano-cli-golden/files/input/key/non-extended-keys/extended-drep.vkey
+++ b/cardano-cli/test/cardano-cli-golden/files/input/key/non-extended-keys/extended-drep.vkey
@@ -1,0 +1,5 @@
+{
+  "type": "DRepExtendedVerificationKey_ed25519_bip32",
+  "description": "Delegate Representative Verification Key",
+  "cborHex": "5840b0cd9e6e3e274f4f38f55ef274af123cf4600ac0c58294399b7e076175262553dde8b75f847f2b7e61a8748627292a06d739c8ba8e78ac83e666030d1093fb3e"
+}


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Support converting a drep extended key to its non-extended version
# uncomment types applicable to the change:
  type:
  - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Fixes #358

# Roadmap

- [x] Add a golden test
- [x] Merge https://github.com/input-output-hk/cardano-api/pull/320
- [x] Release cardano-api
- [X] Merge https://github.com/input-output-hk/cardano-cli/pull/389
- [x] Realize https://github.com/input-output-hk/cardano-api/pull/320 misses something :upside_down_face:, so onto a new round of cardano-api PR/release/update cardano-cli
- [X] Merge https://github.com/input-output-hk/cardano-api/pull/327
- [X] Release cardano-api, and update cardano-cli to use new cardano-api
- [ ] Merge this PR

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- NA The version bounds in `.cabal` files are updated
- [X] CI passes. See note on CI.  The following CI checks are required:
  - [X] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [X] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [X] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [X] Self-reviewed the diff