### PR TITLE
query stake-pools: add --output-[json,text] flag to control format of the output

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Query.hs
@@ -101,6 +101,7 @@ data QueryStakePoolsCmdArgs = QueryStakePoolsCmdArgs
   , consensusModeParams :: !ConsensusModeParams
   , networkId           :: !NetworkId
   , target              :: !(Consensus.Target ChainPoint)
+  , format              :: Maybe QueryOutputFormat
   , mOutFile            :: !(Maybe (File () Out))
   } deriving (Generic, Show)
 

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Query.hs
@@ -154,6 +154,7 @@ pQueryStakePoolsCmd era envCli =
       <*> pConsensusModeParams
       <*> pNetworkId envCli
       <*> pTarget era
+      <*> (optional $ pQueryOutputFormat "stake-pools")
       <*> pMaybeOutputFile
 
 pQueryStakeDistributionCmd :: CardanoEra era -> EnvCli -> Parser (QueryCmds era)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Query.hs
@@ -1126,6 +1126,7 @@ runQueryStakePoolsCmd
     , Cmd.consensusModeParams
     , Cmd.networkId
     , Cmd.target
+    , Cmd.format
     , Cmd.mOutFile
     } = do
   let localNodeConnInfo = LocalNodeConnectInfo consensusModeParams networkId nodeSocketPath
@@ -1142,21 +1143,27 @@ runQueryStakePoolsCmd
           & onLeft (left . QueryCmdEraMismatch)
 
         pure $ do
-          writeStakePools mOutFile poolIds
+          writeStakePools (newOutputFormat format mOutFile) mOutFile poolIds
     ) & onLeft (left . QueryCmdAcquireFailure)
       & onLeft left
 
 writeStakePools
-  :: Maybe (File () Out)
+  :: QueryOutputFormat
+  -> Maybe (File () Out)
   -> Set PoolId
   -> ExceptT QueryCmdError IO ()
-writeStakePools (Just (File outFile)) stakePools =
-  handleIOExceptT (QueryCmdWriteFileError . FileIOError outFile) $
-    LBS.writeFile outFile (encodePretty stakePools)
-
-writeStakePools Nothing stakePools =
-  forM_ (Set.toList stakePools) $ \poolId ->
-    liftIO . putStrLn $ Text.unpack (serialiseToBech32 poolId)
+writeStakePools format mOutFile stakePools =
+  firstExceptT QueryCmdWriteFileError . newExceptT $
+      writeLazyByteStringOutput mOutFile toWrite
+  where
+    toWrite :: LBS.ByteString =
+      case format of
+        QueryOutputFormatText ->
+          LBS.unlines
+            $ map (strictTextToLazyBytestring . serialiseToBech32)
+            $ Set.toList stakePools
+        QueryOutputFormatJson ->
+          encodePretty stakePools
 
 runQueryStakeDistributionCmd :: ()
   => Cmd.QueryStakeDistributionCmdArgs

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Query.hs
@@ -1027,15 +1027,9 @@ writeFilteredUTxOs sbe format mOutFile utxo =
   shelleyBasedEraConstraints sbe $
     firstExceptT QueryCmdWriteFileError . newExceptT .
       writeLazyByteStringOutput mOutFile $
-        case format' of
+        case newOutputFormat format mOutFile of
           QueryOutputFormatJson -> encodePretty utxo
-          QueryOutputFormatText -> BS.fromChunks [Text.encodeUtf8 $ filteredUTxOsToText sbe utxo]
-  where
-    format' =
-      case (format, mOutFile) of
-        (Just f, _) -> f -- Take flag from CLI if specified
-        (Nothing, Nothing) -> QueryOutputFormatText -- No CLI flag, writing to stdout: write text
-        (Nothing, Just _) -> QueryOutputFormatJson -- No CLI flag, writing to a file: write JSON
+          QueryOutputFormatText -> strictTextToLazyBytestring $ filteredUTxOsToText sbe utxo
 
 filteredUTxOsToText :: Api.ShelleyBasedEra era -> UTxO era -> Text
 filteredUTxOsToText sbe (UTxO utxo) = do
