### PR TITLE
Add missing newlines to `cardano-cli query utxo` output

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Query.hs
@@ -1034,8 +1034,7 @@ writeFilteredUTxOs sbe format mOutFile utxo =
 filteredUTxOsToText :: Api.ShelleyBasedEra era -> UTxO era -> Text
 filteredUTxOsToText sbe (UTxO utxo) = do
   mconcat
-    [ title
-    , Text.replicate (Text.length title + 2) "-"
+    [ Text.unlines [title, Text.replicate (Text.length title + 2) "-"]
     , Text.unlines $ case sbe of
         ShelleyBasedEraShelley ->
           map (utxoToText sbe) $ Map.toList utxo


### PR DESCRIPTION
Text output is missing newlines after title line and underline.

# Changelog

```yaml
- description: |
    Add missing newlines to `cardano-cli query utxo` text output.
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Fixes https://github.com/IntersectMBO/cardano-cli/issues/619

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
