### PR TITLE
legacy query: remove constitution-hash option

### DIFF
--- a/cardano-cli/src/Cardano/CLI/Legacy/Commands/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Commands/Query.hs
@@ -35,7 +35,6 @@ import           GHC.Generics
 data LegacyQueryCmds
   = QueryLeadershipScheduleCmd  !LegacyQueryLeadershipScheduleCmdArgs
   | QueryProtocolParametersCmd  !LegacyQueryProtocolParametersCmdArgs
-  | QueryConstitutionHashCmd    !LegacyQueryConstitutionHashCmdArgs
   | QueryTipCmd                 !LegacyQueryTipCmdArgs
   | QueryStakePoolsCmd          !LegacyQueryStakePoolsCmdArgs
   | QueryStakeDistributionCmd   !LegacyQueryStakeDistributionCmdArgs
@@ -169,7 +168,6 @@ renderLegacyQueryCmds :: LegacyQueryCmds -> Text
 renderLegacyQueryCmds = \case
   QueryLeadershipScheduleCmd {} -> "query leadership-schedule"
   QueryProtocolParametersCmd {} -> "query protocol-parameters "
-  QueryConstitutionHashCmd {} -> "query constitution-hash "
   QueryTipCmd {} -> "query tip"
   QueryStakePoolsCmd {} -> "query stake-pools"
   QueryStakeDistributionCmd {} -> "query stake-distribution"

