### PR TITLE
Fix changelog syntax, so that cardano-dev's tag.sh script works

### DIFF
--- a/cardano-cli/CHANGELOG.md
+++ b/cardano-cli/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog for cardano-cli
 
-# 8.18.0.0
+## 8.18.0.0
 
 - Upgrade hedgehog-extras to 0.5.0.0
   (compatible)


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Fix changelog syntax
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

The changelog entry for 8.18.0.0 is missing a #, making tag.sh from cardano-dev fail :facepalm: 