### PR TITLE
Fix error messages as CLI format is no longer supported

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -24,7 +24,7 @@ jobs:
 
     env:
       # Modify this value to "invalidate" the cabal cache.
-      CABAL_CACHE_VERSION: "2024-02-06-1"
+      CABAL_CACHE_VERSION: "2024-02-12-1"
 
     concurrency:
       group: >

--- a/cardano-cli/src/Cardano/CLI/Read.hs
+++ b/cardano-cli/src/Cardano/CLI/Read.hs
@@ -521,8 +521,8 @@ data CddlError = CddlErrorTextEnv
 instance Error CddlError where
   prettyError = \case
     CddlErrorTextEnv textEnvErr cddlErr ->
-      "Failed to decode neither the cli's serialisation format nor the ledger's " <>
-      "CDDL serialisation format. TextEnvelope error: " <> prettyError textEnvErr <> "\n" <>
+      "Failed to decode the ledger's CDDL serialisation format. " <>
+      "TextEnvelope error: " <> prettyError textEnvErr <> "\n" <>
       "TextEnvelopeCddl error: " <> prettyError cddlErr
     CddlIOError e ->
       prettyError e
@@ -584,9 +584,8 @@ data CddlWitnessError
 instance Error CddlWitnessError where
   prettyError = \case
     CddlWitnessErrorTextEnv teErr cddlErr ->
-      "Failed to decode neither the cli's serialisation format nor the ledger's \
-      \CDDL serialisation format. TextEnvelope error: " <> prettyError teErr <> "\n" <>
-      "TextEnvelopeCddl error: " <> prettyError cddlErr
+      "Failed to decode the ledger's CDDL serialisation format. TextEnvelope error: " <>
+      prettyError teErr <> "\n" <> "TextEnvelopeCddl error: " <> prettyError cddlErr
     CddlWitnessIOError fileE ->
       prettyError fileE
 

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/TxCmdError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/TxCmdError.hs
@@ -168,8 +168,8 @@ renderTxCmdError = \case
     prettyError err'
   TxCmdTextEnvCddlError textEnvErr cddlErr ->
     mconcat
-    [ "Failed to decode neither the cli's serialisation format nor the ledger's "
-    , "CDDL serialisation format. TextEnvelope error: " <> prettyError textEnvErr <> "\n"
+    [ "Failed to decode the ledger's CDDL serialisation format. "
+    , "TextEnvelope error: " <> prettyError textEnvErr <> "\n"
     , "TextEnvelopeCddl error: " <> prettyError cddlErr
     ]
   TxCmdTxExecUnitsErr (AnyTxCmdTxExecUnitsErr err') ->

--- a/cardano-cli/test/cardano-cli-golden/files/golden/errors/Cardano.CLI.Types.Errors.GovernanceCmdError.GovernanceCmdError/GovernanceCmdCddlError.txt
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/errors/Cardano.CLI.Types.Errors.GovernanceCmdError.GovernanceCmdError/GovernanceCmdCddlError.txt
@@ -1,2 +1,2 @@
-Reading transaction CDDL file error: Failed to decode neither the cli's serialisation format nor the ledger's CDDL serialisation format. TextEnvelope error: path/file.txt: TextEnvelope decode error: DecoderErrorCustom "todecode" "decodeerr"
+Reading transaction CDDL file error: Failed to decode the ledger's CDDL serialisation format. TextEnvelope error: path/file.txt: TextEnvelope decode error: DecoderErrorCustom "todecode" "decodeerr"
 TextEnvelopeCddl error: path/file.txt: Unknown key witness specified


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Fix error messages as support for cardano-cli serialisation format was already removed.
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Additional context for the PR goes here. If the PR fixes a particular issue please provide a [link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=) to the issue.

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
