### PR TITLE
Integrate latest ledger, consensus and api for 8.6.0

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -14,7 +14,7 @@ repository cardano-haskell-packages
 -- you need to run if you change them
 index-state:
   , hackage.haskell.org 2023-08-08T19:56:09Z
-  , cardano-haskell-packages 2023-10-20T00:31:44Z
+  , cardano-haskell-packages 2023-10-27T12:25:48Z
 
 packages:
   cardano-cli

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -203,19 +203,19 @@ library
                       , binary
                       , bytestring
                       , canonical-json
-                      , cardano-api ^>= 8.28.0.0
+                      , cardano-api ^>= 8.29.0.0
                       , cardano-binary
                       , cardano-crypto
                       , cardano-crypto-class ^>= 2.1.2
                       , cardano-crypto-wrapper ^>= 1.5.1
-                      , cardano-data >= 1.0
+                      , cardano-data >= 1.1
                       , cardano-git-rev
-                      , cardano-ledger-alonzo >= 1.3.1.1
-                      , cardano-ledger-binary >= 1.0
+                      , cardano-ledger-alonzo >= 1.5.0.0
+                      , cardano-ledger-binary >= 1.2
                       , cardano-ledger-byron >= 1.0.0.2
-                      , cardano-ledger-conway >= 1.5
-                      , cardano-ledger-core >= 1.2
-                      , cardano-ledger-shelley >=1.4.1.0
+                      , cardano-ledger-conway >= 1.10
+                      , cardano-ledger-core >= 1.8
+                      , cardano-ledger-shelley >=1.7.0.0
                       , cardano-ping ^>= 0.2.0.5
                       , cardano-prelude
                       , cardano-slotting ^>= 0.1
@@ -234,9 +234,9 @@ library
                       , microlens
                       , network
                       , optparse-applicative-fork
-                      , ouroboros-consensus >= 0.12
-                      , ouroboros-consensus-cardano >= 0.10
-                      , ouroboros-consensus-protocol >= 0.5.0.4
+                      , ouroboros-consensus >= 0.13
+                      , ouroboros-consensus-cardano >= 0.11
+                      , ouroboros-consensus-protocol >= 0.6.0.0
                       , ouroboros-network-api
                       , ouroboros-network-protocols
                       , parsec

--- a/cardano-cli/src/Cardano/CLI/Byron/Tx.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Tx.hs
@@ -158,10 +158,8 @@ txSpendGenesisUTxOByronPBFT gc nId sk (ByronAddress bAddr) outs = do
             , txTotalCollateral = TxTotalCollateralNone
             , txReturnCollateral = TxReturnCollateralNone
             , txFee = TxFeeImplicit ByronEraOnlyByron
-            , txValidityRange =
-                ( TxValidityNoLowerBound
-                , defaultTxValidityUpperBound ByronEra
-                )
+            , txValidityLowerBound = TxValidityNoLowerBound
+            , txValidityUpperBound = defaultTxValidityUpperBound ByronEra
             , txMetadata = TxMetadataNone
             , txAuxScripts = TxAuxScriptsNone
             , txExtraKeyWits = TxExtraKeyWitnessesNone
@@ -207,10 +205,8 @@ txSpendUTxOByronPBFT nId sk txIns outs = do
           , txTotalCollateral = TxTotalCollateralNone
           , txReturnCollateral = TxReturnCollateralNone
           , txFee = TxFeeImplicit ByronEraOnlyByron
-          , txValidityRange =
-              ( TxValidityNoLowerBound
-              , defaultTxValidityUpperBound ByronEra
-              )
+          , txValidityLowerBound = TxValidityNoLowerBound
+          , txValidityUpperBound = defaultTxValidityUpperBound ByronEra
           , txMetadata = TxMetadataNone
           , txAuxScripts = TxAuxScriptsNone
           , txExtraKeyWits = TxExtraKeyWitnessesNone

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/Committee.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/Committee.hs
@@ -13,6 +13,8 @@ module Cardano.CLI.EraBased.Commands.Governance.Committee
   ) where
 
 import           Cardano.Api
+import qualified Cardano.Api.Ledger as Ledger
+import           Cardano.Api.Shelley
 
 import           Cardano.CLI.Types.Key
 import           Cardano.CLI.Types.Key.VerificationKey
@@ -59,6 +61,7 @@ data GovernanceCommitteeCreateColdKeyResignationCertificateCmdArgs era =
   GovernanceCommitteeCreateColdKeyResignationCertificateCmdArgs
     { eon               :: !(ConwayEraOnwards era)
     , vkeyColdKeySource :: !(VerificationKeyOrHashOrFile CommitteeColdKey)
+    , anchor            :: !(Maybe (Ledger.Anchor (Ledger.EraCrypto (ShelleyLedgerEra era))))
     , outFile           :: !(File () Out)
     } deriving Show
 

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Query.hs
@@ -5,6 +5,7 @@
 
 module Cardano.CLI.EraBased.Commands.Query
   ( QueryCmds (..)
+  , QueryCommitteeMembersStateCmdArgs(..)
   , QueryLeadershipScheduleCmdArgs(..)
   , QueryProtocolParametersCmdArgs(..)
   , QueryConstitutionHashCmdArgs(..)
@@ -55,7 +56,7 @@ data QueryCmds era
   | QueryGovStateCmd                !(QueryNoArgCmdArgs era)
   | QueryDRepStateCmd               !(QueryDRepStateCmdArgs era)
   | QueryDRepStakeDistributionCmd   !(QueryDRepStakeDistributionCmdArgs era)
-  | QueryCommitteeStateCmd          !(QueryNoArgCmdArgs era)
+  | QueryCommitteeMembersStateCmd   !(QueryCommitteeMembersStateCmdArgs era)
   deriving (Generic, Show)
 
 data QueryLeadershipScheduleCmdArgs = QueryLeadershipScheduleCmdArgs
@@ -199,6 +200,17 @@ data QueryDRepStakeDistributionCmdArgs era = QueryDRepStakeDistributionCmdArgs
   , mOutFile            :: !(Maybe (File () Out))
   } deriving Show
 
