### PR TITLE
Check that poll answer index is not negative, to avoid a Prelude.!! error

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Poll.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Poll.hs
@@ -129,7 +129,8 @@ runGovernanceAnswerPoll _ pollFile maybeChoice mOutFile = do
   validateChoice :: GovernancePoll -> Word -> ExceptT GovernanceCmdError IO ()
   validateChoice GovernancePoll{govPollAnswers} ix = do
     let maxAnswerIndex = length govPollAnswers - 1
-    when (fromIntegral ix > maxAnswerIndex) $ left $
+        ixInt = fromIntegral ix
+    when (ixInt < 0 || ixInt > maxAnswerIndex) $ left $
       GovernanceCmdPollOutOfBoundAnswer maxAnswerIndex
 
   askInteractively :: GovernancePoll -> ExceptT GovernanceCmdError IO Word


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Check that poll answer index is not negative. This replaces a Prelude.!! error by a regular `GovernanceCmdError` error
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Fixes https://github.com/input-output-hk/cardano-node/issues/5182

# How to trust this PR

Execute before the PR, observe `Prelude.!!` error:

```
→ cabal run cardano-cli -- governance answer-poll --poll-file cardano-cli/test/cardano-cli-golden/files/input/governance/polls/basic.json --answer -1

cardano-cli: Prelude.!!: negative index
```

Execute on this PR, witness it fails with a regular error:

```
→ cabal run cardano-cli -- governance answer-poll --poll-file cardano-cli/test/cardano-cli-golden/files/input/governance/polls/basic.json --answer -1
Command failed: governance answer-poll  Error: Poll answer out of bounds. Choices are between 0 and 1
```

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] The change log section in the PR description has been filled in
- NA New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- NA The version bounds in `.cabal` files are updated
- [X] CI passes. See note on CI.  The following CI checks are required:
- [X] Self-reviewed the diff