### PR TITLE
Fix create-testnet-data creating negative supply

### DIFF
--- a/cardano-cli/src/Cardano/CLI/Types/Errors/GenesisCmdError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/GenesisCmdError.hs
@@ -39,6 +39,7 @@ data GenesisCmdError
   | GenesisCmdStakePoolRelayFileError !FilePath !IOException
   | GenesisCmdStakePoolRelayJsonDecodeError !FilePath !String
   | GenesisCmdFileInputDecodeError !(FileError InputDecodeError)
+  | GenesisCmdNegativeInitialFunds !Integer -- ^ total supply underflow
   deriving Show
 
 instance Error GenesisCmdError where
@@ -97,3 +98,5 @@ instance Error GenesisCmdError where
       " Error: " <> pretty e
     GenesisCmdFileInputDecodeError ide ->
       "Error occured while decoding a file: " <> pshow ide
+    GenesisCmdNegativeInitialFunds underflow ->
+      "Provided delegated supply value results in negative initial funds. Decrease delegated amount by " <> pretty ((-1) * underflow) <> " or increase total supply by it."

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/CreateTestnetData.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/CreateTestnetData.hs
@@ -1,12 +1,28 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
 module Test.Cli.CreateTestnetData where
 
-
-
+import           Control.Monad
+import           Control.Monad.IO.Class
+import           Data.Aeson (FromJSON, ToJSON)
+import qualified Data.Aeson as A
+import qualified Data.ByteString.Lazy as LBS
+import           Data.Map.Strict (Map)
+import qualified Data.Map.Strict as M
+import           Data.Text (Text)
+import           GHC.Generics
+import           GHC.IO.Exception (ExitCode (..))
+import           GHC.Stack
 import           System.FilePath
 
-import           Test.Cardano.CLI.Util (execCardanoCLI)
+import           Test.Cardano.CLI.Util (execCardanoCLI, execDetailCardanoCLI)
 
-import           Hedgehog (Property)
+import           Hedgehog (MonadTest, Property, success, (===))
+import qualified Hedgehog as H
 import           Hedgehog.Extras (moduleWorkspace, propertyOnce)
 import qualified Hedgehog.Extras as H
 
@@ -19,11 +35,69 @@ hprop_create_testnet_data_minimal =
 
     let outputDir = tempDir </> "out"
 
+    -- We test that the command doesn't crash, because otherwise
+    -- execCardanoCLI would fail.
     H.noteM_ $ execCardanoCLI
       ["conway",  "genesis", "create-testnet-data"
       , "--testnet-magic", "42"
       , "--out-dir", outputDir
       ]
+    success
 
-    -- We test that the command doesn't crash, because otherwise
-    -- execCardanoCLI would fail.
+hprop_create_testnet_data_create_nonegative_supply :: Property
+hprop_create_testnet_data_create_nonegative_supply = do
+  -- FIXME rewrite this as a property test
+  let supplyValues =
+        [ -- (total supply, delegated supply, exit code)
+          (2_000_000_000, 1_000_000_000, ExitSuccess)
+        , (1_100_000_000, 1_000_000_000, ExitSuccess)
+        , (1_000_000_000, 1_000_000_000, ExitFailure 1)
+        , (1_000_000_000, 2_000_000_000, ExitFailure 1)
+        ] :: [(Int, Int, ExitCode)]
+
+  propertyOnce $ forM_ supplyValues $ \(totalSupply, delegatedSupply, expectedExitCode) ->
+    moduleWorkspace "tmp" $ \tempDir -> do
+      let outputDir = tempDir </> "out"
+
+      (exitCode, _, _) <- H.noteShowM $ execDetailCardanoCLI
+        ["conway",  "genesis", "create-testnet-data"
+        , "--testnet-magic", "42"
+        , "--pools", "3"
+        , "--total-supply", show totalSupply
+        , "--delegated-supply", show delegatedSupply
+        , "--stake-delegators", "3"
+        , "--utxo-keys", "3"
+        , "--drep-keys", "3"
+        , "--out-dir", outputDir
+        ]
+
+      H.note_ "check that exit code is equal to the expected one"
+      exitCode === expectedExitCode
+
+      when (exitCode == ExitSuccess) $ do
+        testGenesis@TestGenesis{maxLovelaceSupply, initialFunds} <- H.leftFailM . readJsonFile $ outputDir </> "genesis.json"
+        H.note_ $ show testGenesis
+
+        H.note_ "check that max lovelace supply is set equal to --total-supply flag value"
+        maxLovelaceSupply === totalSupply
+
+        H.note_ "check that all initial funds are positive"
+        H.assertWith initialFunds $ all (>= 0) . M.elems
+
+        H.note_ "check that initial funds are not bigger than max lovelace supply"
+        H.assertWith initialFunds $ \initialFunds' -> do
+          let totalDistributed = sum . M.elems $ initialFunds'
+          totalDistributed <= maxLovelaceSupply
+
+data TestGenesis = TestGenesis
+  { maxLovelaceSupply :: Int
+  , initialFunds :: Map Text Int
+  } deriving (Show, Generic, ToJSON, FromJSON)
+
+
+-- compabitility shim for hedgehog-extras until https://github.com/input-output-hk/hedgehog-extras/pull/60
+-- gets integrated - remove afterwards
+readJsonFile :: forall a m. (MonadTest m, MonadIO m, FromJSON a, HasCallStack) => FilePath -> m (Either String a)
+readJsonFile filePath = withFrozenCallStack $ do
+  void . H.annotate $ "Reading JSON file: " <> filePath
+  H.evalIO $ A.eitherDecode <$> LBS.readFile filePath


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Fix `create-testnet-data` creating negative supply
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
   - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

`create-testnet-data` was creating negative supply which was preventing node from start

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
