### PR TITLE
Enable Haskell CI for `main` branch push trigger

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -3,6 +3,11 @@ name: Haskell CI
 on:
   merge_group:
   pull_request:
+  push:
+    # we need this to populate cache for `main` branch to make it available to the child branches, see
+    # https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache
+    branches:
+      - main
 
 jobs:
   build:
@@ -12,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         # If you edit these versions, make sure the version in the lonely macos-latest job below is updated accordingly
-        ghc: ["9.6.4", "9.8.1"]
+        ghc: ["9.6.4", "9.8.2"]
         cabal: ["3.10.2.1"]
         os: [windows-latest, ubuntu-latest]
         include:
@@ -61,7 +66,7 @@ jobs:
       with:
         use-sodium-vrf: true # default is true
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Cabal update
       run: cabal update
@@ -149,7 +154,7 @@ jobs:
         done
 
     - name: Save Artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: artifacts-${{ matrix.os }}-${{ matrix.ghc }}
         path: ./artifacts
@@ -192,7 +197,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Create Release Tag
       id: create_release_tag


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Enable Haskell CI for `main` branch push trigger
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
   - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

This analogous change to the one in API: https://github.com/IntersectMBO/cardano-api/pull/469

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
