### PR TITLE
Clarify DRep queries with an all-or-some logic

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Query.hs
@@ -187,7 +187,7 @@ data QueryDRepStateCmdArgs era = QueryDRepStateCmdArgs
   , nodeSocketPath      :: !SocketPath
   , consensusModeParams :: !ConsensusModeParams
   , networkId           :: !NetworkId
-  , drepKeys            :: ![VerificationKeyOrHashOrFile DRepKey]
+  , drepKeys            :: !(AllOrOnly (VerificationKeyOrHashOrFile DRepKey))
   , mOutFile            :: !(Maybe (File () Out))
   } deriving Show
 
@@ -196,7 +196,7 @@ data QueryDRepStakeDistributionCmdArgs era = QueryDRepStakeDistributionCmdArgs
   , nodeSocketPath      :: !SocketPath
   , consensusModeParams :: !ConsensusModeParams
   , networkId           :: !NetworkId
-  , drepKeys            :: ![VerificationKeyOrHashOrFile DRepKey]
+  , drepKeys            :: !(AllOrOnly (VerificationKeyOrHashOrFile DRepKey))
   , mOutFile            :: !(Maybe (File () Out))
   } deriving Show
 

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
@@ -3064,39 +3064,21 @@ pDRepVerificationKeyOrHashOrFile =
     , VerificationKeyHash <$> pDRepVerificationKeyHash
     ]
 
-pCombinedDRepVerificationKey :: Parser (VerificationKey DRepKey)
-pCombinedDRepVerificationKey =
-  Opt.option (readVerificationKey AsDRepKey) $ mconcat
-    [ Opt.long "combined-drep-verification-key"
-    , Opt.metavar "STRING"
-    , Opt.help "DRep verification key (Bech32 or hex-encoded)."
-    ]
-
-pCombinedDRepVerificationKeyOrFile :: Parser (VerificationKeyOrFile DRepKey)
-pCombinedDRepVerificationKeyOrFile =
-  asum
-    [ VerificationKeyValue <$> pCombinedDRepVerificationKey
-    , VerificationKeyFilePath <$> pCombinedDRepVerificationKeyFile
-    ]
-
-pCombinedDRepVerificationKeyFile :: Parser (VerificationKeyFile In)
-pCombinedDRepVerificationKeyFile =
-  fmap File . Opt.strOption $ mconcat
-    [ Opt.long "combined-drep-verification-key-file"
-    , Opt.metavar "FILE"
-    , Opt.help "Filepath of the DRep verification key."
-    , Opt.completer (Opt.bashCompleter "file")
-    ]
+pAllOrOnlyDRepVerificationKeyOrHashOrFile
+  :: Parser (AllOrOnly (VerificationKeyOrHashOrFile DRepKey))
+pAllOrOnlyDRepVerificationKeyOrHashOrFile = pAll <|> pOnly
+  where pOnly = Only <$> some pDRepVerificationKeyOrHashOrFile
+        pAll = Opt.flag' All $ mconcat
+          [ Opt.long "all-dreps"
+          , Opt.help "Query for all DReps."
+          ]
 
 pDRepVerificationKeyHash :: Parser (Hash DRepKey)
 pDRepVerificationKeyHash =
     Opt.option (pBech32KeyHash AsDRepKey <|> pHexHash AsDRepKey) $ mconcat
       [ Opt.long "drep-key-hash"
       , Opt.metavar "HASH"
-      , Opt.help $ mconcat
-          [ "DRep verification key hash (either Bech32-encoded or hex-encoded).  "
-          , "Zero or more occurences of this option is allowed."
-          ]
+      , Opt.help "DRep verification key hash (either Bech32-encoded or hex-encoded)."
       ]
 
 pDRepVerificationKey :: Parser (VerificationKey DRepKey)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
@@ -937,55 +937,6 @@ pStakePoolVerificationKeyOrHashOrFile prefix =
     , VerificationKeyHash <$> pStakePoolVerificationKeyHash prefix
     ]
 
