### PR TITLE
Update the `--key-output-format` help text: default is text-envelope

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
@@ -1549,7 +1549,7 @@ pKeyOutputFormat =
     , Opt.metavar "STRING"
     , Opt.help $ mconcat
       [ "Optional key output format. Accepted output formats are \"text-envelope\" "
-      , "and \"bech32\" (default is \"bech32\")."
+      , "and \"bech32\" (default is \"text-envelope\")."
       ]
     , Opt.value KeyOutputFormatTextEnvelope
     ]

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/address_key-gen.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/address_key-gen.cli
@@ -12,7 +12,7 @@ Available options:
   --key-output-format STRING
                            Optional key output format. Accepted output formats
                            are "text-envelope" and "bech32" (default is
-                           "bech32").
+                           "text-envelope").
   --normal-key             Use a normal Shelley-era key (default).
   --extended-key           Use an extended ed25519 Shelley-era key.
   --byron-key              Use a Byron-era key.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_address_key-gen.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_address_key-gen.cli
@@ -12,7 +12,7 @@ Available options:
   --key-output-format STRING
                            Optional key output format. Accepted output formats
                            are "text-envelope" and "bech32" (default is
-                           "bech32").
+                           "text-envelope").
   --normal-key             Use a normal Shelley-era key (default).
   --extended-key           Use an extended ed25519 Shelley-era key.
   --byron-key              Use a Byron-era key.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_genesis_create-staked.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_genesis_create-staked.cli
@@ -22,7 +22,7 @@ Available options:
   --key-output-format STRING
                            Optional key output format. Accepted output formats
                            are "text-envelope" and "bech32" (default is
-                           "bech32").
+                           "text-envelope").
   --genesis-dir DIR        The genesis directory containing the genesis template
                            and required genesis/delegation/spending keys.
   --gen-genesis-keys INT   The number of genesis keys to make [default is 3].

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_genesis_create.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_genesis_create.cli
@@ -15,7 +15,7 @@ Available options:
   --key-output-format STRING
                            Optional key output format. Accepted output formats
                            are "text-envelope" and "bech32" (default is
-                           "bech32").
+                           "text-envelope").
   --genesis-dir DIR        The genesis directory containing the genesis template
                            and required genesis/delegation/spending keys.
   --gen-genesis-keys INT   The number of genesis keys to make [default is 3].

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_node_key-gen-KES.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_node_key-gen-KES.cli
@@ -8,7 +8,7 @@ Available options:
   --key-output-format STRING
                            Optional key output format. Accepted output formats
                            are "text-envelope" and "bech32" (default is
-                           "bech32").
+                           "text-envelope").
   --verification-key-file FILE
                            Output filepath of the verification key.
   --signing-key-file FILE  Output filepath of the signing key.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_node_key-gen-VRF.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_node_key-gen-VRF.cli
@@ -8,7 +8,7 @@ Available options:
   --key-output-format STRING
                            Optional key output format. Accepted output formats
                            are "text-envelope" and "bech32" (default is
-                           "bech32").
+                           "text-envelope").
   --verification-key-file FILE
                            Output filepath of the verification key.
   --signing-key-file FILE  Output filepath of the signing key.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_node_key-gen.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_node_key-gen.cli
@@ -10,7 +10,7 @@ Available options:
   --key-output-format STRING
                            Optional key output format. Accepted output formats
                            are "text-envelope" and "bech32" (default is
-                           "bech32").
+                           "text-envelope").
   --cold-verification-key-file FILE
                            Filepath of the cold verification key.
   --cold-signing-key-file FILE

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_stake-address_key-gen.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_stake-address_key-gen.cli
@@ -8,7 +8,7 @@ Available options:
   --key-output-format STRING
                            Optional key output format. Accepted output formats
                            are "text-envelope" and "bech32" (default is
-                           "bech32").
+                           "text-envelope").
   --verification-key-file FILE
                            Output filepath of the verification key.
   --signing-key-file FILE  Output filepath of the signing key.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_address_key-gen.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_address_key-gen.cli
