### PR TITLE
Extend committee `create-hot-key-authorization-certificate` to support scripts

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -14,7 +14,7 @@ repository cardano-haskell-packages
 -- you need to run if you change them
 index-state:
   , hackage.haskell.org 2024-03-05T09:38:08Z
-  , cardano-haskell-packages 2024-03-14T09:14:40Z
+  , cardano-haskell-packages 2024-03-15T13:35:00Z
 
 packages:
   cardano-cli

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -196,7 +196,7 @@ library
                       , binary
                       , bytestring
                       , canonical-json
-                      , cardano-api ^>= 8.40.0.0
+                      , cardano-api ^>= 8.41.0.0
                       , cardano-binary
                       , cardano-crypto
                       , cardano-crypto-class ^>= 2.1.2

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/Committee.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/Committee.hs
@@ -52,8 +52,8 @@ data GovernanceCommitteeKeyHashCmdArgs era =
 data GovernanceCommitteeCreateHotKeyAuthorizationCertificateCmdArgs era =
   GovernanceCommitteeCreateHotKeyAuthorizationCertificateCmdArgs
     { eon               :: !(ConwayEraOnwards era)
-    , vkeyColdKeySource :: !(VerificationKeyOrHashOrFile CommitteeColdKey)
-    , vkeyHotKeySource  :: !(VerificationKeyOrHashOrFile CommitteeHotKey)
+    , vkeyColdKeySource :: !(VerificationKeyOrHashOrFileOrScript CommitteeColdKey)
+    , vkeyHotKeySource  :: !(VerificationKeyOrHashOrFileOrScript CommitteeHotKey)
     , outFile           :: !(File () Out)
     } deriving Show
 
@@ -66,14 +66,14 @@ data GovernanceCommitteeCreateColdKeyResignationCertificateCmdArgs era =
     } deriving Show
 
 renderGovernanceCommitteeCmds :: GovernanceCommitteeCmds era -> Text
-renderGovernanceCommitteeCmds = \case
+renderGovernanceCommitteeCmds = ("governance committee " <>) . \case
   GovernanceCommitteeKeyGenColdCmd {} ->
-    "governance committee key-gen-cold"
+    "key-gen-cold"
   GovernanceCommitteeKeyGenHotCmd {} ->
-    "governance committee key-gen-hot"
+    "key-gen-hot"
   GovernanceCommitteeKeyHashCmd {} ->
-    "governance committee key-hash"
+    "key-hash"
   GovernanceCommitteeCreateHotKeyAuthorizationCertificateCmd {} ->
-    "governance committee create-hot-key-authorization-certificate"
+    "create-hot-key-authorization-certificate"
   GovernanceCommitteeCreateColdKeyResignationCertificateCmd {} ->
-    "governance committee create-cold-key-resignation-certificate"
+    "create-cold-key-resignation-certificate"

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
@@ -241,7 +241,7 @@ pStakeVerificationKeyOrFile prefix =
 
 pScriptFor :: String -> Maybe String -> String -> Parser ScriptFile
 pScriptFor name Nothing help' =
-  fmap ScriptFile $ Opt.strOption $ mconcat
+  fmap File $ Opt.strOption $ mconcat
     [ Opt.long name
     , Opt.metavar "FILE"
     , Opt.help help'
@@ -250,7 +250,7 @@ pScriptFor name Nothing help' =
 
 pScriptFor name (Just deprecated) help' =
       pScriptFor name Nothing help'
-  <|> ScriptFile <$> Opt.strOption
+  <|> File <$> Opt.strOption
         (  Opt.long deprecated
         <> Opt.internal
         )

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Committee.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Committee.hs
@@ -11,7 +11,9 @@ import qualified Cardano.Api.Ledger as L
 import           Cardano.CLI.EraBased.Commands.Governance.Committee
 import           Cardano.CLI.EraBased.Options.Common hiding (pAnchorUrl)
 import           Cardano.CLI.Read
+import           Cardano.CLI.Types.Key
 
+import           Data.Foldable (asum)
 import           Options.Applicative (Parser)
 import qualified Options.Applicative as Opt
 
@@ -103,14 +105,23 @@ pGovernanceCommitteeCreateHotKeyAuthorizationCertificateCmd era = do
     $ Opt.info
         ( fmap GovernanceCommitteeCreateHotKeyAuthorizationCertificateCmd $
             GovernanceCommitteeCreateHotKeyAuthorizationCertificateCmdArgs w
-              <$> pCommitteeColdVerificationKeyOrHashOrFile
-              <*> pCommitteeHotKeyOrHashOrFile
+              <$> pColdVerificationKeyOrHashOrFileOrScript
+              <*> pHotVerificationKeyOrHashOrFileOrScript
               <*> pOutputFile
         )
     $ Opt.progDesc
     $ mconcat
         [ "Create hot key authorization certificate for a Constitutional Committee Member"
         ]
+  where
+    pColdVerificationKeyOrHashOrFileOrScript = asum
+      [ VkhfsKeyHashFile <$> pCommitteeColdVerificationKeyOrHashOrFile
+      , VkhfsScript <$> pScriptFor "cold-script-file" Nothing "Cold Native or Plutus script file"
+      ]
+    pHotVerificationKeyOrHashOrFileOrScript = asum
+      [ VkhfsKeyHashFile <$> pCommitteeHotKeyOrHashOrFile
+      , VkhfsScript <$> pScriptFor "hot-script-file" Nothing "Hot Native or Plutus script file"
+      ]
 
 pGovernanceCommitteeCreateColdKeyResignationCertificateCmd :: ()
   => CardanoEra era

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Address.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Address.hs
@@ -171,7 +171,7 @@ runAddressBuildCmd paymentVerifier mbStakeVerifier nw mOutFp = do
           left $ AddressCmdExpectedPaymentVerificationKey nonPaymentKey
       return $ serialiseAddress (addr :: AddressAny)
 
-    PaymentVerifierScriptFile (ScriptFile fp) -> do
+    PaymentVerifierScriptFile (File fp) -> do
       ScriptInAnyLang _lang script <-
         firstExceptT AddressCmdReadScriptFileError $
           readFileScriptInAnyLang fp
@@ -199,7 +199,7 @@ makeStakeAddressRef stakeIdentifier =
 
           return . StakeAddressByValue $ StakeCredentialByKey stakeVKeyHash
 
-        StakeVerifierScriptFile (ScriptFile fp) -> do
+        StakeVerifierScriptFile (File fp) -> do
           ScriptInAnyLang _lang script <-
             firstExceptT AddressCmdReadScriptFileError $
               readFileScriptInAnyLang fp

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/DRep.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/DRep.hs
@@ -16,7 +16,6 @@ module Cardano.CLI.EraBased.Run.Governance.DRep
 
 import           Cardano.Api
 import           Cardano.Api.Ledger (Credential (KeyHashObj))
-import qualified Cardano.Api.Ledger as L
 import           Cardano.Api.Shelley
 
 import qualified Cardano.CLI.EraBased.Commands.Governance.DRep as Cmd
@@ -111,16 +110,7 @@ runGovernanceDRepRegistrationCertificateCmd
       , outFile
       } =
   conwayEraOnwardsConstraints w $ do
-    drepCred <-
-      case drepHashSource of
-        DRepHashSourceScript (ScriptHash scriptHash) ->
-          return $ L.ScriptHashObj scriptHash
-        DRepHashSourceVerificationKey drepVkeyHashSource -> do
-          DRepKeyHash drepKeyHash <-
-            firstExceptT RegistrationReadError
-              . newExceptT
-              $ readVerificationKeyOrHashOrFile AsDRepKey drepVkeyHashSource
-          return $ L.KeyHashObj $ conwayEraOnwardsConstraints w drepKeyHash
+    drepCred <- modifyError RegistrationReadError $ readDRepCredential drepHashSource
     let req = DRepRegistrationRequirements w drepCred deposit
         registrationCert = makeDrepRegistrationCertificate req mAnchor
         description = Just @TextEnvelopeDescr "DRep Key Registration Certificate"

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Hash.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Hash.hs
@@ -7,8 +7,6 @@
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-{- HLINT ignore "Use let" -}
-
 module Cardano.CLI.EraBased.Run.Governance.Hash
   ( runGovernanceHashCmds
   ) where
@@ -18,7 +16,6 @@ import qualified Cardano.Api.Ledger as L
 
 import qualified Cardano.CLI.EraBased.Commands.Governance.Hash as Cmd
 import           Cardano.CLI.Read
