### PR TITLE
Split governance `MIRTransferConstructor`

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance.hs
@@ -15,23 +15,25 @@ import           Cardano.CLI.EraBased.Commands.Governance.Committee
 import           Cardano.CLI.EraBased.Commands.Governance.DRep
 import           Cardano.CLI.EraBased.Commands.Governance.Poll
 import           Cardano.CLI.EraBased.Commands.Governance.Vote
-import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Key (VerificationKeyOrHashOrFile)
 
 import           Data.Text (Text)
 
 data GovernanceCmds era
-  = GovernanceMIRPayStakeAddressesCertificate
+  = GovernanceCreateMirCertificateStakeAddressesCmd
       (ShelleyToBabbageEra era)
       MIRPot
       [StakeAddress]
       [Lovelace]
       (File () Out)
-  | GovernanceMIRTransfer
+  | GovernanceCreateMirCertificateTransferToTreasuryCmd
       (ShelleyToBabbageEra era)
       Lovelace
       (File () Out)
-      TransferDirection
+  | GovernanceCreateMirCertificateTransferToReservesCmd
+      (ShelleyToBabbageEra era)
+      Lovelace
+      (File () Out)
   | GovernanceGenesisKeyDelegationCertificate
       (ShelleyToBabbageEra era)
       (VerificationKeyOrHashOrFile GenesisKey)
@@ -51,11 +53,11 @@ data GovernanceCmds era
 
 renderGovernanceCmds :: GovernanceCmds era -> Text
 renderGovernanceCmds = \case
-  GovernanceMIRPayStakeAddressesCertificate {} ->
+  GovernanceCreateMirCertificateStakeAddressesCmd {} ->
     "governance create-mir-certificate stake-addresses"
-  GovernanceMIRTransfer _ _ _ TransferToTreasury ->
+  GovernanceCreateMirCertificateTransferToTreasuryCmd {} ->
     "governance create-mir-certificate transfer-to-treasury"
-  GovernanceMIRTransfer _ _ _ TransferToReserves ->
+  GovernanceCreateMirCertificateTransferToReservesCmd {} ->
     "governance create-mir-certificate transfer-to-reserves"
   GovernanceGenesisKeyDelegationCertificate {} ->
     "governance create-genesis-key-delegation-certificate"

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance.hs
@@ -33,7 +33,7 @@ data GovernanceCmds era
       (File () Out)
       TransferDirection
   | GovernanceGenesisKeyDelegationCertificate
-      (ShelleyToAlonzoEra era)
+      (ShelleyToBabbageEra era)
       (VerificationKeyOrHashOrFile GenesisKey)
       (VerificationKeyOrHashOrFile GenesisDelegateKey)
       (VerificationKeyOrHashOrFile VrfKey)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance.hs
@@ -16,7 +16,6 @@ import           Cardano.CLI.EraBased.Options.Governance.Committee
 import           Cardano.CLI.EraBased.Options.Governance.DRep
 import           Cardano.CLI.EraBased.Options.Governance.Poll
 import           Cardano.CLI.EraBased.Options.Governance.Vote
-import           Cardano.CLI.Types.Common
 
 import           Data.Foldable
 import           Options.Applicative
@@ -58,10 +57,10 @@ mirCertParsers w =
       $ Opt.info (pMIRPayStakeAddresses w)
       $ Opt.progDesc "Create an MIR certificate to pay stake addresses"
     , subParser "transfer-to-treasury"
-      $ Opt.info (pMIRTransferToTreasury w)
+      $ Opt.info (pGovernanceCreateMirCertificateTransferToTreasuryCmd w)
       $ Opt.progDesc "Create an MIR certificate to transfer from the reserves pot to the treasury pot"
     , subParser "transfer-to-rewards"
-      $ Opt.info (pMIRTransferToReserves w)
+      $ Opt.info (pGovernanceCreateMirCertificateTransferToReservesCmd w)
       $ Opt.progDesc "Create an MIR certificate to transfer from the treasury pot to the reserves pot"
     ]
 
