### PR TITLE
Make cardano `create-testnet-data` register DReps and delegate stake delegators to them

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -14,7 +14,7 @@ repository cardano-haskell-packages
 -- you need to run if you change them
 index-state:
   , hackage.haskell.org 2024-03-05T09:38:08Z
-  , cardano-haskell-packages 2024-03-15T13:35:00Z
+  , cardano-haskell-packages 2024-03-15T18:07:40Z
 
 packages:
   cardano-cli

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Genesis.hs
@@ -85,11 +85,13 @@ data GenesisCreateStakedCmdArgs = GenesisCreateStakedCmdArgs
   } deriving Show
 
 data GenesisCreateTestNetDataCmdArgs = GenesisCreateTestNetDataCmdArgs
-  { specShelley :: !(Maybe FilePath) -- ^ Path to the @genesis-shelley@ file to use. If unspecified, a default one will be used if omitted.
+  { specShelley :: !(Maybe FilePath) -- ^ Path to the @genesis-shelley@ file to use. If unspecified, a default one will be used.
+  , specAlonzo :: !(Maybe FilePath) -- ^ Path to the @genesis-alonzo@ file to use. If unspecified, a default one will be used.
+  , specConway :: !(Maybe FilePath) -- ^ Path to the @genesis-conway@ file to use. If unspecified, a default one will be used.
   , numGenesisKeys :: !Word -- ^ The number of genesis keys credentials to create and write to disk.
   , numPools :: !Word -- ^ The number of stake pools credentials to create and write to disk.
-  , stakeDelegators :: !StakeDelegators -- ^ The number of delegators to pools to create.
-  , numDrepKeys :: !Word -- ^ The number of DRep keys to create. Right now they receive neither delegation nor are registrated. This will come later.
+  , stakeDelegators :: !StakeDelegators -- ^ The number of delegators to pools and DReps to create.
+  , numDRepKeys :: !DRepCredentials -- ^ The number of DRep keys to create. They are registered and get delegated to by stake delegators
   , numStuffedUtxo :: !Word -- ^ The number of UTxO accounts to make. They are "stuffed" because the credentials are not written to disk.
   , numUtxoKeys :: !Word -- ^ The number of UTxO credentials to create and write to disk.
   , totalSupply :: !(Maybe Coin) -- ^ The total number of Lovelace

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Genesis.hs
@@ -213,6 +213,8 @@ pGenesisCreateTestNetData :: EnvCli -> Parser (GenesisCmds era)
 pGenesisCreateTestNetData envCli =
   fmap GenesisCreateTestNetData $ GenesisCreateTestNetDataCmdArgs
     <$> (optional $ pSpecFile "shelley")
+    <*> (optional $ pSpecFile "alonzo")
+    <*> (optional $ pSpecFile "conway")
     <*> pNumGenesisKeys
     <*> pNumPools
     <*> pNumStakeDelegs
@@ -245,27 +247,32 @@ pGenesisCreateTestNetData envCli =
         , Opt.help "The number of stake pool credential sets to make (default is 0)."
         , Opt.value 0
         ]
-    pNumDReps :: Parser Word
+    pNumDReps :: Parser DRepCredentials
     pNumDReps =
-      Opt.option Opt.auto $ mconcat
-        [ Opt.long "drep-keys"
-        , Opt.metavar "INT"
-        , Opt.help "The number of DRep credentials to make (default is 0)."
-        , Opt.value 0
-        ]
+          pDReps OnDisk "drep-keys" "Credentials are written to disk."
+      <|> pDReps Transient "transient-drep-keys" "The credentials are NOT written to disk."
+      where
+        pDReps :: CredentialGenerationMode -> String -> String -> Parser DRepCredentials
+        pDReps mode modeOptionName modeExplanation =
+          DRepCredentials mode <$>
+              (Opt.option Opt.auto $ mconcat
+                 [ Opt.long modeOptionName
+                 , Opt.help $ "The number of DRep credentials to make (default is 0). " <> modeExplanation
+                 , Opt.metavar "INT", Opt.value 0
+                 ])
     pNumStakeDelegs :: Parser StakeDelegators
     pNumStakeDelegs =
-      pNumOnDiskStakeDelegators <|> pNumTransientStakeDelegs
+          pStakeDelegators OnDisk "stake-delegators" "Credentials are written to disk."
+      <|> pStakeDelegators Transient "transient-stake-delegators" "The credentials are NOT written to disk."
       where
-        pNumOnDiskStakeDelegators = fmap OnDisk $ Opt.option Opt.auto $ mconcat $
-          [ Opt.long "stake-delegators"
-          , Opt.help "The number of stake delegator credential sets to make (default is 0). Credentials are written to disk."
-          ] ++ common
-        pNumTransientStakeDelegs = fmap Transient $ Opt.option Opt.auto $ mconcat $
-          [ Opt.long "transient-stake-delegators"
-          , Opt.help "The number of stake delegator credential sets to make (default is 0). The credentials are NOT written to disk."
-          ] ++ common
-        common = [Opt.metavar "INT", Opt.value 0]
+        pStakeDelegators :: CredentialGenerationMode -> String -> String -> Parser StakeDelegators
+        pStakeDelegators mode modeOptionName modeExplanation =
+          StakeDelegators mode <$>
+              (Opt.option Opt.auto $ mconcat
+                 [ Opt.long modeOptionName
+                 , Opt.help $ "The number of stake delegator credential sets to make (default is 0). " <> modeExplanation
+                 , Opt.metavar "INT", Opt.value 0
+                 ])
     pNumStuffedUtxoCount :: Parser Word
     pNumStuffedUtxoCount =
       Opt.option Opt.auto $ mconcat

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Genesis.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE TypeApplications #-}
@@ -404,11 +405,11 @@ runGenesisCreateCardanoCmd
       , sgSecurityParam = unBlockCount security
       , sgUpdateQuorum = fromIntegral $ ((numGenesisKeys `div` 3) * 2) + 1
       , sgEpochLength = EpochSize $ floor $ (fromIntegral (unBlockCount security) * 10) / slotCoeff
-      , sgMaxLovelaceSupply = 45000000000000000
+      , sgMaxLovelaceSupply = 45_000_000_000_000_000
       , sgSystemStart = getSystemStart start
       , sgSlotLength = L.secondsToNominalDiffTimeMicro $ MkFixed (fromIntegral slotLength) * 1000
       }
-  shelleyGenesisTemplate' <- liftIO $ overrideShelleyGenesis . fromRight (error "shelley genesis template not found") <$> TN.readAndDecodeShelleyGenesis shelleyGenesisTemplate
+  shelleyGenesisTemplate' <- liftIO $ overrideShelleyGenesis . fromRight (error "shelley genesis template not found") <$> TN.readAndDecodeGenesisFile shelleyGenesisTemplate
   alonzoGenesis <- readAlonzoGenesis alonzoGenesisTemplate
   conwayGenesis <- readConwayGenesis conwayGenesisTemplate
   (delegateMap, vrfKeys, kesKeys, opCerts) <- liftIO $ generateShelleyNodeSecrets shelleyDelegateKeys shelleyGenesisvkeys
@@ -782,7 +783,7 @@ createPoolCredentials fmt dir index = do
         (KESPeriod 0)
         (File $ dir </> "opcert" ++ strIndex ++ ".cert")
   firstExceptT GenesisCmdStakeAddressCmdError $
-    runStakeAddressKeyGenCmd
+    void $ runStakeAddressKeyGenCmd
         fmt
         (File @(VerificationKey ()) $ dir </> "staking-reward" ++ strIndex ++ ".vkey")
         (File @(SigningKey ()) $ dir </> "staking-reward" ++ strIndex ++ ".skey")
@@ -897,7 +898,7 @@ readShelleyGenesisWithDefault
   -> (ShelleyGenesis L.StandardCrypto -> ShelleyGenesis L.StandardCrypto)
   -> ExceptT GenesisCmdError IO (ShelleyGenesis L.StandardCrypto)
 readShelleyGenesisWithDefault fpath adjustDefaults = do
-    newExceptT (TN.readAndDecodeShelleyGenesis fpath)
+    newExceptT (TN.readAndDecodeGenesisFile fpath)
       `catchError` \err ->
         case err of
           GenesisCmdGenesisFileReadError (FileIOError _ ioe)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Query.hs
@@ -44,7 +44,7 @@ import qualified Cardano.Api.Ledger as L
 import           Cardano.Api.Shelley hiding (QueryInShelleyBasedEra (..))
 
 import qualified Cardano.CLI.EraBased.Commands.Query as Cmd
-import           Cardano.CLI.EraBased.Run.CreateTestnetData (readAndDecodeShelleyGenesis)
+import           Cardano.CLI.EraBased.Run.CreateTestnetData (readAndDecodeGenesisFile)
 import           Cardano.CLI.Helpers
 import           Cardano.CLI.Read
 import           Cardano.CLI.Types.Common
@@ -1229,7 +1229,7 @@ runQueryLeadershipScheduleCmd
   vrkSkey <- lift (readFileTextEnvelope (AsSigningKey AsVrfKey) vrkSkeyFp)
     & onLeft (left . QueryCmdTextEnvelopeReadError)
 
-  shelleyGenesis <- lift (readAndDecodeShelleyGenesis genFile)
+  shelleyGenesis <- lift (readAndDecodeGenesisFile @(ShelleyGenesis StandardCrypto) genFile)
     & onLeft (left . QueryCmdGenesisReadError)
 
   join $ lift

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/StakeAddress.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/StakeAddress.hs
@@ -31,6 +31,7 @@ import           Cardano.CLI.Types.Errors.StakeAddressRegistrationError
 import           Cardano.CLI.Types.Governance
 import           Cardano.CLI.Types.Key
 
+import           Control.Monad (void)
 import qualified Data.ByteString.Char8 as BS
 import           Data.Function ((&))
 import qualified Data.Text.IO as Text
