### PR TITLE
Remove usage of stake pool keys as credentials

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/Actions.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/Actions.hs
@@ -18,8 +18,6 @@ module Cardano.CLI.EraBased.Commands.Governance.Actions
   , UpdateProtocolParametersConwayOnwards(..)
   , UpdateProtocolParametersPreConway(..)
   , renderGovernanceActionCmds
-
-  , AnyStakeIdentifier(..)
   ) where
 
 import           Cardano.Api
@@ -47,7 +45,7 @@ data GoveranceActionUpdateCommitteeCmdArgs era
       { eon                     :: !(ConwayEraOnwards era)
       , networkId               :: !Ledger.Network
       , deposit                 :: !Lovelace
-      , returnAddress           :: !AnyStakeIdentifier
+      , returnAddress           :: !(VerificationKeyOrHashOrFile StakeKey)
       , proposalUrl             :: !ProposalUrl
       , proposalHashSource      :: !ProposalHashSource
       , oldCommitteeVkeySource  :: ![VerificationKeyOrHashOrFile CommitteeColdKey]
@@ -62,7 +60,7 @@ data GovernanceActionCreateConstitutionCmdArgs era
       { eon                     :: !(ConwayEraOnwards era)
       , networkId               :: !Ledger.Network
       , deposit                 :: !Lovelace
-      , stakeCredential         :: !AnyStakeIdentifier
+      , stakeCredential         :: !(VerificationKeyOrHashOrFile StakeKey)
       , mPrevGovernanceActionId :: !(Maybe (TxId, Word32))
       , proposalUrl             :: !ProposalUrl
       , proposalHashSource      :: !ProposalHashSource
@@ -77,7 +75,7 @@ data GovernanceActionInfoCmdArgs era
       { eon                 :: !(ConwayEraOnwards era)
       , networkId           :: !Ledger.Network
       , deposit             :: !Lovelace
-      , returnStakeAddress  :: !AnyStakeIdentifier
+      , returnStakeAddress  :: !(VerificationKeyOrHashOrFile StakeKey)
       , proposalUrl         :: !ProposalUrl
       , proposalHashSource  :: !ProposalHashSource
       , outFile             :: !(File () Out)
@@ -88,7 +86,7 @@ data GovernanceActionCreateNoConfidenceCmdArgs era
       { eon                   :: !(ConwayEraOnwards era)
       , networkId             :: !Ledger.Network
       , deposit               :: !Lovelace
-      , returnStakeAddress    :: !AnyStakeIdentifier
+      , returnStakeAddress    :: !(VerificationKeyOrHashOrFile StakeKey)
       , proposalUrl           :: !ProposalUrl
       , proposalHashSource    :: !ProposalHashSource
       , governanceActionId    :: !TxId
@@ -110,10 +108,10 @@ data GovernanceActionTreasuryWithdrawalCmdArgs era
       { eon                 :: !(ConwayEraOnwards era)
       , networkId           :: !Ledger.Network
       , deposit             :: !Lovelace
-      , returnAddr          :: !AnyStakeIdentifier
+      , returnAddr          :: !(VerificationKeyOrHashOrFile StakeKey)
       , proposalUrl         :: !ProposalUrl
       , proposalHashSource  :: !ProposalHashSource
-      , treasuryWithdrawal  :: ![(AnyStakeIdentifier, Lovelace)]
+      , treasuryWithdrawal  :: ![(VerificationKeyOrHashOrFile StakeKey, Lovelace)]
       , outFile             :: !(File () Out)
       } deriving Show
 
@@ -130,7 +128,7 @@ data UpdateProtocolParametersConwayOnwards era
       { eon                 :: !(ConwayEraOnwards era)
       , networkId           :: !Ledger.Network
       , deposit             :: !Lovelace
-      , returnAddr          :: !AnyStakeIdentifier
+      , returnAddr          :: !(VerificationKeyOrHashOrFile StakeKey)
       , proposalUrl         :: !ProposalUrl
       , proposalHashSource  :: !ProposalHashSource
       , governanceActionId  :: !(Maybe (TxId, Word32))
@@ -170,8 +168,3 @@ renderGovernanceActionCmds = ("governance action " <>) . \case
 
   GovernanceActionViewCmd {} ->
     "view"
-
-data AnyStakeIdentifier
-  = AnyStakeKey (VerificationKeyOrHashOrFile StakeKey)
-  | AnyStakePoolKey (VerificationKeyOrHashOrFile StakePoolKey)
-  deriving Show

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Actions.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Actions.hs
@@ -68,7 +68,7 @@ pGovernanceActionNewInfoCmd era = do
             Cmd.GovernanceActionInfoCmdArgs eon
               <$> pNetwork
               <*> pGovActionDeposit
-              <*> pAnyStakeIdentifier Nothing
+              <*> pStakeVerificationKeyOrHashOrFile Nothing
               <*> pProposalUrl
               <*> pProposalHashSource
               <*> pFileOutDirection "out-file" "Path to action file to be used later on with build or build-raw "
@@ -88,7 +88,7 @@ pGovernanceActionNewConstitutionCmd era = do
             Cmd.GovernanceActionCreateConstitutionCmdArgs eon
               <$> pNetwork
               <*> pGovActionDeposit
-              <*> pAnyStakeIdentifier Nothing
+              <*> pStakeVerificationKeyOrHashOrFile Nothing
               <*> pPreviousGovernanceAction
               <*> pProposalUrl
               <*> pProposalHashSource
@@ -118,7 +118,7 @@ pUpdateCommitteeCmd eon =
   Cmd.GoveranceActionUpdateCommitteeCmdArgs eon
     <$> pNetwork
     <*> pGovActionDeposit
-    <*> pAnyStakeIdentifier Nothing
+    <*> pStakeVerificationKeyOrHashOrFile Nothing
     <*> pProposalUrl
     <*> pProposalHashSource
     <*> many pRemoveCommitteeColdVerificationKeyOrHashOrFile
@@ -143,7 +143,7 @@ pGovernanceActionNoConfidenceCmd era = do
             Cmd.GovernanceActionCreateNoConfidenceCmdArgs eon
               <$> pNetwork
               <*> pGovActionDeposit
-              <*> pAnyStakeIdentifier Nothing
+              <*> pStakeVerificationKeyOrHashOrFile Nothing
               <*> pProposalUrl
               <*> pProposalHashSource
               <*> pTxId "governance-action-tx-id" "Previous txid of `NoConfidence` or `NewCommittee` governance action."
@@ -151,14 +151,6 @@ pGovernanceActionNoConfidenceCmd era = do
               <*> pFileOutDirection "out-file" "Output filepath of the no confidence proposal."
         )
     $ Opt.progDesc "Create a no confidence proposal."
-
--- | The first argument is the optional prefix.
-pAnyStakeIdentifier :: Maybe String -> Parser Cmd.AnyStakeIdentifier
-pAnyStakeIdentifier prefix =
-  asum
-    [ Cmd.AnyStakePoolKey <$> pStakePoolVerificationKeyOrHashOrFile prefix
-    , Cmd.AnyStakeKey <$> pStakeVerificationKeyOrHashOrFile prefix
-    ]
 
 pUpdateProtocolParametersPreConway :: ShelleyToBabbageEra era -> Parser (Cmd.UpdateProtocolParametersPreConway era)
 pUpdateProtocolParametersPreConway shelleyToBab =
@@ -171,7 +163,7 @@ pUpdateProtocolParametersPostConway conwayOnwards =
   Cmd.UpdateProtocolParametersConwayOnwards conwayOnwards
     <$> pNetwork
     <*> pGovActionDeposit
-    <*> pAnyStakeIdentifier Nothing
+    <*> pStakeVerificationKeyOrHashOrFile Nothing
     <*> pProposalUrl
     <*> pProposalHashSource
     <*> pPreviousGovernanceAction
@@ -340,10 +332,10 @@ pGovernanceActionTreasuryWithdrawalCmd era = do
             Cmd.GovernanceActionTreasuryWithdrawalCmdArgs eon
               <$> pNetwork
               <*> pGovActionDeposit
-              <*> pAnyStakeIdentifier (Just "deposit-return")
+              <*> pStakeVerificationKeyOrHashOrFile (Just "deposit-return")
               <*> pProposalUrl
               <*> pProposalHashSource
-              <*> many ((,) <$> pAnyStakeIdentifier (Just "funds-receiving") <*> pTransferAmt)
+              <*> many ((,) <$> pStakeVerificationKeyOrHashOrFile (Just "funds-receiving") <*> pTransferAmt)
               <*> pFileOutDirection "out-file" "Output filepath of the treasury withdrawal."
         )
     $ Opt.progDesc "Create a treasury withdrawal."

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/DRep.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/DRep.hs
@@ -113,8 +113,7 @@ runGovernanceDRepRegistrationCertificateCmd
     . newExceptT
     $ readVerificationKeyOrHashOrFile AsDRepKey drepVkeyHashSource
   let drepCred = Ledger.KeyHashObj $ conwayEraOnwardsConstraints w drepKeyHash
-      votingCredential = VotingCredential drepCred
-      req = DRepRegistrationRequirements w votingCredential deposit
+      req = DRepRegistrationRequirements w drepCred deposit
       registrationCert = makeDrepRegistrationCertificate req mAnchor
       description = Just @TextEnvelopeDescr "DRep Key Registration Certificate"
 
@@ -138,7 +137,7 @@ runGovernanceDRepRetirementCertificateCmd
     DRepKeyHash drepKeyHash <- firstExceptT GovernanceCmdKeyReadError
       . newExceptT
       $ readVerificationKeyOrHashOrFile AsDRepKey vkeyHashSource
-    makeDrepUnregistrationCertificate (DRepUnregistrationRequirements w (VotingCredential $ KeyHashObj drepKeyHash) deposit)
+    makeDrepUnregistrationCertificate (DRepUnregistrationRequirements w (KeyHashObj drepKeyHash) deposit)
       & writeFileTextEnvelope outFile (Just genKeyDelegCertDesc)
       & firstExceptT GovernanceCmdTextEnvWriteError . newExceptT
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -5915,10 +5915,7 @@ Usage: cardano-cli conway governance action create-constitution
                                                                   | --testnet
                                                                   )
                                                                   --governance-action-deposit NATURAL
-                                                                  ( --stake-pool-verification-key STRING
-                                                                  | --cold-verification-key-file FILE
-                                                                  | --stake-pool-id STAKE_POOL_ID
-                                                                  | --stake-verification-key STRING
+                                                                  ( --stake-verification-key STRING
                                                                   | --stake-verification-key-file FILE
                                                                   | --stake-key-hash HASH
                                                                   )
@@ -5943,10 +5940,7 @@ Usage: cardano-cli conway governance action update-committee
                                                                | --testnet
                                                                )
                                                                --governance-action-deposit NATURAL
-                                                               ( --stake-pool-verification-key STRING
-                                                               | --cold-verification-key-file FILE
-                                                               | --stake-pool-id STAKE_POOL_ID
-                                                               | --stake-verification-key STRING
+                                                               ( --stake-verification-key STRING
                                                                | --stake-verification-key-file FILE
                                                                | --stake-key-hash HASH
                                                                )
@@ -5974,10 +5968,7 @@ Usage: cardano-cli conway governance action update-committee
 
 Usage: cardano-cli conway governance action create-info (--mainnet | --testnet)
                                                           --governance-action-deposit NATURAL
-                                                          ( --stake-pool-verification-key STRING
-                                                          | --cold-verification-key-file FILE
-                                                          | --stake-pool-id STAKE_POOL_ID
-                                                          | --stake-verification-key STRING
+                                                          ( --stake-verification-key STRING
                                                           | --stake-verification-key-file FILE
                                                           | --stake-key-hash HASH
                                                           )
@@ -5995,10 +5986,7 @@ Usage: cardano-cli conway governance action create-no-confidence
                                                                    | --testnet
                                                                    )
                                                                    --governance-action-deposit NATURAL
-                                                                   ( --stake-pool-verification-key STRING
-                                                                   | --cold-verification-key-file FILE
-                                                                   | --stake-pool-id STAKE_POOL_ID
-                                                                   | --stake-verification-key STRING
+                                                                   ( --stake-verification-key STRING
                                                                    | --stake-verification-key-file FILE
                                                                    | --stake-key-hash HASH
                                                                    )
@@ -6018,10 +6006,7 @@ Usage: cardano-cli conway governance action create-protocol-parameters-update
                                                                                 | --testnet
                                                                                 )
                                                                                 --governance-action-deposit NATURAL
-                                                                                ( --stake-pool-verification-key STRING
-                                                                                | --cold-verification-key-file FILE
-                                                                                | --stake-pool-id STAKE_POOL_ID
-                                                                                | --stake-verification-key STRING
+                                                                                ( --stake-verification-key STRING
                                                                                 | --stake-verification-key-file FILE
                                                                                 | --stake-key-hash HASH
                                                                                 )
@@ -6084,10 +6069,7 @@ Usage: cardano-cli conway governance action create-treasury-withdrawal
                                                                          | --testnet
                                                                          )
                                                                          --governance-action-deposit NATURAL
-                                                                         ( --deposit-return-stake-pool-verification-key STRING
-                                                                         | --deposit-return-cold-verification-key-file FILE
-                                                                         | --deposit-return-stake-pool-id STAKE_POOL_ID
-                                                                         | --deposit-return-stake-verification-key STRING
+                                                                         ( --deposit-return-stake-verification-key STRING
                                                                          | --deposit-return-stake-verification-key-file FILE
                                                                          | --deposit-return-stake-key-hash HASH
                                                                          )
@@ -6097,10 +6079,7 @@ Usage: cardano-cli conway governance action create-treasury-withdrawal
                                                                          | --proposal-anchor-metadata-hash HASH
                                                                          )
                                                                          [
-                                                                           ( --funds-receiving-stake-pool-verification-key STRING
-                                                                           | --funds-receiving-cold-verification-key-file FILE
-                                                                           | --funds-receiving-stake-pool-id STAKE_POOL_ID
-                                                                           | --funds-receiving-stake-verification-key STRING
+                                                                           ( --funds-receiving-stake-verification-key STRING
                                                                            | --funds-receiving-stake-verification-key-file FILE
                                                                            | --funds-receiving-stake-key-hash HASH
                                                                            )

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_create-constitution.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_create-constitution.cli
@@ -3,10 +3,7 @@ Usage: cardano-cli conway governance action create-constitution
                                                                   | --testnet
                                                                   )
                                                                   --governance-action-deposit NATURAL
-                                                                  ( --stake-pool-verification-key STRING
-                                                                  | --cold-verification-key-file FILE
-                                                                  | --stake-pool-id STAKE_POOL_ID
-                                                                  | --stake-verification-key STRING
+                                                                  ( --stake-verification-key STRING
                                                                   | --stake-verification-key-file FILE
                                                                   | --stake-key-hash HASH
                                                                   )
@@ -31,14 +28,6 @@ Available options:
   --testnet                Use the testnet magic id.
   --governance-action-deposit NATURAL
                            Deposit required to submit a governance action.
-  --stake-pool-verification-key STRING
-                           Stake pool verification key (Bech32 or hex-encoded).
-  --cold-verification-key-file FILE
-                           Filepath of the stake pool verification key.
-  --stake-pool-id STAKE_POOL_ID
-                           Stake pool ID/verification key hash (either
-                           Bech32-encoded or hex-encoded). Zero or more
-                           occurences of this option is allowed.
   --stake-verification-key STRING
                            Stake verification key (Bech32 or hex-encoded).
   --stake-verification-key-file FILE

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_create-info.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_create-info.cli
@@ -1,9 +1,6 @@
 Usage: cardano-cli conway governance action create-info (--mainnet | --testnet)
                                                           --governance-action-deposit NATURAL
-                                                          ( --stake-pool-verification-key STRING
-                                                          | --cold-verification-key-file FILE
-                                                          | --stake-pool-id STAKE_POOL_ID
-                                                          | --stake-verification-key STRING
+                                                          ( --stake-verification-key STRING
                                                           | --stake-verification-key-file FILE
                                                           | --stake-key-hash HASH
                                                           )
@@ -21,14 +18,6 @@ Available options:
   --testnet                Use the testnet magic id.
   --governance-action-deposit NATURAL
                            Deposit required to submit a governance action.
-  --stake-pool-verification-key STRING
-                           Stake pool verification key (Bech32 or hex-encoded).
-  --cold-verification-key-file FILE
-                           Filepath of the stake pool verification key.
-  --stake-pool-id STAKE_POOL_ID
-                           Stake pool ID/verification key hash (either
-                           Bech32-encoded or hex-encoded). Zero or more
-                           occurences of this option is allowed.
   --stake-verification-key STRING
                            Stake verification key (Bech32 or hex-encoded).
   --stake-verification-key-file FILE

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_create-no-confidence.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_create-no-confidence.cli
@@ -3,10 +3,7 @@ Usage: cardano-cli conway governance action create-no-confidence
                                                                    | --testnet
                                                                    )
                                                                    --governance-action-deposit NATURAL
-                                                                   ( --stake-pool-verification-key STRING
-                                                                   | --cold-verification-key-file FILE
-                                                                   | --stake-pool-id STAKE_POOL_ID
-                                                                   | --stake-verification-key STRING
+                                                                   ( --stake-verification-key STRING
                                                                    | --stake-verification-key-file FILE
                                                                    | --stake-key-hash HASH
                                                                    )
@@ -26,14 +23,6 @@ Available options:
   --testnet                Use the testnet magic id.
   --governance-action-deposit NATURAL
                            Deposit required to submit a governance action.
-  --stake-pool-verification-key STRING
-                           Stake pool verification key (Bech32 or hex-encoded).
-  --cold-verification-key-file FILE
-                           Filepath of the stake pool verification key.
-  --stake-pool-id STAKE_POOL_ID
-                           Stake pool ID/verification key hash (either
-                           Bech32-encoded or hex-encoded). Zero or more
-                           occurences of this option is allowed.
   --stake-verification-key STRING
                            Stake verification key (Bech32 or hex-encoded).
   --stake-verification-key-file FILE

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_create-protocol-parameters-update.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_create-protocol-parameters-update.cli
@@ -3,10 +3,7 @@ Usage: cardano-cli conway governance action create-protocol-parameters-update
                                                                                 | --testnet
                                                                                 )
                                                                                 --governance-action-deposit NATURAL
-                                                                                ( --stake-pool-verification-key STRING
-                                                                                | --cold-verification-key-file FILE
-                                                                                | --stake-pool-id STAKE_POOL_ID
-                                                                                | --stake-verification-key STRING
+                                                                                ( --stake-verification-key STRING
                                                                                 | --stake-verification-key-file FILE
                                                                                 | --stake-key-hash HASH
                                                                                 )
@@ -69,14 +66,6 @@ Available options:
   --testnet                Use the testnet magic id.
   --governance-action-deposit NATURAL
                            Deposit required to submit a governance action.
-  --stake-pool-verification-key STRING
-                           Stake pool verification key (Bech32 or hex-encoded).
-  --cold-verification-key-file FILE
-                           Filepath of the stake pool verification key.
-  --stake-pool-id STAKE_POOL_ID
-                           Stake pool ID/verification key hash (either
-                           Bech32-encoded or hex-encoded). Zero or more
-                           occurences of this option is allowed.
   --stake-verification-key STRING
                            Stake verification key (Bech32 or hex-encoded).
   --stake-verification-key-file FILE

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_create-treasury-withdrawal.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_create-treasury-withdrawal.cli
@@ -3,10 +3,7 @@ Usage: cardano-cli conway governance action create-treasury-withdrawal
                                                                          | --testnet
                                                                          )
                                                                          --governance-action-deposit NATURAL
-                                                                         ( --deposit-return-stake-pool-verification-key STRING
-                                                                         | --deposit-return-cold-verification-key-file FILE
-                                                                         | --deposit-return-stake-pool-id STAKE_POOL_ID
-                                                                         | --deposit-return-stake-verification-key STRING
+                                                                         ( --deposit-return-stake-verification-key STRING
                                                                          | --deposit-return-stake-verification-key-file FILE
                                                                          | --deposit-return-stake-key-hash HASH
                                                                          )
@@ -16,10 +13,7 @@ Usage: cardano-cli conway governance action create-treasury-withdrawal
                                                                          | --proposal-anchor-metadata-hash HASH
                                                                          )
                                                                          [
-                                                                           ( --funds-receiving-stake-pool-verification-key STRING
-                                                                           | --funds-receiving-cold-verification-key-file FILE
-                                                                           | --funds-receiving-stake-pool-id STAKE_POOL_ID
-                                                                           | --funds-receiving-stake-verification-key STRING
+                                                                           ( --funds-receiving-stake-verification-key STRING
                                                                            | --funds-receiving-stake-verification-key-file FILE
                                                                            | --funds-receiving-stake-key-hash HASH
                                                                            )
@@ -33,14 +27,6 @@ Available options:
   --testnet                Use the testnet magic id.
   --governance-action-deposit NATURAL
                            Deposit required to submit a governance action.
-  --deposit-return-stake-pool-verification-key STRING
-                           Stake pool verification key (Bech32 or hex-encoded).
-  --deposit-return-cold-verification-key-file FILE
-                           Filepath of the stake pool verification key.
-  --deposit-return-stake-pool-id STAKE_POOL_ID
-                           Stake pool ID/verification key hash (either
-                           Bech32-encoded or hex-encoded). Zero or more
-                           occurences of this option is allowed.
   --deposit-return-stake-verification-key STRING
                            Stake verification key (Bech32 or hex-encoded).
   --deposit-return-stake-verification-key-file FILE
@@ -55,14 +41,6 @@ Available options:
                            Proposal anchor contents as a text file.
   --proposal-anchor-metadata-hash HASH
                            Proposal anchor data hash.
-  --funds-receiving-stake-pool-verification-key STRING
-                           Stake pool verification key (Bech32 or hex-encoded).
-  --funds-receiving-cold-verification-key-file FILE
-                           Filepath of the stake pool verification key.
-  --funds-receiving-stake-pool-id STAKE_POOL_ID
-                           Stake pool ID/verification key hash (either
-                           Bech32-encoded or hex-encoded). Zero or more
-                           occurences of this option is allowed.
   --funds-receiving-stake-verification-key STRING
                            Stake verification key (Bech32 or hex-encoded).
   --funds-receiving-stake-verification-key-file FILE

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_update-committee.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_update-committee.cli
@@ -3,10 +3,7 @@ Usage: cardano-cli conway governance action update-committee
                                                                | --testnet
                                                                )
                                                                --governance-action-deposit NATURAL
-                                                               ( --stake-pool-verification-key STRING
-                                                               | --cold-verification-key-file FILE
-                                                               | --stake-pool-id STAKE_POOL_ID
-                                                               | --stake-verification-key STRING
+                                                               ( --stake-verification-key STRING
                                                                | --stake-verification-key-file FILE
                                                                | --stake-key-hash HASH
                                                                )
@@ -37,14 +34,6 @@ Available options:
   --testnet                Use the testnet magic id.
   --governance-action-deposit NATURAL
                            Deposit required to submit a governance action.
-  --stake-pool-verification-key STRING
-                           Stake pool verification key (Bech32 or hex-encoded).
-  --cold-verification-key-file FILE
-                           Filepath of the stake pool verification key.
-  --stake-pool-id STAKE_POOL_ID
-                           Stake pool ID/verification key hash (either
-                           Bech32-encoded or hex-encoded). Zero or more
-                           occurences of this option is allowed.
   --stake-verification-key STRING
                            Stake verification key (Bech32 or hex-encoded).
   --stake-verification-key-file FILE


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Removes usage of stake pool keys as credentials
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
   - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
   - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

This PR removes usage of stake pool keys as credentials. This also removes coercing of the keys types in the code.

The context for the change: https://input-output-rnd.slack.com/archives/G011N23CEAE/p1698227871191609

Requires:
- [ ] https://github.com/input-output-hk/cardano-api/pull/341

***This PR requres input-output-hk/cardano-api#341 to compile. To be merged after merging of the required PR in API.***

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
