### PR TITLE
Simplify `toTxOutInAnyEra`

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -43,3 +43,9 @@ write-ghc-environment-files: always
 -- IMPORTANT
 -- Do NOT add more source-repository-package stanzas here unless they are strictly
 -- temporary! Please read the section in CONTRIBUTING about updating dependencies.
+
+source-repository-package
+    type: git
+    location: https://github.com/input-output-hk/cardano-api
+    tag: 9281f5ed808ca4841373da8adf55250072a8614c
+    subdir: cardano-api

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run.hs
@@ -74,15 +74,6 @@ runCmds = \case
     runTransactionCmds cmd
       & firstExceptT CmdTransactionError
 
--- TODO smelc Move me to cardano-api. Or is there another way? I'd be surprised
--- this is the first time we need this.
-shelleyToAlonzoEraToShelleyToBabbageEra :: ShelleyToAlonzoEra era -> ShelleyToBabbageEra era
-shelleyToAlonzoEraToShelleyToBabbageEra = \case
-  ShelleyToAlonzoEraShelley -> ShelleyToBabbageEraShelley
-  ShelleyToAlonzoEraAllegra -> ShelleyToBabbageEraAllegra
-  ShelleyToAlonzoEraMary -> ShelleyToBabbageEraMary
-  ShelleyToAlonzoEraAlonzo -> ShelleyToBabbageEraAlonzo
-
 runGovernanceCmds :: ()
   => GovernanceCmds era
   -> ExceptT CmdError IO ()


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Simplify `toTxOutInAnyEra`
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

This PR proves that `AlonzoEraOnly` is a false eon.

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