-pCombinedStakePoolVerificationKeyOrHashOrFile
-  :: Parser (VerificationKeyOrHashOrFile StakePoolKey)
-pCombinedStakePoolVerificationKeyOrHashOrFile =
-  asum
-    [ VerificationKeyOrFile <$> pCombinedStakePoolVerificationKeyOrFile
-    , VerificationKeyHash <$> pCombinedStakePoolVerificationKeyHash
-    ]
-
-pCombinedStakePoolVerificationKeyOrFile :: Parser (VerificationKeyOrFile StakePoolKey)
-pCombinedStakePoolVerificationKeyOrFile =
-  asum
-    [ VerificationKeyValue <$> pCombinedStakePoolVerificationKey
-    , VerificationKeyFilePath <$> pCombinedStakePoolVerificationKeyFile
-    ]
-
-pCombinedStakePoolVerificationKeyHash :: Parser (Hash StakePoolKey)
-pCombinedStakePoolVerificationKeyHash =
-    Opt.option (pBech32KeyHash AsStakePoolKey <|> pHexHash AsStakePoolKey) $ mconcat
-      [ Opt.long "combined-stake-pool-id"
-      , Opt.metavar "STAKE_POOL_ID"
-      , Opt.help $ mconcat
-          [ "Stake pool ID/verification key hash (either Bech32-encoded or hex-encoded).  "
-          , "Zero or more occurences of this option is allowed."
-          ]
-      ]
-
-pCombinedStakePoolVerificationKey :: Parser (VerificationKey StakePoolKey)
-pCombinedStakePoolVerificationKey =
-  Opt.option (readVerificationKey AsStakePoolKey) $ mconcat
-    [ Opt.long "combined-stake-pool-verification-key"
-    , Opt.metavar "STRING"
-    , Opt.help "Stake pool verification key (Bech32 or hex-encoded)."
-    ]
-
-pCombinedStakePoolVerificationKeyFile :: Parser (VerificationKeyFile In)
-pCombinedStakePoolVerificationKeyFile =
-  File <$> asum
-    [ Opt.strOption $ mconcat
-      [ Opt.long "combined-cold-verification-key-file"
-      , Opt.metavar "FILE"
-      , Opt.help "Filepath of the stake pool verification key."
-      , Opt.completer (Opt.bashCompleter "file")
-      ]
-    , Opt.strOption $ mconcat
-      [ Opt.long "stake-pool-verification-key-file"
-      , Opt.internal
-      ]
-    ]
-
 --------------------------------------------------------------------------------
 
 pCBORInFile :: Parser FilePath

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Query.hs
@@ -322,7 +322,7 @@ pQueryDRepStateCmd era envCli = do
         <$> pSocketPath envCli
         <*> pConsensusModeParams
         <*> pNetworkId envCli
-        <*> many pDRepVerificationKeyOrHashOrFile
+        <*> pAllOrOnlyDRepVerificationKeyOrHashOrFile
         <*> optional pOutputFile
 
 pQueryDRepStakeDistributionCmd :: ()
@@ -341,7 +341,7 @@ pQueryDRepStakeDistributionCmd era envCli = do
       <$> pSocketPath envCli
       <*> pConsensusModeParams
       <*> pNetworkId envCli
-      <*> many pDRepVerificationKeyOrHashOrFile
+      <*> pAllOrOnlyDRepVerificationKeyOrHashOrFile
       <*> optional pOutputFile
 
 pQueryGetCommitteeStateCmd :: ()

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Query.hs
@@ -1393,11 +1393,14 @@ runQueryDRepState
       , Cmd.nodeSocketPath
       , Cmd.consensusModeParams
       , Cmd.networkId
-      , Cmd.drepKeys = drepKeys
+      , Cmd.drepKeys = drepKeys'
       , Cmd.mOutFile
       } = conwayEraOnwardsConstraints eon $ do
   let localNodeConnInfo = LocalNodeConnectInfo consensusModeParams networkId nodeSocketPath
 
