### PR TITLE
protocol-(major|minor)-version disappears in conway's create-protocol-parameters-update command

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Actions.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Actions.hs
@@ -247,7 +247,6 @@ pCommonProtocolParameters =
     <*> convertToLedger toNonNegativeIntervalOrErr (optional pPoolInfluence)
     <*> convertToLedger toUnitIntervalOrErr (optional pTreasuryExpansion)
     <*> convertToLedger toUnitIntervalOrErr (optional pMonetaryExpansion)
-    <*> convertToLedger mkProtocolVersionOrErr (optional pProtocolVersion)
     <*> convertToLedger toShelleyLovelace (optional pMinPoolCost)
 
 
@@ -255,6 +254,11 @@ pDeprecatedAfterMaryPParams :: Parser (DeprecatedAfterMaryPParams ledgerera)
 pDeprecatedAfterMaryPParams =
   DeprecatedAfterMaryPParams
     <$> convertToLedger toShelleyLovelace (optional pMinUTxOValue)
+
+pDeprecatedAfterBabbagePParams :: Parser (DeprecatedAfterBabbagePParams ledgerera)
+pDeprecatedAfterBabbagePParams =
+  DeprecatedAfterBabbagePParams
+    <$> convertToLedger mkProtocolVersionOrErr (optional pProtocolVersion)
 
 pShelleyToAlonzoPParams :: Parser (ShelleyToAlonzoPParams ledgerera)
 pShelleyToAlonzoPParams =
@@ -302,26 +306,31 @@ dpGovActionProtocolParametersUpdate = \case
     ShelleyEraBasedProtocolParametersUpdate
       <$> pCommonProtocolParameters
       <*> pDeprecatedAfterMaryPParams
+      <*> pDeprecatedAfterBabbagePParams
       <*> pShelleyToAlonzoPParams
   ShelleyBasedEraAllegra ->
     AllegraEraBasedProtocolParametersUpdate
       <$> pCommonProtocolParameters
       <*> pDeprecatedAfterMaryPParams
       <*> pShelleyToAlonzoPParams
+      <*> pDeprecatedAfterBabbagePParams
   ShelleyBasedEraMary ->
     MaryEraBasedProtocolParametersUpdate
       <$> pCommonProtocolParameters
       <*> pDeprecatedAfterMaryPParams
       <*> pShelleyToAlonzoPParams
+      <*> pDeprecatedAfterBabbagePParams
   ShelleyBasedEraAlonzo ->
     AlonzoEraBasedProtocolParametersUpdate
       <$> pCommonProtocolParameters
       <*> pShelleyToAlonzoPParams
       <*> pAlonzoOnwardsPParams
+      <*> pDeprecatedAfterBabbagePParams
   ShelleyBasedEraBabbage ->
     BabbageEraBasedProtocolParametersUpdate
       <$> pCommonProtocolParameters
       <*> pAlonzoOnwardsPParams
+      <*> pDeprecatedAfterBabbagePParams
       <*> pIntroducedInBabbagePParams
   ShelleyBasedEraConway ->
     ConwayEraBasedProtocolParametersUpdate

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -341,10 +341,10 @@ Usage: cardano-cli shelley governance action create-protocol-parameters-update -
                                                                                  [--pool-influence RATIONAL]
                                                                                  [--treasury-expansion RATIONAL]
                                                                                  [--monetary-expansion RATIONAL]
-                                                                                 [--protocol-major-version NATURAL
-                                                                                   --protocol-minor-version NATURAL]
                                                                                  [--min-pool-cost NATURAL]
                                                                                  [--min-utxo-value NATURAL]
+                                                                                 [--protocol-major-version NATURAL
+                                                                                   --protocol-minor-version NATURAL]
                                                                                  [ --extra-entropy HEX
                                                                                  | --reset-extra-entropy
                                                                                  ]
@@ -1466,14 +1466,14 @@ Usage: cardano-cli allegra governance action create-protocol-parameters-update -
                                                                                  [--pool-influence RATIONAL]
                                                                                  [--treasury-expansion RATIONAL]
                                                                                  [--monetary-expansion RATIONAL]