+data QueryCommitteeMembersStateCmdArgs era = QueryCommitteeMembersStateCmdArgs
+  { eon                     :: !(ConwayEraOnwards era)
+  , nodeSocketPath          :: !SocketPath
+  , consensusModeParams     :: !AnyConsensusModeParams
+  , networkId               :: !NetworkId
+  , committeeColdKeys       :: ![VerificationKeyOrHashOrFile CommitteeColdKey]
+  , committeeHotKeys        :: ![VerificationKeyOrHashOrFile CommitteeHotKey]
+  , memberStatuses          :: ![MemberStatus]
+  , mOutFile                :: !(Maybe (File () Out))
+  } deriving Show
+
 renderQueryCmds :: QueryCmds era -> Text
 renderQueryCmds = \case
   QueryLeadershipScheduleCmd {} ->
@@ -239,7 +251,7 @@ renderQueryCmds = \case
     "drep-state"
   QueryDRepStakeDistributionCmd {} ->
     "drep-stake-distribution"
-  QueryCommitteeStateCmd {} ->
+  QueryCommitteeMembersStateCmd {} ->
     "committee-state"
 
 renderTxMempoolQuery :: TxMempoolQuery -> Text

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Transaction.hs
@@ -62,7 +62,7 @@ data TransactionBuildRawCmdArgs era = TransactionBuildRawCmdArgs
     -- ^ Multi-Asset value with script witness
   , mValidityLowerBound   :: !(Maybe SlotNo)
     -- ^ Transaction validity lower bound
-  , mValidityUpperBound   :: !(Maybe SlotNo)
+  , mValidityUpperBound   :: !(TxValidityUpperBound era)
     -- ^ Transaction validity upper bound
   , fee                   :: !(Maybe Lovelace)
     -- ^ Transaction fee
@@ -110,7 +110,7 @@ data TransactionBuildCmdArgs era = TransactionBuildCmdArgs
     -- ^ Multi-Asset value with script witness
   , mValidityLowerBound     :: !(Maybe SlotNo)
     -- ^ Transaction validity lower bound
-  , mValidityUpperBound     :: !(Maybe SlotNo)
+  , mValidityUpperBound     :: !(TxValidityUpperBound era)
     -- ^ Transaction validity upper bound
   , certificates            :: ![(CertificateFile, Maybe (ScriptWitnessFiles WitCtxStake))]
     -- ^ Certificates with potential script witness

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
@@ -2560,7 +2560,6 @@ pProtocolParametersUpdate =
     <*> optional pPoolInfluence
     <*> optional pMonetaryExpansion
     <*> optional pTreasuryExpansion
-    <*> pure Nothing
     <*> pure mempty
     <*> optional pExecutionUnitPrices
     <*> optional pMaxTxExecutionUnits

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
@@ -2077,30 +2077,62 @@ pInvalidBefore = fmap SlotNo $ asum
     ]
   ]
 
-pInvalidHereafter :: Parser SlotNo
-pInvalidHereafter =
+pLegacyInvalidHereafter :: Parser SlotNo
+pLegacyInvalidHereafter =
   fmap SlotNo $ asum
