### PR TITLE
Fix git revision reported by --version on nix build

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -40,6 +40,10 @@
         };
         inherit (nixpkgs) lib;
 
+        gitRevFlag = if inputs.self ? rev
+                     then [ ("--ghc-option=-D__GIT_REV__=\\\"" + inputs.self.rev + "\\\"") ]
+                     else [];
+
         # see flake `variants` below for alternative compilers
         defaultCompiler = "ghc963";
         # We use cabalProject' to ensure we don't build the plan for
@@ -85,7 +89,7 @@
           # specific enough, or doesn't allow setting these.
           modules = [
             ({pkgs, ...}: {
-              packages.cardano-cli.configureFlags = ["--ghc-option=-Werror"];
+              packages.cardano-cli.configureFlags = [ "--ghc-option=-Werror" ] ++ gitRevFlag;
               packages.cardano-cli.components.tests.cardano-cli-test.build-tools =
                 with pkgs.buildPackages; [ jq coreutils shellcheck ];
               packages.cardano-cli.components.tests.cardano-cli-golden.build-tools =


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Fixed git revision showed by --version flag when built using nix
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Addresses this issue: https://github.com/IntersectMBO/cardano-cli/tree/bug-all-zeros-git-revision

# How to trust this PR

It can be tested with and without the `__GIT_REV__` compiler flag and see that it works either way.

The other thing to pay attention to, is that I have only modified the default logic (when both `gitRevEmbed` and `fromGit` are empty)

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
