### PR TITLE
Update hedgehog-extras to 0.6.0.1

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -14,7 +14,7 @@ repository cardano-haskell-packages
 -- you need to run if you change them
 index-state:
   , hackage.haskell.org 2024-01-23T08:19:39Z
-  , cardano-haskell-packages 2024-01-18T14:07:29Z
+  , cardano-haskell-packages 2024-01-25T13:05:04Z
 
 packages:
   cardano-cli

--- a/cabal.project
+++ b/cabal.project
@@ -13,7 +13,7 @@ repository cardano-haskell-packages
 -- See CONTRIBUTING for information about these, including some Nix commands
 -- you need to run if you change them
 index-state:
-  , hackage.haskell.org 2024-01-16T14:48:13Z
+  , hackage.haskell.org 2024-01-23T08:19:39Z
   , cardano-haskell-packages 2024-01-18T14:07:29Z
 
 packages:

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -272,7 +272,7 @@ library cardano-cli-test-lib
                       , exceptions
                       , filepath
                       , hedgehog
-                      , hedgehog-extras ^>= 0.6.0.0
+                      , hedgehog-extras ^>= 0.6.0.1
                       , process
                       , text
                       , transformers
@@ -296,7 +296,7 @@ test-suite cardano-cli-test
                       , containers
                       , filepath
                       , hedgehog
-                      , hedgehog-extras ^>= 0.6.0.0
+                      , hedgehog-extras ^>= 0.6.0.1
                       , tasty
                       , tasty-hedgehog
                       , text
@@ -346,7 +346,7 @@ test-suite cardano-cli-golden
                       , extra
                       , filepath
                       , hedgehog ^>= 1.3
-                      , hedgehog-extras ^>= 0.6.0.0
+                      , hedgehog-extras ^>= 0.6.0.1
                       , regex-compat
                       , regex-tdfa
                       , tasty

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1706004183,
-        "narHash": "sha256-WKfiLsitgXL9wxHr8LA+lyIhHXog4/HOOdQwIUdSW04=",
+        "lastModified": 1706189917,
+        "narHash": "sha256-X3OubU+ac8zRusECafdBSTv+AP4uRNZEnccd85FrukI=",
         "owner": "input-output-hk",
         "repo": "cardano-haskell-packages",
-        "rev": "44cf7d3dcee77eb6ee8e4462bf63616351dfbb1d",
+        "rev": "834f1277d402a8c4aeef912dc0d7e00aeb6753a7",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Bump hedgehog-extras to 0.6.0.1 to benefit of this fix: https://github.com/input-output-hk/hedgehog-extras/pull/58
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```