### PR TITLE
create-testnet-data: fix that treasury could be unexpectedly negative

### DIFF
--- a/cardano-cli/src/Cardano/CLI/Types/Errors/GenesisCmdError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/GenesisCmdError.hs
@@ -39,7 +39,7 @@ data GenesisCmdError
   | GenesisCmdStakePoolRelayFileError !FilePath !IOException
   | GenesisCmdStakePoolRelayJsonDecodeError !FilePath !String
   | GenesisCmdFileInputDecodeError !(FileError InputDecodeError)
-  | GenesisCmdNegativeInitialFunds !Integer -- ^ total supply underflow
+  | GenesisCmdDelegatedSupplyExceedsTotalSupply !Integer !Integer -- ^ First @Integer@ is the delegate supply, second @Integer@ is the total supply
   deriving Show
 
 instance Error GenesisCmdError where
@@ -101,5 +101,7 @@ instance Error GenesisCmdError where
       " Error: " <> pretty e
     GenesisCmdFileInputDecodeError ide ->
       "Error occured while decoding a file: " <> pshow ide
-    GenesisCmdNegativeInitialFunds underflow ->
-      "Provided delegated supply value results in negative initial funds. Decrease delegated amount by " <> pretty ((-1) * underflow) <> " or increase total supply by it."
+    GenesisCmdDelegatedSupplyExceedsTotalSupply delegated total ->
+      "Provided delegated supply is " <> pretty delegated <> ", which is greater than the specified total supply: " <> pretty total <> "." <>
+      "This is incorrect: the delegated supply should be less or equal to the total supply." <>
+      " Note that the total supply can either come from --total-supply or from the default template. Please fix what you use."

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/CreateTestnetData.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/CreateTestnetData.hs
@@ -8,6 +8,7 @@ module Test.Cli.CreateTestnetData where
 
 import           Control.Monad
 import           Data.Aeson (FromJSON, ToJSON)
+import           Data.List (isInfixOf)
 import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as M
 import           Data.Text (Text)
@@ -50,6 +51,7 @@ hprop_create_testnet_data_create_nonegative_supply = do
         , (1_100_000_000, 1_000_000_000, ExitSuccess)
         , (1_000_000_000, 1_000_000_000, ExitSuccess)
         , (1_000_000_000_000, 1_000_000_000, ExitSuccess)
+        , (1_000_000_000, 1_000_000_001, ExitFailure 1)
         , (1_000_000_000, 1_100_000_001, ExitFailure 1)
         , (1_000_000_000, 2_000_000_000, ExitFailure 1)
         ] :: [(Int, Int, ExitCode)]
@@ -58,7 +60,7 @@ hprop_create_testnet_data_create_nonegative_supply = do
     moduleWorkspace "tmp" $ \tempDir -> do
       let outputDir = tempDir </> "out"
 
-      (exitCode, _, _) <- H.noteShowM $ execDetailCardanoCLI
+      (exitCode, _stdout, stderr) <- H.noteShowM $ execDetailCardanoCLI
         ["conway",  "genesis", "create-testnet-data"
         , "--testnet-magic", "42"
         , "--pools", "3"
@@ -73,7 +75,8 @@ hprop_create_testnet_data_create_nonegative_supply = do
       H.note_ "check that exit code is equal to the expected one"
       exitCode === expectedExitCode
 
-      when (exitCode == ExitSuccess) $ do
+      if exitCode == ExitSuccess
+      then do
         testGenesis@TestGenesis{maxLovelaceSupply, initialFunds} <- H.leftFailM . H.readJsonFile $ outputDir </> "genesis.json"
         H.note_ $ show testGenesis
 
@@ -87,6 +90,11 @@ hprop_create_testnet_data_create_nonegative_supply = do
         H.assertWith initialFunds $ \initialFunds' -> do
           let totalDistributed = sum . M.elems $ initialFunds'
           totalDistributed <= maxLovelaceSupply
+      else do
+        H.assertWith stderr (`contains` "delegated supply should be less or equal to the total supply")
+  where
+    contains s1 s2 = s2 `isInfixOf` s1
+
 
 data TestGenesis = TestGenesis
   { maxLovelaceSupply :: Int

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/CreateTestnetData.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/CreateTestnetData.hs
@@ -49,6 +49,7 @@ hprop_create_testnet_data_create_nonegative_supply = do
           (2_000_000_000, 1_000_000_000, ExitSuccess)
         , (1_100_000_000, 1_000_000_000, ExitSuccess)
         , (1_000_000_000, 1_000_000_000, ExitSuccess)
+        , (1_000_000_000_000, 1_000_000_000, ExitSuccess)
         , (1_000_000_000, 1_100_000_001, ExitFailure 1)
         , (1_000_000_000, 2_000_000_000, ExitFailure 1)
         ] :: [(Int, Int, ExitCode)]


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    create-testnet-data: fix that treasury could be unexpectedly negative
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - improvement    # QoL changes e.g. refactoring
  - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Fixes https://github.com/IntersectMBO/cardano-cli/issues/643

# How to trust this PR

I wanted to test that `cabal test cardano-testnet` passed on `cardano-node`,  using this version of `cardano-cli`; but it's not easy to do right now. Still I think this is safe.

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [X] Self-reviewed the diff