### PR TITLE
Update help for `drep-stake-distribution` and `drep-state` queries

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Query.hs
@@ -314,7 +314,7 @@ pQueryDRepStateCmd era envCli = do
   pure
     $ subParser "drep-state"
     $ Opt.info (QueryDRepStateCmd <$> pQueryDRepStateCmdArgs w)
-    $ Opt.progDesc "Get the DRep state. If no DRep credentials are provided, return states for all of them."
+    $ Opt.progDesc "Get the DRep state."
   where
     pQueryDRepStateCmdArgs :: ConwayEraOnwards era -> Parser (QueryDRepStateCmdArgs era)
     pQueryDRepStateCmdArgs w =
@@ -334,7 +334,7 @@ pQueryDRepStakeDistributionCmd era envCli = do
   pure
     $ subParser "drep-stake-distribution"
     $ Opt.info (QueryDRepStakeDistributionCmd <$> pQueryDRepStakeDistributionCmdArgs w)
-    $ Opt.progDesc "Get the DRep stake distribution. If no DRep credentials are provided, return stake distributions for all of them."
+    $ Opt.progDesc "Get the DRep stake distribution."
   where
     pQueryDRepStakeDistributionCmdArgs :: ConwayEraOnwards era -> Parser (QueryDRepStakeDistributionCmdArgs era)
     pQueryDRepStakeDistributionCmdArgs w = QueryDRepStakeDistributionCmdArgs w

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -6723,8 +6723,7 @@ Usage: cardano-cli conway query drep-state --socket-path SOCKET_PATH
                                              )
                                              [--out-file FILE]
 
-  Get the DRep state. If no DRep credentials are provided, return states for all
-  of them.
+  Get the DRep state.
 
 Usage: cardano-cli conway query drep-stake-distribution 
                                                           --socket-path SOCKET_PATH
@@ -6742,8 +6741,7 @@ Usage: cardano-cli conway query drep-stake-distribution
                                                           )
                                                           [--out-file FILE]
 
-  Get the DRep stake distribution. If no DRep credentials are provided, return
-  stake distributions for all of them.
+  Get the DRep stake distribution.
 
 Usage: cardano-cli conway query committee-state --socket-path SOCKET_PATH
                                                   [--cardano-mode

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query.cli
@@ -54,9 +54,6 @@ Available commands:
   slot-number              Query slot number for UTC timestamp
   constitution             Get the constitution
   gov-state                Get the governance state
-  drep-state               Get the DRep state. If no DRep credentials are
-                           provided, return states for all of them.
-  drep-stake-distribution  Get the DRep stake distribution. If no DRep
-                           credentials are provided, return stake distributions
-                           for all of them.
+  drep-state               Get the DRep state.
+  drep-stake-distribution  Get the DRep stake distribution.
   committee-state          Get the committee state

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_drep-stake-distribution.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_drep-stake-distribution.cli
@@ -14,8 +14,7 @@ Usage: cardano-cli conway query drep-stake-distribution
                                                           )
                                                           [--out-file FILE]
 
-  Get the DRep stake distribution. If no DRep credentials are provided, return
-  stake distributions for all of them.
+  Get the DRep stake distribution.
 
 Available options:
   --socket-path SOCKET_PATH

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_drep-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_drep-state.cli
@@ -13,8 +13,7 @@ Usage: cardano-cli conway query drep-state --socket-path SOCKET_PATH
                                              )
                                              [--out-file FILE]
 
-  Get the DRep state. If no DRep credentials are provided, return states for all
-  of them.
+  Get the DRep state.
 
 Available options:
   --socket-path SOCKET_PATH


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Update help for `drep-stake-distribution` and `drep-state` queries
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

The `drep-stake-distribution` and `drep-state` queries no longer query all DReps by default. It is now necessary to pass `--all-dreps`.

# How to trust this PR

Golden tests pass.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
