### PR TITLE
Fix delegating to always-no-confidence

### DIFF
--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -374,6 +374,7 @@ test-suite cardano-cli-golden
                         Test.Golden.Governance.Action
                         Test.Golden.Governance.Committee
                         Test.Golden.Governance.DRep
+                        Test.Golden.Governance.StakeAddress
                         Test.Golden.Governance.Vote
                         Test.Golden.Help
                         Test.Golden.Key.NonExtendedKey

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
@@ -3035,7 +3035,7 @@ pVoteDelegationTarget =
   asum
     [ VoteDelegationTargetOfDRep <$> pDRepHashSource
     , VoteDelegationTargetOfAbstain <$ pAlwaysAbstain
-    , VoteDelegationTargetOfAbstain <$ pAlwaysNoConfidence
+    , VoteDelegationTargetOfNoConfidence <$ pAlwaysNoConfidence
     ]
 
 pAlwaysAbstain :: Parser ()

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/StakeAddress.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/StakeAddress.hs
@@ -191,7 +191,7 @@ runStakeAddressStakeDelegationCertificateCmd sbe stakeVerifier poolVKeyOrHashOrF
     firstExceptT StakeAddressCmdWriteFileError
       . newExceptT
       $ writeLazyByteStringFile outFp
-      $ textEnvelopeToJSON (Just @TextEnvelopeDescr "Stake Address Delegation Certificate") certificate
+      $ textEnvelopeToJSON (Just @TextEnvelopeDescr "Stake Delegation Certificate") certificate
 
 runStakeAddressStakeAndVoteDelegationCertificateCmd :: ()
   => ConwayEraOnwards era
@@ -226,7 +226,7 @@ runStakeAddressStakeAndVoteDelegationCertificateCmd w stakeVerifier poolVKeyOrHa
     firstExceptT StakeAddressCmdWriteFileError
       . newExceptT
       $ writeLazyByteStringFile outFp
-      $ textEnvelopeToJSON (Just @TextEnvelopeDescr "Stake Address Delegation Certificate") certificate
+      $ textEnvelopeToJSON (Just @TextEnvelopeDescr "Stake and Vote Delegation Certificate") certificate
 
 runStakeAddressVoteDelegationCertificateCmd :: ()
   => ConwayEraOnwards era
@@ -255,7 +255,7 @@ runStakeAddressVoteDelegationCertificateCmd w stakeVerifier voteDelegationTarget
     firstExceptT StakeAddressCmdWriteFileError
       . newExceptT
       $ writeLazyByteStringFile outFp