@@ -69,29 +68,27 @@ pMIRPayStakeAddresses :: ()
   => ShelleyToBabbageEra era
   -> Parser (GovernanceCmds era)
 pMIRPayStakeAddresses w =
-  GovernanceMIRPayStakeAddressesCertificate w
+  GovernanceCreateMirCertificateStakeAddressesCmd w
     <$> pMIRPot
     <*> some pStakeAddress
     <*> some pRewardAmt
     <*> pOutputFile
 
-pMIRTransferToTreasury :: ()
+pGovernanceCreateMirCertificateTransferToTreasuryCmd :: ()
   => ShelleyToBabbageEra era
   -> Parser (GovernanceCmds era)
-pMIRTransferToTreasury w =
-  GovernanceMIRTransfer w
+pGovernanceCreateMirCertificateTransferToTreasuryCmd w =
+  GovernanceCreateMirCertificateTransferToTreasuryCmd w
     <$> pTransferAmt
     <*> pOutputFile
-    <*> pure TransferToTreasury
 
-pMIRTransferToReserves :: ()
+pGovernanceCreateMirCertificateTransferToReservesCmd :: ()
   => ShelleyToBabbageEra era
   -> Parser (GovernanceCmds era)
-pMIRTransferToReserves w =
-  GovernanceMIRTransfer w
+pGovernanceCreateMirCertificateTransferToReservesCmd w =
+  GovernanceCreateMirCertificateTransferToReservesCmd w
     <$> pTransferAmt
     <*> pOutputFile
-    <*> pure TransferToReserves
 
 pGovernanceGenesisKeyDelegationCertificate :: ()
   => CardanoEra era

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run.hs
@@ -10,17 +10,9 @@ module Cardano.CLI.EraBased.Run
 import           Cardano.Api
 
 import           Cardano.CLI.EraBased.Commands
-import           Cardano.CLI.EraBased.Options.Governance
 import           Cardano.CLI.EraBased.Run.Address
 import           Cardano.CLI.EraBased.Run.Genesis
 import           Cardano.CLI.EraBased.Run.Governance
-import           Cardano.CLI.EraBased.Run.Governance.Actions
-import           Cardano.CLI.EraBased.Run.Governance.Committee
-import           Cardano.CLI.EraBased.Run.Governance.DRep
-import           Cardano.CLI.EraBased.Run.Governance.GenesisKeyDelegationCertificate
-                   (runGovernanceGenesisKeyDelegationCertificate)
-import           Cardano.CLI.EraBased.Run.Governance.Poll (runGovernancePollCmds)
-import           Cardano.CLI.EraBased.Run.Governance.Vote
 import           Cardano.CLI.EraBased.Run.Key
 import           Cardano.CLI.EraBased.Run.Node
 import           Cardano.CLI.EraBased.Run.Query
@@ -73,38 +65,3 @@ runCmds = \case
   TransactionCmds cmd ->
     runTransactionCmds cmd
       & firstExceptT CmdTransactionError
