### PR TITLE
Correct conway parser, so that --key-reg-deposit-amt is mandatory

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/StakeAddress.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/StakeAddress.hs
@@ -146,7 +146,7 @@ runStakeAddressRegistrationCertificateCmd sbe stakeIdentifier mDeposit oFp = do
 createRegistrationCertRequirements :: ()
   => ShelleyBasedEra era
   -> StakeCredential
-  -> Maybe Lovelace
+  -> Maybe Lovelace -- ^ Deposit required in conway era
   -> Either StakeAddressRegistrationError (StakeAddressRequirements era)
 createRegistrationCertRequirements sbe stakeCred mdeposit =
   case sbe of
@@ -162,8 +162,10 @@ createRegistrationCertRequirements sbe stakeCred mdeposit =
       return $ StakeAddrRegistrationPreConway ShelleyToBabbageEraBabbage stakeCred
     ShelleyBasedEraConway ->
       case mdeposit of
-        -- TODO: This error constructor will never be called
-        Nothing -> Left StakeAddressRegistrationDepositRequired
+        Nothing ->
+          -- This case is made impossible by the parser, that distinguishes between Conway
+          -- and pre-Conway.
+          Left StakeAddressRegistrationDepositRequired
         Just dep ->
           return $ StakeAddrRegistrationConway ConwayEraOnwardsConway dep stakeCred
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Help.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Help.hs
@@ -100,6 +100,6 @@ hprop_golden_HelpCmds =
         H.noteShow_ usage
         let expectedCmdHelpFp = "test/cardano-cli-golden/files/golden/help" </> Text.unpack (Text.intercalate "_" usage) <> ".cli"
 
-        cmdHelp <- filterAnsi . third <$> H.execDetailCardanoCli (fmap Text.unpack usage)
+        cmdHelp <- filterAnsi . third <$> H.execDetailCardanoCLI (fmap Text.unpack usage)
 
         H.diffVsGoldenFile cmdHelp expectedCmdHelpFp

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/StakeAddress/RegistrationCertificate.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/StakeAddress/RegistrationCertificate.hs
@@ -9,8 +9,8 @@ import           Test.Cardano.CLI.Util
 
 import           Hedgehog
 import qualified Hedgehog.Extras.Test.Base as H
-import qualified Hedgehog.Extras.Test.Process as H
 import qualified Hedgehog.Extras.Test.Golden as H
+import qualified Hedgehog.Extras.Test.Process as H
 
 {- HLINT ignore "Use camelCase" -}
 
@@ -67,3 +67,15 @@ hprop_golden_shelley_stake_address_registration_certificate_with_build_raw = pro
 
   goldenFile2 <- H.note "test/cardano-cli-golden/files/golden/shelley/stake-address/build-raw-out.json"
   H.diffFileVsGoldenFile txRawFile goldenFile2
+
+hprop_golden_shelley_stake_address_registration_certificate_missing_reg_deposit :: Property
+hprop_golden_shelley_stake_address_registration_certificate_missing_reg_deposit = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  keyGenStakingVerificationKeyFile <- noteInputFile "test/cardano-cli-golden/files/input/shelley/keys/stake_keys/verification_key"
+  registrationCertFile <- noteTempFile tempDir "registration.cert"
+
+  void $ execDetailCardanoCli
+    [ "conway", "stake-address", "registration-certificate"
+    , "--staking-verification-key-file", keyGenStakingVerificationKeyFile
+    -- , "--key-reg-deposit-amt", "2000000" This argument being mandatory in conway, the call should fail
+    , "--out-file", registrationCertFile
+    ]

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/StakeAddress/RegistrationCertificate.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/StakeAddress/RegistrationCertificate.hs
@@ -73,7 +73,7 @@ hprop_golden_shelley_stake_address_registration_certificate_missing_reg_deposit 
   keyGenStakingVerificationKeyFile <- noteInputFile "test/cardano-cli-golden/files/input/shelley/keys/stake_keys/verification_key"
   registrationCertFile <- noteTempFile tempDir "registration.cert"
 
-  void $ execDetailCardanoCli
+  void $ execDetailCardanoCLI
     [ "conway", "stake-address", "registration-certificate"
     , "--staking-verification-key-file", keyGenStakingVerificationKeyFile
     -- , "--key-reg-deposit-amt", "2000000" This argument being mandatory in conway, the call should fail

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -6598,7 +6598,7 @@ Usage: cardano-cli conway stake-address registration-certificate
                                                                    | --stake-script-file FILE
                                                                    | --stake-address ADDRESS
                                                                    )
-                                                                   [--key-reg-deposit-amt NATURAL]
+                                                                   --key-reg-deposit-amt NATURAL
                                                                    --out-file FILE
 
   Create a stake address registration certificate

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_stake-address_registration-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_stake-address_registration-certificate.cli
@@ -4,7 +4,7 @@ Usage: cardano-cli conway stake-address registration-certificate
                                                                    | --stake-script-file FILE
                                                                    | --stake-address ADDRESS
                                                                    )
-                                                                   [--key-reg-deposit-amt NATURAL]
+                                                                   --key-reg-deposit-amt NATURAL
                                                                    --out-file FILE
 
   Create a stake address registration certificate

--- a/cardano-cli/test/cardano-cli-test-lib/Test/Cardano/CLI/Util.hs
+++ b/cardano-cli/test/cardano-cli-test-lib/Test/Cardano/CLI/Util.hs
@@ -3,7 +3,7 @@ module Test.Cardano.CLI.Util
   , checkTextEnvelopeFormat
   , equivalence
   , execCardanoCLI
-  , execDetailCardanoCli
+  , execDetailCardanoCLI
   , tryExecCardanoCLI
   , propertyOnce
   , withSnd
@@ -64,13 +64,13 @@ execCardanoCLI = GHC.withFrozenCallStack $ H.execFlex "cardano-cli" "CARDANO_CLI
 -- | Execute cardano-cli via the command line, expecting it to fail.
 --
 -- Waits for the process to finish and returns the exit code, stdout and stderr.
-execDetailCardanoCli
+execDetailCardanoCLI
   :: (MonadTest m, MonadCatch m, MonadIO m, HasCallStack)
   => [String]
   -- ^ Arguments to the CLI command
   -> m (IO.ExitCode, String, String)
   -- ^ Captured stdout
-execDetailCardanoCli = GHC.withFrozenCallStack $ execDetailFlex H.defaultExecConfig "cardano-cli" "CARDANO_CLI"
+execDetailCardanoCLI = GHC.withFrozenCallStack $ execDetailFlex H.defaultExecConfig "cardano-cli" "CARDANO_CLI"
 
 procFlex'
   :: (MonadTest m, MonadCatch m, MonadIO m, HasCallStack)


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Make --key-reg-deposit-amt mandatory in the parser of conway stake-address registration-certificate, because it is actually mandatory.
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - improvement    # QoL changes e.g. refactoring
  - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Fixes https://github.com/input-output-hk/cardano-cli/issues/449

# How to trust this PR

* Observe the change in golden files

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [X] Self-reviewed the diff