### PR TITLE
Make `query pool-state` default to returning information on all pools

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Query.hs
@@ -155,7 +155,7 @@ data QueryPoolStateCmdArgs = QueryPoolStateCmdArgs
   { nodeSocketPath      :: !SocketPath
   , consensusModeParams :: !ConsensusModeParams
   , networkId           :: !NetworkId
-  , poolIds             :: ![Hash StakePoolKey]
+  , allOrOnlyPoolIds    :: !(AllOrOnly [Hash StakePoolKey])
   } deriving (Generic, Show)
 
 data QueryTxMempoolCmdArgs = QueryTxMempoolCmdArgs

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Query.hs
@@ -216,7 +216,7 @@ pQueryPoolStateCmd envCli =
       <$> pSocketPath envCli
       <*> pConsensusModeParams
       <*> pNetworkId envCli
-      <*> many (pStakePoolVerificationKeyHash Nothing)
+      <*> pAllStakePoolsOrOnly
 
 pQueryTxMempoolCmd :: EnvCli -> Parser (QueryCmds era)
 pQueryTxMempoolCmd envCli =

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Query.hs
@@ -619,7 +619,7 @@ runQueryPoolStateCmd
     { Cmd.nodeSocketPath
     , Cmd.consensusModeParams
     , Cmd.networkId
-    , Cmd.poolIds
+    , Cmd.allOrOnlyPoolIds
     } = do
   let localNodeConnInfo = LocalNodeConnectInfo consensusModeParams networkId nodeSocketPath
 
@@ -633,7 +633,11 @@ runQueryPoolStateCmd
 
         beo <- requireEon BabbageEra era
 
-        result <- lift (queryPoolState beo $ Just $ Set.fromList poolIds)
+        let poolFilter = case allOrOnlyPoolIds of
+              All -> Nothing
+              Only poolIds -> Just $ Set.fromList poolIds
+
+        result <- lift (queryPoolState beo poolFilter)
           & onLeft (left . QueryCmdUnsupportedNtcVersion)
           & onLeft (left . QueryCmdLocalStateQueryError . EraMismatchError)
 

--- a/cardano-cli/src/Cardano/CLI/Legacy/Commands/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Commands/Query.hs
@@ -146,7 +146,7 @@ data LegacyQueryPoolStateCmdArgs = LegacyQueryPoolStateCmdArgs
   { nodeSocketPath      :: !SocketPath
   , consensusModeParams :: !ConsensusModeParams
   , networkId           :: !NetworkId
-  , poolIds             :: ![Hash StakePoolKey]
+  , allOrOnlyPoolIds    :: !(AllOrOnly [Hash StakePoolKey])
   } deriving (Generic, Show)
 
 data LegacyQueryTxMempoolCmdArgs = LegacyQueryTxMempoolCmdArgs

--- a/cardano-cli/src/Cardano/CLI/Legacy/Options.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Options.hs
@@ -735,7 +735,7 @@ pQueryCmds envCli =
           <$> pSocketPath envCli
           <*> pConsensusModeParams
           <*> pNetworkId envCli
-          <*> many (pStakePoolVerificationKeyHash Nothing)
+          <*> pAllStakePoolsOrOnly
 
     pQueryTxMempool :: Parser LegacyQueryCmds
     pQueryTxMempool =

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -552,7 +552,9 @@ Usage: cardano-cli shelley query pool-params --socket-path SOCKET_PATH
                                                ( --mainnet
                                                | --testnet-magic NATURAL
                                                )
-                                               [--stake-pool-id STAKE_POOL_ID]
+                                               [ --all-stake-pools
+                                               | [--stake-pool-id STAKE_POOL_ID]
+                                               ]
 
   DEPRECATED. Use query pool-state instead. Dump the pool parameters
   (Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced
@@ -593,7 +595,9 @@ Usage: cardano-cli shelley query pool-state --socket-path SOCKET_PATH
                                               ( --mainnet
                                               | --testnet-magic NATURAL
                                               )
-                                              [--stake-pool-id STAKE_POOL_ID]
+                                              [ --all-stake-pools
+                                              | [--stake-pool-id STAKE_POOL_ID]
+                                              ]
 
   Dump the pool state
 
@@ -1710,7 +1714,9 @@ Usage: cardano-cli allegra query pool-params --socket-path SOCKET_PATH
                                                ( --mainnet
                                                | --testnet-magic NATURAL
                                                )
-                                               [--stake-pool-id STAKE_POOL_ID]
+                                               [ --all-stake-pools
+                                               | [--stake-pool-id STAKE_POOL_ID]
+                                               ]
 
   DEPRECATED. Use query pool-state instead. Dump the pool parameters
   (Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced
@@ -1751,7 +1757,9 @@ Usage: cardano-cli allegra query pool-state --socket-path SOCKET_PATH
                                               ( --mainnet
                                               | --testnet-magic NATURAL
                                               )
-                                              [--stake-pool-id STAKE_POOL_ID]
+                                              [ --all-stake-pools
+                                              | [--stake-pool-id STAKE_POOL_ID]
+                                              ]
 
   Dump the pool state
 
@@ -2865,7 +2873,9 @@ Usage: cardano-cli mary query pool-params --socket-path SOCKET_PATH
                                             ( --mainnet
                                             | --testnet-magic NATURAL
                                             )
-                                            [--stake-pool-id STAKE_POOL_ID]
+                                            [ --all-stake-pools
+                                            | [--stake-pool-id STAKE_POOL_ID]
+                                            ]
 
   DEPRECATED. Use query pool-state instead. Dump the pool parameters
   (Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced
@@ -2904,7 +2914,9 @@ Usage: cardano-cli mary query pool-state --socket-path SOCKET_PATH
                                            [--cardano-mode
                                              [--epoch-slots SLOTS]]
                                            (--mainnet | --testnet-magic NATURAL)
-                                           [--stake-pool-id STAKE_POOL_ID]
+                                           [ --all-stake-pools
+                                           | [--stake-pool-id STAKE_POOL_ID]
+                                           ]
 
   Dump the pool state
 
@@ -4012,7 +4024,9 @@ Usage: cardano-cli alonzo query pool-params --socket-path SOCKET_PATH
                                               ( --mainnet
                                               | --testnet-magic NATURAL
                                               )
-                                              [--stake-pool-id STAKE_POOL_ID]
+                                              [ --all-stake-pools
+                                              | [--stake-pool-id STAKE_POOL_ID]
+                                              ]
 
   DEPRECATED. Use query pool-state instead. Dump the pool parameters
   (Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced
@@ -4053,7 +4067,9 @@ Usage: cardano-cli alonzo query pool-state --socket-path SOCKET_PATH
                                              ( --mainnet
                                              | --testnet-magic NATURAL
                                              )
-                                             [--stake-pool-id STAKE_POOL_ID]
+                                             [ --all-stake-pools
+                                             | [--stake-pool-id STAKE_POOL_ID]
+                                             ]
 
   Dump the pool state
 
@@ -5195,7 +5211,9 @@ Usage: cardano-cli babbage query pool-params --socket-path SOCKET_PATH
                                                ( --mainnet
                                                | --testnet-magic NATURAL
                                                )
-                                               [--stake-pool-id STAKE_POOL_ID]
+                                               [ --all-stake-pools
+                                               | [--stake-pool-id STAKE_POOL_ID]
+                                               ]
 
   DEPRECATED. Use query pool-state instead. Dump the pool parameters
   (Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced
@@ -5236,7 +5254,9 @@ Usage: cardano-cli babbage query pool-state --socket-path SOCKET_PATH
                                               ( --mainnet
                                               | --testnet-magic NATURAL
                                               )
-                                              [--stake-pool-id STAKE_POOL_ID]
+                                              [ --all-stake-pools
+                                              | [--stake-pool-id STAKE_POOL_ID]
+                                              ]
 
   Dump the pool state
 
@@ -6585,7 +6605,9 @@ Usage: cardano-cli conway query pool-params --socket-path SOCKET_PATH
                                               ( --mainnet
                                               | --testnet-magic NATURAL
                                               )
-                                              [--stake-pool-id STAKE_POOL_ID]
+                                              [ --all-stake-pools
+                                              | [--stake-pool-id STAKE_POOL_ID]
+                                              ]
 
   DEPRECATED. Use query pool-state instead. Dump the pool parameters
   (Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced
@@ -6626,7 +6648,9 @@ Usage: cardano-cli conway query pool-state --socket-path SOCKET_PATH
                                              ( --mainnet
                                              | --testnet-magic NATURAL
                                              )
-                                             [--stake-pool-id STAKE_POOL_ID]
+                                             [ --all-stake-pools
+                                             | [--stake-pool-id STAKE_POOL_ID]
+                                             ]
 
   Dump the pool state
 
@@ -7880,7 +7904,9 @@ Usage: cardano-cli latest query pool-params --socket-path SOCKET_PATH
                                               ( --mainnet
                                               | --testnet-magic NATURAL
                                               )
-                                              [--stake-pool-id STAKE_POOL_ID]
+                                              [ --all-stake-pools
+                                              | [--stake-pool-id STAKE_POOL_ID]
+                                              ]
 
   DEPRECATED. Use query pool-state instead. Dump the pool parameters
   (Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced
@@ -7921,7 +7947,9 @@ Usage: cardano-cli latest query pool-state --socket-path SOCKET_PATH
                                              ( --mainnet
                                              | --testnet-magic NATURAL
                                              )
-                                             [--stake-pool-id STAKE_POOL_ID]
+                                             [ --all-stake-pools
+                                             | [--stake-pool-id STAKE_POOL_ID]
+                                             ]
 
   Dump the pool state
 
@@ -8906,7 +8934,9 @@ Usage: cardano-cli legacy query pool-params --socket-path SOCKET_PATH
                                               ( --mainnet
                                               | --testnet-magic NATURAL
                                               )
-                                              [--stake-pool-id STAKE_POOL_ID]
+                                              [ --all-stake-pools
+                                              | [--stake-pool-id STAKE_POOL_ID]
+                                              ]
 
   DEPRECATED. Use query pool-state instead. Dump the pool parameters
   (Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced
@@ -8947,7 +8977,9 @@ Usage: cardano-cli legacy query pool-state --socket-path SOCKET_PATH
                                              ( --mainnet
                                              | --testnet-magic NATURAL
                                              )
-                                             [--stake-pool-id STAKE_POOL_ID]
+                                             [ --all-stake-pools
+                                             | [--stake-pool-id STAKE_POOL_ID]
+                                             ]
 
   Dump the pool state
 
@@ -10139,7 +10171,9 @@ Usage: cardano-cli query stake-snapshot --socket-path SOCKET_PATH
 Usage: cardano-cli query pool-params --socket-path SOCKET_PATH
                                        [--cardano-mode [--epoch-slots SLOTS]]
                                        (--mainnet | --testnet-magic NATURAL)
-                                       [--stake-pool-id STAKE_POOL_ID]
+                                       [ --all-stake-pools
+                                       | [--stake-pool-id STAKE_POOL_ID]
+                                       ]
 
   DEPRECATED. Use query pool-state instead. Dump the pool parameters
   (Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced
@@ -10175,7 +10209,9 @@ Usage: cardano-cli query kes-period-info --socket-path SOCKET_PATH
 Usage: cardano-cli query pool-state --socket-path SOCKET_PATH
                                       [--cardano-mode [--epoch-slots SLOTS]]
                                       (--mainnet | --testnet-magic NATURAL)
-                                      [--stake-pool-id STAKE_POOL_ID]
+                                      [ --all-stake-pools
+                                      | [--stake-pool-id STAKE_POOL_ID]
+                                      ]
 
   Dump the pool state
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_pool-params.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_pool-params.cli
@@ -4,7 +4,9 @@ Usage: cardano-cli allegra query pool-params --socket-path SOCKET_PATH
                                                ( --mainnet
                                                | --testnet-magic NATURAL
                                                )
-                                               [--stake-pool-id STAKE_POOL_ID]
+                                               [ --all-stake-pools
+                                               | [--stake-pool-id STAKE_POOL_ID]
+                                               ]
 
   DEPRECATED. Use query pool-state instead. Dump the pool parameters
   (Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced
@@ -24,6 +26,7 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --all-stake-pools        Query for all stake pools
   --stake-pool-id STAKE_POOL_ID
                            Stake pool ID/verification key hash (either
                            Bech32-encoded or hex-encoded). Zero or more

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_pool-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_pool-state.cli
@@ -4,7 +4,9 @@ Usage: cardano-cli allegra query pool-state --socket-path SOCKET_PATH
                                               ( --mainnet
                                               | --testnet-magic NATURAL
                                               )
-                                              [--stake-pool-id STAKE_POOL_ID]
+                                              [ --all-stake-pools
+                                              | [--stake-pool-id STAKE_POOL_ID]
+                                              ]
 
   Dump the pool state
 
@@ -22,6 +24,7 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --all-stake-pools        Query for all stake pools
   --stake-pool-id STAKE_POOL_ID
                            Stake pool ID/verification key hash (either
                            Bech32-encoded or hex-encoded). Zero or more

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_pool-params.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_pool-params.cli
@@ -4,7 +4,9 @@ Usage: cardano-cli alonzo query pool-params --socket-path SOCKET_PATH
                                               ( --mainnet
                                               | --testnet-magic NATURAL
                                               )
-                                              [--stake-pool-id STAKE_POOL_ID]
+                                              [ --all-stake-pools
+                                              | [--stake-pool-id STAKE_POOL_ID]
+                                              ]
 
   DEPRECATED. Use query pool-state instead. Dump the pool parameters
   (Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced
@@ -24,6 +26,7 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --all-stake-pools        Query for all stake pools
   --stake-pool-id STAKE_POOL_ID
                            Stake pool ID/verification key hash (either
                            Bech32-encoded or hex-encoded). Zero or more

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_pool-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_pool-state.cli
@@ -4,7 +4,9 @@ Usage: cardano-cli alonzo query pool-state --socket-path SOCKET_PATH
                                              ( --mainnet
                                              | --testnet-magic NATURAL
                                              )
-                                             [--stake-pool-id STAKE_POOL_ID]
+                                             [ --all-stake-pools
+                                             | [--stake-pool-id STAKE_POOL_ID]
+                                             ]
 
   Dump the pool state
 
@@ -22,6 +24,7 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --all-stake-pools        Query for all stake pools
   --stake-pool-id STAKE_POOL_ID
                            Stake pool ID/verification key hash (either
                            Bech32-encoded or hex-encoded). Zero or more

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_pool-params.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_pool-params.cli
@@ -4,7 +4,9 @@ Usage: cardano-cli babbage query pool-params --socket-path SOCKET_PATH
                                                ( --mainnet
                                                | --testnet-magic NATURAL
                                                )
-                                               [--stake-pool-id STAKE_POOL_ID]
+                                               [ --all-stake-pools
+                                               | [--stake-pool-id STAKE_POOL_ID]
+                                               ]
 
   DEPRECATED. Use query pool-state instead. Dump the pool parameters
   (Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced
@@ -24,6 +26,7 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --all-stake-pools        Query for all stake pools
   --stake-pool-id STAKE_POOL_ID
                            Stake pool ID/verification key hash (either
                            Bech32-encoded or hex-encoded). Zero or more

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_pool-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_pool-state.cli
@@ -4,7 +4,9 @@ Usage: cardano-cli babbage query pool-state --socket-path SOCKET_PATH
                                               ( --mainnet
                                               | --testnet-magic NATURAL
                                               )
-                                              [--stake-pool-id STAKE_POOL_ID]
+                                              [ --all-stake-pools
+                                              | [--stake-pool-id STAKE_POOL_ID]
+                                              ]
 
   Dump the pool state
 
@@ -22,6 +24,7 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --all-stake-pools        Query for all stake pools
   --stake-pool-id STAKE_POOL_ID
                            Stake pool ID/verification key hash (either
                            Bech32-encoded or hex-encoded). Zero or more

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_pool-params.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_pool-params.cli
@@ -4,7 +4,9 @@ Usage: cardano-cli conway query pool-params --socket-path SOCKET_PATH
                                               ( --mainnet
                                               | --testnet-magic NATURAL
                                               )
-                                              [--stake-pool-id STAKE_POOL_ID]
+                                              [ --all-stake-pools
+                                              | [--stake-pool-id STAKE_POOL_ID]
+                                              ]
 
   DEPRECATED. Use query pool-state instead. Dump the pool parameters
   (Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced
@@ -24,6 +26,7 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --all-stake-pools        Query for all stake pools
   --stake-pool-id STAKE_POOL_ID
                            Stake pool ID/verification key hash (either
                            Bech32-encoded or hex-encoded). Zero or more

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_pool-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_pool-state.cli
@@ -4,7 +4,9 @@ Usage: cardano-cli conway query pool-state --socket-path SOCKET_PATH
                                              ( --mainnet
                                              | --testnet-magic NATURAL
                                              )
-                                             [--stake-pool-id STAKE_POOL_ID]
+                                             [ --all-stake-pools
+                                             | [--stake-pool-id STAKE_POOL_ID]
+                                             ]
 
   Dump the pool state
 
@@ -22,6 +24,7 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --all-stake-pools        Query for all stake pools
   --stake-pool-id STAKE_POOL_ID
                            Stake pool ID/verification key hash (either
                            Bech32-encoded or hex-encoded). Zero or more

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_pool-params.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_pool-params.cli
@@ -4,7 +4,9 @@ Usage: cardano-cli latest query pool-params --socket-path SOCKET_PATH
                                               ( --mainnet
                                               | --testnet-magic NATURAL
                                               )
-                                              [--stake-pool-id STAKE_POOL_ID]
+                                              [ --all-stake-pools
+                                              | [--stake-pool-id STAKE_POOL_ID]
+                                              ]
 
   DEPRECATED. Use query pool-state instead. Dump the pool parameters
   (Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced
@@ -24,6 +26,7 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --all-stake-pools        Query for all stake pools
   --stake-pool-id STAKE_POOL_ID
                            Stake pool ID/verification key hash (either
                            Bech32-encoded or hex-encoded). Zero or more

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_pool-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_pool-state.cli
@@ -4,7 +4,9 @@ Usage: cardano-cli latest query pool-state --socket-path SOCKET_PATH
                                              ( --mainnet
                                              | --testnet-magic NATURAL
                                              )
-                                             [--stake-pool-id STAKE_POOL_ID]
+                                             [ --all-stake-pools
+                                             | [--stake-pool-id STAKE_POOL_ID]
+                                             ]
 
   Dump the pool state
 
@@ -22,6 +24,7 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --all-stake-pools        Query for all stake pools
   --stake-pool-id STAKE_POOL_ID
                            Stake pool ID/verification key hash (either
                            Bech32-encoded or hex-encoded). Zero or more

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_query_pool-params.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_query_pool-params.cli
@@ -4,7 +4,9 @@ Usage: cardano-cli legacy query pool-params --socket-path SOCKET_PATH
                                               ( --mainnet
                                               | --testnet-magic NATURAL
                                               )
-                                              [--stake-pool-id STAKE_POOL_ID]
+                                              [ --all-stake-pools
+                                              | [--stake-pool-id STAKE_POOL_ID]
+                                              ]
 
   DEPRECATED. Use query pool-state instead. Dump the pool parameters
   (Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced
@@ -24,6 +26,7 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --all-stake-pools        Query for all stake pools
   --stake-pool-id STAKE_POOL_ID
                            Stake pool ID/verification key hash (either
                            Bech32-encoded or hex-encoded). Zero or more

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_query_pool-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_query_pool-state.cli
@@ -4,7 +4,9 @@ Usage: cardano-cli legacy query pool-state --socket-path SOCKET_PATH
                                              ( --mainnet
                                              | --testnet-magic NATURAL
                                              )
-                                             [--stake-pool-id STAKE_POOL_ID]
+                                             [ --all-stake-pools
+                                             | [--stake-pool-id STAKE_POOL_ID]
+                                             ]
 
   Dump the pool state
 
@@ -22,6 +24,7 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --all-stake-pools        Query for all stake pools
   --stake-pool-id STAKE_POOL_ID
                            Stake pool ID/verification key hash (either
                            Bech32-encoded or hex-encoded). Zero or more

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_pool-params.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_pool-params.cli
@@ -4,7 +4,9 @@ Usage: cardano-cli mary query pool-params --socket-path SOCKET_PATH
                                             ( --mainnet
                                             | --testnet-magic NATURAL
                                             )
-                                            [--stake-pool-id STAKE_POOL_ID]
+                                            [ --all-stake-pools
+                                            | [--stake-pool-id STAKE_POOL_ID]
+                                            ]
 
   DEPRECATED. Use query pool-state instead. Dump the pool parameters
   (Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced
@@ -24,6 +26,7 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --all-stake-pools        Query for all stake pools
   --stake-pool-id STAKE_POOL_ID
                            Stake pool ID/verification key hash (either
                            Bech32-encoded or hex-encoded). Zero or more

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_pool-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_pool-state.cli
@@ -2,7 +2,9 @@ Usage: cardano-cli mary query pool-state --socket-path SOCKET_PATH
                                            [--cardano-mode
                                              [--epoch-slots SLOTS]]
                                            (--mainnet | --testnet-magic NATURAL)
-                                           [--stake-pool-id STAKE_POOL_ID]
+                                           [ --all-stake-pools
+                                           | [--stake-pool-id STAKE_POOL_ID]
+                                           ]
 
   Dump the pool state
 
@@ -20,6 +22,7 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --all-stake-pools        Query for all stake pools
   --stake-pool-id STAKE_POOL_ID
                            Stake pool ID/verification key hash (either
                            Bech32-encoded or hex-encoded). Zero or more

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/query_pool-params.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/query_pool-params.cli
@@ -1,7 +1,9 @@
 Usage: cardano-cli query pool-params --socket-path SOCKET_PATH
                                        [--cardano-mode [--epoch-slots SLOTS]]
                                        (--mainnet | --testnet-magic NATURAL)
-                                       [--stake-pool-id STAKE_POOL_ID]
+                                       [ --all-stake-pools
+                                       | [--stake-pool-id STAKE_POOL_ID]
+                                       ]
 
   DEPRECATED. Use query pool-state instead. Dump the pool parameters
   (Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced
@@ -21,6 +23,7 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --all-stake-pools        Query for all stake pools
   --stake-pool-id STAKE_POOL_ID
                            Stake pool ID/verification key hash (either
                            Bech32-encoded or hex-encoded). Zero or more

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/query_pool-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/query_pool-state.cli
@@ -1,7 +1,9 @@
 Usage: cardano-cli query pool-state --socket-path SOCKET_PATH
                                       [--cardano-mode [--epoch-slots SLOTS]]
                                       (--mainnet | --testnet-magic NATURAL)
-                                      [--stake-pool-id STAKE_POOL_ID]
+                                      [ --all-stake-pools
+                                      | [--stake-pool-id STAKE_POOL_ID]
+                                      ]
 
   Dump the pool state
 
@@ -19,6 +21,7 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --all-stake-pools        Query for all stake pools
   --stake-pool-id STAKE_POOL_ID
                            Stake pool ID/verification key hash (either
                            Bech32-encoded or hex-encoded). Zero or more

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_pool-params.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_pool-params.cli
@@ -4,7 +4,9 @@ Usage: cardano-cli shelley query pool-params --socket-path SOCKET_PATH
                                                ( --mainnet
                                                | --testnet-magic NATURAL
                                                )
-                                               [--stake-pool-id STAKE_POOL_ID]
+                                               [ --all-stake-pools
+                                               | [--stake-pool-id STAKE_POOL_ID]
+                                               ]
 
   DEPRECATED. Use query pool-state instead. Dump the pool parameters
   (Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced
@@ -24,6 +26,7 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --all-stake-pools        Query for all stake pools
   --stake-pool-id STAKE_POOL_ID
                            Stake pool ID/verification key hash (either
                            Bech32-encoded or hex-encoded). Zero or more

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_pool-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_pool-state.cli
@@ -4,7 +4,9 @@ Usage: cardano-cli shelley query pool-state --socket-path SOCKET_PATH
                                               ( --mainnet
                                               | --testnet-magic NATURAL
                                               )
-                                              [--stake-pool-id STAKE_POOL_ID]
+                                              [ --all-stake-pools
+                                              | [--stake-pool-id STAKE_POOL_ID]
+                                              ]
 
   Dump the pool state
 
@@ -22,6 +24,7 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --all-stake-pools        Query for all stake pools
   --stake-pool-id STAKE_POOL_ID
                            Stake pool ID/verification key hash (either
                            Bech32-encoded or hex-encoded). Zero or more


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Make `query pool-state` default to returning information on all pools
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

This PR closes #496. I also took the liberty of making the flags of the `pool-state` query a bit more explicit, with an `--all-stake-pools` flag. This is similar to the `stake-snapshot` query.

There's also a remark from @CarlosLopezDeLara on the issue, where he notes that the query doesn't seem to work in Babbage. Before we figure out what's going on there, I propose we proceed with this PR, since it is orthogonal.

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