-  [ Opt.option (bounded "SLOT") $ mconcat
-    [ Opt.long "invalid-hereafter"
-    , Opt.metavar "SLOT"
-    , Opt.help "Time that transaction is valid until (in slots)."
-    ]
-  , Opt.option (bounded "SLOT") $ mconcat
-    [ Opt.long "upper-bound"
-    , Opt.metavar "SLOT"
-    , Opt.help $ mconcat
-      [ "Time that transaction is valid until (in slots) "
-      , "(deprecated; use --invalid-hereafter instead)."
+    [ Opt.option (bounded "SLOT") $ mconcat
+      [ Opt.long "invalid-hereafter"
+      , Opt.metavar "SLOT"
+      , Opt.help "Time that transaction is valid until (in slots)."
       ]
-    , Opt.internal
+    , Opt.option (bounded "SLOT") $ mconcat
+      [ Opt.long "upper-bound"
+      , Opt.metavar "SLOT"
+      , Opt.help $ mconcat
+        [ "Time that transaction is valid until (in slots) "
+        , "(deprecated; use --invalid-hereafter instead)."
+        ]
+      , Opt.internal
+      ]
+    , Opt.option (bounded "SLOT") $ mconcat
+      [ Opt.long "ttl"
+      , Opt.metavar "SLOT"
+      , Opt.help "Time to live (in slots) (deprecated; use --invalid-hereafter instead)."
+      , Opt.internal
+      ]
     ]
-  , Opt.option (bounded "SLOT") $ mconcat
-    [ Opt.long "ttl"
-    , Opt.metavar "SLOT"
-    , Opt.help "Time to live (in slots) (deprecated; use --invalid-hereafter instead)."
-    , Opt.internal
-    ]
-  ]
+
+pInvalidHereafter :: ()
+  => CardanoEra era
+  -> Parser (TxValidityUpperBound era)
+pInvalidHereafter =
+  caseByronOrShelleyBasedEra
+    (pure . TxValidityNoUpperBound)
+    (\eon ->
+      fmap (TxValidityUpperBound eon) $ asum
+        [ fmap (Just . SlotNo) $ Opt.option (bounded "SLOT") $ mconcat
+          [ Opt.long "invalid-hereafter"
+          , Opt.metavar "SLOT"
+          , Opt.help "Time that transaction is valid until (in slots)."
+          ]
+        , fmap (Just . SlotNo) $ Opt.option (bounded "SLOT") $ mconcat
+          [ Opt.long "upper-bound"
+          , Opt.metavar "SLOT"
+          , Opt.help $ mconcat
+            [ "Time that transaction is valid until (in slots) "
+            , "(deprecated; use --invalid-hereafter instead)."
+            ]
+          , Opt.internal
+          ]
+        , fmap (Just . SlotNo) $ Opt.option (bounded "SLOT") $ mconcat
+          [ Opt.long "ttl"
+          , Opt.metavar "SLOT"
+          , Opt.help "Time to live (in slots) (deprecated; use --invalid-hereafter instead)."
+          , Opt.internal
+          ]
+        , pure Nothing
+        ]
+    )
 
 pTxFee :: Parser Lovelace
 pTxFee =

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Actions.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Actions.hs
@@ -256,9 +256,9 @@ pDeprecatedAfterMaryPParams =
   DeprecatedAfterMaryPParams
     <$> convertToLedger toShelleyLovelace (optional pMinUTxOValue)
 
-pShelleyToAlonzoPParams :: Parser (ShelleyToAlonzoPParams' ledgerera)
+pShelleyToAlonzoPParams :: Parser (ShelleyToAlonzoPParams ledgerera)
 pShelleyToAlonzoPParams =
-  ShelleyToAlonzoPParams'
+  ShelleyToAlonzoPParams
     <$> convertToLedger id (optional $ toLedgerNonce <$> pExtraEntropy)
     <*> convertToLedger toUnitIntervalOrErr (optional pDecentralParam)
 
@@ -318,7 +318,6 @@ dpGovActionProtocolParametersUpdate = \case
       <$> pCommonProtocolParameters
       <*> pShelleyToAlonzoPParams
       <*> pAlonzoOnwardsPParams
-      <*> pure (ShelleyToAlonzoPParams SNothing)
   ShelleyBasedEraBabbage ->
     BabbageEraBasedProtocolParametersUpdate
       <$> pCommonProtocolParameters

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Committee.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Committee.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE TypeFamilies #-}
 
 module Cardano.CLI.EraBased.Options.Governance.Committee
   ( pGovernanceCommitteeCmds
@@ -8,6 +9,10 @@ import           Cardano.Api
 
 import           Cardano.CLI.EraBased.Commands.Governance.Committee
 import           Cardano.CLI.EraBased.Options.Common
+import           Cardano.CLI.Read
+import qualified Cardano.Ledger.BaseTypes as L
+import qualified Cardano.Ledger.Crypto as Crypto
+import qualified Cardano.Ledger.SafeHash as L
 
 import           Options.Applicative (Parser)
 import qualified Options.Applicative as Opt
@@ -116,13 +121,36 @@ pGovernanceCommitteeCreateColdKeyResignationCertificateCmd era = do
   w <- forEraMaybeEon era
   pure
     $ subParser "create-cold-key-resignation-certificate"
-    $ Opt.info
-        ( fmap GovernanceCommitteeCreateColdKeyResignationCertificateCmd $
-            GovernanceCommitteeCreateColdKeyResignationCertificateCmdArgs w
-              <$> pCommitteeColdVerificationKeyOrHashOrFile
-              <*> pOutputFile
-        )
+    $ Opt.info (conwayEraOnwardsConstraints w $ mkParser w)
     $ Opt.progDesc
     $ mconcat
         [ "Create cold key resignation certificate for a Constitutional Committee Member"
         ]
+ where
+  mkParser w = GovernanceCommitteeCreateColdKeyResignationCertificateCmd <$>
+    (
+      GovernanceCommitteeCreateColdKeyResignationCertificateCmdArgs w <$>
+        pCommitteeColdVerificationKeyOrHashOrFile <*>
+        pAnchor <*>
+        pOutputFile
+    )
+
+pAnchor :: Parser (Maybe (L.Anchor Crypto.StandardCrypto))
+pAnchor =
+  Opt.optional $
+    L.Anchor
+      <$> fmap unAnchorUrl pAnchorUrl
+      <*> pSafeHash
+
+pAnchorUrl :: Parser AnchorUrl
+pAnchorUrl =
+  AnchorUrl
+    <$> pUrl "committee-cold-key-resignation-certificate-metadata-url" "Committee cold key resignation certificate URL"
+
+pSafeHash ::  Parser (L.SafeHash Crypto.StandardCrypto L.AnchorData)
+pSafeHash =
+  Opt.option readSafeHash $ mconcat
+    [ Opt.long "committee-cold-key-resignation-certificate-metadata-hash"
+    , Opt.metavar "HASH"
+    , Opt.help "Committee cold key resignation certificate metadata hash."
+    ]

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Committee.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Committee.hs
@@ -145,12 +145,12 @@ pAnchor =
 pAnchorUrl :: Parser AnchorUrl
 pAnchorUrl =
   AnchorUrl
-    <$> pUrl "committee-cold-key-resignation-certificate-metadata-url" "Committee cold key resignation certificate URL"
+    <$> pUrl "resignation-metadata-url" "Constitutional Committee cold key resignation certificate URL"
 
 pSafeHash ::  Parser (L.SafeHash Crypto.StandardCrypto L.AnchorData)
 pSafeHash =
   Opt.option readSafeHash $ mconcat
-    [ Opt.long "committee-cold-key-resignation-certificate-metadata-hash"
+    [ Opt.long "resignation-metadata-hash"
     , Opt.metavar "HASH"
-    , Opt.help "Committee cold key resignation certificate metadata hash."
+    , Opt.help "Constitutional Committee cold key resignation certificate metadata hash"
     ]

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Transaction.hs
@@ -155,9 +155,9 @@ pTransactionBuildCmd era envCli = do
         ]
   where
     pCmd :: ShelleyBasedEra era ->  Parser (TransactionCmds era)
-    pCmd w =
+    pCmd sbe =
       fmap TransactionBuildCmd $
-        TransactionBuildCmdArgs w
+        TransactionBuildCmdArgs sbe
           <$> pSocketPath envCli
           <*> pConsensusModeParams
           <*> pNetworkId envCli
@@ -173,7 +173,7 @@ pTransactionBuildCmd era envCli = do
           <*> pChangeAddress
           <*> optional (pMintMultiAsset AutoBalance)
           <*> optional pInvalidBefore
-          <*> optional pInvalidHereafter
+          <*> pInvalidHereafter (shelleyBasedToCardanoEra sbe)
           <*> many (pCertificateFile AutoBalance)
           <*> many (pWithdrawal AutoBalance)
           <*> pTxMetadataJsonSchema
@@ -182,7 +182,7 @@ pTransactionBuildCmd era envCli = do
                       Nothing
                       "Filepath of auxiliary script(s)")
           <*> many pMetadataFile
-          <*> pFeatured (shelleyBasedToCardanoEra w) (optional pUpdateProposalFile)
+          <*> pFeatured (shelleyBasedToCardanoEra sbe) (optional pUpdateProposalFile)
           <*> many (pFileInDirection "vote-file" "Filepath of the vote.")
           <*> many (pFileInDirection "proposal-file" "Filepath of the proposal.")
           <*> (OutputTxBodyOnly <$> pTxBodyFileOut <|> pCalculatePlutusScriptCost)
@@ -209,7 +209,7 @@ pTransactionBuildRaw era =
       <*> many pTxOut
       <*> optional (pMintMultiAsset ManualBalance)
       <*> optional pInvalidBefore
-      <*> optional pInvalidHereafter
+      <*> pInvalidHereafter era
       <*> optional pTxFee
       <*> many (pCertificateFile ManualBalance )
       <*> many (pWithdrawal ManualBalance)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Committee.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Committee.hs
@@ -172,6 +172,7 @@ runGovernanceCommitteeColdKeyResignationCertificate
     Cmd.GovernanceCommitteeCreateColdKeyResignationCertificateCmdArgs
       { Cmd.eon               = w
       , Cmd.vkeyColdKeySource = coldVkOrHashOrFp
+      , Cmd.anchor            = anchor
       , Cmd.outFile           = oFp
       } =
   conwayEraOnwardsConstraints w $ do
@@ -179,7 +180,7 @@ runGovernanceCommitteeColdKeyResignationCertificate
       lift (readVerificationKeyOrHashOrTextEnvFile AsCommitteeColdKey coldVkOrHashOrFp)
         & onLeft (left . GovernanceCommitteeCmdKeyReadError)
 
-    makeCommitteeColdkeyResignationCertificate (CommitteeColdkeyResignationRequirements w coldVKHash)
+    makeCommitteeColdkeyResignationCertificate (CommitteeColdkeyResignationRequirements w coldVKHash anchor)
       & textEnvelopeToJSON (Just genKeyDelegCertDesc)
       & writeLazyByteStringFile oFp
       & firstExceptT GovernanceCommitteeCmdTextEnvWriteError . newExceptT

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Query.hs
@@ -1572,7 +1572,7 @@ runQueryCommitteeMembersState
 
   committeeState <- runQuery localNodeConnInfo $
     queryCommitteeMembersState eraInMode sbe coldKeys hotKeys (Set.fromList memberStatuses)
-  writeOutput mOutFile committeeState
+  writeOutput mOutFile $ A.toJSON committeeState
 
 runQuery :: LocalNodeConnectInfo mode
          -> LocalStateQueryExpr

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Query.hs
@@ -129,7 +129,7 @@ runQueryCmds = \case
   Cmd.QueryGovStateCmd              args -> runQueryGovState args
   Cmd.QueryDRepStateCmd             args -> runQueryDRepState args
   Cmd.QueryDRepStakeDistributionCmd args -> runQueryDRepStakeDistribution args
-  Cmd.QueryCommitteeStateCmd        args -> runQueryCommitteeState args
+  Cmd.QueryCommitteeMembersStateCmd args -> runQueryCommitteeMembersState args
 
 runQueryConstitutionHashCmd :: ()
   => Cmd.QueryConstitutionHashCmdArgs
@@ -1540,29 +1540,39 @@ runQueryDRepStakeDistribution
   writeOutput mOutFile $
     Map.assocs drepStakeDistribution
 
-runQueryCommitteeState
-  :: Cmd.QueryNoArgCmdArgs era
+runQueryCommitteeMembersState
+  :: Cmd.QueryCommitteeMembersStateCmdArgs era
   -> ExceptT QueryCmdError IO ()
-runQueryCommitteeState
-    Cmd.QueryNoArgCmdArgs
+runQueryCommitteeMembersState
+    Cmd.QueryCommitteeMembersStateCmdArgs
       { Cmd.eon
       , Cmd.nodeSocketPath
       , Cmd.consensusModeParams = AnyConsensusModeParams cModeParams
       , Cmd.networkId
       , Cmd.mOutFile
-      }
-    = conwayEraOnwardsConstraints eon $ do
+      , Cmd.committeeColdKeys  = coldCredKeys
+      , Cmd.committeeHotKeys = hotCredKeys
+      , Cmd.memberStatuses = memberStatuses
+      } = conwayEraOnwardsConstraints eon $ do
   let localNodeConnInfo = LocalNodeConnectInfo cModeParams networkId nodeSocketPath
       sbe = conwayEraOnwardsToShelleyBasedEra eon
       cEra = conwayEraOnwardsToCardanoEra eon
       cMode = consensusModeOnly cModeParams
 
+  let coldKeysFromVerKeyHashOrFile =
+        firstExceptT QueryCmdCommitteeColdKeyError . getCommitteeColdCredentialFromVerKeyHashOrFile
+  coldKeys <- Set.fromList <$> mapM coldKeysFromVerKeyHashOrFile coldCredKeys
+
+  let hotKeysFromVerKeyHashOrFile =
+        firstExceptT QueryCmdCommitteeHotKeyError . getCommitteeHotCredentialFromVerKeyHashOrFile
+  hotKeys <- Set.fromList <$> mapM hotKeysFromVerKeyHashOrFile hotCredKeys
+
   eraInMode <- toEraInMode cEra cMode
     & hoistMaybe (QueryCmdEraConsensusModeMismatch (AnyConsensusMode cMode) (AnyCardanoEra cEra))
 
-  committeeState <- runQuery localNodeConnInfo $ queryCommitteeState eraInMode sbe
-  writeOutput mOutFile $
-    Map.assocs $ committeeState ^. Ledger.csCommitteeCredsL
+  committeeState <- runQuery localNodeConnInfo $
+    queryCommitteeMembersState eraInMode sbe coldKeys hotKeys (Set.fromList memberStatuses)
+  writeOutput mOutFile committeeState
 
 runQuery :: LocalNodeConnectInfo mode
          -> LocalStateQueryExpr

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Transaction.hs
@@ -376,7 +376,7 @@ runTxBuildRaw :: ()
   -> [TxOut CtxTx era]
   -> Maybe SlotNo
   -- ^ Tx lower bound
-  -> Maybe SlotNo
+  -> TxValidityUpperBound era
   -- ^ Tx upper bound
   -> Maybe Lovelace
   -- ^ Tx fee
@@ -420,8 +420,6 @@ runTxBuildRaw era
       <- first TxCmdTxFeeValidationError $ validateTxFee era mFee
     validatedLowerBound
       <- first TxCmdTxValidityLowerBoundValidationError (validateTxValidityLowerBound era mLowerBound)
-    validatedUpperBound
-      <- first TxCmdTxValidityUpperBoundValidationError (validateTxValidityUpperBound era mUpperBound)
     validatedReqSigners
       <- first TxCmdRequiredSignersValidationError $ validateRequiredSigners era reqSigners
     validatedPParams
@@ -446,7 +444,7 @@ runTxBuildRaw era
             , txReturnCollateral = validatedRetCol
             , txFee = validatedFee
             , txValidityLowerBound = validatedLowerBound
-            , txValidityUpperBound = validatedUpperBound
+            , txValidityUpperBound = mUpperBound
             , txMetadata = txMetadata
             , txAuxScripts = txAuxScripts
             , txExtraKeyWits = validatedReqSigners
@@ -488,7 +486,7 @@ runTxBuild :: ()
   -- ^ Multi-Asset value(s)
   -> Maybe SlotNo
   -- ^ Tx lower bound
-  -> Maybe SlotNo
+  -> TxValidityUpperBound era
   -- ^ Tx upper bound
   -> [(Certificate era, Maybe (ScriptWitness WitCtxStake era))]
   -- ^ Certificate with potential script witness
@@ -532,7 +530,6 @@ runTxBuild
     <- hoistEither $ first TxCmdReturnCollateralValidationError $ validateTxReturnCollateral era mReturnCollateral
   dFee <- hoistEither $ first TxCmdTxFeeValidationError $ validateTxFee era dummyFee
   validatedLowerBound <- hoistEither (first TxCmdTxValidityLowerBoundValidationError (validateTxValidityLowerBound era mLowerBound))
-  validatedUpperBound <- hoistEither (first TxCmdTxValidityUpperBoundValidationError (validateTxValidityUpperBound era mUpperBound))
   validatedReqSigners <- hoistEither (first TxCmdRequiredSignersValidationError $ validateRequiredSigners era reqSigners)
   validatedTxWtdrwls <- hoistEither (first TxCmdTxWithdrawalsValidationError $ validateTxWithdrawals era withdrawals)
   validatedTxCerts <- hoistEither (first TxCmdTxCertificatesValidationError $ validateTxCertificates era certsAndMaybeScriptWits)
@@ -583,7 +580,7 @@ runTxBuild
               , txReturnCollateral = validatedRetCol
               , txFee = dFee
               , txValidityLowerBound = validatedLowerBound
-              , txValidityUpperBound = validatedUpperBound
+              , txValidityUpperBound = mUpperBound
               , txMetadata = txMetadata
               , txAuxScripts = txAuxScripts
               , txExtraKeyWits = validatedReqSigners

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Transaction.hs
@@ -418,8 +418,10 @@ runTxBuildRaw era
       <- first TxCmdReturnCollateralValidationError $ validateTxReturnCollateral era mReturnCollateral
     validatedFee
       <- first TxCmdTxFeeValidationError $ validateTxFee era mFee
-    validatedBounds <- (,) <$> first TxCmdTxValidityLowerBoundValidationError (validateTxValidityLowerBound era mLowerBound)
-                           <*> first TxCmdTxValidityUpperBoundValidationError (validateTxValidityUpperBound era mUpperBound)
+    validatedLowerBound
+      <- first TxCmdTxValidityLowerBoundValidationError (validateTxValidityLowerBound era mLowerBound)
+    validatedUpperBound
+      <- first TxCmdTxValidityUpperBoundValidationError (validateTxValidityUpperBound era mUpperBound)
     validatedReqSigners
       <- first TxCmdRequiredSignersValidationError $ validateRequiredSigners era reqSigners
     validatedPParams
@@ -443,7 +445,8 @@ runTxBuildRaw era
             , txTotalCollateral = validatedTotCollateral
             , txReturnCollateral = validatedRetCol
             , txFee = validatedFee
-            , txValidityRange = validatedBounds
+            , txValidityLowerBound = validatedLowerBound
+            , txValidityUpperBound = validatedUpperBound
             , txMetadata = txMetadata
             , txAuxScripts = txAuxScripts
             , txExtraKeyWits = validatedReqSigners
@@ -528,8 +531,8 @@ runTxBuild
   validatedRetCol
     <- hoistEither $ first TxCmdReturnCollateralValidationError $ validateTxReturnCollateral era mReturnCollateral
   dFee <- hoistEither $ first TxCmdTxFeeValidationError $ validateTxFee era dummyFee
-  validatedBounds <- (,) <$> hoistEither (first TxCmdTxValidityLowerBoundValidationError $ validateTxValidityLowerBound era mLowerBound)
-                         <*> hoistEither (first TxCmdTxValidityUpperBoundValidationError $ validateTxValidityUpperBound era mUpperBound)
+  validatedLowerBound <- hoistEither (first TxCmdTxValidityLowerBoundValidationError (validateTxValidityLowerBound era mLowerBound))
+  validatedUpperBound <- hoistEither (first TxCmdTxValidityUpperBoundValidationError (validateTxValidityUpperBound era mUpperBound))
   validatedReqSigners <- hoistEither (first TxCmdRequiredSignersValidationError $ validateRequiredSigners era reqSigners)
   validatedTxWtdrwls <- hoistEither (first TxCmdTxWithdrawalsValidationError $ validateTxWithdrawals era withdrawals)
   validatedTxCerts <- hoistEither (first TxCmdTxCertificatesValidationError $ validateTxCertificates era certsAndMaybeScriptWits)
@@ -579,7 +582,8 @@ runTxBuild
               , txTotalCollateral = validatedTotCollateral
               , txReturnCollateral = validatedRetCol
               , txFee = dFee
-              , txValidityRange = validatedBounds
+              , txValidityLowerBound = validatedLowerBound
+              , txValidityUpperBound = validatedUpperBound
               , txMetadata = txMetadata
               , txAuxScripts = txAuxScripts
               , txExtraKeyWits = validatedReqSigners

--- a/cardano-cli/src/Cardano/CLI/Json/Friendly.hs
+++ b/cardano-cli/src/Cardano/CLI/Json/Friendly.hs
@@ -426,10 +426,12 @@ renderCertificate sbe = \case
                 [ "cold key hash" .= ck
                 , "hot key hash" .= hk
                 ]
-        Ledger.ResignCommitteeColdTxCert cred -> case cred of
+        Ledger.ResignCommitteeColdTxCert cred anchor -> case cred of
           Shelley.ScriptHashObj sh ->
             "Cold committee resignation" .= object
-              [ "script hash" .=  sh ]
+              [ "script hash" .=  sh
+              , "anchor" .= anchor
+              ]
           Shelley.KeyHashObj ck@Shelley.KeyHash{} ->
             "Constitutional committee cold key resignation" .= object
               [ "cold key hash" .= ck

--- a/cardano-cli/src/Cardano/CLI/Json/Friendly.hs
+++ b/cardano-cli/src/Cardano/CLI/Json/Friendly.hs
@@ -188,21 +188,11 @@ friendlyExtraKeyWits = \case
   TxExtraKeyWitnessesNone -> Null
   TxExtraKeyWitnesses _supported paymentKeyHashes -> toJSON paymentKeyHashes
 
--- | Special case of validity range:
--- in Shelley, upper bound is TTL, and no lower bound
-pattern ShelleyTtl
-  :: Maybe SlotNo -> (TxValidityLowerBound era, TxValidityUpperBound era)
-pattern ShelleyTtl ttl <-
-  ( TxValidityNoLowerBound
-  , TxValidityUpperBound _ ttl
-  )
-
 friendlyValidityRange
   :: CardanoEra era
   -> (TxValidityLowerBound era, TxValidityUpperBound era)
   -> Aeson.Value
 friendlyValidityRange era = \case
-  ShelleyTtl ttl -> object ["time to live" .= ttl]
   (lowerBound, upperBound)
     | isLowerBoundSupported || isUpperBoundSupported ->
         object

--- a/cardano-cli/src/Cardano/CLI/Json/Friendly.hs
+++ b/cardano-cli/src/Cardano/CLI/Json/Friendly.hs
@@ -151,7 +151,8 @@ friendlyTxBodyImpl
       , txReturnCollateral
       , txInsReference
       , txUpdateProposal
-      , txValidityRange
+      , txValidityLowerBound
+       ,txValidityUpperBound
       , txWithdrawals
       }) =
     [ "auxiliary scripts" .= friendlyAuxScripts txAuxScripts
@@ -169,7 +170,7 @@ friendlyTxBodyImpl
     , "required signers (payment key hashes needed for scripts)" .=
         friendlyExtraKeyWits txExtraKeyWits
     , "update proposal" .= friendlyUpdateProposal txUpdateProposal
-    , "validity range" .= friendlyValidityRange era txValidityRange
+    , "validity range" .= friendlyValidityRange era (txValidityLowerBound, txValidityUpperBound)
     , "withdrawals" .= friendlyWithdrawals txWithdrawals
     ]
 
@@ -190,7 +191,7 @@ friendlyExtraKeyWits = \case
 -- | Special case of validity range:
 -- in Shelley, upper bound is TTL, and no lower bound
 pattern ShelleyTtl
-  :: SlotNo -> (TxValidityLowerBound era, TxValidityUpperBound era)
+  :: Maybe SlotNo -> (TxValidityLowerBound era, TxValidityUpperBound era)
 pattern ShelleyTtl ttl <-
   ( TxValidityNoLowerBound
   , TxValidityUpperBound _ ttl

--- a/cardano-cli/src/Cardano/CLI/Legacy/Options.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Options.hs
@@ -324,7 +324,7 @@ pTransaction envCli =
       <*> pChangeAddress
       <*> optional (pMintMultiAsset AutoBalance)
       <*> optional pInvalidBefore
-      <*> optional pInvalidHereafter
+      <*> optional pLegacyInvalidHereafter
       <*> many (pCertificateFile AutoBalance)
       <*> many (pWithdrawal AutoBalance)
       <*> pTxMetadataJsonSchema
@@ -360,7 +360,7 @@ pTransaction envCli =
       <*> many pTxOut
       <*> optional (pMintMultiAsset ManualBalance)
       <*> optional pInvalidBefore
-      <*> optional pInvalidHereafter
+      <*> optional pLegacyInvalidHereafter
       <*> optional pTxFee
       <*> many (pCertificateFile ManualBalance )
       <*> many (pWithdrawal ManualBalance)

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/QueryCmdError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/QueryCmdError.hs
@@ -56,6 +56,8 @@ data QueryCmdError
   | QueryCmdUnsupportedNtcVersion !UnsupportedNtcVersionError
   | QueryCmdProtocolParameterConversionError !ProtocolParametersConversionError
   | QueryCmdDRepKeyError !(FileError InputDecodeError)
+  | QueryCmdCommitteeColdKeyError !(FileError InputDecodeError)
+  | QueryCmdCommitteeHotKeyError !(FileError InputDecodeError)
   deriving Show
 
 renderQueryCmdError :: QueryCmdError -> Text
@@ -94,3 +96,7 @@ renderQueryCmdError = \case
   QueryCmdConvenienceError qce -> renderQueryConvenienceError qce
   QueryCmdDRepKeyError e ->
     "Error reading delegation representative key: " <> Text.pack (displayError e)
+  QueryCmdCommitteeColdKeyError e ->
+    "Error reading committee cold key: " <> Text.pack (displayError e)
+  QueryCmdCommitteeHotKeyError e ->
+    "Error reading committee hot key: " <> Text.pack (displayError e)

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/TxValidationError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/TxValidationError.hs
@@ -276,7 +276,7 @@ validateTxCertificates era certsAndScriptWitnesses = cardanoEraConstraints era $
           L.DelegTxCert sCred _             -> Just sCred
           L.RegDepositDelegTxCert sCred _ _ -> Just sCred
           L.AuthCommitteeHotKeyTxCert{}     -> Nothing
-          L.ResignCommitteeColdTxCert _     -> Nothing
+          L.ResignCommitteeColdTxCert _ _     -> Nothing
           L.RegDRepTxCert{}                 -> Nothing
           L.UnRegDRepTxCert{}               -> Nothing
           L.UpdateDRepTxCert{}              -> Nothing

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/TxValidationError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/TxValidationError.hs
@@ -157,7 +157,7 @@ validateTxValidityUpperBound
 validateTxValidityUpperBound era = \case
   Just slot -> do
     supported <- conjureWitness era TxValidityUpperBoundNotSupported
-    pure $ TxValidityUpperBound supported slot
+    pure $ TxValidityUpperBound supported (Just slot)
   Nothing -> do
     supported <- conjureWitness era TxValidityUpperBoundNotSupported
     pure $ TxValidityNoUpperBound supported

--- a/cardano-cli/test/cardano-cli-golden/files/golden/allegra/transaction-view.out
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/allegra/transaction-view.out
@@ -22,5 +22,6 @@ return collateral: null
 total collateral: null
 update proposal: null
 validity range:
-  time to live: 101
+  lower bound: null
+  upper bound: 101
 withdrawals: null

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -6467,6 +6467,8 @@ Usage: cardano-cli conway governance committee create-cold-key-resignation-certi
                                                                                          | --cold-verification-key-file FILE
                                                                                          | --cold-verification-key-hash STRING
                                                                                          )
+                                                                                         [--committee-cold-key-resignation-certificate-metadata-url TEXT
+                                                                                           --committee-cold-key-resignation-certificate-metadata-hash HASH]
                                                                                          --out-file FILE
 
   Create cold key resignation certificate for a Constitutional Committee Member
@@ -6953,6 +6955,18 @@ Usage: cardano-cli conway query committee-state --socket-path SOCKET_PATH
                                                   ( --mainnet
                                                   | --testnet-magic NATURAL
                                                   )
+                                                  [ --cold-verification-key STRING
+                                                  | --cold-verification-key-file FILE
+                                                  | --cold-verification-key-hash STRING
+                                                  ]
+                                                  [ --hot-key STRING
+                                                  | --hot-key-file FILE
+                                                  | --hot-key-hash STRING
+                                                  ]
+                                                  [ --active
+                                                  | --expired
+                                                  | --unrecognized
+                                                  ]
                                                   [--out-file FILE]
 
   Get the committee state

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -6467,8 +6467,8 @@ Usage: cardano-cli conway governance committee create-cold-key-resignation-certi
                                                                                          | --cold-verification-key-file FILE
                                                                                          | --cold-verification-key-hash STRING
                                                                                          )