@@ -12,7 +12,7 @@ Available options:
   --key-output-format STRING
                            Optional key output format. Accepted output formats
                            are "text-envelope" and "bech32" (default is
-                           "bech32").
+                           "text-envelope").
   --normal-key             Use a normal Shelley-era key (default).
   --extended-key           Use an extended ed25519 Shelley-era key.
   --byron-key              Use a Byron-era key.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_genesis_create-staked.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_genesis_create-staked.cli
@@ -22,7 +22,7 @@ Available options:
   --key-output-format STRING
                            Optional key output format. Accepted output formats
                            are "text-envelope" and "bech32" (default is
-                           "bech32").
+                           "text-envelope").
   --genesis-dir DIR        The genesis directory containing the genesis template
                            and required genesis/delegation/spending keys.
   --gen-genesis-keys INT   The number of genesis keys to make [default is 3].

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_genesis_create.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_genesis_create.cli
@@ -13,7 +13,7 @@ Available options:
   --key-output-format STRING
                            Optional key output format. Accepted output formats
                            are "text-envelope" and "bech32" (default is
-                           "bech32").
+                           "text-envelope").
   --genesis-dir DIR        The genesis directory containing the genesis template
                            and required genesis/delegation/spending keys.
   --gen-genesis-keys INT   The number of genesis keys to make [default is 3].

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_node_key-gen-KES.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_node_key-gen-KES.cli
@@ -8,7 +8,7 @@ Available options:
   --key-output-format STRING
                            Optional key output format. Accepted output formats
                            are "text-envelope" and "bech32" (default is
-                           "bech32").
+                           "text-envelope").
   --verification-key-file FILE
                            Output filepath of the verification key.
   --signing-key-file FILE  Output filepath of the signing key.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_node_key-gen-VRF.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_node_key-gen-VRF.cli
@@ -8,7 +8,7 @@ Available options:
   --key-output-format STRING
                            Optional key output format. Accepted output formats
                            are "text-envelope" and "bech32" (default is
-                           "bech32").
+                           "text-envelope").
   --verification-key-file FILE
                            Output filepath of the verification key.
   --signing-key-file FILE  Output filepath of the signing key.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_node_key-gen.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_node_key-gen.cli
@@ -10,7 +10,7 @@ Available options:
   --key-output-format STRING
                            Optional key output format. Accepted output formats
                            are "text-envelope" and "bech32" (default is
-                           "bech32").
+                           "text-envelope").
   --cold-verification-key-file FILE
                            Filepath of the cold verification key.
   --cold-signing-key-file FILE

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_stake-address_key-gen.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_stake-address_key-gen.cli
@@ -8,7 +8,7 @@ Available options:
   --key-output-format STRING
                            Optional key output format. Accepted output formats
                            are "text-envelope" and "bech32" (default is
-                           "bech32").
+                           "text-envelope").
   --verification-key-file FILE
                            Output filepath of the verification key.
   --signing-key-file FILE  Output filepath of the signing key.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_address_key-gen.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_address_key-gen.cli
@@ -12,7 +12,7 @@ Available options:
   --key-output-format STRING
                            Optional key output format. Accepted output formats
                            are "text-envelope" and "bech32" (default is
-                           "bech32").
+                           "text-envelope").
   --normal-key             Use a normal Shelley-era key (default).
   --extended-key           Use an extended ed25519 Shelley-era key.
   --byron-key              Use a Byron-era key.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_genesis_create-staked.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_genesis_create-staked.cli
