### PR TITLE
Extended to non-extended key: write description field in all cases

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Address.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Address.hs
@@ -18,6 +18,7 @@ import           Cardano.Api.Shelley
 
 import           Cardano.CLI.EraBased.Commands.Address
 import           Cardano.CLI.EraBased.Run.Address.Info
+import qualified Cardano.CLI.EraBased.Run.Key as Key
 import           Cardano.CLI.Read
 import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Errors.AddressCmdError
@@ -105,16 +106,15 @@ writePaymentKeyFiles fmt vkeyPath skeyPath vkey skey = do
       KeyOutputFormatTextEnvelope ->
         newExceptT
           $ writeLazyByteStringFile vkeyPath
-          $ textEnvelopeToJSON (Just vkeyDesc) vkey
+          $ textEnvelopeToJSON (Just Key.paymentVkeyDesc) vkey
       KeyOutputFormatBech32 ->
         newExceptT
           $ writeTextFile vkeyPath
           $ serialiseToBech32 vkey
 
   where
-    skeyDesc, vkeyDesc :: TextEnvelopeDescr
+    skeyDesc :: TextEnvelopeDescr
     skeyDesc = "Payment Signing Key"
-    vkeyDesc = "Payment Verification Key"
 
 writeByronPaymentKeyFiles
    :: Key keyrole
@@ -127,11 +127,10 @@ writeByronPaymentKeyFiles vkeyPath skeyPath vkey skey = do
   firstExceptT AddressCmdWriteFileError $ do
     -- No bech32 encoding for Byron keys
     newExceptT $ writeLazyByteStringFile skeyPath $ textEnvelopeToJSON (Just skeyDesc) skey
-    newExceptT $ writeLazyByteStringFile vkeyPath $ textEnvelopeToJSON (Just vkeyDesc) vkey
+    newExceptT $ writeLazyByteStringFile vkeyPath $ textEnvelopeToJSON (Just Key.paymentVkeyDesc) vkey
   where
-    skeyDesc, vkeyDesc :: TextEnvelopeDescr
+    skeyDesc :: TextEnvelopeDescr
     skeyDesc = "Payment Signing Key"
-    vkeyDesc = "Payment Verification Key"
 
 runAddressKeyHashCmd :: VerificationKeyTextOrFile
                   -> Maybe (File () Out)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Genesis.hs
@@ -57,6 +57,7 @@ import           Cardano.CLI.Byron.Delegation
 import           Cardano.CLI.Byron.Genesis as Byron
 import qualified Cardano.CLI.Byron.Key as Byron
 import           Cardano.CLI.EraBased.Commands.Genesis as Cmd
+import qualified Cardano.CLI.EraBased.Run.Key as Key
 import           Cardano.CLI.EraBased.Run.Node (runNodeIssueOpCertCmd, runNodeKeyGenColdCmd,
                    runNodeKeyGenKesCmd, runNodeKeyGenVrfCmd)
 import           Cardano.CLI.EraBased.Run.StakeAddress (runStakeAddressKeyGenCmd)
@@ -172,11 +173,10 @@ runGenesisKeyGenGenesisCmd
     firstExceptT GenesisCmdGenesisFileError
       . newExceptT
       $ writeLazyByteStringFile verificationKeyPath
-      $ textEnvelopeToJSON (Just vkeyDesc) vkey
+      $ textEnvelopeToJSON (Just Key.genesisVkeyDesc) vkey
   where
-    skeyDesc, vkeyDesc :: TextEnvelopeDescr
+    skeyDesc :: TextEnvelopeDescr
     skeyDesc = "Genesis Signing Key"
-    vkeyDesc = "Genesis Verification Key"
 
 
 runGenesisKeyGenDelegateCmd
@@ -197,7 +197,7 @@ runGenesisKeyGenDelegateCmd
     firstExceptT GenesisCmdGenesisFileError
       . newExceptT
       $ writeLazyByteStringFile verificationKeyPath
-      $ textEnvelopeToJSON (Just vkeyDesc) vkey
+      $ textEnvelopeToJSON (Just Key.genesisVkeyDelegateDesc) vkey
     firstExceptT GenesisCmdGenesisFileError
       . newExceptT
       $ writeLazyByteStringFile opCertCounterPath
@@ -206,9 +206,8 @@ runGenesisKeyGenDelegateCmd
           initialCounter
           (castVerificationKey vkey)  -- Cast to a 'StakePoolKey'
   where
-    skeyDesc, vkeyDesc, certCtrDesc :: TextEnvelopeDescr
+    skeyDesc, certCtrDesc :: TextEnvelopeDescr
     skeyDesc = "Genesis delegate operator key"
-    vkeyDesc = "Genesis delegate operator key"
     certCtrDesc = "Next certificate issue number: "
                <> fromString (show initialCounter)
 

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/DRep.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/DRep.hs
@@ -68,7 +68,7 @@ runGovernanceDRepKeyGenCmd
   skey <- liftIO $ generateSigningKey AsDRepKey
   let vkey = getVerificationKey skey
   newExceptT $ writeLazyByteStringFile skeyFile (textEnvelopeToJSON (Just skeyDesc) skey)
-  newExceptT $ writeLazyByteStringFile vkeyFile (textEnvelopeToJSON (Just Key.drepKeyEnvelopeDescr) vkey)
+  newExceptT $ writeLazyByteStringFile vkeyFile (textEnvelopeToJSON (Just Key.drepVkeyDesc) vkey)
   where
     skeyDesc :: TextEnvelopeDescr
     skeyDesc = "Delegate Representative Signing Key"

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Key.hs
@@ -18,7 +18,11 @@ module Cardano.CLI.EraBased.Run.Key
   , runNonExtendedKeyCmd
   , runVerificationKeyCmd
 
-  , drepKeyEnvelopeDescr
+  , drepVkeyDesc
+  , genesisVkeyDesc
+  , genesisVkeyDelegateDesc
+  , stakeVkeyDesc
+  , paymentVkeyDesc
 
     -- * Exports for testing
   , decodeBech32
@@ -56,8 +60,23 @@ import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import           System.Exit (exitFailure)
 
-drepKeyEnvelopeDescr :: TextEnvelopeDescr
-drepKeyEnvelopeDescr = "Delegate Representative Verification Key"
+-- Note on these constants:
+-- https://github.com/input-output-hk/cardano-cli/pull/416#discussion_r1378789737
+
+drepVkeyDesc :: TextEnvelopeDescr
+drepVkeyDesc = "Delegate Representative Verification Key"
+
+genesisVkeyDesc :: TextEnvelopeDescr
+genesisVkeyDesc = "Genesis Verification Key"
+
+genesisVkeyDelegateDesc :: TextEnvelopeDescr
+genesisVkeyDelegateDesc = "Genesis delegate operator key"
+
+paymentVkeyDesc :: TextEnvelopeDescr
+paymentVkeyDesc = "Payment Verification Key"
+
+stakeVkeyDesc :: TextEnvelopeDescr
+stakeVkeyDesc = "Stake Verification Key"
 
 runKeyCmds :: ()
   => Cmd.KeyCmds era
@@ -115,15 +134,15 @@ runNonExtendedKeyCmd
   writeVerificationKey ssk =
     case ssk of
       APaymentExtendedVerificationKey vk ->
-        writeToDisk vkf Nothing (castVerificationKey vk :: VerificationKey PaymentKey)
+        writeToDisk vkf (Just paymentVkeyDesc) (castVerificationKey vk :: VerificationKey PaymentKey)
       ADRepExtendedVerificationKey vk ->
-        writeToDisk vkf (Just drepKeyEnvelopeDescr) (castVerificationKey vk :: VerificationKey DRepKey)
+        writeToDisk vkf (Just drepVkeyDesc) (castVerificationKey vk :: VerificationKey DRepKey)
       AStakeExtendedVerificationKey vk ->
-        writeToDisk vkf Nothing (castVerificationKey vk :: VerificationKey StakeKey)
+        writeToDisk vkf (Just stakeVkeyDesc) (castVerificationKey vk :: VerificationKey StakeKey)
       AGenesisExtendedVerificationKey vk ->
-        writeToDisk vkf Nothing (castVerificationKey vk :: VerificationKey GenesisKey)
+        writeToDisk vkf (Just genesisVkeyDesc) (castVerificationKey vk :: VerificationKey GenesisKey)
       AGenesisDelegateExtendedVerificationKey vk ->
-        writeToDisk vkf Nothing (castVerificationKey vk :: VerificationKey GenesisDelegateKey)
+        writeToDisk vkf (Just genesisVkeyDelegateDesc) (castVerificationKey vk :: VerificationKey GenesisDelegateKey)
       nonExtendedKey -> left $ KeyCmdExpectedExtendedVerificationKey nonExtendedKey
 
 

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/StakeAddress.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/StakeAddress.hs
@@ -23,6 +23,7 @@ import qualified Cardano.Api.Ledger as Ledger
 import           Cardano.Api.Shelley
 
 import           Cardano.CLI.EraBased.Commands.StakeAddress
+import qualified Cardano.CLI.EraBased.Run.Key as Key
 import           Cardano.CLI.Read
 import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Errors.StakeAddressCmdError
@@ -67,7 +68,6 @@ runStakeAddressKeyGenCmd :: ()
   -> ExceptT StakeAddressCmdError IO ()
 runStakeAddressKeyGenCmd fmt vkFp skFp = do
   let skeyDesc = "Stake Signing Key"
-  let vkeyDesc = "Stake Verification Key"
 
   skey <- liftIO $ generateSigningKey AsStakeKey
 
@@ -82,7 +82,7 @@ runStakeAddressKeyGenCmd fmt vkFp skFp = do
 
     case fmt of
       KeyOutputFormatTextEnvelope ->
-        newExceptT $ writeLazyByteStringFile vkFp $ textEnvelopeToJSON (Just vkeyDesc) vkey
+        newExceptT $ writeLazyByteStringFile vkFp $ textEnvelopeToJSON (Just Key.stakeVkeyDesc) vkey
       KeyOutputFormatBech32 ->
         newExceptT $ writeTextFile vkFp $ serialiseToBech32 vkey
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/key/non-extended-keys/non-extended-shelley.000.vkey
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/key/non-extended-keys/non-extended-shelley.000.vkey
@@ -1,5 +1,5 @@
 {
     "type": "GenesisVerificationKey_ed25519",
-    "description": "",
+    "description": "Genesis Verification Key",
     "cborHex": "58200834b58f4bdda9522bb202af1f546db4cbbd94b068ae72c9fd96d9b55279edf0"
 }

--- a/cardano-cli/test/cardano-cli-golden/files/golden/key/non-extended-keys/non-extended-stake.000.vkey
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/key/non-extended-keys/non-extended-stake.000.vkey
@@ -1,5 +1,5 @@
 {
     "type": "StakeVerificationKeyShelley_ed25519",
-    "description": "",
+    "description": "Stake Verification Key",
     "cborHex": "58200f205175c0a47cba409c328f066e31ea4e81ef211f539c12b64b4b14e1d87188"
 }


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Extended to non-extended key: write description field in all cases
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

* Follow-up of https://github.com/input-output-hk/cardano-cli/pull/377#discussion_r1376374603
* Fixes https://github.com/input-output-hk/cardano-cli/issues/413

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
