### PR TITLE
Use AnyShelleyBasedEra in ScriptWitnessErrorReferenceScriptsNotSupportedInEra

### DIFF
--- a/cardano-cli/src/Cardano/CLI/Read.hs
+++ b/cardano-cli/src/Cardano/CLI/Read.hs
@@ -225,7 +225,7 @@ data ScriptWitnessError
   | ScriptWitnessErrorScriptLanguageNotSupportedInEra AnyScriptLanguage AnyCardanoEra
   | ScriptWitnessErrorExpectedSimple !FilePath !AnyScriptLanguage
   | ScriptWitnessErrorExpectedPlutus !FilePath !AnyScriptLanguage
-  | ScriptWitnessErrorReferenceScriptsNotSupportedInEra !AnyCardanoEra
+  | ScriptWitnessErrorReferenceScriptsNotSupportedInEra !AnyShelleyBasedEra
   | ScriptWitnessErrorScriptData ScriptDataError
 
 renderScriptWitnessError :: ScriptWitnessError -> Doc ann
@@ -244,7 +244,7 @@ renderScriptWitnessError = \case
     pretty file <> ": expected a script in the Plutus script language, " <>
     "but it is actually using " <> pshow lang <> "."
   ScriptWitnessErrorReferenceScriptsNotSupportedInEra anyEra ->
-    "Reference scripts not supported in era: " <> pretty anyEra
+    "Reference scripts not supported in era: " <> pshow anyEra
   ScriptWitnessErrorScriptData sDataError ->
     renderScriptDataError sDataError
 
@@ -324,8 +324,7 @@ readScriptWitness era (PlutusReferenceScriptWitnessFiles refTxIn
   caseShelleyToAlonzoOrBabbageEraOnwards
     ( const $ left
         $ ScriptWitnessErrorReferenceScriptsNotSupportedInEra
-          -- TODO: Update error to use AnyShelleyBasedEra
-        $ cardanoEraConstraints (toCardanoEra era) (AnyCardanoEra $ toCardanoEra era)
+        $ cardanoEraConstraints (toCardanoEra era) (AnyShelleyBasedEra era)
     )
     ( const $
         case scriptLanguageSupportedInEra era anyScriptLanguage of
@@ -354,7 +353,7 @@ readScriptWitness era (SimpleReferenceScriptWitnessFiles refTxIn
   caseShelleyToAlonzoOrBabbageEraOnwards
     ( const $ left
         $ ScriptWitnessErrorReferenceScriptsNotSupportedInEra
-        $ cardanoEraConstraints (toCardanoEra era) (AnyCardanoEra $ toCardanoEra era)
+        $ cardanoEraConstraints (toCardanoEra era) (AnyShelleyBasedEra era)
     )
     ( const $
         case scriptLanguageSupportedInEra era anyScriptLanguage of


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    use AnyShelleyBasedEra
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Just removing a TODO in code

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
