### PR TITLE
Sketch a way to filter DRep queries

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Query.hs
@@ -187,7 +187,7 @@ data QueryDRepStateCmdArgs era = QueryDRepStateCmdArgs
   , nodeSocketPath      :: !SocketPath
   , consensusModeParams :: !ConsensusModeParams
   , networkId           :: !NetworkId
-  , drepKeys            :: !(AllOrOnly (VerificationKeyOrHashOrFile DRepKey))
+  , drepSources            :: !(AllOrOnly DRepSource)
   , mOutFile            :: !(Maybe (File () Out))
   } deriving Show
 
@@ -196,7 +196,7 @@ data QueryDRepStakeDistributionCmdArgs era = QueryDRepStakeDistributionCmdArgs
   , nodeSocketPath      :: !SocketPath
   , consensusModeParams :: !ConsensusModeParams
   , networkId           :: !NetworkId
-  , drepKeys            :: !(AllOrOnly (VerificationKeyOrHashOrFile DRepKey))
+  , drepSources            :: !(AllOrOnly DRepSource)
   , mOutFile            :: !(Maybe (File () Out))
   } deriving Show
 

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
@@ -3046,6 +3046,22 @@ pDRepHashSource =
     , DRepHashSourceVerificationKey <$> pDRepVerificationKeyOrHashOrFile
     ]
 
+pDRepSource :: Parser DRepSource
+pDRepSource =
+  asum
+    [ FromHash <$> pDRepHashSource
+    , Opt.flag' AlwaysAbstain $
+        mconcat
+          [ Opt.long "always-abstain"
+          , Opt.help "The trivial DRep that always abstains."
+          ]
+    , Opt.flag' AlwaysNoConfidence $
+        mconcat
+          [ Opt.long "always-no-confidence"
+          , Opt.help "The trivial DRep that always votes no-confidence."
+          ]
+    ]
+
 pDRepScriptHash :: Parser ScriptHash
 pDRepScriptHash =
   Opt.option scriptHashReader $ mconcat
@@ -3062,10 +3078,9 @@ pDRepVerificationKeyOrHashOrFile =
     , VerificationKeyHash <$> pDRepVerificationKeyHash
     ]
 
-pAllOrOnlyDRepVerificationKeyOrHashOrFile
-  :: Parser (AllOrOnly (VerificationKeyOrHashOrFile DRepKey))
-pAllOrOnlyDRepVerificationKeyOrHashOrFile = pAll <|> pOnly
-  where pOnly = Only <$> some pDRepVerificationKeyOrHashOrFile
+pAllOrOnlyDRepSource :: Parser (AllOrOnly DRepSource)
+pAllOrOnlyDRepSource = pAll <|> pOnly
+  where pOnly = Only <$> some pDRepSource
         pAll = Opt.flag' All $ mconcat
           [ Opt.long "all-dreps"
           , Opt.help "Query for all DReps."

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Query.hs
@@ -322,7 +322,7 @@ pQueryDRepStateCmd era envCli = do
         <$> pSocketPath envCli
         <*> pConsensusModeParams
         <*> pNetworkId envCli
-        <*> pAllOrOnlyDRepVerificationKeyOrHashOrFile
+        <*> pAllOrOnlyDRepSource
         <*> optional pOutputFile
 
 pQueryDRepStakeDistributionCmd :: ()
@@ -341,7 +341,7 @@ pQueryDRepStakeDistributionCmd era envCli = do
       <$> pSocketPath envCli
       <*> pConsensusModeParams
       <*> pNetworkId envCli
-      <*> pAllOrOnlyDRepVerificationKeyOrHashOrFile
+      <*> pAllOrOnlyDRepSource
       <*> optional pOutputFile
 
 pQueryGetCommitteeStateCmd :: ()

--- a/cardano-cli/src/Cardano/CLI/Types/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Key.hs
@@ -41,6 +41,8 @@ module Cardano.CLI.Types.Key
 
   , readDRepCredential
 
+  , DRepSource(..)
+
   , SomeSigningKey(..)
   , withSomeSigningKey
   , readSigningKeyFile
@@ -339,6 +341,7 @@ readDRepCredential = \case
         & onLeft (left . DelegationDRepReadError)
     pure $ L.KeyHashObj drepKeyHash
 
+data DRepSource = FromHash DRepHashSource | AlwaysAbstain | AlwaysNoConfidence deriving (Eq, Show)
 
 data SomeSigningKey
   = AByronSigningKey                    (SigningKey ByronKey)


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    <insert-changelog-description-here>
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

This draft pr sketches a way to filter DRep queries by scripts or the two default DReps ("always abstain" and "always no confidence"), as required by #562.

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
