### PR TITLE
Update hedgehog-extras to 0.5.0.0

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -13,7 +13,7 @@ repository cardano-haskell-packages
 -- See CONTRIBUTING for information about these, including some Nix commands
 -- you need to run if you change them
 index-state:
-  , hackage.haskell.org 2023-11-20T23:52:53Z
+  , hackage.haskell.org 2023-12-16T11:21:56Z
   , cardano-haskell-packages 2023-12-06T18:36:58Z
 
 packages:

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -272,7 +272,7 @@ library cardano-cli-test-lib
                       , exceptions
                       , filepath
                       , hedgehog
-                      , hedgehog-extras ^>= 0.4.7.0
+                      , hedgehog-extras ^>= 0.5.0.0
                       , process
                       , text
                       , transformers
@@ -296,7 +296,7 @@ test-suite cardano-cli-test
                       , containers
                       , filepath
                       , hedgehog
-                      , hedgehog-extras ^>= 0.4.7.0
+                      , hedgehog-extras ^>= 0.5.0.0
                       , tasty
                       , tasty-hedgehog
                       , text
@@ -345,7 +345,7 @@ test-suite cardano-cli-golden
                       , directory
                       , filepath
                       , hedgehog ^>= 1.3
-                      , hedgehog-extras ^>= 0.4.7.0
+                      , hedgehog-extras ^>= 0.5.0.0
                       , regex-compat
                       , regex-tdfa
                       , tasty


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Upgrade hedgehog-extras to 0.5.0.0
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

* Prepare for newer version of cardano-api, that requires hedgehog-extras 0.5.0.0

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- NA New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [X] Self-reviewed the diff