### PR TITLE
Upgrade to `cardano-api-8.26.0.0`

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -14,7 +14,7 @@ repository cardano-haskell-packages
 -- you need to run if you change them
 index-state:
   , hackage.haskell.org 2023-08-08T19:56:09Z
-  , cardano-haskell-packages 2023-10-05T18:49:55Z
+  , cardano-haskell-packages 2023-10-18T12:25:04Z
 
 packages:
   cardano-cli

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -203,7 +203,7 @@ library
                       , binary
                       , bytestring
                       , canonical-json
-                      , cardano-api ^>= 8.25.2.0
+                      , cardano-api ^>= 8.26.0.0
                       , cardano-binary
                       , cardano-crypto
                       , cardano-crypto-class ^>= 2.1.2

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Address.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Address.hs
@@ -227,16 +227,20 @@ buildShelleyAddress vkey mbStakeVerifier nw =
 --
 
 
-foldSomeAddressVerificationKey :: (forall keyrole. Key keyrole =>
-                                   VerificationKey keyrole -> a)
-                               -> SomeAddressVerificationKey -> a
-foldSomeAddressVerificationKey f (AByronVerificationKey           vk) = f vk
-foldSomeAddressVerificationKey f (APaymentVerificationKey         vk) = f vk
-foldSomeAddressVerificationKey f (APaymentExtendedVerificationKey vk) = f vk
-foldSomeAddressVerificationKey f (AGenesisUTxOVerificationKey     vk) = f vk
-foldSomeAddressVerificationKey f (AKesVerificationKey             vk) = f vk
-foldSomeAddressVerificationKey f (AGenesisDelegateExtendedVerificationKey vk) = f vk
-foldSomeAddressVerificationKey f (AGenesisExtendedVerificationKey vk) = f vk
-foldSomeAddressVerificationKey f (AVrfVerificationKey             vk) = f vk
-foldSomeAddressVerificationKey f (AStakeVerificationKey           vk) = f vk
-foldSomeAddressVerificationKey f (AStakeExtendedVerificationKey   vk) = f vk
+foldSomeAddressVerificationKey :: ()
+  => (forall keyrole. Key keyrole => VerificationKey keyrole -> a)
+  -> SomeAddressVerificationKey
+  -> a
+foldSomeAddressVerificationKey f = \case
+  AByronVerificationKey                   vk -> f vk
+  APaymentVerificationKey                 vk -> f vk
+  APaymentExtendedVerificationKey         vk -> f vk
+  AGenesisUTxOVerificationKey             vk -> f vk
+  AKesVerificationKey                     vk -> f vk
+  AGenesisDelegateExtendedVerificationKey vk -> f vk
+  AGenesisExtendedVerificationKey         vk -> f vk
+  AVrfVerificationKey                     vk -> f vk
+  AStakeVerificationKey                   vk -> f vk
+  AStakeExtendedVerificationKey           vk -> f vk
+  ADRepVerificationKey                    vk -> f vk
+  ADRepExtendedVerificationKey            vk -> f vk

--- a/cardano-cli/src/Cardano/CLI/Types/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Common.hs
@@ -6,9 +6,7 @@
 {-# LANGUAGE StandaloneDeriving #-}
 
 module Cardano.CLI.Types.Common
-  ( AnchorDataHash(..)
-  , AnchorUrl(..)
-  , AllOrOnly(..)
+  ( AllOrOnly(..)
   , AddressKeyType(..)
   , BalanceTxExecUnits (..)
   , BlockId(..)

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1696532530,
-        "narHash": "sha256-Tabp1I371941jDRh+5X7/zp4cxKACt3H4hrXR5TdA8Y=",
+        "lastModified": 1697632644,
+        "narHash": "sha256-izvf9heGTXW2r7Hv9xJ1uDsWiiwWAagH5qncCSEK1h0=",
         "owner": "input-output-hk",
         "repo": "cardano-haskell-packages",
-        "rev": "6d33ceace68c32707cb6a5d08483dd7c35059f31",
+        "rev": "8839bc5d2b941da822b189605950489620befb1f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Upgrade to `cardano-api-8.26.0.0`
    Support for DRep verification key and DRep extended keys
# uncomment types applicable to the change:
  type:
  - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context


# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] The change log section in the PR description has been filled in
- [ ] New tests are added if needed and existing tests are updated.  These may include:
  - golden tests
  - property tests
  - round trip tests
  - integration tests
  See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] The version bounds in `.cabal` files are updated
- [ ] CI passes. See note on CI.  The following CI checks are required:
  - [ ] Code is linted with `hlint`.  See `.github/workflows/check-hlint.yml` to get the `hlint` version
  - [ ] Code is formatted with `stylish-haskell`.  See `.github/workflows/stylish-haskell.yml` to get the `stylish-haskell` version
  - [ ] Code builds on Linux, MacOS and Windows for `ghc-8.10.7` and `ghc-9.2.7`
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
