### PR TITLE
CI: Limit to a single Haskell job on macOS

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -11,12 +11,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ghc: ["8.10.7", "9.2.7", "9.6.2"]
-        cabal: ["3.10.1.0"]
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        exclude:
-          - ghc: "9.2.7"
-            os: macos-latest
+        # If you edit these versions, make sure the version in the lonely macos-latest job below is updated accordingly
+        ghc: ["9.2.8", "9.6.3"]
+        cabal: ["3.10.2.1"]
+        os: [windows-latest, ubuntu-latest]
+        include:
+          # Using include, to make sure there will only be one macOS job, even if the matrix gets expanded later on.
+          # We want a single job, because macOS runners are scarce.
+          - os: macos-latest
+            cabal: "3.10.2.1"
+            ghc: "9.6.3"
 
     env:
       # Modify this value to "invalidate" the cabal cache.


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    CI: Limit to a single Haskell job on macOS
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Additional context for the PR goes here. If the PR fixes a particular issue please provide a [link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=) to the issue.

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
