### PR TITLE
create-testnet-data: add --drep-keys flag

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Genesis.hs
@@ -88,6 +88,7 @@ data GenesisCreateTestNetDataCmdArgs = GenesisCreateTestNetDataCmdArgs
   , numGenesisKeys :: !Word -- ^ The number of genesis keys credentials to create and write to disk.
   , numPools :: !Word -- ^ The number of stake pools credentials to create and write to disk.
   , stakeDelegators :: !StakeDelegators -- ^ The number of delegators to pools to create.
+  , numDrepKeys :: !Word -- ^ The number of DRep keys to create. Right now they receive neither delegation nor are registrated. This will come later.
   , numStuffedUtxo :: !Word -- ^ The number of UTxO accounts to make. They are "stuffed" because the credentials are not written to disk.
   , numUtxoKeys :: !Word -- ^ The number of UTxO credentials to create and write to disk.
   , supply :: !(Maybe Lovelace) -- ^ The number of Lovelace to distribute over initial, non-delegating stake holders.

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Genesis.hs
@@ -205,6 +205,7 @@ pGenesisCreateTestNetData envCli =
     <*> pNumGenesisKeys
     <*> pNumPools
     <*> pNumStakeDelegs
+    <*> pNumDReps
     <*> pNumStuffedUtxoCount
     <*> pNumUtxoKeys
     <*> pSupply
@@ -230,6 +231,14 @@ pGenesisCreateTestNetData envCli =
         [ Opt.long "pools"
         , Opt.metavar "INT"
         , Opt.help "The number of stake pool credential sets to make (default is 0)."
+        , Opt.value 0
+        ]
+    pNumDReps :: Parser Word
+    pNumDReps =
+      Opt.option Opt.auto $ mconcat
+        [ Opt.long "drep-keys"
+        , Opt.metavar "INT"
+        , Opt.help "The number of DRep credentials to make (default is 0)."
         , Opt.value 0
         ]
     pNumStakeDelegs :: Parser StakeDelegators

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/CreateTestnetData.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/CreateTestnetData.hs
@@ -32,6 +32,8 @@ import           Cardano.Api.Shelley
 import           Cardano.CLI.EraBased.Commands.Genesis as Cmd
 import qualified Cardano.CLI.EraBased.Commands.Node as Cmd
 import           Cardano.CLI.EraBased.Run.Address (runAddressKeyGenCmd)
+import qualified Cardano.CLI.EraBased.Run.Governance.DRep as DRep
+import qualified Cardano.CLI.EraBased.Commands.Governance.DRep as DRep
 import qualified Cardano.CLI.EraBased.Run.Key as Key
 import           Cardano.CLI.EraBased.Run.Node (runNodeIssueOpCertCmd, runNodeKeyGenColdCmd,
                    runNodeKeyGenKesCmd, runNodeKeyGenVrfCmd)
@@ -187,6 +189,7 @@ runGenesisCreateTestNetDataCmd Cmd.GenesisCreateTestNetDataCmdArgs
    , numGenesisKeys
    , numPools
    , stakeDelegators
+   , numDrepKeys
    , numStuffedUtxo
    , numUtxoKeys
    , supply
@@ -237,6 +240,15 @@ runGenesisCreateTestNetDataCmd Cmd.GenesisCreateTestNetDataCmdArgs
     buildPoolParams networkId poolDir Nothing (fromMaybe mempty mayStakePoolRelays)
 
   writeREADME poolsDir poolsREADME
+
+  -- DReps
+  forM_ [ 1 .. numDrepKeys ] $ \index -> do
+    let drepDir = outputDir </> "drep-keys" </> "drep" <> show index
+        vkeyFile = File @(VerificationKey ()) $ drepDir </> "drep.vkey"
+        skeyFile = File @(SigningKey ()) $ drepDir </> "drep.skey"
+        cmd = DRep.GovernanceDRepKeyGenCmdArgs ConwayEraOnwardsConway vkeyFile skeyFile
+    liftIO $ createDirectoryIfMissing True drepDir
+    firstExceptT GenesisCmdFileError $ DRep.runGovernanceDRepKeyGenCmd cmd
 
   -- Stake delegators
   case stakeDelegators of

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/DRep.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/DRep.hs
@@ -11,6 +11,7 @@
 
 module Cardano.CLI.EraBased.Run.Governance.DRep
   ( runGovernanceDRepCmds
+  , runGovernanceDRepKeyGenCmd
   ) where
 
 import           Cardano.Api
