### PR TITLE
Replace usages of assertFileOccurences (6/6)

### DIFF
--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Node/KeyGen.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Node/KeyGen.hs
@@ -5,6 +5,7 @@ module Test.Golden.Shelley.Node.KeyGen
 
 import           Control.Monad (void)
 
+import           Test.Cardano.CLI.Aeson
 import           Test.Cardano.CLI.Util
 
 import           Hedgehog (Property)
@@ -26,9 +27,9 @@ hprop_golden_shelleyNodeKeyGen = propertyOnce . H.moduleWorkspace "tmp" $ \tempD
     , "--operational-certificate-issue-counter", opCertCounterFile
     ]
 
-  H.assertFileOccurences 1 "StakePoolVerificationKey_ed25519" verificationKeyFile
-  H.assertFileOccurences 1 "StakePoolSigningKey_ed25519" signingKeyFile
-  H.assertFileOccurences 1 "NodeOperationalCertificateIssueCounter" opCertCounterFile
+  assertHasMappings [("type", "StakePoolVerificationKey_ed25519"), ("description", "Stake Pool Operator Verification Key")] verificationKeyFile
+  assertHasMappings [("type", "StakePoolSigningKey_ed25519"), ("description", "Stake Pool Operator Signing Key")] signingKeyFile
+  assertHasMappings [("type", "NodeOperationalCertificateIssueCounter"), ("description", "Next certificate issue number: 0")] opCertCounterFile
 
   H.assertEndsWithSingleNewline verificationKeyFile
   H.assertEndsWithSingleNewline signingKeyFile
@@ -47,9 +48,9 @@ hprop_golden_shelleyNodeKeyGen_te = propertyOnce . H.moduleWorkspace "tmp" $ \te
     , "--operational-certificate-issue-counter", opCertCounterFile
     ]
 
-  H.assertFileOccurences 1 "StakePoolVerificationKey_ed25519" verificationKeyFile
-  H.assertFileOccurences 1 "StakePoolSigningKey_ed25519" signingKeyFile
-  H.assertFileOccurences 1 "NodeOperationalCertificateIssueCounter" opCertCounterFile
+  assertHasMappings [("type", "StakePoolVerificationKey_ed25519"), ("description", "Stake Pool Operator Verification Key")] verificationKeyFile
+  assertHasMappings [("type", "StakePoolSigningKey_ed25519"), ("description", "Stake Pool Operator Signing Key")] signingKeyFile
+  assertHasMappings [("type", "NodeOperationalCertificateIssueCounter"), ("description", "Next certificate issue number: 0")] opCertCounterFile
 
   H.assertEndsWithSingleNewline verificationKeyFile
   H.assertEndsWithSingleNewline signingKeyFile
@@ -71,6 +72,6 @@ hprop_golden_shelleyNodeKeyGen_bech32 = propertyOnce . H.moduleWorkspace "tmp" $
 
   H.assertFileOccurences 1 "pool_vk" verificationKeyFile
   H.assertFileOccurences 1 "pool_sk" signingKeyFile
-  H.assertFileOccurences 1 "NodeOperationalCertificateIssueCounter" opCertCounterFile
+  assertHasMappings [("type", "NodeOperationalCertificateIssueCounter"), ("description", "Next certificate issue number: 0")] opCertCounterFile
 
   H.assertEndsWithSingleNewline opCertCounterFile

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Node/KeyGenKes.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Node/KeyGenKes.hs
@@ -4,6 +4,7 @@ module Test.Golden.Shelley.Node.KeyGenKes where
 
 import           Control.Monad (void)
 
+import           Test.Cardano.CLI.Aeson
 import           Test.Cardano.CLI.Util
 
 import           Hedgehog (Property)
@@ -23,8 +24,8 @@ hprop_golden_shelleyNodeKeyGenKes = propertyOnce . H.moduleWorkspace "tmp" $ \te
     , "--signing-key-file", signingKey
     ]
 
-  H.assertFileOccurences 1 "KesVerificationKey_ed25519_kes_2^6" verificationKey
-  H.assertFileOccurences 1 "KesSigningKey_ed25519_kes_2^6" signingKey
+  assertHasMappings [("type", "KesVerificationKey_ed25519_kes_2^6"), ("description", "KES Verification Key")] verificationKey
+  assertHasMappings [("type", "KesSigningKey_ed25519_kes_2^6"), ("description", "KES Signing Key")] signingKey
 
   H.assertEndsWithSingleNewline verificationKey
   H.assertEndsWithSingleNewline signingKey
@@ -41,8 +42,8 @@ hprop_golden_shelleyNodeKeyGenKes_te = propertyOnce . H.moduleWorkspace "tmp" $ 
     , "--signing-key-file", signingKey
     ]
 
-  H.assertFileOccurences 1 "KesVerificationKey_ed25519_kes_2^6" verificationKey
-  H.assertFileOccurences 1 "KesSigningKey_ed25519_kes_2^6" signingKey
+  assertHasMappings [("type", "KesVerificationKey_ed25519_kes_2^6"), ("description", "KES Verification Key")] verificationKey
+  assertHasMappings [("type", "KesSigningKey_ed25519_kes_2^6"), ("description", "KES Signing Key")] signingKey
 
   H.assertEndsWithSingleNewline verificationKey
   H.assertEndsWithSingleNewline signingKey


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Replace usages of assertFileOccurences by usage of new functions 
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

* This the last PR in this streak. As such, it fixes https://github.com/input-output-hk/cardano-cli/issues/415
* Like https://github.com/input-output-hk/cardano-cli/pull/444, this one doesn't introduce golden files: instead it makes some existing tests that have nondeterministic content more precise.
* I did that, because - during the previous PRs -, I witnessed some tests that could be enhanced.
* I'm done going over all files that used `assertFileOccurences`

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff