### PR TITLE
Remove `--update-proposal-file` from Conway onwards

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Transaction.hs
@@ -74,7 +74,7 @@ data TransactionBuildRawCmdArgs era = TransactionBuildRawCmdArgs
     -- ^ Auxiliary scripts
   , metadataFiles         :: ![MetadataFile]
   , mProtocolParamsFile   :: !(Maybe ProtocolParamsFile)
-  , mUpdateProprosalFile  :: !(Maybe UpdateProposalFile)
+  , mUpdateProprosalFile  :: !(Maybe (Featured ShelleyToBabbageEra era (Maybe UpdateProposalFile)))
   , voteFiles             :: ![VoteFile In]
   , proposalFiles         :: ![ProposalFile In]
   , txBodyOutFile         :: !(TxBodyFile Out)
@@ -120,7 +120,7 @@ data TransactionBuildCmdArgs era = TransactionBuildCmdArgs
   , scriptFiles             :: ![ScriptFile]
     -- ^ Auxiliary scripts
   , metadataFiles           :: ![MetadataFile]
-  , mUpdateProposalFile     :: !(Maybe UpdateProposalFile)
+  , mfUpdateProposalFile    :: !(Maybe (Featured ShelleyToBabbageEra era (Maybe UpdateProposalFile)))
   , voteFiles               :: ![VoteFile In]
   , proposalFiles           :: ![ProposalFile In]
   , buildOutputOptions      :: !TxBuildOutputOptions

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
@@ -3246,6 +3246,18 @@ pTxId l h =
 -- Helpers
 --------------------------------------------------------------------------------
 
+pFeatured :: ()
+  => Eon eon
+  => ToCardanoEra peon
+  => peon era
+  -> Parser a
+  -> Parser (Maybe (Featured eon era a))
+pFeatured peon p = do
+  let mw = forEraMaybeEon (toCardanoEra peon)
+  case mw of
+    Nothing -> pure Nothing
+    Just eon' -> Just . Featured eon' <$> p
+
 hiddenSubParser :: String -> ParserInfo a -> Parser a
 hiddenSubParser availableCommand pInfo =
   Opt.hsubparser $ Opt.command availableCommand pInfo <> Opt.metavar availableCommand <> Opt.hidden

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Transaction.hs
@@ -182,7 +182,7 @@ pTransactionBuildCmd era envCli = do
                       Nothing
                       "Filepath of auxiliary script(s)")
           <*> many pMetadataFile
-          <*> optional pUpdateProposalFile
+          <*> pFeatured (shelleyBasedToCardanoEra w) (optional pUpdateProposalFile)
           <*> many (pFileInDirection "vote-file" "Filepath of the vote.")
           <*> many (pFileInDirection "proposal-file" "Filepath of the proposal.")
           <*> (OutputTxBodyOnly <$> pTxBodyFileOut <|> pCalculatePlutusScriptCost)
@@ -217,7 +217,7 @@ pTransactionBuildRaw era =
       <*> many (pScriptFor "auxiliary-script-file" Nothing "Filepath of auxiliary script(s)")
       <*> many pMetadataFile
       <*> optional pProtocolParamsFile
-      <*> optional pUpdateProposalFile
+      <*> pFeatured era (optional pUpdateProposalFile)
       <*> many (pFileInDirection "vote-file" "Filepath of the vote.")
       <*> many (pFileInDirection "proposal-file" "Filepath of the proposal.")
       <*> pTxBodyFileOut

--- a/cardano-cli/src/Cardano/CLI/Read.hs
+++ b/cardano-cli/src/Cardano/CLI/Read.hs
@@ -85,6 +85,8 @@ module Cardano.CLI.Read
 
   , scriptHashReader
 
+  -- * Update proposals
+  , readTxUpdateProposal
 
   -- * Vote related
   , readVoteDelegationTarget
@@ -787,6 +789,13 @@ readVotingProceduresFiles w = \case
     vpss <- forM files (ExceptT . readVotingProceduresFile w)
 
     pure $ foldl unsafeMergeVotingProcedures emptyVotingProcedures vpss
+
+readTxUpdateProposal :: ()
+  => ShelleyToBabbageEra era
+  -> UpdateProposalFile
+  -> ExceptT (FileError TextEnvelopeError) IO (TxUpdateProposal era)
+readTxUpdateProposal w (UpdateProposalFile upFp) = do
+  TxUpdateProposal w <$> newExceptT (readFileTextEnvelope AsUpdateProposal (File upFp))
 
 readVotingProceduresFile :: ()
   => ConwayEraOnwards era

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -7278,7 +7278,6 @@ Usage: cardano-cli conway transaction build-raw
                                                   | --metadata-cbor-file FILE
                                                   ]
                                                   [--protocol-params-file FILE]
-                                                  [--update-proposal-file FILE]
                                                   [--vote-file FILE]
                                                   [--proposal-file FILE]
                                                   --out-file FILE
@@ -7399,7 +7398,6 @@ Usage: cardano-cli conway transaction build --socket-path SOCKET_PATH
                                               [ --metadata-json-file FILE
                                               | --metadata-cbor-file FILE
                                               ]
-                                              [--update-proposal-file FILE]
                                               [--vote-file FILE]
                                               [--proposal-file FILE]
                                               ( --out-file FILE

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_build-raw.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_build-raw.cli
@@ -112,7 +112,6 @@ Usage: cardano-cli conway transaction build-raw
                                                   | --metadata-cbor-file FILE
                                                   ]
                                                   [--protocol-params-file FILE]
-                                                  [--update-proposal-file FILE]
                                                   [--vote-file FILE]
                                                   [--proposal-file FILE]
                                                   --out-file FILE
@@ -381,8 +380,6 @@ Available options:
                            Filepath of the metadata, in raw CBOR format.
   --protocol-params-file FILE
                            Filepath of the JSON-encoded protocol parameters file
-  --update-proposal-file FILE
-                           Filepath of the update proposal.
   --vote-file FILE         Filepath of the vote.
   --proposal-file FILE     Filepath of the proposal.
   --out-file FILE          Output filepath of the JSON TxBody.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_build.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_build.cli
@@ -110,7 +110,6 @@ Usage: cardano-cli conway transaction build --socket-path SOCKET_PATH
                                               [ --metadata-json-file FILE
                                               | --metadata-cbor-file FILE
                                               ]
-                                              [--update-proposal-file FILE]
                                               [--vote-file FILE]
                                               [--proposal-file FILE]
                                               ( --out-file FILE
@@ -382,8 +381,6 @@ Available options:
                            Filepath of the metadata file, in JSON format.
   --metadata-cbor-file FILE
                            Filepath of the metadata, in raw CBOR format.
-  --update-proposal-file FILE
-                           Filepath of the update proposal.
   --vote-file FILE         Filepath of the vote.
   --proposal-file FILE     Filepath of the proposal.
   --out-file FILE          Output filepath of the JSON TxBody.


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Remove `--update-proposal-file` from Conway onwards
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

This option is not supported from Conway onwards to remove it from the CLI parser rather than accept it and then fail validation.

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
