### PR TITLE
Replace usages of assertFileOccurences by comparisons with golden files (3/n)

### DIFF
--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Conway/Transaction/Assemble.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Conway/Transaction/Assemble.hs
@@ -14,11 +14,12 @@ import qualified Hedgehog.Extras.Test.Golden as H
 
 -- Check that we can assemble a txbody and a tx witness to form a transaction
 
-hprop_golden_conwayTransactionAssembleWitness_SigningKey :: Property
-hprop_golden_conwayTransactionAssembleWitness_SigningKey = propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir -> do
+hprop_golden_conway_transaction_assemble_witness_signing_key :: Property
+hprop_golden_conway_transaction_assemble_witness_signing_key = propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir -> do
   witnessTx <- noteTempFile tempDir "single-signing-key-witness-tx"
   txBodyFile <- noteInputFile "test/cardano-cli-golden/files/input/conway/txbody"
   signingKeyWitnessFile <- noteInputFile "test/cardano-cli-golden/files/input/conway/singleSigningKeyWitness"
+
   void $ execCardanoCLI
     [ "conway", "transaction", "assemble"
     , "--tx-body-file", txBodyFile
@@ -28,5 +29,4 @@ hprop_golden_conwayTransactionAssembleWitness_SigningKey = propertyOnce $ H.modu
     ]
 
   goldenFile <- H.note "test/cardano-cli-golden/files/golden/conway/transaction/assemble_out"
-
   H.diffFileVsGoldenFile witnessTx goldenFile

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/StakeAddress/DeregistrationCertificate.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/StakeAddress/DeregistrationCertificate.hs
@@ -9,13 +9,13 @@ import           Test.Cardano.CLI.Util
 
 import           Hedgehog (Property)
 import qualified Hedgehog.Extras.Test.Base as H
-import qualified Hedgehog.Extras.Test.File as H
 import qualified Hedgehog.Extras.Test.Process as H
+import qualified Hedgehog.Extras.Test.Golden as H
 
 {- HLINT ignore "Use camelCase" -}
 
-hprop_golden_shelleyStakeAddressDeregistrationCertificate :: Property
-hprop_golden_shelleyStakeAddressDeregistrationCertificate = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+hprop_golden_shelley_stake_address_deregistration_certificate :: Property
+hprop_golden_shelley_stake_address_deregistration_certificate = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
   base <- H.getProjectBase
 
   verificationKeyFile <- noteInputFile "test/cardano-cli-golden/files/input/shelley/keys/stake_keys/verification_key"
@@ -29,7 +29,8 @@ hprop_golden_shelleyStakeAddressDeregistrationCertificate = propertyOnce . H.mod
     , "--out-file", deregistrationCertFile
     ]
 
-  H.assertFileOccurences 1 "Stake Address Deregistration Certificate" deregistrationCertFile
+  goldenFile1 <- H.note "test/cardano-cli-golden/files/golden/shelley/dereg-cert-1.json"
+  H.diffFileVsGoldenFile deregistrationCertFile goldenFile1
 
   void $ execCardanoCLI
     [ "babbage", "stake-address","deregistration-certificate"
@@ -37,6 +38,5 @@ hprop_golden_shelleyStakeAddressDeregistrationCertificate = propertyOnce . H.mod
     , "--out-file", scriptDeregistrationCertFile
     ]
 
-  H.assertFileOccurences 1 "Stake Address Deregistration Certificate" scriptDeregistrationCertFile
-
-  H.assertEndsWithSingleNewline deregistrationCertFile
+  goldenFile2 <- H.note "test/cardano-cli-golden/files/golden/shelley/dereg-cert-2.json"
+  H.diffFileVsGoldenFile scriptDeregistrationCertFile goldenFile2

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/StakeAddress/RegistrationCertificate.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/StakeAddress/RegistrationCertificate.hs
@@ -9,13 +9,13 @@ import           Test.Cardano.CLI.Util
 
 import           Hedgehog
 import qualified Hedgehog.Extras.Test.Base as H