-                                                                                         [--committee-cold-key-resignation-certificate-metadata-url TEXT
-                                                                                           --committee-cold-key-resignation-certificate-metadata-hash HASH]
+                                                                                         [--resignation-metadata-url TEXT
+                                                                                           --resignation-metadata-hash HASH]
                                                                                          --out-file FILE
 
   Create cold key resignation certificate for a Constitutional Committee Member

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_committee_create-cold-key-resignation-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_committee_create-cold-key-resignation-certificate.cli
@@ -3,8 +3,8 @@ Usage: cardano-cli conway governance committee create-cold-key-resignation-certi
                                                                                          | --cold-verification-key-file FILE
                                                                                          | --cold-verification-key-hash STRING
                                                                                          )
-                                                                                         [--committee-cold-key-resignation-certificate-metadata-url TEXT
-                                                                                           --committee-cold-key-resignation-certificate-metadata-hash HASH]
+                                                                                         [--resignation-metadata-url TEXT
+                                                                                           --resignation-metadata-hash HASH]
                                                                                          --out-file FILE
 
   Create cold key resignation certificate for a Constitutional Committee Member
@@ -16,10 +16,11 @@ Available options:
                            Filepath of the Consitutional Committee cold key.
   --cold-verification-key-hash STRING
                            Constitutional Committee key hash (hex-encoded).
