### PR TITLE
Add immutable tip parameter to conway queries

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -24,7 +24,7 @@ jobs:
 
     env:
       # Modify this value to "invalidate" the cabal cache.
-      CABAL_CACHE_VERSION: "2024-02-12-1"
+      CABAL_CACHE_VERSION: "2024-02-12-2"
 
     concurrency:
       group: >

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Query.hs
@@ -31,6 +31,7 @@ import           Cardano.Api.Shelley hiding (QueryInShelleyBasedEra (..))
 
 import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Key
+import qualified Ouroboros.Network.Protocol.LocalStateQuery.Type as Consensus
 
 import           Data.Text (Text)
 import           Data.Time.Clock
@@ -67,6 +68,7 @@ data QueryLeadershipScheduleCmdArgs = QueryLeadershipScheduleCmdArgs
   , poolColdVerKeyFile  :: !(VerificationKeyOrHashOrFile StakePoolKey)
   , vrkSkeyFp           :: !(SigningKeyFile In)
   , whichSchedule       :: !EpochLeadershipSchedule
+  , target              :: !(Consensus.Target ChainPoint)
   , mOutFile            :: !(Maybe (File () Out))
   } deriving (Generic, Show)
 
@@ -81,6 +83,7 @@ data QueryConstitutionHashCmdArgs = QueryConstitutionHashCmdArgs
   { nodeSocketPath      :: !SocketPath
   , consensusModeParams :: !ConsensusModeParams
   , networkId           :: !NetworkId
+  , target              :: !(Consensus.Target ChainPoint)
   , mOutFile            :: !(Maybe (File () Out))
   } deriving (Generic, Show)
 
@@ -88,6 +91,7 @@ data QueryTipCmdArgs = QueryTipCmdArgs
   { nodeSocketPath      :: !SocketPath
   , consensusModeParams :: !ConsensusModeParams
   , networkId           :: !NetworkId
+  , target              :: !(Consensus.Target ChainPoint)
   , mOutFile            :: !(Maybe (File () Out))
   } deriving (Generic, Show)
 
@@ -95,6 +99,7 @@ data QueryStakePoolsCmdArgs = QueryStakePoolsCmdArgs
   { nodeSocketPath      :: !SocketPath
   , consensusModeParams :: !ConsensusModeParams
   , networkId           :: !NetworkId
+  , target              :: !(Consensus.Target ChainPoint)
   , mOutFile            :: !(Maybe (File () Out))
   } deriving (Generic, Show)
 
@@ -102,6 +107,7 @@ data QueryStakeDistributionCmdArgs = QueryStakeDistributionCmdArgs
   { nodeSocketPath      :: !SocketPath
   , consensusModeParams :: !ConsensusModeParams
   , networkId           :: !NetworkId
+  , target              :: !(Consensus.Target ChainPoint)
   , mOutFile            :: !(Maybe (File () Out))
   } deriving (Generic, Show)
 
@@ -110,6 +116,7 @@ data QueryStakeAddressInfoCmdArgs = QueryStakeAddressInfoCmdArgs
   , consensusModeParams :: !ConsensusModeParams
   , addr                :: !StakeAddress
   , networkId           :: !NetworkId
+  , target              :: !(Consensus.Target ChainPoint)
   , mOutFile            :: !(Maybe (File () Out))
   } deriving (Generic, Show)
 
@@ -118,6 +125,7 @@ data QueryUTxOCmdArgs = QueryUTxOCmdArgs
   , consensusModeParams :: !ConsensusModeParams
   , queryFilter         :: !QueryUTxOFilter
   , networkId           :: !NetworkId
+  , target              :: !(Consensus.Target ChainPoint)
   , mOutFile            :: !(Maybe (File () Out))
   } deriving (Generic, Show)
 
@@ -125,6 +133,7 @@ data QueryLedgerStateCmdArgs = QueryLedgerStateCmdArgs
   { nodeSocketPath      :: !SocketPath
   , consensusModeParams :: !ConsensusModeParams
   , networkId           :: !NetworkId
+  , target              :: !(Consensus.Target ChainPoint)
   , mOutFile            :: !(Maybe (File () Out))
   } deriving (Generic, Show)
 
@@ -132,6 +141,7 @@ data QueryProtocolStateCmdArgs = QueryProtocolStateCmdArgs
   { nodeSocketPath      :: !SocketPath
   , consensusModeParams :: !ConsensusModeParams
   , networkId           :: !NetworkId
+  , target              :: !(Consensus.Target ChainPoint)
   , mOutFile            :: !(Maybe (File () Out))
   } deriving (Generic, Show)
 
@@ -140,6 +150,7 @@ data QueryStakeSnapshotCmdArgs = QueryStakeSnapshotCmdArgs
   , consensusModeParams :: !ConsensusModeParams
   , networkId           :: !NetworkId
   , allOrOnlyPoolIds    :: !(AllOrOnly (Hash StakePoolKey))
+  , target              :: !(Consensus.Target ChainPoint)
   , mOutFile            :: !(Maybe (File () Out))
   } deriving (Generic, Show)
 
@@ -148,6 +159,7 @@ data QueryKesPeriodInfoCmdArgs = QueryKesPeriodInfoCmdArgs
   , consensusModeParams :: !ConsensusModeParams
   , networkId           :: !NetworkId
   , nodeOpCertFp        :: !(File () In) -- ^ Node operational certificate
+  , target              :: !(Consensus.Target ChainPoint)
   , mOutFile            :: !(Maybe (File () Out))
   } deriving (Generic, Show)
 
@@ -156,6 +168,7 @@ data QueryPoolStateCmdArgs = QueryPoolStateCmdArgs
   , consensusModeParams :: !ConsensusModeParams
   , networkId           :: !NetworkId
   , allOrOnlyPoolIds    :: !(AllOrOnly (Hash StakePoolKey))
+  , target              :: !(Consensus.Target ChainPoint)
   } deriving (Generic, Show)
 
 data QueryTxMempoolCmdArgs = QueryTxMempoolCmdArgs
@@ -171,6 +184,7 @@ data QuerySlotNumberCmdArgs = QuerySlotNumberCmdArgs
   { nodeSocketPath      :: !SocketPath
   , consensusModeParams :: !ConsensusModeParams
   , networkId           :: !NetworkId
+  , target              :: !(Consensus.Target ChainPoint)
   , utcTime             :: !UTCTime
   } deriving (Generic, Show)
 
@@ -179,6 +193,7 @@ data QueryNoArgCmdArgs era = QueryNoArgCmdArgs
   , nodeSocketPath      :: !SocketPath
   , consensusModeParams :: !ConsensusModeParams
   , networkId           :: !NetworkId
+  , target              :: !(Consensus.Target ChainPoint)
   , mOutFile            :: !(Maybe (File () Out))
   } deriving Show
 
@@ -188,6 +203,7 @@ data QueryDRepStateCmdArgs era = QueryDRepStateCmdArgs
   , consensusModeParams :: !ConsensusModeParams
   , networkId           :: !NetworkId
   , drepKeys            :: !(AllOrOnly (VerificationKeyOrHashOrFile DRepKey))
+  , target              :: !(Consensus.Target ChainPoint)
   , mOutFile            :: !(Maybe (File () Out))
   } deriving Show
 
@@ -197,6 +213,7 @@ data QueryDRepStakeDistributionCmdArgs era = QueryDRepStakeDistributionCmdArgs
   , consensusModeParams :: !ConsensusModeParams
   , networkId           :: !NetworkId
   , drepKeys            :: !(AllOrOnly (VerificationKeyOrHashOrFile DRepKey))
+  , target              :: !(Consensus.Target ChainPoint)
   , mOutFile            :: !(Maybe (File () Out))
   } deriving Show
 
@@ -208,6 +225,7 @@ data QueryCommitteeMembersStateCmdArgs era = QueryCommitteeMembersStateCmdArgs
   , committeeColdKeys       :: ![VerificationKeyOrHashOrFile CommitteeColdKey]
   , committeeHotKeys        :: ![VerificationKeyOrHashOrFile CommitteeHotKey]
   , memberStatuses          :: ![MemberStatus]
+  , target                  :: !(Consensus.Target ChainPoint)
   , mOutFile                :: !(Maybe (File () Out))
   } deriving Show
 

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Query.hs
@@ -41,64 +41,64 @@ pQueryCmds era envCli =
         $ Opt.progDesc "Get the node's current protocol parameters"
     , Just
         $ subParser "tip"
-        $ Opt.info (pQueryTipCmd envCli)
+        $ Opt.info (pQueryTipCmd era envCli)
         $ Opt.progDesc "Get the node's current tip (slot no, hash, block no)"
     , Just
         $ subParser "stake-pools"
-        $ Opt.info (pQueryStakePoolsCmd envCli)
+        $ Opt.info (pQueryStakePoolsCmd era envCli)
         $ Opt.progDesc "Get the node's current set of stake pool ids"
     , Just
         $ subParser "stake-distribution"
-        $ Opt.info (pQueryStakeDistributionCmd envCli)
+        $ Opt.info (pQueryStakeDistributionCmd era envCli)
         $ Opt.progDesc "Get the node's current aggregated stake distribution"
     , Just
         $ subParser "stake-address-info"
-        $ Opt.info (pQueryStakeAddressInfoCmd envCli)
+        $ Opt.info (pQueryStakeAddressInfoCmd era envCli)
         $ Opt.progDesc $ mconcat
             [ "Get the current delegations and reward accounts filtered by stake address."
             ]
     , Just
         $ subParser "utxo"
-        $ Opt.info (pQueryUTxOCmd envCli)
+        $ Opt.info (pQueryUTxOCmd era envCli)
         $ Opt.progDesc $ mconcat
             [ "Get a portion of the current UTxO: by tx in, by address or the whole."
             ]
     , Just
         $ subParser "ledger-state"
-        $ Opt.info (pQueryLedgerStateCmd envCli)
+        $ Opt.info (pQueryLedgerStateCmd era envCli)
         $ Opt.progDesc $ mconcat
             [ "Dump the current ledger state of the node (Ledger.NewEpochState -- advanced command)"
             ]
     , Just
         $ subParser "protocol-state"
-        $ Opt.info (pQueryProtocolStateCmd envCli)
+        $ Opt.info (pQueryProtocolStateCmd era envCli)
         $ Opt.progDesc $ mconcat
             [ "Dump the current protocol state of the node (Ledger.ChainDepState -- advanced command)"
             ]
     , Just
         $ subParser "stake-snapshot"
-        $ Opt.info (pQueryStakeSnapshotCmd envCli)
+        $ Opt.info (pQueryStakeSnapshotCmd era envCli)
         $ Opt.progDesc $ mconcat
             [ "Obtain the three stake snapshots for a pool, plus the total active stake (advanced command)"
             ]
     , Just
         $ hiddenSubParser "pool-params"
-        $ Opt.info (pQueryPoolStateCmd envCli)
+        $ Opt.info (pQueryPoolStateCmd era envCli)
         $ Opt.progDesc $ mconcat
             [ "DEPRECATED.  Use query pool-state instead.  Dump the pool parameters "
             , "(Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced command)"
             ]
     , Just
         $ subParser "leadership-schedule"
-        $ Opt.info (pLeadershipScheduleCmd envCli)
+        $ Opt.info (pLeadershipScheduleCmd era envCli)
         $ Opt.progDesc "Get the slots the node is expected to mint a block in (advanced command)"
     , Just
         $ subParser "kes-period-info"
-        $ Opt.info (pKesPeriodInfoCmd envCli)
+        $ Opt.info (pKesPeriodInfoCmd era envCli)
         $ Opt.progDesc "Get information about the current KES period and your node's operational certificate."
     , Just
         $ subParser "pool-state"
-        $ Opt.info (pQueryPoolStateCmd envCli)
+        $ Opt.info (pQueryPoolStateCmd era envCli)
         $ Opt.progDesc "Dump the pool state"
     , Just
         $ subParser "tx-mempool"
@@ -106,7 +106,7 @@ pQueryCmds era envCli =
         $ Opt.progDesc "Local Mempool info"
     , Just
         $ subParser "slot-number"
-        $ Opt.info (pQuerySlotNumberCmd envCli)
+        $ Opt.info (pQuerySlotNumberCmd era envCli)
         $ Opt.progDesc "Query slot number for UTC timestamp"
     , pQueryGetConstitutionCmd era envCli
     , pQueryGetGovStateCmd era envCli
@@ -124,69 +124,76 @@ pQueryProtocolParametersCmd envCli =
       <*> pNetworkId envCli
       <*> pMaybeOutputFile
 
-pQueryTipCmd :: EnvCli -> Parser (QueryCmds era)
-pQueryTipCmd envCli =
+pQueryTipCmd :: CardanoEra era -> EnvCli -> Parser (QueryCmds era)
+pQueryTipCmd era envCli =
   fmap QueryTipCmd $
     QueryTipCmdArgs
       <$> pSocketPath envCli
       <*> pConsensusModeParams
       <*> pNetworkId envCli
+      <*> pTarget era
       <*> pMaybeOutputFile
 
-pQueryUTxOCmd :: EnvCli -> Parser (QueryCmds era)
-pQueryUTxOCmd envCli =
+pQueryUTxOCmd :: CardanoEra era -> EnvCli -> Parser (QueryCmds era)
+pQueryUTxOCmd era envCli =
   fmap QueryUTxOCmd $
     QueryUTxOCmdArgs
       <$> pSocketPath envCli
       <*> pConsensusModeParams
       <*> pQueryUTxOFilter
       <*> pNetworkId envCli
+      <*> pTarget era
       <*> pMaybeOutputFile
 
-pQueryStakePoolsCmd :: EnvCli -> Parser (QueryCmds era)
-pQueryStakePoolsCmd envCli =
+pQueryStakePoolsCmd :: CardanoEra era -> EnvCli -> Parser (QueryCmds era)
+pQueryStakePoolsCmd era envCli =
   fmap QueryStakePoolsCmd $
     QueryStakePoolsCmdArgs
       <$> pSocketPath envCli
       <*> pConsensusModeParams
       <*> pNetworkId envCli
+      <*> pTarget era
       <*> pMaybeOutputFile
 
-pQueryStakeDistributionCmd :: EnvCli -> Parser (QueryCmds era)
-pQueryStakeDistributionCmd envCli =
+pQueryStakeDistributionCmd :: CardanoEra era -> EnvCli -> Parser (QueryCmds era)
+pQueryStakeDistributionCmd era envCli =
   fmap QueryStakeDistributionCmd $
     QueryStakeDistributionCmdArgs
       <$> pSocketPath envCli
       <*> pConsensusModeParams
       <*> pNetworkId envCli
+      <*> pTarget era
       <*> pMaybeOutputFile
 
-pQueryStakeAddressInfoCmd :: EnvCli -> Parser (QueryCmds era)
-pQueryStakeAddressInfoCmd envCli =
+pQueryStakeAddressInfoCmd :: CardanoEra era -> EnvCli -> Parser (QueryCmds era)
+pQueryStakeAddressInfoCmd era envCli =
   fmap QueryStakeAddressInfoCmd $
     QueryStakeAddressInfoCmdArgs
       <$> pSocketPath envCli
       <*> pConsensusModeParams
       <*> pFilterByStakeAddress
       <*> pNetworkId envCli
+      <*> pTarget era
       <*> pMaybeOutputFile
 
-pQueryLedgerStateCmd :: EnvCli -> Parser (QueryCmds era)
-pQueryLedgerStateCmd envCli =
+pQueryLedgerStateCmd :: CardanoEra era -> EnvCli -> Parser (QueryCmds era)
+pQueryLedgerStateCmd era envCli =
   fmap QueryLedgerStateCmd $
     QueryLedgerStateCmdArgs
       <$> pSocketPath envCli
       <*> pConsensusModeParams
       <*> pNetworkId envCli
+      <*> pTarget era
       <*> pMaybeOutputFile
 
-pQueryProtocolStateCmd :: EnvCli -> Parser (QueryCmds era)
-pQueryProtocolStateCmd envCli =
+pQueryProtocolStateCmd :: CardanoEra era -> EnvCli -> Parser (QueryCmds era)
+pQueryProtocolStateCmd era envCli =
   fmap QueryProtocolStateCmd $
     QueryProtocolStateCmdArgs
       <$> pSocketPath envCli
       <*> pConsensusModeParams
       <*> pNetworkId envCli
+      <*> pTarget era
       <*> pMaybeOutputFile
 
 pAllStakePoolsOrSome :: Parser (AllOrOnly (Hash StakePoolKey))
@@ -199,24 +206,26 @@ pAllStakePoolsOrSome = pAll <|> pOnly
         pOnly :: Parser (AllOrOnly (Hash StakePoolKey))
         pOnly = Only <$> some (pStakePoolVerificationKeyHash Nothing)
 
-pQueryStakeSnapshotCmd :: EnvCli -> Parser (QueryCmds era)
-pQueryStakeSnapshotCmd envCli =
+pQueryStakeSnapshotCmd :: CardanoEra era -> EnvCli -> Parser (QueryCmds era)
+pQueryStakeSnapshotCmd era envCli =
   fmap QueryStakeSnapshotCmd $
     QueryStakeSnapshotCmdArgs
       <$> pSocketPath envCli
       <*> pConsensusModeParams
       <*> pNetworkId envCli
       <*> pAllStakePoolsOrSome
+      <*> pTarget era
       <*> pMaybeOutputFile
 
-pQueryPoolStateCmd :: EnvCli -> Parser (QueryCmds era)
-pQueryPoolStateCmd envCli =
+pQueryPoolStateCmd :: CardanoEra era -> EnvCli -> Parser (QueryCmds era)
+pQueryPoolStateCmd era envCli =
   fmap QueryPoolStateCmd $
     QueryPoolStateCmdArgs
       <$> pSocketPath envCli
       <*> pConsensusModeParams
       <*> pNetworkId envCli
       <*> pAllStakePoolsOrSome
+      <*> pTarget era
 
 pQueryTxMempoolCmd :: EnvCli -> Parser (QueryCmds era)
 pQueryTxMempoolCmd envCli =
@@ -240,8 +249,8 @@ pQueryTxMempoolCmd envCli =
           $ Opt.info (TxMempoolQueryTxExists <$> argument Opt.str (metavar "TX_ID"))
           $ Opt.progDesc "Query if a particular transaction exists in the mempool"
       ]
-pLeadershipScheduleCmd :: EnvCli -> Parser (QueryCmds era)
-pLeadershipScheduleCmd envCli =
+pLeadershipScheduleCmd :: CardanoEra era -> EnvCli -> Parser (QueryCmds era)
+pLeadershipScheduleCmd era envCli =
   fmap QueryLeadershipScheduleCmd $
     QueryLeadershipScheduleCmdArgs
       <$> pSocketPath envCli
@@ -251,25 +260,28 @@ pLeadershipScheduleCmd envCli =
       <*> pStakePoolVerificationKeyOrHashOrFile Nothing
       <*> pVrfSigningKeyFile
       <*> pWhichLeadershipSchedule
+      <*> pTarget era
       <*> pMaybeOutputFile
 
-pKesPeriodInfoCmd :: EnvCli -> Parser (QueryCmds era)
-pKesPeriodInfoCmd envCli =
+pKesPeriodInfoCmd :: CardanoEra era -> EnvCli -> Parser (QueryCmds era)
+pKesPeriodInfoCmd era envCli =
   fmap QueryKesPeriodInfoCmd $
     QueryKesPeriodInfoCmdArgs
       <$> pSocketPath envCli
       <*> pConsensusModeParams
       <*> pNetworkId envCli
       <*> pOperationalCertificateFile
+      <*> pTarget era
       <*> pMaybeOutputFile
 
-pQuerySlotNumberCmd :: EnvCli -> Parser (QueryCmds era)
-pQuerySlotNumberCmd envCli =
+pQuerySlotNumberCmd :: CardanoEra era -> EnvCli -> Parser (QueryCmds era)
+pQuerySlotNumberCmd era envCli =
   fmap QuerySlotNumberCmd $
     QuerySlotNumberCmdArgs
       <$> pSocketPath envCli
       <*> pConsensusModeParams
       <*> pNetworkId envCli
+      <*> pTarget era
       <*> pUtcTimestamp
   where
     pUtcTimestamp =
@@ -286,7 +298,7 @@ pQueryGetConstitutionCmd era envCli = do
   w <- forEraMaybeEon era
   pure
     $ subParser "constitution"
-    $ Opt.info (QueryConstitutionCmd <$> pQueryNoArgCmdArgs w envCli)
+    $ Opt.info (QueryConstitutionCmd <$> pQueryNoArgCmdArgs w era envCli)
     $ Opt.progDesc "Get the constitution"
 
 pQueryGetGovStateCmd :: ()
@@ -297,7 +309,7 @@ pQueryGetGovStateCmd era envCli = do
   w <- forEraMaybeEon era
   pure
     $ subParser "gov-state"
-    $ Opt.info (QueryGovStateCmd <$> pQueryNoArgCmdArgs w envCli)
+    $ Opt.info (QueryGovStateCmd <$> pQueryNoArgCmdArgs w era envCli)
     $ Opt.progDesc "Get the governance state"
 
 -- TODO Conway: DRep State and DRep Stake Distribution parsers use DRep keys to obtain DRep credentials. This only
@@ -323,6 +335,7 @@ pQueryDRepStateCmd era envCli = do
         <*> pConsensusModeParams
         <*> pNetworkId envCli
         <*> pAllOrOnlyDRepVerificationKeyOrHashOrFile
+        <*> pTarget era
         <*> optional pOutputFile
 
 pQueryDRepStakeDistributionCmd :: ()
@@ -342,6 +355,7 @@ pQueryDRepStakeDistributionCmd era envCli = do
       <*> pConsensusModeParams
       <*> pNetworkId envCli
       <*> pAllOrOnlyDRepVerificationKeyOrHashOrFile
+      <*> pTarget era
       <*> optional pOutputFile
 
 pQueryGetCommitteeStateCmd :: ()
@@ -363,6 +377,7 @@ pQueryGetCommitteeStateCmd era envCli = do
       <*> many pCommitteeColdVerificationKeyOrHashOrFile
       <*> many pCommitteeHotKeyOrHashOrFile
       <*> many pMemberStatus
+      <*> pTarget era
       <*> optional pOutputFile
 
     pMemberStatus :: Parser MemberStatus
@@ -384,11 +399,13 @@ pQueryGetCommitteeStateCmd era envCli = do
 
 pQueryNoArgCmdArgs :: ()
   => ConwayEraOnwards era
+  -> CardanoEra era
   -> EnvCli
   -> Parser (QueryNoArgCmdArgs era)
-pQueryNoArgCmdArgs w envCli =
+pQueryNoArgCmdArgs w era envCli =
   QueryNoArgCmdArgs w
     <$> pSocketPath envCli
     <*> pConsensusModeParams
     <*> pNetworkId envCli
+    <*> pTarget era
     <*> optional pOutputFile

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Query.hs
@@ -144,11 +144,12 @@ runQueryConstitutionHashCmd
     { Cmd.nodeSocketPath
     , Cmd.consensusModeParams
     , Cmd.networkId
+    , Cmd.target
     , Cmd.mOutFile
     } = do
   let localNodeConnInfo = LocalNodeConnectInfo consensusModeParams networkId nodeSocketPath
 
-  result <- liftIO $ executeLocalStateQueryExpr localNodeConnInfo Consensus.VolatileTip $ runExceptT $ do
+  result <- liftIO $ executeLocalStateQueryExpr localNodeConnInfo target $ runExceptT $ do
     AnyCardanoEra era <- lift queryCurrentEra & onLeft (left . QueryCmdUnsupportedNtcVersion)
 
     sbe <- requireShelleyBasedEra era
@@ -245,12 +246,13 @@ runQueryTipCmd
     { Cmd.nodeSocketPath
     , Cmd.consensusModeParams
     , Cmd.networkId
+    , Cmd.target
     , Cmd.mOutFile
     } = do
   let localNodeConnInfo = LocalNodeConnectInfo consensusModeParams networkId nodeSocketPath
 
   eLocalState <- ExceptT $ fmap sequence $
-    executeLocalStateQueryExpr localNodeConnInfo Consensus.VolatileTip $ runExceptT $ do
+    executeLocalStateQueryExpr localNodeConnInfo target $ runExceptT $ do
       era <- lift queryCurrentEra & onLeft (left . QueryCmdUnsupportedNtcVersion)
       eraHistory <- lift queryEraHistory & onLeft (left . QueryCmdUnsupportedNtcVersion)
       mChainBlockNo <- lift queryChainBlockNo & onLeft (left . QueryCmdUnsupportedNtcVersion) & fmap Just
@@ -329,12 +331,13 @@ runQueryUTxOCmd
     , Cmd.consensusModeParams
     , Cmd.queryFilter
     , Cmd.networkId
+    , Cmd.target
     , Cmd.mOutFile
     } = do
   let localNodeConnInfo = LocalNodeConnectInfo consensusModeParams networkId nodeSocketPath
 
   join $ lift
-    ( executeLocalStateQueryExpr localNodeConnInfo Consensus.VolatileTip $ runExceptT $ do
+    ( executeLocalStateQueryExpr localNodeConnInfo target $ runExceptT $ do
         AnyCardanoEra era <- lift queryCurrentEra
           & onLeft (left . QueryCmdUnsupportedNtcVersion)
 
@@ -360,6 +363,7 @@ runQueryKesPeriodInfoCmd
     , Cmd.consensusModeParams
     , Cmd.networkId
     , Cmd.nodeOpCertFp
+    , Cmd.target
     , Cmd.mOutFile
     } = do
   opCert <- lift (readFileTextEnvelope AsOperationalCertificate nodeOpCertFp)
@@ -368,7 +372,7 @@ runQueryKesPeriodInfoCmd
   let localNodeConnInfo = LocalNodeConnectInfo consensusModeParams networkId nodeSocketPath
 
   join $ lift
-    ( executeLocalStateQueryExpr localNodeConnInfo Consensus.VolatileTip $ runExceptT $ do
+    ( executeLocalStateQueryExpr localNodeConnInfo target $ runExceptT $ do
         AnyCardanoEra era <- lift queryCurrentEra
           & onLeft (left . QueryCmdUnsupportedNtcVersion)
 
@@ -621,11 +625,12 @@ runQueryPoolStateCmd
     , Cmd.consensusModeParams
     , Cmd.networkId
     , Cmd.allOrOnlyPoolIds
+    , Cmd.target
     } = do
   let localNodeConnInfo = LocalNodeConnectInfo consensusModeParams networkId nodeSocketPath
 
   join $ lift
-    ( executeLocalStateQueryExpr localNodeConnInfo Consensus.VolatileTip $ runExceptT $ do
+    ( executeLocalStateQueryExpr localNodeConnInfo target $ runExceptT $ do
         AnyCardanoEra era <- lift queryCurrentEra
           & onLeft (left . QueryCmdUnsupportedNtcVersion)
 
@@ -686,8 +691,9 @@ runQuerySlotNumberCmd
     , Cmd.consensusModeParams
     , Cmd.networkId
     , Cmd.utcTime
+    , Cmd.target
     } = do
-  SlotNo slotNo <- utcTimeToSlotNo nodeSocketPath consensusModeParams networkId utcTime
+  SlotNo slotNo <- utcTimeToSlotNo nodeSocketPath consensusModeParams networkId target utcTime
   liftIO . putStr $ show slotNo
 
 -- | Obtain stake snapshot information for a pool, plus information about the total active stake.
@@ -702,12 +708,13 @@ runQueryStakeSnapshotCmd
     , Cmd.consensusModeParams
     , Cmd.networkId
     , Cmd.allOrOnlyPoolIds
+    , Cmd.target
     , Cmd.mOutFile
     } = do
   let localNodeConnInfo = LocalNodeConnectInfo consensusModeParams networkId nodeSocketPath
 
   join $ lift
-    ( executeLocalStateQueryExpr localNodeConnInfo Consensus.VolatileTip $ runExceptT $ do
+    ( executeLocalStateQueryExpr localNodeConnInfo target $ runExceptT $ do
         AnyCardanoEra era <- lift queryCurrentEra
           & onLeft (left . QueryCmdUnsupportedNtcVersion)
 
@@ -738,12 +745,13 @@ runQueryLedgerStateCmd
     { Cmd.nodeSocketPath
     , Cmd.consensusModeParams
     , Cmd.networkId
+    , Cmd.target
     , Cmd.mOutFile
      } = do
   let localNodeConnInfo = LocalNodeConnectInfo consensusModeParams networkId nodeSocketPath
 
   join $ lift
-    ( executeLocalStateQueryExpr localNodeConnInfo Consensus.VolatileTip $ runExceptT $ do
+    ( executeLocalStateQueryExpr localNodeConnInfo target $ runExceptT $ do
         AnyCardanoEra era <- lift queryCurrentEra
           & onLeft (left . QueryCmdUnsupportedNtcVersion)
 
@@ -768,12 +776,13 @@ runQueryProtocolStateCmd
     { Cmd.nodeSocketPath
     , Cmd.consensusModeParams
     , Cmd.networkId
+    , Cmd.target
     , Cmd.mOutFile
      } = do
   let localNodeConnInfo = LocalNodeConnectInfo consensusModeParams networkId nodeSocketPath
 
   join $ lift
-    ( executeLocalStateQueryExpr localNodeConnInfo Consensus.VolatileTip $ runExceptT $ do
+    ( executeLocalStateQueryExpr localNodeConnInfo target $ runExceptT $ do
         AnyCardanoEra era <- lift queryCurrentEra
           & onLeft (left . QueryCmdUnsupportedNtcVersion)
 
@@ -801,12 +810,13 @@ runQueryStakeAddressInfoCmd
     , Cmd.consensusModeParams
     , Cmd.addr = StakeAddress _ addr
     , Cmd.networkId
+    , Cmd.target
     , Cmd.mOutFile
     } = do
   let localNodeConnInfo = LocalNodeConnectInfo consensusModeParams networkId nodeSocketPath
 
   join $ lift
-    ( executeLocalStateQueryExpr localNodeConnInfo Consensus.VolatileTip $ runExceptT $ do
+    ( executeLocalStateQueryExpr localNodeConnInfo target $ runExceptT $ do
         AnyCardanoEra era <- lift queryCurrentEra
           & onLeft (left . QueryCmdUnsupportedNtcVersion)
 
@@ -1123,12 +1133,13 @@ runQueryStakePoolsCmd
     { Cmd.nodeSocketPath
     , Cmd.consensusModeParams
     , Cmd.networkId
+    , Cmd.target
     , Cmd.mOutFile
     } = do
   let localNodeConnInfo = LocalNodeConnectInfo consensusModeParams networkId nodeSocketPath
 
   join $ lift
-    ( executeLocalStateQueryExpr localNodeConnInfo Consensus.VolatileTip $ runExceptT @QueryCmdError $ do
+    ( executeLocalStateQueryExpr localNodeConnInfo target $ runExceptT @QueryCmdError $ do
         AnyCardanoEra era <- lift queryCurrentEra & onLeft (left . QueryCmdUnsupportedNtcVersion)
 
         sbe <- requireShelleyBasedEra era
@@ -1163,12 +1174,13 @@ runQueryStakeDistributionCmd
     { Cmd.nodeSocketPath
     , Cmd.consensusModeParams
     , Cmd.networkId
+    , Cmd.target
     , Cmd.mOutFile
     } = do
   let localNodeConnInfo = LocalNodeConnectInfo consensusModeParams networkId nodeSocketPath
 
   join $ lift
-    ( executeLocalStateQueryExpr localNodeConnInfo Consensus.VolatileTip $ runExceptT $ do
+    ( executeLocalStateQueryExpr localNodeConnInfo target $ runExceptT $ do
         AnyCardanoEra era <- lift queryCurrentEra
           & onLeft (left . QueryCmdUnsupportedNtcVersion)
 
@@ -1232,6 +1244,7 @@ runQueryLeadershipScheduleCmd
     , Cmd.poolColdVerKeyFile
     , Cmd.vrkSkeyFp
     , Cmd.whichSchedule
+    , Cmd.target
     , Cmd.mOutFile
     } = do
   let localNodeConnInfo = LocalNodeConnectInfo consensusModeParams networkId nodeSocketPath
@@ -1246,7 +1259,7 @@ runQueryLeadershipScheduleCmd
     & onLeft (left . QueryCmdGenesisReadError)
 
   join $ lift
-    ( executeLocalStateQueryExpr localNodeConnInfo Consensus.VolatileTip $ runExceptT $ do
+    ( executeLocalStateQueryExpr localNodeConnInfo target $ runExceptT $ do
         AnyCardanoEra era <- lift queryCurrentEra
           & onLeft (left . QueryCmdUnsupportedNtcVersion)
 
@@ -1388,10 +1401,11 @@ runQueryConstitution
       , Cmd.nodeSocketPath
       , Cmd.consensusModeParams
       , Cmd.networkId
+      , Cmd.target
       , Cmd.mOutFile
       } = conwayEraOnwardsConstraints eon $ do
   let localNodeConnInfo = LocalNodeConnectInfo consensusModeParams networkId nodeSocketPath
-  constitution <- runQuery localNodeConnInfo $ queryConstitution eon
+  constitution <- runQuery localNodeConnInfo target $ queryConstitution eon
   writeOutput mOutFile constitution
 
 runQueryGovState
@@ -1403,10 +1417,11 @@ runQueryGovState
       , Cmd.nodeSocketPath
       , Cmd.consensusModeParams
       , Cmd.networkId
+      , Cmd.target
       , Cmd.mOutFile
       } = conwayEraOnwardsConstraints eon $ do
   let localNodeConnInfo = LocalNodeConnectInfo consensusModeParams networkId nodeSocketPath
-  govState <- runQuery localNodeConnInfo $ queryGovState eon
+  govState <- runQuery localNodeConnInfo target $ queryGovState eon
   writeOutput mOutFile govState
 
 runQueryDRepState
@@ -1419,6 +1434,7 @@ runQueryDRepState
       , Cmd.consensusModeParams
       , Cmd.networkId
       , Cmd.drepKeys = drepKeys'
+      , Cmd.target
       , Cmd.mOutFile
       } = conwayEraOnwardsConstraints eon $ do
   let localNodeConnInfo = LocalNodeConnectInfo consensusModeParams networkId nodeSocketPath
@@ -1428,7 +1444,7 @@ runQueryDRepState
                    Only l -> l
   drepCreds <- Set.fromList <$> mapM (firstExceptT QueryCmdDRepKeyError . getDRepCredentialFromVerKeyHashOrFile) drepKeys
 
-  drepState <- runQuery localNodeConnInfo $ queryDRepState eon drepCreds
+  drepState <- runQuery localNodeConnInfo target $ queryDRepState eon drepCreds
   writeOutput mOutFile $
     second drepStateToJson <$> Map.assocs drepState
   where
@@ -1448,6 +1464,7 @@ runQueryDRepStakeDistribution
       , Cmd.consensusModeParams
       , Cmd.networkId
       , Cmd.drepKeys = drepKeys'
+      , Cmd.target
       , Cmd.mOutFile
       } = conwayEraOnwardsConstraints eon $ do
   let localNodeConnInfo = LocalNodeConnectInfo consensusModeParams networkId nodeSocketPath
@@ -1460,7 +1477,7 @@ runQueryDRepStakeDistribution
                    Only l -> l
   dreps <- Set.fromList <$> mapM drepFromVrfKey drepKeys
 
-  drepStakeDistribution <- runQuery localNodeConnInfo $ queryDRepStakeDistribution eon dreps
+  drepStakeDistribution <- runQuery localNodeConnInfo target $ queryDRepStakeDistribution eon dreps
   writeOutput mOutFile $
     Map.assocs drepStakeDistribution
 
@@ -1473,6 +1490,7 @@ runQueryCommitteeMembersState
       , Cmd.nodeSocketPath
       , Cmd.consensusModeParams
       , Cmd.networkId
+      , Cmd.target
       , Cmd.mOutFile
       , Cmd.committeeColdKeys  = coldCredKeys
       , Cmd.committeeHotKeys = hotCredKeys
@@ -1488,11 +1506,12 @@ runQueryCommitteeMembersState
         firstExceptT QueryCmdCommitteeHotKeyError . getCommitteeHotCredentialFromVerKeyHashOrFile
   hotKeys <- Set.fromList <$> mapM hotKeysFromVerKeyHashOrFile hotCredKeys
 
-  committeeState <- runQuery localNodeConnInfo $
+  committeeState <- runQuery localNodeConnInfo target $
     queryCommitteeMembersState eon coldKeys hotKeys (Set.fromList memberStatuses)
   writeOutput mOutFile $ A.toJSON committeeState
 
 runQuery :: LocalNodeConnectInfo
+         -> Consensus.Target ChainPoint
          -> LocalStateQueryExpr
              BlockInMode
              ChainPoint
@@ -1503,9 +1522,9 @@ runQuery :: LocalNodeConnectInfo
                 UnsupportedNtcVersionError
                 (Either Consensus.EraMismatch a))
          -> ExceptT QueryCmdError IO a
-runQuery localNodeConnInfo query =
+runQuery localNodeConnInfo target query =
   firstExceptT QueryCmdAcquireFailure
-    ( newExceptT $ executeLocalStateQueryExpr localNodeConnInfo Consensus.VolatileTip query)
+    ( newExceptT $ executeLocalStateQueryExpr localNodeConnInfo target query)
       & onLeft (left . QueryCmdUnsupportedNtcVersion)
       & onLeft (left . QueryCmdEraMismatch)
 
@@ -1549,13 +1568,14 @@ utcTimeToSlotNo
   :: SocketPath
   -> ConsensusModeParams
   -> NetworkId
+  -> Consensus.Target ChainPoint
   -> UTCTime
   -> ExceptT QueryCmdError IO SlotNo
-utcTimeToSlotNo nodeSocketPath consensusModeParams networkId utcTime = do
+utcTimeToSlotNo nodeSocketPath consensusModeParams networkId target utcTime = do
   let localNodeConnInfo = LocalNodeConnectInfo consensusModeParams networkId nodeSocketPath
 
   lift
-    ( executeLocalStateQueryExpr localNodeConnInfo Consensus.VolatileTip $ runExceptT $ do
+    ( executeLocalStateQueryExpr localNodeConnInfo target $ runExceptT $ do
         systemStart <- lift querySystemStart
           & onLeft (left . QueryCmdUnsupportedNtcVersion)
 

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Query.hs
@@ -13,6 +13,7 @@ import qualified Cardano.CLI.EraBased.Commands.Query as EraBased
 import qualified Cardano.CLI.EraBased.Run.Query as EraBased
 import qualified Cardano.CLI.Legacy.Commands.Query as Cmd
 import           Cardano.CLI.Types.Errors.QueryCmdError
+import qualified Ouroboros.Network.Protocol.LocalStateQuery.Type as Consensus
 
 import           Control.Monad.Trans.Except
 
@@ -43,7 +44,7 @@ runLegacyQueryTipCmd :: ()
   => Cmd.LegacyQueryTipCmdArgs
   -> ExceptT QueryCmdError IO ()
 runLegacyQueryTipCmd Cmd.LegacyQueryTipCmdArgs {..} =
-  EraBased.runQueryTipCmd EraBased.QueryTipCmdArgs {..}
+  EraBased.runQueryTipCmd EraBased.QueryTipCmdArgs {target = Consensus.VolatileTip, ..}
 
 -- | Query the UTxO, filtered by a given set of addresses, from a Shelley node
 -- via the local state query protocol.
@@ -51,13 +52,13 @@ runLegacyQueryUTxOCmd :: ()
   => Cmd.LegacyQueryUTxOCmdArgs
   -> ExceptT QueryCmdError IO ()
 runLegacyQueryUTxOCmd Cmd.LegacyQueryUTxOCmdArgs {..} =
-  EraBased.runQueryUTxOCmd EraBased.QueryUTxOCmdArgs {..}
+  EraBased.runQueryUTxOCmd EraBased.QueryUTxOCmdArgs {target = Consensus.VolatileTip, ..}
 
 runLegacyQueryKesPeriodInfoCmd :: ()
   => Cmd.LegacyQueryKesPeriodInfoCmdArgs
   -> ExceptT QueryCmdError IO ()
 runLegacyQueryKesPeriodInfoCmd Cmd.LegacyQueryKesPeriodInfoCmdArgs {..} =
-  EraBased.runQueryKesPeriodInfoCmd EraBased.QueryKesPeriodInfoCmdArgs {..}
+  EraBased.runQueryKesPeriodInfoCmd EraBased.QueryKesPeriodInfoCmdArgs {target = Consensus.VolatileTip, ..}
 
 -- | Query the current and future parameters for a stake pool, including the retirement date.
 -- Any of these may be empty (in which case a null will be displayed).
@@ -66,7 +67,7 @@ runLegacyQueryPoolStateCmd :: ()
   => Cmd.LegacyQueryPoolStateCmdArgs
   -> ExceptT QueryCmdError IO ()
 runLegacyQueryPoolStateCmd Cmd.LegacyQueryPoolStateCmdArgs {..} =
-  EraBased.runQueryPoolStateCmd EraBased.QueryPoolStateCmdArgs {..}
+  EraBased.runQueryPoolStateCmd EraBased.QueryPoolStateCmdArgs {target = Consensus.VolatileTip, ..}
 
 -- | Query the local mempool state
 runLegacyQueryTxMempoolCmd :: ()
@@ -79,7 +80,7 @@ runLegacyQuerySlotNumberCmd :: ()
   => Cmd.LegacyQuerySlotNumberCmdArgs
   -> ExceptT QueryCmdError IO ()
 runLegacyQuerySlotNumberCmd Cmd.LegacyQuerySlotNumberCmdArgs {..} =
-  EraBased.runQuerySlotNumberCmd EraBased.QuerySlotNumberCmdArgs {..}
+  EraBased.runQuerySlotNumberCmd EraBased.QuerySlotNumberCmdArgs {target = Consensus.VolatileTip, ..}
 
 -- | Obtain stake snapshot information for a pool, plus information about the total active stake.
 -- This information can be used for leader slot calculation, for example, and has been requested by SPOs.
@@ -88,19 +89,19 @@ runLegacyQueryStakeSnapshotCmd :: ()
   => Cmd.LegacyQueryStakeSnapshotCmdArgs
   -> ExceptT QueryCmdError IO ()
 runLegacyQueryStakeSnapshotCmd Cmd.LegacyQueryStakeSnapshotCmdArgs {..} =
-  EraBased.runQueryStakeSnapshotCmd EraBased.QueryStakeSnapshotCmdArgs {..}
+  EraBased.runQueryStakeSnapshotCmd EraBased.QueryStakeSnapshotCmdArgs {target = Consensus.VolatileTip, ..}
 
 runLegacyQueryLedgerStateCmd :: ()
   => Cmd.LegacyQueryLedgerStateCmdArgs
   -> ExceptT QueryCmdError IO ()
 runLegacyQueryLedgerStateCmd Cmd.LegacyQueryLedgerStateCmdArgs {..} =
-  EraBased.runQueryLedgerStateCmd EraBased.QueryLedgerStateCmdArgs {..}
+  EraBased.runQueryLedgerStateCmd EraBased.QueryLedgerStateCmdArgs {target = Consensus.VolatileTip, ..}
 
 runLegacyQueryProtocolStateCmd :: ()
   => Cmd.LegacyQueryProtocolStateCmdArgs
   -> ExceptT QueryCmdError IO ()
 runLegacyQueryProtocolStateCmd Cmd.LegacyQueryProtocolStateCmdArgs {..} =
-  EraBased.runQueryProtocolStateCmd EraBased.QueryProtocolStateCmdArgs {..}
+  EraBased.runQueryProtocolStateCmd EraBased.QueryProtocolStateCmdArgs {target = Consensus.VolatileTip, ..}
 
 -- | Query the current delegations and reward accounts, filtered by a given
 -- set of addresses, from a Shelley node via the local state query protocol.
@@ -109,22 +110,22 @@ runLegacyQueryStakeAddressInfoCmd :: ()
   => Cmd.LegacyQueryStakeAddressInfoCmdArgs
   -> ExceptT QueryCmdError IO ()
 runLegacyQueryStakeAddressInfoCmd Cmd.LegacyQueryStakeAddressInfoCmdArgs {..} =
-  EraBased.runQueryStakeAddressInfoCmd EraBased.QueryStakeAddressInfoCmdArgs {..}
+  EraBased.runQueryStakeAddressInfoCmd EraBased.QueryStakeAddressInfoCmdArgs {target = Consensus.VolatileTip, ..}
 
 runLegacyQueryStakePoolsCmd :: ()
   => Cmd.LegacyQueryStakePoolsCmdArgs
   -> ExceptT QueryCmdError IO ()
 runLegacyQueryStakePoolsCmd Cmd.LegacyQueryStakePoolsCmdArgs {..} =
-  EraBased.runQueryStakePoolsCmd EraBased.QueryStakePoolsCmdArgs {..}
+  EraBased.runQueryStakePoolsCmd EraBased.QueryStakePoolsCmdArgs {target = Consensus.VolatileTip, ..}
 
 runLegacyQueryStakeDistributionCmd :: ()
   => Cmd.LegacyQueryStakeDistributionCmdArgs
   -> ExceptT QueryCmdError IO ()
 runLegacyQueryStakeDistributionCmd Cmd.LegacyQueryStakeDistributionCmdArgs {..} =
-  EraBased.runQueryStakeDistributionCmd EraBased.QueryStakeDistributionCmdArgs {..}
+  EraBased.runQueryStakeDistributionCmd EraBased.QueryStakeDistributionCmdArgs {target = Consensus.VolatileTip, ..}
 
 runLegacyQueryLeadershipScheduleCmd :: ()
   => Cmd.LegacyQueryLeadershipScheduleCmdArgs
   -> ExceptT QueryCmdError IO ()
 runLegacyQueryLeadershipScheduleCmd Cmd.LegacyQueryLeadershipScheduleCmdArgs {..} =
-  EraBased.runQueryLeadershipScheduleCmd EraBased.QueryLeadershipScheduleCmdArgs {..}
+  EraBased.runQueryLeadershipScheduleCmd EraBased.QueryLeadershipScheduleCmdArgs {target = Consensus.VolatileTip, ..}

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -6509,6 +6509,7 @@ Usage: cardano-cli conway query protocol-parameters --socket-path SOCKET_PATH
 Usage: cardano-cli conway query tip --socket-path SOCKET_PATH
                                       [--cardano-mode [--epoch-slots SLOTS]]
                                       (--mainnet | --testnet-magic NATURAL)
+                                      [--volatile-tip | --immutable-tip]
                                       [--out-file FILE]
 
   Get the node's current tip (slot no, hash, block no)
@@ -6519,6 +6520,7 @@ Usage: cardano-cli conway query stake-pools --socket-path SOCKET_PATH
                                               ( --mainnet
                                               | --testnet-magic NATURAL
                                               )
+                                              [--volatile-tip | --immutable-tip]
                                               [--out-file FILE]
 
   Get the node's current set of stake pool ids
@@ -6529,6 +6531,9 @@ Usage: cardano-cli conway query stake-distribution --socket-path SOCKET_PATH
                                                      ( --mainnet
                                                      | --testnet-magic NATURAL
                                                      )
+                                                     [ --volatile-tip
+                                                     | --immutable-tip
+                                                     ]
                                                      [--out-file FILE]
 
   Get the node's current aggregated stake distribution
@@ -6540,6 +6545,9 @@ Usage: cardano-cli conway query stake-address-info --socket-path SOCKET_PATH
                                                      ( --mainnet
                                                      | --testnet-magic NATURAL
                                                      )
+                                                     [ --volatile-tip
+                                                     | --immutable-tip
+                                                     ]
                                                      [--out-file FILE]
 
   Get the current delegations and reward accounts filtered by stake address.
@@ -6551,6 +6559,7 @@ Usage: cardano-cli conway query utxo --socket-path SOCKET_PATH
                                        | (--tx-in TX-IN)
                                        )
                                        (--mainnet | --testnet-magic NATURAL)
+                                       [--volatile-tip | --immutable-tip]
                                        [--out-file FILE]
 
   Get a portion of the current UTxO: by tx in, by address or the whole.
@@ -6561,6 +6570,9 @@ Usage: cardano-cli conway query ledger-state --socket-path SOCKET_PATH
                                                ( --mainnet
                                                | --testnet-magic NATURAL
                                                )
+                                               [ --volatile-tip
+                                               | --immutable-tip
+                                               ]
                                                [--out-file FILE]
 
   Dump the current ledger state of the node (Ledger.NewEpochState -- advanced
@@ -6572,6 +6584,9 @@ Usage: cardano-cli conway query protocol-state --socket-path SOCKET_PATH
                                                  ( --mainnet
                                                  | --testnet-magic NATURAL
                                                  )
+                                                 [ --volatile-tip
+                                                 | --immutable-tip
+                                                 ]
                                                  [--out-file FILE]
 
   Dump the current protocol state of the node (Ledger.ChainDepState -- advanced
@@ -6586,6 +6601,9 @@ Usage: cardano-cli conway query stake-snapshot --socket-path SOCKET_PATH
                                                  ( --all-stake-pools
                                                  | (--stake-pool-id STAKE_POOL_ID)
                                                  )
+                                                 [ --volatile-tip
+                                                 | --immutable-tip
+                                                 ]
                                                  [--out-file FILE]
 
   Obtain the three stake snapshots for a pool, plus the total active stake
@@ -6600,6 +6618,7 @@ Usage: cardano-cli conway query pool-params --socket-path SOCKET_PATH
                                               ( --all-stake-pools
                                               | (--stake-pool-id STAKE_POOL_ID)
                                               )
+                                              [--volatile-tip | --immutable-tip]
 
   DEPRECATED. Use query pool-state instead. Dump the pool parameters
   (Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced
@@ -6618,6 +6637,9 @@ Usage: cardano-cli conway query leadership-schedule --socket-path SOCKET_PATH
                                                       )
                                                       --vrf-signing-key-file FILE
                                                       (--current | --next)
+                                                      [ --volatile-tip
+                                                      | --immutable-tip
+                                                      ]
                                                       [--out-file FILE]
 
   Get the slots the node is expected to mint a block in (advanced command)
@@ -6629,6 +6651,9 @@ Usage: cardano-cli conway query kes-period-info --socket-path SOCKET_PATH
                                                   | --testnet-magic NATURAL
                                                   )
                                                   --op-cert-file FILE
+                                                  [ --volatile-tip
+                                                  | --immutable-tip
+                                                  ]
                                                   [--out-file FILE]
 
   Get information about the current KES period and your node's operational
@@ -6643,6 +6668,7 @@ Usage: cardano-cli conway query pool-state --socket-path SOCKET_PATH
                                              ( --all-stake-pools
                                              | (--stake-pool-id STAKE_POOL_ID)
                                              )
+                                             [--volatile-tip | --immutable-tip]
 
   Dump the pool state
 
@@ -6675,6 +6701,7 @@ Usage: cardano-cli conway query slot-number --socket-path SOCKET_PATH
                                               ( --mainnet
                                               | --testnet-magic NATURAL
                                               )
+                                              [--volatile-tip | --immutable-tip]
                                               TIMESTAMP
 
   Query slot number for UTC timestamp
@@ -6685,6 +6712,9 @@ Usage: cardano-cli conway query constitution --socket-path SOCKET_PATH
                                                ( --mainnet
                                                | --testnet-magic NATURAL
                                                )
+                                               [ --volatile-tip
+                                               | --immutable-tip
+                                               ]
                                                [--out-file FILE]
 
   Get the constitution
@@ -6695,6 +6725,7 @@ Usage: cardano-cli conway query gov-state --socket-path SOCKET_PATH
                                             ( --mainnet
                                             | --testnet-magic NATURAL
                                             )
+                                            [--volatile-tip | --immutable-tip]
                                             [--out-file FILE]
 
   Get the governance state
@@ -6712,6 +6743,7 @@ Usage: cardano-cli conway query drep-state --socket-path SOCKET_PATH
                                              | --drep-key-hash HASH
                                              )
                                              )
+                                             [--volatile-tip | --immutable-tip]
                                              [--out-file FILE]
 
   Get the DRep state.
@@ -6730,6 +6762,9 @@ Usage: cardano-cli conway query drep-stake-distribution
                                                           | --drep-key-hash HASH
                                                           )
                                                           )
+                                                          [ --volatile-tip
+                                                          | --immutable-tip
+                                                          ]
                                                           [--out-file FILE]
 
   Get the DRep stake distribution.
@@ -6751,6 +6786,9 @@ Usage: cardano-cli conway query committee-state --socket-path SOCKET_PATH
                                                   [ --active
                                                   | --expired
                                                   | --unrecognized
+                                                  ]
+                                                  [ --volatile-tip
+                                                  | --immutable-tip
                                                   ]
                                                   [--out-file FILE]
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_committee-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_committee-state.cli
@@ -16,6 +16,9 @@ Usage: cardano-cli conway query committee-state --socket-path SOCKET_PATH
                                                   | --expired
                                                   | --unrecognized
                                                   ]
+                                                  [ --volatile-tip
+                                                  | --immutable-tip
+                                                  ]
                                                   [--out-file FILE]
 
   Get the committee state
@@ -48,5 +51,8 @@ Available options:
   --expired                Expired committee members
   --unrecognized           Unrecognized committe members: a hot credential for
                            an unknown cold credential
+  --volatile-tip           Use the volatile tip as a target. (This is the
+                           default)
+  --immutable-tip          Use the immutable tip as a target.
   --out-file FILE          The output file.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_constitution.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_constitution.cli
@@ -4,6 +4,9 @@ Usage: cardano-cli conway query constitution --socket-path SOCKET_PATH
                                                ( --mainnet
                                                | --testnet-magic NATURAL
                                                )
+                                               [ --volatile-tip
+                                               | --immutable-tip
+                                               ]
                                                [--out-file FILE]
 
   Get the constitution
@@ -22,5 +25,8 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --volatile-tip           Use the volatile tip as a target. (This is the
+                           default)
+  --immutable-tip          Use the immutable tip as a target.
   --out-file FILE          The output file.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_drep-stake-distribution.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_drep-stake-distribution.cli
@@ -12,6 +12,9 @@ Usage: cardano-cli conway query drep-stake-distribution
                                                           | --drep-key-hash HASH
                                                           )
                                                           )
+                                                          [ --volatile-tip
+                                                          | --immutable-tip
+                                                          ]
                                                           [--out-file FILE]
 
   Get the DRep stake distribution.
@@ -37,5 +40,8 @@ Available options:
                            Filepath of the DRep verification key.
   --drep-key-hash HASH     DRep verification key hash (either Bech32-encoded or
                            hex-encoded).
+  --volatile-tip           Use the volatile tip as a target. (This is the
+                           default)
+  --immutable-tip          Use the immutable tip as a target.
   --out-file FILE          The output file.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_drep-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_drep-state.cli
@@ -11,6 +11,7 @@ Usage: cardano-cli conway query drep-state --socket-path SOCKET_PATH
                                              | --drep-key-hash HASH
                                              )
                                              )
+                                             [--volatile-tip | --immutable-tip]
                                              [--out-file FILE]
 
   Get the DRep state.
@@ -36,5 +37,8 @@ Available options:
                            Filepath of the DRep verification key.
   --drep-key-hash HASH     DRep verification key hash (either Bech32-encoded or
                            hex-encoded).
+  --volatile-tip           Use the volatile tip as a target. (This is the
+                           default)
+  --immutable-tip          Use the immutable tip as a target.
   --out-file FILE          The output file.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_gov-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_gov-state.cli
@@ -4,6 +4,7 @@ Usage: cardano-cli conway query gov-state --socket-path SOCKET_PATH
                                             ( --mainnet
                                             | --testnet-magic NATURAL
                                             )
+                                            [--volatile-tip | --immutable-tip]
                                             [--out-file FILE]
 
   Get the governance state
@@ -22,5 +23,8 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --volatile-tip           Use the volatile tip as a target. (This is the
+                           default)
+  --immutable-tip          Use the immutable tip as a target.
   --out-file FILE          The output file.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_kes-period-info.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_kes-period-info.cli
@@ -5,6 +5,9 @@ Usage: cardano-cli conway query kes-period-info --socket-path SOCKET_PATH
                                                   | --testnet-magic NATURAL
                                                   )
                                                   --op-cert-file FILE
+                                                  [ --volatile-tip
+                                                  | --immutable-tip
+                                                  ]
                                                   [--out-file FILE]
 
   Get information about the current KES period and your node's operational
@@ -25,5 +28,8 @@ Available options:
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
   --op-cert-file FILE      Filepath of the node's operational certificate.
+  --volatile-tip           Use the volatile tip as a target. (This is the
+                           default)
+  --immutable-tip          Use the immutable tip as a target.
   --out-file FILE          Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_leadership-schedule.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_leadership-schedule.cli
@@ -11,6 +11,9 @@ Usage: cardano-cli conway query leadership-schedule --socket-path SOCKET_PATH
                                                       )
                                                       --vrf-signing-key-file FILE
                                                       (--current | --next)
