### PR TITLE
governance vote view: use `--output-format`, like other commands, instead of `--yaml`

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/Actions.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/Actions.hs
@@ -132,7 +132,7 @@ data GovernanceActionViewCmdArgs era
   = GovernanceActionViewCmdArgs
       { eon        :: !(ConwayEraOnwards era)
       , actionFile :: !(ProposalFile In)
-      , outFormat  :: !GovernanceActionViewOutputFormat
+      , outFormat  :: !ViewOutputFormat
       , mOutFile   :: !(Maybe (File () Out))
       } deriving Show
 

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/Vote.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/Vote.hs
@@ -39,7 +39,7 @@ data GovernanceVoteCreateCmdArgs era
 data GovernanceVoteViewCmdArgs era
   = GovernanceVoteViewCmdArgs
       { eon         :: ConwayEraOnwards era
-      , yamlOutput  :: Bool
+      , outFormat  :: !ViewOutputFormat
       , voteFile    :: VoteFile In
       , mOutFile    :: Maybe (File () Out)
       }

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Transaction.hs
@@ -182,7 +182,7 @@ newtype TransactionTxIdCmdArgs = TransactionTxIdCmdArgs
   } deriving Show
 
 data TransactionViewCmdArgs = TransactionViewCmdArgs
-  { outputFormat        :: !TxViewOutputFormat
+  { outputFormat        :: !ViewOutputFormat
   , mOutFile            :: !(Maybe (File () Out))
   , inputTxBodyOrTxFile :: !InputTxBodyOrTxFile
   } deriving Show

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
@@ -1566,28 +1566,27 @@ pPoolIdOutputFormat =
     , Opt.value IdOutputFormatBech32
     ]
 
-pTxViewOutputFormat :: Parser TxViewOutputFormat
-pTxViewOutputFormat =
-  Opt.option readTxViewOutputFormat $ mconcat
-    [ Opt.long "output-format"
-    , Opt.metavar "STRING"
-    , Opt.help $ mconcat
-      [ "Optional transaction view output format. Accepted output formats are \"json\" "
-      , "and \"yaml\" (default is \"json\")."
-      ]
-    , Opt.value TxViewOutputFormatJson
-    ]
+pTxViewOutputFormat :: Parser ViewOutputFormat
+pTxViewOutputFormat = pViewOutputFormat "transaction"
 
-pGovernanceActionViewOutputFormat :: Parser GovernanceActionViewOutputFormat
-pGovernanceActionViewOutputFormat =
-  Opt.option readGovernanceActionViewOutputFormat $ mconcat
+pGovernanceActionViewOutputFormat :: Parser ViewOutputFormat
+pGovernanceActionViewOutputFormat = pViewOutputFormat "governance action"
+
+pGovernanceVoteViewOutputFormat :: Parser ViewOutputFormat
+pGovernanceVoteViewOutputFormat = pViewOutputFormat "governance vote"
+
+-- | @pViewOutputFormat kind@ is a parser to specify in which format
+-- to view some data (json or yaml). @what@ is the kind of data considered.
+pViewOutputFormat :: String -> Parser ViewOutputFormat
+pViewOutputFormat kind =
+  Opt.option (readViewOutputFormat kind) $ mconcat
     [ Opt.long "output-format"
     , Opt.metavar "STRING"
     , Opt.help $ mconcat
-      [ "Optional governance action view output format. Accepted output formats are \"json\" "
+      [ "Optional ", kind ," view output format. Accepted output formats are \"json\" "
       , "and \"yaml\" (default is \"json\")."
       ]
-    , Opt.value GovernanceActionViewOutputFormatJson
+    , Opt.value ViewOutputFormatJson
     ]
 
 pMaybeOutputFile :: Parser (Maybe (File content Out))

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Vote.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Vote.hs
@@ -70,13 +70,6 @@ pGovernanceVoteViewCmd era = do
 pGovernanceVoteViewCmdArgs :: ConwayEraOnwards era -> Parser (GovernanceVoteViewCmdArgs era)
 pGovernanceVoteViewCmdArgs cOnwards =
   GovernanceVoteViewCmdArgs cOnwards
-    <$> pYamlOutput
+    <$> pGovernanceVoteViewOutputFormat
     <*> pFileInDirection "vote-file" "Input filepath of the vote."
     <*> pMaybeOutputFile
-  where
-    pYamlOutput :: Parser Bool
-    pYamlOutput =
-      Opt.switch
-        ( Opt.long "yaml"
-            <> Opt.help "Output vote in YAML format (and not JSON)."
-        )

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Actions.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Actions.hs
@@ -71,8 +71,8 @@ runGovernanceActionViewCmd
   firstExceptT GovernanceActionsCmdWriteFileError . newExceptT $
     friendlyProposal
       (case outFormat of
-        GovernanceActionViewOutputFormatJson -> FriendlyJson
-        GovernanceActionViewOutputFormatYaml -> FriendlyYaml)
+        ViewOutputFormatJson -> FriendlyJson
+        ViewOutputFormatYaml -> FriendlyYaml)
       mOutFile
       eon
       proposal

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Vote.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Vote.hs
@@ -85,7 +85,7 @@ runGovernanceVoteViewCmd :: ()
 runGovernanceVoteViewCmd
     Cmd.GovernanceVoteViewCmdArgs
       { eon
-      , yamlOutput
+      , outFormat
       , voteFile
       , mOutFile
       } = do