-      $ textEnvelopeToJSON (Just @TextEnvelopeDescr "Stake Address Delegation Certificate") certificate
+      $ textEnvelopeToJSON (Just @TextEnvelopeDescr "Vote Delegation Certificate") certificate
 
 createStakeDelegationCertificate :: forall era. ()
   => StakeCredential

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Governance/StakeAddress.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Governance/StakeAddress.hs
@@ -1,0 +1,98 @@
+{- HLINT ignore "Use camelCase" -}
+
+module Test.Golden.Governance.StakeAddress where
+
+import           Control.Monad (void)
+
+import           Test.Cardano.CLI.Util (execCardanoCLI, noteInputFile, propertyOnce)
+
+import           Hedgehog
+import qualified Hedgehog.Extras.Test.Base as H
+import qualified Hedgehog.Extras.Test.Golden as H
+
+hprop_golden_conway_stakeaddress_delegate_no_confidence :: Property
+hprop_golden_conway_stakeaddress_delegate_no_confidence =
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+    vkeyFile <- noteInputFile "test/cardano-cli-golden/files/input/conway/stake.vkey"
+    delegFile <- H.noteTempFile tempDir "deleg"
+    delegGold <- H.note "test/cardano-cli-golden/files/golden/governance/stakeaddress/noConfidenceDeleg.cert"
+
+    void $ execCardanoCLI
+      [ "conway", "stake-address", "vote-delegation-certificate"
+      , "--stake-verification-key-file", vkeyFile
+      , "--always-no-confidence"
+      , "--out-file", delegFile
+      ]
+
+    H.diffFileVsGoldenFile delegFile delegGold
+
+hprop_golden_conway_stakeaddress_delegate_always_abstain :: Property
+hprop_golden_conway_stakeaddress_delegate_always_abstain =
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+    vkeyFile <- noteInputFile "test/cardano-cli-golden/files/input/conway/stake.vkey"
+    delegFile <- H.noteTempFile tempDir "deleg"
+    delegGold <- H.note "test/cardano-cli-golden/files/golden/governance/stakeaddress/alwaysAbstainDeleg.cert"
+
+    void $ execCardanoCLI
+      [ "conway", "stake-address", "vote-delegation-certificate"
+      , "--stake-verification-key-file", vkeyFile
+      , "--always-abstain"
+      , "--out-file", delegFile
+      ]
+
+    H.diffFileVsGoldenFile delegFile delegGold
+
+hprop_golden_conway_stakeaddress_delegate_pool_and_no_confidence :: Property
+hprop_golden_conway_stakeaddress_delegate_pool_and_no_confidence =
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+    vkeyFile <- noteInputFile "test/cardano-cli-golden/files/input/conway/stake.vkey"
+    vkeyPool <- noteInputFile "test/cardano-cli-golden/files/input/conway/poolCold.vkey"
+    delegFile <- H.noteTempFile tempDir "deleg"
+    delegGold <- H.note "test/cardano-cli-golden/files/golden/governance/stakeaddress/poolAndNoConfidenceDeleg.cert"
+
+    void $ execCardanoCLI
+      [ "conway", "stake-address", "stake-and-vote-delegation-certificate"
+      , "--stake-verification-key-file", vkeyFile
+      , "--cold-verification-key-file", vkeyPool
+      , "--always-no-confidence"
+      , "--out-file", delegFile
+      ]
+
+    H.diffFileVsGoldenFile delegFile delegGold
+
+hprop_golden_conway_stakeaddress_delegate_pool_and_always_abstain :: Property
+hprop_golden_conway_stakeaddress_delegate_pool_and_always_abstain =
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+    vkeyFile <- noteInputFile "test/cardano-cli-golden/files/input/conway/stake.vkey"
+    vkeyPool <- noteInputFile "test/cardano-cli-golden/files/input/conway/poolCold.vkey"
+    delegFile <- H.noteTempFile tempDir "deleg"
+    delegGold <- H.note "test/cardano-cli-golden/files/golden/governance/stakeaddress/poolAndAlwaysAbstainDeleg.cert"
+
+    void $ execCardanoCLI
+      [ "conway", "stake-address", "stake-and-vote-delegation-certificate"
+      , "--stake-verification-key-file", vkeyFile
+      , "--cold-verification-key-file", vkeyPool
+      , "--always-abstain"
+      , "--out-file", delegFile
+      ]
+
+    H.diffFileVsGoldenFile delegFile delegGold
+
+hprop_golden_conway_stakeaddress_delegate_pool_and_drep :: Property
+hprop_golden_conway_stakeaddress_delegate_pool_and_drep =
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+    vkeyFile <- noteInputFile "test/cardano-cli-golden/files/input/conway/stake.vkey"
+    vkeyPool <- noteInputFile "test/cardano-cli-golden/files/input/conway/poolCold.vkey"
+    vkeyDrep <- noteInputFile "test/cardano-cli-golden/files/golden/governance/drep/drep.vkey"
+    delegFile <- H.noteTempFile tempDir "deleg"
+    delegGold <- H.note "test/cardano-cli-golden/files/golden/governance/stakeaddress/poolAndDrepVkeyDeleg.cert"
+
+    void $ execCardanoCLI
+      [ "conway", "stake-address", "stake-and-vote-delegation-certificate"
+      , "--stake-verification-key-file", vkeyFile
+      , "--cold-verification-key-file", vkeyPool
+      , "--drep-verification-key-file", vkeyDrep
+      , "--out-file", delegFile
+      ]
+
+    H.diffFileVsGoldenFile delegFile delegGold

--- a/cardano-cli/test/cardano-cli-golden/files/golden/governance/stakeaddress/alwaysAbstainDeleg.cert
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/governance/stakeaddress/alwaysAbstainDeleg.cert
@@ -1,0 +1,5 @@
+{
+    "type": "CertificateShelley",
+    "description": "Vote Delegation Certificate",
+    "cborHex": "83098200581cef1785cf18928f8353c90e76b7a8fc60855472d31a0ea1c1c774ab018102"
+}

--- a/cardano-cli/test/cardano-cli-golden/files/golden/governance/stakeaddress/noConfidenceDeleg.cert
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/governance/stakeaddress/noConfidenceDeleg.cert
@@ -1,0 +1,5 @@
+{
+    "type": "CertificateShelley",
+    "description": "Vote Delegation Certificate",
+    "cborHex": "83098200581cef1785cf18928f8353c90e76b7a8fc60855472d31a0ea1c1c774ab018103"
+}

