### PR TITLE
Replace usages of assertFileOccurences (5/6)

### DIFF
--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Genesis/Create.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Genesis/Create.hs
@@ -17,6 +17,7 @@ import qualified Data.HashMap.Lazy as HM
 import qualified Data.Set as S
 import qualified Data.Time.Clock as DT
 
+import           Test.Cardano.CLI.Aeson (assertHasMappings)
 import           Test.Cardano.CLI.Util as OP
 
 import           Hedgehog (Property, forAll, (===))
@@ -129,24 +130,24 @@ hprop_golden_shelleyGenesisCreate = propertyOnce $ do
 
     for_ [1 .. delegateCount] $ \i -> do
       -- Check Genesis keys
-      H.assertFileOccurences 1 "GenesisSigningKey_ed25519" $ tempDir <> "/genesis-keys/genesis" <> show i <> ".skey"
-      H.assertFileOccurences 1 "GenesisVerificationKey_ed25519" $ tempDir <> "/genesis-keys/genesis" <> show i <> ".vkey"
+      assertHasMappings [("type", "GenesisVerificationKey_ed25519")] $ tempDir <> "/genesis-keys/genesis" <> show i <> ".vkey"
+      assertHasMappings [("type", "GenesisSigningKey_ed25519")] $ tempDir <> "/genesis-keys/genesis" <> show i <> ".skey"
 
       H.assertEndsWithSingleNewline $ tempDir <> "/genesis-keys/genesis" <> show i <> ".skey"
       H.assertEndsWithSingleNewline $ tempDir <> "/genesis-keys/genesis" <> show i <> ".vkey"
 
       -- Check delegate keys
-      H.assertFileOccurences 1 "GenesisDelegateSigningKey_ed25519" $ tempDir <> "/delegate-keys/delegate" <> show i <> ".skey"
-      H.assertFileOccurences 1 "GenesisDelegateVerificationKey_ed25519" $ tempDir <> "/delegate-keys/delegate" <> show i <> ".vkey"
-      H.assertFileOccurences 1 "NodeOperationalCertificateIssueCounter" $ tempDir <> "/delegate-keys/delegate" <> show i <> ".counter"
+      assertHasMappings [("type", "GenesisDelegateSigningKey_ed25519")] $ tempDir <> "/delegate-keys/delegate" <> show i <> ".skey"
+      assertHasMappings [("type", "GenesisDelegateVerificationKey_ed25519")] $ tempDir <> "/delegate-keys/delegate" <> show i <> ".vkey"
+      assertHasMappings [("type", "NodeOperationalCertificateIssueCounter")] $ tempDir <> "/delegate-keys/delegate" <> show i <> ".counter"
 
       H.assertEndsWithSingleNewline $ tempDir <> "/delegate-keys/delegate" <> show i <> ".skey"
       H.assertEndsWithSingleNewline $ tempDir <> "/delegate-keys/delegate" <> show i <> ".vkey"
       H.assertEndsWithSingleNewline $ tempDir <> "/delegate-keys/delegate" <> show i <> ".counter"
 
       -- Check utxo keys
-      H.assertFileOccurences 1 "GenesisUTxOSigningKey_ed25519" $ tempDir <> "/utxo-keys/utxo" <> show i <> ".skey"
-      H.assertFileOccurences 1 "GenesisUTxOVerificationKey_ed25519"  $ tempDir <> "/utxo-keys/utxo" <> show i <> ".vkey"
+      assertHasMappings [("type", "GenesisUTxOSigningKey_ed25519")] $ tempDir <> "/utxo-keys/utxo" <> show i <> ".skey"
+      assertHasMappings [("type", "GenesisUTxOVerificationKey_ed25519")]  $ tempDir <> "/utxo-keys/utxo" <> show i <> ".vkey"
 
       H.assertEndsWithSingleNewline $ tempDir <> "/utxo-keys/utxo" <> show i <> ".skey"
       H.assertEndsWithSingleNewline $ tempDir <> "/utxo-keys/utxo" <> show i <> ".vkey"
@@ -208,24 +209,24 @@ hprop_golden_shelleyGenesisCreate = propertyOnce $ do
 
     for_ [1 .. delegateCount] $ \i -> do
       -- Check Genesis keys
-      H.assertFileOccurences 1 "GenesisSigningKey_ed25519" $ tempDir <> "/genesis-keys/genesis" <> show i <> ".skey"
-      H.assertFileOccurences 1 "GenesisVerificationKey_ed25519" $ tempDir <> "/genesis-keys/genesis" <> show i <> ".vkey"
+      assertHasMappings [("type", "GenesisSigningKey_ed25519")] $ tempDir <> "/genesis-keys/genesis" <> show i <> ".skey"
+      assertHasMappings [("type", "GenesisVerificationKey_ed25519")] $ tempDir <> "/genesis-keys/genesis" <> show i <> ".vkey"
 
       H.assertEndsWithSingleNewline $ tempDir <> "/genesis-keys/genesis" <> show i <> ".skey"
       H.assertEndsWithSingleNewline $ tempDir <> "/genesis-keys/genesis" <> show i <> ".vkey"
 
       -- Check delegate keys
-      H.assertFileOccurences 1 "GenesisDelegateSigningKey_ed25519" $ tempDir <> "/delegate-keys/delegate" <> show i <> ".skey"
-      H.assertFileOccurences 1 "GenesisDelegateVerificationKey_ed25519" $ tempDir <> "/delegate-keys/delegate" <> show i <> ".vkey"
-      H.assertFileOccurences 1 "NodeOperationalCertificateIssueCounter" $ tempDir <> "/delegate-keys/delegate" <> show i <> ".counter"
+      assertHasMappings [("type", "GenesisDelegateSigningKey_ed25519")] $ tempDir <> "/delegate-keys/delegate" <> show i <> ".skey"
+      assertHasMappings [("type", "GenesisDelegateVerificationKey_ed25519")] $ tempDir <> "/delegate-keys/delegate" <> show i <> ".vkey"
+      assertHasMappings [("type", "NodeOperationalCertificateIssueCounter")] $ tempDir <> "/delegate-keys/delegate" <> show i <> ".counter"
 
       H.assertEndsWithSingleNewline $ tempDir <> "/delegate-keys/delegate" <> show i <> ".skey"
       H.assertEndsWithSingleNewline $ tempDir <> "/delegate-keys/delegate" <> show i <> ".vkey"
       H.assertEndsWithSingleNewline $ tempDir <> "/delegate-keys/delegate" <> show i <> ".counter"
 
       -- Check utxo keys
-      H.assertFileOccurences 1 "GenesisUTxOSigningKey_ed25519" $ tempDir <> "/utxo-keys/utxo" <> show i <> ".skey"
-      H.assertFileOccurences 1 "GenesisUTxOVerificationKey_ed25519"  $ tempDir <> "/utxo-keys/utxo" <> show i <> ".vkey"
+      assertHasMappings [("type", "GenesisUTxOSigningKey_ed25519")] $ tempDir <> "/utxo-keys/utxo" <> show i <> ".skey"
+      assertHasMappings [("type", "GenesisUTxOVerificationKey_ed25519")]  $ tempDir <> "/utxo-keys/utxo" <> show i <> ".vkey"
 
       H.assertEndsWithSingleNewline $ tempDir <> "/utxo-keys/utxo" <> show i <> ".skey"
       H.assertEndsWithSingleNewline $ tempDir <> "/utxo-keys/utxo" <> show i <> ".vkey"

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Genesis/KeyGenGenesis.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Genesis/KeyGenGenesis.hs
@@ -4,6 +4,7 @@ module Test.Golden.Shelley.Genesis.KeyGenGenesis where
 
 import           Control.Monad (void)
 
+import           Test.Cardano.CLI.Aeson
 import           Test.Cardano.CLI.Util
 
 import           Hedgehog (Property)
@@ -23,8 +24,8 @@ hprop_golden_shelleyGenesisKeyGenGenesis = propertyOnce . H.moduleWorkspace "tmp
     , "--signing-key-file", signingKeyFile
     ]
 
-  H.assertFileOccurences 1 "GenesisVerificationKey_ed25519" verificationKeyFile
-  H.assertFileOccurences 1 "GenesisSigningKey_ed25519" signingKeyFile
+  assertHasMappings [("type", "GenesisVerificationKey_ed25519")] verificationKeyFile
+  assertHasMappings [("type", "GenesisSigningKey_ed25519")] signingKeyFile
 
   H.assertEndsWithSingleNewline verificationKeyFile
   H.assertEndsWithSingleNewline signingKeyFile

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Genesis/KeyGenUtxo.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Genesis/KeyGenUtxo.hs
@@ -4,6 +4,7 @@ module Test.Golden.Shelley.Genesis.KeyGenUtxo where
 
 import           Control.Monad (void)
 
+import           Test.Cardano.CLI.Aeson
 import           Test.Cardano.CLI.Util
 
 import           Hedgehog (Property)
@@ -23,8 +24,8 @@ hprop_golden_shelleyGenesisKeyGenUtxo = propertyOnce . H.moduleWorkspace "tmp" $
     , "--signing-key-file", utxoSigningKeyFile
     ]
 
-  H.assertFileOccurences 1 "GenesisUTxOVerificationKey_ed25519" utxoVerificationKeyFile
-  H.assertFileOccurences 1 "GenesisUTxOSigningKey_ed25519" utxoSigningKeyFile
+  assertHasMappings [("type", "GenesisUTxOVerificationKey_ed25519")] utxoVerificationKeyFile
+  assertHasMappings [("type", "GenesisUTxOSigningKey_ed25519")] utxoSigningKeyFile
 
   H.assertEndsWithSingleNewline utxoVerificationKeyFile
   H.assertEndsWithSingleNewline utxoSigningKeyFile

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Node/IssueOpCert.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Node/IssueOpCert.hs
@@ -4,6 +4,7 @@ module Test.Golden.Shelley.Node.IssueOpCert where
 
 import           Control.Monad (void)
 
+import           Test.Cardano.CLI.Aeson (assertHasMappings)
 import           Test.Cardano.CLI.Util
 
 import           Hedgehog (Property)
@@ -37,8 +38,8 @@ hprop_golden_shelleyNodeIssueOpCert = propertyOnce . H.moduleWorkspace "tmp" $ \
     , "--out-file", operationalCertFile
     ]
 
-  H.assertFileOccurences 1 "NodeOperationalCertificate" operationalCertFile
-  H.assertFileOccurences 1 "Next certificate issue number: 1" operationalCertificateIssueCounterFile
+  assertHasMappings [("type", "NodeOperationalCertificate")] operationalCertFile
+  assertHasMappings [("type", "NodeOperationalCertificateIssueCounter"), ("description", "Next certificate issue number: 1")] operationalCertificateIssueCounterFile
 
   H.assertEndsWithSingleNewline operationalCertFile
   H.assertEndsWithSingleNewline operationalCertificateIssueCounterFile

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Node/KeyGenVrf.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Node/KeyGenVrf.hs
@@ -4,6 +4,7 @@ module Test.Golden.Shelley.Node.KeyGenVrf where
 
 import           Control.Monad (void)
 
+import           Test.Cardano.CLI.Aeson
 import           Test.Cardano.CLI.Util
 
 import           Hedgehog (Property)
@@ -23,8 +24,8 @@ hprop_golden_shelleyNodeKeyGenVrf = propertyOnce . H.moduleWorkspace "tmp" $ \te
     , "--signing-key-file", signingKey
     ]
 
-  H.assertFileOccurences 1 "VRF Verification Key" verificationKey
-  H.assertFileOccurences 1 "VRF Signing Key" signingKey
+  assertHasMappings [("type", "VrfVerificationKey_PraosVRF"), ("description", "VRF Verification Key")] verificationKey
+  assertHasMappings [("type", "VrfSigningKey_PraosVRF"), ("description", "VRF Signing Key")] signingKey
 
   H.assertEndsWithSingleNewline verificationKey
   H.assertEndsWithSingleNewline signingKey
@@ -41,8 +42,8 @@ hprop_golden_shelleyNodeKeyGenVrf_te = propertyOnce . H.moduleWorkspace "tmp" $ 
     , "--signing-key-file", signingKey
     ]
 
-  H.assertFileOccurences 1 "VRF Verification Key" verificationKey
-  H.assertFileOccurences 1 "VRF Signing Key" signingKey
+  assertHasMappings [("type", "VrfVerificationKey_PraosVRF"), ("description", "VRF Verification Key")] verificationKey
+  assertHasMappings [("type", "VrfSigningKey_PraosVRF"), ("description", "VRF Signing Key")] signingKey
 
   H.assertEndsWithSingleNewline verificationKey
   H.assertEndsWithSingleNewline signingKey


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Replace usages of assertFileOccurences by usage of new functions 
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

* Contributes to fixing https://github.com/input-output-hk/cardano-cli/issues/415
* Like https://github.com/input-output-hk/cardano-cli/pull/444, this one doesn't introduce golden files: instead it makes some existing tests that have nondeterministic content more precise.
* I did that, because - during the previous PRs -, I witnessed some tests that could be enhanced.
* This is the before last PR in this series. I'm nearly done going all files that used `assertFileOccurences`

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff