### PR TITLE
create-testnet-data: allow to specify relays for SPOs (like create-staked)

### DIFF
--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -333,6 +333,7 @@ test-suite cardano-cli-golden
                       , cardano-crypto-wrapper
                       , cardano-ledger-byron
                       , cardano-ledger-shelley >=1.7.0.0
+                      , cardano-strict-containers ^>= 0.1
                       , cborg
                       , containers
                       , directory

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Genesis.hs
@@ -94,6 +94,7 @@ data GenesisCreateTestNetDataCmdArgs = GenesisCreateTestNetDataCmdArgs
   , totalSupply :: !(Maybe Lovelace) -- ^ The total number of Lovelace
   , delegatedSupply :: !(Maybe Lovelace) -- ^ The number of Lovelace being delegated
   , networkId :: !(Maybe NetworkId) -- ^ The network ID to use. Overrides the network id supplied in the spec file.
+  , relays :: !(Maybe FilePath) -- ^ Filepath of the specification of relays
   , systemStart :: !(Maybe SystemStart) -- ^ The genesis start time.
   , outputDir :: !FilePath -- ^ Directory where to write credentials and files.
   } deriving Show

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Genesis.hs
@@ -198,6 +198,15 @@ pGenesisCreateStaked envCli =
     <*> pBulkPoolsPerFile
     <*> pStuffedUtxoCount
     <*> Opt.optional pRelayJsonFp
+  where
+    pRelayJsonFp :: Parser FilePath
+    pRelayJsonFp =
+      Opt.strOption $ mconcat
+        [ Opt.long "relay-specification-file"
+        , Opt.metavar "FILE"
+        , Opt.help "JSON file specified the relays of each stake pool."
+        , Opt.completer (Opt.bashCompleter "file")
+        ]
 
 pGenesisCreateTestNetData :: EnvCli -> Parser (GenesisCmds era)
 pGenesisCreateTestNetData envCli =
@@ -212,6 +221,7 @@ pGenesisCreateTestNetData envCli =
     <*> pSupply
     <*> pSupplyDelegated
     <*> (optional $ pNetworkIdForTestnetData envCli)
+    <*> Opt.optional pRelays
     <*> pMaybeSystemStart
     <*> pOutputDir
   where
@@ -291,6 +301,14 @@ pGenesisCreateTestNetData envCli =
                              ]
         , Opt.value 500_000_000_000
         ]
+    pRelays :: Parser FilePath
+    pRelays =
+      Opt.strOption $ mconcat
+        [ Opt.long "relays"
+        , Opt.metavar "FILE"
+        , Opt.help "JSON file specifying the relays of each stake pool."
+        , Opt.completer (Opt.bashCompleter "file")
+        ]
     pOutputDir = Opt.strOption $ mconcat
       [ Opt.long "out-dir"
       , Opt.metavar "DIR"
@@ -363,15 +381,6 @@ pStuffedUtxoCount =
     , Opt.metavar "INT"
     , Opt.help "The number of fake UTxO entries to generate [default is 0]."
     , Opt.value 0
-    ]
-
-pRelayJsonFp :: Parser FilePath
-pRelayJsonFp =
-  Opt.strOption $ mconcat
-    [ Opt.long "relay-specification-file"
-    , Opt.metavar "FILE"
-    , Opt.help "JSON file specified the relays of each stake pool."
-    , Opt.completer (Opt.bashCompleter "file")
     ]
 
 pInitialSupplyNonDelegated :: Parser (Maybe Lovelace)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Genesis.hs
@@ -560,13 +560,7 @@ runGenesisCreateStakedCmd
   forM_ [ 1 .. numUTxOKeys ] $ \index ->
     createUtxoKeys utxodir index
 
-  mayStakePoolRelays
-    <- forM mStakePoolRelaySpecFile $
-       \fp -> do
-         relaySpecJsonBs <-
-           handleIOExceptT (GenesisCmdStakePoolRelayFileError fp) (LBS.readFile fp)
-         firstExceptT (GenesisCmdStakePoolRelayJsonDecodeError fp)
-           . hoistEither $ Aeson.eitherDecode relaySpecJsonBs
+  mayStakePoolRelays <- forM mStakePoolRelaySpecFile TN.readRelays
 
   poolParams <- forM [ 1 .. numPools ] $ \index -> do
     createPoolCredentials keyOutputFormat pooldir index

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/GenesisCmdError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/GenesisCmdError.hs
@@ -35,6 +35,7 @@ data GenesisCmdError
   | GenesisCmdStakePoolCmdError !StakePoolCmdError
   | GenesisCmdCostModelsError !FilePath
   | GenesisCmdByronError !ByronGenesisError
+  | GenesisCmdTooManyRelaysError !FilePath !Int !Int -- ^ First @Int@ is the number of SPOs, second @Int@ is number of relays
   | GenesisCmdStakePoolRelayFileError !FilePath !IOException
   | GenesisCmdStakePoolRelayJsonDecodeError !FilePath !String
   | GenesisCmdFileInputDecodeError !(FileError InputDecodeError)
@@ -89,6 +90,9 @@ instance Error GenesisCmdError where
     GenesisCmdGenesisFileReadError e ->
       prettyError e
     GenesisCmdByronError e -> pshow e
+    GenesisCmdTooManyRelaysError fp nbSPOs nbRelays ->
+      pretty fp <> " specifies " <> pretty nbRelays <> " relays, but only " <> pretty nbSPOs <> " SPOs have been specified." <>
+      " Please specify a number of relays that is lesser or equal to the number of SPOs."
     GenesisCmdStakePoolRelayFileError fp e ->
       "Error occurred while reading the stake pool relay specification file: " <> pretty fp <>
       " Error: " <> pshow e

--- a/cardano-cli/src/Cardano/CLI/Types/Output.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Output.hs
@@ -2,6 +2,8 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE LambdaCase #-}
 
+-- | Types that are used when writing to standard output or to files.
+-- These types (and their encodings) are typically consumed by users of @cardano-cli@.
 module Cardano.CLI.Types.Output
   ( PlutusScriptCostError
   , QueryKesPeriodInfoOutput (..)

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -272,6 +272,7 @@ Usage: cardano-cli shelley genesis create-testnet-data [--spec-shelley FILE]
                                                          [--total-supply LOVELACE]
                                                          [--delegated-supply LOVELACE]
                                                          [--testnet-magic NATURAL]
+                                                         [--relays FILE]
                                                          [--start-time UTC-TIME]
                                                          --out-dir DIR
 
@@ -1434,6 +1435,7 @@ Usage: cardano-cli allegra genesis create-testnet-data [--spec-shelley FILE]
                                                          [--total-supply LOVELACE]
                                                          [--delegated-supply LOVELACE]
                                                          [--testnet-magic NATURAL]
+                                                         [--relays FILE]
                                                          [--start-time UTC-TIME]
                                                          --out-dir DIR
 
@@ -2594,6 +2596,7 @@ Usage: cardano-cli mary genesis create-testnet-data [--spec-shelley FILE]
                                                       [--total-supply LOVELACE]
                                                       [--delegated-supply LOVELACE]
                                                       [--testnet-magic NATURAL]
+                                                      [--relays FILE]
                                                       [--start-time UTC-TIME]
                                                       --out-dir DIR
 
@@ -3739,6 +3742,7 @@ Usage: cardano-cli alonzo genesis create-testnet-data [--spec-shelley FILE]
                                                         [--total-supply LOVELACE]
                                                         [--delegated-supply LOVELACE]
                                                         [--testnet-magic NATURAL]
+                                                        [--relays FILE]
                                                         [--start-time UTC-TIME]
                                                         --out-dir DIR
 
@@ -4907,6 +4911,7 @@ Usage: cardano-cli babbage genesis create-testnet-data [--spec-shelley FILE]
                                                          [--total-supply LOVELACE]
                                                          [--delegated-supply LOVELACE]
                                                          [--testnet-magic NATURAL]
+                                                         [--relays FILE]
                                                          [--start-time UTC-TIME]
                                                          --out-dir DIR
 
@@ -6093,6 +6098,7 @@ Usage: cardano-cli conway genesis create-testnet-data [--spec-shelley FILE]
                                                         [--total-supply LOVELACE]
                                                         [--delegated-supply LOVELACE]
                                                         [--testnet-magic NATURAL]
+                                                        [--relays FILE]
                                                         [--start-time UTC-TIME]
                                                         --out-dir DIR
 
@@ -7715,6 +7721,7 @@ Usage: cardano-cli latest genesis create-testnet-data [--spec-shelley FILE]
                                                         [--total-supply LOVELACE]
                                                         [--delegated-supply LOVELACE]
                                                         [--testnet-magic NATURAL]
+                                                        [--relays FILE]
                                                         [--start-time UTC-TIME]
                                                         --out-dir DIR
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_genesis_create-testnet-data.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_genesis_create-testnet-data.cli
@@ -10,6 +10,7 @@ Usage: cardano-cli allegra genesis create-testnet-data [--spec-shelley FILE]
                                                          [--total-supply LOVELACE]
                                                          [--delegated-supply LOVELACE]
                                                          [--testnet-magic NATURAL]
+                                                         [--relays FILE]
                                                          [--start-time UTC-TIME]
                                                          --out-dir DIR
 
@@ -45,6 +46,7 @@ Available options:
   --testnet-magic NATURAL  Specify a testnet magic id for the cluster. This
                            overrides both the network magic from the spec file
                            and CARDANO_NODE_NETWORK_ID environment variable.
+  --relays FILE            JSON file specifying the relays of each stake pool.
   --start-time UTC-TIME    The genesis start time in YYYY-MM-DDThh:mm:ssZ
                            format. If unspecified, will be the current time +30
                            seconds.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_genesis_create-testnet-data.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_genesis_create-testnet-data.cli
@@ -10,6 +10,7 @@ Usage: cardano-cli alonzo genesis create-testnet-data [--spec-shelley FILE]
                                                         [--total-supply LOVELACE]
                                                         [--delegated-supply LOVELACE]
                                                         [--testnet-magic NATURAL]
+                                                        [--relays FILE]
                                                         [--start-time UTC-TIME]
                                                         --out-dir DIR
 
@@ -45,6 +46,7 @@ Available options:
   --testnet-magic NATURAL  Specify a testnet magic id for the cluster. This
                            overrides both the network magic from the spec file
                            and CARDANO_NODE_NETWORK_ID environment variable.
+  --relays FILE            JSON file specifying the relays of each stake pool.
   --start-time UTC-TIME    The genesis start time in YYYY-MM-DDThh:mm:ssZ
                            format. If unspecified, will be the current time +30
                            seconds.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_genesis_create-testnet-data.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_genesis_create-testnet-data.cli
@@ -10,6 +10,7 @@ Usage: cardano-cli babbage genesis create-testnet-data [--spec-shelley FILE]
                                                          [--total-supply LOVELACE]
                                                          [--delegated-supply LOVELACE]
                                                          [--testnet-magic NATURAL]
+                                                         [--relays FILE]
                                                          [--start-time UTC-TIME]
                                                          --out-dir DIR
 
@@ -45,6 +46,7 @@ Available options:
   --testnet-magic NATURAL  Specify a testnet magic id for the cluster. This
                            overrides both the network magic from the spec file
                            and CARDANO_NODE_NETWORK_ID environment variable.
+  --relays FILE            JSON file specifying the relays of each stake pool.
   --start-time UTC-TIME    The genesis start time in YYYY-MM-DDThh:mm:ssZ
                            format. If unspecified, will be the current time +30
                            seconds.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_genesis_create-testnet-data.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_genesis_create-testnet-data.cli
@@ -10,6 +10,7 @@ Usage: cardano-cli conway genesis create-testnet-data [--spec-shelley FILE]
                                                         [--total-supply LOVELACE]
                                                         [--delegated-supply LOVELACE]
                                                         [--testnet-magic NATURAL]
+                                                        [--relays FILE]
                                                         [--start-time UTC-TIME]
                                                         --out-dir DIR
 
@@ -45,6 +46,7 @@ Available options:
   --testnet-magic NATURAL  Specify a testnet magic id for the cluster. This
                            overrides both the network magic from the spec file
                            and CARDANO_NODE_NETWORK_ID environment variable.
+  --relays FILE            JSON file specifying the relays of each stake pool.
   --start-time UTC-TIME    The genesis start time in YYYY-MM-DDThh:mm:ssZ
                            format. If unspecified, will be the current time +30
                            seconds.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_genesis_create-testnet-data.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_genesis_create-testnet-data.cli
@@ -10,6 +10,7 @@ Usage: cardano-cli latest genesis create-testnet-data [--spec-shelley FILE]
                                                         [--total-supply LOVELACE]
                                                         [--delegated-supply LOVELACE]
                                                         [--testnet-magic NATURAL]
+                                                        [--relays FILE]
                                                         [--start-time UTC-TIME]
                                                         --out-dir DIR
 
@@ -45,6 +46,7 @@ Available options:
   --testnet-magic NATURAL  Specify a testnet magic id for the cluster. This
                            overrides both the network magic from the spec file
                            and CARDANO_NODE_NETWORK_ID environment variable.
+  --relays FILE            JSON file specifying the relays of each stake pool.
   --start-time UTC-TIME    The genesis start time in YYYY-MM-DDThh:mm:ssZ
                            format. If unspecified, will be the current time +30
                            seconds.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_genesis_create-testnet-data.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_genesis_create-testnet-data.cli
@@ -10,6 +10,7 @@ Usage: cardano-cli mary genesis create-testnet-data [--spec-shelley FILE]
                                                       [--total-supply LOVELACE]
                                                       [--delegated-supply LOVELACE]
                                                       [--testnet-magic NATURAL]
+                                                      [--relays FILE]
                                                       [--start-time UTC-TIME]
                                                       --out-dir DIR
 
@@ -45,6 +46,7 @@ Available options:
   --testnet-magic NATURAL  Specify a testnet magic id for the cluster. This
                            overrides both the network magic from the spec file
                            and CARDANO_NODE_NETWORK_ID environment variable.
+  --relays FILE            JSON file specifying the relays of each stake pool.
   --start-time UTC-TIME    The genesis start time in YYYY-MM-DDThh:mm:ssZ
                            format. If unspecified, will be the current time +30
                            seconds.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_genesis_create-testnet-data.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_genesis_create-testnet-data.cli
@@ -10,6 +10,7 @@ Usage: cardano-cli shelley genesis create-testnet-data [--spec-shelley FILE]
                                                          [--total-supply LOVELACE]
                                                          [--delegated-supply LOVELACE]
                                                          [--testnet-magic NATURAL]
+                                                         [--relays FILE]
                                                          [--start-time UTC-TIME]
                                                          --out-dir DIR
 
@@ -45,6 +46,7 @@ Available options:
   --testnet-magic NATURAL  Specify a testnet magic id for the cluster. This
                            overrides both the network magic from the spec file
                            and CARDANO_NODE_NETWORK_ID environment variable.
+  --relays FILE            JSON file specifying the relays of each stake pool.
   --start-time UTC-TIME    The genesis start time in YYYY-MM-DDThh:mm:ssZ
                            format. If unspecified, will be the current time +30
                            seconds.

--- a/cardano-cli/test/cardano-cli-golden/files/input/shelley/genesis/relays.json
+++ b/cardano-cli/test/cardano-cli-golden/files/input/shelley/genesis/relays.json
@@ -1,0 +1,18 @@
+{
+  "0": [
+    {
+      "single host name": {
+        "dnsName": "node-0",
+        "port": 30000
+      }
+    }
+  ],
+  "1": [
+    {
+      "single host name": {
+        "dnsName": "node-1",
+        "port": 30001
+      }
+    }
+  ]
+}


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    create-testnet-data: allow to specify relays for SPOs (like create-staked)
# uncomment types applicable to the change:
  type:
  - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Fixes https://github.com/IntersectMBO/cardano-cli/issues/630

# How to trust this PR

Run the following:

```bash
cabal run cardano-cli -- conway genesis create-testnet-data --out-dir create_testnet_out --stake-delegators 3 --pools 4 --utxo-keys 5 --genesis-keys 6 --testnet-magic 42 --relays pool-relays.json
```

`pool-relays.json` is the following file:

```json
{
  "0": [
    {
      "single host name": {
        "dnsName": "node-0",
        "port": 30000
      }
    }
  ],
  "1": [
    {
      "single host name": {
        "dnsName": "node-1",
        "port": 30001
      }
    }
  ]
}
```

Then open `create_testnet_out/genesis.json` and observe that the pools have a non-empty entry in their `relays` field.

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [X] Self-reviewed the diff