@@ -39,7 +40,7 @@ runGovernanceDRepCmds :: ()
 runGovernanceDRepCmds = \case
   Cmd.GovernanceDRepKeyGenCmd args ->
     runGovernanceDRepKeyGenCmd args
-      & firstExceptT CmdGovernanceCmdError
+      & firstExceptT (CmdGovernanceCmdError . GovernanceCmdWriteFileError)
 
   Cmd.GovernanceDRepIdCmd args ->
     runGovernanceDRepIdCmd args
@@ -59,12 +60,12 @@ runGovernanceDRepCmds = \case
 
 runGovernanceDRepKeyGenCmd :: ()
   => Cmd.GovernanceDRepKeyGenCmdArgs era
-  -> ExceptT GovernanceCmdError IO ()
+  -> ExceptT (FileError ()) IO ()
 runGovernanceDRepKeyGenCmd
     Cmd.GovernanceDRepKeyGenCmdArgs
       { vkeyFile
       , skeyFile
-     } = firstExceptT GovernanceCmdWriteFileError $ do
+      } = do
   skey <- liftIO $ generateSigningKey AsDRepKey
   let vkey = getVerificationKey skey
   newExceptT $ writeLazyByteStringFile skeyFile (textEnvelopeToJSON (Just skeyDesc) skey)

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/CreateTestnetData.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/CreateTestnetData.hs
@@ -54,6 +54,8 @@ hprop_golden_create_testnet_data =
 
     H.diffVsGoldenFile generated'' "test/cardano-cli-golden/files/golden/conway/create-testnet-data.out"
 
+-- | This test tests the non-transient case, i.e. it generates strictly
+-- less things to disk than 'hprop_golden_create_testnet_data'
 hprop_golden_create_testnet_data_transient_stake_delegators :: Property
 hprop_golden_create_testnet_data_transient_stake_delegators =
   propertyOnce $ moduleWorkspace "tmp" $ \tempDir -> do
@@ -68,7 +70,7 @@ hprop_golden_create_testnet_data_transient_stake_delegators =
          , "--out-dir", outputDir
          , "--testnet-magic", "42"
          , "--pools", "2"
-         , "--stake-delegators", "4"
+         , "--transient-stake-delegators", "4"
         ]
 
     -- We just test that the command doesn't crash when we execute a different path.

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/CreateTestnetData.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/CreateTestnetData.hs
@@ -15,6 +15,19 @@ import qualified Hedgehog.Extras.Test.Golden as H
 
 {- HLINT ignore "Use camelCase" -}
 
+-- | A function to create the arguments, so that they are shared
+-- between the two tests, except for the possibly transient ones.
+mkArguments :: String -> [String]
+mkArguments outputDir =
+  ["conway",  "genesis", "create-testnet-data"
+   , "--genesis-keys", "2"
+   , "--utxo-keys", "3"
+   , "--out-dir", outputDir
+   , "--testnet-magic", "42"
+   , "--pools", "2"
+   , "--drep-keys", "5"
+  ]
+
 -- | Given a root directory, returns files within this root (recursively)
 tree :: FilePath -> IO [FilePath]
 tree root = do
@@ -26,22 +39,16 @@ tree root = do
   subTrees <- mapM tree subs
   return $ files ++ concat subTrees
 
+-- | This test tests the non-transient case, i.e. it maximizes the files
+-- that can be written to disk. Execute this test with:
+-- @cabal test cardano-cli-golden --test-options '-p "/golden create testnet data/'@
 hprop_golden_create_testnet_data :: Property
 hprop_golden_create_testnet_data =
   propertyOnce $ moduleWorkspace "tmp" $ \tempDir -> do
 
     let outputDir = tempDir </> "out"
 
-    void $
-      execCardanoCLI
-        ["conway",  "genesis", "create-testnet-data"
-         , "--genesis-keys", "2"
-         , "--utxo-keys", "3"
-         , "--out-dir", outputDir
-         , "--testnet-magic", "42"
-         , "--pools", "2"
-         , "--stake-delegators", "4"
-        ]
+    void $ execCardanoCLI $ mkArguments outputDir <> ["--stake-delegators", "4"]
 
     generated <- liftIO $ tree outputDir
     -- Sort output for stability, and make relative to avoid storing
@@ -54,24 +61,16 @@ hprop_golden_create_testnet_data =
 
     H.diffVsGoldenFile generated'' "test/cardano-cli-golden/files/golden/conway/create-testnet-data.out"
 
--- | This test tests the non-transient case, i.e. it generates strictly
--- less things to disk than 'hprop_golden_create_testnet_data'
+-- | This test tests the transient case, i.e. it writes strictly
+-- less things to disk than 'hprop_golden_create_testnet_data'. Execute this test with:
+-- @cabal test cardano-cli-golden --test-options '-p "/golden create testnet data transient stake delegators/'@
 hprop_golden_create_testnet_data_transient_stake_delegators :: Property
 hprop_golden_create_testnet_data_transient_stake_delegators =
   propertyOnce $ moduleWorkspace "tmp" $ \tempDir -> do
 
     let outputDir = tempDir </> "out"
 
-    void $
-      execCardanoCLI
-        ["conway",  "genesis", "create-testnet-data"
-         , "--genesis-keys", "2"
-         , "--utxo-keys", "3"
-         , "--out-dir", outputDir
-         , "--testnet-magic", "42"
-         , "--pools", "2"
-         , "--transient-stake-delegators", "4"
-        ]
+    void $ execCardanoCLI $ mkArguments outputDir <> ["--transient-stake-delegators", "4"]
 
     -- We just test that the command doesn't crash when we execute a different path.
     -- For the golden part of this test, we are anyway covered by 'hprop_golden_create_testnet_data'

--- a/cardano-cli/test/cardano-cli-golden/files/golden/conway/create-testnet-data.out
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/conway/create-testnet-data.out
@@ -15,6 +15,16 @@ delegate-keys/delegate2/opcert.cert
 delegate-keys/delegate2/opcert.counter
 delegate-keys/delegate2/vrf.skey
 delegate-keys/delegate2/vrf.vkey
+drep-keys/drep1/drep.skey
+drep-keys/drep1/drep.vkey
+drep-keys/drep2/drep.skey
+drep-keys/drep2/drep.vkey
+drep-keys/drep3/drep.skey
+drep-keys/drep3/drep.vkey
+drep-keys/drep4/drep.skey
+drep-keys/drep4/drep.vkey
+drep-keys/drep5/drep.skey
+drep-keys/drep5/drep.vkey
 genesis-keys/README.md
 genesis-keys/genesis1/key.skey
 genesis-keys/genesis1/key.vkey

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -265,6 +265,7 @@ Usage: cardano-cli shelley genesis create-testnet-data [--spec-shelley FILE]
                                                          [ --stake-delegators INT
                                                          | --transient-stake-delegators INT
                                                          ]
+                                                         [--drep-keys INT]
                                                          [--stuffed-utxo INT]
                                                          [--utxo-keys INT]
                                                          [--supply LOVELACE]
@@ -1423,6 +1424,7 @@ Usage: cardano-cli allegra genesis create-testnet-data [--spec-shelley FILE]
                                                          [ --stake-delegators INT
                                                          | --transient-stake-delegators INT
                                                          ]
+                                                         [--drep-keys INT]
                                                          [--stuffed-utxo INT]
                                                          [--utxo-keys INT]
                                                          [--supply LOVELACE]
@@ -2579,6 +2581,7 @@ Usage: cardano-cli mary genesis create-testnet-data [--spec-shelley FILE]
                                                       [ --stake-delegators INT
                                                       | --transient-stake-delegators INT
                                                       ]
+                                                      [--drep-keys INT]
                                                       [--stuffed-utxo INT]
                                                       [--utxo-keys INT]
                                                       [--supply LOVELACE]
