### PR TITLE
create-testnet-data: fix computation of not-delegated amount

### DIFF
--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -334,6 +334,7 @@ test-suite cardano-cli-golden
                       , cardano-cli
                       , cardano-cli:cardano-cli-test-lib
                       , cardano-crypto-wrapper
+                      , cardano-data >= 1.1
                       , cardano-ledger-byron
                       , cardano-ledger-shelley >=1.7.0.0
                       , cardano-strict-containers ^>= 0.1

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/CreateTestnetData.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/CreateTestnetData.hs
@@ -606,9 +606,8 @@ updateOutputTemplate
     getCoinForDistribution :: Integer -> m Natural
     getCoinForDistribution inputCoin = do
       let value = inputCoin - subtrahendForTreasury
-      if value < 0
-         then throwError $ GenesisCmdNegativeInitialFunds value
-         else pure $ fromInteger value
+      when (value < 0) $ throwError $ GenesisCmdNegativeInitialFunds value
+      pure $ fromInteger value
 
     nUtxoAddrsNonDeleg  = length utxoAddrsNonDeleg
     maximumLovelaceSupply :: Word64

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/CreateTestnetData.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/CreateTestnetData.hs
@@ -622,7 +622,8 @@ updateOutputTemplate
     totalSupply = fromIntegral $ maybe maximumLovelaceSupply unLovelace mTotalSupply
 
     delegCoinRaw, nonDelegCoinRaw :: Integer
-    delegCoinRaw = case mDelegatedSupply of Nothing -> 0; Just (Lovelace amountDeleg) -> totalSupply - amountDeleg
+    delegCoinRaw = maybe 0 unLovelace mDelegatedSupply
+    -- Since the user can specify total supply and delegated amount, the non-delegated amount is:
     nonDelegCoinRaw = totalSupply - delegCoinRaw
 
     distribute :: Natural -> Int -> [AddressInEra ShelleyEra] -> [(AddressInEra ShelleyEra, Lovelace)]

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/CreateTestnetData.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/CreateTestnetData.hs
@@ -10,8 +10,6 @@ import           Control.Concurrent (newQSem)
 import           Control.Concurrent.QSem (QSem)
 import           Control.Monad
 import           Control.Monad.IO.Class
-import qualified Data.Aeson as Aeson
-import qualified Data.ByteString.Lazy as LBS
 import           Data.List (intercalate, sort)
 import qualified Data.ListMap as ListMap
 import qualified Data.Sequence.Strict as Seq
@@ -117,8 +115,7 @@ golden_create_testnet_data mShelleyTemplate =
     bracketSem createTestnetDataOutSem $
       H.diffVsGoldenFile generated'' "test/cardano-cli-golden/files/golden/conway/create-testnet-data.out"
 
-    bs <- liftIO $ LBS.readFile $ outputDir </> "genesis.json"
-    genesis :: ShelleyGenesis StandardCrypto <- Aeson.throwDecode bs
+    genesis :: ShelleyGenesis StandardCrypto <- H.readJsonFileOk $ outputDir </> "genesis.json"
 
     sgNetworkMagic genesis H.=== networkMagic
     length (L.sgsPools $ sgStaking genesis) H.=== numPools
@@ -164,8 +161,7 @@ hprop_golden_create_testnet_data_deleg_non_deleg =
       , "--delegated-supply", show delegatedSupply
       , "--out-dir", outputDir]
 
-    bs <- liftIO $ LBS.readFile $ outputDir </> "genesis.json"
-    genesis :: ShelleyGenesis StandardCrypto <- Aeson.throwDecode bs
+    genesis :: ShelleyGenesis StandardCrypto <- H.readJsonFileOk $ outputDir </> "genesis.json"
 
     -- Because we don't test this elsewhere in this file:
     (L.sgMaxLovelaceSupply genesis) H.=== (fromIntegral totalSupply)

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/CreateTestnetData.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/CreateTestnetData.hs
@@ -39,6 +39,8 @@ hprop_create_testnet_data_minimal =
       ]
     success
 
+-- Execute this test with:
+-- @cabal test cardano-cli-test --test-options '-p "/create testnet data create nonegative supply/"'@
 hprop_create_testnet_data_create_nonegative_supply :: Property
 hprop_create_testnet_data_create_nonegative_supply = do
   -- FIXME rewrite this as a property test
@@ -46,7 +48,8 @@ hprop_create_testnet_data_create_nonegative_supply = do
         [ -- (total supply, delegated supply, exit code)
           (2_000_000_000, 1_000_000_000, ExitSuccess)
         , (1_100_000_000, 1_000_000_000, ExitSuccess)
-        , (1_000_000_000, 1_000_000_000, ExitFailure 1)
+        , (1_000_000_000, 1_000_000_000, ExitSuccess)
+        , (1_000_000_000, 1_100_000_001, ExitFailure 1)
         , (1_000_000_000, 2_000_000_000, ExitFailure 1)
         ] :: [(Int, Int, ExitCode)]
 


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    create-testnet-data: fixes that amount of delegated coins was incorrect
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Fixes https://github.com/IntersectMBO/cardano-cli/issues/631

# How to trust this PR

1. Run the new test (`cabal test cardano-cli-golden --test-options '-p "/golden create testnet data deleg non deleg/"'`) before the fix, witness the test fails
2. Run the test on the head of this PR. Enjoy the passing test.
3. Tested on `cardano-node` locally
4. Tested CI on `cardano-node`: https://github.com/IntersectMBO/cardano-node/pull/5712

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [X] Self-reviewed the diff