### PR TITLE
create-staked: simplify some code

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Genesis.hs
@@ -167,14 +167,9 @@ runGenesisKeyGenGenesisCmd
     } = do
     skey <- liftIO $ generateSigningKey AsGenesisKey
     let vkey = getVerificationKey skey
-    firstExceptT GenesisCmdGenesisFileError
-      . newExceptT
-      $ writeLazyByteStringFile signingKeyPath
-      $ textEnvelopeToJSON (Just skeyDesc) skey
-    firstExceptT GenesisCmdGenesisFileError
-      . newExceptT
-      $ writeLazyByteStringFile verificationKeyPath
-      $ textEnvelopeToJSON (Just Key.genesisVkeyDesc) vkey
+    firstExceptT GenesisCmdGenesisFileError . newExceptT $ do
+      void $ writeLazyByteStringFile signingKeyPath $ textEnvelopeToJSON (Just skeyDesc) skey
+      writeLazyByteStringFile verificationKeyPath $ textEnvelopeToJSON (Just Key.genesisVkeyDesc) vkey
   where
     skeyDesc :: TextEnvelopeDescr
     skeyDesc = "Genesis Signing Key"
@@ -191,21 +186,16 @@ runGenesisKeyGenDelegateCmd
     } = do
     skey <- liftIO $ generateSigningKey AsGenesisDelegateKey
     let vkey = getVerificationKey skey
-    firstExceptT GenesisCmdGenesisFileError
-      . newExceptT
-      $ writeLazyByteStringFile signingKeyPath
-      $ textEnvelopeToJSON (Just skeyDesc) skey
-    firstExceptT GenesisCmdGenesisFileError
-      . newExceptT
-      $ writeLazyByteStringFile verificationKeyPath
-      $ textEnvelopeToJSON (Just Key.genesisVkeyDelegateDesc) vkey
-    firstExceptT GenesisCmdGenesisFileError
-      . newExceptT
-      $ writeLazyByteStringFile opCertCounterPath
-      $ textEnvelopeToJSON (Just certCtrDesc)
-      $ OperationalCertificateIssueCounter
-          initialCounter
-          (castVerificationKey vkey)  -- Cast to a 'StakePoolKey'
+    firstExceptT GenesisCmdGenesisFileError . newExceptT $ do
+      void $ writeLazyByteStringFile signingKeyPath
+        $ textEnvelopeToJSON (Just skeyDesc) skey
+      void $ writeLazyByteStringFile verificationKeyPath
+        $ textEnvelopeToJSON (Just Key.genesisVkeyDelegateDesc) vkey
+      writeLazyByteStringFile opCertCounterPath
+        $ textEnvelopeToJSON (Just certCtrDesc)
+        $ OperationalCertificateIssueCounter
+            initialCounter
+            (castVerificationKey vkey)  -- Cast to a 'StakePoolKey'
   where
     skeyDesc, certCtrDesc :: TextEnvelopeDescr
     skeyDesc = "Genesis delegate operator key"
@@ -223,14 +213,11 @@ runGenesisKeyGenDelegateVRF ::
 runGenesisKeyGenDelegateVRF vkeyPath skeyPath = do
     skey <- liftIO $ generateSigningKey AsVrfKey
     let vkey = getVerificationKey skey
-    firstExceptT GenesisCmdGenesisFileError
-      . newExceptT
-      $ writeLazyByteStringFile skeyPath
-      $ textEnvelopeToJSON (Just skeyDesc) skey
-    firstExceptT GenesisCmdGenesisFileError
-      . newExceptT
-      $ writeLazyByteStringFile vkeyPath
-      $ textEnvelopeToJSON (Just vkeyDesc) vkey
+    firstExceptT GenesisCmdGenesisFileError . newExceptT $ do
+      void $ writeLazyByteStringFile skeyPath
+        $ textEnvelopeToJSON (Just skeyDesc) skey
+      writeLazyByteStringFile vkeyPath
+        $ textEnvelopeToJSON (Just vkeyDesc) vkey
   where
     skeyDesc, vkeyDesc :: TextEnvelopeDescr
     skeyDesc = "VRF Signing Key"
@@ -247,14 +234,11 @@ runGenesisKeyGenUTxOCmd
     } = do
     skey <- liftIO $ generateSigningKey AsGenesisUTxOKey
     let vkey = getVerificationKey skey
-    firstExceptT GenesisCmdGenesisFileError
-      . newExceptT
-      $ writeLazyByteStringFile signingKeyPath
-      $ textEnvelopeToJSON (Just skeyDesc) skey
-    firstExceptT GenesisCmdGenesisFileError
-      . newExceptT
-      $ writeLazyByteStringFile verificationKeyPath
-      $ textEnvelopeToJSON (Just vkeyDesc) vkey
+    firstExceptT GenesisCmdGenesisFileError . newExceptT $ do
+      void $ writeLazyByteStringFile signingKeyPath
+        $ textEnvelopeToJSON (Just skeyDesc) skey
+      writeLazyByteStringFile verificationKeyPath
+        $ textEnvelopeToJSON (Just vkeyDesc) vkey
   where
     skeyDesc, vkeyDesc :: TextEnvelopeDescr
     skeyDesc = "Genesis Initial UTxO Signing Key"


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Join some calls `writeLazyByteStringFile` in do blocks
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

* This is a spinoff of https://github.com/input-output-hk/cardano-cli/pull/488
* This is in code common to `create-staked` and `create-testnet-data`, so this change will stay, even if we delete `create-staked` ultimately.
* @carbolymer asked for this change https://github.com/input-output-hk/cardano-cli/pull/488#discussion_r1411782261, but I'm doing it in a standalone PR, for faster merging, and to reduce the size of https://github.com/input-output-hk/cardano-cli/pull/488.

# How to trust this PR

* Notice that this is just a symbolic change, the runtime execution doesn't change.

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- NA New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [X] Self-reviewed the diff