@@ -1614,3 +1608,16 @@ requireEon minEra era =
   hoistMaybe
     (QueryCmdLocalStateQueryError $ mkEraMismatchError NodeEraMismatchError { nodeEra = era, era = minEra })
     (forEraMaybeEon era)
+
+-- | The output format to use, for commands with a recently introduced --output-[json,text] flag
+-- and that used to have the following default: --out-file implies JSON,
+-- output to stdout implied text.
+newOutputFormat :: Maybe QueryOutputFormat -> Maybe a -> QueryOutputFormat
+newOutputFormat format mOutFile =
+  case (format, mOutFile) of
+    (Just f, _) -> f -- Take flag from CLI if specified
+    (Nothing, Nothing) -> QueryOutputFormatText -- No CLI flag, writing to stdout: write text
+    (Nothing, Just _) -> QueryOutputFormatJson -- No CLI flag, writing to a file: write JSON
+
+strictTextToLazyBytestring :: Text -> LBS.ByteString
+strictTextToLazyBytestring t = BS.fromChunks [Text.encodeUtf8 t]

--- a/cardano-cli/src/Cardano/CLI/Legacy/Commands/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Commands/Query.hs
@@ -85,6 +85,7 @@ data LegacyQueryStakePoolsCmdArgs = LegacyQueryStakePoolsCmdArgs
   { nodeSocketPath      :: !SocketPath
   , consensusModeParams :: !ConsensusModeParams
   , networkId           :: !NetworkId
+  , format              :: Maybe QueryOutputFormat
   , mOutFile            :: !(Maybe (File () Out))
   } deriving (Generic, Show)
 

--- a/cardano-cli/src/Cardano/CLI/Legacy/Options.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Options.hs
@@ -658,6 +658,7 @@ pQueryCmds envCli =
           <$> pSocketPath envCli
           <*> pConsensusModeParams
           <*> pNetworkId envCli
+          <*> (optional $ pQueryOutputFormat "stake-pools")
           <*> pMaybeOutputFile
 
     pQueryStakeDistribution :: Parser LegacyQueryCmds

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -474,6 +474,7 @@ Usage: cardano-cli shelley query stake-pools --socket-path SOCKET_PATH
                                                ( --mainnet
                                                | --testnet-magic NATURAL
                                                )
+                                               [--output-json | --output-text]
                                                [--out-file FILE]
 
   Get the node's current set of stake pool ids
@@ -1632,6 +1633,7 @@ Usage: cardano-cli allegra query stake-pools --socket-path SOCKET_PATH
                                                ( --mainnet
                                                | --testnet-magic NATURAL
                                                )
+                                               [--output-json | --output-text]
                                                [--out-file FILE]
 
   Get the node's current set of stake pool ids
@@ -2788,6 +2790,7 @@ Usage: cardano-cli mary query stake-pools --socket-path SOCKET_PATH
                                             ( --mainnet
                                             | --testnet-magic NATURAL
                                             )
+                                            [--output-json | --output-text]
                                             [--out-file FILE]
 
   Get the node's current set of stake pool ids
@@ -3935,6 +3938,7 @@ Usage: cardano-cli alonzo query stake-pools --socket-path SOCKET_PATH
                                               ( --mainnet
                                               | --testnet-magic NATURAL
                                               )
+                                              [--output-json | --output-text]
                                               [--out-file FILE]
 
   Get the node's current set of stake pool ids
@@ -5118,6 +5122,7 @@ Usage: cardano-cli babbage query stake-pools --socket-path SOCKET_PATH
                                                ( --mainnet
                                                | --testnet-magic NATURAL
                                                )
+                                               [--output-json | --output-text]
                                                [--out-file FILE]
 
   Get the node's current set of stake pool ids
@@ -6538,6 +6543,7 @@ Usage: cardano-cli conway query stake-pools --socket-path SOCKET_PATH
                                               | --testnet-magic NATURAL
                                               )
                                               [--volatile-tip | --immutable-tip]