-
-runGovernanceCmds :: ()
-  => GovernanceCmds era
-  -> ExceptT CmdError IO ()
-runGovernanceCmds = \case
-  GovernanceMIRPayStakeAddressesCertificate w mirpot vKeys rewards out ->
-    runGovernanceMIRCertificatePayStakeAddrs w mirpot vKeys rewards out
-      & firstExceptT CmdGovernanceCmdError
-
-  GovernanceMIRTransfer w ll oFp direction ->
-    runGovernanceMIRCertificateTransfer w ll oFp direction
-      & firstExceptT CmdGovernanceCmdError
-
-  GovernanceGenesisKeyDelegationCertificate sta genVk genDelegVk vrfVk out ->
-    let stb = shelleyToAlonzoEraToShelleyToBabbageEra sta in
-    runGovernanceGenesisKeyDelegationCertificate stb genVk genDelegVk vrfVk out
-      & firstExceptT CmdGovernanceCmdError
-
-  GovernanceCommitteeCmds cmds ->
-    runGovernanceCommitteeCmds cmds
-      & firstExceptT CmdGovernanceCommitteeError
-
-  GovernanceActionCmds cmds ->
-    runGovernanceActionCmds cmds
-      & firstExceptT CmdGovernanceActionError
-
-  GovernanceDRepCmds cmds ->
-    runGovernanceDRepCmds cmds
-
-  GovernancePollCmds cmds ->
-    runGovernancePollCmds cmds
-      & firstExceptT CmdGovernanceCmdError
-
-  GovernanceVoteCmds cmds ->
-    runGovernanceVoteCmds cmds

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance.hs
@@ -49,8 +49,7 @@ runGovernanceCmds = \case
       & firstExceptT CmdGovernanceCmdError
 
   Cmd.GovernanceGenesisKeyDelegationCertificate sta genVk genDelegVk vrfVk out ->
-    let stb = shelleyToAlonzoEraToShelleyToBabbageEra sta in
-    runGovernanceGenesisKeyDelegationCertificate stb genVk genDelegVk vrfVk out
+    runGovernanceGenesisKeyDelegationCertificate sta genVk genDelegVk vrfVk out
       & firstExceptT CmdGovernanceCmdError
 
   Cmd.GovernanceCommitteeCmds cmds ->

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance.hs
@@ -3,11 +3,14 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
 module Cardano.CLI.EraBased.Run.Governance