@@ -22,7 +22,7 @@ Available options:
   --key-output-format STRING
                            Optional key output format. Accepted output formats
                            are "text-envelope" and "bech32" (default is
-                           "bech32").
+                           "text-envelope").
   --genesis-dir DIR        The genesis directory containing the genesis template
                            and required genesis/delegation/spending keys.
   --gen-genesis-keys INT   The number of genesis keys to make [default is 3].

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_genesis_create.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_genesis_create.cli
@@ -15,7 +15,7 @@ Available options:
   --key-output-format STRING
                            Optional key output format. Accepted output formats
                            are "text-envelope" and "bech32" (default is
-                           "bech32").
+                           "text-envelope").
   --genesis-dir DIR        The genesis directory containing the genesis template
                            and required genesis/delegation/spending keys.
   --gen-genesis-keys INT   The number of genesis keys to make [default is 3].

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_node_key-gen-KES.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_node_key-gen-KES.cli
@@ -8,7 +8,7 @@ Available options:
   --key-output-format STRING
                            Optional key output format. Accepted output formats
                            are "text-envelope" and "bech32" (default is
-                           "bech32").
+                           "text-envelope").
   --verification-key-file FILE
                            Output filepath of the verification key.
   --signing-key-file FILE  Output filepath of the signing key.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_node_key-gen-VRF.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_node_key-gen-VRF.cli
@@ -8,7 +8,7 @@ Available options:
   --key-output-format STRING
                            Optional key output format. Accepted output formats
                            are "text-envelope" and "bech32" (default is
-                           "bech32").
+                           "text-envelope").
   --verification-key-file FILE
                            Output filepath of the verification key.
   --signing-key-file FILE  Output filepath of the signing key.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_node_key-gen.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_node_key-gen.cli
@@ -10,7 +10,7 @@ Available options:
   --key-output-format STRING
                            Optional key output format. Accepted output formats
                            are "text-envelope" and "bech32" (default is
-                           "bech32").
+                           "text-envelope").
   --cold-verification-key-file FILE
                            Filepath of the cold verification key.
   --cold-signing-key-file FILE

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_stake-address_key-gen.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_stake-address_key-gen.cli
@@ -8,7 +8,7 @@ Available options:
   --key-output-format STRING
                            Optional key output format. Accepted output formats
                            are "text-envelope" and "bech32" (default is
-                           "bech32").
+                           "text-envelope").
   --verification-key-file FILE
                            Output filepath of the verification key.
   --signing-key-file FILE  Output filepath of the signing key.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_address_key-gen.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_address_key-gen.cli
@@ -12,7 +12,7 @@ Available options:
   --key-output-format STRING
                            Optional key output format. Accepted output formats
                            are "text-envelope" and "bech32" (default is
-                           "bech32").
+                           "text-envelope").
   --normal-key             Use a normal Shelley-era key (default).
   --extended-key           Use an extended ed25519 Shelley-era key.
   --byron-key              Use a Byron-era key.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_genesis_create-staked.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_genesis_create-staked.cli
@@ -22,7 +22,7 @@ Available options:
   --key-output-format STRING
                            Optional key output format. Accepted output formats
                            are "text-envelope" and "bech32" (default is
-                           "bech32").
+                           "text-envelope").
   --genesis-dir DIR        The genesis directory containing the genesis template
                            and required genesis/delegation/spending keys.
   --gen-genesis-keys INT   The number of genesis keys to make [default is 3].

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_genesis_create.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_genesis_create.cli
@@ -13,7 +13,7 @@ Available options:
   --key-output-format STRING
                            Optional key output format. Accepted output formats
                            are "text-envelope" and "bech32" (default is
-                           "bech32").
+                           "text-envelope").
   --genesis-dir DIR        The genesis directory containing the genesis template
                            and required genesis/delegation/spending keys.
   --gen-genesis-keys INT   The number of genesis keys to make [default is 3].

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_node_key-gen-KES.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_node_key-gen-KES.cli
@@ -8,7 +8,7 @@ Available options:
   --key-output-format STRING
                            Optional key output format. Accepted output formats
                            are "text-envelope" and "bech32" (default is
-                           "bech32").
+                           "text-envelope").
   --verification-key-file FILE
                            Output filepath of the verification key.
   --signing-key-file FILE  Output filepath of the signing key.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_node_key-gen-VRF.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_node_key-gen-VRF.cli
@@ -8,7 +8,7 @@ Available options:
   --key-output-format STRING
                            Optional key output format. Accepted output formats
                            are "text-envelope" and "bech32" (default is
-                           "bech32").
+                           "text-envelope").
   --verification-key-file FILE
                            Output filepath of the verification key.
   --signing-key-file FILE  Output filepath of the signing key.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_node_key-gen.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_node_key-gen.cli
@@ -10,7 +10,7 @@ Available options:
   --key-output-format STRING
                            Optional key output format. Accepted output formats
                            are "text-envelope" and "bech32" (default is
-                           "bech32").
+                           "text-envelope").
   --cold-verification-key-file FILE
                            Filepath of the cold verification key.
   --cold-signing-key-file FILE

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_stake-address_key-gen.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_stake-address_key-gen.cli
@@ -8,7 +8,7 @@ Available options:
   --key-output-format STRING
                            Optional key output format. Accepted output formats
                            are "text-envelope" and "bech32" (default is
-                           "bech32").
+                           "text-envelope").
   --verification-key-file FILE
                            Output filepath of the verification key.
   --signing-key-file FILE  Output filepath of the signing key.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/genesis_create-staked.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/genesis_create-staked.cli
@@ -20,7 +20,7 @@ Available options:
   --key-output-format STRING
                            Optional key output format. Accepted output formats
                            are "text-envelope" and "bech32" (default is
-                           "bech32").
+                           "text-envelope").
   --genesis-dir DIR        The genesis directory containing the genesis template
                            and required genesis/delegation/spending keys.
   --gen-genesis-keys INT   The number of genesis keys to make [default is 3].

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/genesis_create.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/genesis_create.cli
@@ -13,7 +13,7 @@ Available options:
   --key-output-format STRING
                            Optional key output format. Accepted output formats
                            are "text-envelope" and "bech32" (default is
-                           "bech32").
+                           "text-envelope").
   --genesis-dir DIR        The genesis directory containing the genesis template
                            and required genesis/delegation/spending keys.
   --gen-genesis-keys INT   The number of genesis keys to make [default is 3].

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_address_key-gen.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_address_key-gen.cli
@@ -12,7 +12,7 @@ Available options:
   --key-output-format STRING
                            Optional key output format. Accepted output formats
                            are "text-envelope" and "bech32" (default is
-                           "bech32").
+                           "text-envelope").
   --normal-key             Use a normal Shelley-era key (default).
   --extended-key           Use an extended ed25519 Shelley-era key.
   --byron-key              Use a Byron-era key.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_genesis_create-staked.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_genesis_create-staked.cli
@@ -22,7 +22,7 @@ Available options:
   --key-output-format STRING
                            Optional key output format. Accepted output formats
                            are "text-envelope" and "bech32" (default is
-                           "bech32").
+                           "text-envelope").
   --genesis-dir DIR        The genesis directory containing the genesis template
                            and required genesis/delegation/spending keys.
   --gen-genesis-keys INT   The number of genesis keys to make [default is 3].

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_genesis_create.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_genesis_create.cli
@@ -13,7 +13,7 @@ Available options:
   --key-output-format STRING
                            Optional key output format. Accepted output formats
                            are "text-envelope" and "bech32" (default is
-                           "bech32").
+                           "text-envelope").
   --genesis-dir DIR        The genesis directory containing the genesis template
                            and required genesis/delegation/spending keys.
   --gen-genesis-keys INT   The number of genesis keys to make [default is 3].

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_node_key-gen-KES.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_node_key-gen-KES.cli
@@ -8,7 +8,7 @@ Available options:
   --key-output-format STRING
                            Optional key output format. Accepted output formats
                            are "text-envelope" and "bech32" (default is
-                           "bech32").
+                           "text-envelope").
   --verification-key-file FILE
                            Output filepath of the verification key.
   --signing-key-file FILE  Output filepath of the signing key.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_node_key-gen-VRF.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_node_key-gen-VRF.cli
