### PR TITLE
create-testnet-data: don't fail trying to create irrelevant READMEs

### DIFF
--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -307,6 +307,7 @@ test-suite cardano-cli-test
 
   other-modules:        Test.Cli.AddCostModels
                         Test.Cli.CliIntermediateFormat
+                        Test.Cli.CreateTestnetData
                         Test.Cli.FilePermissions
                         Test.Cli.Governance.Hash
                         Test.Cli.ITN

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/CreateTestnetData.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/CreateTestnetData.hs
@@ -260,8 +260,12 @@ runGenesisCreateTestNetDataCmd Cmd.GenesisCreateTestNetDataCmdArgs
         createStakeDelegatorCredentials (stakeDelegatorsDir </> "delegator" <> show index)
     Transient _ -> pure ()
 
-  let (delegsPerPool, delegsRemaining) = numStakeDelegators `divMod` numPools
-      delegsForPool poolIx = if delegsRemaining /= 0 && poolIx == numPools
+  let (delegsPerPool, delegsRemaining) =
+        if numPools == 0
+        then (0, 0)
+        else numStakeDelegators `divMod` numPools
+      delegsForPool poolIx =
+        if delegsRemaining /= 0 && poolIx == numPools
         then delegsPerPool
         else delegsPerPool + delegsRemaining
       distribution = [pool | (pool, poolIx) <- zip poolParams [1 ..], _ <- [1 .. delegsForPool poolIx]]

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/CreateTestnetData.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/CreateTestnetData.hs
@@ -59,7 +59,7 @@ import qualified Cardano.Ledger.Shelley.API as Ledger
 import           Ouroboros.Consensus.Shelley.Node (ShelleyGenesisStaking (..))
 
 import           Control.DeepSeq (NFData, force)
-import           Control.Monad (forM, forM_, unless, void, zipWithM)
+import           Control.Monad (forM, forM_, unless, void, when, zipWithM)
 import           Control.Monad.Except (MonadError (..), runExceptT)
 import           Control.Monad.IO.Class (MonadIO (..))
 import           Control.Monad.Trans.Except (ExceptT)
@@ -219,8 +219,9 @@ runGenesisCreateTestNetDataCmd Cmd.GenesisCreateTestNetDataCmdArgs
     createGenesisKeys (genesisDir </> ("genesis" <> show index))
     createDelegateKeys desiredKeyOutputFormat (delegateDir </> ("delegate" <> show index))
 