-  ( runGovernanceMIRCertificatePayStakeAddrs
+  ( runGovernanceCmds
+
+  , runGovernanceMIRCertificatePayStakeAddrs
   , runGovernanceMIRCertificateTransfer
   ) where
 
@@ -15,14 +18,58 @@ import           Cardano.Api
 import qualified Cardano.Api.Ledger as Ledger
 import           Cardano.Api.Shelley
 
+import qualified Cardano.CLI.EraBased.Commands.Governance as Cmd
+import           Cardano.CLI.EraBased.Run.Governance.Actions
+import           Cardano.CLI.EraBased.Run.Governance.Committee
+import           Cardano.CLI.EraBased.Run.Governance.DRep
+import           Cardano.CLI.EraBased.Run.Governance.GenesisKeyDelegationCertificate
+import           Cardano.CLI.EraBased.Run.Governance.Poll
+import           Cardano.CLI.EraBased.Run.Governance.Vote
 import           Cardano.CLI.Types.Common
+import           Cardano.CLI.Types.Errors.CmdError
 import           Cardano.CLI.Types.Errors.GovernanceCmdError
 import qualified Cardano.Ledger.Shelley.TxBody as Shelley
 
 import           Control.Monad
 import           Control.Monad.Trans.Except (ExceptT)
 import           Control.Monad.Trans.Except.Extra
+import           Data.Function
 import qualified Data.Map.Strict as Map
+
+runGovernanceCmds :: ()
+  => Cmd.GovernanceCmds era
+  -> ExceptT CmdError IO ()
+runGovernanceCmds = \case
+  Cmd.GovernanceMIRPayStakeAddressesCertificate w mirpot vKeys rewards out ->
+    runGovernanceMIRCertificatePayStakeAddrs w mirpot vKeys rewards out
+      & firstExceptT CmdGovernanceCmdError
+
+  Cmd.GovernanceMIRTransfer w ll oFp direction ->
+    runGovernanceMIRCertificateTransfer w ll oFp direction
+      & firstExceptT CmdGovernanceCmdError
+
+  Cmd.GovernanceGenesisKeyDelegationCertificate sta genVk genDelegVk vrfVk out ->
+    let stb = shelleyToAlonzoEraToShelleyToBabbageEra sta in
+    runGovernanceGenesisKeyDelegationCertificate stb genVk genDelegVk vrfVk out
+      & firstExceptT CmdGovernanceCmdError
+
+  Cmd.GovernanceCommitteeCmds cmds ->
+    runGovernanceCommitteeCmds cmds
+      & firstExceptT CmdGovernanceCommitteeError
+
+  Cmd.GovernanceActionCmds cmds ->
+    runGovernanceActionCmds cmds
+      & firstExceptT CmdGovernanceActionError
+
+  Cmd.GovernanceDRepCmds cmds ->
+    runGovernanceDRepCmds cmds
+
+  Cmd.GovernancePollCmds cmds ->
+    runGovernancePollCmds cmds
+      & firstExceptT CmdGovernanceCmdError
+
+  Cmd.GovernanceVoteCmds cmds ->
+    runGovernanceVoteCmds cmds
 
 runGovernanceMIRCertificatePayStakeAddrs
   :: ShelleyToBabbageEra era

--- a/cardano-cli/src/Cardano/CLI/Legacy/Commands/Governance.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Commands/Governance.hs
@@ -13,17 +13,20 @@ import           Cardano.CLI.Types.Key
 import           Data.Text (Text)
 
 data LegacyGovernanceCmds
-  = GovernanceMIRPayStakeAddressesCertificate
+  = GovernanceCreateMirCertificateStakeAddressesCmd
       (EraInEon ShelleyToBabbageEra)
       MIRPot
       [StakeAddress]
       [Lovelace]
       (File () Out)
-  | GovernanceMIRTransfer
+  | GovernanceCreateMirCertificateTransferToTreasuryCmd
       (EraInEon ShelleyToBabbageEra)
       Lovelace
       (File () Out)
-      TransferDirection
+  | GovernanceCreateMirCertificateTransferToReservesCmd
+      (EraInEon ShelleyToBabbageEra)
+      Lovelace
+      (File () Out)
   | GovernanceGenesisKeyDelegationCertificate
       (EraInEon ShelleyToBabbageEra)
       (VerificationKeyOrHashOrFile GenesisKey)
@@ -53,9 +56,9 @@ data LegacyGovernanceCmds
 renderLegacyGovernanceCmds :: LegacyGovernanceCmds -> Text
 renderLegacyGovernanceCmds = \case
   GovernanceGenesisKeyDelegationCertificate {} -> "governance create-genesis-key-delegation-certificate"
-  GovernanceMIRPayStakeAddressesCertificate {} -> "governance create-mir-certificate stake-addresses"
-  GovernanceMIRTransfer _ _ _ TransferToTreasury -> "governance create-mir-certificate transfer-to-treasury"
-  GovernanceMIRTransfer _ _ _ TransferToReserves -> "governance create-mir-certificate transfer-to-reserves"
+  GovernanceCreateMirCertificateStakeAddressesCmd {} -> "governance create-mir-certificate stake-addresses"
+  GovernanceCreateMirCertificateTransferToTreasuryCmd {} -> "governance create-mir-certificate transfer-to-treasury"
+  GovernanceCreateMirCertificateTransferToReservesCmd {} -> "governance create-mir-certificate transfer-to-reserves"
   GovernanceUpdateProposal {} -> "governance create-update-proposal"
   GovernanceCreatePoll{} -> "governance create-poll"
   GovernanceAnswerPoll{} -> "governance answer-poll"

--- a/cardano-cli/src/Cardano/CLI/Legacy/Options.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Options.hs
@@ -829,7 +829,7 @@ pGovernanceCmds envCli =
 
     pLegacyMIRPayStakeAddresses :: Parser LegacyGovernanceCmds
     pLegacyMIRPayStakeAddresses =
-      GovernanceMIRPayStakeAddressesCertificate
+      GovernanceCreateMirCertificateStakeAddressesCmd
         <$> pAnyShelleyToBabbageEra envCli
         <*> pMIRPot
         <*> some pStakeAddress
@@ -838,19 +838,17 @@ pGovernanceCmds envCli =
 
     pLegacyMIRTransferToTreasury :: Parser LegacyGovernanceCmds
     pLegacyMIRTransferToTreasury =
-      GovernanceMIRTransfer
+      GovernanceCreateMirCertificateTransferToTreasuryCmd
         <$> pAnyShelleyToBabbageEra envCli
         <*> pTransferAmt
         <*> pOutputFile
-        <*> pure TransferToTreasury
 
     pLegacyMIRTransferToReserves :: Parser LegacyGovernanceCmds
     pLegacyMIRTransferToReserves =
-      GovernanceMIRTransfer
+      GovernanceCreateMirCertificateTransferToReservesCmd
         <$> pAnyShelleyToBabbageEra envCli
         <*> pTransferAmt
         <*> pOutputFile
-        <*> pure TransferToReserves
 
     pGovernanceGenesisKeyDelegationCertificate :: Parser LegacyGovernanceCmds
     pGovernanceGenesisKeyDelegationCertificate =

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Governance.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Governance.hs
@@ -33,10 +33,12 @@ import qualified Data.Text as Text
 
 runLegacyGovernanceCmds :: LegacyGovernanceCmds -> ExceptT GovernanceCmdError IO ()
 runLegacyGovernanceCmds = \case
-  GovernanceMIRPayStakeAddressesCertificate anyEra mirpot vKeys rewards out ->
+  GovernanceCreateMirCertificateStakeAddressesCmd anyEra mirpot vKeys rewards out ->
     runLegacyGovernanceMIRCertificatePayStakeAddrs anyEra mirpot vKeys rewards out
-  GovernanceMIRTransfer anyEra amt out direction -> do
-    runLegacyGovernanceMIRCertificateTransfer anyEra amt out direction
+  GovernanceCreateMirCertificateTransferToTreasuryCmd anyEra amt out -> do
+    runLegacyGovernanceCreateMirCertificateTransferToTreasuryCmd anyEra amt out
+  GovernanceCreateMirCertificateTransferToReservesCmd anyEra amt out -> do
+    runLegacyGovernanceCreateMirCertificateTransferToReservesCmd anyEra amt out
   GovernanceGenesisKeyDelegationCertificate (EraInEon sbe) genVk genDelegVk vrfVk out ->
     runGovernanceGenesisKeyDelegationCertificate sbe genVk genDelegVk vrfVk out
   GovernanceUpdateProposal out eNo genVKeys ppUp mCostModelFp ->
@@ -102,14 +104,21 @@ runLegacyGovernanceMIRCertificatePayStakeAddrs
 runLegacyGovernanceMIRCertificatePayStakeAddrs (EraInEon w) =
   runGovernanceMIRCertificatePayStakeAddrs w
 
-runLegacyGovernanceMIRCertificateTransfer
+runLegacyGovernanceCreateMirCertificateTransferToTreasuryCmd
   :: EraInEon ShelleyToBabbageEra
   -> Lovelace
   -> File () Out
-  -> TransferDirection
   -> ExceptT GovernanceCmdError IO ()
-runLegacyGovernanceMIRCertificateTransfer (EraInEon w) =
-  runGovernanceMIRCertificateTransfer w
+runLegacyGovernanceCreateMirCertificateTransferToTreasuryCmd (EraInEon w) =
+  runGovernanceCreateMirCertificateTransferToTreasuryCmd w
+
+runLegacyGovernanceCreateMirCertificateTransferToReservesCmd
+  :: EraInEon ShelleyToBabbageEra
+  -> Lovelace
+  -> File () Out
+  -> ExceptT GovernanceCmdError IO ()
+runLegacyGovernanceCreateMirCertificateTransferToReservesCmd (EraInEon w) =
+  runGovernanceCreateMirCertificateTransferToReservesCmd w
 
 runLegacyGovernanceUpdateProposal
   :: File () Out

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -4748,6 +4748,7 @@ Usage: cardano-cli babbage genesis hash --genesis FILE
 
 Usage: cardano-cli babbage governance 
                                         ( create-mir-certificate
+                                        | create-genesis-key-delegation-certificate
                                         | action
                                         | create-poll
                                         | answer-poll
@@ -4791,6 +4792,23 @@ Usage: cardano-cli babbage governance create-mir-certificate transfer-to-rewards
 
   Create an MIR certificate to transfer from the treasury pot to the reserves
   pot
+
+Usage: cardano-cli babbage governance create-genesis-key-delegation-certificate 
+                                                                                  ( --genesis-verification-key STRING
+                                                                                  | --genesis-verification-key-file FILE
+                                                                                  | --genesis-verification-key-hash STRING
+                                                                                  )
+                                                                                  ( --genesis-delegate-verification-key STRING
+                                                                                  | --genesis-delegate-verification-key-file FILE
+                                                                                  | --genesis-delegate-verification-key-hash STRING
+                                                                                  )
+                                                                                  ( --vrf-verification-key STRING
+                                                                                  | --vrf-verification-key-file FILE
+                                                                                  | --vrf-verification-key-hash STRING
+                                                                                  )
+                                                                                  --out-file FILE
+
+  Create a genesis key delegation certificate
 
 Usage: cardano-cli babbage governance action create-protocol-parameters-update
 
@@ -7384,6 +7402,7 @@ Usage: cardano-cli latest genesis hash --genesis FILE
 
 Usage: cardano-cli latest governance 
                                        ( create-mir-certificate
+                                       | create-genesis-key-delegation-certificate
                                        | action
                                        | create-poll
                                        | answer-poll
@@ -7427,6 +7446,23 @@ Usage: cardano-cli latest governance create-mir-certificate transfer-to-rewards 
 
   Create an MIR certificate to transfer from the treasury pot to the reserves
   pot
+
+Usage: cardano-cli latest governance create-genesis-key-delegation-certificate 
+                                                                                 ( --genesis-verification-key STRING
+                                                                                 | --genesis-verification-key-file FILE
+                                                                                 | --genesis-verification-key-hash STRING
+                                                                                 )
+                                                                                 ( --genesis-delegate-verification-key STRING
+                                                                                 | --genesis-delegate-verification-key-file FILE
+                                                                                 | --genesis-delegate-verification-key-hash STRING
+                                                                                 )
+                                                                                 ( --vrf-verification-key STRING
+                                                                                 | --vrf-verification-key-file FILE
+                                                                                 | --vrf-verification-key-hash STRING
+                                                                                 )
+                                                                                 --out-file FILE
+
+  Create a genesis key delegation certificate
 
 Usage: cardano-cli latest governance action create-protocol-parameters-update
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_governance.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_governance.cli
@@ -1,5 +1,6 @@
 Usage: cardano-cli babbage governance 
                                         ( create-mir-certificate
+                                        | create-genesis-key-delegation-certificate
                                         | action
                                         | create-poll
                                         | answer-poll
@@ -14,6 +15,8 @@ Available options:
 Available commands:
   create-mir-certificate   Create an MIR (Move Instantaneous Rewards)
                            certificate
+  create-genesis-key-delegation-certificate
+                           Create a genesis key delegation certificate
   action                   Governance action commands.
   create-poll              Create an SPO poll
   answer-poll              Answer an SPO poll

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_governance_create-genesis-key-delegation-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_governance_create-genesis-key-delegation-certificate.cli
@@ -1,0 +1,38 @@
+Usage: cardano-cli babbage governance create-genesis-key-delegation-certificate 
+                                                                                  ( --genesis-verification-key STRING
+                                                                                  | --genesis-verification-key-file FILE
+                                                                                  | --genesis-verification-key-hash STRING
+                                                                                  )
+                                                                                  ( --genesis-delegate-verification-key STRING
+                                                                                  | --genesis-delegate-verification-key-file FILE
+                                                                                  | --genesis-delegate-verification-key-hash STRING
+                                                                                  )
+                                                                                  ( --vrf-verification-key STRING
+                                                                                  | --vrf-verification-key-file FILE
+                                                                                  | --vrf-verification-key-hash STRING
+                                                                                  )
+                                                                                  --out-file FILE
+
+  Create a genesis key delegation certificate
+
+Available options:
+  --genesis-verification-key STRING
+                           Genesis verification key (hex-encoded).
+  --genesis-verification-key-file FILE
+                           Filepath of the genesis verification key.
+  --genesis-verification-key-hash STRING
+                           Genesis verification key hash (hex-encoded).
+  --genesis-delegate-verification-key STRING
+                           Genesis delegate verification key (hex-encoded).
+  --genesis-delegate-verification-key-file FILE
+                           Filepath of the genesis delegate verification key.
+  --genesis-delegate-verification-key-hash STRING
+                           Genesis delegate verification key hash (hex-encoded).
+  --vrf-verification-key STRING
+                           VRF verification key (Bech32 or hex-encoded).
+  --vrf-verification-key-file FILE
+                           Filepath of the VRF verification key.
+  --vrf-verification-key-hash STRING
+                           VRF verification key hash (hex-encoded).
+  --out-file FILE          The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_governance.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_governance.cli
@@ -1,5 +1,6 @@
 Usage: cardano-cli latest governance 
                                        ( create-mir-certificate
+                                       | create-genesis-key-delegation-certificate
                                        | action
                                        | create-poll
                                        | answer-poll
@@ -14,6 +15,8 @@ Available options:
 Available commands:
   create-mir-certificate   Create an MIR (Move Instantaneous Rewards)
                            certificate
+  create-genesis-key-delegation-certificate
+                           Create a genesis key delegation certificate
   action                   Governance action commands.
   create-poll              Create an SPO poll
   answer-poll              Answer an SPO poll

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_governance_create-genesis-key-delegation-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_governance_create-genesis-key-delegation-certificate.cli
@@ -1,0 +1,38 @@
+Usage: cardano-cli latest governance create-genesis-key-delegation-certificate 
+                                                                                 ( --genesis-verification-key STRING
+                                                                                 | --genesis-verification-key-file FILE
+                                                                                 | --genesis-verification-key-hash STRING
+                                                                                 )
+                                                                                 ( --genesis-delegate-verification-key STRING
+                                                                                 | --genesis-delegate-verification-key-file FILE
+                                                                                 | --genesis-delegate-verification-key-hash STRING
+                                                                                 )
+                                                                                 ( --vrf-verification-key STRING
+                                                                                 | --vrf-verification-key-file FILE
+                                                                                 | --vrf-verification-key-hash STRING
+                                                                                 )
+                                                                                 --out-file FILE
+
+  Create a genesis key delegation certificate
+
+Available options:
+  --genesis-verification-key STRING
+                           Genesis verification key (hex-encoded).
+  --genesis-verification-key-file FILE
+                           Filepath of the genesis verification key.
+  --genesis-verification-key-hash STRING
+                           Genesis verification key hash (hex-encoded).
+  --genesis-delegate-verification-key STRING
+                           Genesis delegate verification key (hex-encoded).
+  --genesis-delegate-verification-key-file FILE
+                           Filepath of the genesis delegate verification key.
+  --genesis-delegate-verification-key-hash STRING
+                           Genesis delegate verification key hash (hex-encoded).
+  --vrf-verification-key STRING
+                           VRF verification key (Bech32 or hex-encoded).
+  --vrf-verification-key-file FILE
+                           Filepath of the VRF verification key.
+  --vrf-verification-key-hash STRING
+                           VRF verification key hash (hex-encoded).
+  --out-file FILE          The output file.
+  -h,--help                Show this help text


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Split governance `MIRTransferConstructor`
    Add `babbage governance create-genesis-key-delegation-certificate`
# uncomment types applicable to the change:
  type:
  - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

The `MIRTransferConstructor` was previously shared between to commands.  Split this constructor so that the constructor is no longer shared.

Add `babbage governance create-genesis-key-delegation-certificate`

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