-                                                                                 [--protocol-major-version NATURAL
-                                                                                   --protocol-minor-version NATURAL]
                                                                                  [--min-pool-cost NATURAL]
                                                                                  [--min-utxo-value NATURAL]
                                                                                  [ --extra-entropy HEX
                                                                                  | --reset-extra-entropy
                                                                                  ]
                                                                                  [--decentralization-parameter RATIONAL]
+                                                                                 [--protocol-major-version NATURAL
+                                                                                   --protocol-minor-version NATURAL]
                                                                                  --out-file FILE
 
   Create a protocol parameters update.
@@ -2589,14 +2589,14 @@ Usage: cardano-cli mary governance action create-protocol-parameters-update --ep
                                                                               [--pool-influence RATIONAL]
                                                                               [--treasury-expansion RATIONAL]
                                                                               [--monetary-expansion RATIONAL]
-                                                                              [--protocol-major-version NATURAL
-                                                                                --protocol-minor-version NATURAL]
                                                                               [--min-pool-cost NATURAL]
                                                                               [--min-utxo-value NATURAL]
                                                                               [ --extra-entropy HEX
                                                                               | --reset-extra-entropy
                                                                               ]
                                                                               [--decentralization-parameter RATIONAL]
+                                                                              [--protocol-major-version NATURAL
+                                                                                --protocol-minor-version NATURAL]
                                                                               --out-file FILE
 
   Create a protocol parameters update.
@@ -3695,8 +3695,6 @@ Usage: cardano-cli alonzo governance action create-protocol-parameters-update --
                                                                                 [--pool-influence RATIONAL]
                                                                                 [--treasury-expansion RATIONAL]
                                                                                 [--monetary-expansion RATIONAL]
