### PR TITLE
Fix using queryStakeVoteDelegatees in eras before conway

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Query.hs
@@ -814,9 +814,10 @@ runQueryStakeAddressInfoCmd
           & onLeft (left . QueryCmdUnsupportedNtcVersion)
           & onLeft (left . QueryCmdLocalStateQueryError . EraMismatchError)
 
-        stakeVoteDelegatees <- lift (queryStakeVoteDelegatees sbe stakeAddr)
-          & onLeft (left . QueryCmdUnsupportedNtcVersion)
-          & onLeft (left . QueryCmdLocalStateQueryError . EraMismatchError)
+        stakeVoteDelegatees <- monoidForEraInEonA era $ \(_ :: ConwayEraOnwards era) ->
+          lift (queryStakeVoteDelegatees sbe stakeAddr)
+            & onLeft (left . QueryCmdUnsupportedNtcVersion)
+            & onLeft (left . QueryCmdLocalStateQueryError . EraMismatchError)
 
         return $ do
           writeStakeAddressInfo


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Fix using queryStakeVoteDelegatees in eras before conway
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
   - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
   - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Fix https://github.com/input-output-hk/cardano-cli/issues/480

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