@@ -3719,6 +3722,7 @@ Usage: cardano-cli alonzo genesis create-testnet-data [--spec-shelley FILE]
                                                         [ --stake-delegators INT
                                                         | --transient-stake-delegators INT
                                                         ]
+                                                        [--drep-keys INT]
                                                         [--stuffed-utxo INT]
                                                         [--utxo-keys INT]
                                                         [--supply LOVELACE]
@@ -4883,6 +4887,7 @@ Usage: cardano-cli babbage genesis create-testnet-data [--spec-shelley FILE]
                                                          [ --stake-delegators INT
                                                          | --transient-stake-delegators INT
                                                          ]
+                                                         [--drep-keys INT]
                                                          [--stuffed-utxo INT]
                                                          [--utxo-keys INT]
                                                          [--supply LOVELACE]
@@ -6065,6 +6070,7 @@ Usage: cardano-cli conway genesis create-testnet-data [--spec-shelley FILE]
                                                         [ --stake-delegators INT
                                                         | --transient-stake-delegators INT
                                                         ]
+                                                        [--drep-keys INT]
                                                         [--stuffed-utxo INT]
                                                         [--utxo-keys INT]
                                                         [--supply LOVELACE]
@@ -7581,6 +7587,7 @@ Usage: cardano-cli latest genesis create-testnet-data [--spec-shelley FILE]
                                                         [ --stake-delegators INT
                                                         | --transient-stake-delegators INT
                                                         ]
+                                                        [--drep-keys INT]
                                                         [--stuffed-utxo INT]
                                                         [--utxo-keys INT]
                                                         [--supply LOVELACE]

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_genesis_create-testnet-data.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_genesis_create-testnet-data.cli
@@ -4,6 +4,7 @@ Usage: cardano-cli allegra genesis create-testnet-data [--spec-shelley FILE]
                                                          [ --stake-delegators INT
                                                          | --transient-stake-delegators INT
                                                          ]
+                                                         [--drep-keys INT]
                                                          [--stuffed-utxo INT]
                                                          [--utxo-keys INT]
                                                          [--supply LOVELACE]
@@ -28,6 +29,8 @@ Available options:
                            The number of stake delegator credential sets to make
                            (default is 0). The credentials are NOT written to
                            disk.
+  --drep-keys INT          The number of DRep credentials to make (default is
+                           0).
   --stuffed-utxo INT       The number of fake UTxO entries to generate (default
                            is 0).
   --utxo-keys INT          The number of UTxO keys to make (default is 0).

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_genesis_create-testnet-data.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_genesis_create-testnet-data.cli
@@ -4,6 +4,7 @@ Usage: cardano-cli alonzo genesis create-testnet-data [--spec-shelley FILE]
                                                         [ --stake-delegators INT
                                                         | --transient-stake-delegators INT
                                                         ]
+                                                        [--drep-keys INT]
                                                         [--stuffed-utxo INT]
                                                         [--utxo-keys INT]
                                                         [--supply LOVELACE]
@@ -28,6 +29,8 @@ Available options:
                            The number of stake delegator credential sets to make
                            (default is 0). The credentials are NOT written to
                            disk.
+  --drep-keys INT          The number of DRep credentials to make (default is
+                           0).
   --stuffed-utxo INT       The number of fake UTxO entries to generate (default
                            is 0).
   --utxo-keys INT          The number of UTxO keys to make (default is 0).

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_genesis_create-testnet-data.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_genesis_create-testnet-data.cli
@@ -4,6 +4,7 @@ Usage: cardano-cli babbage genesis create-testnet-data [--spec-shelley FILE]
                                                          [ --stake-delegators INT
                                                          | --transient-stake-delegators INT
                                                          ]
+                                                         [--drep-keys INT]
                                                          [--stuffed-utxo INT]
                                                          [--utxo-keys INT]
                                                          [--supply LOVELACE]
@@ -28,6 +29,8 @@ Available options:
                            The number of stake delegator credential sets to make
                            (default is 0). The credentials are NOT written to
                            disk.
+  --drep-keys INT          The number of DRep credentials to make (default is
+                           0).
   --stuffed-utxo INT       The number of fake UTxO entries to generate (default
                            is 0).
   --utxo-keys INT          The number of UTxO keys to make (default is 0).

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_genesis_create-testnet-data.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_genesis_create-testnet-data.cli
@@ -4,6 +4,7 @@ Usage: cardano-cli conway genesis create-testnet-data [--spec-shelley FILE]
                                                         [ --stake-delegators INT
                                                         | --transient-stake-delegators INT
                                                         ]
+                                                        [--drep-keys INT]
                                                         [--stuffed-utxo INT]
                                                         [--utxo-keys INT]
                                                         [--supply LOVELACE]
@@ -28,6 +29,8 @@ Available options:
                            The number of stake delegator credential sets to make
                            (default is 0). The credentials are NOT written to
                            disk.
+  --drep-keys INT          The number of DRep credentials to make (default is
+                           0).
   --stuffed-utxo INT       The number of fake UTxO entries to generate (default
                            is 0).
   --utxo-keys INT          The number of UTxO keys to make (default is 0).

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_genesis_create-testnet-data.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_genesis_create-testnet-data.cli
@@ -4,6 +4,7 @@ Usage: cardano-cli latest genesis create-testnet-data [--spec-shelley FILE]
                                                         [ --stake-delegators INT
                                                         | --transient-stake-delegators INT
                                                         ]
+                                                        [--drep-keys INT]
                                                         [--stuffed-utxo INT]
                                                         [--utxo-keys INT]
                                                         [--supply LOVELACE]
@@ -28,6 +29,8 @@ Available options:
                            The number of stake delegator credential sets to make
                            (default is 0). The credentials are NOT written to
                            disk.
+  --drep-keys INT          The number of DRep credentials to make (default is
+                           0).
   --stuffed-utxo INT       The number of fake UTxO entries to generate (default
                            is 0).
   --utxo-keys INT          The number of UTxO keys to make (default is 0).

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_genesis_create-testnet-data.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_genesis_create-testnet-data.cli
@@ -4,6 +4,7 @@ Usage: cardano-cli mary genesis create-testnet-data [--spec-shelley FILE]
                                                       [ --stake-delegators INT
                                                       | --transient-stake-delegators INT
                                                       ]
+                                                      [--drep-keys INT]
                                                       [--stuffed-utxo INT]
                                                       [--utxo-keys INT]
                                                       [--supply LOVELACE]
@@ -28,6 +29,8 @@ Available options:
                            The number of stake delegator credential sets to make
                            (default is 0). The credentials are NOT written to
                            disk.
+  --drep-keys INT          The number of DRep credentials to make (default is
+                           0).
   --stuffed-utxo INT       The number of fake UTxO entries to generate (default
                            is 0).
   --utxo-keys INT          The number of UTxO keys to make (default is 0).

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_genesis_create-testnet-data.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_genesis_create-testnet-data.cli
@@ -4,6 +4,7 @@ Usage: cardano-cli shelley genesis create-testnet-data [--spec-shelley FILE]
                                                          [ --stake-delegators INT
                                                          | --transient-stake-delegators INT
                                                          ]
+                                                         [--drep-keys INT]
                                                          [--stuffed-utxo INT]
                                                          [--utxo-keys INT]
                                                          [--supply LOVELACE]
@@ -28,6 +29,8 @@ Available options:
                            The number of stake delegator credential sets to make
                            (default is 0). The credentials are NOT written to
                            disk.
+  --drep-keys INT          The number of DRep credentials to make (default is
+                           0).
   --stuffed-utxo INT       The number of fake UTxO entries to generate (default
                            is 0).
   --utxo-keys INT          The number of UTxO keys to make (default is 0).


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Add --drep-keys flag to --create-testnet-data
# uncomment types applicable to the change:
  type:
  - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

We cannot yet create the registration and the delegation for the dreps, but we'll need to generate keys when we do, and this first step will already help us remove some code in cardano-node [here](https://github.com/IntersectMBO/cardano-node/blob/3b2839ad72c6669fa68aafcbf01f9acc6fa5defe/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/LedgerEvents/Gov/ProposeNewConstitution.hs#L123).

# How to trust this PR

* The command calls the correct `key-gen` backend
* The existing test is augmented

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [X] Self-reviewed the diff