### PR TITLE
Allow an output file to be specified for query pool-state

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Query.hs
@@ -172,6 +172,7 @@ data QueryPoolStateCmdArgs = QueryPoolStateCmdArgs
   , networkId           :: !NetworkId
   , allOrOnlyPoolIds    :: !(AllOrOnly (Hash StakePoolKey))
   , target              :: !(Consensus.Target ChainPoint)
+  , mOutFile            :: !(Maybe (File () Out))
   } deriving (Generic, Show)
 
 data QueryTxMempoolCmdArgs = QueryTxMempoolCmdArgs

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Query.hs
@@ -228,6 +228,7 @@ pQueryPoolStateCmd era envCli =
       <*> pNetworkId envCli
       <*> pAllStakePoolsOrSome
       <*> pTarget era
+      <*> pMaybeOutputFile
 
 pQueryTxMempoolCmd :: EnvCli -> Parser (QueryCmds era)
 pQueryTxMempoolCmd envCli =

--- a/cardano-cli/src/Cardano/CLI/Legacy/Commands/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Commands/Query.hs
@@ -148,6 +148,7 @@ data LegacyQueryPoolStateCmdArgs = LegacyQueryPoolStateCmdArgs
   , consensusModeParams :: !ConsensusModeParams
   , networkId           :: !NetworkId
   , allOrOnlyPoolIds    :: !(AllOrOnly (Hash StakePoolKey))
+  , mOutFile            :: !(Maybe (File () Out))
   } deriving (Generic, Show)
 
 data LegacyQueryTxMempoolCmdArgs = LegacyQueryTxMempoolCmdArgs

--- a/cardano-cli/src/Cardano/CLI/Legacy/Options.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Options.hs
@@ -726,6 +726,7 @@ pQueryCmds envCli =
           <*> pConsensusModeParams
           <*> pNetworkId envCli
           <*> pAllStakePoolsOrOnly
+          <*> pMaybeOutputFile
 
     pQueryTxMempool :: Parser LegacyQueryCmds
     pQueryTxMempool =

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -559,6 +559,7 @@ Usage: cardano-cli shelley query pool-params --socket-path SOCKET_PATH
                                                ( --all-stake-pools
                                                | (--stake-pool-id STAKE_POOL_ID)
                                                )