@@ -40,7 +41,7 @@ runStakeAddressCmds :: ()
   -> ExceptT StakeAddressCmdError IO ()
 runStakeAddressCmds = \case
   StakeAddressKeyGenCmd _ fmt vk sk ->
-    runStakeAddressKeyGenCmd fmt vk sk
+    void $ runStakeAddressKeyGenCmd fmt vk sk
   StakeAddressKeyHashCmd _ vk mOutputFp ->
     runStakeAddressKeyHashCmd vk mOutputFp
   StakeAddressBuildCmd _ stakeVerifier nw mOutputFp ->
@@ -60,7 +61,7 @@ runStakeAddressKeyGenCmd :: ()
   => KeyOutputFormat
   -> VerificationKeyFile Out
   -> SigningKeyFile Out
-  -> ExceptT StakeAddressCmdError IO ()
+  -> ExceptT StakeAddressCmdError IO (VerificationKey StakeKey, SigningKey StakeKey)
 runStakeAddressKeyGenCmd fmt vkFp skFp = do
   let skeyDesc = "Stake Signing Key"
 
@@ -80,6 +81,7 @@ runStakeAddressKeyGenCmd fmt vkFp skFp = do
         newExceptT $ writeLazyByteStringFile vkFp $ textEnvelopeToJSON (Just Key.stakeVkeyDesc) vkey
       KeyOutputFormatBech32 ->
         newExceptT $ writeTextFile vkFp $ serialiseToBech32 vkey
+  return (vkey, skey)
 
 runStakeAddressKeyHashCmd :: ()
   => VerificationKeyOrFile StakeKey

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/StakeAddress.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/StakeAddress.hs
@@ -15,6 +15,8 @@ import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Errors.StakeAddressCmdError
 import           Cardano.CLI.Types.Key
 
+import           Control.Monad (void)
+
 runLegacyStakeAddressCmds :: ()
   => LegacyStakeAddressCmds
   -> ExceptT StakeAddressCmdError IO ()
@@ -37,8 +39,8 @@ runLegacyStakeAddressKeyGenCmd :: ()
   -> VerificationKeyFile Out
   -> SigningKeyFile Out
   -> ExceptT StakeAddressCmdError IO ()
-runLegacyStakeAddressKeyGenCmd =
-  runStakeAddressKeyGenCmd
+runLegacyStakeAddressKeyGenCmd vk sk =
+  void <$> runStakeAddressKeyGenCmd vk sk
 
 runLegacyStakeAddressKeyHashCmd :: ()
   => VerificationKeyOrFile StakeKey

--- a/cardano-cli/src/Cardano/CLI/Types/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Common.hs
@@ -18,7 +18,9 @@ module Cardano.CLI.Types.Common
   , ConstitutionHashSource(..)
   , ConstitutionText(..)
   , ConstitutionUrl(..)
+  , CredentialGenerationMode(..)
   , CurrentKesPeriod (..)
+  , DRepCredentials (..)
   , EpochLeadershipSchedule (..)
   , File(..)
   , FileDirection (..)
@@ -138,10 +140,20 @@ data VoteHashSource
   | VoteHashSourceHash (L.SafeHash L.StandardCrypto L.AnchorData)
   deriving Show
 
-data StakeDelegators
-  = OnDisk !Word -- ^ The number of credentials to write to disk
-  | Transient !Word -- ^ The number of credentials, that are not written to disk
-  deriving Show
+data StakeDelegators = StakeDelegators
+  { stakeDelegatorsGenerationMode :: !CredentialGenerationMode  -- ^ Whether to write them to disk
+  , numOfStakeDelegators :: !Word -- ^ The number of stake credentials to generate
+  } deriving Show
+
+data DRepCredentials = DRepCredentials
+  { dRepCredentialGenerationMode :: !CredentialGenerationMode  -- ^ Whether to write them to disk
+  , numOfDRepCredentials :: !Word -- ^ The number of DRep credentials to generate
+  } deriving Show
+
+data CredentialGenerationMode
+  = OnDisk -- ^ Write credentials to disk
+  | Transient -- ^ Don't write them to disk (process them in memory)
+  deriving (Show, Eq)
 
 -- | Specify whether to render the script cost as JSON
 -- in the cli's build command.

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Genesis/Create.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Genesis/Create.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE NumericUnderscores #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeApplications #-}
 
@@ -85,7 +86,7 @@ hprop_golden_shelleyGenesisCreate = propertyOnce $ do
 
     fmtStartTime <- fmap H.formatIso8601 $ H.evalIO DT.getCurrentTime
 
-    (supply, fmtSupply) <- fmap (OP.withSnd show) $ forAll $ G.int (R.linear 10000000 4000000000)
+    (supply, fmtSupply) <- fmap (OP.withSnd show) $ forAll $ G.int (R.linear 10_000_000 4_000_000_000)
     (delegateCount, fmtDelegateCount) <- fmap (OP.withSnd show) $ forAll $ G.int (R.linear 4 19)
     (utxoCount, fmtUtxoCount) <- fmap (OP.withSnd show) $ forAll $ G.int (R.linear 4 19)
 
