### PR TITLE
Update pCmds to take `ShelleyBasedEra era` instead of `Cardano era`

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands.hs
@@ -10,7 +10,7 @@ module Cardano.CLI.EraBased.Commands
   , pCmds
   ) where
 
-import           Cardano.Api (CardanoEra (..), ShelleyBasedEra (..))
+import           Cardano.Api (ShelleyBasedEra (..), toCardanoEra)
 
 import           Cardano.CLI.Environment
 import           Cardano.CLI.EraBased.Commands.Address
@@ -88,40 +88,40 @@ pAnyEraCommand envCli =
     [ -- Note, byron is ommitted because there is already a legacy command group for it.
 
       subParser "shelley"
-        $ Opt.info (AnyEraCommandOf ShelleyBasedEraShelley <$> pCmds ShelleyEra envCli)
+        $ Opt.info (AnyEraCommandOf ShelleyBasedEraShelley <$> pCmds ShelleyBasedEraShelley envCli)
         $ Opt.progDesc "Shelley era commands"
     , subParser "allegra"
-        $ Opt.info (AnyEraCommandOf ShelleyBasedEraAllegra <$> pCmds AllegraEra envCli)
+        $ Opt.info (AnyEraCommandOf ShelleyBasedEraAllegra <$> pCmds ShelleyBasedEraAllegra envCli)
         $ Opt.progDesc "Allegra era commands"
     , subParser "mary"
-        $ Opt.info (AnyEraCommandOf ShelleyBasedEraMary <$> pCmds MaryEra envCli)
+        $ Opt.info (AnyEraCommandOf ShelleyBasedEraMary <$> pCmds ShelleyBasedEraMary envCli)
         $ Opt.progDesc "Mary era commands"
     , subParser "alonzo"
-        $ Opt.info (AnyEraCommandOf ShelleyBasedEraAlonzo <$> pCmds AlonzoEra envCli)
+        $ Opt.info (AnyEraCommandOf ShelleyBasedEraAlonzo <$> pCmds ShelleyBasedEraAlonzo envCli)
         $ Opt.progDesc "Alonzo era commands"
     , subParser "babbage"
-        $ Opt.info (AnyEraCommandOf ShelleyBasedEraBabbage <$> pCmds BabbageEra envCli)
+        $ Opt.info (AnyEraCommandOf ShelleyBasedEraBabbage <$> pCmds ShelleyBasedEraBabbage envCli)
         $ Opt.progDesc "Babbage era commands"
     , subParser "conway"
-        $ Opt.info (AnyEraCommandOf ShelleyBasedEraConway <$> pCmds ConwayEra envCli)
+        $ Opt.info (AnyEraCommandOf ShelleyBasedEraConway <$> pCmds ShelleyBasedEraConway envCli)
         $ Opt.progDesc "Conway era commands"
 
     , subParser "latest"
-        $ Opt.info (AnyEraCommandOf ShelleyBasedEraBabbage <$> pCmds BabbageEra envCli)
+        $ Opt.info (AnyEraCommandOf ShelleyBasedEraBabbage <$> pCmds ShelleyBasedEraBabbage envCli)
         $ Opt.progDesc "Latest era commands (Babbage)"
     ]
 
-pCmds :: CardanoEra era -> EnvCli -> Parser (Cmds era)
+pCmds :: ShelleyBasedEra era -> EnvCli -> Parser (Cmds era)
 pCmds era envCli =
   asum $ catMaybes
-    [ fmap AddressCmds      <$> pAddressCmds era envCli
+    [ fmap AddressCmds      <$> pAddressCmds (toCardanoEra era) envCli
     , fmap KeyCmds          <$> pKeyCmds
     , fmap GenesisCmds      <$> pGenesisCmds envCli
-    , fmap GovernanceCmds   <$> pGovernanceCmds era
+    , fmap GovernanceCmds   <$> pGovernanceCmds (toCardanoEra era)
     , fmap NodeCmds         <$> pNodeCmds
-    , fmap QueryCmds        <$> pQueryCmds era envCli
-    , fmap StakeAddressCmds <$> pStakeAddressCmds era envCli
-    , fmap StakePoolCmds    <$> pStakePoolCmds era envCli
+    , fmap QueryCmds        <$> pQueryCmds (toCardanoEra era) envCli
+    , fmap StakeAddressCmds <$> pStakeAddressCmds (toCardanoEra era) envCli
+    , fmap StakePoolCmds    <$> pStakePoolCmds (toCardanoEra era) envCli
     , fmap TextViewCmds     <$> pTextViewCmds
-    , fmap TransactionCmds  <$> pTransactionCmds era envCli
+    , fmap TransactionCmds  <$> pTransactionCmds (toCardanoEra era) envCli
     ]

--- a/cardano-cli/src/Cardano/CLI/Options.hs
+++ b/cardano-cli/src/Cardano/CLI/Options.hs
@@ -8,7 +8,7 @@ module Cardano.CLI.Options
   , pref
   ) where
 
-import           Cardano.Api (CardanoEra (..), ShelleyBasedEra (..))
+import           Cardano.Api (ShelleyBasedEra (..))
 
 import           Cardano.CLI.Byron.Parsers (backwardsCompatibilityCommands, parseByronCommands)
 import           Cardano.CLI.Environment (EnvCli)
@@ -82,7 +82,7 @@ parseLegacy envCli =
 
 _parseTopLevelLatest :: EnvCli -> Parser ClientCommand
 _parseTopLevelLatest envCli =
-  AnyEraCommand . AnyEraCommandOf ShelleyBasedEraBabbage <$> pCmds BabbageEra envCli
+  AnyEraCommand . AnyEraCommandOf ShelleyBasedEraBabbage <$> pCmds ShelleyBasedEraBabbage envCli
 
 -- | Parse Legacy commands at the top level of the CLI.
 parseTopLevelLegacy :: EnvCli -> Parser ClientCommand


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Update pCmds to take ShelleyBasedEra era instead of Cardano era
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Additional context for the PR goes here. If the PR fixes a particular issue please provide a [link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=) to the issue.

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
