### PR TITLE
Convenience flag to query stake distribution with `drep-state` query

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Query.hs
@@ -25,6 +25,7 @@ module Cardano.CLI.EraBased.Commands.Query
   , QueryDRepStateCmdArgs(..)
   , QueryDRepStakeDistributionCmdArgs(..)
   , renderQueryCmds
+  , IncludeStake (..)
   ) where
 
 import           Cardano.Api.Shelley hiding (QueryInShelleyBasedEra (..))
@@ -203,9 +204,15 @@ data QueryDRepStateCmdArgs era = QueryDRepStateCmdArgs
   , consensusModeParams :: !ConsensusModeParams
   , networkId           :: !NetworkId
   , drepKeys            :: !(AllOrOnly (VerificationKeyOrHashOrFile DRepKey))
+  , includeStake        :: !IncludeStake
   , target              :: !(Consensus.Target ChainPoint)
   , mOutFile            :: !(Maybe (File () Out))
   } deriving Show
+
+-- | Whether to include the stake, as queried by drep-stake-distribution, in
+-- the output of drep-state. This is (computationally) expensive, but sometimes
+-- convenient.
+data IncludeStake = WithStake | NoStake deriving Show
 
 data QueryDRepStakeDistributionCmdArgs era = QueryDRepStakeDistributionCmdArgs
   { eon                 :: !(ConwayEraOnwards era)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Query.hs
@@ -335,6 +335,16 @@ pQueryDRepStateCmd era envCli = do
         <*> pConsensusModeParams
         <*> pNetworkId envCli
         <*> pAllOrOnlyDRepVerificationKeyOrHashOrFile
+        <*> Opt.flag WithStake NoStake (mconcat
+              [ Opt.long "include-stake"
+              , Opt.help $ mconcat
+                 [ "Also return the stake associated with each DRep. "
+                 , "The result is the same as with \"drep-stake-distribution\"; "
+                 , "this is a convenience option to obtain all information concerning a DRep at once. "
+                 , "This is a potentially expensive query."
+                 ]
+              ]
+            )
         <*> pTarget era
         <*> optional pOutputFile
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -6743,6 +6743,7 @@ Usage: cardano-cli conway query drep-state --socket-path SOCKET_PATH
                                              | --drep-key-hash HASH
                                              )
                                              )
+                                             [--include-stake]
                                              [--volatile-tip | --immutable-tip]
                                              [--out-file FILE]
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_drep-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_drep-state.cli
@@ -11,6 +11,7 @@ Usage: cardano-cli conway query drep-state --socket-path SOCKET_PATH
                                              | --drep-key-hash HASH
                                              )
                                              )
+                                             [--include-stake]
                                              [--volatile-tip | --immutable-tip]
                                              [--out-file FILE]
 
@@ -37,6 +38,11 @@ Available options:
                            Filepath of the DRep verification key.
   --drep-key-hash HASH     DRep verification key hash (either Bech32-encoded or
                            hex-encoded).
+  --include-stake          Also return the stake associated with each DRep. The
+                           result is the same as with "drep-stake-distribution";
+                           this is a convenience option to obtain all
+                           information concerning a DRep at once. This is a
+                           potentially expensive query.
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Add `--include-stake` flag to obtain the stake in the `drep-state` query
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

This PR closes #551. 

I introduce an overlap between the `drep-state` and `drep-stake-distribution` queries. With the `--include-stake` flag, the former now subsumes the latter. AFAICT, the queries are exposed separately because [`drep-stake-distribution` is expensive](https://github.com/IntersectMBO/ouroboros-consensus/blob/404aaec8a4c8091594b4bc5a38e26f6ea9627f6b/ouroboros-consensus-cardano/src/shelley/Ouroboros/Consensus/Shelley/Ledger/Query.hs#L254). This makes obtaining all information associated with a DRep credential a two-command process. With the new flag, the expensive query is still guarded, but the CLI gets more user-friendly.

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
