### PR TITLE
governance action: prefix stake-verification-key/stake-key arguments with --deposit-return

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Actions.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Actions.hs
@@ -68,7 +68,7 @@ pGovernanceActionNewInfoCmd era = do
             Cmd.GovernanceActionInfoCmdArgs eon
               <$> pNetwork
               <*> pGovActionDeposit
-              <*> pStakeVerificationKeyOrHashOrFile Nothing
+              <*> pStakeVerificationKeyOrHashOrFile (Just "deposit-return")
               <*> pAnchorUrl
               <*> pAnchorDataHash
               <*> pFileOutDirection "out-file" "Path to action file to be used later on with build or build-raw "
@@ -88,7 +88,7 @@ pGovernanceActionNewConstitutionCmd era = do
             Cmd.GovernanceActionCreateConstitutionCmdArgs eon
               <$> pNetwork
               <*> pGovActionDeposit
-              <*> pStakeVerificationKeyOrHashOrFile Nothing
+              <*> pStakeVerificationKeyOrHashOrFile (Just "deposit-return")
               <*> pPreviousGovernanceAction
               <*> pAnchorUrl
               <*> pAnchorDataHash
@@ -118,7 +118,7 @@ pUpdateCommitteeCmd eon =
   Cmd.GoveranceActionUpdateCommitteeCmdArgs eon
     <$> pNetwork
     <*> pGovActionDeposit
-    <*> pStakeVerificationKeyOrHashOrFile Nothing
+    <*> pStakeVerificationKeyOrHashOrFile (Just "deposit-return")
     <*> pAnchorUrl
     <*> pAnchorDataHash
     <*> many pRemoveCommitteeColdVerificationKeyOrHashOrFile
@@ -143,7 +143,7 @@ pGovernanceActionNoConfidenceCmd era = do
             Cmd.GovernanceActionCreateNoConfidenceCmdArgs eon
               <$> pNetwork
               <*> pGovActionDeposit
-              <*> pStakeVerificationKeyOrHashOrFile Nothing
+              <*> pStakeVerificationKeyOrHashOrFile (Just "deposit-return")
               <*> pAnchorUrl
               <*> pAnchorDataHash
               <*> pTxId "governance-action-tx-id" "Previous txid of `NoConfidence` or `NewCommittee` governance action."
@@ -163,7 +163,7 @@ pUpdateProtocolParametersPostConway conwayOnwards =
   Cmd.UpdateProtocolParametersConwayOnwards conwayOnwards
     <$> pNetwork
     <*> pGovActionDeposit
-    <*> pStakeVerificationKeyOrHashOrFile Nothing
+    <*> pStakeVerificationKeyOrHashOrFile (Just "deposit-return")
     <*> pAnchorUrl
     <*> pAnchorDataHash
     <*> pPreviousGovernanceAction

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Governance/Action.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Governance/Action.hs
@@ -8,9 +8,8 @@ import qualified Test.Cardano.CLI.Util as H
 import           Test.Cardano.CLI.Util
 
 import           Hedgehog (Property)
-import qualified Hedgehog.Extras.Test.Base as H
-import qualified Hedgehog.Extras.Test.Golden as H
 import qualified Hedgehog.Extras as H
+import qualified Hedgehog.Extras.Test.Golden as H
 
 hprop_golden_governance_action_create_constitution :: Property
 hprop_golden_governance_action_create_constitution =
@@ -41,7 +40,7 @@ hprop_golden_governance_action_create_constitution =
       , "--anchor-data-hash", "c7ddb5b493faa4d3d2d679847740bdce0c5d358d56f9b1470ca67f5652a02745"
       , "--anchor-url", proposalHash
       , "--governance-action-deposit", "10"
-      , "--stake-verification-key-file", stakeAddressVKeyFile
+      , "--deposit-return-stake-verification-key-file", stakeAddressVKeyFile
       , "--out-file", actionFile
       , "--constitution-url", "constitution-dummy-url"
       , "--constitution-hash", constitutionHash
@@ -82,7 +81,7 @@ hprop_golden_conway_governance_action_view_constitution_json =
       , "--anchor-data-hash", proposalHash
       , "--anchor-url", "proposal-dummy-url"
       , "--governance-action-deposit", "10"
-      , "--stake-verification-key-file", stakeAddressVKeyFile
+      , "--deposit-return-stake-verification-key-file", stakeAddressVKeyFile
       , "--out-file", actionFile
       , "--constitution-url", "http://my-great-constitution.rocks"
       , "--constitution-hash", constitutionHash
@@ -106,7 +105,7 @@ hprop_golden_conway_governance_action_view_update_committee_yaml =
       [ "conway", "governance", "action", "update-committee"
       , "--mainnet"
       , "--governance-action-deposit", "10"
-      , "--stake-verification-key-file", stakeAddressVKeyFile
+      , "--deposit-return-stake-verification-key-file", stakeAddressVKeyFile
       , "--anchor-url", "proposal-dummy-url"
       , "--anchor-data-hash", "c7ddb5b493faa4d3d2d679847740bdce0c5d358d56f9b1470ca67f5652a02745"
       , "--quorum", "0.61"
@@ -132,7 +131,7 @@ hprop_golden_conway_governance_action_view_create_info_json_outfile =
       [ "conway", "governance", "action", "create-info"
       , "--testnet"
       , "--governance-action-deposit", "10"
-      , "--stake-verification-key-file", stakeAddressVKeyFile
+      , "--deposit-return-stake-verification-key-file", stakeAddressVKeyFile
       , "--anchor-url", "proposal-dummy-url"
       , "--anchor-data-hash", "c7ddb5b493faa4d3d2d679847740bdce0c5d358d56f9b1470ca67f5652a02745"
       , "--out-file", actionFile
@@ -158,7 +157,7 @@ hprop_golden_governanceActionCreateNoConfidence =
       [ "conway", "governance", "action", "create-no-confidence"
       , "--mainnet"
       , "--governance-action-deposit", "10"
-      , "--stake-verification-key-file", stakeAddressVKeyFile
+      , "--deposit-return-stake-verification-key-file", stakeAddressVKeyFile
       , "--anchor-url", "proposal-dummy-url"
       , "--anchor-data-hash", "c7ddb5b493faa4d3d2d679847740bdce0c5d358d56f9b1470ca67f5652a02745"
       , "--governance-action-index", "5"

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Governance/Committee.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Governance/Committee.hs
@@ -169,7 +169,7 @@ hprop_golden_governanceUpdateCommittee =
     void $ execCardanoCLI
       [ "conway", "governance", "action", "update-committee"
       , "--testnet", "--governance-action-deposit", "0"
-      , "--stake-verification-key-file", stakeVkey
+      , "--deposit-return-stake-verification-key-file", stakeVkey
       , "--anchor-url", "http://dummy"
       , "--anchor-data-hash", proposalHash
       , "--add-cc-cold-verification-key-file", coldCCVkey1

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -5915,9 +5915,9 @@ Usage: cardano-cli conway governance action create-constitution
                                                                   | --testnet
                                                                   )
                                                                   --governance-action-deposit NATURAL
-                                                                  ( --stake-verification-key STRING
-                                                                  | --stake-verification-key-file FILE
-                                                                  | --stake-key-hash HASH
+                                                                  ( --deposit-return-stake-verification-key STRING
+                                                                  | --deposit-return-stake-verification-key-file FILE
+                                                                  | --deposit-return-stake-key-hash HASH
                                                                   )
                                                                   [--governance-action-tx-id TXID
                                                                     --governance-action-index WORD32]
@@ -5934,9 +5934,9 @@ Usage: cardano-cli conway governance action update-committee
                                                                | --testnet
                                                                )
                                                                --governance-action-deposit NATURAL
-                                                               ( --stake-verification-key STRING
-                                                               | --stake-verification-key-file FILE
-                                                               | --stake-key-hash HASH
+                                                               ( --deposit-return-stake-verification-key STRING
+                                                               | --deposit-return-stake-verification-key-file FILE
+                                                               | --deposit-return-stake-key-hash HASH
                                                                )
                                                                --anchor-url TEXT
                                                                --anchor-data-hash HASH
@@ -5959,9 +5959,9 @@ Usage: cardano-cli conway governance action update-committee
 
 Usage: cardano-cli conway governance action create-info (--mainnet | --testnet)
                                                           --governance-action-deposit NATURAL
-                                                          ( --stake-verification-key STRING
-                                                          | --stake-verification-key-file FILE
-                                                          | --stake-key-hash HASH
+                                                          ( --deposit-return-stake-verification-key STRING
+                                                          | --deposit-return-stake-verification-key-file FILE
+                                                          | --deposit-return-stake-key-hash HASH
                                                           )
                                                           --anchor-url TEXT
                                                           --anchor-data-hash HASH
@@ -5974,9 +5974,9 @@ Usage: cardano-cli conway governance action create-no-confidence
                                                                    | --testnet
                                                                    )
                                                                    --governance-action-deposit NATURAL
-                                                                   ( --stake-verification-key STRING
-                                                                   | --stake-verification-key-file FILE
-                                                                   | --stake-key-hash HASH
+                                                                   ( --deposit-return-stake-verification-key STRING
+                                                                   | --deposit-return-stake-verification-key-file FILE
+                                                                   | --deposit-return-stake-key-hash HASH
                                                                    )
                                                                    --anchor-url TEXT
                                                                    --anchor-data-hash HASH
@@ -5991,9 +5991,9 @@ Usage: cardano-cli conway governance action create-protocol-parameters-update
                                                                                 | --testnet
                                                                                 )
                                                                                 --governance-action-deposit NATURAL
-                                                                                ( --stake-verification-key STRING
-                                                                                | --stake-verification-key-file FILE
-                                                                                | --stake-key-hash HASH
+                                                                                ( --deposit-return-stake-verification-key STRING
+                                                                                | --deposit-return-stake-verification-key-file FILE
+                                                                                | --deposit-return-stake-key-hash HASH
                                                                                 )
                                                                                 --anchor-url TEXT
                                                                                 --anchor-data-hash HASH

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_create-constitution.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_create-constitution.cli
@@ -3,9 +3,9 @@ Usage: cardano-cli conway governance action create-constitution
                                                                   | --testnet
                                                                   )
                                                                   --governance-action-deposit NATURAL
-                                                                  ( --stake-verification-key STRING
-                                                                  | --stake-verification-key-file FILE
-                                                                  | --stake-key-hash HASH
+                                                                  ( --deposit-return-stake-verification-key STRING
+                                                                  | --deposit-return-stake-verification-key-file FILE
+                                                                  | --deposit-return-stake-key-hash HASH
                                                                   )
                                                                   [--governance-action-tx-id TXID
                                                                     --governance-action-index WORD32]
@@ -22,11 +22,12 @@ Available options:
   --testnet                Use the testnet magic id.
   --governance-action-deposit NATURAL
                            Deposit required to submit a governance action.
-  --stake-verification-key STRING
+  --deposit-return-stake-verification-key STRING
                            Stake verification key (Bech32 or hex-encoded).
-  --stake-verification-key-file FILE
+  --deposit-return-stake-verification-key-file FILE
                            Filepath of the staking verification key.
-  --stake-key-hash HASH    Stake verification key hash (hex-encoded).
+  --deposit-return-stake-key-hash HASH
+                           Stake verification key hash (hex-encoded).
   --governance-action-tx-id TXID
                            Previous txid of the governance action.
   --governance-action-index WORD32

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_create-info.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_create-info.cli
@@ -1,8 +1,8 @@
 Usage: cardano-cli conway governance action create-info (--mainnet | --testnet)
                                                           --governance-action-deposit NATURAL
-                                                          ( --stake-verification-key STRING
-                                                          | --stake-verification-key-file FILE
-                                                          | --stake-key-hash HASH
+                                                          ( --deposit-return-stake-verification-key STRING
+                                                          | --deposit-return-stake-verification-key-file FILE
+                                                          | --deposit-return-stake-key-hash HASH
                                                           )
                                                           --anchor-url TEXT
                                                           --anchor-data-hash HASH
@@ -15,11 +15,12 @@ Available options:
   --testnet                Use the testnet magic id.
   --governance-action-deposit NATURAL
                            Deposit required to submit a governance action.
-  --stake-verification-key STRING
+  --deposit-return-stake-verification-key STRING
                            Stake verification key (Bech32 or hex-encoded).
-  --stake-verification-key-file FILE
+  --deposit-return-stake-verification-key-file FILE
                            Filepath of the staking verification key.
-  --stake-key-hash HASH    Stake verification key hash (hex-encoded).
+  --deposit-return-stake-key-hash HASH
+                           Stake verification key hash (hex-encoded).
   --anchor-url TEXT        Anchor URL
   --anchor-data-hash HASH  Proposal anchor data hash (obtain it with
                            "cardano-cli conway governance hash ...")

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_create-no-confidence.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_create-no-confidence.cli
@@ -3,9 +3,9 @@ Usage: cardano-cli conway governance action create-no-confidence
                                                                    | --testnet
                                                                    )
                                                                    --governance-action-deposit NATURAL
-                                                                   ( --stake-verification-key STRING
-                                                                   | --stake-verification-key-file FILE
-                                                                   | --stake-key-hash HASH
+                                                                   ( --deposit-return-stake-verification-key STRING
+                                                                   | --deposit-return-stake-verification-key-file FILE
+                                                                   | --deposit-return-stake-key-hash HASH
                                                                    )
                                                                    --anchor-url TEXT
                                                                    --anchor-data-hash HASH
@@ -20,11 +20,12 @@ Available options:
   --testnet                Use the testnet magic id.
   --governance-action-deposit NATURAL
                            Deposit required to submit a governance action.
-  --stake-verification-key STRING
+  --deposit-return-stake-verification-key STRING
                            Stake verification key (Bech32 or hex-encoded).
-  --stake-verification-key-file FILE
+  --deposit-return-stake-verification-key-file FILE
                            Filepath of the staking verification key.
-  --stake-key-hash HASH    Stake verification key hash (hex-encoded).
+  --deposit-return-stake-key-hash HASH
+                           Stake verification key hash (hex-encoded).
   --anchor-url TEXT        Anchor URL
   --anchor-data-hash HASH  Proposal anchor data hash (obtain it with
                            "cardano-cli conway governance hash ...")

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_create-protocol-parameters-update.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_create-protocol-parameters-update.cli
@@ -3,9 +3,9 @@ Usage: cardano-cli conway governance action create-protocol-parameters-update
                                                                                 | --testnet
                                                                                 )
                                                                                 --governance-action-deposit NATURAL
-                                                                                ( --stake-verification-key STRING
-                                                                                | --stake-verification-key-file FILE
-                                                                                | --stake-key-hash HASH
+                                                                                ( --deposit-return-stake-verification-key STRING
+                                                                                | --deposit-return-stake-verification-key-file FILE
+                                                                                | --deposit-return-stake-key-hash HASH
                                                                                 )
                                                                                 --anchor-url TEXT
                                                                                 --anchor-data-hash HASH
@@ -61,11 +61,12 @@ Available options:
   --testnet                Use the testnet magic id.
   --governance-action-deposit NATURAL
                            Deposit required to submit a governance action.
-  --stake-verification-key STRING
+  --deposit-return-stake-verification-key STRING
                            Stake verification key (Bech32 or hex-encoded).
-  --stake-verification-key-file FILE
+  --deposit-return-stake-verification-key-file FILE
                            Filepath of the staking verification key.
-  --stake-key-hash HASH    Stake verification key hash (hex-encoded).
+  --deposit-return-stake-key-hash HASH
+                           Stake verification key hash (hex-encoded).
   --anchor-url TEXT        Anchor URL
   --anchor-data-hash HASH  Proposal anchor data hash (obtain it with
                            "cardano-cli conway governance hash ...")

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_update-committee.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_update-committee.cli
@@ -3,9 +3,9 @@ Usage: cardano-cli conway governance action update-committee
                                                                | --testnet
                                                                )
                                                                --governance-action-deposit NATURAL
-                                                               ( --stake-verification-key STRING
-                                                               | --stake-verification-key-file FILE
-                                                               | --stake-key-hash HASH
+                                                               ( --deposit-return-stake-verification-key STRING
+                                                               | --deposit-return-stake-verification-key-file FILE
+                                                               | --deposit-return-stake-key-hash HASH
                                                                )
                                                                --anchor-url TEXT
                                                                --anchor-data-hash HASH
@@ -31,11 +31,12 @@ Available options:
   --testnet                Use the testnet magic id.
   --governance-action-deposit NATURAL
                            Deposit required to submit a governance action.
-  --stake-verification-key STRING
+  --deposit-return-stake-verification-key STRING
                            Stake verification key (Bech32 or hex-encoded).
-  --stake-verification-key-file FILE
+  --deposit-return-stake-verification-key-file FILE
                            Filepath of the staking verification key.
-  --stake-key-hash HASH    Stake verification key hash (hex-encoded).
+  --deposit-return-stake-key-hash HASH
+                           Stake verification key hash (hex-encoded).
   --anchor-url TEXT        Anchor URL
   --anchor-data-hash HASH  Proposal anchor data hash (obtain it with
                            "cardano-cli conway governance hash ...")


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    governance actions: prefix `--stake-verification-key-*` and `--stake-key` arguments so that they are prefixed with `--deposit-return` now.
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Fixes https://github.com/input-output-hk/cardano-cli/issues/422

# How to trust this PR

* Only parsers within `Options/Governance/Actions.hs` are modified: we're not changing the behavior outside the `governance action` scope.

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [X] Self-reviewed the diff