@@ -8,7 +8,7 @@ Available options:
   --key-output-format STRING
                            Optional key output format. Accepted output formats
                            are "text-envelope" and "bech32" (default is
-                           "bech32").
+                           "text-envelope").
   --verification-key-file FILE
                            Output filepath of the verification key.
   --signing-key-file FILE  Output filepath of the signing key.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_node_key-gen.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_node_key-gen.cli
@@ -10,7 +10,7 @@ Available options:
   --key-output-format STRING
                            Optional key output format. Accepted output formats
                            are "text-envelope" and "bech32" (default is
-                           "bech32").
+                           "text-envelope").
   --cold-verification-key-file FILE
                            Filepath of the cold verification key.
   --cold-signing-key-file FILE

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_stake-address_key-gen.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_stake-address_key-gen.cli
@@ -8,7 +8,7 @@ Available options:
   --key-output-format STRING
                            Optional key output format. Accepted output formats
                            are "text-envelope" and "bech32" (default is
-                           "bech32").
+                           "text-envelope").
   --verification-key-file FILE
                            Output filepath of the verification key.
   --signing-key-file FILE  Output filepath of the signing key.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_address_key-gen.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_address_key-gen.cli
@@ -12,7 +12,7 @@ Available options:
   --key-output-format STRING
                            Optional key output format. Accepted output formats
                            are "text-envelope" and "bech32" (default is
-                           "bech32").
+                           "text-envelope").
   --normal-key             Use a normal Shelley-era key (default).
   --extended-key           Use an extended ed25519 Shelley-era key.
   --byron-key              Use a Byron-era key.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_genesis_create-staked.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_genesis_create-staked.cli
@@ -22,7 +22,7 @@ Available options:
   --key-output-format STRING
                            Optional key output format. Accepted output formats
                            are "text-envelope" and "bech32" (default is
-                           "bech32").
+                           "text-envelope").
   --genesis-dir DIR        The genesis directory containing the genesis template
                            and required genesis/delegation/spending keys.
   --gen-genesis-keys INT   The number of genesis keys to make [default is 3].

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_genesis_create.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_genesis_create.cli
@@ -13,7 +13,7 @@ Available options:
   --key-output-format STRING
                            Optional key output format. Accepted output formats
                            are "text-envelope" and "bech32" (default is
-                           "bech32").
+                           "text-envelope").
   --genesis-dir DIR        The genesis directory containing the genesis template
                            and required genesis/delegation/spending keys.
   --gen-genesis-keys INT   The number of genesis keys to make [default is 3].

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_node_key-gen-KES.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_node_key-gen-KES.cli
@@ -8,7 +8,7 @@ Available options:
   --key-output-format STRING
                            Optional key output format. Accepted output formats
                            are "text-envelope" and "bech32" (default is
-                           "bech32").
+                           "text-envelope").
   --verification-key-file FILE
                            Output filepath of the verification key.
   --signing-key-file FILE  Output filepath of the signing key.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_node_key-gen-VRF.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_node_key-gen-VRF.cli
@@ -8,7 +8,7 @@ Available options:
   --key-output-format STRING
                            Optional key output format. Accepted output formats
                            are "text-envelope" and "bech32" (default is
-                           "bech32").
+                           "text-envelope").
   --verification-key-file FILE
                            Output filepath of the verification key.
   --signing-key-file FILE  Output filepath of the signing key.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_node_key-gen.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_node_key-gen.cli
@@ -10,7 +10,7 @@ Available options:
   --key-output-format STRING
                            Optional key output format. Accepted output formats
                            are "text-envelope" and "bech32" (default is
-                           "bech32").
+                           "text-envelope").
   --cold-verification-key-file FILE
                            Filepath of the cold verification key.
   --cold-signing-key-file FILE

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_stake-address_key-gen.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_stake-address_key-gen.cli
@@ -8,7 +8,7 @@ Available options:
   --key-output-format STRING
                            Optional key output format. Accepted output formats
                            are "text-envelope" and "bech32" (default is
-                           "bech32").
+                           "text-envelope").
   --verification-key-file FILE
                            Output filepath of the verification key.
   --signing-key-file FILE  Output filepath of the signing key.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_address_key-gen.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_address_key-gen.cli
@@ -12,7 +12,7 @@ Available options:
   --key-output-format STRING
                            Optional key output format. Accepted output formats
                            are "text-envelope" and "bech32" (default is
-                           "bech32").
+                           "text-envelope").
   --normal-key             Use a normal Shelley-era key (default).
   --extended-key           Use an extended ed25519 Shelley-era key.
   --byron-key              Use a Byron-era key.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_genesis_create-staked.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_genesis_create-staked.cli
@@ -22,7 +22,7 @@ Available options:
   --key-output-format STRING
                            Optional key output format. Accepted output formats
                            are "text-envelope" and "bech32" (default is
-                           "bech32").
+                           "text-envelope").
   --genesis-dir DIR        The genesis directory containing the genesis template
                            and required genesis/delegation/spending keys.
   --gen-genesis-keys INT   The number of genesis keys to make [default is 3].

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_genesis_create.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_genesis_create.cli
@@ -13,7 +13,7 @@ Available options:
   --key-output-format STRING
                            Optional key output format. Accepted output formats
                            are "text-envelope" and "bech32" (default is
-                           "bech32").
+                           "text-envelope").
   --genesis-dir DIR        The genesis directory containing the genesis template
                            and required genesis/delegation/spending keys.
   --gen-genesis-keys INT   The number of genesis keys to make [default is 3].

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_node_key-gen-KES.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_node_key-gen-KES.cli
@@ -8,7 +8,7 @@ Available options:
   --key-output-format STRING
                            Optional key output format. Accepted output formats
                            are "text-envelope" and "bech32" (default is
-                           "bech32").
+                           "text-envelope").
   --verification-key-file FILE
                            Output filepath of the verification key.
   --signing-key-file FILE  Output filepath of the signing key.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_node_key-gen-VRF.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_node_key-gen-VRF.cli
@@ -8,7 +8,7 @@ Available options:
   --key-output-format STRING
                            Optional key output format. Accepted output formats
                            are "text-envelope" and "bech32" (default is
-                           "bech32").
+                           "text-envelope").
   --verification-key-file FILE
                            Output filepath of the verification key.
   --signing-key-file FILE  Output filepath of the signing key.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_node_key-gen.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_node_key-gen.cli
@@ -10,7 +10,7 @@ Available options:
   --key-output-format STRING
                            Optional key output format. Accepted output formats
                            are "text-envelope" and "bech32" (default is
-                           "bech32").
+                           "text-envelope").
   --cold-verification-key-file FILE
                            Filepath of the cold verification key.
   --cold-signing-key-file FILE

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_stake-address_key-gen.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_stake-address_key-gen.cli
@@ -8,7 +8,7 @@ Available options:
   --key-output-format STRING
                            Optional key output format. Accepted output formats
                            are "text-envelope" and "bech32" (default is
-                           "bech32").
+                           "text-envelope").
   --verification-key-file FILE
                            Output filepath of the verification key.
   --signing-key-file FILE  Output filepath of the signing key.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/node_key-gen-KES.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/node_key-gen-KES.cli
@@ -8,7 +8,7 @@ Available options:
   --key-output-format STRING
                            Optional key output format. Accepted output formats
                            are "text-envelope" and "bech32" (default is
-                           "bech32").
+                           "text-envelope").
   --verification-key-file FILE
                            Output filepath of the verification key.
   --signing-key-file FILE  Output filepath of the signing key.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/node_key-gen-VRF.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/node_key-gen-VRF.cli
@@ -8,7 +8,7 @@ Available options:
   --key-output-format STRING
                            Optional key output format. Accepted output formats
                            are "text-envelope" and "bech32" (default is
-                           "bech32").
+                           "text-envelope").
   --verification-key-file FILE
                            Output filepath of the verification key.
   --signing-key-file FILE  Output filepath of the signing key.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/node_key-gen.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/node_key-gen.cli
