### PR TITLE
Revert #569: Back to cardano-api JSON for protocol parameters

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Query.hs
@@ -56,7 +56,6 @@ import           Cardano.CLI.Types.Key
 import qualified Cardano.CLI.Types.Output as O
 import           Cardano.Crypto.Hash (hashToBytesAsHex)
 import qualified Cardano.Crypto.Hash.Blake2b as Blake2b
-import           Cardano.Ledger.Alonzo.Core (EraPParams (ppProtocolVersionL))
 import qualified Cardano.Ledger.BaseTypes as L
 import qualified Cardano.Ledger.Core as Core
 import qualified Cardano.Ledger.Credential as L
@@ -85,7 +84,6 @@ import           Control.Monad.Trans.Except.Extra
 import           Data.Aeson as Aeson
 import qualified Data.Aeson as A
 import           Data.Aeson.Encode.Pretty (encodePretty)
-import qualified Data.Aeson.KeyMap as Aeson
 import           Data.Bifunctor (Bifunctor (..))
 import qualified Data.ByteString.Lazy.Char8 as LBS
 import           Data.Coerce (coerce)
@@ -186,39 +184,23 @@ runQueryProtocolParametersCmd
   AnyCardanoEra era <- firstExceptT QueryCmdAcquireFailure $ newExceptT $ determineEra localNodeConnInfo
   sbe <- forEraInEon @ShelleyBasedEra era (left QueryCmdByronEra) pure
   let qInMode = QueryInEra $ QueryInShelleyBasedEra sbe Api.QueryProtocolParameters
-  pParams <- firstExceptT QueryCmdConvenienceError
-              . newExceptT $ executeQueryAnyMode localNodeConnInfo qInMode
-  writeProtocolParameters sbe mOutFile pParams
+  pp <- firstExceptT QueryCmdConvenienceError
+          . newExceptT $ executeQueryAnyMode localNodeConnInfo qInMode
+  writeProtocolParameters sbe mOutFile pp
   where
+    -- TODO: Conway era - use ledger PParams JSON
     writeProtocolParameters
       :: ShelleyBasedEra era
       -> Maybe (File () Out)
       -> Ledger.PParams (ShelleyLedgerEra era)
       -> ExceptT QueryCmdError IO ()
     writeProtocolParameters sbe mOutFile' pparams =
-      firstExceptT QueryCmdWriteFileError . newExceptT $
-        writeLazyByteStringOutput mOutFile' (encodePretty $ toJSONWithPParams sbe pparams)
-      where
-        -- TODO: (written 2024-01-16) Currently, the ToJSON implementation for
-        -- Conway protocol parameters from cardano-ledger misses the
-        -- 'protocolVersion' field. The commit that fixes this is already on
-        -- main, but not part of a released version of cardano-ledger that we
-        -- can depend on. It's this one:
-        --
-        -- https://github.com/IntersectMBO/cardano-ledger/pull/3953/commits/df9ee19944099a75d75019b8b36e99b03db5b558
-        --
-        -- Until we have that in our dependencies, this workaround will ensure
-        -- we're printing the protocol version. It'll also do no harm after
-        -- that point, apart from heating the room a little.
-        toJSONWithPParams :: ShelleyBasedEra era -> Ledger.PParams (ShelleyLedgerEra era) -> Aeson.Value
-        toJSONWithPParams w pps = shelleyBasedEraConstraints w $
-          case toJSON pps of
-            Aeson.Object almostAllPairs ->
-              caseShelleyToBabbageOrConwayEraOnwards
-                (const . Aeson.Object $ almostAllPairs)
-                (const . Aeson.Object . Aeson.insert "protocolVersion" (toJSON $ pps ^. ppProtocolVersionL) $ almostAllPairs)
-                sbe
-            _ -> error "Expected the protocol parameters to be a 'KeyMap'. This is part of a temporary hack. Alert the cardano-cli team of this."
+      let apiPParamsJSON = (encodePretty $ fromLedgerPParams sbe pparams)
+      in case mOutFile' of
+        Nothing -> liftIO $ LBS.putStrLn apiPParamsJSON
+        Just (File fpath) ->
+          handleIOExceptT (QueryCmdWriteFileError . FileIOError fpath) $
+            LBS.writeFile fpath apiPParamsJSON
 
 -- | Calculate the percentage sync rendered as text.
 percentage


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Revert #569, where we tried to adapt the output of the `protocol-parameters` query to show all parameters in Conway, and which broke round-tripping and downstream requirements.
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

The discussion is in the post-merge commits of #569, and I propose we continue it there.

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