@@ -116,9 +117,9 @@ hprop_golden_shelleyGenesisCreate = propertyOnce $ do
     actualStartTime === fmtStartTime
     actualDelegateCount === delegateCount
     actualDelegateCount === utxoCount
-    actualTotalSupply === supply - 1000000  -- Check that the sum of the initial fund amounts matches the total supply
-                                            -- We don't use the entire supply so there is ada in the treasury. This is
-                                            -- required for stake pool rewards.
+    actualTotalSupply === supply - 1_000_000 -- Check that the sum of the initial fund amounts matches the total supply
+                                             -- We don't use the entire supply so there is ada in the treasury. This is
+                                             -- required for stake pool rewards.
 
     -- Check uniqueness and count of hash keys
     S.size (S.fromList actualHashKeys) === length actualHashKeys -- This isn't strictly necessary because we use aeson which guarantees uniqueness of keys
@@ -157,7 +158,7 @@ hprop_golden_shelleyGenesisCreate = propertyOnce $ do
 
     fmtStartTime <- fmap H.formatIso8601 $ H.evalIO DT.getCurrentTime
 
-    (supply, fmtSupply) <- fmap (OP.withSnd show) $ forAll $ G.int (R.linear 10000000 4000000000)
+    (supply, fmtSupply) <- fmap (OP.withSnd show) $ forAll $ G.int (R.linear 10_000_000 4_000_000_000)
     (delegateCount, fmtDelegateCount) <- fmap (OP.withSnd show) $ forAll $ G.int (R.linear 4 19)
     (utxoCount, fmtUtxoCount) <- fmap (OP.withSnd show) $ forAll $ G.int (R.linear 4 19)
 
@@ -196,7 +197,7 @@ hprop_golden_shelleyGenesisCreate = propertyOnce $ do
     actualStartTime === fmtStartTime
     actualDelegateCount === delegateCount
     actualDelegateCount === utxoCount
-    actualTotalSupply === supply - 1000000  -- Check that the sum of the initial fund amounts matches the total supply
+    actualTotalSupply === supply - 1_000_000  -- Check that the sum of the initial fund amounts matches the total supply
                                             -- We don't use the entire supply so there is ada in the treasury. This is
                                             -- required for stake pool rewards.
     -- Check uniqueness and count of hash keys

--- a/cardano-cli/test/cardano-cli-golden/files/golden/conway/create-testnet-data.out
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/conway/create-testnet-data.out
@@ -1,3 +1,5 @@
+alonzo-genesis.json
+conway-genesis.json
 delegate-keys/README.md
 delegate-keys/delegate1/kes.skey
 delegate-keys/delegate1/kes.vkey
@@ -31,7 +33,6 @@ genesis-keys/genesis1/key.skey
 genesis-keys/genesis1/key.vkey
 genesis-keys/genesis2/key.skey
 genesis-keys/genesis2/key.vkey
-genesis.json
 pools-keys/README.md
 pools-keys/pool1/cold.skey
 pools-keys/pool1/cold.vkey
@@ -53,6 +54,7 @@ pools-keys/pool2/staking-reward.skey
 pools-keys/pool2/staking-reward.vkey
 pools-keys/pool2/vrf.skey
 pools-keys/pool2/vrf.vkey
+shelley-genesis.json
 stake-delegators/delegator1/payment.skey
 stake-delegators/delegator1/payment.vkey
 stake-delegators/delegator1/staking.skey

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -261,12 +261,16 @@ Usage: cardano-cli shelley genesis create-staked [--key-output-format STRING]
   genesis/delegation/spending keys.
 
 Usage: cardano-cli shelley genesis create-testnet-data [--spec-shelley FILE]
+                                                         [--spec-alonzo FILE]
+                                                         [--spec-conway FILE]
                                                          [--genesis-keys INT]
                                                          [--pools INT]
                                                          [ --stake-delegators INT
                                                          | --transient-stake-delegators INT
                                                          ]
-                                                         [--drep-keys INT]
+                                                         [ --drep-keys INT
+                                                         | --transient-drep-keys INT
+                                                         ]
                                                          [--stuffed-utxo INT]
                                                          [--utxo-keys INT]
                                                          [--total-supply LOVELACE]
@@ -1429,12 +1433,16 @@ Usage: cardano-cli allegra genesis create-staked [--key-output-format STRING]
   genesis/delegation/spending keys.
 
 Usage: cardano-cli allegra genesis create-testnet-data [--spec-shelley FILE]
+                                                         [--spec-alonzo FILE]
+                                                         [--spec-conway FILE]
                                                          [--genesis-keys INT]
                                                          [--pools INT]
                                                          [ --stake-delegators INT
                                                          | --transient-stake-delegators INT
                                                          ]
-                                                         [--drep-keys INT]
+                                                         [ --drep-keys INT
+                                                         | --transient-drep-keys INT
+                                                         ]
                                                          [--stuffed-utxo INT]
                                                          [--utxo-keys INT]
                                                          [--total-supply LOVELACE]