@@ -10,7 +10,7 @@ Available options:
   --key-output-format STRING
                            Optional key output format. Accepted output formats
                            are "text-envelope" and "bech32" (default is
-                           "bech32").
+                           "text-envelope").
   --cold-verification-key-file FILE
                            Filepath of the cold verification key.
   --cold-signing-key-file FILE

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_address_key-gen.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_address_key-gen.cli
@@ -12,7 +12,7 @@ Available options:
   --key-output-format STRING
                            Optional key output format. Accepted output formats
                            are "text-envelope" and "bech32" (default is
-                           "bech32").
+                           "text-envelope").
   --normal-key             Use a normal Shelley-era key (default).
   --extended-key           Use an extended ed25519 Shelley-era key.
   --byron-key              Use a Byron-era key.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_genesis_create-staked.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_genesis_create-staked.cli
@@ -22,7 +22,7 @@ Available options:
   --key-output-format STRING
                            Optional key output format. Accepted output formats
                            are "text-envelope" and "bech32" (default is
-                           "bech32").
+                           "text-envelope").
   --genesis-dir DIR        The genesis directory containing the genesis template
                            and required genesis/delegation/spending keys.
   --gen-genesis-keys INT   The number of genesis keys to make [default is 3].

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_genesis_create.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_genesis_create.cli
@@ -15,7 +15,7 @@ Available options:
   --key-output-format STRING
                            Optional key output format. Accepted output formats
                            are "text-envelope" and "bech32" (default is
-                           "bech32").
+                           "text-envelope").
   --genesis-dir DIR        The genesis directory containing the genesis template
                            and required genesis/delegation/spending keys.
   --gen-genesis-keys INT   The number of genesis keys to make [default is 3].

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_node_key-gen-KES.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_node_key-gen-KES.cli
@@ -8,7 +8,7 @@ Available options:
   --key-output-format STRING
                            Optional key output format. Accepted output formats
                            are "text-envelope" and "bech32" (default is
-                           "bech32").
+                           "text-envelope").
   --verification-key-file FILE
                            Output filepath of the verification key.
   --signing-key-file FILE  Output filepath of the signing key.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_node_key-gen-VRF.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_node_key-gen-VRF.cli
@@ -8,7 +8,7 @@ Available options:
   --key-output-format STRING
                            Optional key output format. Accepted output formats
                            are "text-envelope" and "bech32" (default is
-                           "bech32").
+                           "text-envelope").
   --verification-key-file FILE
                            Output filepath of the verification key.
   --signing-key-file FILE  Output filepath of the signing key.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_node_key-gen.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_node_key-gen.cli
@@ -10,7 +10,7 @@ Available options:
   --key-output-format STRING
                            Optional key output format. Accepted output formats
                            are "text-envelope" and "bech32" (default is
-                           "bech32").
+                           "text-envelope").
   --cold-verification-key-file FILE
                            Filepath of the cold verification key.
   --cold-signing-key-file FILE

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_stake-address_key-gen.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_stake-address_key-gen.cli
@@ -8,7 +8,7 @@ Available options:
   --key-output-format STRING
                            Optional key output format. Accepted output formats
                            are "text-envelope" and "bech32" (default is
-                           "bech32").
+                           "text-envelope").
   --verification-key-file FILE
                            Output filepath of the verification key.
   --signing-key-file FILE  Output filepath of the signing key.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/stake-address_key-gen.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/stake-address_key-gen.cli
@@ -8,7 +8,7 @@ Available options:
   --key-output-format STRING
                            Optional key output format. Accepted output formats
                            are "text-envelope" and "bech32" (default is
-                           "bech32").
+                           "text-envelope").
   --verification-key-file FILE
                            Output filepath of the verification key.
   --signing-key-file FILE  Output filepath of the signing key.


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Update the help text for `--key-output-format` to say that the default is text-envelope
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  - documentation  # change in code docs, haddocks...
```

# Context

This closes #485.

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