+                                              [--output-json | --output-text]
                                               [--out-file FILE]
 
   Get the node's current set of stake pool ids
@@ -7903,6 +7909,7 @@ Usage: cardano-cli latest query stake-pools --socket-path SOCKET_PATH
                                               ( --mainnet
                                               | --testnet-magic NATURAL
                                               )
+                                              [--output-json | --output-text]
                                               [--out-file FILE]
 
   Get the node's current set of stake pool ids
@@ -8917,6 +8924,7 @@ Usage: cardano-cli legacy query stake-pools --socket-path SOCKET_PATH
                                               ( --mainnet
                                               | --testnet-magic NATURAL
                                               )
+                                              [--output-json | --output-text]
                                               [--out-file FILE]
 
   Get the node's current set of stake pool ids
@@ -10166,6 +10174,7 @@ Usage: cardano-cli query tip --socket-path SOCKET_PATH
 Usage: cardano-cli query stake-pools --socket-path SOCKET_PATH
                                        [--cardano-mode [--epoch-slots SLOTS]]
                                        (--mainnet | --testnet-magic NATURAL)
+                                       [--output-json | --output-text]
                                        [--out-file FILE]
 
   Get the node's current set of stake pool ids

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_stake-pools.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_stake-pools.cli
@@ -4,6 +4,7 @@ Usage: cardano-cli allegra query stake-pools --socket-path SOCKET_PATH
                                                ( --mainnet
                                                | --testnet-magic NATURAL
                                                )
+                                               [--output-json | --output-text]
                                                [--out-file FILE]
 
   Get the node's current set of stake pool ids
@@ -22,5 +23,9 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --output-json            Format stake-pools query output to JSON. Default
+                           format when writing to a file
+  --output-text            Format stake-pools query output to TEXT. Default
+                           format when writing to stdout
   --out-file FILE          Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_stake-pools.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_stake-pools.cli
@@ -4,6 +4,7 @@ Usage: cardano-cli alonzo query stake-pools --socket-path SOCKET_PATH
                                               ( --mainnet
                                               | --testnet-magic NATURAL
                                               )
+                                              [--output-json | --output-text]
                                               [--out-file FILE]
 
   Get the node's current set of stake pool ids
@@ -22,5 +23,9 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --output-json            Format stake-pools query output to JSON. Default
+                           format when writing to a file
+  --output-text            Format stake-pools query output to TEXT. Default
+                           format when writing to stdout
   --out-file FILE          Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_stake-pools.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_stake-pools.cli
@@ -4,6 +4,7 @@ Usage: cardano-cli babbage query stake-pools --socket-path SOCKET_PATH
                                                ( --mainnet
                                                | --testnet-magic NATURAL
                                                )
+                                               [--output-json | --output-text]
                                                [--out-file FILE]
 
   Get the node's current set of stake pool ids
@@ -22,5 +23,9 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --output-json            Format stake-pools query output to JSON. Default
+                           format when writing to a file
+  --output-text            Format stake-pools query output to TEXT. Default
+                           format when writing to stdout
   --out-file FILE          Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_stake-pools.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_stake-pools.cli
@@ -5,6 +5,7 @@ Usage: cardano-cli conway query stake-pools --socket-path SOCKET_PATH
                                               | --testnet-magic NATURAL
                                               )
                                               [--volatile-tip | --immutable-tip]
+                                              [--output-json | --output-text]
                                               [--out-file FILE]
 
   Get the node's current set of stake pool ids
@@ -26,5 +27,9 @@ Available options:
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.
+  --output-json            Format stake-pools query output to JSON. Default
+                           format when writing to a file
+  --output-text            Format stake-pools query output to TEXT. Default
+                           format when writing to stdout
   --out-file FILE          Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_stake-pools.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_stake-pools.cli
@@ -4,6 +4,7 @@ Usage: cardano-cli latest query stake-pools --socket-path SOCKET_PATH
                                               ( --mainnet
                                               | --testnet-magic NATURAL
                                               )
+                                              [--output-json | --output-text]
                                               [--out-file FILE]
 
   Get the node's current set of stake pool ids