@@ -96,8 +96,12 @@ runGovernanceVoteViewCmd
      readVotingProceduresFile eon voteFile
     firstExceptT GovernanceVoteCmdWriteError .
       newExceptT .
-      (if yamlOutput
-      then writeByteStringOutput mOutFile . Yaml.encodePretty (Yaml.setConfCompare compare Yaml.defConfig)
-      else writeLazyByteStringOutput mOutFile . encodePretty' (defConfig {confCompare = compare})) .
+      (case outFormat of
+         ViewOutputFormatYaml ->
+           writeByteStringOutput mOutFile . Yaml.encodePretty
+             (Yaml.setConfCompare compare Yaml.defConfig)
+         ViewOutputFormatJson ->
+           writeLazyByteStringOutput mOutFile . encodePretty'
+             (defConfig {confCompare = compare})) .
       unVotingProcedures $
       voteProcedures

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Transaction.hs
@@ -1189,15 +1189,15 @@ runTransactionViewCmd
       -- is arguably not part of the transaction body.
       firstExceptT TxCmdWriteFileError . newExceptT $
         case outputFormat of
-          TxViewOutputFormatYaml -> friendlyTxBody FriendlyYaml mOutFile (toCardanoEra era) txbody
-          TxViewOutputFormatJson -> friendlyTxBody FriendlyJson mOutFile (toCardanoEra era) txbody
+          ViewOutputFormatYaml -> friendlyTxBody FriendlyYaml mOutFile (toCardanoEra era) txbody
+          ViewOutputFormatJson -> friendlyTxBody FriendlyJson mOutFile (toCardanoEra era) txbody
     InputTxFile (File txFilePath) -> do
       txFile <- liftIO $ fileOrPipe txFilePath
       InAnyShelleyBasedEra era tx <- lift (readFileTx txFile) & onLeft (left . TxCmdCddlError)
       firstExceptT TxCmdWriteFileError . newExceptT $
         case outputFormat of
-          TxViewOutputFormatYaml -> friendlyTx FriendlyYaml mOutFile (toCardanoEra era) tx
-          TxViewOutputFormatJson -> friendlyTx FriendlyJson mOutFile (toCardanoEra era) tx
+          ViewOutputFormatYaml -> friendlyTx FriendlyYaml mOutFile (toCardanoEra era) tx
+          ViewOutputFormatJson -> friendlyTx FriendlyJson mOutFile (toCardanoEra era) tx
 
 -- ----------------------------------------------------------------------------
 -- Witness commands

--- a/cardano-cli/src/Cardano/CLI/Legacy/Commands/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Commands/Transaction.hs
@@ -131,7 +131,7 @@ data LegacyTransactionCmds
   | TransactionTxIdCmd
       InputTxBodyOrTxFile
   | TransactionViewCmd
-      TxViewOutputFormat
+      ViewOutputFormat
       (Maybe (File () Out))
       InputTxBodyOrTxFile
 

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Transaction.hs
@@ -287,7 +287,7 @@ runLegacyTransactionTxIdCmd txfile =
         txfile
     )
 
-runLegacyTransactionViewCmd :: TxViewOutputFormat -> Maybe (File () Out) -> InputTxBodyOrTxFile -> ExceptT TxCmdError IO ()
+runLegacyTransactionViewCmd :: ViewOutputFormat -> Maybe (File () Out) -> InputTxBodyOrTxFile -> ExceptT TxCmdError IO ()
 runLegacyTransactionViewCmd
     yamlOrJson
     mOutFile

--- a/cardano-cli/src/Cardano/CLI/Parser.hs
+++ b/cardano-cli/src/Cardano/CLI/Parser.hs
@@ -3,15 +3,16 @@
 module Cardano.CLI.Parser
   ( readerFromAttoParser
   , readFractionAsRational
+  , readGovernanceActionViewOutputFormat
   , readKeyOutputFormat
   , readIdOutputFormat
   , readTxViewOutputFormat
   , readRational
   , readRationalUnitInterval
   , readStringOfMaxLength
+  , readViewOutputFormat
   , readURIOfMaxLength
   , eDNSName
-  , readGovernanceActionViewOutputFormat
   ) where
 
 import           Cardano.CLI.Types.Common
@@ -51,29 +52,23 @@ readKeyOutputFormat = do
         , ". Accepted output formats are \"text-envelope\" and \"bech32\"."
         ]
 
-readTxViewOutputFormat :: Opt.ReadM TxViewOutputFormat
-readTxViewOutputFormat = do
+readTxViewOutputFormat :: Opt.ReadM ViewOutputFormat
+readTxViewOutputFormat = readViewOutputFormat "transaction"
+
+readViewOutputFormat :: String -> Opt.ReadM ViewOutputFormat
+readViewOutputFormat kind = do
   s <- Opt.str @String
   case s of