@@ -2595,12 +2603,16 @@ Usage: cardano-cli mary genesis create-staked [--key-output-format STRING]
   genesis/delegation/spending keys.
 
 Usage: cardano-cli mary genesis create-testnet-data [--spec-shelley FILE]
+                                                      [--spec-alonzo FILE]
+                                                      [--spec-conway FILE]
                                                       [--genesis-keys INT]
                                                       [--pools INT]
                                                       [ --stake-delegators INT
                                                       | --transient-stake-delegators INT
                                                       ]
-                                                      [--drep-keys INT]
+                                                      [ --drep-keys INT
+                                                      | --transient-drep-keys INT
+                                                      ]
                                                       [--stuffed-utxo INT]
                                                       [--utxo-keys INT]
                                                       [--total-supply LOVELACE]
@@ -3746,12 +3758,16 @@ Usage: cardano-cli alonzo genesis create-staked [--key-output-format STRING]
   genesis/delegation/spending keys.
 
 Usage: cardano-cli alonzo genesis create-testnet-data [--spec-shelley FILE]
+                                                        [--spec-alonzo FILE]
+                                                        [--spec-conway FILE]
                                                         [--genesis-keys INT]
                                                         [--pools INT]
                                                         [ --stake-delegators INT
                                                         | --transient-stake-delegators INT
                                                         ]
-                                                        [--drep-keys INT]
+                                                        [ --drep-keys INT
+                                                        | --transient-drep-keys INT
+                                                        ]
                                                         [--stuffed-utxo INT]
                                                         [--utxo-keys INT]
                                                         [--total-supply LOVELACE]
@@ -4920,12 +4936,16 @@ Usage: cardano-cli babbage genesis create-staked [--key-output-format STRING]
   genesis/delegation/spending keys.
 
 Usage: cardano-cli babbage genesis create-testnet-data [--spec-shelley FILE]
+                                                         [--spec-alonzo FILE]
+                                                         [--spec-conway FILE]
                                                          [--genesis-keys INT]
                                                          [--pools INT]
                                                          [ --stake-delegators INT
                                                          | --transient-stake-delegators INT
                                                          ]
-                                                         [--drep-keys INT]
+                                                         [ --drep-keys INT
+                                                         | --transient-drep-keys INT
+                                                         ]
                                                          [--stuffed-utxo INT]
                                                          [--utxo-keys INT]
                                                          [--total-supply LOVELACE]
@@ -6112,12 +6132,16 @@ Usage: cardano-cli conway genesis create-staked [--key-output-format STRING]
   genesis/delegation/spending keys.
 
 Usage: cardano-cli conway genesis create-testnet-data [--spec-shelley FILE]
+                                                        [--spec-alonzo FILE]
+                                                        [--spec-conway FILE]
                                                         [--genesis-keys INT]
                                                         [--pools INT]
                                                         [ --stake-delegators INT
                                                         | --transient-stake-delegators INT
                                                         ]
-                                                        [--drep-keys INT]
+                                                        [ --drep-keys INT
+                                                        | --transient-drep-keys INT
+                                                        ]
                                                         [--stuffed-utxo INT]
                                                         [--utxo-keys INT]
                                                         [--total-supply LOVELACE]
@@ -7742,12 +7766,16 @@ Usage: cardano-cli latest genesis create-staked [--key-output-format STRING]
   genesis/delegation/spending keys.
 
 Usage: cardano-cli latest genesis create-testnet-data [--spec-shelley FILE]
+                                                        [--spec-alonzo FILE]
+                                                        [--spec-conway FILE]
                                                         [--genesis-keys INT]
                                                         [--pools INT]
                                                         [ --stake-delegators INT
                                                         | --transient-stake-delegators INT
                                                         ]
-                                                        [--drep-keys INT]
+                                                        [ --drep-keys INT
+                                                        | --transient-drep-keys INT
+                                                        ]
                                                         [--stuffed-utxo INT]
                                                         [--utxo-keys INT]
                                                         [--total-supply LOVELACE]

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_genesis_create-testnet-data.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_genesis_create-testnet-data.cli
@@ -1,10 +1,14 @@
 Usage: cardano-cli allegra genesis create-testnet-data [--spec-shelley FILE]
+                                                         [--spec-alonzo FILE]
+                                                         [--spec-conway FILE]
                                                          [--genesis-keys INT]
                                                          [--pools INT]
                                                          [ --stake-delegators INT
                                                          | --transient-stake-delegators INT
                                                          ]
-                                                         [--drep-keys INT]
+                                                         [ --drep-keys INT
+                                                         | --transient-drep-keys INT
+                                                         ]
                                                          [--stuffed-utxo INT]
                                                          [--utxo-keys INT]
                                                          [--total-supply LOVELACE]
@@ -19,6 +23,10 @@ Usage: cardano-cli allegra genesis create-testnet-data [--spec-shelley FILE]
 Available options:
   --spec-shelley FILE      The shelley specification file to use as input. A
                            default one is generated if omitted.
