### PR TITLE
put n shelley/byron key witnesses arguments in correct order

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Transaction.hs
@@ -969,7 +969,7 @@ runTransactionCalculateMinFeeCmd
                             (protocolParamTxFeePerByte pparams)
                             tx
                             nInputs nOutputs
-                            nByronKeyWitnesses nShelleyKeyWitnesses
+                            nShelleyKeyWitnesses nByronKeyWitnesses
 
       liftIO $ putStrLn $ (show fee :: String) <> " Lovelace"
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Transaction/CalculateMinFee.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Transaction/CalculateMinFee.hs
@@ -19,8 +19,8 @@ hprop_golden_shelley_transaction_calculate_min_fee = propertyOnce $ do
     [ "transaction","calculate-min-fee"
     , "--tx-in-count", "32"
     , "--tx-out-count", "27"
-    , "--byron-witness-count", "5"
-    , "--witness-count", "10"
+    , "--byron-witness-count", "10"
+    , "--witness-count", "5"
     , "--testnet-magic", "4036000900"
     , "--protocol-params-file", protocolParamsJsonFile
     , "--tx-body-file", txBodyFile


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Puts the `nShelleyKeyWitnesses`, `nByronKeyWitnesses` arguments to `runCalculateMinFeeCmd` in the correct order.
  type:
    - bugfix  
```

# Context

The `runCalculateMinFeeCmd` swaps the number of Byron and Shelley witnesses used to calculate fees, in its call to [estimateTransactionFee](https://github.com/input-output-hk/cardano-api/blob/95dbeb718106cce98452130018ba7dc4fc403b8e/cardano-api/internal/Cardano/Api/Fees.hs#L139) (see [here in the function's body](https://github.com/input-output-hk/cardano-api/blob/6d91127efc127c838689e011f67618d3cd2ffe4b/cardano-api/internal/Cardano/Api/Fees.hs#L156)) of `cardano-api-8.30.0.0`.

The witness numbers get multiplied by a factor that differs for the Byron and Shelley eras, and the Byron multiplier is larger than the Shelley number as defined [here](https://github.com/input-output-hk/cardano-api/blob/95dbeb718106cce98452130018ba7dc4fc403b8e/cardano-api/internal/Cardano/Api/Fees.hs#L171).

So the min fee printed by `runCalculateMinFeeCmd` will be larger than it should be if the number of Shelley witnesses exceeds the number Byron witnesses provided.

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [X] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
