### PR TITLE
 Restore the inclusion of datum hashes in Alonzo era tx bodies

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -14,7 +14,7 @@ repository cardano-haskell-packages
 -- you need to run if you change them
 index-state:
   , hackage.haskell.org 2023-11-20T23:52:53Z
-  , cardano-haskell-packages 2023-12-04T19:04:02Z
+  , cardano-haskell-packages 2023-12-06T18:36:58Z
 
 packages:
   cardano-cli
@@ -43,3 +43,4 @@ write-ghc-environment-files: always
 -- IMPORTANT
 -- Do NOT add more source-repository-package stanzas here unless they are strictly
 -- temporary! Please read the section in CONTRIBUTING about updating dependencies.
+

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -196,7 +196,7 @@ library
                       , binary
                       , bytestring
                       , canonical-json
-                      , cardano-api ^>= 8.36.0.1
+                      , cardano-api ^>= 8.36.1.1
                       , cardano-binary
                       , cardano-crypto
                       , cardano-crypto-class ^>= 2.1.2

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1701717386,
-        "narHash": "sha256-/9vQ2DdQlHsCfh72owZUae+djjSAumMVWdxGA7ugkZ0=",
+        "lastModified": 1701888566,
+        "narHash": "sha256-ew8qcUwIqiq3kLdbyL1KX1qWhylWaiWwCqTxbl30JgY=",
         "owner": "input-output-hk",
         "repo": "cardano-haskell-packages",
-        "rev": "13b6ae939b747ad82ea8286f13b4e8f6ce8a3c49",
+        "rev": "594eb0dd6adfb4a344d6e8b7807fb9e697e0d890",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Restore the inclusion of datum hashes in Alonzo era tx bodies
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
   - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Includes fix:
* https://github.com/input-output-hk/cardano-api/pull/398

Fixes: https://github.com/input-output-hk/cardano-cli/issues/501


# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
