### PR TITLE
Shorten PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,27 +19,16 @@
 
 # Context
 
-Additional context for the PR goes here.
+Additional context for the PR goes here. If the PR fixes a particular issue please provide a [link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=) to the issue.
 
-If the PR fixes a particular issue please provide a
-[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
-to the issue.
+# How to trust this PR
+
+Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.
 
 # Checklist
 
 - [ ] Commit sequence broadly makes sense and commits have useful messages
-- [ ] The change log section in the PR description has been filled in
-- [ ] New tests are added if needed and existing tests are updated.  These may include:
-  - golden tests
-  - property tests
-  - round trip tests
-  - integration tests
-  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
-- [ ] The version bounds in `.cabal` files are updated
-- [ ] CI passes. See note on CI.  The following CI checks are required:
-  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
-  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
-  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
+- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
 - [ ] Self-reviewed the diff
 
 <!-- 


### PR DESCRIPTION
This PR changes the PR template so that it looks like below. The rationale is that right now most developers don't use the PR list of checkboxes, so I have:

- Removed all checkboxes that are enforced by CI anyway
- Kept only checkboxes that are good practices reminders
- I have added a _How to trust this PR section_ In my experience, this section can entice developers to help the reviewers, which is important, because reviews is often a bottleneck we're all blocked on regularly :slightly_smiling_face: 

# New PR template

# Changelog

```yaml
- description: |
    Change PR template
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Additional context for the PR goes here. If the PR fixes a particular issue please provide a [link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=) to the issue.

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!-- ### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. -->