### PR TITLE
`transaction build` only works from `ShelleyEraOnwards`

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Transaction.hs
@@ -82,7 +82,7 @@ data TransactionBuildRawCmdArgs era = TransactionBuildRawCmdArgs
 
 -- | Like 'TransactionBuildRaw' but without the fee, and with a change output.
 data TransactionBuildCmdArgs era = TransactionBuildCmdArgs
-  { eon                     :: !(CardanoEra era)
+  { eon                     :: !(ShelleyBasedEra era)
   , nodeSocketPath          :: !SocketPath
   , consensusModeParams     :: !AnyConsensusModeParams
   , networkId               :: !NetworkId

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Transaction.hs
@@ -154,7 +154,7 @@ pTransactionBuildCmd era envCli = do
             ]
         ]
   where
-    pCmd :: CardanoEra era ->  Parser (TransactionCmds era)
+    pCmd :: ShelleyBasedEra era ->  Parser (TransactionCmds era)
     pCmd w =
       fmap TransactionBuildCmd $
         TransactionBuildCmdArgs w

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Transaction.hs
@@ -125,7 +125,8 @@ runTransactionBuildCmd
       , voteFiles
       , proposalFiles
       , buildOutputOptions
-      } = do
+      } = shelleyBasedEraConstraints eon $ do
+  let era = shelleyBasedToCardanoEra eon
 
   -- The user can specify an era prior to the era that the node is currently in.
   -- We cannot use the user specified era to construct a query against a node because it may differ
@@ -137,45 +138,41 @@ runTransactionBuildCmd
                             , localNodeSocketPath = nodeSocketPath
                             }
 
-  inputsAndMaybeScriptWits <- firstExceptT TxCmdScriptWitnessError $ readScriptWitnessFiles eon txins
-  certFilesAndMaybeScriptWits <- firstExceptT TxCmdScriptWitnessError $ readScriptWitnessFiles eon certificates
+  inputsAndMaybeScriptWits <- firstExceptT TxCmdScriptWitnessError $ readScriptWitnessFiles era txins
+  certFilesAndMaybeScriptWits <- firstExceptT TxCmdScriptWitnessError $ readScriptWitnessFiles era certificates
 
   -- TODO: Conway Era - How can we make this more composable?
   certsAndMaybeScriptWits <-
-    case cardanoEraStyle eon of
-      LegacyByronEra -> return []
-      ShelleyBasedEra sbe ->
-        shelleyBasedEraConstraints sbe $
-          sequence
-            [ fmap (,mSwit) (firstExceptT TxCmdReadTextViewFileError . newExceptT $
-                readFileTextEnvelope AsCertificate (File certFile))
-            | (CertificateFile certFile, mSwit) <- certFilesAndMaybeScriptWits
-            ]
+      sequence
+        [ fmap (,mSwit) (firstExceptT TxCmdReadTextViewFileError . newExceptT $
+            readFileTextEnvelope AsCertificate (File certFile))
+        | (CertificateFile certFile, mSwit) <- certFilesAndMaybeScriptWits
+        ]
   withdrawalsAndMaybeScriptWits <- firstExceptT TxCmdScriptWitnessError $
-    readScriptWitnessFilesThruple eon withdrawals
+    readScriptWitnessFilesThruple era withdrawals
   txMetadata <- firstExceptT TxCmdMetadataError . newExceptT $
-    readTxMetadata eon metadataSchema metadataFiles
-  valuesWithScriptWits <- readValueScriptWitnesses eon $ fromMaybe mempty mValue
+    readTxMetadata era metadataSchema metadataFiles
+  valuesWithScriptWits <- readValueScriptWitnesses era $ fromMaybe mempty mValue
   scripts <- firstExceptT TxCmdScriptFileError $
     mapM (readFileScriptInAnyLang . unScriptFile) scriptFiles
-  txAuxScripts <- hoistEither $ first TxCmdAuxScriptsValidationError $ validateTxAuxScripts eon scripts
+  txAuxScripts <- hoistEither $ first TxCmdAuxScriptsValidationError $ validateTxAuxScripts era scripts
 
   mProp <- forM mUpdateProposalFile $ \(UpdateProposalFile upFp) ->
     firstExceptT TxCmdReadTextViewFileError (newExceptT $ readFileTextEnvelope AsUpdateProposal (File upFp))
   requiredSigners  <- mapM (firstExceptT TxCmdRequiredSignerError .  newExceptT . readRequiredSigner) reqSigners
-  mReturnCollateral <- forM mReturnColl $ toTxOutInAnyEra eon
+  mReturnCollateral <- forM mReturnColl $ toTxOutInAnyEra era
 
-  txOuts <- mapM (toTxOutInAnyEra eon) txouts
+  txOuts <- mapM (toTxOutInAnyEra era) txouts
 
   -- Conway related
   votingProcedures <-
     inEonForEra
       (pure emptyVotingProcedures)
       (\w -> firstExceptT TxCmdVoteError $ ExceptT (readVotingProceduresFiles w voteFiles))
-      eon
+      era
 
   proposals <- newExceptT $ first TxCmdConstitutionError
-                  <$> readTxGovernanceActions eon proposalFiles
+                  <$> readTxGovernanceActions era proposalFiles
 
   -- the same collateral input can be used for several plutus scripts
   let filteredTxinsc = Set.toList $ Set.fromList txinsc
@@ -183,13 +180,13 @@ runTransactionBuildCmd
   -- We need to construct the txBodycontent outside of runTxBuild
   BalancedTxBody txBodyContent balancedTxBody _ _ <-
     runTxBuild
-      eon nodeSocketPath consensusModeParams networkId mScriptValidity inputsAndMaybeScriptWits readOnlyReferenceInputs
+      era nodeSocketPath consensusModeParams networkId mScriptValidity inputsAndMaybeScriptWits readOnlyReferenceInputs
       filteredTxinsc mReturnCollateral mTotalCollateral txOuts changeAddresses valuesWithScriptWits
       mValidityLowerBound mValidityUpperBound certsAndMaybeScriptWits withdrawalsAndMaybeScriptWits
       requiredSigners txAuxScripts txMetadata mProp mOverrideWitnesses votingProcedures proposals buildOutputOptions
 
   let mScriptWits =
-        forEraInEon eon [] $ \sbe -> collectTxBodyScriptWitnesses sbe txBodyContent
+        forEraInEon era [] $ \sbe -> collectTxBodyScriptWitnesses sbe txBodyContent
 
   let allReferenceInputs = getAllReferenceInputs
                              inputsAndMaybeScriptWits
@@ -209,7 +206,7 @@ runTransactionBuildCmd
       let BuildTxWith mTxProtocolParams = txProtocolParams txBodyContent
 
       pparams <- pure mTxProtocolParams & onNothing (left TxCmdProtocolParametersNotPresentInTxBody)
-      executionUnitPrices <- pure (getExecutionUnitPrices eon pparams) & onNothing (left TxCmdPParamExecutionUnitsNotAvailable)
+      executionUnitPrices <- pure (getExecutionUnitPrices era pparams) & onNothing (left TxCmdPParamExecutionUnitsNotAvailable)
       let consensusMode = consensusModeOnly cModeParams
 
       case consensusMode of
@@ -223,8 +220,8 @@ runTransactionBuildCmd
               & onLeft (left . TxCmdQueryConvenienceError . AcqFailure)
               & onLeft (left . TxCmdQueryConvenienceError)
 
-          Refl <- testEquality eon nodeEra
-            & hoistMaybe (TxCmdTxNodeEraMismatchError $ NodeEraMismatchError eon nodeEra)
+          Refl <- testEquality era nodeEra
+            & hoistMaybe (TxCmdTxNodeEraMismatchError $ NodeEraMismatchError era nodeEra)
 
           scriptExecUnitsMap <-
             firstExceptT TxCmdTxExecUnitsErr $ hoistEither
@@ -244,7 +241,7 @@ runTransactionBuildCmd
 
     OutputTxBodyOnly fpath ->
       let noWitTx = makeSignedTransaction [] balancedTxBody
-      in  lift (cardanoEraConstraints eon $ writeTxFileTextEnvelopeCddl eon fpath noWitTx)
+      in  lift (cardanoEraConstraints era $ writeTxFileTextEnvelopeCddl era fpath noWitTx)
             & onLeft (left . TxCmdWriteFileError)
 
 getExecutionUnitPrices :: CardanoEra era -> LedgerProtocolParameters era -> Maybe Ledger.Prices

--- a/cardano-cli/src/Cardano/CLI/Legacy/Commands/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Commands/Transaction.hs
@@ -53,7 +53,7 @@ data LegacyTransactionCmds
     -- | Like 'TransactionBuildRaw' but without the fee, and with a change output.
   | TransactionBuildCmd
       SocketPath
-      AnyCardanoEra
+      (EraInEon ShelleyBasedEra)
       AnyConsensusModeParams
       NetworkId
       (Maybe ScriptValidity) -- ^ Mark script as expected to pass or fail validation

--- a/cardano-cli/src/Cardano/CLI/Legacy/Options.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Options.hs
@@ -15,6 +15,7 @@ module Cardano.CLI.Legacy.Options
   , parseTxIn
 
   , pLegacyCardanoEra
+  , pLegacyShelleyBasedEra
   , pKeyRegistDeposit
   , pStakePoolRegistrationParserRequirements
   , pStakePoolVerificationKeyOrHashOrFile
@@ -24,7 +25,7 @@ import           Cardano.Api hiding (QueryInShelleyBasedEra (..))
 import           Cardano.Api.Shelley hiding (QueryInShelleyBasedEra (..))
 
 import           Cardano.Chain.Common (BlockCount (BlockCount))
-import           Cardano.CLI.Environment (EnvCli (..))
+import           Cardano.CLI.Environment
 import           Cardano.CLI.EraBased.Options.Common
 import           Cardano.CLI.Legacy.Commands
 import           Cardano.CLI.Legacy.Commands.Address
@@ -1240,3 +1241,31 @@ pLegacyCardanoEra envCli =
       defaultCardanoEra = defaultShelleyBasedEra & \(EraInEon era) ->
         let cera = toCardanoEra era
          in cardanoEraConstraints cera (AnyCardanoEra cera)
+
+pLegacyShelleyBasedEra :: EnvCli -> Parser (EraInEon ShelleyBasedEra)
+pLegacyShelleyBasedEra envCli =
+  asum $ mconcat
+    [ [ Opt.flag' (EraInEon ShelleyBasedEraShelley) $ mconcat
+        [ Opt.long "shelley-era"
+        , Opt.help "Specify the Shelley era"
+        ]
+      , Opt.flag' (EraInEon ShelleyBasedEraAllegra) $ mconcat
+        [ Opt.long "allegra-era"
+        , Opt.help "Specify the Allegra era"
+        ]
+      , Opt.flag' (EraInEon ShelleyBasedEraMary) $ mconcat
+        [ Opt.long "mary-era"
+        , Opt.help "Specify the Mary era"
+        ]
+      , Opt.flag' (EraInEon ShelleyBasedEraAlonzo) $ mconcat
+        [ Opt.long "alonzo-era"
+        , Opt.help "Specify the Alonzo era"
+        ]
+      , Opt.flag' (EraInEon ShelleyBasedEraBabbage) $ mconcat
+        [ Opt.long "babbage-era"
+        , Opt.help "Specify the Babbage era (default)"
+        ]
+      ]
+    , maybeToList $ pure <$> envCliAnyShelleyBasedEra envCli
+    , pure $ pure defaultShelleyBasedEra
+  ]

--- a/cardano-cli/src/Cardano/CLI/Legacy/Options.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Options.hs
@@ -309,7 +309,7 @@ pTransaction envCli =
   pTransactionBuild =
     TransactionBuildCmd
       <$> pSocketPath envCli
-      <*> pLegacyCardanoEra envCli
+      <*> pLegacyShelleyBasedEra envCli
       <*> pConsensusModeParams
       <*> pNetworkId envCli
       <*> optional pScriptValidity

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Transaction.hs
@@ -19,7 +19,6 @@ import           Cardano.CLI.Types.Errors.TxCmdError
 import           Cardano.CLI.Types.Governance
 
 import           Control.Monad.Trans.Except
-import           Control.Monad.Trans.Except.Extra
 
 runLegacyTransactionCmds :: LegacyTransactionCmds -> ExceptT TxCmdError IO ()
 runLegacyTransactionCmds = \case
@@ -64,7 +63,7 @@ runLegacyTransactionCmds = \case
 
 runLegacyTransactionBuildCmd :: ()
   => SocketPath
-  -> AnyCardanoEra
+  -> EraInEon ShelleyBasedEra
   -> AnyConsensusModeParams
   -> NetworkId
   -> Maybe ScriptValidity
@@ -91,14 +90,11 @@ runLegacyTransactionBuildCmd :: ()
   -> TxBuildOutputOptions
   -> ExceptT TxCmdError IO ()
 runLegacyTransactionBuildCmd
-    socketPath (AnyCardanoEra era)
+    socketPath (EraInEon sbe)
     consensusModeParams nid mScriptValidity mOverrideWits txins readOnlyRefIns
     reqSigners txinsc mReturnColl mTotCollateral txouts changeAddr mValue mLowBound
     mUpperBound certs wdrls metadataSchema scriptFiles metadataFiles mUpProp voteFiles
-    proposalFiles outputOptions = do
-
-  AnyShelleyBasedEra sbe <- forEraInEon era (left TxCmdByronEra) (pure . AnyShelleyBasedEra)
-
+    proposalFiles outputOptions =
   runTransactionBuildCmd
     ( Cmd.TransactionBuildCmdArgs sbe socketPath
         consensusModeParams nid mScriptValidity mOverrideWits txins readOnlyRefIns

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Transaction.hs
@@ -19,7 +19,7 @@ import           Cardano.CLI.Types.Errors.TxCmdError
 import           Cardano.CLI.Types.Governance
 
 import           Control.Monad.Trans.Except
-
+import           Control.Monad.Trans.Except.Extra
 
 runLegacyTransactionCmds :: LegacyTransactionCmds -> ExceptT TxCmdError IO ()
 runLegacyTransactionCmds = \case
@@ -95,9 +95,12 @@ runLegacyTransactionBuildCmd
     consensusModeParams nid mScriptValidity mOverrideWits txins readOnlyRefIns
     reqSigners txinsc mReturnColl mTotCollateral txouts changeAddr mValue mLowBound
     mUpperBound certs wdrls metadataSchema scriptFiles metadataFiles mUpProp voteFiles
-    proposalFiles outputOptions =
+    proposalFiles outputOptions = do
+
+  AnyShelleyBasedEra sbe <- forEraInEon era (left TxCmdByronEra) (pure . AnyShelleyBasedEra)
+
   runTransactionBuildCmd
-    ( Cmd.TransactionBuildCmdArgs era socketPath
+    ( Cmd.TransactionBuildCmdArgs sbe socketPath
         consensusModeParams nid mScriptValidity mOverrideWits txins readOnlyRefIns
         reqSigners txinsc mReturnColl mTotCollateral txouts changeAddr mValue mLowBound
         mUpperBound certs wdrls metadataSchema scriptFiles metadataFiles mUpProp voteFiles

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -9350,8 +9350,7 @@ Usage: cardano-cli legacy transaction build-raw
   Please note the order of some cmd options is crucial. If used incorrectly may produce undesired tx body. See nested [] notation above for details.[0;22;23;24m
 
 Usage: cardano-cli legacy transaction build --socket-path SOCKET_PATH
-                                              [ --byron-era
-                                              | --shelley-era
+                                              [ --shelley-era
                                               | --allegra-era
                                               | --mary-era
                                               | --alonzo-era
@@ -10616,8 +10615,7 @@ Usage: cardano-cli transaction build-raw
   Please note the order of some cmd options is crucial. If used incorrectly may produce undesired tx body. See nested [] notation above for details.[0;22;23;24m
 
 Usage: cardano-cli transaction build --socket-path SOCKET_PATH
-                                       [ --byron-era
-                                       | --shelley-era
+                                       [ --shelley-era
                                        | --allegra-era
                                        | --mary-era
                                        | --alonzo-era

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_transaction_build.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_transaction_build.cli
@@ -1,6 +1,5 @@
 Usage: cardano-cli legacy transaction build --socket-path SOCKET_PATH
-                                              [ --byron-era
-                                              | --shelley-era
+                                              [ --shelley-era
                                               | --allegra-era
                                               | --mary-era
                                               | --alonzo-era
@@ -134,7 +133,6 @@ Available options:
                            CARDANO_NODE_SOCKET_PATH environment variable. The
                            argument is optional if CARDANO_NODE_SOCKET_PATH is
                            defined and mandatory otherwise.
-  --byron-era              Specify the Byron era
   --shelley-era            Specify the Shelley era
   --allegra-era            Specify the Allegra era
   --mary-era               Specify the Mary era

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/transaction_build.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/transaction_build.cli
@@ -1,6 +1,5 @@
 Usage: cardano-cli transaction build --socket-path SOCKET_PATH
-                                       [ --byron-era
-                                       | --shelley-era
+                                       [ --shelley-era
                                        | --allegra-era
                                        | --mary-era
                                        | --alonzo-era
@@ -127,7 +126,6 @@ Available options:
                            CARDANO_NODE_SOCKET_PATH environment variable. The
                            argument is optional if CARDANO_NODE_SOCKET_PATH is
                            defined and mandatory otherwise.
-  --byron-era              Specify the Byron era
   --shelley-era            Specify the Shelley era
   --allegra-era            Specify the Allegra era
   --mary-era               Specify the Mary era


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Remove `--byron-era` from legacy `transaction build` command.
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

The `transaction build` commands only work from Shelley era onwards so it doesn't make sense to declare they work for Byron.

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