--- a/cardano-cli/src/Cardano/CLI/Legacy/Options.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Options.hs
@@ -565,9 +565,6 @@ pQueryCmds envCli =
     [ subParser "protocol-parameters"
         $ Opt.info pQueryProtocolParameters
         $ Opt.progDesc "Get the node's current protocol parameters"
-    , subParser "constitution-hash"
-        $ Opt.info pQueryConstitutionHash
-        $ Opt.progDesc "Get the constitution hash"
     , subParser "tip"
         $ Opt.info pQueryTip
         $ Opt.progDesc "Get the node's current tip (slot no, hash, block no)"
@@ -629,15 +626,6 @@ pQueryCmds envCli =
     pQueryProtocolParameters =
       fmap QueryProtocolParametersCmd $
         LegacyQueryProtocolParametersCmdArgs
-          <$> pSocketPath envCli
-          <*> pConsensusModeParams
-          <*> pNetworkId envCli
-          <*> pMaybeOutputFile
-
-    pQueryConstitutionHash :: Parser LegacyQueryCmds
-    pQueryConstitutionHash =
-      fmap QueryConstitutionHashCmd $
-        LegacyQueryConstitutionHashCmdArgs
           <$> pSocketPath envCli
           <*> pConsensusModeParams
           <*> pNetworkId envCli

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Query.hs
@@ -20,7 +20,6 @@ runLegacyQueryCmds :: Cmd.LegacyQueryCmds -> ExceptT QueryCmdError IO ()
 runLegacyQueryCmds = \case
   Cmd.QueryLeadershipScheduleCmd  args -> runLegacyQueryLeadershipScheduleCmd args
   Cmd.QueryProtocolParametersCmd  args -> runLegacyQueryProtocolParametersCmd args
-  Cmd.QueryConstitutionHashCmd    args -> runLegacyQueryConstitutionHashCmd args
   Cmd.QueryTipCmd                 args -> runLegacyQueryTipCmd args
   Cmd.QueryStakePoolsCmd          args -> runLegacyQueryStakePoolsCmd args
   Cmd.QueryStakeDistributionCmd   args -> runLegacyQueryStakeDistributionCmd args
@@ -33,12 +32,6 @@ runLegacyQueryCmds = \case
   Cmd.QueryPoolStateCmd           args -> runLegacyQueryPoolStateCmd args
   Cmd.QueryTxMempoolCmd           args -> runLegacyQueryTxMempoolCmd args
   Cmd.QuerySlotNumberCmd          args -> runLegacyQuerySlotNumberCmd args
-
-runLegacyQueryConstitutionHashCmd :: ()
-  => Cmd.LegacyQueryConstitutionHashCmdArgs
-  -> ExceptT QueryCmdError IO ()
-runLegacyQueryConstitutionHashCmd Cmd.LegacyQueryConstitutionHashCmdArgs {..} =
-  EraBased.runQueryConstitutionHashCmd EraBased.QueryConstitutionHashCmdArgs {..}
 
 runLegacyQueryProtocolParametersCmd :: ()
   => Cmd.LegacyQueryProtocolParametersCmdArgs

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -8775,7 +8775,6 @@ Usage: cardano-cli legacy genesis hash --genesis FILE
 
 Usage: cardano-cli legacy query 
                                   ( protocol-parameters
-                                  | constitution-hash
                                   | tip
                                   | stake-pools
                                   | stake-distribution
@@ -8803,16 +8802,6 @@ Usage: cardano-cli legacy query protocol-parameters --socket-path SOCKET_PATH
                                                       [--out-file FILE]
 
   Get the node's current protocol parameters
-
-Usage: cardano-cli legacy query constitution-hash --socket-path SOCKET_PATH
-                                                    [--cardano-mode
-                                                      [--epoch-slots SLOTS]]
-                                                    ( --mainnet
-                                                    | --testnet-magic NATURAL
-                                                    )
-                                                    [--out-file FILE]
-
-  Get the constitution hash
 
 Usage: cardano-cli legacy query tip --socket-path SOCKET_PATH
                                       [--cardano-mode [--epoch-slots SLOTS]]
@@ -10024,7 +10013,6 @@ Usage: cardano-cli genesis hash --genesis FILE
 
 Usage: cardano-cli query 
                            ( protocol-parameters
-                           | constitution-hash
                            | tip
                            | stake-pools
                            | stake-distribution
@@ -10052,16 +10040,6 @@ Usage: cardano-cli query protocol-parameters --socket-path SOCKET_PATH
                                                [--out-file FILE]
 
   Get the node's current protocol parameters
-
-Usage: cardano-cli query constitution-hash --socket-path SOCKET_PATH
-                                             [--cardano-mode
-                                               [--epoch-slots SLOTS]]
-                                             ( --mainnet
-                                             | --testnet-magic NATURAL
-                                             )
-                                             [--out-file FILE]
-
-  Get the constitution hash
 
 Usage: cardano-cli query tip --socket-path SOCKET_PATH
                                [--cardano-mode [--epoch-slots SLOTS]]

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_query.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_query.cli
@@ -1,6 +1,5 @@
 Usage: cardano-cli legacy query 
                                   ( protocol-parameters
-                                  | constitution-hash
                                   | tip
                                   | stake-pools
                                   | stake-distribution
@@ -24,7 +23,6 @@ Available options:
 
 Available commands:
   protocol-parameters      Get the node's current protocol parameters
-  constitution-hash        Get the constitution hash
   tip                      Get the node's current tip (slot no, hash, block no)
   stake-pools              Get the node's current set of stake pool ids
   stake-distribution       Get the node's current aggregated stake distribution

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/query.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/query.cli
@@ -1,6 +1,5 @@
 Usage: cardano-cli query 
                            ( protocol-parameters
-                           | constitution-hash
                            | tip
                            | stake-pools
                            | stake-distribution
@@ -24,7 +23,6 @@ Available options:
 
 Available commands:
   protocol-parameters      Get the node's current protocol parameters
-  constitution-hash        Get the constitution hash
   tip                      Get the node's current tip (slot no, hash, block no)
   stake-pools              Get the node's current set of stake pool ids
   stake-distribution       Get the node's current aggregated stake distribution


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Remove the `constitution-hash` option from the non-conway versions of `query`
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Fixes #503

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [X] Self-reviewed the diff