-  --committee-cold-key-resignation-certificate-metadata-url TEXT
-                           Committee cold key resignation certificate URL
-  --committee-cold-key-resignation-certificate-metadata-hash HASH
-                           Committee cold key resignation certificate metadata
-                           hash.
+  --resignation-metadata-url TEXT
+                           Constitutional Committee cold key resignation
+                           certificate URL
+  --resignation-metadata-hash HASH
+                           Constitutional Committee cold key resignation
+                           certificate metadata hash
   --out-file FILE          The output file.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_committee_create-cold-key-resignation-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_committee_create-cold-key-resignation-certificate.cli
@@ -3,6 +3,8 @@ Usage: cardano-cli conway governance committee create-cold-key-resignation-certi
                                                                                          | --cold-verification-key-file FILE
                                                                                          | --cold-verification-key-hash STRING
                                                                                          )
+                                                                                         [--committee-cold-key-resignation-certificate-metadata-url TEXT
+                                                                                           --committee-cold-key-resignation-certificate-metadata-hash HASH]
                                                                                          --out-file FILE
 
   Create cold key resignation certificate for a Constitutional Committee Member
@@ -14,5 +16,10 @@ Available options:
                            Filepath of the Consitutional Committee cold key.
   --cold-verification-key-hash STRING
                            Constitutional Committee key hash (hex-encoded).