@@ -22,5 +23,9 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --output-json            Format stake-pools query output to JSON. Default
+                           format when writing to a file
+  --output-text            Format stake-pools query output to TEXT. Default
+                           format when writing to stdout
   --out-file FILE          Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_query_stake-pools.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_query_stake-pools.cli
@@ -4,6 +4,7 @@ Usage: cardano-cli legacy query stake-pools --socket-path SOCKET_PATH
                                               ( --mainnet
                                               | --testnet-magic NATURAL
                                               )
+                                              [--output-json | --output-text]
                                               [--out-file FILE]
 
   Get the node's current set of stake pool ids
@@ -22,5 +23,9 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --output-json            Format stake-pools query output to JSON. Default
+                           format when writing to a file
+  --output-text            Format stake-pools query output to TEXT. Default
+                           format when writing to stdout
   --out-file FILE          Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_stake-pools.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_stake-pools.cli
@@ -4,6 +4,7 @@ Usage: cardano-cli mary query stake-pools --socket-path SOCKET_PATH
                                             ( --mainnet
                                             | --testnet-magic NATURAL
                                             )
+                                            [--output-json | --output-text]
                                             [--out-file FILE]
 
   Get the node's current set of stake pool ids
@@ -22,5 +23,9 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --output-json            Format stake-pools query output to JSON. Default
+                           format when writing to a file
+  --output-text            Format stake-pools query output to TEXT. Default
+                           format when writing to stdout
   --out-file FILE          Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/query_stake-pools.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/query_stake-pools.cli
@@ -1,6 +1,7 @@
 Usage: cardano-cli query stake-pools --socket-path SOCKET_PATH
                                        [--cardano-mode [--epoch-slots SLOTS]]
                                        (--mainnet | --testnet-magic NATURAL)
+                                       [--output-json | --output-text]
                                        [--out-file FILE]
 
   Get the node's current set of stake pool ids
@@ -19,5 +20,9 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --output-json            Format stake-pools query output to JSON. Default
+                           format when writing to a file
+  --output-text            Format stake-pools query output to TEXT. Default
+                           format when writing to stdout
   --out-file FILE          Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_stake-pools.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_stake-pools.cli
@@ -4,6 +4,7 @@ Usage: cardano-cli shelley query stake-pools --socket-path SOCKET_PATH
                                                ( --mainnet
                                                | --testnet-magic NATURAL
                                                )
+                                               [--output-json | --output-text]
                                                [--out-file FILE]
 
   Get the node's current set of stake pool ids
@@ -22,5 +23,9 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --output-json            Format stake-pools query output to JSON. Default
+                           format when writing to a file
+  --output-text            Format stake-pools query output to TEXT. Default
+                           format when writing to stdout
   --out-file FILE          Optional output file. Default is to write to stdout.
   -h,--help                Show this help text


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    query stake-pools, add --output-[json,text] flag to control format of the output
# uncomment types applicable to the change:
  type:
  - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

* Part of fixing https://github.com/IntersectMBO/cardano-cli/issues/566
* Part of this stream of PRs: https://github.com/IntersectMBO/cardano-cli/pull/523, https://github.com/IntersectMBO/cardano-cli/pull/611
* Spin-off of https://github.com/IntersectMBO/cardano-node/commits/smelc/test-cli-queries/

# How to trust this PR

1. See is the output of `query stake-pools` before this PR (so no using the new flags): https://github.com/IntersectMBO/cardano-node/blob/smelc/test-cardano-cli-query-stake-pools-output-new/log.txt
1. See the output of `query stake-pools` after this PR, when not using the new flags, so clunky defaults: https://github.com/IntersectMBO/cardano-node/blob/smelc/test-cardano-cli-query-stake-pools-output-new/log_new.txt. Note it's the same as item 1.
2. See the output of `query stake-pools` after this PR, when using all combinations of new flags: https://github.com/IntersectMBO/cardano-node/blob/smelc/test-cardano-cli-query-stake-pools-output-new/log_all_new_cases.txt Notice the behaviors are the expected ones for all combinations.

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] Self-reviewed the diff