### PR TITLE
Show vote delegation in `stake-address-info`

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Query.hs
@@ -58,6 +58,7 @@ import           Cardano.Crypto.Hash (hashToBytesAsHex)
 import qualified Cardano.Crypto.Hash.Blake2b as Blake2b
 import qualified Cardano.Ledger.BaseTypes as L
 import qualified Cardano.Ledger.Core as Core
+import qualified Cardano.Ledger.Credential as L
 import qualified Cardano.Ledger.Crypto as Crypto
 import           Cardano.Ledger.Keys (KeyHash (..), KeyRole (..))
 import           Cardano.Ledger.SafeHash (SafeHash)
@@ -849,13 +850,19 @@ writeStakeAddressInfo
       (\(addr, mBalance, mPoolId, mDRep, mDeposit) ->
         Aeson.object
         [ "address" .= addr
-        , "delegation" .= mPoolId
-        , "voteDelegation" .= mDRep
+        , "stakeDelegation" .= mPoolId
+        , "voteDelegation" .= fmap friendlyDRep mDRep
         , "rewardAccountBalance" .= mBalance
         , "delegationDeposit" .= mDeposit
         ]
       )
       merged
+
+  friendlyDRep :: L.DRep L.StandardCrypto -> Text
+  friendlyDRep L.DRepAlwaysAbstain = "alwaysAbstain"
+  friendlyDRep L.DRepAlwaysNoConfidence = "alwaysNoConfidence"
+  friendlyDRep (L.DRepCredential cred) =
+    L.credToText cred -- this will pring "keyHash-..." or "scriptHash-...", depending on the type of credential
 
   merged :: [(StakeAddress, Maybe Lovelace, Maybe PoolId, Maybe (L.DRep L.StandardCrypto), Maybe Lovelace)]
   merged =


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    add the vote delegateee to the output of `stake-address-info`
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

This PR closes #423.

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