+  let drepKeys = case drepKeys' of
+                   All -> []
+                   Only l -> l
   drepCreds <- Set.fromList <$> mapM (firstExceptT QueryCmdDRepKeyError . getDRepCredentialFromVerKeyHashOrFile) drepKeys
 
   drepState <- runQuery localNodeConnInfo $ queryDRepState eon drepCreds
@@ -1419,7 +1422,7 @@ runQueryDRepStakeDistribution
       , Cmd.nodeSocketPath
       , Cmd.consensusModeParams
       , Cmd.networkId
-      , Cmd.drepKeys = drepKeys
+      , Cmd.drepKeys = drepKeys'
       , Cmd.mOutFile
       } = conwayEraOnwardsConstraints eon $ do
   let localNodeConnInfo = LocalNodeConnectInfo consensusModeParams networkId nodeSocketPath
@@ -1427,6 +1430,9 @@ runQueryDRepStakeDistribution
   let drepFromVrfKey = fmap Ledger.DRepCredential
                      . firstExceptT QueryCmdDRepKeyError
                      . getDRepCredentialFromVerKeyHashOrFile
+      drepKeys = case drepKeys' of
+                   All -> []
+                   Only l -> l
   dreps <- Set.fromList <$> mapM drepFromVrfKey drepKeys
 
   drepStakeDistribution <- runQuery localNodeConnInfo $ queryDRepStakeDistribution eon dreps

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -6697,10 +6697,13 @@ Usage: cardano-cli conway query drep-state --socket-path SOCKET_PATH
                                              ( --mainnet
                                              | --testnet-magic NATURAL
                                              )
-                                             [ --drep-verification-key STRING
+                                             ( --all-dreps
+                                             | 
+                                             ( --drep-verification-key STRING
                                              | --drep-verification-key-file FILE
                                              | --drep-key-hash HASH
-                                             ]
+                                             )
+                                             )
                                              [--out-file FILE]
 
   Get the DRep state. If no DRep credentials are provided, return states for all
@@ -6713,10 +6716,13 @@ Usage: cardano-cli conway query drep-stake-distribution
                                                           ( --mainnet
                                                           | --testnet-magic NATURAL
                                                           )
-                                                          [ --drep-verification-key STRING
+                                                          ( --all-dreps
+                                                          | 
+                                                          ( --drep-verification-key STRING
                                                           | --drep-verification-key-file FILE
                                                           | --drep-key-hash HASH
-                                                          ]
+                                                          )
+                                                          )
                                                           [--out-file FILE]
 
   Get the DRep stake distribution. If no DRep credentials are provided, return

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_drep_registration-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_drep_registration-certificate.cli
@@ -16,8 +16,7 @@ Available options:
   --drep-verification-key-file FILE
                            Filepath of the DRep verification key.
   --drep-key-hash HASH     DRep verification key hash (either Bech32-encoded or
-                           hex-encoded). Zero or more occurences of this option
-                           is allowed.
+                           hex-encoded).
   --key-reg-deposit-amt NATURAL
                            Key registration deposit amount.
   --drep-metadata-url TEXT DRep anchor URL

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_drep_retirement-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_drep_retirement-certificate.cli
@@ -14,8 +14,7 @@ Available options:
   --drep-verification-key-file FILE
                            Filepath of the DRep verification key.
   --drep-key-hash HASH     DRep verification key hash (either Bech32-encoded or
-                           hex-encoded). Zero or more occurences of this option
-                           is allowed.
+                           hex-encoded).
   --deposit-amt LOVELACE   DRep deposit amount (same at registration and
                            retirement).
   --out-file FILE          The output file.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_vote_create.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_vote_create.cli
@@ -27,8 +27,7 @@ Available options:
   --drep-verification-key-file FILE
                            Filepath of the DRep verification key.
   --drep-key-hash HASH     DRep verification key hash (either Bech32-encoded or
-                           hex-encoded). Zero or more occurences of this option
-                           is allowed.
+                           hex-encoded).
   --stake-pool-verification-key STRING
                            Stake pool verification key (Bech32 or hex-encoded).
   --cold-verification-key-file FILE

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_drep-stake-distribution.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_drep-stake-distribution.cli
@@ -5,10 +5,13 @@ Usage: cardano-cli conway query drep-stake-distribution
                                                           ( --mainnet
                                                           | --testnet-magic NATURAL
                                                           )
-                                                          [ --drep-verification-key STRING
+                                                          ( --all-dreps
+                                                          | 
+                                                          ( --drep-verification-key STRING
                                                           | --drep-verification-key-file FILE
                                                           | --drep-key-hash HASH
-                                                          ]
+                                                          )
+                                                          )
                                                           [--out-file FILE]
 
   Get the DRep stake distribution. If no DRep credentials are provided, return
@@ -28,12 +31,12 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --all-dreps              Query for all DReps.
   --drep-verification-key STRING
                            DRep verification key (Bech32 or hex-encoded).
   --drep-verification-key-file FILE
                            Filepath of the DRep verification key.
   --drep-key-hash HASH     DRep verification key hash (either Bech32-encoded or
-                           hex-encoded). Zero or more occurences of this option
-                           is allowed.
+                           hex-encoded).
   --out-file FILE          The output file.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_drep-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_drep-state.cli
@@ -4,10 +4,13 @@ Usage: cardano-cli conway query drep-state --socket-path SOCKET_PATH
                                              ( --mainnet
                                              | --testnet-magic NATURAL
                                              )
-                                             [ --drep-verification-key STRING
+                                             ( --all-dreps
+                                             | 
+                                             ( --drep-verification-key STRING
                                              | --drep-verification-key-file FILE
                                              | --drep-key-hash HASH
-                                             ]
+                                             )
+                                             )
                                              [--out-file FILE]
 
   Get the DRep state. If no DRep credentials are provided, return states for all
@@ -27,12 +30,12 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --all-dreps              Query for all DReps.
   --drep-verification-key STRING
                            DRep verification key (Bech32 or hex-encoded).
   --drep-verification-key-file FILE
                            Filepath of the DRep verification key.
   --drep-key-hash HASH     DRep verification key hash (either Bech32-encoded or
-                           hex-encoded). Zero or more occurences of this option
-                           is allowed.
+                           hex-encoded).
   --out-file FILE          The output file.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_stake-address_stake-and-vote-delegation-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_stake-address_stake-and-vote-delegation-certificate.cli
@@ -40,8 +40,7 @@ Available options:
   --drep-verification-key-file FILE
                            Filepath of the DRep verification key.
   --drep-key-hash HASH     DRep verification key hash (either Bech32-encoded or
-                           hex-encoded). Zero or more occurences of this option
-                           is allowed.
+                           hex-encoded).
   --always-abstain         Abstain from voting on all proposals.
   --always-no-confidence   Always vote no confidence
   --out-file FILE          The output file.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_stake-address_vote-delegation-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_stake-address_vote-delegation-certificate.cli
@@ -29,8 +29,7 @@ Available options:
   --drep-verification-key-file FILE
                            Filepath of the DRep verification key.
   --drep-key-hash HASH     DRep verification key hash (either Bech32-encoded or
-                           hex-encoded). Zero or more occurences of this option
-                           is allowed.
+                           hex-encoded).
   --always-abstain         Abstain from voting on all proposals.
   --always-no-confidence   Always vote no confidence
   --out-file FILE          The output file.


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Make queries that optionally filter their result by DRep keys more explicit:
    - `cardano-cli conway query drep-state`
    - `cardano-cli conway query drep-stake-distribution`
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

This is in the same spirit as #541. I'm targeting the branch of that PR here, to make the diff clearer. When #541 is merged, that'll be the diff to `main`.

I also deleted a few unused parsers in `Cardano.CLI.EraBased.Options.Common`.

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
