### PR TITLE
Use node queries with tighter eons. Simplify prettyprinting.

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -14,7 +14,7 @@ repository cardano-haskell-packages
 -- you need to run if you change them
 index-state:
   , hackage.haskell.org 2023-11-09T23:50:15Z
-  , cardano-haskell-packages 2023-11-24T10:15:21Z
+  , cardano-haskell-packages 2023-11-28T17:03:30Z
 
 packages:
   cardano-cli

--- a/cardano-cli/app/cardano-cli.hs
+++ b/cardano-cli/app/cardano-cli.hs
@@ -33,4 +33,4 @@ main = toplevelExceptionHandler $ do
 #endif
   co <- Opt.customExecParser pref (opts envCli)
 
-  orDie (prettyToText . renderClientCommandError) $ runClientCommand co
+  orDie (docToText . renderClientCommandError) $ runClientCommand co

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -206,7 +206,7 @@ library
                       , binary
                       , bytestring
                       , canonical-json
-                      , cardano-api ^>= 8.34.1.0
+                      , cardano-api ^>= 8.35.0.0
                       , cardano-binary
                       , cardano-crypto
                       , cardano-crypto-class ^>= 2.1.2

--- a/cardano-cli/src/Cardano/CLI/Byron/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Parsers.hs
@@ -266,7 +266,7 @@ parseTxIdAtto = (<?> "Transaction ID (hexadecimal)") $ do
   bstr <- Atto.takeWhile1 Char.isHexDigit
   case deserialiseFromRawBytesHex AsTxId bstr of
     Right addr -> return addr