-  writeREADME genesisDir genesisREADME
-  writeREADME delegateDir delegatesREADME
+  when (0 < numGenesisKeys) $ do
+    writeREADME genesisDir genesisREADME
+    writeREADME delegateDir delegatesREADME
 
   -- UTxO keys
   let utxoKeys = [utxoKeysDir </> ("utxo" <> show index) </> "utxo.vkey"
@@ -228,7 +229,7 @@ runGenesisCreateTestNetDataCmd Cmd.GenesisCreateTestNetDataCmdArgs
   forM_ [ 1 .. numUtxoKeys ] $ \index ->
     createUtxoKeys $ utxoKeysDir </> ("utxo" <> show index)
 
-  writeREADME utxoKeysDir utxoKeysREADME
+  when (0 < numUtxoKeys) $ writeREADME utxoKeysDir utxoKeysREADME
 
   let mayStakePoolRelays = Nothing -- TODO @smelc temporary?
 
@@ -239,7 +240,7 @@ runGenesisCreateTestNetDataCmd Cmd.GenesisCreateTestNetDataCmdArgs
     createPoolCredentials desiredKeyOutputFormat poolDir
     buildPoolParams networkId poolDir Nothing (fromMaybe mempty mayStakePoolRelays)
 
-  writeREADME poolsDir poolsREADME
+  when (0 < numPools) $ writeREADME poolsDir poolsREADME
 
   -- DReps
   forM_ [ 1 .. numDrepKeys ] $ \index -> do
@@ -250,7 +251,7 @@ runGenesisCreateTestNetDataCmd Cmd.GenesisCreateTestNetDataCmdArgs
     liftIO $ createDirectoryIfMissing True drepDir
     firstExceptT GenesisCmdFileError $ DRep.runGovernanceDRepKeyGenCmd cmd
 
-  writeREADME drepsDir drepsREADME
+  when (0 < numDrepKeys) $ writeREADME drepsDir drepsREADME
 
   -- Stake delegators
   case stakeDelegators of

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/CreateTestnetData.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/CreateTestnetData.hs
@@ -271,6 +271,10 @@ runGenesisCreateTestNetDataCmd Cmd.GenesisCreateTestNetDataCmdArgs
   -- Distribute M delegates across N pools:
   delegations <-
     case stakeDelegators of
+      OnDisk 0 ->
+        -- Required because the most general case below loops in this case
+        -- (try @zipWith _ (concat $ repeat []) _@ in a REPL)
+        pure []
       OnDisk _ -> do
         let delegates = concat $ repeat stakeDelegatorsDirs
         -- We don't need to be attentive to laziness here, because anyway this

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Genesis.hs
@@ -596,8 +596,12 @@ runGenesisCreateStakedCmd
   forM_ (zip [ 1 .. numBulkPoolCredFiles ] bulkSlices) $
     uncurry (writeBulkPoolCredentials pooldir)
 
-  let (delegsPerPool, delegsRemaining) = divMod numStakeDelegators numPools
-      delegsForPool poolIx = if delegsRemaining /= 0 && poolIx == numPools
+  let (delegsPerPool, delegsRemaining) =
+        if numPools == 0
+        then (0, 0)
+        else numStakeDelegators `divMod` numPools
+      delegsForPool poolIx =
+        if delegsRemaining /= 0 && poolIx == numPools
         then delegsPerPool
         else delegsPerPool + delegsRemaining
       distribution = [pool | (pool, poolIx) <- zip poolParams [1 ..], _ <- [1 .. delegsForPool poolIx]]

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/CreateTestnetData.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/CreateTestnetData.hs
@@ -1,0 +1,29 @@
+module Test.Cli.CreateTestnetData where
+
+
+
+import           System.FilePath
+
+import           Test.Cardano.CLI.Util (execCardanoCLI)
+
+import           Hedgehog (Property)
+import           Hedgehog.Extras (moduleWorkspace, propertyOnce)
+import qualified Hedgehog.Extras as H
+
+-- | Test case for https://github.com/IntersectMBO/cardano-cli/issues/587
+-- Execute this test with:
+-- @cabal test cardano-cli-test --test-options '-p "/create testnet data minimal/"'@
+hprop_create_testnet_data_minimal :: Property
+hprop_create_testnet_data_minimal =
+  propertyOnce $ moduleWorkspace "tmp" $ \tempDir -> do
+
+    let outputDir = tempDir </> "out"
+
+    H.noteM_ $ execCardanoCLI
+      ["conway",  "genesis", "create-testnet-data"
+      , "--testnet-magic", "42"
+      , "--out-dir", outputDir
+      ]
+
+    -- We test that the command doesn't crash, because otherwise
+    -- execCardanoCLI would fail.


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Avoid an internal crash of `create-testnet-data`
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Fixes https://github.com/IntersectMBO/cardano-cli/issues/587

When using `create-testnet-data` in https://github.com/IntersectMBO/cardano-node/pull/5646, I was faced with the fact that it was crashing when omitting some flags, because it was trying to create the `README` for some keys, whose parent directory wasn't being created; because the concerned keys where not requested. This is https://github.com/IntersectMBO/cardano-cli/issues/587.

When fixing that, I also noticed that `create-testnet-data` was looping when neither `--stake-delegators` nor `--transient--stake-delegators` was specified. This was due to a `zipWith` call with `concat $ repeat ([])` as an argument (the crux is to pass `[]` to `repeat`). So this PR also fixes that.

On the way, I also noticed that `create-staked` and `create-testnet-data` were avoiding a division by zero because of laziness. I made this less brittle by avoiding the division by zero explicitly.

# How to trust this PR

A test is introduced. The test fails before this PR and it succeeds after the PR.

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [X] Self-reviewed the diff