-    "json" -> pure TxViewOutputFormatJson
-    "yaml" -> pure TxViewOutputFormatYaml
+    "json" -> pure ViewOutputFormatJson
+    "yaml" -> pure ViewOutputFormatYaml
     _ ->
       fail $ mconcat
-        [ "Invalid transaction view output format: " <> show s
+        [ "Invalid ", kind, " output format: " <> show s
         , ". Accepted output formats are \"json\" and \"yaml\"."
         ]
 
-readGovernanceActionViewOutputFormat :: Opt.ReadM GovernanceActionViewOutputFormat
-readGovernanceActionViewOutputFormat = do
-  s <- Opt.str @String
-  case s of
-    "json" -> pure GovernanceActionViewOutputFormatJson
-    "yaml" -> pure GovernanceActionViewOutputFormatYaml
-    _ ->
-      fail $ mconcat
-        [ "Invalid governance action view output format: " <> show s
-        , ". Accepted output formats are \"json\" and \"yaml\"."
-        ]
+readGovernanceActionViewOutputFormat :: Opt.ReadM ViewOutputFormat
+readGovernanceActionViewOutputFormat = readViewOutputFormat "governance action view"
 
 readURIOfMaxLength :: Int -> Opt.ReadM Text
 readURIOfMaxLength maxLen =

--- a/cardano-cli/src/Cardano/CLI/Types/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Common.hs
@@ -25,7 +25,6 @@ module Cardano.CLI.Types.Common
   , GenesisDir(..)
   , GenesisFile (..)
   , GenesisKeyFile(..)
-  , GovernanceActionViewOutputFormat(..)
   , InputTxBodyOrTxFile (..)
   , KeyOutputFormat(..)
   , MetadataFile(..)
@@ -70,10 +69,10 @@ module Cardano.CLI.Types.Common
   , TxOutCount(..)
   , TxOutDatumAnyEra (..)
   , TxShelleyWitnessCount(..)
-  , TxViewOutputFormat(..)
   , UpdateProposalFile (..)
   , VerificationKeyBase64(..)
   , VerificationKeyFile
+  , ViewOutputFormat(..)
   , VoteUrl(..)
   , VoteText(..)
   , VoteHashSource(..)
@@ -459,14 +458,9 @@ data TxMempoolQuery =
     | TxMempoolQueryInfo
   deriving Show
 
-data TxViewOutputFormat
-  = TxViewOutputFormatJson
-  | TxViewOutputFormatYaml
-  deriving Show
-
-data GovernanceActionViewOutputFormat
-  = GovernanceActionViewOutputFormatJson
-  | GovernanceActionViewOutputFormatYaml
+data ViewOutputFormat
+  = ViewOutputFormatJson
+  | ViewOutputFormatYaml
   deriving Show
 --
 -- Shelley CLI flag/option data types

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Governance/Vote.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Governance/Vote.hs
@@ -63,7 +63,7 @@ hprop_golden_governance_governance_vote_view_yaml =
     voteViewGold <- H.note "test/cardano-cli-golden/files/golden/governance/vote/voteViewYAML"
     voteView <- execCardanoCLI
       [ "conway", "governance", "vote", "view"
-      , "--yaml"
+      , "--output-format", "yaml"
       , "--vote-file", voteFile
       ]
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -6399,7 +6399,7 @@ Usage: cardano-cli conway governance vote create (--yes | --no | --abstain)
 
   Vote creation.
 
-Usage: cardano-cli conway governance vote view [--yaml]
+Usage: cardano-cli conway governance vote view [--output-format STRING]
                                                  --vote-file FILE
                                                  [--out-file FILE]
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_vote_view.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_vote_view.cli
@@ -1,11 +1,13 @@
-Usage: cardano-cli conway governance vote view [--yaml]
+Usage: cardano-cli conway governance vote view [--output-format STRING]
                                                  --vote-file FILE
                                                  [--out-file FILE]
 
   Vote viewing.
 
 Available options:
-  --yaml                   Output vote in YAML format (and not JSON).
+  --output-format STRING   Optional governance vote view output format. Accepted
+                           output formats are "json" and "yaml" (default is
+                           "json").
   --vote-file FILE         Input filepath of the vote.
   --out-file FILE          Optional output file. Default is to write to stdout.
   -h,--help                Show this help text


### PR DESCRIPTION
> [!NOTE]
>
> I will squash before merging but wanted to keep the commits separate in case there are comments, to better control history for myself

# Changelog

```yaml
- description: |
    governance vote view: use `--output-format`, like other commands, instead of `--yaml`
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Fixes https://github.com/input-output-hk/cardano-cli/issues/516

On the way, I shared some code in the parsers; because code duplication is what brought this issue in the first place I think.

# How to trust this PR

Inspect the diff in golden files

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [X] Self-reviewed the diff