+                                                      [ --volatile-tip
+                                                      | --immutable-tip
+                                                      ]
                                                       [--out-file FILE]
 
   Get the slots the node is expected to mint a block in (advanced command)
@@ -41,5 +44,8 @@ Available options:
                            Input filepath of the VRF signing key.
   --current                Get the leadership schedule for the current epoch.
   --next                   Get the leadership schedule for the following epoch.
+  --volatile-tip           Use the volatile tip as a target. (This is the
+                           default)
+  --immutable-tip          Use the immutable tip as a target.
   --out-file FILE          Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_ledger-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_ledger-state.cli
@@ -4,6 +4,9 @@ Usage: cardano-cli conway query ledger-state --socket-path SOCKET_PATH
                                                ( --mainnet
                                                | --testnet-magic NATURAL
                                                )
+                                               [ --volatile-tip
+                                               | --immutable-tip
+                                               ]
                                                [--out-file FILE]
 
   Dump the current ledger state of the node (Ledger.NewEpochState -- advanced
@@ -23,5 +26,8 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --volatile-tip           Use the volatile tip as a target. (This is the
+                           default)
+  --immutable-tip          Use the immutable tip as a target.
   --out-file FILE          Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_pool-params.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_pool-params.cli
@@ -7,6 +7,7 @@ Usage: cardano-cli conway query pool-params --socket-path SOCKET_PATH
                                               ( --all-stake-pools
                                               | (--stake-pool-id STAKE_POOL_ID)
                                               )
+                                              [--volatile-tip | --immutable-tip]
 
   DEPRECATED. Use query pool-state instead. Dump the pool parameters
   (Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced
@@ -30,4 +31,7 @@ Available options:
   --stake-pool-id STAKE_POOL_ID
                            Stake pool ID/verification key hash (either
                            Bech32-encoded or hex-encoded).
+  --volatile-tip           Use the volatile tip as a target. (This is the
+                           default)
+  --immutable-tip          Use the immutable tip as a target.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_pool-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_pool-state.cli
@@ -7,6 +7,7 @@ Usage: cardano-cli conway query pool-state --socket-path SOCKET_PATH
                                              ( --all-stake-pools
                                              | (--stake-pool-id STAKE_POOL_ID)
                                              )
+                                             [--volatile-tip | --immutable-tip]
 
   Dump the pool state
 
@@ -28,4 +29,7 @@ Available options:
   --stake-pool-id STAKE_POOL_ID
                            Stake pool ID/verification key hash (either
                            Bech32-encoded or hex-encoded).
+  --volatile-tip           Use the volatile tip as a target. (This is the
+                           default)
+  --immutable-tip          Use the immutable tip as a target.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_protocol-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_protocol-state.cli
@@ -4,6 +4,9 @@ Usage: cardano-cli conway query protocol-state --socket-path SOCKET_PATH
                                                  ( --mainnet
                                                  | --testnet-magic NATURAL
                                                  )
+                                                 [ --volatile-tip
+                                                 | --immutable-tip
+                                                 ]
                                                  [--out-file FILE]
 
   Dump the current protocol state of the node (Ledger.ChainDepState -- advanced
@@ -23,5 +26,8 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --volatile-tip           Use the volatile tip as a target. (This is the
+                           default)
+  --immutable-tip          Use the immutable tip as a target.
   --out-file FILE          Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_slot-number.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_slot-number.cli
@@ -4,6 +4,7 @@ Usage: cardano-cli conway query slot-number --socket-path SOCKET_PATH
                                               ( --mainnet
                                               | --testnet-magic NATURAL
                                               )
+                                              [--volatile-tip | --immutable-tip]
                                               TIMESTAMP
 
   Query slot number for UTC timestamp
@@ -22,5 +23,8 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --volatile-tip           Use the volatile tip as a target. (This is the
+                           default)
+  --immutable-tip          Use the immutable tip as a target.
   TIMESTAMP                UTC timestamp in YYYY-MM-DDThh:mm:ssZ format
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_stake-address-info.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_stake-address-info.cli
@@ -5,6 +5,9 @@ Usage: cardano-cli conway query stake-address-info --socket-path SOCKET_PATH
                                                      ( --mainnet
                                                      | --testnet-magic NATURAL
                                                      )
+                                                     [ --volatile-tip
+                                                     | --immutable-tip
+                                                     ]
                                                      [--out-file FILE]
 
   Get the current delegations and reward accounts filtered by stake address.
@@ -24,5 +27,8 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --volatile-tip           Use the volatile tip as a target. (This is the
+                           default)
+  --immutable-tip          Use the immutable tip as a target.
   --out-file FILE          Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_stake-distribution.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_stake-distribution.cli
@@ -4,6 +4,9 @@ Usage: cardano-cli conway query stake-distribution --socket-path SOCKET_PATH
                                                      ( --mainnet
                                                      | --testnet-magic NATURAL
                                                      )
+                                                     [ --volatile-tip
+                                                     | --immutable-tip
+                                                     ]
                                                      [--out-file FILE]
 
   Get the node's current aggregated stake distribution
@@ -22,5 +25,8 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --volatile-tip           Use the volatile tip as a target. (This is the
+                           default)
+  --immutable-tip          Use the immutable tip as a target.
   --out-file FILE          Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_stake-pools.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_stake-pools.cli
@@ -4,6 +4,7 @@ Usage: cardano-cli conway query stake-pools --socket-path SOCKET_PATH
                                               ( --mainnet
                                               | --testnet-magic NATURAL
                                               )
+                                              [--volatile-tip | --immutable-tip]
                                               [--out-file FILE]
 
   Get the node's current set of stake pool ids
@@ -22,5 +23,8 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --volatile-tip           Use the volatile tip as a target. (This is the
+                           default)
+  --immutable-tip          Use the immutable tip as a target.
   --out-file FILE          Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_stake-snapshot.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_stake-snapshot.cli
@@ -7,6 +7,9 @@ Usage: cardano-cli conway query stake-snapshot --socket-path SOCKET_PATH
                                                  ( --all-stake-pools
                                                  | (--stake-pool-id STAKE_POOL_ID)
                                                  )
+                                                 [ --volatile-tip
+                                                 | --immutable-tip
+                                                 ]
                                                  [--out-file FILE]
 
   Obtain the three stake snapshots for a pool, plus the total active stake
@@ -30,5 +33,8 @@ Available options:
   --stake-pool-id STAKE_POOL_ID
                            Stake pool ID/verification key hash (either
                            Bech32-encoded or hex-encoded).
+  --volatile-tip           Use the volatile tip as a target. (This is the
+                           default)
+  --immutable-tip          Use the immutable tip as a target.
   --out-file FILE          Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_tip.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_tip.cli
@@ -1,6 +1,7 @@
 Usage: cardano-cli conway query tip --socket-path SOCKET_PATH
                                       [--cardano-mode [--epoch-slots SLOTS]]
                                       (--mainnet | --testnet-magic NATURAL)
+                                      [--volatile-tip | --immutable-tip]
                                       [--out-file FILE]
 
   Get the node's current tip (slot no, hash, block no)
@@ -19,5 +20,8 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --volatile-tip           Use the volatile tip as a target. (This is the
+                           default)
+  --immutable-tip          Use the immutable tip as a target.
   --out-file FILE          Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_utxo.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_utxo.cli
@@ -5,6 +5,7 @@ Usage: cardano-cli conway query utxo --socket-path SOCKET_PATH
                                        | (--tx-in TX-IN)
                                        )
                                        (--mainnet | --testnet-magic NATURAL)
+                                       [--volatile-tip | --immutable-tip]
                                        [--out-file FILE]
 
   Get a portion of the current UTxO: by tx in, by address or the whole.
@@ -27,5 +28,8 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --volatile-tip           Use the volatile tip as a target. (This is the
+                           default)
+  --immutable-tip          Use the immutable tip as a target.
   --out-file FILE          Optional output file. Default is to write to stdout.
   -h,--help                Show this help text


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Allow users to specify the target in conway queries (either immutable tip or volatile tip)
  type:
    - feature        # introduces a new feature
```

# How to trust this PR

Don't trust it, look at it with a magnifying glass.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff

