### PR TITLE
Unify previous governance action parameters across actions

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Actions.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Actions.hs
@@ -146,8 +146,8 @@ pGovernanceActionNoConfidenceCmd era = do
               <*> pStakeVerificationKeyOrHashOrFile (Just "deposit-return")
               <*> pAnchorUrl
               <*> pAnchorDataHash
-              <*> pTxId "governance-action-tx-id" "Previous txid of `NoConfidence` or `NewCommittee` governance action."
-              <*> pWord32 "governance-action-index" "Previous tx's governance action index of `NoConfidence` or `NewCommittee` governance action."
+              <*> pTxId "prev-governance-action-tx-id" "Txid of the previous governance action."
+              <*> pWord32 "prev-governance-action-index" "Action index of the previous governance action."
               <*> pFileOutDirection "out-file" "Output filepath of the no confidence proposal."
         )
     $ Opt.progDesc "Create a no confidence proposal."

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Governance/Action.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Governance/Action.hs
@@ -160,8 +160,8 @@ hprop_golden_governanceActionCreateNoConfidence =
       , "--deposit-return-stake-verification-key-file", stakeAddressVKeyFile
       , "--anchor-url", "proposal-dummy-url"
       , "--anchor-data-hash", "c7ddb5b493faa4d3d2d679847740bdce0c5d358d56f9b1470ca67f5652a02745"
-      , "--governance-action-index", "5"
-      , "--governance-action-tx-id", "b1015258a99351c143a7a40b7b58f033ace10e3cc09c67780ed5b2b0992aa60a"
+      , "--prev-governance-action-index", "5"
+      , "--prev-governance-action-tx-id", "b1015258a99351c143a7a40b7b58f033ace10e3cc09c67780ed5b2b0992aa60a"
       , "--out-file", actionFile
       ]
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -6164,8 +6164,8 @@ Usage: cardano-cli conway governance action create-no-confidence
                                                                    )
                                                                    --anchor-url TEXT
                                                                    --anchor-data-hash HASH
-                                                                   --governance-action-tx-id TXID
-                                                                   --governance-action-index WORD32
+                                                                   --prev-governance-action-tx-id TXID
+                                                                   --prev-governance-action-index WORD32
                                                                    --out-file FILE
 
   Create a no confidence proposal.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_create-no-confidence.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_create-no-confidence.cli
@@ -9,8 +9,8 @@ Usage: cardano-cli conway governance action create-no-confidence
                                                                    )
                                                                    --anchor-url TEXT
                                                                    --anchor-data-hash HASH
-                                                                   --governance-action-tx-id TXID
-                                                                   --governance-action-index WORD32
+                                                                   --prev-governance-action-tx-id TXID
+                                                                   --prev-governance-action-index WORD32
                                                                    --out-file FILE
 
   Create a no confidence proposal.
@@ -29,11 +29,9 @@ Available options:
   --anchor-url TEXT        Anchor URL
   --anchor-data-hash HASH  Proposal anchor data hash (obtain it with
                            "cardano-cli conway governance hash ...")
-  --governance-action-tx-id TXID
-                           Previous txid of `NoConfidence` or `NewCommittee`
-                           governance action.
-  --governance-action-index WORD32
-                           Previous tx's governance action index of
-                           `NoConfidence` or `NewCommittee` governance action.
+  --prev-governance-action-tx-id TXID
+                           Txid of the previous governance action.
+  --prev-governance-action-index WORD32
+                           Action index of the previous governance action.
   --out-file FILE          Output filepath of the no confidence proposal.
   -h,--help                Show this help text


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Use the same parameter names for previous governance action txid and tx index in all governance actions.
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

The `create-no-confidence` is using `--governance-action-tx-id` and `--governance-action-index` while all the other actions use `--prev-governance-action-tx-id` and `--prev-governance-action-index`.

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