-    Left e -> fail $ prettyToString $ "Incorrect transaction id format: " <> prettyError e
+    Left e -> fail $ docToString $ "Incorrect transaction id format: " <> prettyError e
 
 parseTxIxAtto :: Atto.Parser TxIx
 parseTxIxAtto = toEnum <$> Atto.decimal

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
@@ -178,7 +178,7 @@ parseTxId = do
   str' <- some Parsec.hexDigit <?> "transaction id (hexadecimal)"
   case deserialiseFromRawBytesHex AsTxId (BSC.pack str') of
     Right addr -> return addr
-    Left e -> fail $ prettyToString $ "Incorrect transaction id format: " <> prettyError e
+    Left e -> fail $ docToString $ "Incorrect transaction id format: " <> prettyError e
 
 parseTxIx :: Parsec.Parser TxIx
 parseTxIx = TxIx . fromIntegral <$> decimal
@@ -260,7 +260,7 @@ readVerificationKey asType =
       :: String
       -> Either String (VerificationKey keyrole)
     deserialiseFromBech32OrHex str' =
-      first (prettyToString . renderInputDecodeError) $
+      first (docToString . renderInputDecodeError) $
         deserialiseInput (AsVerificationKey asType) keyFormats (BSC.pack str')
 
 -- | The first argument is the optional prefix.
@@ -498,14 +498,14 @@ pHexHash
   :: SerialiseAsRawBytes (Hash a) => AsType a -> ReadM (Hash a)
 pHexHash a =
   Opt.eitherReader $
-    first (prettyToString . prettyError)
+    first (docToString . prettyError)
       . deserialiseFromRawBytesHex (AsHash a)
       . BSC.pack
 
 pBech32KeyHash :: SerialiseAsBech32 (Hash a) => AsType a -> ReadM (Hash a)
 pBech32KeyHash a =
   Opt.eitherReader $
-    first (prettyToString . prettyError)
+    first (docToString . prettyError)
     . deserialiseFromBech32 (AsHash a)
     . Text.pack
 
@@ -522,7 +522,7 @@ pGenesisDelegateVerificationKey =
       -> Either String (VerificationKey GenesisDelegateKey)
     deserialiseFromHex =
       first
-        (\e -> prettyToString $ "Invalid genesis delegate verification key: " <> prettyError e)
+        (\e -> docToString $ "Invalid genesis delegate verification key: " <> prettyError e)
         . deserialiseFromRawBytesHex (AsVerificationKey AsGenesisDelegateKey)
         . BSC.pack
 
@@ -619,7 +619,7 @@ pAddCommitteeColdVerificationKeyHash =
   where
     deserialiseFromHex :: String -> Either String (Hash CommitteeColdKey)
     deserialiseFromHex =
-      first (\e -> prettyToString $ "Invalid Consitutional Committee cold key hash: " <> prettyError e)
+      first (\e -> docToString $ "Invalid Consitutional Committee cold key hash: " <> prettyError e)
         . deserialiseFromRawBytesHex (AsHash AsCommitteeColdKey)
         . BSC.pack
 
@@ -640,7 +640,7 @@ pAddCommitteeColdVerificationKey =
   where
     deserialiseFromHex :: String -> Either String (VerificationKey CommitteeColdKey)
     deserialiseFromHex =
-      first (\e -> prettyToString $ "Invalid Constitutional Committee cold key: " <> prettyError e)
+      first (\e -> docToString $ "Invalid Constitutional Committee cold key: " <> prettyError e)
         . deserialiseFromRawBytesHex (AsVerificationKey AsCommitteeColdKey)
         . BSC.pack
 
@@ -671,7 +671,7 @@ pRemoveCommitteeColdVerificationKeyHash =
   where
     deserialiseFromHex :: String -> Either String (Hash CommitteeColdKey)
     deserialiseFromHex =
-      first (\e -> prettyToString $ "Invalid Consitutional Committee cold key hash: " <> prettyError e)
+      first (\e -> docToString $ "Invalid Consitutional Committee cold key hash: " <> prettyError e)
         . deserialiseFromRawBytesHex (AsHash AsCommitteeColdKey)
         . BSC.pack
 
@@ -692,7 +692,7 @@ pRemoveCommitteeColdVerificationKey =
   where
     deserialiseFromHex :: String -> Either String (VerificationKey CommitteeColdKey)
     deserialiseFromHex =
-      first (\e -> prettyToString $ "Invalid Constitutional Committee cold key: " <> prettyError e)
+      first (\e -> docToString $ "Invalid Constitutional Committee cold key: " <> prettyError e)
         . deserialiseFromRawBytesHex (AsVerificationKey AsCommitteeColdKey)
         . BSC.pack
 
@@ -731,7 +731,7 @@ pCommitteeColdVerificationKey =
   where
     deserialiseFromHex :: String -> Either String (VerificationKey CommitteeColdKey)
     deserialiseFromHex =
-      first (\e -> prettyToString $ "Invalid Constitutional Committee cold key: " <> prettyError e)
+      first (\e -> docToString $ "Invalid Constitutional Committee cold key: " <> prettyError e)
         . deserialiseFromRawBytesHex (AsVerificationKey AsCommitteeColdKey)
         . BSC.pack
 
@@ -745,7 +745,7 @@ pCommitteeColdVerificationKeyHash =
   where
     deserialiseFromHex :: String -> Either String (Hash CommitteeColdKey)
     deserialiseFromHex =
-      first (\e -> prettyToString $ "Invalid Consitutional Committee cold key hash: " <> prettyError e)
+      first (\e -> docToString $ "Invalid Consitutional Committee cold key hash: " <> prettyError e)
         . deserialiseFromRawBytesHex (AsHash AsCommitteeColdKey)
         . BSC.pack
 
@@ -809,7 +809,7 @@ pCommitteeHotVerificationKey =
 
 deserialiseHotCCKeyFromHex :: String -> Either String (VerificationKey CommitteeHotKey)
 deserialiseHotCCKeyFromHex =
-  first (\e -> prettyToString $ "Invalid Constitutional Committee hot key: " <> prettyError e)
+  first (\e -> docToString $ "Invalid Constitutional Committee hot key: " <> prettyError e)
     . deserialiseFromRawBytesHex (AsVerificationKey AsCommitteeHotKey)
     . BSC.pack
 
@@ -842,7 +842,7 @@ pCommitteeHotKeyHash prefix =
   where
     deserialiseFromHex :: String -> Either String (Hash CommitteeHotKey)
     deserialiseFromHex =
-      first (\e -> prettyToString $ "Invalid Consitutional Committee hot key hash: " <> prettyError e)
+      first (\e -> docToString $ "Invalid Consitutional Committee hot key hash: " <> prettyError e)
         . deserialiseFromRawBytesHex (AsHash AsCommitteeHotKey)
         . BSC.pack
 
@@ -1162,7 +1162,7 @@ pScriptDataOrFile dataFlagPrefix helpTextForValue helpTextForFile =
         Left e -> fail $ "readerScriptData: " <> e
         Right sDataValue ->
           case scriptDataJsonToHashable ScriptDataJsonNoSchema sDataValue of
-            Left err -> fail $ prettyToString $ prettyError err
+            Left err -> fail $ docToString $ prettyError err
             Right sd -> return sd
 
 --------------------------------------------------------------------------------
@@ -1648,7 +1648,7 @@ pGenesisVerificationKeyHash =
   where
     deserialiseFromHex :: String -> Either String (Hash GenesisKey)
     deserialiseFromHex =
-      first (\e -> prettyToString $ "Invalid genesis verification key hash: " <> prettyError e)
+      first (\e -> docToString $ "Invalid genesis verification key hash: " <> prettyError e)
         . deserialiseFromRawBytesHex (AsHash AsGenesisKey)
         . BSC.pack
 
@@ -1662,7 +1662,7 @@ pGenesisVerificationKey =
   where
     deserialiseFromHex :: String -> Either String (VerificationKey GenesisKey)
     deserialiseFromHex =
-      first (\e -> prettyToString $ "Invalid genesis verification key: " <> prettyError e)
+      first (\e -> docToString $ "Invalid genesis verification key: " <> prettyError e)
         . deserialiseFromRawBytesHex (AsVerificationKey AsGenesisKey)
         . BSC.pack
 
@@ -1701,7 +1701,7 @@ pGenesisDelegateVerificationKeyHash =
     deserialiseFromHex =
       first
         (\e ->
-          prettyToString $ "Invalid genesis delegate verification key hash: " <> prettyError e)
+          docToString $ "Invalid genesis delegate verification key hash: " <> prettyError e)
         . deserialiseFromRawBytesHex (AsHash AsGenesisDelegateKey)
         . BSC.pack
 
@@ -1745,15 +1745,15 @@ pKesVerificationKey =
         Right res -> Right res
 
         -- The input was valid Bech32, but some other error occurred.
-        Left err@(Bech32UnexpectedPrefix _ _) -> Left (prettyToString $ prettyError err)
-        Left err@(Bech32DataPartToBytesError _) -> Left (prettyToString $ prettyError err)
-        Left err@(Bech32DeserialiseFromBytesError _) -> Left (prettyToString $ prettyError err)
-        Left err@(Bech32WrongPrefix _ _) -> Left (prettyToString $ prettyError err)
+        Left err@(Bech32UnexpectedPrefix _ _) -> Left (docToString $ prettyError err)
+        Left err@(Bech32DataPartToBytesError _) -> Left (docToString $ prettyError err)
+        Left err@(Bech32DeserialiseFromBytesError _) -> Left (docToString $ prettyError err)
+        Left err@(Bech32WrongPrefix _ _) -> Left (docToString $ prettyError err)
 
         -- The input was not valid Bech32. Attempt to deserialise it as hex.
         Left (Bech32DecodingError _) ->
           first
-            (\e -> prettyToString $ "Invalid stake pool verification key: " <> prettyError e) $
+            (\e -> docToString $ "Invalid stake pool verification key: " <> prettyError e) $
           deserialiseFromRawBytesHex asType (BSC.pack str)
 
 pKesVerificationKeyFile :: Parser (VerificationKeyFile In)
@@ -2318,7 +2318,7 @@ pVrfVerificationKeyHash =
   where
     deserialiseFromHex :: String -> Either String (Hash VrfKey)
     deserialiseFromHex =
-      first (\e -> prettyToString $ "Invalid VRF verification key hash: " <> prettyError e)
+      first (\e -> docToString $ "Invalid VRF verification key hash: " <> prettyError e)
         . deserialiseFromRawBytesHex (AsHash AsVrfKey)
         . BSC.pack
 
@@ -2535,7 +2535,7 @@ pStakePoolMetadataHash =
   where
     metadataHash :: String -> Either String (Hash StakePoolMetadata)
     metadataHash =
-      first (prettyToString . prettyError)
+      first (docToString . prettyError)
         . deserialiseFromRawBytesHex (AsHash AsStakePoolMetadata)
         . BSC.pack
 

--- a/cardano-cli/src/Cardano/CLI/Pretty.hs
+++ b/cardano-cli/src/Cardano/CLI/Pretty.hs
@@ -23,7 +23,7 @@ consoleBracket :: IO a -> IO a
 consoleBracket = bracket_ (IO.waitQSem sem) (IO.signalQSem sem)
 
 putLn :: MonadIO m => Doc AnsiStyle -> m ()
-putLn = liftIO . consoleBracket . TextLazy.putStrLn . prettyToLazyText
+putLn = liftIO . consoleBracket . TextLazy.putStrLn . docToLazyText
 
 hPutLn :: MonadIO m => IO.Handle -> Doc AnsiStyle -> m ()
-hPutLn h = liftIO . consoleBracket . TextLazy.hPutStr h . prettyToLazyText
+hPutLn h = liftIO . consoleBracket . TextLazy.hPutStr h . docToLazyText

--- a/cardano-cli/src/Cardano/CLI/Read.hs
+++ b/cardano-cli/src/Cardano/CLI/Read.hs
@@ -234,7 +234,7 @@ renderScriptWitnessError = \case
     prettyError err
   ScriptWitnessErrorScriptLanguageNotSupportedInEra (AnyScriptLanguage lang) anyEra ->
     "The script language " <> pshow lang <> " is not supported in the " <>
-    pretty (renderEra anyEra) <> " era."
+    pretty anyEra <> " era."
   ScriptWitnessErrorExpectedSimple file (AnyScriptLanguage lang) ->
     pretty file <> ": expected a script in the simple script language, " <>
     "but it is actually using " <> pshow lang <> ". Alternatively, to use " <>
@@ -244,7 +244,7 @@ renderScriptWitnessError = \case
     pretty file <> ": expected a script in the Plutus script language, " <>
     "but it is actually using " <> pshow lang <> "."
   ScriptWitnessErrorReferenceScriptsNotSupportedInEra anyEra ->
-    "Reference scripts not supported in era: " <> pretty (renderEra anyEra)
+    "Reference scripts not supported in era: " <> pretty anyEra
   ScriptWitnessErrorScriptData sDataError ->
     renderScriptDataError sDataError
 

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/QueryCmdLocalStateQueryError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/QueryCmdLocalStateQueryError.hs
@@ -1,12 +1,15 @@
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NamedFieldPuns #-}
 
 module Cardano.CLI.Types.Errors.QueryCmdLocalStateQueryError
   ( QueryCmdLocalStateQueryError(..)
+  , mkEraMismatchError
   , renderLocalStateQueryError
   ) where
 
 import           Cardano.Api.Pretty
 
+import           Cardano.CLI.Types.Errors.NodeEraMismatchError
 import           Ouroboros.Consensus.Cardano.Block (EraMismatch (..))
 
 -- | An error that can occur while querying a node's local state.
@@ -15,6 +18,11 @@ newtype QueryCmdLocalStateQueryError
   -- ^ A query from a certain era was applied to a ledger from a different
   -- era.
   deriving (Eq, Show)
+
+mkEraMismatchError :: NodeEraMismatchError -> QueryCmdLocalStateQueryError
+mkEraMismatchError NodeEraMismatchError{nodeEra, era} =
+  EraMismatchError EraMismatch{ ledgerEraName = docToText $ pretty nodeEra
+                              , otherEraName = docToText $ pretty era}
 
 renderLocalStateQueryError :: QueryCmdLocalStateQueryError -> Doc ann
 renderLocalStateQueryError = \case

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/StakeAddressDelegationError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/StakeAddressDelegationError.hs
@@ -8,13 +8,8 @@ module Cardano.CLI.Types.Errors.StakeAddressDelegationError
 import           Cardano.Api
 import           Cardano.Api.Pretty
 
-import qualified Data.Text as Text
-
 newtype StakeAddressDelegationError = VoteDelegationNotSupported (EraInEon ShelleyToBabbageEra) deriving Show
 
 instance Error StakeAddressDelegationError where
   prettyError = \case
-    VoteDelegationNotSupported (EraInEon eraInEon) -> "Vote delegation not supported in " <> pshow eraTxt <> " era."
-      where
-        cEra = toCardanoEra eraInEon
-        eraTxt = cardanoEraConstraints cEra $ Text.unpack . renderEra $ AnyCardanoEra cEra
+    VoteDelegationNotSupported (EraInEon eraInEon) -> "Vote delegation not supported in " <> pretty (toCardanoEra eraInEon) <> " era."

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/TxCmdError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/TxCmdError.hs
@@ -110,13 +110,13 @@ renderTxCmdError = \case
     renderBootstrapWitnessError sbwErr
   TxCmdTxFeatureMismatch era TxFeatureImplicitFees ->
     "An explicit transaction fee must be specified for " <>
-    pretty (renderEra era) <> " era transactions."
+    pretty era <> " era transactions."
 
   TxCmdTxFeatureMismatch (AnyCardanoEra ShelleyEra) TxFeatureValidityNoUpperBound ->
     "A TTL must be specified for Shelley era transactions."
 
   TxCmdTxFeatureMismatch era feature ->
-    pretty (renderFeature feature) <> " cannot be used for " <> pretty (renderEra era) <>
+    pretty (renderFeature feature) <> " cannot be used for " <> pretty era <>
     " era transactions."
 
   TxCmdTxBodyError err' ->
@@ -127,8 +127,8 @@ renderTxCmdError = \case
 
   TxCmdWitnessEraMismatch era era' (WitnessFile file) ->
     "The era of a witness does not match the era of the transaction. " <>
-    "The transaction is for the " <> pretty (renderEra era) <> " era, but the " <>
-    "witness in " <> pshow file <> " is for the " <> pretty (renderEra era') <> " era."
+    "The transaction is for the " <> pretty era <> " era, but the " <>
+    "witness in " <> pshow file <> " is for the " <> pretty era' <> " era."
 
   TxCmdPolicyIdsMissing policyids ->
     mconcat
@@ -170,8 +170,8 @@ renderTxCmdError = \case
   TxCmdTxNodeEraMismatchError (NodeEraMismatchError { NEM.era = valueEra, nodeEra = nodeEra }) ->
     cardanoEraConstraints nodeEra $ cardanoEraConstraints valueEra $ mconcat
       [ "Transactions can only be produced in the same era as the node. Requested era: "
-      , pretty (renderEra (AnyCardanoEra valueEra)) <> ", node era: "
-      , pretty (renderEra (AnyCardanoEra nodeEra)) <> "."
+      , pretty valueEra <> ", node era: "
+      , pretty nodeEra <> "."
       ]
   TxCmdQueryConvenienceError e ->
     pretty $ renderQueryConvenienceError e

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/TxValidationError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/TxValidationError.hs
@@ -54,7 +54,7 @@ instance Error ScriptLanguageValidationError where
   prettyError = \case
     ScriptLanguageValidationError lang era ->
       "The script language " <> pshow lang <> " is not supported in the " <>
-      pretty (renderEra era) <> " era."
+      pretty era <> " era."
 
 validateScriptSupportedInEra
   :: ShelleyBasedEra era
@@ -74,9 +74,9 @@ data TxFeeValidationError
 
 instance Error TxFeeValidationError where
   prettyError (TxFeatureImplicitFeesE era) =
-    "Implicit transaction fee not supported in " <> pretty (renderEra era)
+    "Implicit transaction fee not supported in " <> pretty era
   prettyError (TxFeatureExplicitFeesE era) =
-    "Explicit transaction fee not supported in " <> pretty (renderEra era)
+    "Explicit transaction fee not supported in " <> pretty era
 
 validateTxFee :: CardanoEra era
               -> Maybe Lovelace
@@ -99,7 +99,7 @@ newtype TxTotalCollateralValidationError
 
 instance Error TxTotalCollateralValidationError where
   prettyError (TxTotalCollateralNotSupported era) =
-    "Transaction collateral not supported in " <> pretty (renderEra era)
+    "Transaction collateral not supported in " <> pretty era
 
 validateTxTotalCollateral :: CardanoEra era
                           -> Maybe Lovelace
@@ -115,7 +115,7 @@ newtype TxReturnCollateralValidationError
 
 instance Error TxReturnCollateralValidationError where
   prettyError (TxReturnCollateralNotSupported era) =
-    "Transaction return collateral not supported in " <> pretty (renderEra era)
+    "Transaction return collateral not supported in " <> pretty era
 
 validateTxReturnCollateral :: CardanoEra era
                            -> Maybe (TxOut CtxTx era)
@@ -131,7 +131,7 @@ newtype TxValidityLowerBoundValidationError
 
 instance Error TxValidityLowerBoundValidationError where
   prettyError (TxValidityLowerBoundNotSupported era) =
-    "Transaction validity lower bound not supported in " <> pretty (renderEra era)
+    "Transaction validity lower bound not supported in " <> pretty era
 
 
 validateTxValidityLowerBound :: CardanoEra era
@@ -148,7 +148,7 @@ newtype TxValidityUpperBoundValidationError
 
 instance Error TxValidityUpperBoundValidationError where
   prettyError (TxValidityUpperBoundNotSupported era) =
-    "Transaction validity upper bound must be specified in " <> pretty (renderEra era)
+    "Transaction validity upper bound must be specified in " <> pretty era
 
 validateTxValidityUpperBound
   :: CardanoEra era
@@ -169,7 +169,7 @@ data TxAuxScriptsValidationError
 
 instance Error TxAuxScriptsValidationError where
   prettyError (TxAuxScriptsNotSupportedInEra era) =
-    "Transaction auxiliary scripts are not supported in " <> pretty (renderEra era)
+    "Transaction auxiliary scripts are not supported in " <> pretty era
   prettyError (TxAuxScriptsLanguageError e) =
     "Transaction auxiliary scripts error: " <> prettyError e
 
@@ -189,7 +189,7 @@ newtype TxRequiredSignersValidationError
 
 instance Error TxRequiredSignersValidationError where
   prettyError (TxRequiredSignersValidationError e) =
-    "Transaction required signers are not supported in " <> pretty (renderEra e)
+    "Transaction required signers are not supported in " <> pretty e
 
 validateRequiredSigners
   :: CardanoEra era
@@ -206,7 +206,7 @@ newtype TxWithdrawalsValidationError
 
 instance Error TxWithdrawalsValidationError where
   prettyError (TxWithdrawalsNotSupported e) =
-    "Transaction withdrawals are not supported in " <> pretty (renderEra e)
+    "Transaction withdrawals are not supported in " <> pretty e
 
 validateTxWithdrawals
   :: forall era.
@@ -233,7 +233,7 @@ newtype TxCertificatesValidationError
 
 instance Error TxCertificatesValidationError where
   prettyError (TxCertificatesValidationNotSupported e) =
-    "Transaction certificates are not supported in " <> pretty (renderEra e)
+    "Transaction certificates are not supported in " <> pretty e
 
 validateTxCertificates
   :: forall era.
@@ -262,7 +262,7 @@ newtype TxProtocolParametersValidationError
 
 instance Error TxProtocolParametersValidationError where
   prettyError (ProtocolParametersNotSupported e) =
-    "Transaction protocol parameters are not supported in " <> pretty (renderEra e)
+    "Transaction protocol parameters are not supported in " <> pretty e
 
 validateProtocolParameters
   :: CardanoEra era
@@ -279,7 +279,7 @@ newtype TxUpdateProposalValidationError
 
 instance Error TxUpdateProposalValidationError where
   prettyError (TxUpdateProposalNotSupported e) =
-    "Transaction update proposal is not supported in " <> pretty (renderEra e)
+    "Transaction update proposal is not supported in " <> pretty e
 
 newtype TxScriptValidityValidationError
   = ScriptValidityNotSupported AnyCardanoEra
@@ -287,7 +287,7 @@ newtype TxScriptValidityValidationError
 
 instance Error TxScriptValidityValidationError where
   prettyError (ScriptValidityNotSupported e) =
-    "Transaction script validity is not supported in " <> pretty (renderEra e)
+    "Transaction script validity is not supported in " <> pretty e
 
 validateTxScriptValidity
   :: CardanoEra era

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Byron/Tx.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Byron/Tx.hs
@@ -60,7 +60,7 @@ getTxByteString :: FilePath -> H.PropertyT IO (ATxAux ByteString)
 getTxByteString txFp = do
   eATxAuxBS <- liftIO . runExceptT $ readByronTx $ File txFp
   case eATxAuxBS of
-    Left err -> failWith Nothing . prettyToString $ renderByronTxError err
+    Left err -> failWith Nothing . docToString $ renderByronTxError err
     Right aTxAuxBS -> return aTxAuxBS
 
 compareByronTxs :: FilePath -> FilePath -> H.PropertyT IO ()

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Byron/UpdateProposal.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Byron/UpdateProposal.hs
@@ -39,12 +39,12 @@ hprop_byron_update_proposal = propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir 
 
   eExpected <- liftIO . runExceptT $ readByronUpdateProposal expectedUpdateProposal
   expected <- case eExpected of
-              Left err -> failWith Nothing . prettyToString $ renderByronUpdateProposalError err
+              Left err -> failWith Nothing . docToString $ renderByronUpdateProposalError err
               Right prop -> return prop
 
   eCreated <- liftIO . runExceptT $ readByronUpdateProposal createdUpdateProposal
   created <- case eCreated of
-               Left err -> failWith Nothing . prettyToString $ renderByronUpdateProposalError err
+               Left err -> failWith Nothing . docToString $ renderByronUpdateProposalError err
                Right prop -> return prop
 
   expected === created

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Byron/Vote.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Byron/Vote.hs
@@ -35,12 +35,12 @@ hprop_byron_yes_vote = propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir -> do
 
   eExpected <- liftIO . runExceptT $ readByronVote expectedYesVote
   expected <- case eExpected of
-              Left err -> failWith Nothing . prettyToString $ renderByronVoteError err
+              Left err -> failWith Nothing . docToString $ renderByronVoteError err
               Right prop -> return prop
 
   eCreated <- liftIO . runExceptT $ readByronVote createdYesVote
   created <- case eCreated of
-               Left err -> failWith Nothing . prettyToString $ renderByronVoteError err
+               Left err -> failWith Nothing . docToString $ renderByronVoteError err
                Right prop -> return prop
 
   expected === created
@@ -62,12 +62,12 @@ hprop_byron_no_vote = propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir -> do
 
   eExpected <- liftIO . runExceptT $ readByronVote expectedNoVote
   expected <- case eExpected of
-              Left err -> failWith Nothing . prettyToString $ renderByronVoteError err
+              Left err -> failWith Nothing . docToString $ renderByronVoteError err
               Right prop -> return prop
 
   eCreated <- liftIO . runExceptT $ readByronVote createdNoVote
   created <- case eCreated of
-               Left err -> failWith Nothing . prettyToString $ renderByronVoteError err
+               Left err -> failWith Nothing . docToString $ renderByronVoteError err
                Right prop -> return prop
 
   expected === created

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/EraBased/Governance/VerifyPoll.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/EraBased/Governance/VerifyPoll.hs
@@ -36,7 +36,7 @@ hprop_golden_governanceVerifyPoll = propertyOnce $ do
 
   liftIO (readVerificationKeyOrTextEnvFile AsStakePoolKey goldenVkFile) >>= \case
     Left e ->
-      H.failWith Nothing $ prettyToString $ prettyError e
+      H.failWith Nothing $ docToString $ prettyError e
     Right vk -> do
       let expected = prettyPrintJSON $ serialiseToRawBytesHexText <$> [verificationKeyHash vk]
       H.assert $ expected `BSC.isInfixOf` stdout

--- a/cardano-cli/test/cardano-cli-test-lib/Test/Cardano/CLI/Util.hs
+++ b/cardano-cli/test/cardano-cli-test-lib/Test/Cardano/CLI/Util.hs
@@ -143,7 +143,7 @@ checkTextEnvelopeFormat tve reference created = GHC.withFrozenCallStack $ do
       Right refTextEnvelope ->
         return refTextEnvelope
       Left fileErr ->
-        failWithCustom GHC.callStack Nothing . (prettyToString . prettyError) $ fileErr
+        failWithCustom GHC.callStack Nothing . (docToString . prettyError) $ fileErr
 
     typeTitleEquivalence :: (MonadTest m, HasCallStack) => TextEnvelope -> TextEnvelope -> m ()
     typeTitleEquivalence (TextEnvelope refType refTitle _)

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1700821603,
-        "narHash": "sha256-BORkay1OBvfVPJ6mbKzhAO3TbRiYbRgqmjJBeMfvMjc=",
+        "lastModified": 1701240793,
+        "narHash": "sha256-mZtPJ5sjCaXXQimpXEPhVxrqOAIdI6gnVjj0srQI6Hk=",
         "owner": "input-output-hk",
         "repo": "cardano-haskell-packages",
-        "rev": "1809a05dc4d7c3eae3b794fe608c29f8953cb13f",
+        "rev": "90d9afaf20e4516840d0e9c6e4a9c40f94f31208",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Use node queries with tighter eons. Simplify prettyprinting.
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
   - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

This PR integrates latest API and requires:
* https://github.com/input-output-hk/cardano-api/pull/386
* https://github.com/input-output-hk/cardano-api/pull/387

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