-import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Errors.CmdError
 import           Cardano.CLI.Types.Errors.GovernanceCmdError
 import           Cardano.CLI.Types.Errors.GovernanceHashError
@@ -71,12 +68,11 @@ runGovernanceHashAnchorDataCmd Cmd.GovernanceHashAnchorDataCmdArgs { toHash, mou
 runGovernanceHashScriptCmd :: ()
   => Cmd.GovernanceHashScriptCmdArgs era
   -> ExceptT GovernanceHashError IO ()
-runGovernanceHashScriptCmd Cmd.GovernanceHashScriptCmdArgs { Cmd.toHash = ScriptFile toHash, moutFile } = do
+runGovernanceHashScriptCmd Cmd.GovernanceHashScriptCmdArgs { Cmd.toHash = File toHash, moutFile } = do
   ScriptInAnyLang _ script <-
     readFileScriptInAnyLang toHash
       & firstExceptT (GovernanceHashReadScriptError toHash)
   firstExceptT GovernanceHashWriteFileError
     . newExceptT
     . writeTextOutput moutFile . serialiseToRawBytesHexText $ hashScript script
-
 

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Transaction.hs
@@ -151,7 +151,7 @@ runTransactionBuildCmd
     readTxMetadata eon metadataSchema metadataFiles
   valuesWithScriptWits <- readValueScriptWitnesses eon $ fromMaybe mempty mValue
   scripts <- firstExceptT TxCmdScriptFileError $
-    mapM (readFileScriptInAnyLang . unScriptFile) scriptFiles
+    mapM (readFileScriptInAnyLang . unFile) scriptFiles
   txAuxScripts <- hoistEither $ first TxCmdAuxScriptsValidationError $ validateTxAuxScripts eon scripts
 
   mProp <- case mfUpdateProposalFile of
@@ -288,7 +288,7 @@ runTransactionBuildRawCmd
                   . newExceptT $ readTxMetadata eon metadataSchema metadataFiles
   valuesWithScriptWits <- readValueScriptWitnesses eon $ fromMaybe mempty mValue
   scripts <- firstExceptT TxCmdScriptFileError $
-                     mapM (readFileScriptInAnyLang . unScriptFile) scriptFiles
+                     mapM (readFileScriptInAnyLang . unFile) scriptFiles
   txAuxScripts <- hoistEither $ first TxCmdAuxScriptsValidationError $ validateTxAuxScripts eon scripts
 
   -- TODO: Conway era - update readProtocolParameters to rely on L.PParams JSON instances
@@ -1077,7 +1077,7 @@ runTransactionPolicyIdCmd :: ()
   -> ExceptT TxCmdError IO ()
 runTransactionPolicyIdCmd
     Cmd.TransactionPolicyIdCmdArgs
-      { scriptFile = ScriptFile sFile
+      { scriptFile = File sFile
       } = do
   ScriptInAnyLang _ script <- firstExceptT TxCmdScriptFileError $
                                 readFileScriptInAnyLang sFile

--- a/cardano-cli/src/Cardano/CLI/Types/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Common.hs
@@ -49,7 +49,7 @@ module Cardano.CLI.Types.Common
   , RequiredSigner (..)
   , ScriptDataOrFile (..)
   , ScriptDatumOrFile (..)
-  , ScriptFile (..)
+  , ScriptFile
   , ScriptRedeemerOrFile
   , ScriptWitnessFiles (..)
   , SigningKeyFile
@@ -82,7 +82,7 @@ module Cardano.CLI.Types.Common
   , DRepMetadataFile
   ) where
 
-import           Cardano.Api
+import           Cardano.Api hiding (Script)
 import qualified Cardano.Api.Ledger as L
 
 import qualified Cardano.Chain.Slotting as Byron
@@ -322,8 +322,7 @@ newtype UpdateProposalFile = UpdateProposalFile { unUpdateProposalFile :: FilePa
 
 type VerificationKeyFile = File (VerificationKey ())
 
-newtype ScriptFile = ScriptFile { unScriptFile :: FilePath }
-                     deriving (Eq, Show)
+type ScriptFile = File ScriptInAnyLang In
 
 data ScriptDataOrFile = ScriptDataCborFile  FilePath   -- ^ By reference to a CBOR file
                       | ScriptDataJsonFile  FilePath   -- ^ By reference to a JSON file

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/GovernanceCommitteeError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/GovernanceCommitteeError.hs
@@ -6,9 +6,12 @@ module Cardano.CLI.Types.Errors.GovernanceCommitteeError
 
 import           Cardano.Api
 
+import           Cardano.CLI.Types.Errors.ScriptDecodeError
+
 data GovernanceCommitteeError
   = GovernanceCommitteeCmdKeyDecodeError InputDecodeError
   | GovernanceCommitteeCmdKeyReadError (FileError InputDecodeError)
+  | GovernanceCommitteeCmdScriptReadError (FileError ScriptDecodeError)
   | GovernanceCommitteeCmdTextEnvReadFileError (FileError TextEnvelopeError)
   | GovernanceCommitteeCmdTextEnvWriteError (FileError ())
   | GovernanceCommitteeCmdWriteFileError (FileError ())
@@ -26,3 +29,5 @@ instance Error GovernanceCommitteeError where
       "Cannot read text envelope file: " <> prettyError e
     GovernanceCommitteeCmdTextEnvWriteError e ->
       "Cannot write text envelope file: " <> prettyError e
+    GovernanceCommitteeCmdScriptReadError e ->
+      "Cannot read script file: " <> prettyError e

--- a/cardano-cli/src/Cardano/CLI/Types/Key/VerificationKey.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Key/VerificationKey.hs
@@ -21,3 +21,4 @@ data AnyVerificationKeySource
   = AnyVerificationKeySourceOfText !AnyVerificationKeyText
   | AnyVerificationKeySourceOfFile !(File (VerificationKey ()) In)
   deriving (Eq, Show)
+

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -6361,10 +6361,12 @@ Usage: cardano-cli conway governance committee create-hot-key-authorization-cert
                                                                                           ( --cold-verification-key STRING
                                                                                           | --cold-verification-key-file FILE
                                                                                           | --cold-verification-key-hash STRING
+                                                                                          | --cold-script-file FILE
                                                                                           )
                                                                                           ( --hot-key STRING
                                                                                           | --hot-key-file FILE
                                                                                           | --hot-key-hash STRING
+                                                                                          | --hot-script-file FILE
                                                                                           )
                                                                                           --out-file FILE
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_committee_create-hot-key-authorization-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_committee_create-hot-key-authorization-certificate.cli
@@ -2,10 +2,12 @@ Usage: cardano-cli conway governance committee create-hot-key-authorization-cert
                                                                                           ( --cold-verification-key STRING
                                                                                           | --cold-verification-key-file FILE
                                                                                           | --cold-verification-key-hash STRING
+                                                                                          | --cold-script-file FILE
                                                                                           )
                                                                                           ( --hot-key STRING
                                                                                           | --hot-key-file FILE
                                                                                           | --hot-key-hash STRING
+                                                                                          | --hot-script-file FILE
                                                                                           )
                                                                                           --out-file FILE
 
@@ -18,8 +20,10 @@ Available options:
                            Filepath of the Consitutional Committee cold key.
   --cold-verification-key-hash STRING
                            Constitutional Committee key hash (hex-encoded).
+  --cold-script-file FILE  Cold Native or Plutus script file
   --hot-key STRING         Constitutional Committee hot key (hex-encoded).
   --hot-key-file FILE      Filepath of the Consitutional Committee hot key.
   --hot-key-hash STRING    Constitutional Committee key hash (hex-encoded).
+  --hot-script-file FILE   Hot Native or Plutus script file
   --out-file FILE          The output file.
   -h,--help                Show this help text

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1710408447,
-        "narHash": "sha256-zfERQOTVkZp4DDIrRE6V5xLMd5DRnXEdRn89WlLEJvI=",
+        "lastModified": 1710510430,
+        "narHash": "sha256-bP8YcyEXUQKvNmwrGHfPmkZLiToTPpDPeousn9crTmQ=",
         "owner": "input-output-hk",
         "repo": "cardano-haskell-packages",
-        "rev": "37b94f464b015f4f5857c7c20f82347cb5f79af9",
+        "rev": "19c85340ad39f68b443d145192b0f10834633dc3",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Extend committee `create-hot-key-authorization-certificate` to support scripts
# uncomment types applicable to the change:
  type:
   - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
   - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
   - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Requires:
* https://github.com/IntersectMBO/cardano-api/pull/476

# How to trust this PR

Trust no one.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