+  --spec-alonzo FILE       The alonzo specification file to use as input. A
+                           default one is generated if omitted.
+  --spec-conway FILE       The conway specification file to use as input. A
+                           default one is generated if omitted.
   --genesis-keys INT       The number of genesis keys to make (default is 3).
   --pools INT              The number of stake pool credential sets to make
                            (default is 0).
@@ -29,7 +37,10 @@ Available options:
                            (default is 0). The credentials are NOT written to
                            disk.
   --drep-keys INT          The number of DRep credentials to make (default is
-                           0).
+                           0). Credentials are written to disk.
+  --transient-drep-keys INT
+                           The number of DRep credentials to make (default is
+                           0). The credentials are NOT written to disk.
   --stuffed-utxo INT       The number of fake UTxO entries to generate (default
                            is 0).
   --utxo-keys INT          The number of UTxO keys to make (default is 0).

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_genesis_create-testnet-data.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_genesis_create-testnet-data.cli
@@ -1,10 +1,14 @@
 Usage: cardano-cli alonzo genesis create-testnet-data [--spec-shelley FILE]
+                                                        [--spec-alonzo FILE]
+                                                        [--spec-conway FILE]
                                                         [--genesis-keys INT]
                                                         [--pools INT]
                                                         [ --stake-delegators INT
                                                         | --transient-stake-delegators INT
                                                         ]
-                                                        [--drep-keys INT]
+                                                        [ --drep-keys INT
+                                                        | --transient-drep-keys INT
+                                                        ]
                                                         [--stuffed-utxo INT]
                                                         [--utxo-keys INT]
                                                         [--total-supply LOVELACE]
@@ -19,6 +23,10 @@ Usage: cardano-cli alonzo genesis create-testnet-data [--spec-shelley FILE]
 Available options:
   --spec-shelley FILE      The shelley specification file to use as input. A
                            default one is generated if omitted.
+  --spec-alonzo FILE       The alonzo specification file to use as input. A
+                           default one is generated if omitted.
+  --spec-conway FILE       The conway specification file to use as input. A
+                           default one is generated if omitted.
   --genesis-keys INT       The number of genesis keys to make (default is 3).
   --pools INT              The number of stake pool credential sets to make
                            (default is 0).
@@ -29,7 +37,10 @@ Available options:
                            (default is 0). The credentials are NOT written to
                            disk.
   --drep-keys INT          The number of DRep credentials to make (default is
-                           0).
+                           0). Credentials are written to disk.
+  --transient-drep-keys INT
+                           The number of DRep credentials to make (default is
+                           0). The credentials are NOT written to disk.
   --stuffed-utxo INT       The number of fake UTxO entries to generate (default
                            is 0).
   --utxo-keys INT          The number of UTxO keys to make (default is 0).

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_genesis_create-testnet-data.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_genesis_create-testnet-data.cli
@@ -1,10 +1,14 @@
 Usage: cardano-cli babbage genesis create-testnet-data [--spec-shelley FILE]
+                                                         [--spec-alonzo FILE]
+                                                         [--spec-conway FILE]
                                                          [--genesis-keys INT]
                                                          [--pools INT]
                                                          [ --stake-delegators INT
                                                          | --transient-stake-delegators INT
                                                          ]
-                                                         [--drep-keys INT]
+                                                         [ --drep-keys INT
+                                                         | --transient-drep-keys INT
+                                                         ]
                                                          [--stuffed-utxo INT]
                                                          [--utxo-keys INT]
                                                          [--total-supply LOVELACE]
@@ -19,6 +23,10 @@ Usage: cardano-cli babbage genesis create-testnet-data [--spec-shelley FILE]
 Available options:
   --spec-shelley FILE      The shelley specification file to use as input. A
                            default one is generated if omitted.
+  --spec-alonzo FILE       The alonzo specification file to use as input. A
+                           default one is generated if omitted.
+  --spec-conway FILE       The conway specification file to use as input. A
+                           default one is generated if omitted.
   --genesis-keys INT       The number of genesis keys to make (default is 3).
   --pools INT              The number of stake pool credential sets to make
                            (default is 0).
@@ -29,7 +37,10 @@ Available options:
                            (default is 0). The credentials are NOT written to
                            disk.
   --drep-keys INT          The number of DRep credentials to make (default is
-                           0).
+                           0). Credentials are written to disk.
+  --transient-drep-keys INT
+                           The number of DRep credentials to make (default is
+                           0). The credentials are NOT written to disk.
   --stuffed-utxo INT       The number of fake UTxO entries to generate (default
                            is 0).
   --utxo-keys INT          The number of UTxO keys to make (default is 0).

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_genesis_create-testnet-data.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_genesis_create-testnet-data.cli
@@ -1,10 +1,14 @@
 Usage: cardano-cli conway genesis create-testnet-data [--spec-shelley FILE]
+                                                        [--spec-alonzo FILE]
+                                                        [--spec-conway FILE]
                                                         [--genesis-keys INT]
                                                         [--pools INT]
                                                         [ --stake-delegators INT
                                                         | --transient-stake-delegators INT
                                                         ]
-                                                        [--drep-keys INT]
+                                                        [ --drep-keys INT
+                                                        | --transient-drep-keys INT
+                                                        ]
                                                         [--stuffed-utxo INT]
                                                         [--utxo-keys INT]
                                                         [--total-supply LOVELACE]
@@ -19,6 +23,10 @@ Usage: cardano-cli conway genesis create-testnet-data [--spec-shelley FILE]
 Available options:
   --spec-shelley FILE      The shelley specification file to use as input. A
                            default one is generated if omitted.
+  --spec-alonzo FILE       The alonzo specification file to use as input. A
+                           default one is generated if omitted.
+  --spec-conway FILE       The conway specification file to use as input. A
+                           default one is generated if omitted.
   --genesis-keys INT       The number of genesis keys to make (default is 3).
   --pools INT              The number of stake pool credential sets to make
                            (default is 0).
@@ -29,7 +37,10 @@ Available options:
                            (default is 0). The credentials are NOT written to
                            disk.
   --drep-keys INT          The number of DRep credentials to make (default is
-                           0).
+                           0). Credentials are written to disk.
+  --transient-drep-keys INT
+                           The number of DRep credentials to make (default is
+                           0). The credentials are NOT written to disk.
   --stuffed-utxo INT       The number of fake UTxO entries to generate (default
                            is 0).
   --utxo-keys INT          The number of UTxO keys to make (default is 0).

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_genesis_create-testnet-data.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_genesis_create-testnet-data.cli
@@ -1,10 +1,14 @@
 Usage: cardano-cli latest genesis create-testnet-data [--spec-shelley FILE]
+                                                        [--spec-alonzo FILE]
+                                                        [--spec-conway FILE]
                                                         [--genesis-keys INT]
                                                         [--pools INT]
                                                         [ --stake-delegators INT
                                                         | --transient-stake-delegators INT
                                                         ]
-                                                        [--drep-keys INT]
+                                                        [ --drep-keys INT
+                                                        | --transient-drep-keys INT
+                                                        ]
                                                         [--stuffed-utxo INT]
                                                         [--utxo-keys INT]
                                                         [--total-supply LOVELACE]
@@ -19,6 +23,10 @@ Usage: cardano-cli latest genesis create-testnet-data [--spec-shelley FILE]
 Available options:
   --spec-shelley FILE      The shelley specification file to use as input. A
                            default one is generated if omitted.
+  --spec-alonzo FILE       The alonzo specification file to use as input. A
+                           default one is generated if omitted.
+  --spec-conway FILE       The conway specification file to use as input. A
+                           default one is generated if omitted.
   --genesis-keys INT       The number of genesis keys to make (default is 3).
   --pools INT              The number of stake pool credential sets to make
                            (default is 0).
@@ -29,7 +37,10 @@ Available options:
                            (default is 0). The credentials are NOT written to
                            disk.
   --drep-keys INT          The number of DRep credentials to make (default is
-                           0).
+                           0). Credentials are written to disk.
+  --transient-drep-keys INT
+                           The number of DRep credentials to make (default is
+                           0). The credentials are NOT written to disk.
   --stuffed-utxo INT       The number of fake UTxO entries to generate (default
                            is 0).
   --utxo-keys INT          The number of UTxO keys to make (default is 0).

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_genesis_create-testnet-data.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_genesis_create-testnet-data.cli
@@ -1,10 +1,14 @@
 Usage: cardano-cli mary genesis create-testnet-data [--spec-shelley FILE]
+                                                      [--spec-alonzo FILE]
+                                                      [--spec-conway FILE]
                                                       [--genesis-keys INT]
                                                       [--pools INT]
                                                       [ --stake-delegators INT
                                                       | --transient-stake-delegators INT
                                                       ]
-                                                      [--drep-keys INT]
+                                                      [ --drep-keys INT
+                                                      | --transient-drep-keys INT
+                                                      ]
                                                       [--stuffed-utxo INT]
                                                       [--utxo-keys INT]
                                                       [--total-supply LOVELACE]
@@ -19,6 +23,10 @@ Usage: cardano-cli mary genesis create-testnet-data [--spec-shelley FILE]
 Available options:
   --spec-shelley FILE      The shelley specification file to use as input. A
                            default one is generated if omitted.
+  --spec-alonzo FILE       The alonzo specification file to use as input. A
+                           default one is generated if omitted.
+  --spec-conway FILE       The conway specification file to use as input. A
+                           default one is generated if omitted.
   --genesis-keys INT       The number of genesis keys to make (default is 3).
   --pools INT              The number of stake pool credential sets to make
                            (default is 0).
@@ -29,7 +37,10 @@ Available options:
                            (default is 0). The credentials are NOT written to
                            disk.
   --drep-keys INT          The number of DRep credentials to make (default is
-                           0).
+                           0). Credentials are written to disk.
+  --transient-drep-keys INT
+                           The number of DRep credentials to make (default is
+                           0). The credentials are NOT written to disk.
   --stuffed-utxo INT       The number of fake UTxO entries to generate (default
                            is 0).
   --utxo-keys INT          The number of UTxO keys to make (default is 0).

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_genesis_create-testnet-data.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_genesis_create-testnet-data.cli
@@ -1,10 +1,14 @@
 Usage: cardano-cli shelley genesis create-testnet-data [--spec-shelley FILE]
