### PR TITLE
Delete `--utxo-cost-per-word`.  No longer supporting this flag in any era going forward

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
@@ -2560,7 +2560,7 @@ pProtocolParametersUpdate =
     <*> optional pPoolInfluence
     <*> optional pMonetaryExpansion
     <*> optional pTreasuryExpansion
-    <*> optional pUTxOCostPerWord
+    <*> pure Nothing
     <*> pure mempty
     <*> optional pExecutionUnitPrices
     <*> optional pMaxTxExecutionUnits
@@ -2728,14 +2728,6 @@ pExtraEntropy =
     parseEntropyBytes = either fail return
                       . B16.decode . BSC.pack
                     =<< some Parsec.hexDigit
-
-pUTxOCostPerWord :: Parser Lovelace
-pUTxOCostPerWord =
-  Opt.option (readerFromParsecParser parseLovelace) $ mconcat
-    [ Opt.long "utxo-cost-per-word"
-    , Opt.metavar "LOVELACE"
-    , Opt.help "Cost in lovelace per unit of UTxO storage (from Alonzo era)."
-    ]
 
 pUTxOCostPerByte :: Parser Lovelace
 pUTxOCostPerByte =

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Actions.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Actions.hs
@@ -256,17 +256,11 @@ pDeprecatedAfterMaryPParams =
   DeprecatedAfterMaryPParams
     <$> convertToLedger toShelleyLovelace (optional pMinUTxOValue)
 
-pShelleyToAlonzoPParams' :: Parser (ShelleyToAlonzoPParams' ledgerera)
-pShelleyToAlonzoPParams' =
+pShelleyToAlonzoPParams :: Parser (ShelleyToAlonzoPParams' ledgerera)
+pShelleyToAlonzoPParams =
   ShelleyToAlonzoPParams'
     <$> convertToLedger id (optional $ toLedgerNonce <$> pExtraEntropy)
     <*> convertToLedger toUnitIntervalOrErr (optional pDecentralParam)
-
-pShelleyToAlonzoPParams :: Parser (ShelleyToAlonzoPParams era)
-pShelleyToAlonzoPParams =
-  ShelleyToAlonzoPParams
-    <$> convertToLedger (CoinPerWord . toShelleyLovelace) (optional pUTxOCostPerWord)
-
 
 pAlonzoOnwardsPParams :: Parser (AlonzoOnwardsPParams ledgerera)
 pAlonzoOnwardsPParams =
@@ -308,23 +302,23 @@ dpGovActionProtocolParametersUpdate = \case
     ShelleyEraBasedProtocolParametersUpdate
       <$> pCommonProtocolParameters
       <*> pDeprecatedAfterMaryPParams
-      <*> pShelleyToAlonzoPParams'
+      <*> pShelleyToAlonzoPParams
   ShelleyBasedEraAllegra ->
     AllegraEraBasedProtocolParametersUpdate
       <$> pCommonProtocolParameters
       <*> pDeprecatedAfterMaryPParams
-      <*> pShelleyToAlonzoPParams'
+      <*> pShelleyToAlonzoPParams
   ShelleyBasedEraMary ->
     MaryEraBasedProtocolParametersUpdate
       <$> pCommonProtocolParameters
       <*> pDeprecatedAfterMaryPParams
-      <*> pShelleyToAlonzoPParams'
+      <*> pShelleyToAlonzoPParams
   ShelleyBasedEraAlonzo ->
     AlonzoEraBasedProtocolParametersUpdate
       <$> pCommonProtocolParameters
-      <*> pShelleyToAlonzoPParams'
-      <*> pAlonzoOnwardsPParams
       <*> pShelleyToAlonzoPParams
+      <*> pAlonzoOnwardsPParams
+      <*> pure (ShelleyToAlonzoPParams SNothing)
   ShelleyBasedEraBabbage ->
     BabbageEraBasedProtocolParametersUpdate
       <$> pCommonProtocolParameters

--- a/cardano-cli/src/Cardano/CLI/Json/Friendly.hs
+++ b/cardano-cli/src/Cardano/CLI/Json/Friendly.hs
@@ -306,7 +306,6 @@ friendlyProtocolParametersUpdate
     , protocolUpdatePoolPledgeInfluence
     , protocolUpdateMonetaryExpansion
     , protocolUpdateTreasuryCut
-    , protocolUpdateUTxOCostPerWord
     , protocolUpdateCollateralPercent
     , protocolUpdateMaxBlockExUnits
     , protocolUpdateMaxCollateralInputs
@@ -340,8 +339,6 @@ friendlyProtocolParametersUpdate
     , protocolUpdateMonetaryExpansion <&>
         ("monetary expansion" .=) . friendlyRational
     , protocolUpdateTreasuryCut <&> ("treasury expansion" .=) . friendlyRational
-    , protocolUpdateUTxOCostPerWord <&>
-        ("UTxO storage cost per word" .=) . friendlyLovelace . toShelleyLovelace
     , protocolUpdateCollateralPercent <&>
         ("collateral inputs share" .=) . (<> "%") . textShow
     , protocolUpdateMaxBlockExUnits <&> ("max block execution units" .=)

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/TxView.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/TxView.hs
@@ -288,7 +288,6 @@ hprop_golden_view_alonzo_yaml =
           , "--epoch", "190"
           , "--genesis-verification-key-file"
           ,   "test/cardano-cli-golden/files/input/shelley/keys/genesis_keys/verification_key"
-          , "--utxo-cost-per-word", "194"
           , "--price-execution-steps", "195/196"
           , "--price-execution-memory", "196/197"
           , "--max-tx-execution-units", "(197, 198)"

--- a/cardano-cli/test/cardano-cli-golden/files/golden/alonzo/transaction-view.out
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/alonzo/transaction-view.out
@@ -20,7 +20,6 @@ update proposal:
   updates:
   - genesis key hash: 1bafa294233a5a7ffbf539ae798da0943aa83d2a19398c2d0e5af114
     update:
-      UTxO storage cost per word: 194 Lovelace
       collateral inputs share: 200%
       execution prices:
         memory: 196/197

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -3901,7 +3901,6 @@ Usage: cardano-cli alonzo governance action create-protocol-parameters-update --
                                                                                 [--max-value-size INT]
                                                                                 [--collateral-percent INT]
                                                                                 [--max-collateral-inputs INT]
-                                                                                [--utxo-cost-per-word LOVELACE]
                                                                                 --out-file FILE
 
   Create a protocol parameters update.
@@ -8860,7 +8859,6 @@ Usage: cardano-cli legacy governance create-update-proposal --out-file FILE
                                                               [--pool-influence RATIONAL]
                                                               [--monetary-expansion RATIONAL]
                                                               [--treasury-expansion RATIONAL]
-                                                              [--utxo-cost-per-word LOVELACE]
                                                               [--price-execution-steps RATIONAL
                                                                 --price-execution-memory RATIONAL]
                                                               [--max-tx-execution-units (INT, INT)]
@@ -10170,7 +10168,6 @@ Usage: cardano-cli governance create-update-proposal --out-file FILE
                                                        [--pool-influence RATIONAL]
                                                        [--monetary-expansion RATIONAL]
                                                        [--treasury-expansion RATIONAL]
-                                                       [--utxo-cost-per-word LOVELACE]
                                                        [--price-execution-steps RATIONAL
                                                          --price-execution-memory RATIONAL]
                                                        [--max-tx-execution-units (INT, INT)]

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_governance_action_create-protocol-parameters-update.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_governance_action_create-protocol-parameters-update.cli
@@ -26,7 +26,6 @@ Usage: cardano-cli alonzo governance action create-protocol-parameters-update --
                                                                                 [--max-value-size INT]
                                                                                 [--collateral-percent INT]
                                                                                 [--max-collateral-inputs INT]
-                                                                                [--utxo-cost-per-word LOVELACE]
                                                                                 --out-file FILE
 
   Create a protocol parameters update.
@@ -96,8 +95,5 @@ Available options:
   --max-collateral-inputs INT
                            The maximum number of collateral inputs allowed in a
                            transaction (from Alonzo era).
-  --utxo-cost-per-word LOVELACE
-                           Cost in lovelace per unit of UTxO storage (from
-                           Alonzo era).
   --out-file FILE          The output file.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_create-update-proposal.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/governance_create-update-proposal.cli
@@ -21,7 +21,6 @@ Usage: cardano-cli governance create-update-proposal --out-file FILE
                                                        [--pool-influence RATIONAL]
                                                        [--monetary-expansion RATIONAL]
                                                        [--treasury-expansion RATIONAL]
-                                                       [--utxo-cost-per-word LOVELACE]
                                                        [--price-execution-steps RATIONAL
                                                          --price-execution-memory RATIONAL]
                                                        [--max-tx-execution-units (INT, INT)]
@@ -78,9 +77,6 @@ Available options:
                            Monetary expansion.
   --treasury-expansion RATIONAL
                            Treasury expansion.
-  --utxo-cost-per-word LOVELACE
-                           Cost in lovelace per unit of UTxO storage (from
-                           Alonzo era).
   --price-execution-steps RATIONAL
                            Step price of execution units for script languages
                            that use them (from Alonzo era). (Examples: '1.1',

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_governance_create-update-proposal.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_governance_create-update-proposal.cli
@@ -21,7 +21,6 @@ Usage: cardano-cli legacy governance create-update-proposal --out-file FILE
                                                               [--pool-influence RATIONAL]
                                                               [--monetary-expansion RATIONAL]
                                                               [--treasury-expansion RATIONAL]
-                                                              [--utxo-cost-per-word LOVELACE]
                                                               [--price-execution-steps RATIONAL
                                                                 --price-execution-memory RATIONAL]
                                                               [--max-tx-execution-units (INT, INT)]
@@ -78,9 +77,6 @@ Available options:
                            Monetary expansion.
   --treasury-expansion RATIONAL
                            Treasury expansion.
-  --utxo-cost-per-word LOVELACE
-                           Cost in lovelace per unit of UTxO storage (from
-                           Alonzo era).
   --price-execution-steps RATIONAL
                            Step price of execution units for script languages
                            that use them (from Alonzo era). (Examples: '1.1',


### PR DESCRIPTION

# Changelog

```yaml
- description: |
    Delete `--utxo-cost-per-word`.  No longer supporting this flag in any era going forward
    This include deleting the CLI option from both legacy and era-base commands
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

This protocol parameter was introduced in Alonzo era and then remove immediately thereafter.

There isn't a good reason to use this protocol parameter because we can hard fork to Babbage and use `--utxo-cost-per-byte` instead.

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
