### PR TITLE
Fix era mismatch error in stake-address-info

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Query.hs
@@ -32,7 +32,6 @@ module Cardano.CLI.EraBased.Run.Query
 
   , DelegationsAndRewards(..)
   , renderQueryCmdError
-  , renderLocalStateQueryError
   , renderOpCertIntervalInformation
   , percentage
   ) where
@@ -821,11 +820,10 @@ runQueryStakeAddressInfoCmd
           & onLeft (left . QueryCmdUnsupportedNtcVersion)
           & onLeft (left . QueryCmdLocalStateQueryError . EraMismatchError)
 
-        ceo <- requireEon ConwayEra era
-
-        stakeVoteDelegatees <- lift (queryStakeVoteDelegatees ceo stakeAddr)
-          & onLeft (left . QueryCmdUnsupportedNtcVersion)
-          & onLeft (left . QueryCmdLocalStateQueryError . EraMismatchError)
+        stakeVoteDelegatees <- monoidForEraInEonA era $ \ceo ->
+          lift (queryStakeVoteDelegatees ceo stakeAddr)
+            & onLeft (left . QueryCmdUnsupportedNtcVersion)
+            & onLeft (left . QueryCmdLocalStateQueryError . EraMismatchError)
 
         return $ do
           writeStakeAddressInfo

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/QueryCmdError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/QueryCmdError.hs
@@ -59,7 +59,7 @@ data QueryCmdError
 renderQueryCmdError :: QueryCmdError -> Doc ann
 renderQueryCmdError = \case
   QueryCmdLocalStateQueryError lsqErr ->
-    renderLocalStateQueryError lsqErr
+    prettyError lsqErr
   QueryCmdWriteFileError fileErr ->
     prettyError fileErr
   QueryCmdHelpersError helpersErr ->

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/QueryCmdLocalStateQueryError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/QueryCmdLocalStateQueryError.hs
@@ -4,19 +4,20 @@
 module Cardano.CLI.Types.Errors.QueryCmdLocalStateQueryError
   ( QueryCmdLocalStateQueryError(..)
   , mkEraMismatchError
-  , renderLocalStateQueryError
   ) where
 
+import           Cardano.Api (Error (..))
 import           Cardano.Api.Pretty
 
 import           Cardano.CLI.Types.Errors.NodeEraMismatchError
 import           Ouroboros.Consensus.Cardano.Block (EraMismatch (..))
 
+import           Prettyprinter ((<+>))
+
 -- | An error that can occur while querying a node's local state.
 newtype QueryCmdLocalStateQueryError
   = EraMismatchError EraMismatch
-  -- ^ A query from a certain era was applied to a ledger from a different
-  -- era.
+  -- ^ A query from a certain era was applied to a ledger from a different era.
   deriving (Eq, Show)
 
 mkEraMismatchError :: NodeEraMismatchError -> QueryCmdLocalStateQueryError
@@ -24,7 +25,7 @@ mkEraMismatchError NodeEraMismatchError{nodeEra, era} =
   EraMismatchError EraMismatch{ ledgerEraName = docToText $ pretty nodeEra
                               , otherEraName = docToText $ pretty era}
 
-renderLocalStateQueryError :: QueryCmdLocalStateQueryError -> Doc ann
-renderLocalStateQueryError = \case
-  EraMismatchError err ->
-    "A query from a certain era was applied to a ledger from a different era: " <> pshow err
+instance Error QueryCmdLocalStateQueryError where
+  prettyError = \case
+    EraMismatchError EraMismatch{ledgerEraName, otherEraName} ->
+      "A query from" <+> pretty otherEraName <+> "era was applied to a ledger from a different era:" <+> pretty ledgerEraName


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Fix era mismatch error in stake-address-info
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
   - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
   - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Additional context for the PR goes here. If the PR fixes a particular issue please provide a [link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=) to the issue.

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