-import qualified Hedgehog.Extras.Test.File as H
 import qualified Hedgehog.Extras.Test.Process as H
+import qualified Hedgehog.Extras.Test.Golden as H
 
 {- HLINT ignore "Use camelCase" -}
 
-hprop_golden_shelleyStakeAddressRegistrationCertificate :: Property
-hprop_golden_shelleyStakeAddressRegistrationCertificate = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+hprop_golden_shelley_stake_address_registration_certificate :: Property
+hprop_golden_shelley_stake_address_registration_certificate = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
   base <- H.getProjectBase
 
   keyGenStakingVerificationKeyFile <- noteInputFile "test/cardano-cli-golden/files/input/shelley/keys/stake_keys/verification_key"
@@ -29,7 +29,8 @@ hprop_golden_shelleyStakeAddressRegistrationCertificate = propertyOnce . H.modul
     , "--out-file", registrationCertFile
     ]
 
-  H.assertFileOccurences 1 "Stake Address Registration Certificate" registrationCertFile
+  goldenFile1 <- H.note "test/cardano-cli-golden/files/golden/shelley/stake-address/reg-certificate-1.json"
+  H.diffFileVsGoldenFile registrationCertFile goldenFile1
 
   void $ execCardanoCLI
     [ "babbage", "stake-address", "registration-certificate"
@@ -37,12 +38,11 @@ hprop_golden_shelleyStakeAddressRegistrationCertificate = propertyOnce . H.modul
     , "--out-file", scriptRegistrationCertFile
     ]
 
-  H.assertFileOccurences 1 "Stake Address Registration Certificate" scriptRegistrationCertFile
+  goldenFile2 <- H.note "test/cardano-cli-golden/files/golden/shelley/stake-address/script-reg-certificate.json"
+  H.diffFileVsGoldenFile scriptRegistrationCertFile goldenFile2
 
-  H.assertEndsWithSingleNewline registrationCertFile
-
-hprop_golden_shelleyStakeAddressRegistrationCertificateWithBuildRaw :: Property
-hprop_golden_shelleyStakeAddressRegistrationCertificateWithBuildRaw = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+hprop_golden_shelley_stake_address_registration_certificate_with_build_raw :: Property
+hprop_golden_shelley_stake_address_registration_certificate_with_build_raw = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
   keyGenStakingVerificationKeyFile <- noteInputFile "test/cardano-cli-golden/files/input/shelley/keys/stake_keys/verification_key"
   registrationCertFile <- noteTempFile tempDir "registration.cert"
   txRawFile <- noteTempFile tempDir "tx.raw"
@@ -54,7 +54,8 @@ hprop_golden_shelleyStakeAddressRegistrationCertificateWithBuildRaw = propertyOn
     , "--out-file", registrationCertFile
     ]
 
-  H.assertFileOccurences 1 "Stake Address Registration Certificate" registrationCertFile
+  goldenFile1 <- H.note "test/cardano-cli-golden/files/golden/shelley/stake-address/reg-certificate-2.json"
+  H.diffFileVsGoldenFile registrationCertFile goldenFile1
 
   void $ execCardanoCLI
     [ "conway", "transaction", "build-raw"
@@ -63,3 +64,6 @@ hprop_golden_shelleyStakeAddressRegistrationCertificateWithBuildRaw = propertyOn
     , "--certificate-file", registrationCertFile
     , "--out-file", txRawFile
     ]
+
+  goldenFile2 <- H.note "test/cardano-cli-golden/files/golden/shelley/stake-address/build-raw-out.json"
+  H.diffFileVsGoldenFile txRawFile goldenFile2

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Transaction/CalculateMinFee.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Transaction/CalculateMinFee.hs
@@ -6,16 +6,14 @@ module Test.Golden.Shelley.Transaction.CalculateMinFee
 import           Test.Cardano.CLI.Util
 
 import           Hedgehog (Property)
-import qualified Hedgehog.Extras.Test.Base as H
-import qualified Hedgehog.Extras.Test.File as H
+import qualified Hedgehog as H
 
 {- HLINT ignore "Use camelCase" -}
 
-hprop_golden_shelleyTransactionCalculateMinFee :: Property
-hprop_golden_shelleyTransactionCalculateMinFee = propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir -> do
+hprop_golden_shelley_transaction_calculate_min_fee :: Property
+hprop_golden_shelley_transaction_calculate_min_fee = propertyOnce $ do
   protocolParamsJsonFile <- noteInputFile "test/cardano-cli-golden/files/input/shelley/transaction-calculate-min-fee/protocol-params.json"
   txBodyFile <- noteInputFile "test/cardano-cli-golden/files/input/shelley/tx/txbody"
-  minFeeTxtFile <- noteTempFile tempDir "min-fee.txt"
 
   minFeeTxt <- execCardanoCLI
     [ "transaction","calculate-min-fee"
@@ -28,8 +26,4 @@ hprop_golden_shelleyTransactionCalculateMinFee = propertyOnce $ H.moduleWorkspac
     , "--tx-body-file", txBodyFile
     ]
 
-  H.writeFile minFeeTxtFile minFeeTxt
-
-  H.assertFileOccurences 1 "5083100" minFeeTxtFile
-  H.assertFileLines (== 1) minFeeTxtFile
-  H.assertEndsWithSingleNewline minFeeTxtFile
+  H.diff minFeeTxt (==) "5083100 Lovelace\n"

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Transaction/CreateWitness.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Transaction/CreateWitness.hs
@@ -8,7 +8,7 @@ import           Test.Cardano.CLI.Util
 
 import           Hedgehog (Property)
 import qualified Hedgehog.Extras.Test.Base as H
-import qualified Hedgehog.Extras.Test.File as H
+import qualified Hedgehog.Extras.Test.Golden as H
 
 {- HLINT ignore "Use camelCase" -}
 
@@ -18,8 +18,8 @@ txIn = "2392d2b1200b5139fe555c81261697b29a8ccf561c5c783d46e78a479d977053#0"
 txOut :: String
 txOut = "addr1q94cxl99qvtwunsqqv6g9mgj3zrawtpt4edsgwxkjtwpy5dsezcht90tmwfur7t5hc9fk8hjd3r5vjwec2h8vmk3xh8s7er7t3+100"
 
-hprop_golden_shelleyTransactionSigningKeyWitness :: Property
-hprop_golden_shelleyTransactionSigningKeyWitness = propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir -> do
+hprop_golden_shelley_transaction_signing_key_witness :: Property
+hprop_golden_shelley_transaction_signing_key_witness = propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir -> do
   txBodyOutFile <- noteTempFile tempDir "tx-body-out"
 
   -- Create tx body file
@@ -35,6 +35,7 @@ hprop_golden_shelleyTransactionSigningKeyWitness = propertyOnce $ H.moduleWorksp
   -- Create all multisig witness
   witnessOutFile <- noteTempFile tempDir "signingkey-witness"
   signingKeyFile <- noteInputFile "test/cardano-cli-golden/files/input/shelley/keys/payment_keys/signing_key"
+
   void $ execCardanoCLI
     [ "transaction","witness"
     , "--tx-body-file", txBodyOutFile
@@ -43,5 +44,5 @@ hprop_golden_shelleyTransactionSigningKeyWitness = propertyOnce $ H.moduleWorksp
     , "--out-file", witnessOutFile
     ]
 
-  H.assertFileOccurences 1 "TxWitness ShelleyEra" witnessOutFile
-  H.assertEndsWithSingleNewline txBodyOutFile
+  goldenFile <- H.note "test/cardano-cli-golden/files/golden/shelley/witness-out.json"
+  H.diffFileVsGoldenFile witnessOutFile goldenFile

--- a/cardano-cli/test/cardano-cli-golden/files/golden/shelley/dereg-cert-1.json
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/shelley/dereg-cert-1.json
@@ -1,0 +1,5 @@
+{
+    "type": "CertificateShelley",
+    "description": "Stake Address Deregistration Certificate",
+    "cborHex": "82018200581c81b4245f84593f63c0ff2296930254f77a0690fa9de5f969cac27cb0"
+}

--- a/cardano-cli/test/cardano-cli-golden/files/golden/shelley/dereg-cert-2.json
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/shelley/dereg-cert-2.json
@@ -1,0 +1,5 @@
+{
+    "type": "CertificateShelley",
+    "description": "Stake Address Deregistration Certificate",
+    "cborHex": "82018201581cb9ff787a6dedf9ebe602a26352803778805428c7521b99ec7542aa01"
+}

--- a/cardano-cli/test/cardano-cli-golden/files/golden/shelley/stake-address/build-raw-out.json
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/shelley/stake-address/build-raw-out.json
@@ -1,0 +1,5 @@
+{
+    "type": "Unwitnessed Tx ConwayEra",
+    "description": "Ledger Cddl Format",
+    "cborHex": "84a40081825820bdfa7d91a29ffe071c028c0143c5d278c0a7ddb829c1e95f54a1676915fd82c2000180020104d901028183078200581c81b4245f84593f63c0ff2296930254f77a0690fa9de5f969cac27cb01a001e8480a0f5f6"
+}

--- a/cardano-cli/test/cardano-cli-golden/files/golden/shelley/stake-address/reg-certificate-1.json
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/shelley/stake-address/reg-certificate-1.json
@@ -1,0 +1,5 @@
+{
+    "type": "CertificateShelley",
+    "description": "Stake Address Registration Certificate",
+    "cborHex": "82008200581c81b4245f84593f63c0ff2296930254f77a0690fa9de5f969cac27cb0"
+}

--- a/cardano-cli/test/cardano-cli-golden/files/golden/shelley/stake-address/reg-certificate-2.json
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/shelley/stake-address/reg-certificate-2.json
@@ -1,0 +1,5 @@
+{
+    "type": "CertificateShelley",
+    "description": "Stake Address Registration Certificate",
+    "cborHex": "83078200581c81b4245f84593f63c0ff2296930254f77a0690fa9de5f969cac27cb01a001e8480"
+}

--- a/cardano-cli/test/cardano-cli-golden/files/golden/shelley/stake-address/script-reg-certificate.json
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/shelley/stake-address/script-reg-certificate.json
@@ -1,0 +1,5 @@
+{
+    "type": "CertificateShelley",
+    "description": "Stake Address Registration Certificate",
+    "cborHex": "82008201581cb9ff787a6dedf9ebe602a26352803778805428c7521b99ec7542aa01"
+}

--- a/cardano-cli/test/cardano-cli-golden/files/golden/shelley/witness-out.json
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/shelley/witness-out.json
@@ -1,0 +1,5 @@
+{
+    "type": "TxWitness ShelleyEra",
+    "description": "Key Witness ShelleyEra",
+    "cborHex": "8258208dc60533b5dfa60a530955a696323a2ef4f14e8bc95a8f84cf6c441fea4234275840a20a2c8b1ffc2151eee3f659fc4076f9859d7d4d073933275470f270128736d231a2fb5e1bc2a6058ef2e58bc98266d192c55d6435ab591ce72cb165a7ec4e03"
+}


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Replace usages of assertFileOccurences by comparisons with golden files
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

* Continuation of https://github.com/input-output-hk/cardano-cli/pull/426 and https://github.com/input-output-hk/cardano-cli/pull/436
* Contributes to fixing https://github.com/input-output-hk/cardano-cli/issues/415

# How to trust this PR

Observe that calls of the form `assertFileOccurences _ file` have been replaced with `diffFileWithGoldenFile file newGoldenFile`, hence doing more checks.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff