### PR TITLE
conway governance hash: add option to write hash to file (--out-file)

### DIFF
--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -317,6 +317,7 @@ test-suite cardano-cli-test
 
   other-modules:        Test.Cli.CliIntermediateFormat
                         Test.Cli.FilePermissions
+                        Test.Cli.Governance.Hash
                         Test.Cli.ITN
                         Test.Cli.JSON
                         Test.Cli.Pioneers.Exercise1

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/Hash.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/Hash.hs
@@ -20,8 +20,9 @@ newtype GovernanceHashCmds era = GovernanceHashCmd (GovernanceHashCmdArgs era)
 
 data GovernanceHashCmdArgs era
   = GovernanceHashCmdArgs {
-      eon    :: !(ConwayEraOnwards era),
-      toHash :: !GovernanceHashSource
+      eon     :: !(ConwayEraOnwards era)
+    , toHash  :: !GovernanceHashSource
+    , moutFile :: !(Maybe (File () Out)) -- ^ The output file to which the hash is written
   } deriving Show
 
 data GovernanceHashSource

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Hash.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Hash.hs
@@ -25,9 +25,10 @@ pGovernanceHashCmds era = do
   return
     $ subParser "hash"
     $ Opt.info
-        ( Cmd.GovernanceHashCmd . GovernanceHashCmdArgs eon
-            <$> pGovernanceHashSource
-        )
+        ( fmap Cmd.GovernanceHashCmd
+            (GovernanceHashCmdArgs eon
+               <$> pGovernanceHashSource
+               <*> optional pOutputFile))
     $ Opt.progDesc "Compute the hash to pass to the various --*-hash arguments of governance commands."
 
 pGovernanceHashSource :: Parser Cmd.GovernanceHashSource

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/GovernanceHashError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/GovernanceHashError.hs
@@ -8,10 +8,13 @@ import           Cardano.Api
 import           Cardano.Prelude (Exception (displayException), IOException)
 
 data GovernanceHashError
-  = GovernanceHashReadFileError FilePath IOException
+  = GovernanceHashReadFileError !FilePath !IOException
+  | GovernanceHashWriteFileError !(FileError ())
   deriving Show
 
 instance Error GovernanceHashError where
   displayError = \case
     GovernanceHashReadFileError filepath exc ->
       "Cannot read " <> filepath <> ": " <> displayException exc
+    GovernanceHashWriteFileError fileErr ->
+      displayError fileErr

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Governance/Action.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Governance/Action.hs
@@ -10,6 +10,7 @@ import           Test.Cardano.CLI.Util
 import           Hedgehog (Property)
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.Golden as H
+import qualified Hedgehog.Extras as H
 
 hprop_golden_governance_action_create_constitution :: Property
 hprop_golden_governance_action_create_constitution =
@@ -53,12 +54,18 @@ hprop_golden_conway_governance_action_view_constitution_json :: Property
 hprop_golden_conway_governance_action_view_constitution_json =
   propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     stakeAddressVKeyFile <- H.note "test/cardano-cli-golden/files/input/governance/stake-address.vkey"
+    hashFile <- noteTempFile tempDir "hash.txt"
 
     actionFile <- noteTempFile tempDir "action"
 
-    proposalHash <- execCardanoCLI
+    -- We go through a file for the hash, to test --out-file
+    void $ execCardanoCLI
       [ "conway", "governance", "hash"
-      , "--text", "whatever "]
+      , "--text", "whatever "
+      , "--out-file", hashFile
+      ]
+
+    proposalHash <- H.readFile hashFile
 
     void $ execCardanoCLI
       [ "conway", "governance", "action", "create-constitution"

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -6182,6 +6182,7 @@ Usage: cardano-cli conway governance hash
                                             | --file-binary FILE
                                             | --file-text FILE
                                             )
+                                            [--out-file FILE]
 
   Compute the hash to pass to the various --*-hash arguments of governance
   commands.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_hash.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_hash.cli
@@ -3,6 +3,7 @@ Usage: cardano-cli conway governance hash
                                             | --file-binary FILE
                                             | --file-text FILE
                                             )
+                                            [--out-file FILE]
 
   Compute the hash to pass to the various --*-hash arguments of governance
   commands.
@@ -11,4 +12,5 @@ Available options:
   --text TEXT              Text to hash as UTF-8
   --file-binary FILE       Binary file to hash
   --file-text FILE         Text file to hash
+  --out-file FILE          The output file.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/Governance/Hash.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/Governance/Hash.hs
@@ -1,0 +1,42 @@
+{- HLINT ignore "Use camelCase" -}
+
+module Test.Cli.Governance.Hash where
+
+import           Control.Monad (void)
+
+import           Test.Cardano.CLI.Util
+
+import           Hedgehog (Property)
+import qualified Hedgehog as H
+import qualified Hedgehog.Extras as H
+
+hprop_governance_hash_trip :: Property
+hprop_governance_hash_trip =
+  propertyOnce $ do
+    governance_hash_trip_fun "foo"
+    governance_hash_trip_fun "longerText"
+    governance_hash_trip_fun "nonAscii: 你好"
+    governance_hash_trip_fun "nonAscii: à la mode de Cæn"
+
+-- Test that @cardano-cli conway governance hash --text > file1@ and
+-- @cardano-cli conway governance hash --text --out-file file2@ yields
+-- similar @file1@ and @file2@ files.
+governance_hash_trip_fun :: String -> H.PropertyT IO ()
+governance_hash_trip_fun input =
+  H.moduleWorkspace "tmp" $ \tempDir -> do
+    hashFile <- noteTempFile tempDir "hash.txt"
+
+    hash <- execCardanoCLI
+      [ "conway", "governance", "hash"
+        , "--text", input
+      ]
+
+    void $ execCardanoCLI
+      [ "conway", "governance", "hash"
+      , "--text", input
+      , "--out-file", hashFile
+      ]
+
+    hashFromFile <- H.readFile hashFile
+
+    H.diff hash (==) hashFromFile


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Add `--out-file` flag to `conway governance hash` command, so that it can write its result to a file (instead of only to stdout)
# uncomment types applicable to the change:
  type:
    - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Fixes https://github.com/input-output-hk/cardano-cli/issues/446

# How to trust this PR

Execute `cabal run cardano-cli -- conway governance hash --text foo --out-file out` and witness `out` gets created

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff