### PR TITLE
Use `selectStakeCredentialWitness` instead of duplicating credential selection

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -14,7 +14,7 @@ repository cardano-haskell-packages
 -- you need to run if you change them
 index-state:
   , hackage.haskell.org 2023-11-09T23:50:15Z
-  , cardano-haskell-packages 2023-11-21T19:00:47Z
+  , cardano-haskell-packages 2023-11-24T10:15:21Z
 
 packages:
   cardano-cli

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -206,7 +206,7 @@ library
                       , binary
                       , bytestring
                       , canonical-json
-                      , cardano-api ^>= 8.34.0.0
+                      , cardano-api ^>= 8.34.1.0
                       , cardano-binary
                       , cardano-crypto
                       , cardano-crypto-class ^>= 2.1.2

--- a/cardano-cli/src/Cardano/CLI/Read.hs
+++ b/cardano-cli/src/Cardano/CLI/Read.hs
@@ -337,9 +337,9 @@ readScriptWitness era (PlutusReferenceScriptWitnessFiles refTxIn
                 error "readScriptWitness: Should not be possible to specify a simple script"
               PlutusScriptLanguage version -> do
                 datum <- firstExceptT ScriptWitnessErrorScriptData
-                          $ readScriptDatumOrFile    datumOrFile
+                          $ readScriptDatumOrFile datumOrFile
                 redeemer <- firstExceptT ScriptWitnessErrorScriptData
-                              $ readScriptRedeemerOrFile redeemerOrFile
+                          $ readScriptRedeemerOrFile redeemerOrFile
                 return $ PlutusScriptWitness
                           sLangInEra
                           version

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1700639964,
-        "narHash": "sha256-iQ48z5eqSHP8d7B8BBJtnXkVPIKPvdWc0GhIgy4j8cc=",
+        "lastModified": 1700821603,
+        "narHash": "sha256-BORkay1OBvfVPJ6mbKzhAO3TbRiYbRgqmjJBeMfvMjc=",
         "owner": "input-output-hk",
         "repo": "cardano-haskell-packages",
-        "rev": "eaf713ef8029332b9e4e23685fa157f26086da8b",
+        "rev": "1809a05dc4d7c3eae3b794fe608c29f8953cb13f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Use `selectStakeCredentialWitness` instead of duplicating credential selection
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
   - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
   - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

This PR requires:
* https://github.com/input-output-hk/cardano-api/pull/383

Fixes:
* https://github.com/input-output-hk/cardano-cli/issues/297#issuecomment-1747536111

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
