### PR TITLE
Command argument types for `genesis` commands

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Genesis.hs
@@ -7,6 +7,7 @@ module Cardano.CLI.EraBased.Commands.Genesis
   , GenesisCreateCmdArgs (..)
   , GenesisCreateCardanoCmdArgs (..)
   , GenesisCreateStakedCmdArgs (..)
+  , GenesisKeyGenGenesisCmdArgs (..)
   , renderGenesisCmds
   ) where
 
@@ -21,9 +22,7 @@ data GenesisCmds era
   = GenesisCreate !GenesisCreateCmdArgs
   | GenesisCreateCardano !GenesisCreateCardanoCmdArgs
   | GenesisCreateStaked !GenesisCreateStakedCmdArgs
-  | GenesisKeyGenGenesis
-      (VerificationKeyFile Out)
-      (SigningKeyFile Out)
+  | GenesisKeyGenGenesis !GenesisKeyGenGenesisCmdArgs
   | GenesisKeyGenDelegate
       (VerificationKeyFile Out)
       (SigningKeyFile Out)
@@ -90,6 +89,11 @@ data GenesisCreateStakedCmdArgs = GenesisCreateStakedCmdArgs
   , numBulkPoolsPerFile :: !Word
   , numStuffedUtxo :: !Word
   , mStakePoolRelaySpecFile :: !(Maybe FilePath) -- ^ Relay specification filepath
+  } deriving Show
+
+data GenesisKeyGenGenesisCmdArgs = GenesisKeyGenGenesisCmdArgs
+  { verificationKeyPath :: !(VerificationKeyFile Out)
+  , signingKeyPath :: !(SigningKeyFile Out)
   } deriving Show
 
 renderGenesisCmds :: GenesisCmds era -> Text

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Genesis.hs
@@ -6,6 +6,7 @@ module Cardano.CLI.EraBased.Commands.Genesis
   ( GenesisCmds (..)
   , GenesisCreateCmdArgs (..)
   , GenesisCreateCardanoCmdArgs (..)
+  , GenesisCreateStakedCmdArgs (..)
   , renderGenesisCmds
   ) where
 
@@ -19,21 +20,7 @@ import           Data.Text (Text)
 data GenesisCmds era
   = GenesisCreate !GenesisCreateCmdArgs
   | GenesisCreateCardano !GenesisCreateCardanoCmdArgs
-  | GenesisCreateStaked
-      KeyOutputFormat
-      GenesisDir
-      Word
-      Word
-      Word
-      Word
-      (Maybe SystemStart)
-      (Maybe Lovelace)
-      Lovelace
-      NetworkId
-      Word
-      Word
-      Word
-      (Maybe FilePath) -- ^ Relay specification filepath
+  | GenesisCreateStaked !GenesisCreateStakedCmdArgs
   | GenesisKeyGenGenesis
       (VerificationKeyFile Out)
       (SigningKeyFile Out)
@@ -86,6 +73,23 @@ data GenesisCreateCardanoCmdArgs = GenesisCreateCardanoCmdArgs
   , alonzoGenesisTemplate :: !FilePath
   , conwayGenesisTemplate :: !FilePath
   , mNodeConfigTemplate :: !(Maybe FilePath)
+  } deriving Show
+
+data GenesisCreateStakedCmdArgs = GenesisCreateStakedCmdArgs
+  { keyOutputFormat :: !KeyOutputFormat
+  , genesisDir :: !GenesisDir
+  , numGenesisKeys :: !Word
+  , numUTxOKeys :: !Word
+  , numPools :: !Word
+  , numStakeDelegators :: !Word
+  , mSystemStart :: !(Maybe SystemStart)
+  , mNonDelegatedSupply :: !(Maybe Lovelace)
+  , delegatedSupply :: !Lovelace
+  , network :: !NetworkId
+  , numBulkPoolCredFiles :: !Word
+  , numBulkPoolsPerFile :: !Word
+  , numStuffedUtxo :: !Word
+  , mStakePoolRelaySpecFile :: !(Maybe FilePath) -- ^ Relay specification filepath
   } deriving Show
 
 renderGenesisCmds :: GenesisCmds era -> Text

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Genesis.hs
@@ -3,6 +3,7 @@
 
 module Cardano.CLI.EraBased.Commands.Genesis
   ( GenesisCmds (..)
+  , GenesisCreateCmdArgs (..)
   , renderGenesisCmds
   ) where
 
@@ -14,14 +15,7 @@ import           Cardano.CLI.Types.Common
 import           Data.Text (Text)
 
 data GenesisCmds era
-  = GenesisCreate
-      KeyOutputFormat
-      GenesisDir
-      Word
-      Word
-      (Maybe SystemStart)
-      (Maybe Lovelace)
-      NetworkId
+  = GenesisCreate !GenesisCreateCmdArgs
   | GenesisCreateCardano
       GenesisDir
       Word
@@ -78,6 +72,16 @@ data GenesisCmds era
   | GenesisHashFile
       GenesisFile
   deriving Show
+
+data GenesisCreateCmdArgs = GenesisCreateCmdArgs
+  { keyOutputFormat :: !KeyOutputFormat
+  , genesisDir :: !GenesisDir
+  , numGenesisKeys :: !Word
+  , numUTxOKeys :: !Word
+  , mSystemStart :: !(Maybe SystemStart)
+  , mSupply :: !(Maybe Lovelace)
+  , network :: !NetworkId
+  } deriving Show
 
 renderGenesisCmds :: GenesisCmds era -> Text
 renderGenesisCmds = \case

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Genesis.hs
@@ -1,9 +1,11 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE LambdaCase #-}
 
 module Cardano.CLI.EraBased.Commands.Genesis
   ( GenesisCmds (..)
   , GenesisCreateCmdArgs (..)
+  , GenesisCreateCardanoCmdArgs (..)
   , renderGenesisCmds
   ) where
 
@@ -16,21 +18,7 @@ import           Data.Text (Text)
 
 data GenesisCmds era
   = GenesisCreate !GenesisCreateCmdArgs
-  | GenesisCreateCardano
-      GenesisDir
-      Word
-      Word
-      (Maybe SystemStart)
-      (Maybe Lovelace)
-      BlockCount
-      Word
-      Rational
-      NetworkId
-      FilePath
-      FilePath
-      FilePath
-      FilePath
-      (Maybe FilePath)
+  | GenesisCreateCardano !GenesisCreateCardanoCmdArgs
   | GenesisCreateStaked
       KeyOutputFormat
       GenesisDir
@@ -81,6 +69,23 @@ data GenesisCreateCmdArgs = GenesisCreateCmdArgs
   , mSystemStart :: !(Maybe SystemStart)
   , mSupply :: !(Maybe Lovelace)
   , network :: !NetworkId
+  } deriving Show
+
+data GenesisCreateCardanoCmdArgs = GenesisCreateCardanoCmdArgs
+  { genesisDir :: !GenesisDir
+  , numGenesisKeys :: !Word
+  , numUTxOKeys :: !Word
+  , mSystemStart :: !(Maybe SystemStart)
+  , mSupply :: !(Maybe Lovelace)
+  , security :: !BlockCount
+  , slotLength :: !Word
+  , slotCoeff :: !Rational
+  , network :: !NetworkId
+  , byronGenesisTemplate :: !FilePath
+  , shelleyGenesisTemplate :: !FilePath
+  , alonzoGenesisTemplate :: !FilePath
+  , conwayGenesisTemplate :: !FilePath
+  , mNodeConfigTemplate :: !(Maybe FilePath)
   } deriving Show
 
 renderGenesisCmds :: GenesisCmds era -> Text

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Genesis.hs
@@ -10,6 +10,9 @@ module Cardano.CLI.EraBased.Commands.Genesis
   , GenesisKeyGenGenesisCmdArgs (..)
   , GenesisKeyGenDelegateCmdArgs (..)
   , GenesisKeyGenUTxOCmdArgs (..)
+  , GenesisVerKeyCmdArgs (..)
+  , GenesisTxInCmdArgs (..)
+  , GenesisAddrCmdArgs (..)
   , renderGenesisCmds
   ) where
 
@@ -27,21 +30,11 @@ data GenesisCmds era
   | GenesisKeyGenGenesis !GenesisKeyGenGenesisCmdArgs
   | GenesisKeyGenDelegate !GenesisKeyGenDelegateCmdArgs
   | GenesisKeyGenUTxO !GenesisKeyGenUTxOCmdArgs
-  | GenesisCmdKeyHash
-      (VerificationKeyFile In)
-  | GenesisVerKey
-      (VerificationKeyFile Out)
-      (SigningKeyFile In)
-  | GenesisTxIn
-      (VerificationKeyFile In)
-      NetworkId
-      (Maybe (File () Out))
-  | GenesisAddr
-      (VerificationKeyFile In)
-      NetworkId
-      (Maybe (File () Out))
-  | GenesisHashFile
-      GenesisFile
+  | GenesisCmdKeyHash !(VerificationKeyFile In)
+  | GenesisVerKey !GenesisVerKeyCmdArgs
+  | GenesisTxIn !GenesisTxInCmdArgs
+  | GenesisAddr !GenesisAddrCmdArgs
+  | GenesisHashFile !GenesisFile
   deriving Show
 
 data GenesisCreateCmdArgs = GenesisCreateCmdArgs
@@ -104,6 +97,22 @@ data GenesisKeyGenUTxOCmdArgs = GenesisKeyGenUTxOCmdArgs
   , signingKeyPath :: !(SigningKeyFile Out)
   } deriving Show
 
+data GenesisVerKeyCmdArgs = GenesisVerKeyCmdArgs
+  { verificationKeyPath :: !(VerificationKeyFile Out)
+  , signingKeyPath :: !(SigningKeyFile In)
+  } deriving Show
+
+data GenesisTxInCmdArgs = GenesisTxInCmdArgs
+  { verificationKeyPath :: !(VerificationKeyFile In)
+  , network :: !NetworkId
+  , mOutFile :: !(Maybe (File () Out))
+  } deriving Show
+
+data GenesisAddrCmdArgs = GenesisAddrCmdArgs
+  { verificationKeyPath :: !(VerificationKeyFile In)
+  , network :: !NetworkId
+  , mOutFile :: !(Maybe (File () Out))
+  } deriving Show
 
 renderGenesisCmds :: GenesisCmds era -> Text
 renderGenesisCmds = \case

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Genesis.hs
@@ -9,6 +9,7 @@ module Cardano.CLI.EraBased.Commands.Genesis
   , GenesisCreateStakedCmdArgs (..)
   , GenesisKeyGenGenesisCmdArgs (..)
   , GenesisKeyGenDelegateCmdArgs (..)
+  , GenesisKeyGenUTxOCmdArgs (..)
   , renderGenesisCmds
   ) where
 
@@ -25,9 +26,7 @@ data GenesisCmds era
   | GenesisCreateStaked !GenesisCreateStakedCmdArgs
   | GenesisKeyGenGenesis !GenesisKeyGenGenesisCmdArgs
   | GenesisKeyGenDelegate !GenesisKeyGenDelegateCmdArgs
-  | GenesisKeyGenUTxO
-      (VerificationKeyFile Out)
-      (SigningKeyFile Out)
+  | GenesisKeyGenUTxO !GenesisKeyGenUTxOCmdArgs
   | GenesisCmdKeyHash
       (VerificationKeyFile In)
   | GenesisVerKey
@@ -99,6 +98,12 @@ data GenesisKeyGenDelegateCmdArgs = GenesisKeyGenDelegateCmdArgs
   , signingKeyPath :: !(SigningKeyFile Out)
   , opCertCounterPath :: !(OpCertCounterFile Out)
   } deriving Show
+
+data GenesisKeyGenUTxOCmdArgs = GenesisKeyGenUTxOCmdArgs
+  { verificationKeyPath :: !(VerificationKeyFile Out)
+  , signingKeyPath :: !(SigningKeyFile Out)
+  } deriving Show
+
 
 renderGenesisCmds :: GenesisCmds era -> Text
 renderGenesisCmds = \case

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Genesis.hs
@@ -8,6 +8,7 @@ module Cardano.CLI.EraBased.Commands.Genesis
   , GenesisCreateCardanoCmdArgs (..)
   , GenesisCreateStakedCmdArgs (..)
   , GenesisKeyGenGenesisCmdArgs (..)
+  , GenesisKeyGenDelegateCmdArgs (..)
   , renderGenesisCmds
   ) where
 
@@ -23,10 +24,7 @@ data GenesisCmds era
   | GenesisCreateCardano !GenesisCreateCardanoCmdArgs
   | GenesisCreateStaked !GenesisCreateStakedCmdArgs
   | GenesisKeyGenGenesis !GenesisKeyGenGenesisCmdArgs
-  | GenesisKeyGenDelegate
-      (VerificationKeyFile Out)
-      (SigningKeyFile Out)
-      (OpCertCounterFile Out)
+  | GenesisKeyGenDelegate !GenesisKeyGenDelegateCmdArgs
   | GenesisKeyGenUTxO
       (VerificationKeyFile Out)
       (SigningKeyFile Out)
@@ -94,6 +92,12 @@ data GenesisCreateStakedCmdArgs = GenesisCreateStakedCmdArgs
 data GenesisKeyGenGenesisCmdArgs = GenesisKeyGenGenesisCmdArgs
   { verificationKeyPath :: !(VerificationKeyFile Out)
   , signingKeyPath :: !(SigningKeyFile Out)
+  } deriving Show
+
+data GenesisKeyGenDelegateCmdArgs = GenesisKeyGenDelegateCmdArgs
+  { verificationKeyPath :: !(VerificationKeyFile Out)
+  , signingKeyPath :: !(SigningKeyFile Out)
+  , opCertCounterPath :: !(OpCertCounterFile Out)
   } deriving Show
 
 renderGenesisCmds :: GenesisCmds era -> Text

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Genesis.hs
@@ -107,7 +107,7 @@ pGenesisDelegateKeyGen =
 
 pGenesisUTxOKeyGen :: Parser (GenesisCmds era)
 pGenesisUTxOKeyGen =
-  GenesisKeyGenUTxO
+  fmap GenesisKeyGenUTxO $ GenesisKeyGenUTxOCmdArgs
     <$> pVerificationKeyFileOut
     <*> pSigningKeyFileOut
 

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Genesis.hs
@@ -94,7 +94,7 @@ pGenesisCmds envCli =
 
 pGenesisKeyGen :: Parser (GenesisCmds era)
 pGenesisKeyGen =
-  GenesisKeyGenGenesis
+  fmap GenesisKeyGenGenesis $ GenesisKeyGenGenesisCmdArgs
     <$> pVerificationKeyFileOut
     <*> pSigningKeyFileOut
 

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Genesis.hs
@@ -164,7 +164,7 @@ pGenesisCreateCardano envCli =
 
 pGenesisCreate :: EnvCli -> Parser (GenesisCmds era)
 pGenesisCreate envCli =
-  GenesisCreate
+  fmap GenesisCreate $ GenesisCreateCmdArgs
     <$> pKeyOutputFormat
     <*> pGenesisDir
     <*> pGenesisNumGenesisKeys

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Genesis.hs
@@ -138,7 +138,7 @@ pGenesisTxIn envCli =
 
 pGenesisCreateCardano :: EnvCli -> Parser (GenesisCmds era)
 pGenesisCreateCardano envCli =
-  GenesisCreateCardano
+  fmap GenesisCreateCardano $ GenesisCreateCardanoCmdArgs
     <$> pGenesisDir
     <*> pGenesisNumGenesisKeys
     <*> pGenesisNumUTxOKeys

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Genesis.hs
@@ -175,7 +175,7 @@ pGenesisCreate envCli =
 
 pGenesisCreateStaked :: EnvCli -> Parser (GenesisCmds era)
 pGenesisCreateStaked envCli =
-  GenesisCreateStaked
+  fmap GenesisCreateStaked $ GenesisCreateStakedCmdArgs
     <$> pKeyOutputFormat
     <*> pGenesisDir
     <*> pGenesisNumGenesisKeys

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Genesis.hs
@@ -100,7 +100,7 @@ pGenesisKeyGen =
 
 pGenesisDelegateKeyGen :: Parser (GenesisCmds era)
 pGenesisDelegateKeyGen =
-  GenesisKeyGenDelegate
+  fmap GenesisKeyGenDelegate $ GenesisKeyGenDelegateCmdArgs
     <$> pVerificationKeyFileOut
     <*> pSigningKeyFileOut
     <*> pOperatorCertIssueCounterFile

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Genesis.hs
@@ -118,20 +118,20 @@ pGenesisKeyHash =
 
 pGenesisVerKey :: Parser (GenesisCmds era)
 pGenesisVerKey =
-  GenesisVerKey
+  fmap GenesisVerKey $ GenesisVerKeyCmdArgs
     <$> pVerificationKeyFileOut
     <*> pSigningKeyFileIn
 
 pGenesisAddr :: EnvCli -> Parser (GenesisCmds era)
 pGenesisAddr envCli =
-  GenesisAddr
+  fmap GenesisAddr $ GenesisAddrCmdArgs
     <$> pVerificationKeyFileIn
     <*> pNetworkId envCli
     <*> pMaybeOutputFile
 
 pGenesisTxIn :: EnvCli -> Parser (GenesisCmds era)
 pGenesisTxIn envCli =
-  GenesisTxIn
+  fmap GenesisTxIn $ GenesisTxInCmdArgs
     <$> pVerificationKeyFileIn
     <*> pNetworkId envCli
     <*> pMaybeOutputFile

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Genesis.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
 
@@ -123,7 +124,26 @@ runLegacyGenesisCreateCardanoCmd :: ()
   -> FilePath -- ^ Conway Genesis
   -> Maybe FilePath
   -> ExceptT GenesisCmdError IO ()
-runLegacyGenesisCreateCardanoCmd = runGenesisCreateCardanoCmd
+runLegacyGenesisCreateCardanoCmd
+    genDir nGenKeys nUTxOKeys mStart mSupply security slotLength slotCoeff
+    network byronGenesis shelleyGenesis alonzoGenesis conwayGenesis mNodeCfg
+    = runGenesisCreateCardanoCmd
+    Cmd.GenesisCreateCardanoCmdArgs
+    { Cmd.genesisDir = genDir
+    , Cmd.numGenesisKeys = nGenKeys
+    , Cmd.numUTxOKeys = nUTxOKeys
+    , Cmd.mSystemStart = mStart
+    , Cmd.mSupply = mSupply
+    , Cmd.security = security
+    , Cmd.slotLength = slotLength
+    , Cmd.slotCoeff = slotCoeff
+    , Cmd.network = network
+    , Cmd.byronGenesisTemplate = byronGenesis
+    , Cmd.shelleyGenesisTemplate = shelleyGenesis
+    , Cmd.alonzoGenesisTemplate = alonzoGenesis
+    , Cmd.conwayGenesisTemplate = conwayGenesis
+    , Cmd.mNodeConfigTemplate = mNodeCfg
+    }
 
 runLegacyGenesisCreateStakedCmd :: ()
   => KeyOutputFormat    -- ^ key output format

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Genesis.hs
@@ -19,6 +19,7 @@ import           Cardano.CLI.Types.Errors.GenesisCmdError
 
 import           Control.Monad.Trans.Except (ExceptT)
 import qualified Cardano.CLI.EraBased.Commands.Genesis as Cmd
+import Cardano.CLI.EraBased.Commands.Genesis (GenesisKeyGenGenesisCmdArgs(GenesisKeyGenGenesisCmdArgs))
 
 runLegacyGenesisCmds :: LegacyGenesisCmds -> ExceptT GenesisCmdError IO ()
 runLegacyGenesisCmds = \case
@@ -49,7 +50,7 @@ runLegacyGenesisKeyGenGenesisCmd :: ()
   => VerificationKeyFile Out
   -> SigningKeyFile Out
   -> ExceptT GenesisCmdError IO ()
-runLegacyGenesisKeyGenGenesisCmd = runGenesisKeyGenGenesisCmd
+runLegacyGenesisKeyGenGenesisCmd vk sk = runGenesisKeyGenGenesisCmd $ GenesisKeyGenGenesisCmdArgs vk sk
 
 runLegacyGenesisKeyGenDelegateCmd :: ()
   => VerificationKeyFile Out

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Genesis.hs
@@ -57,7 +57,13 @@ runLegacyGenesisKeyGenDelegateCmd :: ()
   -> SigningKeyFile Out
   -> OpCertCounterFile Out
   -> ExceptT GenesisCmdError IO ()
-runLegacyGenesisKeyGenDelegateCmd = runGenesisKeyGenDelegateCmd
+runLegacyGenesisKeyGenDelegateCmd vkf skf okf =
+  runGenesisKeyGenDelegateCmd
+    Cmd.GenesisKeyGenDelegateCmdArgs
+      { Cmd.verificationKeyPath = vkf
+      , Cmd.signingKeyPath = skf
+      , Cmd.opCertCounterPath = okf
+      }
 
 runLegacyGenesisKeyGenUTxOCmd :: ()
   => VerificationKeyFile Out

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Genesis.hs
@@ -12,14 +12,15 @@ module Cardano.CLI.Legacy.Run.Genesis
 import           Cardano.Api
 
 import           Cardano.Chain.Common (BlockCount)
+import           Cardano.CLI.EraBased.Commands.Genesis
+                   (GenesisKeyGenGenesisCmdArgs (GenesisKeyGenGenesisCmdArgs))
+import qualified Cardano.CLI.EraBased.Commands.Genesis as Cmd
 import           Cardano.CLI.EraBased.Run.Genesis
 import           Cardano.CLI.Legacy.Commands.Genesis
 import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Errors.GenesisCmdError
 
 import           Control.Monad.Trans.Except (ExceptT)
-import qualified Cardano.CLI.EraBased.Commands.Genesis as Cmd
-import Cardano.CLI.EraBased.Commands.Genesis (GenesisKeyGenGenesisCmdArgs(GenesisKeyGenGenesisCmdArgs))
 
 runLegacyGenesisCmds :: LegacyGenesisCmds -> ExceptT GenesisCmdError IO ()
 runLegacyGenesisCmds = \case
@@ -83,21 +84,38 @@ runLegacyGenesisVerKeyCmd ::
      VerificationKeyFile Out
   -> SigningKeyFile In
   -> ExceptT GenesisCmdError IO ()
-runLegacyGenesisVerKeyCmd = runGenesisVerKeyCmd
+runLegacyGenesisVerKeyCmd vk sk =
+  runGenesisVerKeyCmd
+    Cmd.GenesisVerKeyCmdArgs
+      { Cmd.verificationKeyPath = vk
+      , Cmd.signingKeyPath = sk
+      }
 
 runLegacyGenesisTxInCmd :: ()
   => VerificationKeyFile In
   -> NetworkId
   -> Maybe (File () Out)
   -> ExceptT GenesisCmdError IO ()
-runLegacyGenesisTxInCmd = runGenesisTxInCmd
+runLegacyGenesisTxInCmd vkt nid mOf =
+  runGenesisTxInCmd
+    Cmd.GenesisTxInCmdArgs
+      { Cmd.verificationKeyPath = vkt
+      , Cmd.network = nid
+      , Cmd.mOutFile = mOf
+      }
 
 runLegacyGenesisAddrCmd :: ()
   => VerificationKeyFile In
   -> NetworkId
   -> Maybe (File () Out)
   -> ExceptT GenesisCmdError IO ()
-runLegacyGenesisAddrCmd = runGenesisAddrCmd
+runLegacyGenesisAddrCmd vkf nid mOf =
+  runGenesisAddrCmd
+    Cmd.GenesisAddrCmdArgs
+      { Cmd.verificationKeyPath = vkf
+      , Cmd.network = nid
+      , Cmd.mOutFile = mOf
+      }
 
 runLegacyGenesisCreateCmd :: ()
   => KeyOutputFormat

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Genesis.hs
@@ -161,7 +161,28 @@ runLegacyGenesisCreateStakedCmd :: ()
   -> Word               -- ^ num stuffed UTxO entries
   -> Maybe FilePath     -- ^ Specified stake pool relays
   -> ExceptT GenesisCmdError IO ()
-runLegacyGenesisCreateStakedCmd = runGenesisCreateStakedCmd
+runLegacyGenesisCreateStakedCmd
+    keyOutputFormat genesisDir numGenesisKeys numUTxOKeys numPools
+    numStakeDelegators mSystemStart mNonDelegatedSupply delegatedSupply
+    network numBulkPoolCredFiles numBulkPoolsPerFile numStuffedUtxo
+    mStakePoolRelaySpecFile
+    = runGenesisCreateStakedCmd
+    Cmd.GenesisCreateStakedCmdArgs
+    { Cmd.keyOutputFormat = keyOutputFormat
+    , Cmd.genesisDir = genesisDir
+    , Cmd.numGenesisKeys = numGenesisKeys
+    , Cmd.numUTxOKeys = numUTxOKeys
+    , Cmd.numPools = numPools
+    , Cmd.numStakeDelegators = numStakeDelegators
+    , Cmd.mSystemStart = mSystemStart
+    , Cmd.mNonDelegatedSupply = mNonDelegatedSupply
+    , Cmd.delegatedSupply = delegatedSupply
+    , Cmd.network = network
+    , Cmd.numBulkPoolCredFiles = numBulkPoolCredFiles
+    , Cmd.numBulkPoolsPerFile = numBulkPoolsPerFile
+    , Cmd.numStuffedUtxo = numStuffedUtxo
+    , Cmd.mStakePoolRelaySpecFile = mStakePoolRelaySpecFile
+    }
 
 -- | Hash a genesis file
 runLegacyGenesisHashFileCmd :: ()

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Genesis.hs
@@ -69,7 +69,12 @@ runLegacyGenesisKeyGenUTxOCmd :: ()
   => VerificationKeyFile Out
   -> SigningKeyFile Out
   -> ExceptT GenesisCmdError IO ()
-runLegacyGenesisKeyGenUTxOCmd = runGenesisKeyGenUTxOCmd
+runLegacyGenesisKeyGenUTxOCmd vk sk =
+  runGenesisKeyGenUTxOCmd
+    Cmd.GenesisKeyGenUTxOCmdArgs
+      { Cmd.verificationKeyPath = vk
+      , Cmd.signingKeyPath = sk
+      }
 
 runLegacyGenesisKeyHashCmd :: VerificationKeyFile In -> ExceptT GenesisCmdError IO ()
 runLegacyGenesisKeyHashCmd = runGenesisKeyHashCmd

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Genesis.hs
@@ -17,6 +17,7 @@ import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Errors.GenesisCmdError
 
 import           Control.Monad.Trans.Except (ExceptT)
+import qualified Cardano.CLI.EraBased.Commands.Genesis as Cmd
 
 runLegacyGenesisCmds :: LegacyGenesisCmds -> ExceptT GenesisCmdError IO ()
 runLegacyGenesisCmds = \case
@@ -94,7 +95,17 @@ runLegacyGenesisCreateCmd :: ()
   -> Maybe Lovelace
   -> NetworkId
   -> ExceptT GenesisCmdError IO ()
-runLegacyGenesisCreateCmd = runGenesisCreateCmd
+runLegacyGenesisCreateCmd fmt genDir nGenKeys nUTxOKeys mStart mSupply network =
+  runGenesisCreateCmd
+    Cmd.GenesisCreateCmdArgs
+    { Cmd.keyOutputFormat = fmt
+    , Cmd.genesisDir = genDir
+    , Cmd.numGenesisKeys = nGenKeys
+    , Cmd.numUTxOKeys = nUTxOKeys
+    , Cmd.mSystemStart = mStart
+    , Cmd.mSupply = mSupply
+    , Cmd.network = network
+    }
 
 runLegacyGenesisCreateCardanoCmd :: ()
   => GenesisDir


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Refactor command argument types for the `genesis` commands.
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

This PR is similar to #360 and #371 and #395. It adds or removes no functionality, and only refactors some types. I'm doing this as a preparation for an upcoming PR that will rework the `genesis create-staked` command.

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
