### PR TITLE
Command argument types for `drep` commands

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/DRep.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/DRep.hs
@@ -1,9 +1,16 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE LambdaCase #-}
 
 module Cardano.CLI.EraBased.Commands.Governance.DRep
-  ( GovernanceDRepCmds (..),
-    renderGovernanceDRepCmds,
+  ( GovernanceDRepCmds (..)
+  , renderGovernanceDRepCmds
+
+  , GovernanceDRepKeyGenCmdArgs(..)
+  , GovernanceDRepIdCmdArgs(..)
+  , GovernanceDRepRegistrationCertificateCmdArgs(..)
+  , GovernanceDRepRetirementCertificateCmdArgs(..)
+  , GovernanceDRepMetadataHashCmdArgs(..)
   )
 where
 
@@ -17,30 +24,50 @@ import           Cardano.CLI.Types.Key
 import           Data.Text (Text)
 
 data GovernanceDRepCmds era
-  = GovernanceDRepKeyGenCmd
-      (ConwayEraOnwards era)
-      (File (VerificationKey ()) Out)
-      (File (SigningKey ()) Out)
-  | GovernanceDRepIdCmd
-      (ConwayEraOnwards era)
-      (VerificationKeyOrFile DRepKey)
-      IdOutputFormat
-      (Maybe (File () Out))
-  | GovernanceDRepRegistrationCertificateCmd
-      (ConwayEraOnwards era)
-      (VerificationKeyOrHashOrFile DRepKey)
-      Lovelace
-      (Maybe (Ledger.Anchor (Ledger.EraCrypto (ShelleyLedgerEra era))))
-      (File () Out)
-  | GovernanceDRepRetirementCertificateCmd
-      (ConwayEraOnwards era)
-      (VerificationKeyOrHashOrFile DRepKey)
-      Lovelace
-      (File () Out)
-  | GovernanceDRepMetadataHashCmd
-      (ConwayEraOnwards era)
-      (DRepMetadataFile In)
-      (Maybe (File () Out))
+  = GovernanceDRepKeyGenCmd                   !(GovernanceDRepKeyGenCmdArgs era)
+  | GovernanceDRepIdCmd                       !(GovernanceDRepIdCmdArgs era)
+  | GovernanceDRepRegistrationCertificateCmd  !(GovernanceDRepRegistrationCertificateCmdArgs era)
+  | GovernanceDRepRetirementCertificateCmd    !(GovernanceDRepRetirementCertificateCmdArgs era)
+  | GovernanceDRepMetadataHashCmd             !(GovernanceDRepMetadataHashCmdArgs era)
+
+data GovernanceDRepKeyGenCmdArgs era =
+  GovernanceDRepKeyGenCmdArgs
+    { eon       :: !(ConwayEraOnwards era)
+    , vkeyFile  :: !(File (VerificationKey ()) Out)
+    , skeyFile  :: !(File (SigningKey ()) Out)
+    }
+
+data GovernanceDRepIdCmdArgs era =
+  GovernanceDRepIdCmdArgs
+    { eon             :: !(ConwayEraOnwards era)
+    , vkeySource      :: !(VerificationKeyOrFile DRepKey)
+    , idOutputFormat  :: !IdOutputFormat
+    , mOutFile        :: !(Maybe (File () Out))
+    }
+
+data GovernanceDRepRegistrationCertificateCmdArgs era =
+  GovernanceDRepRegistrationCertificateCmdArgs
+    { eon                 :: !(ConwayEraOnwards era)
+    , drepVkeyHashSource  :: !(VerificationKeyOrHashOrFile DRepKey)
+    , deposit             :: !Lovelace
+    , mAnchor             :: !(Maybe (Ledger.Anchor (Ledger.EraCrypto (ShelleyLedgerEra era))))
+    , outFile             :: !(File () Out)
+    }
+
+data GovernanceDRepRetirementCertificateCmdArgs era =
+  GovernanceDRepRetirementCertificateCmdArgs
+    { eon             :: !(ConwayEraOnwards era)
+    , vkeyHashSource  :: !(VerificationKeyOrHashOrFile DRepKey)
+    , deposit         :: !Lovelace
+    , outFile         :: !(File () Out)
+    }
+
+data GovernanceDRepMetadataHashCmdArgs era =
+  GovernanceDRepMetadataHashCmdArgs
+    { eon           :: !(ConwayEraOnwards era)
+    , metadataFile  :: !(DRepMetadataFile In)
+    , mOutFile      :: !(Maybe (File () Out))
+    }
 
 renderGovernanceDRepCmds :: ()
   => GovernanceDRepCmds era

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/DRep.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/DRep.hs
@@ -17,7 +17,7 @@ import           Cardano.CLI.Types.Key
 import           Data.Text (Text)
 
 data GovernanceDRepCmds era
-  = GovernanceDRepGenerateKeyCmd
+  = GovernanceDRepKeyGenCmd
       (ConwayEraOnwards era)
       (File (VerificationKey ()) Out)
       (File (SigningKey ()) Out)
@@ -46,7 +46,7 @@ renderGovernanceDRepCmds :: ()
   => GovernanceDRepCmds era
   -> Text
 renderGovernanceDRepCmds = \case
-  GovernanceDRepGenerateKeyCmd {} ->
+  GovernanceDRepKeyGenCmd {} ->
     "governance drep key-gen"
   GovernanceDRepIdCmd {} ->
     "governance drep id"

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/DRep.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/DRep.hs
@@ -52,9 +52,10 @@ pGovernanceDRepKeyGenCmd era = do
   pure
     $ subParser "key-gen"
     $ Opt.info
-        ( GovernanceDRepKeyGenCmd w
-            <$> pVerificationKeyFileOut
-            <*> pSigningKeyFileOut
+        ( fmap GovernanceDRepKeyGenCmd $
+            GovernanceDRepKeyGenCmdArgs w
+              <$> pVerificationKeyFileOut
+              <*> pSigningKeyFileOut
         )
     $ Opt.progDesc "Generate Delegate Representative verification and signing keys."
 
@@ -66,10 +67,11 @@ pGovernanceDRepKeyIdCmd era = do
   pure
     $ subParser "id"
     $ Opt.info
-        ( GovernanceDRepIdCmd w
-            <$> pDRepVerificationKeyOrFile
-            <*> pDRepIdOutputFormat
-            <*> optional pOutputFile
+        ( fmap GovernanceDRepIdCmd $
+            GovernanceDRepIdCmdArgs w
+              <$> pDRepVerificationKeyOrFile
+              <*> pDRepIdOutputFormat
+              <*> optional pOutputFile
         )
     $ Opt.progDesc "Generate a drep id."
 
@@ -97,7 +99,9 @@ pRegistrationCertificateCmd era = do
     $ Opt.info (conwayEraOnwardsConstraints w $ mkParser w)
     $ Opt.progDesc "Create a registration certificate."
  where
-  mkParser w = GovernanceDRepRegistrationCertificateCmd w
+  mkParser w =
+    fmap GovernanceDRepRegistrationCertificateCmd $
+      GovernanceDRepRegistrationCertificateCmdArgs w
         <$> pDRepVerificationKeyOrHashOrFile
         <*> pKeyRegistDeposit
         <*> pDRepMetadata
@@ -131,10 +135,11 @@ pRetirementCertificateCmd era = do
   pure
     $ subParser "retirement-certificate"
     $ Opt.info
-      ( GovernanceDRepRetirementCertificateCmd w
-          <$> pDRepVerificationKeyOrHashOrFile
-          <*> pDrepDeposit
-          <*> pOutputFile
+      ( fmap GovernanceDRepRetirementCertificateCmd $
+          GovernanceDRepRetirementCertificateCmdArgs w
+            <$> pDRepVerificationKeyOrHashOrFile
+            <*> pDrepDeposit
+            <*> pOutputFile
       )
     $ Opt.progDesc "Create a DRep retirement certificate."
 
@@ -146,10 +151,11 @@ pGovernanceDrepMetadataHashCmd era = do
   pure
     $ subParser "metadata-hash"
     $ Opt.info
-        ( GovernanceDRepMetadataHashCmd w
-            <$> pFileInDirection "drep-metadata-file" "JSON Metadata file to hash."
-            <*> pMaybeOutputFile
-            )
+        ( fmap GovernanceDRepMetadataHashCmd $
+            GovernanceDRepMetadataHashCmdArgs w
+              <$> pFileInDirection "drep-metadata-file" "JSON Metadata file to hash."
+              <*> pMaybeOutputFile
+        )
     $ Opt.progDesc "Calculate the hash of a metadata file."
 
 --------------------------------------------------------------------------------

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/DRep.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/DRep.hs
@@ -52,7 +52,7 @@ pGovernanceDRepKeyGenCmd era = do
   pure
     $ subParser "key-gen"
     $ Opt.info
-        ( GovernanceDRepGenerateKeyCmd w
+        ( GovernanceDRepKeyGenCmd w
             <$> pVerificationKeyFileOut
             <*> pSigningKeyFileOut
         )

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance.hs
@@ -9,20 +9,17 @@
 module Cardano.CLI.EraBased.Run.Governance
   ( runGovernanceMIRCertificatePayStakeAddrs
   , runGovernanceMIRCertificateTransfer
-  , runGovernanceDRepKeyGen
   ) where
 
 import           Cardano.Api
 import qualified Cardano.Api.Ledger as Ledger
 import           Cardano.Api.Shelley
 
-import qualified Cardano.CLI.EraBased.Run.Key as Key
 import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Errors.GovernanceCmdError
 import qualified Cardano.Ledger.Shelley.TxBody as Shelley
 
 import           Control.Monad
-import           Control.Monad.IO.Class (liftIO)
 import           Control.Monad.Trans.Except (ExceptT)
 import           Control.Monad.Trans.Except.Extra
 import qualified Data.Map.Strict as Map
@@ -81,18 +78,3 @@ runGovernanceMIRCertificateTransfer w ll oFp direction = do
     mirCertDesc :: TransferDirection -> TextEnvelopeDescr
     mirCertDesc TransferToTreasury = "MIR Certificate Send To Treasury"
     mirCertDesc TransferToReserves = "MIR Certificate Send To Reserves"
-
-runGovernanceDRepKeyGen
-  :: ConwayEraOnwards era
-  -> VerificationKeyFile Out
-  -> SigningKeyFile Out
-  -> ExceptT GovernanceCmdError IO ()
-runGovernanceDRepKeyGen _w vkeyPath skeyPath = firstExceptT GovernanceCmdWriteFileError $ do
-  skey <- liftIO $ generateSigningKey AsDRepKey
-  let vkey = getVerificationKey skey
-  newExceptT $ writeLazyByteStringFile skeyPath (textEnvelopeToJSON (Just skeyDesc) skey)
-  newExceptT $ writeLazyByteStringFile vkeyPath (textEnvelopeToJSON (Just Key.drepKeyEnvelopeDescr) vkey)
-  where
-    skeyDesc :: TextEnvelopeDescr
-    skeyDesc = "Delegate Representative Signing Key"
-

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Committee.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Committee.hs
@@ -45,8 +45,7 @@ runGovernanceCommitteeKeyGenCold :: ()
   -> ExceptT GovernanceCommitteeError IO ()
 runGovernanceCommitteeKeyGenCold
     Cmd.GovernanceCommitteeKeyGenColdCmdArgs
-      { Cmd.eon = _eon
-      , Cmd.vkeyOutFile = vkeyPath
+      { Cmd.vkeyOutFile = vkeyPath
       , Cmd.skeyOutFile = skeyPath
       } = do
   skey <- liftIO $ generateSigningKey AsCommitteeColdKey
@@ -105,8 +104,7 @@ runGovernanceCommitteeKeyHash :: ()
   -> ExceptT GovernanceCommitteeError IO ()
 runGovernanceCommitteeKeyHash
     Cmd.GovernanceCommitteeKeyHashCmdArgs
-      { Cmd.eon = _w
-      , Cmd.vkeySource
+      { Cmd.vkeySource
       } = do
   vkey <-
     case vkeySource of

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/DRep.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/DRep.hs
@@ -35,7 +35,7 @@ runGovernanceDRepCmds :: ()
   => GovernanceDRepCmds era
   -> ExceptT CmdError IO ()
 runGovernanceDRepCmds = \case
-  GovernanceDRepGenerateKeyCmd w vrf sgn ->
+  GovernanceDRepKeyGenCmd w vrf sgn ->
     runGovernanceDRepKeyGen w vrf sgn
       & firstExceptT CmdGovernanceCmdError
 

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/DRep.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/DRep.hs
@@ -45,7 +45,7 @@ runGovernanceDRepCmds = \case
 
   GovernanceDRepRegistrationCertificateCmd w vkey lovelace anchor outFp ->
     conwayEraOnwardsConstraints w $ do
-      runGovernanceRegistrationCertificateCmd w vkey lovelace anchor outFp
+      runGovernanceDRepRegistrationCertificateCmd w vkey lovelace anchor outFp
         & firstExceptT CmdRegistrationError
 
   GovernanceDRepRetirementCertificateCmd w vkeyOrHashOrFile deposit outFp ->
@@ -93,14 +93,14 @@ runGovernanceDRepIdCmd _ vkOrFp idOutputFormat mOutFile = do
 
 -- Registration Certificate related
 
-runGovernanceRegistrationCertificateCmd :: ()
+runGovernanceDRepRegistrationCertificateCmd :: ()
   => ConwayEraOnwards era
   -> VerificationKeyOrHashOrFile DRepKey
   -> Lovelace
   -> Maybe (Ledger.Anchor (Ledger.EraCrypto (ShelleyLedgerEra era)))
   -> File () Out
   -> ExceptT RegistrationError IO ()
-runGovernanceRegistrationCertificateCmd cOnwards drepKOrHOrF deposit anchor outfp = do
+runGovernanceDRepRegistrationCertificateCmd cOnwards drepKOrHOrF deposit anchor outfp = do
     DRepKeyHash drepKeyHash <- firstExceptT RegistrationReadError
       . newExceptT
       $ readVerificationKeyOrHashOrFile AsDRepKey drepKOrHOrF

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/DRep.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/DRep.hs
@@ -36,7 +36,7 @@ runGovernanceDRepCmds :: ()
   -> ExceptT CmdError IO ()
 runGovernanceDRepCmds = \case
   GovernanceDRepKeyGenCmd w vrf sgn ->
-    runGovernanceDRepKeyGen w vrf sgn
+    runGovernanceDRepKeyGenCmd w vrf sgn
       & firstExceptT CmdGovernanceCmdError
 
   GovernanceDRepIdCmd w vkey idOutputFormat mOutFp ->
@@ -56,12 +56,12 @@ runGovernanceDRepCmds = \case
     runGovernanceDRepMetadataHashCmd inFp mOutFp
       & firstExceptT CmdGovernanceCmdError
 
-runGovernanceDRepKeyGen
-  :: ConwayEraOnwards era
+runGovernanceDRepKeyGenCmd :: ()
+  => ConwayEraOnwards era
   -> VerificationKeyFile Out
   -> SigningKeyFile Out
   -> ExceptT GovernanceCmdError IO ()
-runGovernanceDRepKeyGen _w vkeyPath skeyPath = firstExceptT GovernanceCmdWriteFileError $ do
+runGovernanceDRepKeyGenCmd _w vkeyPath skeyPath = firstExceptT GovernanceCmdWriteFileError $ do
   skey <- liftIO $ generateSigningKey AsDRepKey
   let vkey = getVerificationKey skey
   newExceptT $ writeLazyByteStringFile skeyPath (textEnvelopeToJSON (Just skeyDesc) skey)
@@ -93,8 +93,8 @@ runGovernanceDRepIdCmd _ vkOrFp idOutputFormat mOutFile = do
 
 -- Registration Certificate related
 
-runGovernanceRegistrationCertificateCmd
-  :: ConwayEraOnwards era
+runGovernanceRegistrationCertificateCmd :: ()
+  => ConwayEraOnwards era
   -> VerificationKeyOrHashOrFile DRepKey
   -> Lovelace
   -> Maybe (Ledger.Anchor (Ledger.EraCrypto (ShelleyLedgerEra era)))
@@ -116,8 +116,8 @@ runGovernanceRegistrationCertificateCmd cOnwards drepKOrHOrF deposit anchor outf
       $ conwayEraOnwardsConstraints cOnwards
       $ textEnvelopeToJSON description registrationCert
 
-runGovernanceDrepRetirementCertificateCmd
-  :: ConwayEraOnwards era
+runGovernanceDrepRetirementCertificateCmd :: ()
+  => ConwayEraOnwards era
   -> VerificationKeyOrHashOrFile DRepKey
   -> Lovelace
   -> File () 'Out
@@ -135,8 +135,8 @@ runGovernanceDrepRetirementCertificateCmd w vKeyOrHashOrFile deposit outFile =
     genKeyDelegCertDesc :: TextEnvelopeDescr
     genKeyDelegCertDesc = "DRep Retirement Certificate"
 
-runGovernanceDRepMetadataHashCmd
-  :: DRepMetadataFile In
+runGovernanceDRepMetadataHashCmd :: ()
+  => DRepMetadataFile In
   -> Maybe (File () Out)
   -> ExceptT GovernanceCmdError IO ()
 runGovernanceDRepMetadataHashCmd drepMDPath mOutFile = do

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/DRep.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/DRep.hs
@@ -49,7 +49,7 @@ runGovernanceDRepCmds = \case
         & firstExceptT CmdRegistrationError
 
   GovernanceDRepRetirementCertificateCmd w vkeyOrHashOrFile deposit outFp ->
-    runGovernanceDrepRetirementCertificateCmd w vkeyOrHashOrFile deposit outFp
+    runGovernanceDRepRetirementCertificateCmd w vkeyOrHashOrFile deposit outFp
       & firstExceptT CmdGovernanceCmdError
 
   GovernanceDRepMetadataHashCmd _ inFp mOutFp ->
@@ -116,13 +116,13 @@ runGovernanceDRepRegistrationCertificateCmd cOnwards drepKOrHOrF deposit anchor 
       $ conwayEraOnwardsConstraints cOnwards
       $ textEnvelopeToJSON description registrationCert
 
-runGovernanceDrepRetirementCertificateCmd :: ()
+runGovernanceDRepRetirementCertificateCmd :: ()
   => ConwayEraOnwards era
   -> VerificationKeyOrHashOrFile DRepKey
   -> Lovelace
   -> File () 'Out
   -> ExceptT GovernanceCmdError IO ()
-runGovernanceDrepRetirementCertificateCmd w vKeyOrHashOrFile deposit outFile =
+runGovernanceDRepRetirementCertificateCmd w vKeyOrHashOrFile deposit outFile =
    conwayEraOnwardsConstraints w $ do
      DRepKeyHash drepKeyHash <- firstExceptT GovernanceCmdKeyReadError
        . newExceptT


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Command argument types for `drep` commands
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