+                                               [--out-file FILE]
 
   DEPRECATED. Use query pool-state instead. Dump the pool parameters
   (Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced
@@ -602,6 +603,7 @@ Usage: cardano-cli shelley query pool-state --socket-path SOCKET_PATH
                                               ( --all-stake-pools
                                               | (--stake-pool-id STAKE_POOL_ID)
                                               )
+                                              [--out-file FILE]
 
   Dump the pool state
 
@@ -1722,6 +1724,7 @@ Usage: cardano-cli allegra query pool-params --socket-path SOCKET_PATH
                                                ( --all-stake-pools
                                                | (--stake-pool-id STAKE_POOL_ID)
                                                )
+                                               [--out-file FILE]
 
   DEPRECATED. Use query pool-state instead. Dump the pool parameters
   (Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced
@@ -1765,6 +1768,7 @@ Usage: cardano-cli allegra query pool-state --socket-path SOCKET_PATH
                                               ( --all-stake-pools
                                               | (--stake-pool-id STAKE_POOL_ID)
                                               )
+                                              [--out-file FILE]
 
   Dump the pool state
 
@@ -2883,6 +2887,7 @@ Usage: cardano-cli mary query pool-params --socket-path SOCKET_PATH
                                             ( --all-stake-pools
                                             | (--stake-pool-id STAKE_POOL_ID)
                                             )
+                                            [--out-file FILE]
 
   DEPRECATED. Use query pool-state instead. Dump the pool parameters
   (Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced
@@ -2924,6 +2929,7 @@ Usage: cardano-cli mary query pool-state --socket-path SOCKET_PATH
                                            ( --all-stake-pools
                                            | (--stake-pool-id STAKE_POOL_ID)
                                            )
+                                           [--out-file FILE]
 
   Dump the pool state
 
@@ -4036,6 +4042,7 @@ Usage: cardano-cli alonzo query pool-params --socket-path SOCKET_PATH
                                               ( --all-stake-pools
                                               | (--stake-pool-id STAKE_POOL_ID)
                                               )
+                                              [--out-file FILE]
 
   DEPRECATED. Use query pool-state instead. Dump the pool parameters
   (Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced
@@ -4079,6 +4086,7 @@ Usage: cardano-cli alonzo query pool-state --socket-path SOCKET_PATH
                                              ( --all-stake-pools
                                              | (--stake-pool-id STAKE_POOL_ID)
                                              )
+                                             [--out-file FILE]
 
   Dump the pool state
 
@@ -5224,6 +5232,7 @@ Usage: cardano-cli babbage query pool-params --socket-path SOCKET_PATH
                                                ( --all-stake-pools
                                                | (--stake-pool-id STAKE_POOL_ID)
                                                )
+                                               [--out-file FILE]
 
   DEPRECATED. Use query pool-state instead. Dump the pool parameters
   (Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced
@@ -5267,6 +5276,7 @@ Usage: cardano-cli babbage query pool-state --socket-path SOCKET_PATH
                                               ( --all-stake-pools
                                               | (--stake-pool-id STAKE_POOL_ID)
                                               )
+                                              [--out-file FILE]
 
   Dump the pool state
 
@@ -6679,6 +6689,7 @@ Usage: cardano-cli conway query pool-params --socket-path SOCKET_PATH
                                               | (--stake-pool-id STAKE_POOL_ID)
                                               )
                                               [--volatile-tip | --immutable-tip]
+                                              [--out-file FILE]
 
   DEPRECATED. Use query pool-state instead. Dump the pool parameters
   (Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced
@@ -6729,6 +6740,7 @@ Usage: cardano-cli conway query pool-state --socket-path SOCKET_PATH
                                              | (--stake-pool-id STAKE_POOL_ID)
                                              )
                                              [--volatile-tip | --immutable-tip]
+                                             [--out-file FILE]
 
   Dump the pool state
 
@@ -8034,6 +8046,7 @@ Usage: cardano-cli latest query pool-params --socket-path SOCKET_PATH
                                               ( --all-stake-pools
                                               | (--stake-pool-id STAKE_POOL_ID)
                                               )
+                                              [--out-file FILE]
 
   DEPRECATED. Use query pool-state instead. Dump the pool parameters
   (Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced
@@ -8077,6 +8090,7 @@ Usage: cardano-cli latest query pool-state --socket-path SOCKET_PATH
                                              ( --all-stake-pools
                                              | (--stake-pool-id STAKE_POOL_ID)
                                              )
+                                             [--out-file FILE]
 
   Dump the pool state
 
@@ -9051,6 +9065,7 @@ Usage: cardano-cli legacy query pool-params --socket-path SOCKET_PATH
                                               ( --all-stake-pools
                                               | (--stake-pool-id STAKE_POOL_ID)
                                               )
+                                              [--out-file FILE]
 
   DEPRECATED. Use query pool-state instead. Dump the pool parameters
   (Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced
@@ -9094,6 +9109,7 @@ Usage: cardano-cli legacy query pool-state --socket-path SOCKET_PATH
                                              ( --all-stake-pools
                                              | (--stake-pool-id STAKE_POOL_ID)
                                              )
+                                             [--out-file FILE]
 
   Dump the pool state
 
@@ -10292,6 +10308,7 @@ Usage: cardano-cli query pool-params --socket-path SOCKET_PATH
                                        ( --all-stake-pools
                                        | (--stake-pool-id STAKE_POOL_ID)
                                        )
+                                       [--out-file FILE]
 
   DEPRECATED. Use query pool-state instead. Dump the pool parameters
   (Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced
@@ -10330,6 +10347,7 @@ Usage: cardano-cli query pool-state --socket-path SOCKET_PATH
                                       ( --all-stake-pools
                                       | (--stake-pool-id STAKE_POOL_ID)
                                       )
+                                      [--out-file FILE]
 
   Dump the pool state
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_pool-params.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_pool-params.cli
@@ -7,6 +7,7 @@ Usage: cardano-cli allegra query pool-params --socket-path SOCKET_PATH
                                                ( --all-stake-pools
                                                | (--stake-pool-id STAKE_POOL_ID)
                                                )
+                                               [--out-file FILE]
 
   DEPRECATED. Use query pool-state instead. Dump the pool parameters
   (Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced
@@ -30,4 +31,5 @@ Available options:
   --stake-pool-id STAKE_POOL_ID
                            Stake pool ID/verification key hash (either
                            Bech32-encoded or hex-encoded).
+  --out-file FILE          Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_pool-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_pool-state.cli
@@ -7,6 +7,7 @@ Usage: cardano-cli allegra query pool-state --socket-path SOCKET_PATH
                                               ( --all-stake-pools
                                               | (--stake-pool-id STAKE_POOL_ID)
                                               )
+                                              [--out-file FILE]
 
   Dump the pool state
 
@@ -28,4 +29,5 @@ Available options:
   --stake-pool-id STAKE_POOL_ID
                            Stake pool ID/verification key hash (either
                            Bech32-encoded or hex-encoded).
+  --out-file FILE          Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_pool-params.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_pool-params.cli
@@ -7,6 +7,7 @@ Usage: cardano-cli alonzo query pool-params --socket-path SOCKET_PATH
                                               ( --all-stake-pools
                                               | (--stake-pool-id STAKE_POOL_ID)
                                               )
+                                              [--out-file FILE]
 
   DEPRECATED. Use query pool-state instead. Dump the pool parameters
   (Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced
@@ -30,4 +31,5 @@ Available options:
   --stake-pool-id STAKE_POOL_ID
                            Stake pool ID/verification key hash (either
                            Bech32-encoded or hex-encoded).
+  --out-file FILE          Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_pool-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_pool-state.cli
@@ -7,6 +7,7 @@ Usage: cardano-cli alonzo query pool-state --socket-path SOCKET_PATH
                                              ( --all-stake-pools
                                              | (--stake-pool-id STAKE_POOL_ID)
                                              )
+                                             [--out-file FILE]
 
   Dump the pool state
 
@@ -28,4 +29,5 @@ Available options:
   --stake-pool-id STAKE_POOL_ID
                            Stake pool ID/verification key hash (either
                            Bech32-encoded or hex-encoded).
+  --out-file FILE          Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_pool-params.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_pool-params.cli
@@ -7,6 +7,7 @@ Usage: cardano-cli babbage query pool-params --socket-path SOCKET_PATH
                                                ( --all-stake-pools
                                                | (--stake-pool-id STAKE_POOL_ID)
                                                )
+                                               [--out-file FILE]
 
   DEPRECATED. Use query pool-state instead. Dump the pool parameters
   (Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced
@@ -30,4 +31,5 @@ Available options:
   --stake-pool-id STAKE_POOL_ID
                            Stake pool ID/verification key hash (either
                            Bech32-encoded or hex-encoded).
+  --out-file FILE          Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_pool-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_pool-state.cli
@@ -7,6 +7,7 @@ Usage: cardano-cli babbage query pool-state --socket-path SOCKET_PATH
                                               ( --all-stake-pools
                                               | (--stake-pool-id STAKE_POOL_ID)
                                               )
+                                              [--out-file FILE]
 
   Dump the pool state
 
@@ -28,4 +29,5 @@ Available options:
   --stake-pool-id STAKE_POOL_ID
                            Stake pool ID/verification key hash (either
                            Bech32-encoded or hex-encoded).
+  --out-file FILE          Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_pool-params.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_pool-params.cli
@@ -8,6 +8,7 @@ Usage: cardano-cli conway query pool-params --socket-path SOCKET_PATH
                                               | (--stake-pool-id STAKE_POOL_ID)
                                               )
                                               [--volatile-tip | --immutable-tip]
+                                              [--out-file FILE]
 
   DEPRECATED. Use query pool-state instead. Dump the pool parameters
   (Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced
@@ -34,4 +35,5 @@ Available options:
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.
+  --out-file FILE          Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_pool-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_pool-state.cli
@@ -8,6 +8,7 @@ Usage: cardano-cli conway query pool-state --socket-path SOCKET_PATH
                                              | (--stake-pool-id STAKE_POOL_ID)
                                              )
                                              [--volatile-tip | --immutable-tip]
+                                             [--out-file FILE]
 
   Dump the pool state
 
@@ -32,4 +33,5 @@ Available options:
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.
+  --out-file FILE          Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_pool-params.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_pool-params.cli
@@ -7,6 +7,7 @@ Usage: cardano-cli latest query pool-params --socket-path SOCKET_PATH
                                               ( --all-stake-pools
                                               | (--stake-pool-id STAKE_POOL_ID)
                                               )
+                                              [--out-file FILE]
 
   DEPRECATED. Use query pool-state instead. Dump the pool parameters
   (Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced
@@ -30,4 +31,5 @@ Available options:
   --stake-pool-id STAKE_POOL_ID
                            Stake pool ID/verification key hash (either
                            Bech32-encoded or hex-encoded).
+  --out-file FILE          Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_pool-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_pool-state.cli
@@ -7,6 +7,7 @@ Usage: cardano-cli latest query pool-state --socket-path SOCKET_PATH
                                              ( --all-stake-pools
                                              | (--stake-pool-id STAKE_POOL_ID)
                                              )
+                                             [--out-file FILE]
 
   Dump the pool state
 
@@ -28,4 +29,5 @@ Available options:
   --stake-pool-id STAKE_POOL_ID
                            Stake pool ID/verification key hash (either
                            Bech32-encoded or hex-encoded).
+  --out-file FILE          Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_query_pool-params.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_query_pool-params.cli
@@ -7,6 +7,7 @@ Usage: cardano-cli legacy query pool-params --socket-path SOCKET_PATH
                                               ( --all-stake-pools
                                               | (--stake-pool-id STAKE_POOL_ID)
                                               )
+                                              [--out-file FILE]
 
   DEPRECATED. Use query pool-state instead. Dump the pool parameters
   (Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced
@@ -30,4 +31,5 @@ Available options:
   --stake-pool-id STAKE_POOL_ID
                            Stake pool ID/verification key hash (either
                            Bech32-encoded or hex-encoded).
+  --out-file FILE          Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_query_pool-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_query_pool-state.cli
@@ -7,6 +7,7 @@ Usage: cardano-cli legacy query pool-state --socket-path SOCKET_PATH
                                              ( --all-stake-pools
                                              | (--stake-pool-id STAKE_POOL_ID)
                                              )
+                                             [--out-file FILE]
 
   Dump the pool state
 
@@ -28,4 +29,5 @@ Available options:
   --stake-pool-id STAKE_POOL_ID
                            Stake pool ID/verification key hash (either
                            Bech32-encoded or hex-encoded).
+  --out-file FILE          Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_pool-params.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_pool-params.cli
@@ -7,6 +7,7 @@ Usage: cardano-cli mary query pool-params --socket-path SOCKET_PATH
                                             ( --all-stake-pools
                                             | (--stake-pool-id STAKE_POOL_ID)
                                             )
+                                            [--out-file FILE]
 
   DEPRECATED. Use query pool-state instead. Dump the pool parameters
   (Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced
@@ -30,4 +31,5 @@ Available options:
   --stake-pool-id STAKE_POOL_ID
                            Stake pool ID/verification key hash (either
                            Bech32-encoded or hex-encoded).
+  --out-file FILE          Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_pool-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_pool-state.cli
@@ -5,6 +5,7 @@ Usage: cardano-cli mary query pool-state --socket-path SOCKET_PATH
                                            ( --all-stake-pools
                                            | (--stake-pool-id STAKE_POOL_ID)
                                            )
+                                           [--out-file FILE]
 
   Dump the pool state
 
@@ -26,4 +27,5 @@ Available options:
   --stake-pool-id STAKE_POOL_ID
                            Stake pool ID/verification key hash (either
                            Bech32-encoded or hex-encoded).
+  --out-file FILE          Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/query_pool-params.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/query_pool-params.cli
@@ -4,6 +4,7 @@ Usage: cardano-cli query pool-params --socket-path SOCKET_PATH
                                        ( --all-stake-pools
                                        | (--stake-pool-id STAKE_POOL_ID)
                                        )
+                                       [--out-file FILE]
 
   DEPRECATED. Use query pool-state instead. Dump the pool parameters
   (Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced
@@ -27,4 +28,5 @@ Available options:
   --stake-pool-id STAKE_POOL_ID
                            Stake pool ID/verification key hash (either
                            Bech32-encoded or hex-encoded).
+  --out-file FILE          Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/query_pool-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/query_pool-state.cli
@@ -4,6 +4,7 @@ Usage: cardano-cli query pool-state --socket-path SOCKET_PATH
                                       ( --all-stake-pools
                                       | (--stake-pool-id STAKE_POOL_ID)
                                       )
+                                      [--out-file FILE]
 
   Dump the pool state
 
@@ -25,4 +26,5 @@ Available options:
   --stake-pool-id STAKE_POOL_ID
                            Stake pool ID/verification key hash (either
                            Bech32-encoded or hex-encoded).
+  --out-file FILE          Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_pool-params.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_pool-params.cli
@@ -7,6 +7,7 @@ Usage: cardano-cli shelley query pool-params --socket-path SOCKET_PATH
                                                ( --all-stake-pools
                                                | (--stake-pool-id STAKE_POOL_ID)
                                                )
+                                               [--out-file FILE]
 
   DEPRECATED. Use query pool-state instead. Dump the pool parameters
   (Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced
@@ -30,4 +31,5 @@ Available options:
   --stake-pool-id STAKE_POOL_ID
                            Stake pool ID/verification key hash (either
                            Bech32-encoded or hex-encoded).
+  --out-file FILE          Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_pool-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_pool-state.cli
@@ -7,6 +7,7 @@ Usage: cardano-cli shelley query pool-state --socket-path SOCKET_PATH
                                               ( --all-stake-pools
                                               | (--stake-pool-id STAKE_POOL_ID)
                                               )
+                                              [--out-file FILE]
 
   Dump the pool state
 
@@ -28,4 +29,5 @@ Available options:
   --stake-pool-id STAKE_POOL_ID
                            Stake pool ID/verification key hash (either
                            Bech32-encoded or hex-encoded).
+  --out-file FILE          Optional output file. Default is to write to stdout.
   -h,--help                Show this help text


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Allow an output file to be specified for the various versions of query pool-state
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

No corresponding issue.

# How to trust this PR

* Most of the changed lines are in golden files.
* Output logic was copied from other commands.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
