### PR TITLE
Add missing changelog for PR #610

### DIFF
--- a/cardano-cli/CHANGELOG.md
+++ b/cardano-cli/CHANGELOG.md
@@ -30,6 +30,9 @@
   (feature, compatible)
   [PR 596](https://github.com/IntersectMBO/cardano-cli/pull/596)
 
+- Fixed git revision showed by --version flag when built using nix
+  (bugfix, compatible)
+  [PR 610](https://github.com/IntersectMBO/cardano-cli/pull/610)
 
 ## 8.20.0.0
 


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Add missing changelog for PR #610
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
   - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Seems that #610 got in between release PR and tagged merge commit from which we made a release.

![screenshot-20240220_151844](https://github.com/IntersectMBO/cardano-cli/assets/228866/57e6832e-25cb-4fc4-a1c4-ea85ef24c160)



# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
