### PR TITLE
Rename `delegationDeposit` to `deposit`

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Query.hs
@@ -851,7 +851,7 @@ writeStakeAddressInfo
         [ "address" .= addr
         , "delegation" .= mPoolId
         , "rewardAccountBalance" .= mBalance
-        , "delegationDeposit" .= mDeposit
+        , "deposit" .= mDeposit
         ]
       )
       merged


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Rename the `delegationDeposit` field in the output of the `stake-address-info` query to `deposit
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

This closes #417. The other possible solution discussed there, namely to distinguish between the delegation deposit and the other deposits associated to the stake address, seems impracticable: The ledger [maintains only one deposit](https://github.com/input-output-hk/cardano-ledger/blob/0533bfb1f7b6e76d4a81c7087fea6bb1892f6adb/libs/cardano-ledger-core/src/Cardano/Ledger/UMap.hs#L137) for each staking credential.

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