-                                                                                [--protocol-major-version NATURAL
-                                                                                  --protocol-minor-version NATURAL]
                                                                                 [--min-pool-cost NATURAL]
                                                                                 [ --extra-entropy HEX
                                                                                 | --reset-extra-entropy
@@ -3709,6 +3707,8 @@ Usage: cardano-cli alonzo governance action create-protocol-parameters-update --
                                                                                 [--max-value-size INT]
                                                                                 [--collateral-percent INT]
                                                                                 [--max-collateral-inputs INT]
+                                                                                [--protocol-major-version NATURAL
+                                                                                  --protocol-minor-version NATURAL]
                                                                                 --out-file FILE
 
   Create a protocol parameters update.
@@ -4828,8 +4828,6 @@ Usage: cardano-cli babbage governance action create-protocol-parameters-update -
                                                                                  [--pool-influence RATIONAL]
                                                                                  [--treasury-expansion RATIONAL]
                                                                                  [--monetary-expansion RATIONAL]
-                                                                                 [--protocol-major-version NATURAL
-                                                                                   --protocol-minor-version NATURAL]
                                                                                  [--min-pool-cost NATURAL]
                                                                                  [--price-execution-steps RATIONAL
                                                                                    --price-execution-memory RATIONAL]
@@ -4838,6 +4836,8 @@ Usage: cardano-cli babbage governance action create-protocol-parameters-update -
                                                                                  [--max-value-size INT]
                                                                                  [--collateral-percent INT]
                                                                                  [--max-collateral-inputs INT]
+                                                                                 [--protocol-major-version NATURAL
+                                                                                   --protocol-minor-version NATURAL]
                                                                                  [--utxo-cost-per-byte LOVELACE]
                                                                                  --out-file FILE
 
@@ -6044,8 +6044,6 @@ Usage: cardano-cli conway governance action create-protocol-parameters-update
                                                                                 [--pool-influence RATIONAL]
                                                                                 [--treasury-expansion RATIONAL]
                                                                                 [--monetary-expansion RATIONAL]
-                                                                                [--protocol-major-version NATURAL
-                                                                                  --protocol-minor-version NATURAL]
                                                                                 [--min-pool-cost NATURAL]
                                                                                 [--price-execution-steps RATIONAL
                                                                                   --price-execution-memory RATIONAL]
@@ -7482,8 +7480,6 @@ Usage: cardano-cli latest governance action create-protocol-parameters-update --
                                                                                 [--pool-influence RATIONAL]
                                                                                 [--treasury-expansion RATIONAL]
                                                                                 [--monetary-expansion RATIONAL]
-                                                                                [--protocol-major-version NATURAL
-                                                                                  --protocol-minor-version NATURAL]
                                                                                 [--min-pool-cost NATURAL]
                                                                                 [--price-execution-steps RATIONAL
                                                                                   --price-execution-memory RATIONAL]
@@ -7492,6 +7488,8 @@ Usage: cardano-cli latest governance action create-protocol-parameters-update --
                                                                                 [--max-value-size INT]
                                                                                 [--collateral-percent INT]
                                                                                 [--max-collateral-inputs INT]
+                                                                                [--protocol-major-version NATURAL
+                                                                                  --protocol-minor-version NATURAL]
                                                                                 [--utxo-cost-per-byte LOVELACE]
                                                                                 --out-file FILE
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_governance_action_create-protocol-parameters-update.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_governance_action_create-protocol-parameters-update.cli
@@ -12,14 +12,14 @@ Usage: cardano-cli allegra governance action create-protocol-parameters-update -
                                                                                  [--pool-influence RATIONAL]
                                                                                  [--treasury-expansion RATIONAL]
                                                                                  [--monetary-expansion RATIONAL]
-                                                                                 [--protocol-major-version NATURAL
-                                                                                   --protocol-minor-version NATURAL]
                                                                                  [--min-pool-cost NATURAL]
                                                                                  [--min-utxo-value NATURAL]
                                                                                  [ --extra-entropy HEX
                                                                                  | --reset-extra-entropy
                                                                                  ]
                                                                                  [--decentralization-parameter RATIONAL]
+                                                                                 [--protocol-major-version NATURAL
+                                                                                   --protocol-minor-version NATURAL]
                                                                                  --out-file FILE
 
   Create a protocol parameters update.
@@ -53,13 +53,6 @@ Available options:
                            Treasury expansion.
   --monetary-expansion RATIONAL
                            Monetary expansion.
-  --protocol-major-version NATURAL
-                           Major protocol version. An increase indicates a hard
-                           fork.
-  --protocol-minor-version NATURAL
-                           Minor protocol version. An increase indicates a soft
-                           fork (old software canvalidate but not produce new
-                           blocks).
   --min-pool-cost NATURAL  The minimum allowed cost parameter for stake pools.
   --min-utxo-value NATURAL The minimum allowed UTxO value (Shelley to Mary
                            eras).
@@ -67,5 +60,12 @@ Available options:
   --reset-extra-entropy    Reset the Praos extra entropy to none.
   --decentralization-parameter RATIONAL
                            Decentralization parameter.
+  --protocol-major-version NATURAL
+                           Major protocol version. An increase indicates a hard
+                           fork.
+  --protocol-minor-version NATURAL
+                           Minor protocol version. An increase indicates a soft
+                           fork (old software canvalidate but not produce new
+                           blocks).
   --out-file FILE          The output file.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_governance_action_create-protocol-parameters-update.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_governance_action_create-protocol-parameters-update.cli
@@ -12,8 +12,6 @@ Usage: cardano-cli alonzo governance action create-protocol-parameters-update --
                                                                                 [--pool-influence RATIONAL]
                                                                                 [--treasury-expansion RATIONAL]
                                                                                 [--monetary-expansion RATIONAL]
-                                                                                [--protocol-major-version NATURAL
-                                                                                  --protocol-minor-version NATURAL]
                                                                                 [--min-pool-cost NATURAL]
                                                                                 [ --extra-entropy HEX
                                                                                 | --reset-extra-entropy
@@ -26,6 +24,8 @@ Usage: cardano-cli alonzo governance action create-protocol-parameters-update --
                                                                                 [--max-value-size INT]
                                                                                 [--collateral-percent INT]
                                                                                 [--max-collateral-inputs INT]
+                                                                                [--protocol-major-version NATURAL
+                                                                                  --protocol-minor-version NATURAL]
                                                                                 --out-file FILE
 
   Create a protocol parameters update.
@@ -59,13 +59,6 @@ Available options:
                            Treasury expansion.
   --monetary-expansion RATIONAL
                            Monetary expansion.
-  --protocol-major-version NATURAL
-                           Major protocol version. An increase indicates a hard
-                           fork.
-  --protocol-minor-version NATURAL
-                           Minor protocol version. An increase indicates a soft
-                           fork (old software canvalidate but not produce new
-                           blocks).
   --min-pool-cost NATURAL  The minimum allowed cost parameter for stake pools.
   --extra-entropy HEX      Praos extra entropy seed, as a hex byte string.
   --reset-extra-entropy    Reset the Praos extra entropy to none.
@@ -95,5 +88,12 @@ Available options:
   --max-collateral-inputs INT
                            The maximum number of collateral inputs allowed in a
                            transaction (from Alonzo era).
+  --protocol-major-version NATURAL
+                           Major protocol version. An increase indicates a hard
+                           fork.
+  --protocol-minor-version NATURAL
+                           Minor protocol version. An increase indicates a soft
+                           fork (old software canvalidate but not produce new
+                           blocks).
   --out-file FILE          The output file.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_governance_action_create-protocol-parameters-update.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_governance_action_create-protocol-parameters-update.cli
@@ -12,8 +12,6 @@ Usage: cardano-cli babbage governance action create-protocol-parameters-update -
                                                                                  [--pool-influence RATIONAL]
                                                                                  [--treasury-expansion RATIONAL]
                                                                                  [--monetary-expansion RATIONAL]
-                                                                                 [--protocol-major-version NATURAL
-                                                                                   --protocol-minor-version NATURAL]
                                                                                  [--min-pool-cost NATURAL]
                                                                                  [--price-execution-steps RATIONAL
                                                                                    --price-execution-memory RATIONAL]
@@ -22,6 +20,8 @@ Usage: cardano-cli babbage governance action create-protocol-parameters-update -
                                                                                  [--max-value-size INT]
                                                                                  [--collateral-percent INT]
                                                                                  [--max-collateral-inputs INT]
+                                                                                 [--protocol-major-version NATURAL
+                                                                                   --protocol-minor-version NATURAL]
                                                                                  [--utxo-cost-per-byte LOVELACE]
                                                                                  --out-file FILE
 
@@ -56,13 +56,6 @@ Available options:
                            Treasury expansion.
   --monetary-expansion RATIONAL
                            Monetary expansion.
-  --protocol-major-version NATURAL
-                           Major protocol version. An increase indicates a hard
-                           fork.
-  --protocol-minor-version NATURAL
-                           Minor protocol version. An increase indicates a soft
-                           fork (old software canvalidate but not produce new
-                           blocks).
   --min-pool-cost NATURAL  The minimum allowed cost parameter for stake pools.
   --price-execution-steps RATIONAL
                            Step price of execution units for script languages
@@ -88,6 +81,13 @@ Available options:
   --max-collateral-inputs INT
                            The maximum number of collateral inputs allowed in a
                            transaction (from Alonzo era).
+  --protocol-major-version NATURAL
+                           Major protocol version. An increase indicates a hard
+                           fork.
+  --protocol-minor-version NATURAL
+                           Minor protocol version. An increase indicates a soft
+                           fork (old software canvalidate but not produce new
+                           blocks).
   --utxo-cost-per-byte LOVELACE
                            Cost in lovelace per unit of UTxO storage (from
                            Babbage era).

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_create-protocol-parameters-update.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_create-protocol-parameters-update.cli
@@ -29,8 +29,6 @@ Usage: cardano-cli conway governance action create-protocol-parameters-update
                                                                                 [--pool-influence RATIONAL]
                                                                                 [--treasury-expansion RATIONAL]
                                                                                 [--monetary-expansion RATIONAL]
-                                                                                [--protocol-major-version NATURAL
-                                                                                  --protocol-minor-version NATURAL]
                                                                                 [--min-pool-cost NATURAL]
                                                                                 [--price-execution-steps RATIONAL
                                                                                   --price-execution-memory RATIONAL]
@@ -118,13 +116,6 @@ Available options:
                            Treasury expansion.
   --monetary-expansion RATIONAL
                            Monetary expansion.
-  --protocol-major-version NATURAL
-                           Major protocol version. An increase indicates a hard
-                           fork.
-  --protocol-minor-version NATURAL
-                           Minor protocol version. An increase indicates a soft
-                           fork (old software canvalidate but not produce new
-                           blocks).
   --min-pool-cost NATURAL  The minimum allowed cost parameter for stake pools.
   --price-execution-steps RATIONAL
                            Step price of execution units for script languages

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_governance_action_create-protocol-parameters-update.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_governance_action_create-protocol-parameters-update.cli
@@ -12,8 +12,6 @@ Usage: cardano-cli latest governance action create-protocol-parameters-update --
                                                                                 [--pool-influence RATIONAL]
                                                                                 [--treasury-expansion RATIONAL]
                                                                                 [--monetary-expansion RATIONAL]
-                                                                                [--protocol-major-version NATURAL
-                                                                                  --protocol-minor-version NATURAL]
                                                                                 [--min-pool-cost NATURAL]
                                                                                 [--price-execution-steps RATIONAL
                                                                                   --price-execution-memory RATIONAL]
@@ -22,6 +20,8 @@ Usage: cardano-cli latest governance action create-protocol-parameters-update --
                                                                                 [--max-value-size INT]
                                                                                 [--collateral-percent INT]
                                                                                 [--max-collateral-inputs INT]
+                                                                                [--protocol-major-version NATURAL
+                                                                                  --protocol-minor-version NATURAL]
                                                                                 [--utxo-cost-per-byte LOVELACE]
                                                                                 --out-file FILE
 
@@ -56,13 +56,6 @@ Available options:
                            Treasury expansion.
   --monetary-expansion RATIONAL
                            Monetary expansion.
-  --protocol-major-version NATURAL
-                           Major protocol version. An increase indicates a hard
-                           fork.
-  --protocol-minor-version NATURAL
-                           Minor protocol version. An increase indicates a soft
-                           fork (old software canvalidate but not produce new
-                           blocks).
   --min-pool-cost NATURAL  The minimum allowed cost parameter for stake pools.
   --price-execution-steps RATIONAL
                            Step price of execution units for script languages
@@ -88,6 +81,13 @@ Available options:
   --max-collateral-inputs INT
                            The maximum number of collateral inputs allowed in a
                            transaction (from Alonzo era).
+  --protocol-major-version NATURAL
+                           Major protocol version. An increase indicates a hard
+                           fork.
+  --protocol-minor-version NATURAL
+                           Minor protocol version. An increase indicates a soft
+                           fork (old software canvalidate but not produce new
+                           blocks).
   --utxo-cost-per-byte LOVELACE
                            Cost in lovelace per unit of UTxO storage (from
                            Babbage era).

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_governance_action_create-protocol-parameters-update.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_governance_action_create-protocol-parameters-update.cli
@@ -12,14 +12,14 @@ Usage: cardano-cli mary governance action create-protocol-parameters-update --ep
                                                                               [--pool-influence RATIONAL]
                                                                               [--treasury-expansion RATIONAL]
                                                                               [--monetary-expansion RATIONAL]
-                                                                              [--protocol-major-version NATURAL
-                                                                                --protocol-minor-version NATURAL]
                                                                               [--min-pool-cost NATURAL]
                                                                               [--min-utxo-value NATURAL]
                                                                               [ --extra-entropy HEX
                                                                               | --reset-extra-entropy
                                                                               ]
                                                                               [--decentralization-parameter RATIONAL]
+                                                                              [--protocol-major-version NATURAL
+                                                                                --protocol-minor-version NATURAL]
                                                                               --out-file FILE
 
   Create a protocol parameters update.
@@ -53,13 +53,6 @@ Available options:
                            Treasury expansion.
   --monetary-expansion RATIONAL
                            Monetary expansion.
-  --protocol-major-version NATURAL
-                           Major protocol version. An increase indicates a hard
-                           fork.
-  --protocol-minor-version NATURAL
-                           Minor protocol version. An increase indicates a soft
-                           fork (old software canvalidate but not produce new
-                           blocks).
   --min-pool-cost NATURAL  The minimum allowed cost parameter for stake pools.
   --min-utxo-value NATURAL The minimum allowed UTxO value (Shelley to Mary
                            eras).
@@ -67,5 +60,12 @@ Available options:
   --reset-extra-entropy    Reset the Praos extra entropy to none.
   --decentralization-parameter RATIONAL
                            Decentralization parameter.
+  --protocol-major-version NATURAL
+                           Major protocol version. An increase indicates a hard
+                           fork.
+  --protocol-minor-version NATURAL
+                           Minor protocol version. An increase indicates a soft
+                           fork (old software canvalidate but not produce new
+                           blocks).
   --out-file FILE          The output file.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_governance_action_create-protocol-parameters-update.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_governance_action_create-protocol-parameters-update.cli
@@ -12,10 +12,10 @@ Usage: cardano-cli shelley governance action create-protocol-parameters-update -
                                                                                  [--pool-influence RATIONAL]
                                                                                  [--treasury-expansion RATIONAL]
                                                                                  [--monetary-expansion RATIONAL]
-                                                                                 [--protocol-major-version NATURAL
-                                                                                   --protocol-minor-version NATURAL]
                                                                                  [--min-pool-cost NATURAL]
                                                                                  [--min-utxo-value NATURAL]
+                                                                                 [--protocol-major-version NATURAL
+                                                                                   --protocol-minor-version NATURAL]
                                                                                  [ --extra-entropy HEX
                                                                                  | --reset-extra-entropy
                                                                                  ]
@@ -53,6 +53,9 @@ Available options:
                            Treasury expansion.
   --monetary-expansion RATIONAL
                            Monetary expansion.
+  --min-pool-cost NATURAL  The minimum allowed cost parameter for stake pools.
+  --min-utxo-value NATURAL The minimum allowed UTxO value (Shelley to Mary
+                           eras).
   --protocol-major-version NATURAL
                            Major protocol version. An increase indicates a hard
                            fork.
@@ -60,9 +63,6 @@ Available options:
                            Minor protocol version. An increase indicates a soft
                            fork (old software canvalidate but not produce new
                            blocks).
-  --min-pool-cost NATURAL  The minimum allowed cost parameter for stake pools.
-  --min-utxo-value NATURAL The minimum allowed UTxO value (Shelley to Mary
-                           eras).
   --extra-entropy HEX      Praos extra entropy seed, as a hex byte string.
   --reset-extra-entropy    Reset the Praos extra entropy to none.
   --decentralization-parameter RATIONAL


### PR DESCRIPTION
> [!WARNING]
>
> Requires https://github.com/input-output-hk/cardano-api/pull/358 merged and released to build

# Changelog

```yaml
- description: |
    --protocol-(minor|major)-version cannot be changed via create-protocol-parameters-update command in conway
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Fixes https://github.com/input-output-hk/cardano-cli/issues/388

# How to trust this PR

* Observe the diff in golden files is as expected

# Roadmap to merge

- [x] Merge https://github.com/input-output-hk/cardano-api/pull/358
- [ ] Release `cardano-api`
- [ ] Update `cardano-cli` to new `cardano-api` version
- [ ] Merge this PR

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [X] Self-reviewed the diff