### PR TITLE
Release 8.18.0.0

### DIFF
--- a/cardano-cli/CHANGELOG.md
+++ b/cardano-cli/CHANGELOG.md
@@ -1,5 +1,64 @@
 # Changelog for cardano-cli
 
+# 8.18.0.0
+
+- Upgrade hedgehog-extras to 0.5.0.0
+  (compatible)
+  [PR 536](https://github.com/IntersectMBO/cardano-cli/pull/536)
+
+- Make it possible to merge again, by fixing dead links
+  (compatible, improvement)
+  [PR 528](https://github.com/IntersectMBO/cardano-cli/pull/528)
+
+- use AnyShelleyBasedEra
+  (improvement)
+  [PR 535](https://github.com/IntersectMBO/cardano-cli/pull/535)
+
+- In `transaction view` and `governance action view`, replace:
+  
+  `--output-format json` by `--output-json`
+  `--output-format yaml` by `--output-yaml`
+  (breaking)
+  [PR 523](https://github.com/IntersectMBO/cardano-cli/pull/523)
+
+- governance vote view: use `--output-format`, like other commands, instead of `--yaml`
+  (breaking)
+  [PR 521](https://github.com/IntersectMBO/cardano-cli/pull/521)
+
+- split eras in transaction build
+  (bugfix)
+  [PR 520](https://github.com/IntersectMBO/cardano-cli/pull/520)
+
+- create-testnet-data: rename --stake-delegators to --transient-stake-delegators
+  
+  Introduce --stake-delegators, that generates delegators, but write credentials to disk.
+  (feature, breaking)
+  [PR 512](https://github.com/IntersectMBO/cardano-cli/pull/512)
+
+- Make `query pool-state` default to returning information on all pools
+  (bugfix)
+  [PR 514](https://github.com/IntersectMBO/cardano-cli/pull/514)
+
+- `stake-address registration-certificate`: remove flag `--key-reg-deposit-amt` from all eras except conway
+  (breaking)
+  [PR 509](https://github.com/IntersectMBO/cardano-cli/pull/509)
+
+- Remove the `constitution-hash` option from the non-conway versions of `query`
+  (breaking)
+  [PR 515](https://github.com/IntersectMBO/cardano-cli/pull/515)
+
+- replace Aeson encode with encodePretty
+  (improvement)
+  [PR 513](https://github.com/IntersectMBO/cardano-cli/pull/513)
+
+- [create-testnet-data: add succinct documentation in generated directory
+  (breaking)
+  [PR 508](https://github.com/IntersectMBO/cardano-cli/pull/508)
+
+- Use the same parameter names for previous governance action txid and tx index in all governance actions.
+  (breaking, improvement, test)
+  [PR 511](https://github.com/IntersectMBO/cardano-cli/pull/511)
+
 ## 8.17.0.0
 
 - Restore the inclusion of datum hashes in Alonzo era tx bodies

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.4
 
 name:                   cardano-cli
-version:                8.17.0.0
+version:                8.18.0.0
 synopsis:               The Cardano command-line interface
 description:            The Cardano command-line interface.
 copyright:              2020-2023 Input Output Global Inc (IOG).


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Release 8.18.0.0, featuring cardano-api 8.37.0.0
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

We want https://github.com/IntersectMBO/cardano-api/pull/400 available in cardano-node, i.e cardano-api 8.37.0.0, so that adding new Conway tests in cardano-node is easier.

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- NA New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [X] Self-reviewed the diff