### PR TITLE
[--output-format json|--output-format json] format becomes [--output-yaml|--output-json]

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
@@ -1579,15 +1579,17 @@ pGovernanceVoteViewOutputFormat = pViewOutputFormat "governance vote"
 -- to view some data (json or yaml). @what@ is the kind of data considered.
 pViewOutputFormat :: String -> Parser ViewOutputFormat
 pViewOutputFormat kind =
-  Opt.option (readViewOutputFormat kind) $ mconcat
-    [ Opt.long "output-format"
-    , Opt.metavar "STRING"
-    , Opt.help $ mconcat
-      [ "Optional ", kind ," view output format. Accepted output formats are \"json\" "
-      , "and \"yaml\" (default is \"json\")."
-      ]
-    , Opt.value ViewOutputFormatJson
+  asum
+    [ make ViewOutputFormatJson "JSON" "json" Nothing
+    , make ViewOutputFormatYaml "YAML" "yaml" (Just " Defaults to JSON if unspecified.")
     ]
+  where
+    make format desc flag_ extraHelp =
+      Opt.flag ViewOutputFormatJson format $ mconcat
+      [ Opt.help $
+          "Format " <> kind <> " view output to " <> desc <> "."
+            <> fromMaybe "" extraHelp
+      , Opt.long ("output-" <> flag_)]
 
 pMaybeOutputFile :: Parser (Maybe (File content Out))
 pMaybeOutputFile =

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Governance/Action.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Governance/Action.hs
@@ -116,7 +116,7 @@ hprop_golden_conway_governance_action_view_update_committee_yaml =
     actionView <- execCardanoCLI
       [ "conway", "governance", "action", "view"
       , "--action-file", actionFile
-      , "--output-format", "yaml"
+      , "--output-yaml"
       ]
     H.diffVsGoldenFile actionView goldenActionViewFile
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Governance/Vote.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Governance/Vote.hs
@@ -63,7 +63,7 @@ hprop_golden_governance_governance_vote_view_yaml =
     voteViewGold <- H.note "test/cardano-cli-golden/files/golden/governance/vote/voteViewYAML"
     voteView <- execCardanoCLI
       [ "conway", "governance", "vote", "view"
-      , "--output-format", "yaml"
+      , "--output-yaml"
       , "--vote-file", voteFile
       ]
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/TxView.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/TxView.hs
@@ -147,7 +147,7 @@ hprop_golden_view_shelley_yaml = let
     -- View transaction body
     result <-
       execCardanoCLI
-        ["transaction", "view", "--tx-body-file", transactionBodyFile, "--output-format", "yaml"]
+        ["transaction", "view", "--tx-body-file", transactionBodyFile, "--yaml"]
 
     H.diffVsGoldenFile result "test/cardano-cli-golden/files/golden/shelley/transaction-view.out"
 
@@ -245,7 +245,7 @@ hprop_golden_view_mary_yaml =
     -- View transaction body
     result <-
       execCardanoCLI
-        ["transaction", "view", "--tx-body-file", transactionBodyFile, "--output-format", "yaml"]
+        ["transaction", "view", "--tx-body-file", transactionBodyFile, "--yaml"]
     H.diffVsGoldenFile result "test/cardano-cli-golden/files/golden/mary/transaction-view.out"
 
 createAlonzoTxBody :: Maybe FilePath -> FilePath -> Integration ()
@@ -328,6 +328,6 @@ hprop_golden_view_alonzo_signed_yaml =
     -- View transaction body
     result <-
       execCardanoCLI
-        ["transaction", "view", "--tx-file", transactionFile, "--output-format", "yaml"]
+        ["transaction", "view", "--tx-file", transactionFile, "--yaml"]
 
     H.diffVsGoldenFile result (golden </> "signed-transaction-view.out")

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/TxView.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/TxView.hs
@@ -40,7 +40,7 @@ _hprop_golden_view_byron_yaml =
     -- View transaction body
     result <-
       execCardanoCLI
-        ["transaction", "view", "--tx-body-file", transactionBodyFile, "--output-format", "yaml"]
+        ["transaction", "view", "--tx-body-file", transactionBodyFile, "--output-yaml"]
     H.diffVsGoldenFile result "test/cardano-cli-golden/files/golden/byron/transaction-view.out"
 
 -- TODO: Expose command to view byron tx files
@@ -147,7 +147,7 @@ hprop_golden_view_shelley_yaml = let
     -- View transaction body
     result <-
       execCardanoCLI
-        ["transaction", "view", "--tx-body-file", transactionBodyFile, "--yaml"]
+        ["transaction", "view", "--tx-body-file", transactionBodyFile, "--output-yaml"]
 
     H.diffVsGoldenFile result "test/cardano-cli-golden/files/golden/shelley/transaction-view.out"
 
@@ -178,7 +178,7 @@ hprop_golden_view_allegra_yaml =
     -- View transaction body
     result <-
       execCardanoCLI
-        ["transaction", "view", "--tx-body-file", transactionBodyFile, "--output-format", "yaml"]
+        ["transaction", "view", "--tx-body-file", transactionBodyFile, "--output-yaml"]
     H.diffVsGoldenFile result "test/cardano-cli-golden/files/golden/allegra/transaction-view.out"
 
 hprop_golden_view_mary_yaml :: Property
@@ -245,7 +245,7 @@ hprop_golden_view_mary_yaml =
     -- View transaction body
     result <-
       execCardanoCLI
-        ["transaction", "view", "--tx-body-file", transactionBodyFile, "--yaml"]
+        ["transaction", "view", "--tx-body-file", transactionBodyFile, "--output-yaml"]
     H.diffVsGoldenFile result "test/cardano-cli-golden/files/golden/mary/transaction-view.out"
 
 createAlonzoTxBody :: Maybe FilePath -> FilePath -> Integration ()
@@ -302,7 +302,7 @@ hprop_golden_view_alonzo_yaml =
       -- View transaction body
       result <-
         execCardanoCLI
-          ["transaction", "view", "--tx-body-file", transactionBodyFile, "--output-format", "yaml"]
+          ["transaction", "view", "--tx-body-file", transactionBodyFile, "--output-yaml"]
       H.diffVsGoldenFile result "test/cardano-cli-golden/files/golden/alonzo/transaction-view.out"
 
 hprop_golden_view_alonzo_signed_yaml :: Property
@@ -328,6 +328,6 @@ hprop_golden_view_alonzo_signed_yaml =
     -- View transaction body
     result <-
       execCardanoCLI
-        ["transaction", "view", "--tx-file", transactionFile, "--yaml"]
+        ["transaction", "view", "--tx-file", transactionFile, "--output-yaml"]
 
     H.diffVsGoldenFile result (golden </> "signed-transaction-view.out")

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -1164,7 +1164,7 @@ Usage: cardano-cli shelley transaction txid
 
   Print a transaction identifier.
 
-Usage: cardano-cli shelley transaction view [--output-format STRING]
+Usage: cardano-cli shelley transaction view [--output-json | --output-yaml]
                                               [--out-file FILE]
                                               ( --tx-body-file FILE
                                               | --tx-file FILE
@@ -2323,7 +2323,7 @@ Usage: cardano-cli allegra transaction txid
 
   Print a transaction identifier.
 
-Usage: cardano-cli allegra transaction view [--output-format STRING]
+Usage: cardano-cli allegra transaction view [--output-json | --output-yaml]
                                               [--out-file FILE]
                                               ( --tx-body-file FILE
                                               | --tx-file FILE
@@ -3463,7 +3463,7 @@ Usage: cardano-cli mary transaction txid (--tx-body-file FILE | --tx-file FILE)
 
   Print a transaction identifier.
 
-Usage: cardano-cli mary transaction view [--output-format STRING]
+Usage: cardano-cli mary transaction view [--output-json | --output-yaml]
                                            [--out-file FILE]
                                            ( --tx-body-file FILE
                                            | --tx-file FILE
@@ -4626,7 +4626,7 @@ Usage: cardano-cli alonzo transaction txid
 
   Print a transaction identifier.
 
-Usage: cardano-cli alonzo transaction view [--output-format STRING]
+Usage: cardano-cli alonzo transaction view [--output-json | --output-yaml]
                                              [--out-file FILE]
                                              ( --tx-body-file FILE
                                              | --tx-file FILE
@@ -5811,7 +5811,7 @@ Usage: cardano-cli babbage transaction txid
 
   Print a transaction identifier.
 
-Usage: cardano-cli babbage transaction view [--output-format STRING]
+Usage: cardano-cli babbage transaction view [--output-json | --output-yaml]
                                               [--out-file FILE]
                                               ( --tx-body-file FILE
                                               | --tx-file FILE
@@ -6258,7 +6258,9 @@ Usage: cardano-cli conway governance action create-treasury-withdrawal
   Create a treasury withdrawal.
 
 Usage: cardano-cli conway governance action view --action-file FILE
-                                                   [--output-format STRING]
+                                                   [ --output-json
+                                                   | --output-yaml
+                                                   ]
                                                    [--out-file FILE]
 
   View a governance action.
@@ -6399,7 +6401,7 @@ Usage: cardano-cli conway governance vote create (--yes | --no | --abstain)
 
   Vote creation.
 
-Usage: cardano-cli conway governance vote view [--output-format STRING]
+Usage: cardano-cli conway governance vote view [--output-json | --output-yaml]
                                                  --vote-file FILE
                                                  [--out-file FILE]
 
@@ -7320,7 +7322,7 @@ Usage: cardano-cli conway transaction txid
 
   Print a transaction identifier.
 
-Usage: cardano-cli conway transaction view [--output-format STRING]
+Usage: cardano-cli conway transaction view [--output-json | --output-yaml]
                                              [--out-file FILE]
                                              ( --tx-body-file FILE
                                              | --tx-file FILE
@@ -8502,7 +8504,7 @@ Usage: cardano-cli latest transaction txid
 
   Print a transaction identifier.
 
-Usage: cardano-cli latest transaction view [--output-format STRING]
+Usage: cardano-cli latest transaction view [--output-json | --output-yaml]
                                              [--out-file FILE]
                                              ( --tx-body-file FILE
                                              | --tx-file FILE
@@ -9540,7 +9542,7 @@ Usage: cardano-cli legacy transaction txid
 
   Print a transaction identifier.
 
-Usage: cardano-cli legacy transaction view [--output-format STRING]
+Usage: cardano-cli legacy transaction view [--output-json | --output-yaml]
                                              [--out-file FILE]
                                              ( --tx-body-file FILE
                                              | --tx-file FILE
@@ -10733,7 +10735,7 @@ Usage: cardano-cli transaction txid (--tx-body-file FILE | --tx-file FILE)
 
   Print a transaction identifier.
 
-Usage: cardano-cli transaction view [--output-format STRING]
+Usage: cardano-cli transaction view [--output-json | --output-yaml]
                                       [--out-file FILE]
                                       (--tx-body-file FILE | --tx-file FILE)
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_transaction_view.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_transaction_view.cli
@@ -1,4 +1,4 @@
-Usage: cardano-cli allegra transaction view [--output-format STRING]
+Usage: cardano-cli allegra transaction view [--output-json | --output-yaml]
                                               [--out-file FILE]
                                               ( --tx-body-file FILE
                                               | --tx-file FILE
@@ -7,9 +7,9 @@ Usage: cardano-cli allegra transaction view [--output-format STRING]
   Print a transaction.
 
 Available options:
-  --output-format STRING   Optional transaction view output format. Accepted
-                           output formats are "json" and "yaml" (default is
-                           "json").
+  --output-json            Format transaction view output to JSON.
+  --output-yaml            Format transaction view output to YAML. Defaults to
+                           JSON if unspecified.
   --out-file FILE          Optional output file. Default is to write to stdout.
   --tx-body-file FILE      Input filepath of the JSON TxBody.
   --tx-file FILE           Input filepath of the JSON Tx.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_transaction_view.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_transaction_view.cli
@@ -1,4 +1,4 @@
-Usage: cardano-cli alonzo transaction view [--output-format STRING]
+Usage: cardano-cli alonzo transaction view [--output-json | --output-yaml]
                                              [--out-file FILE]
                                              ( --tx-body-file FILE
                                              | --tx-file FILE
@@ -7,9 +7,9 @@ Usage: cardano-cli alonzo transaction view [--output-format STRING]
   Print a transaction.
 
 Available options:
-  --output-format STRING   Optional transaction view output format. Accepted
-                           output formats are "json" and "yaml" (default is
-                           "json").
+  --output-json            Format transaction view output to JSON.
+  --output-yaml            Format transaction view output to YAML. Defaults to
+                           JSON if unspecified.
   --out-file FILE          Optional output file. Default is to write to stdout.
   --tx-body-file FILE      Input filepath of the JSON TxBody.
   --tx-file FILE           Input filepath of the JSON Tx.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_transaction_view.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_transaction_view.cli
@@ -1,4 +1,4 @@
-Usage: cardano-cli babbage transaction view [--output-format STRING]
+Usage: cardano-cli babbage transaction view [--output-json | --output-yaml]
                                               [--out-file FILE]
                                               ( --tx-body-file FILE
                                               | --tx-file FILE
@@ -7,9 +7,9 @@ Usage: cardano-cli babbage transaction view [--output-format STRING]
   Print a transaction.
 
 Available options:
-  --output-format STRING   Optional transaction view output format. Accepted
-                           output formats are "json" and "yaml" (default is
-                           "json").
+  --output-json            Format transaction view output to JSON.
+  --output-yaml            Format transaction view output to YAML. Defaults to
+                           JSON if unspecified.
   --out-file FILE          Optional output file. Default is to write to stdout.
   --tx-body-file FILE      Input filepath of the JSON TxBody.
   --tx-file FILE           Input filepath of the JSON Tx.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_view.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_view.cli
@@ -1,13 +1,15 @@
 Usage: cardano-cli conway governance action view --action-file FILE
-                                                   [--output-format STRING]
+                                                   [ --output-json
+                                                   | --output-yaml
+                                                   ]
                                                    [--out-file FILE]
 
   View a governance action.
 
 Available options:
   --action-file FILE       Path to action file.
-  --output-format STRING   Optional governance action view output format.
-                           Accepted output formats are "json" and "yaml"
-                           (default is "json").
+  --output-json            Format governance action view output to JSON.
+  --output-yaml            Format governance action view output to YAML.
+                           Defaults to JSON if unspecified.
   --out-file FILE          Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_vote_view.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_vote_view.cli
@@ -1,13 +1,13 @@
-Usage: cardano-cli conway governance vote view [--output-format STRING]
+Usage: cardano-cli conway governance vote view [--output-json | --output-yaml]
                                                  --vote-file FILE
                                                  [--out-file FILE]
 
   Vote viewing.
 
 Available options:
-  --output-format STRING   Optional governance vote view output format. Accepted
-                           output formats are "json" and "yaml" (default is
-                           "json").
+  --output-json            Format governance vote view output to JSON.
+  --output-yaml            Format governance vote view output to YAML. Defaults
+                           to JSON if unspecified.
   --vote-file FILE         Input filepath of the vote.
   --out-file FILE          Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_view.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_view.cli
@@ -1,4 +1,4 @@
-Usage: cardano-cli conway transaction view [--output-format STRING]
+Usage: cardano-cli conway transaction view [--output-json | --output-yaml]
                                              [--out-file FILE]
                                              ( --tx-body-file FILE
                                              | --tx-file FILE
@@ -7,9 +7,9 @@ Usage: cardano-cli conway transaction view [--output-format STRING]
   Print a transaction.
 
 Available options:
-  --output-format STRING   Optional transaction view output format. Accepted
-                           output formats are "json" and "yaml" (default is
-                           "json").
+  --output-json            Format transaction view output to JSON.
+  --output-yaml            Format transaction view output to YAML. Defaults to
+                           JSON if unspecified.
   --out-file FILE          Optional output file. Default is to write to stdout.
   --tx-body-file FILE      Input filepath of the JSON TxBody.
   --tx-file FILE           Input filepath of the JSON Tx.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_transaction_view.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_transaction_view.cli
@@ -1,4 +1,4 @@
-Usage: cardano-cli latest transaction view [--output-format STRING]
+Usage: cardano-cli latest transaction view [--output-json | --output-yaml]
                                              [--out-file FILE]
                                              ( --tx-body-file FILE
                                              | --tx-file FILE
@@ -7,9 +7,9 @@ Usage: cardano-cli latest transaction view [--output-format STRING]
   Print a transaction.
 
 Available options:
-  --output-format STRING   Optional transaction view output format. Accepted
-                           output formats are "json" and "yaml" (default is
-                           "json").
+  --output-json            Format transaction view output to JSON.
+  --output-yaml            Format transaction view output to YAML. Defaults to
+                           JSON if unspecified.
   --out-file FILE          Optional output file. Default is to write to stdout.
   --tx-body-file FILE      Input filepath of the JSON TxBody.
   --tx-file FILE           Input filepath of the JSON Tx.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_transaction_view.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_transaction_view.cli
@@ -1,4 +1,4 @@
-Usage: cardano-cli legacy transaction view [--output-format STRING]
+Usage: cardano-cli legacy transaction view [--output-json | --output-yaml]
                                              [--out-file FILE]
                                              ( --tx-body-file FILE
                                              | --tx-file FILE
@@ -7,9 +7,9 @@ Usage: cardano-cli legacy transaction view [--output-format STRING]
   Print a transaction.
 
 Available options:
-  --output-format STRING   Optional transaction view output format. Accepted
-                           output formats are "json" and "yaml" (default is
-                           "json").
+  --output-json            Format transaction view output to JSON.
+  --output-yaml            Format transaction view output to YAML. Defaults to
+                           JSON if unspecified.
   --out-file FILE          Optional output file. Default is to write to stdout.
   --tx-body-file FILE      Input filepath of the JSON TxBody.
   --tx-file FILE           Input filepath of the JSON Tx.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_transaction_view.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_transaction_view.cli
@@ -1,4 +1,4 @@
-Usage: cardano-cli mary transaction view [--output-format STRING]
+Usage: cardano-cli mary transaction view [--output-json | --output-yaml]
                                            [--out-file FILE]
                                            ( --tx-body-file FILE
                                            | --tx-file FILE
@@ -7,9 +7,9 @@ Usage: cardano-cli mary transaction view [--output-format STRING]
   Print a transaction.
 
 Available options:
-  --output-format STRING   Optional transaction view output format. Accepted
-                           output formats are "json" and "yaml" (default is
-                           "json").
+  --output-json            Format transaction view output to JSON.
+  --output-yaml            Format transaction view output to YAML. Defaults to
+                           JSON if unspecified.
   --out-file FILE          Optional output file. Default is to write to stdout.
   --tx-body-file FILE      Input filepath of the JSON TxBody.
   --tx-file FILE           Input filepath of the JSON Tx.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_transaction_view.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_transaction_view.cli
@@ -1,4 +1,4 @@
-Usage: cardano-cli shelley transaction view [--output-format STRING]
+Usage: cardano-cli shelley transaction view [--output-json | --output-yaml]
                                               [--out-file FILE]
                                               ( --tx-body-file FILE
                                               | --tx-file FILE
@@ -7,9 +7,9 @@ Usage: cardano-cli shelley transaction view [--output-format STRING]
   Print a transaction.
 
 Available options:
-  --output-format STRING   Optional transaction view output format. Accepted
-                           output formats are "json" and "yaml" (default is
-                           "json").
+  --output-json            Format transaction view output to JSON.
+  --output-yaml            Format transaction view output to YAML. Defaults to
+                           JSON if unspecified.
   --out-file FILE          Optional output file. Default is to write to stdout.
   --tx-body-file FILE      Input filepath of the JSON TxBody.
   --tx-file FILE           Input filepath of the JSON Tx.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/transaction_view.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/transaction_view.cli
@@ -1,13 +1,13 @@
-Usage: cardano-cli transaction view [--output-format STRING]
+Usage: cardano-cli transaction view [--output-json | --output-yaml]
                                       [--out-file FILE]
                                       (--tx-body-file FILE | --tx-file FILE)
 
   Print a transaction.
 
 Available options:
-  --output-format STRING   Optional transaction view output format. Accepted
-                           output formats are "json" and "yaml" (default is
-                           "json").
+  --output-json            Format transaction view output to JSON.
+  --output-yaml            Format transaction view output to YAML. Defaults to
+                           JSON if unspecified.
   --out-file FILE          Optional output file. Default is to write to stdout.
   --tx-body-file FILE      Input filepath of the JSON TxBody.
   --tx-file FILE           Input filepath of the JSON Tx.


### PR DESCRIPTION
> [!WARNING]
>
> In addition to changing `governance` commands, I changed the behavior of `transaction view` too; to be consistent.
> If we don't want to change `transaction view` (which is a historical command right?), LMK I will revert this part of the change.

# Changelog

```yaml
- description: |
    In `transaction view` and `governance action view`, replace:
    
    `--output-format json` by `--output-json`
    `--output-format yaml` by `--output-yaml`
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

* Follow-up of https://github.com/input-output-hk/cardano-cli/pull/521
* Implementation of this remark: https://github.com/input-output-hk/cardano-cli/pull/521#discussion_r1425479822

# How to trust this PR

Look at the diff of golden files

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [X] Self-reviewed the diff