+                                                         [--spec-alonzo FILE]
+                                                         [--spec-conway FILE]
                                                          [--genesis-keys INT]
                                                          [--pools INT]
                                                          [ --stake-delegators INT
                                                          | --transient-stake-delegators INT
                                                          ]
-                                                         [--drep-keys INT]
+                                                         [ --drep-keys INT
+                                                         | --transient-drep-keys INT
+                                                         ]
                                                          [--stuffed-utxo INT]
                                                          [--utxo-keys INT]
                                                          [--total-supply LOVELACE]
@@ -19,6 +23,10 @@ Usage: cardano-cli shelley genesis create-testnet-data [--spec-shelley FILE]
 Available options:
   --spec-shelley FILE      The shelley specification file to use as input. A
                            default one is generated if omitted.
+  --spec-alonzo FILE       The alonzo specification file to use as input. A
+                           default one is generated if omitted.
+  --spec-conway FILE       The conway specification file to use as input. A
+                           default one is generated if omitted.
   --genesis-keys INT       The number of genesis keys to make (default is 3).
   --pools INT              The number of stake pool credential sets to make
                            (default is 0).
@@ -29,7 +37,10 @@ Available options:
                            (default is 0). The credentials are NOT written to
                            disk.
   --drep-keys INT          The number of DRep credentials to make (default is
-                           0).
+                           0). Credentials are written to disk.
+  --transient-drep-keys INT
+                           The number of DRep credentials to make (default is
+                           0). The credentials are NOT written to disk.
   --stuffed-utxo INT       The number of fake UTxO entries to generate (default
                            is 0).
   --utxo-keys INT          The number of UTxO keys to make (default is 0).

--- a/cardano-cli/test/cardano-cli-test-lib/Test/Cardano/CLI/Util.hs
+++ b/cardano-cli/test/cardano-cli-test-lib/Test/Cardano/CLI/Util.hs
@@ -5,7 +5,8 @@
 {-# LANGUAGE StandaloneDeriving #-}
 
 module Test.Cardano.CLI.Util
-  ( checkTxCddlFormat
+  ( assertDirectoryMissing
+  , checkTxCddlFormat
   , checkTextEnvelopeFormat
   , equivalence
   , execCardanoCLI
@@ -28,6 +29,7 @@ import           Cardano.CLI.Read
 
 import           Control.Concurrent (QSem, newQSem, signalQSem, waitQSem)
 import           Control.Exception.Lifted (bracket_)
+import           Control.Monad (when)
 import           Control.Monad.Base
 import           Control.Monad.Catch hiding (bracket_)
 import           Control.Monad.Trans.Control (MonadBaseControl)
@@ -195,6 +197,13 @@ createFiles :: Bool
 createFiles = IO.unsafePerformIO $ do
   value <- IO.lookupEnv "CREATE_GOLDEN_FILES"
   return $ value == Just "1"
+
+-- | Asserts that the given directory is missing.
+assertDirectoryMissing :: (MonadTest m, MonadIO m, HasCallStack) => FilePath -> m ()
+assertDirectoryMissing dir = GHC.withFrozenCallStack $ do
+  exists <- H.evalIO $ IO.doesDirectoryExist dir
+  when exists $ H.failWithCustom GHC.callStack Nothing (dir <> " should not have been created.")
+
 
 --------------------------------------------------------------------------------
 -- Helpers, Error rendering & Clean up

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1710510430,
-        "narHash": "sha256-bP8YcyEXUQKvNmwrGHfPmkZLiToTPpDPeousn9crTmQ=",
+        "lastModified": 1710529033,
+        "narHash": "sha256-vcxum8uDTGEGV1/h8UWRJmdPXcLhrAqpty/N2LbxRb4=",
         "owner": "input-output-hk",
         "repo": "cardano-haskell-packages",
-        "rev": "19c85340ad39f68b443d145192b0f10834633dc3",
+        "rev": "a744b5fe534c57a42cbc2645b9211bb619c7c243",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Modified `create-testnet-data` option so that it registers DReps generated and delegates stake delegators to them. Also introduced transient drep delegation and refactored existing code so that more is reused.
# uncomment types applicable to the change:
  type:
  - feature        # introduces a new feature
  - improvement    # QoL changes e.g. refactoring
```

# Context

In order to do realistic benchmarking we need to have DReps be registered and to exercise delegation, before this PR DReps were simply extra keys that were generated. We also want it to be possible to generate keys without writing them to disk (other than from the bit in the genesis file), so that tests scale better.

This PR depends on [#482 in `cardano-api`](https://github.com/IntersectMBO/cardano-api/pull/482) in order to not re-add dependencies to `cardano-cli`. It may be a good idea to review both simultaneously.

# How to trust this PR

Check that the conversion of the keys is done correctly, that the right things are being delegated, and that refactorings didn't alter the behaviour of existing code.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff

