### PR TITLE
stake-address registration-certificate: do not allow key-reg-deposit-amt before conway

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/StakeAddress.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/StakeAddress.hs
@@ -87,18 +87,18 @@ pStakeAddressRegistrationCertificateCmd :: ()
 pStakeAddressRegistrationCertificateCmd era = do
   forEraInEonMaybe era $ \sbe ->
     caseShelleyToBabbageOrConwayEraOnwards
-      (\shelleyToBabbage -> subParser "registration-certificate"
+      (const $ subParser "registration-certificate"
             $ Opt.info
-                ( StakeAddressRegistrationCertificateCmd (shelleyToBabbageEraToShelleyBasedEra shelleyToBabbage)
+                ( StakeAddressRegistrationCertificateCmd sbe
                     <$> pStakeIdentifier
-                    <*> optional pKeyRegistDeposit
+                    <*> pure Nothing
                     <*> pOutputFile
                 )
             desc
       )
-      (\conwayOnwards -> subParser "registration-certificate"
+      (const $ subParser "registration-certificate"
             $ Opt.info
-                ( StakeAddressRegistrationCertificateCmd (conwayEraOnwardsToShelleyBasedEra conwayOnwards)
+                ( StakeAddressRegistrationCertificateCmd sbe
                     <$> pStakeIdentifier
                     <*> fmap Just pKeyRegistDeposit
                     <*> pOutputFile

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -673,7 +673,6 @@ Usage: cardano-cli shelley stake-address registration-certificate
                                                                     | --stake-script-file FILE
                                                                     | --stake-address ADDRESS
                                                                     )
-                                                                    [--key-reg-deposit-amt NATURAL]
                                                                     --out-file FILE
 
   Create a stake address registration certificate
@@ -1831,7 +1830,6 @@ Usage: cardano-cli allegra stake-address registration-certificate
                                                                     | --stake-script-file FILE
                                                                     | --stake-address ADDRESS
                                                                     )
-                                                                    [--key-reg-deposit-amt NATURAL]
                                                                     --out-file FILE
 
   Create a stake address registration certificate
@@ -2982,7 +2980,6 @@ Usage: cardano-cli mary stake-address registration-certificate
                                                                  | --stake-script-file FILE
                                                                  | --stake-address ADDRESS
                                                                  )
-                                                                 [--key-reg-deposit-amt NATURAL]
                                                                  --out-file FILE
 
   Create a stake address registration certificate
@@ -4133,7 +4130,6 @@ Usage: cardano-cli alonzo stake-address registration-certificate
                                                                    | --stake-script-file FILE
                                                                    | --stake-address ADDRESS
                                                                    )
-                                                                   [--key-reg-deposit-amt NATURAL]
                                                                    --out-file FILE
 
   Create a stake address registration certificate
@@ -5316,7 +5312,6 @@ Usage: cardano-cli babbage stake-address registration-certificate
                                                                     | --stake-script-file FILE
                                                                     | --stake-address ADDRESS
                                                                     )
-                                                                    [--key-reg-deposit-amt NATURAL]
                                                                     --out-file FILE
 
   Create a stake address registration certificate
@@ -8001,7 +7996,6 @@ Usage: cardano-cli latest stake-address registration-certificate
                                                                    | --stake-script-file FILE
                                                                    | --stake-address ADDRESS
                                                                    )
-                                                                   [--key-reg-deposit-amt NATURAL]
                                                                    --out-file FILE
 
   Create a stake address registration certificate

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_stake-address_registration-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_stake-address_registration-certificate.cli
@@ -4,7 +4,6 @@ Usage: cardano-cli allegra stake-address registration-certificate
                                                                     | --stake-script-file FILE
                                                                     | --stake-address ADDRESS
                                                                     )
-                                                                    [--key-reg-deposit-amt NATURAL]
                                                                     --out-file FILE
 
   Create a stake address registration certificate
@@ -16,7 +15,5 @@ Available options:
                            Filepath of the staking verification key.
   --stake-script-file FILE Filepath of the staking script.
   --stake-address ADDRESS  Target stake address (bech32 format).
-  --key-reg-deposit-amt NATURAL
-                           Key registration deposit amount.
   --out-file FILE          The output file.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_stake-address_registration-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_stake-address_registration-certificate.cli
@@ -4,7 +4,6 @@ Usage: cardano-cli alonzo stake-address registration-certificate
                                                                    | --stake-script-file FILE
                                                                    | --stake-address ADDRESS
                                                                    )
-                                                                   [--key-reg-deposit-amt NATURAL]
                                                                    --out-file FILE
 
   Create a stake address registration certificate
@@ -16,7 +15,5 @@ Available options:
                            Filepath of the staking verification key.
   --stake-script-file FILE Filepath of the staking script.
   --stake-address ADDRESS  Target stake address (bech32 format).
-  --key-reg-deposit-amt NATURAL
-                           Key registration deposit amount.
   --out-file FILE          The output file.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_stake-address_registration-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_stake-address_registration-certificate.cli
@@ -4,7 +4,6 @@ Usage: cardano-cli babbage stake-address registration-certificate
                                                                     | --stake-script-file FILE
                                                                     | --stake-address ADDRESS
                                                                     )
-                                                                    [--key-reg-deposit-amt NATURAL]
                                                                     --out-file FILE
 
   Create a stake address registration certificate
@@ -16,7 +15,5 @@ Available options:
                            Filepath of the staking verification key.
   --stake-script-file FILE Filepath of the staking script.
   --stake-address ADDRESS  Target stake address (bech32 format).
-  --key-reg-deposit-amt NATURAL
-                           Key registration deposit amount.
   --out-file FILE          The output file.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_stake-address_registration-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_stake-address_registration-certificate.cli
@@ -4,7 +4,6 @@ Usage: cardano-cli latest stake-address registration-certificate
                                                                    | --stake-script-file FILE
                                                                    | --stake-address ADDRESS
                                                                    )
-                                                                   [--key-reg-deposit-amt NATURAL]
                                                                    --out-file FILE
 
   Create a stake address registration certificate
@@ -16,7 +15,5 @@ Available options:
                            Filepath of the staking verification key.
   --stake-script-file FILE Filepath of the staking script.
   --stake-address ADDRESS  Target stake address (bech32 format).
-  --key-reg-deposit-amt NATURAL
-                           Key registration deposit amount.
   --out-file FILE          The output file.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_stake-address_registration-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_stake-address_registration-certificate.cli
@@ -4,7 +4,6 @@ Usage: cardano-cli mary stake-address registration-certificate
                                                                  | --stake-script-file FILE
                                                                  | --stake-address ADDRESS
                                                                  )
-                                                                 [--key-reg-deposit-amt NATURAL]
                                                                  --out-file FILE
 
   Create a stake address registration certificate
@@ -16,7 +15,5 @@ Available options:
                            Filepath of the staking verification key.
   --stake-script-file FILE Filepath of the staking script.
   --stake-address ADDRESS  Target stake address (bech32 format).
-  --key-reg-deposit-amt NATURAL
-                           Key registration deposit amount.
   --out-file FILE          The output file.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_stake-address_registration-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_stake-address_registration-certificate.cli
@@ -4,7 +4,6 @@ Usage: cardano-cli shelley stake-address registration-certificate
                                                                     | --stake-script-file FILE
                                                                     | --stake-address ADDRESS
                                                                     )
-                                                                    [--key-reg-deposit-amt NATURAL]
                                                                     --out-file FILE
 
   Create a stake address registration certificate
@@ -16,7 +15,5 @@ Available options:
                            Filepath of the staking verification key.
   --stake-script-file FILE Filepath of the staking script.
   --stake-address ADDRESS  Target stake address (bech32 format).
-  --key-reg-deposit-amt NATURAL
-                           Key registration deposit amount.
   --out-file FILE          The output file.
   -h,--help                Show this help text


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    `stake-address registration-certificate`: remove flag `--key-reg-deposit-amt` from all eras except conway
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Fixes https://github.com/input-output-hk/cardano-cli/issues/504

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [X] Self-reviewed the diff