+  --committee-cold-key-resignation-certificate-metadata-url TEXT
+                           Committee cold key resignation certificate URL
+  --committee-cold-key-resignation-certificate-metadata-hash HASH
+                           Committee cold key resignation certificate metadata
+                           hash.
   --out-file FILE          The output file.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_committee-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_committee-state.cli
@@ -8,6 +8,18 @@ Usage: cardano-cli conway query committee-state --socket-path SOCKET_PATH
                                                   ( --mainnet
                                                   | --testnet-magic NATURAL
                                                   )
+                                                  [ --cold-verification-key STRING
+                                                  | --cold-verification-key-file FILE
+                                                  | --cold-verification-key-hash STRING
+                                                  ]
+                                                  [ --hot-key STRING
+                                                  | --hot-key-file FILE
+                                                  | --hot-key-hash STRING
+                                                  ]
+                                                  [ --active
+                                                  | --expired
+                                                  | --unrecognized
+                                                  ]
                                                   [--out-file FILE]
 
   Get the committee state
@@ -30,5 +42,19 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --cold-verification-key STRING
+                           Constitutional Committee cold key (hex-encoded).
+  --cold-verification-key-file FILE
+                           Filepath of the Consitutional Committee cold key.
+  --cold-verification-key-hash STRING
+                           Constitutional Committee key hash (hex-encoded).
+  --hot-key STRING         Constitutional Committee hot key (hex-encoded).
+  --hot-key-file FILE      Filepath of the Consitutional Committee hot key.
+  --hot-key-hash STRING    Constitutional Committee key hash (hex-encoded).
+  --active                 Active committee members (members whose vote will
+                           count during ratification)
+  --expired                Expired committee members
+  --unrecognized           Unrecognized committe members: a hot credential for
+                           an unknown cold credential
   --out-file FILE          The output file.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/shelley/transaction-view.out
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/shelley/transaction-view.out
@@ -72,7 +72,8 @@ update proposal:
       transaction fee linear per byte: 76
       treasury expansion: 87/88
 validity range:
-  time to live: 33
+  lower bound: null
+  upper bound: 33
 withdrawals:
 - address: stake_test1up00fz9lyqs5sjks82k22eqz7a9srym9vysjgp3h2ua2v2cm522kg
   amount: 42 Lovelace

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1697767832,
-        "narHash": "sha256-RkuWkTcWufRer/fyzcAnvJA7WLvNitdG8JMKSaNDJag=",
+        "lastModified": 1698409315,
+        "narHash": "sha256-0h8SwdLnp/c02K9dXMlT37nTtmhgA1hKVaMjHLEtFYE=",
         "owner": "input-output-hk",
         "repo": "cardano-haskell-packages",
-        "rev": "3a758410d00a426ce51596d4bc236d1b1d388b12",
+        "rev": "9313f1f20599a693e4828600b67a19dbf7db2e30",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Updated cardano-ledger, ouroboros-consensus and cardano-api packages 
    Replaced  queryCommitteState with new queryCommitteeMembersState
    Added anchor to committee cold key resignation certificate command

# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Additional context for the PR goes here.

If the PR fixes a particular issue please provide a
[link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=)
to the issue.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