--- a/cardano-cli/test/cardano-cli-golden/files/golden/governance/stakeaddress/poolAndAlwaysAbstainDeleg.cert
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/governance/stakeaddress/poolAndAlwaysAbstainDeleg.cert
@@ -1,0 +1,5 @@
+{
+    "type": "CertificateShelley",
+    "description": "Stake and Vote Delegation Certificate",
+    "cborHex": "840a8200581cef1785cf18928f8353c90e76b7a8fc60855472d31a0ea1c1c774ab01581cc27cf021914a2b3bcb286d3d741979083422378c577fe757702b69888102"
+}

--- a/cardano-cli/test/cardano-cli-golden/files/golden/governance/stakeaddress/poolAndDrepVkeyDeleg.cert
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/governance/stakeaddress/poolAndDrepVkeyDeleg.cert
@@ -1,0 +1,5 @@
+{
+    "type": "CertificateShelley",
+    "description": "Stake and Vote Delegation Certificate",
+    "cborHex": "840a8200581cef1785cf18928f8353c90e76b7a8fc60855472d31a0ea1c1c774ab01581cc27cf021914a2b3bcb286d3d741979083422378c577fe757702b69888200581ce68f9ee70599cb93d9f60678f9c6463c01938c27d9820c7bf93887a5"
+}

--- a/cardano-cli/test/cardano-cli-golden/files/golden/governance/stakeaddress/poolAndNoConfidenceDeleg.cert
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/governance/stakeaddress/poolAndNoConfidenceDeleg.cert
@@ -1,0 +1,5 @@
+{
+    "type": "CertificateShelley",
+    "description": "Stake and Vote Delegation Certificate",
+    "cborHex": "840a8200581cef1785cf18928f8353c90e76b7a8fc60855472d31a0ea1c1c774ab01581cc27cf021914a2b3bcb286d3d741979083422378c577fe757702b69888103"
+}

--- a/cardano-cli/test/cardano-cli-golden/files/input/conway/poolCold.vkey
+++ b/cardano-cli/test/cardano-cli-golden/files/input/conway/poolCold.vkey
@@ -1,0 +1,5 @@
+{
+    "type": "StakePoolVerificationKey_ed25519",
+    "description": "Stake Pool Operator Verification Key",
+    "cborHex": "58208b2c01cec2081e1f6464b051fd6327a8fc9ed8dabeb4f4db77ea3acad8c4d396"
+}

--- a/cardano-cli/test/cardano-cli-golden/files/input/conway/stake.vkey
+++ b/cardano-cli/test/cardano-cli-golden/files/input/conway/stake.vkey
@@ -1,0 +1,5 @@
+{
+    "type": "StakeVerificationKeyShelley_ed25519",
+    "description": "Stake Verification Key",
+    "cborHex": "58206562dcf0c258273a2d437d07cdf68492dc961b7277c4a5b50132b05898215778"
+}

--- a/cardano-cli/test/cardano-cli-golden/files/input/shelley/certificates/stake_address_delegation_certificate
+++ b/cardano-cli/test/cardano-cli-golden/files/input/shelley/certificates/stake_address_delegation_certificate
@@ -1,5 +1,5 @@
 {
     "type": "CertificateShelley",
-    "description": "Stake Address Delegation Certificate",
+    "description": "Stake Delegation Certificate",
     "cborHex": "83028200581c6b69790498faca4908e4b44a1005d6dbec9a3d511fa62d4636355ff1581c4124a0c2ba8a7ba05824b3df23f706a1c8b3239446ab16709ae85aa1"
 }


### PR DESCRIPTION
# Changelog

```yaml
- description: |
   - Fix delegating to always no confidence default DRep
   - Add golden tests for stake address vote delegation certificates
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
   - bugfix         # fixes a defect
   - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Resolves https://github.com/input-output-hk/cardano-cli/issues/402
Now it carries the corresponding [3] (it was 2)

`[9, [0, h'EF1785CF18928F8353C90E76B7A8FC60855472D31A0EA1C1C774AB01'], [3]]`

**tests pending**

# How to trust this PR

```
              "keyHash-ef1785cf18928f8353c90e76b7a8fc60855472d31a0ea1c1c774ab01": {
                "reward": 310415375988,
                "deposit": 0,
                "ptr": [],
                "spool": "c27cf021914a2b3bcb286d3d741979083422378c577fe757702b6988",
                "drep": {
                  "tag": "DRepAlwaysNoConfidence"
                }
              }
            },
```
Before it was 

```
              "keyHash-3dc96f0f04fdae3ad3c74182dfe0f720ba06c1ed2b15b78761d71290": {
                "reward": 24703004483,
                "deposit": 0,
                "ptr": [],
                "spool": "3d5e0af9fb0a82c2256faa9eb4f9db6d7b2f0af843b9e3c3dcbbfea6",
                "drep": {
                  "tag": "DRepAlwaysAbstain"
                }
              },
```

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
