### PR TITLE
Update cardano-api-8.40.0.0

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -14,7 +14,7 @@ repository cardano-haskell-packages
 -- you need to run if you change them
 index-state:
   , hackage.haskell.org 2024-03-05T09:38:08Z
-  , cardano-haskell-packages 2024-03-05T10:16:08Z
+  , cardano-haskell-packages 2024-03-14T09:14:40Z
 
 packages:
   cardano-cli

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -196,7 +196,7 @@ library
                       , binary
                       , bytestring
                       , canonical-json
-                      , cardano-api ^>= 8.39.2
+                      , cardano-api ^>= 8.40.0.0
                       , cardano-binary
                       , cardano-crypto
                       , cardano-crypto-class ^>= 2.1.2

--- a/cardano-cli/src/Cardano/CLI/Byron/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Parsers.hs
@@ -293,7 +293,7 @@ parseTxOut =
   pLovelaceTxOut l =
     if l > (maxBound :: Word64)
       then error $ show l <> " lovelace exceeds the Word64 upper bound"
-      else TxOutValueByron . Lovelace $ toInteger l
+      else TxOutValueByron $ L.Coin $ toInteger l
 
 readerFromAttoParser :: Atto.Parser a -> Opt.ReadM a
 readerFromAttoParser p =
@@ -696,7 +696,7 @@ parseLovelace optname desc =
     i <- Atto.decimal
     if i > toInteger (maxBound :: Word64)
     then fail $ show i <> " lovelace exceeds the Word64 upper bound"
-    else case toByronLovelace (Lovelace i) of
+    else case toByronLovelace $ L.Coin i of
            Just byronLovelace -> return byronLovelace
            Nothing -> error $ "Error converting lovelace: " <> show i
 

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Genesis.hs
@@ -17,6 +17,7 @@ module Cardano.CLI.EraBased.Commands.Genesis
   , renderGenesisCmds
   ) where
 
+import           Cardano.Api.Ledger (Coin)
 import           Cardano.Api.Shelley
 
 import           Cardano.Chain.Common (BlockCount)
@@ -45,7 +46,7 @@ data GenesisCreateCmdArgs = GenesisCreateCmdArgs
   , numGenesisKeys :: !Word
   , numUTxOKeys :: !Word
   , mSystemStart :: !(Maybe SystemStart)
-  , mSupply :: !(Maybe Lovelace)
+  , mSupply :: !(Maybe Coin)
   , network :: !NetworkId
   } deriving Show
 
@@ -54,7 +55,7 @@ data GenesisCreateCardanoCmdArgs = GenesisCreateCardanoCmdArgs
   , numGenesisKeys :: !Word
   , numUTxOKeys :: !Word
   , mSystemStart :: !(Maybe SystemStart)
-  , mSupply :: !(Maybe Lovelace)
+  , mSupply :: !(Maybe Coin)
   , security :: !BlockCount
   , slotLength :: !Word
   , slotCoeff :: !Rational
@@ -74,8 +75,8 @@ data GenesisCreateStakedCmdArgs = GenesisCreateStakedCmdArgs
   , numPools :: !Word
   , numStakeDelegators :: !Word
   , mSystemStart :: !(Maybe SystemStart)
-  , mNonDelegatedSupply :: !(Maybe Lovelace)
-  , delegatedSupply :: !Lovelace
+  , mNonDelegatedSupply :: !(Maybe Coin)
+  , delegatedSupply :: !Coin
   , network :: !NetworkId
   , numBulkPoolCredFiles :: !Word
   , numBulkPoolsPerFile :: !Word
@@ -91,8 +92,8 @@ data GenesisCreateTestNetDataCmdArgs = GenesisCreateTestNetDataCmdArgs
   , numDrepKeys :: !Word -- ^ The number of DRep keys to create. Right now they receive neither delegation nor are registrated. This will come later.
   , numStuffedUtxo :: !Word -- ^ The number of UTxO accounts to make. They are "stuffed" because the credentials are not written to disk.
   , numUtxoKeys :: !Word -- ^ The number of UTxO credentials to create and write to disk.
-  , totalSupply :: !(Maybe Lovelace) -- ^ The total number of Lovelace
-  , delegatedSupply :: !(Maybe Lovelace) -- ^ The number of Lovelace being delegated
+  , totalSupply :: !(Maybe Coin) -- ^ The total number of Lovelace
+  , delegatedSupply :: !(Maybe Coin) -- ^ The number of Lovelace being delegated
   , networkId :: !(Maybe NetworkId) -- ^ The network ID to use. Overrides the network id supplied in the spec file.
   , relays :: !(Maybe FilePath) -- ^ Filepath of the specification of relays
   , systemStart :: !(Maybe SystemStart) -- ^ The genesis start time.

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance.hs
@@ -8,6 +8,7 @@ module Cardano.CLI.EraBased.Commands.Governance
   ) where
 
 import           Cardano.Api
+import           Cardano.Api.Ledger (Coin)
 import           Cardano.Api.Shelley (VrfKey)
 
 import           Cardano.CLI.EraBased.Commands.Governance.Actions
@@ -25,15 +26,15 @@ data GovernanceCmds era
       (ShelleyToBabbageEra era)
       MIRPot
       [StakeAddress]
-      [Lovelace]
+      [Coin]
       (File () Out)
   | GovernanceCreateMirCertificateTransferToTreasuryCmd
       (ShelleyToBabbageEra era)
-      Lovelace
+      Coin
       (File () Out)
   | GovernanceCreateMirCertificateTransferToReservesCmd
       (ShelleyToBabbageEra era)
-      Lovelace
+      Coin
       (File () Out)
   | GovernanceGenesisKeyDelegationCertificate
       (ShelleyToBabbageEra era)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/Actions.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/Actions.hs
@@ -45,7 +45,7 @@ data GoveranceActionUpdateCommitteeCmdArgs era
   = GoveranceActionUpdateCommitteeCmdArgs
       { eon                     :: !(ConwayEraOnwards era)
       , networkId               :: !L.Network
-      , deposit                 :: !Lovelace
+      , deposit                 :: !L.Coin
       , returnAddress           :: !StakeIdentifier
       , proposalUrl             :: !ProposalUrl
       , proposalHash            :: !(L.SafeHash L.StandardCrypto L.AnchorData)
@@ -60,7 +60,7 @@ data GovernanceActionCreateConstitutionCmdArgs era
   = GovernanceActionCreateConstitutionCmdArgs
       { eon                     :: !(ConwayEraOnwards era)
       , networkId               :: !L.Network
-      , deposit                 :: !Lovelace
+      , deposit                 :: !L.Coin
       , stakeCredential         :: !StakeIdentifier
       , mPrevGovernanceActionId :: !(Maybe (TxId, Word32))
       , proposalUrl             :: !ProposalUrl
@@ -76,7 +76,7 @@ data GovernanceActionInfoCmdArgs era
    = GovernanceActionInfoCmdArgs
       { eon                 :: !(ConwayEraOnwards era)
       , networkId           :: !L.Network
-      , deposit             :: !Lovelace
+      , deposit             :: !L.Coin
       , returnStakeAddress  :: !StakeIdentifier
       , proposalUrl         :: !ProposalUrl
       , proposalHash        :: !(L.SafeHash L.StandardCrypto L.AnchorData)
@@ -87,7 +87,7 @@ data GovernanceActionCreateNoConfidenceCmdArgs era
   = GovernanceActionCreateNoConfidenceCmdArgs
       { eon                   :: !(ConwayEraOnwards era)
       , networkId             :: !L.Network
-      , deposit               :: !Lovelace
+      , deposit               :: !L.Coin
       , returnStakeAddress    :: !StakeIdentifier
       , proposalUrl           :: !ProposalUrl
       , proposalHash          :: !(L.SafeHash L.StandardCrypto L.AnchorData)
@@ -117,11 +117,11 @@ data GovernanceActionTreasuryWithdrawalCmdArgs era
   = GovernanceActionTreasuryWithdrawalCmdArgs
       { eon                    :: !(ConwayEraOnwards era)
       , networkId              :: !L.Network
-      , deposit                :: !Lovelace
+      , deposit                :: !L.Coin
       , returnAddr             :: !StakeIdentifier
       , proposalUrl            :: !ProposalUrl
       , proposalHash           :: !(L.SafeHash L.StandardCrypto L.AnchorData)
-      , treasuryWithdrawal     :: ![(VerificationKeyOrHashOrFile StakeKey, Lovelace)]
+      , treasuryWithdrawal     :: ![(VerificationKeyOrHashOrFile StakeKey, L.Coin)]
       , constitutionScriptHash :: !(Maybe ScriptHash)
       , outFile                :: !(File () Out)
       } deriving Show
@@ -138,7 +138,7 @@ data UpdateProtocolParametersConwayOnwards era
   = UpdateProtocolParametersConwayOnwards
       { eon                 :: !(ConwayEraOnwards era)
       , networkId           :: !L.Network
-      , deposit             :: !Lovelace
+      , deposit             :: !L.Coin
       , returnAddr          :: !StakeIdentifier
       , proposalUrl         :: !ProposalUrl
       , proposalHash        :: !(L.SafeHash L.StandardCrypto L.AnchorData)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/DRep.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/DRep.hs
@@ -51,7 +51,7 @@ data GovernanceDRepRegistrationCertificateCmdArgs era =
   GovernanceDRepRegistrationCertificateCmdArgs
     { eon                 :: !(ConwayEraOnwards era)
     , drepHashSource      :: !DRepHashSource
-    , deposit             :: !Lovelace
+    , deposit             :: !L.Coin
     , mAnchor             :: !(Maybe (L.Anchor (L.EraCrypto (ShelleyLedgerEra era))))
     , outFile             :: !(File () Out)
     }
@@ -60,7 +60,7 @@ data GovernanceDRepRetirementCertificateCmdArgs era =
   GovernanceDRepRetirementCertificateCmdArgs
     { eon             :: !(ConwayEraOnwards era)
     , vkeyHashSource  :: !(VerificationKeyOrHashOrFile DRepKey)
-    , deposit         :: !Lovelace
+    , deposit         :: !L.Coin
     , outFile         :: !(File () Out)
     }
 

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/StakeAddress.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/StakeAddress.hs
@@ -6,6 +6,7 @@ module Cardano.CLI.EraBased.Commands.StakeAddress
   , renderStakeAddressCmds
   ) where
 
+import           Cardano.Api.Ledger (Coin)
 import           Cardano.Api.Shelley
 
 import           Cardano.CLI.Types.Common
@@ -34,7 +35,7 @@ data StakeAddressCmds era
   | StakeAddressRegistrationCertificateCmd
       (ShelleyBasedEra era)
       StakeIdentifier
-      (Maybe Lovelace)
+      (Maybe Coin)
       (File () Out)
   | StakeAddressStakeDelegationCertificateCmd
       (ShelleyBasedEra era)
@@ -55,7 +56,7 @@ data StakeAddressCmds era
   | StakeAddressDeregistrationCertificateCmd
       (ShelleyBasedEra era)
       StakeIdentifier
-      (Maybe Lovelace)
+      (Maybe Coin)
       (File () Out)
   deriving Show
 

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/StakePool.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/StakePool.hs
@@ -12,6 +12,7 @@ module Cardano.CLI.EraBased.Commands.StakePool
   , StakePoolRegistrationCertificateCmdArgs(..)
   ) where
 
+import           Cardano.Api.Ledger (Coin)
 import           Cardano.Api.Shelley hiding (QueryInShelleyBasedEra (..))
 
 import           Cardano.CLI.Types.Common
@@ -57,8 +58,8 @@ data StakePoolRegistrationCertificateCmdArgs era =
     { sbe                               :: !(ShelleyBasedEra era) -- ^ Era in which to register the stake pool.
     , poolVerificationKeyOrFile         :: !(VerificationKeyOrFile StakePoolKey) -- ^ Stake pool verification key.
     , vrfVerificationKeyOrFile          :: !(VerificationKeyOrFile VrfKey) -- ^ VRF Verification key.
-    , poolPledge                        :: !Lovelace -- ^ Pool pledge.
-    , poolCost                          :: !Lovelace -- ^ Pool cost.
+    , poolPledge                        :: !Coin -- ^ Pool pledge.
+    , poolCost                          :: !Coin -- ^ Pool cost.
     , poolMargin                        :: !Rational -- ^ Pool margin.
     , rewardStakeVerificationKeyOrFile  :: !(VerificationKeyOrFile StakeKey) -- ^ Reward account verification staking key.
     , ownerStakeVerificationKeyOrFiles  :: ![VerificationKeyOrFile StakeKey] -- ^ Pool owner verification staking key(s).

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Transaction.hs
@@ -20,6 +20,7 @@ module Cardano.CLI.EraBased.Commands.Transaction
   , renderTransactionCmds
   ) where
 
+import           Cardano.Api.Ledger (Coin)
 import           Cardano.Api.Shelley
 
 import           Cardano.CLI.Types.Common
@@ -53,7 +54,7 @@ data TransactionBuildRawCmdArgs era = TransactionBuildRawCmdArgs
     -- ^ Transaction inputs for collateral, only key witnesses, no scripts.
   , mReturnCollateral     :: !(Maybe TxOutShelleyBasedEra)
     -- ^ Return collateral
-  , mTotalCollateral      :: !(Maybe Lovelace)
+  , mTotalCollateral      :: !(Maybe Coin)
     -- ^ Total collateral
   , requiredSigners       :: ![RequiredSigner]
     -- ^ Required signers
@@ -64,11 +65,11 @@ data TransactionBuildRawCmdArgs era = TransactionBuildRawCmdArgs
     -- ^ Transaction validity lower bound
   , mValidityUpperBound   :: !(TxValidityUpperBound era)
     -- ^ Transaction validity upper bound
-  , fee                   :: !(Maybe Lovelace)
+  , fee                   :: !(Maybe Coin)
     -- ^ Transaction fee
   , certificates          :: ![(CertificateFile, Maybe (ScriptWitnessFiles WitCtxStake))]
     -- ^ Certificates with potential script witness
-  , withdrawals           :: ![(StakeAddress, Lovelace, Maybe (ScriptWitnessFiles WitCtxStake))]
+  , withdrawals           :: ![(StakeAddress, Coin, Maybe (ScriptWitnessFiles WitCtxStake))]
   , metadataSchema        :: !TxMetadataJsonSchema
   , scriptFiles           :: ![ScriptFile]
     -- ^ Auxiliary scripts
@@ -100,7 +101,7 @@ data TransactionBuildCmdArgs era = TransactionBuildCmdArgs
     -- ^ Transaction inputs for collateral, only key witnesses, no scripts.
   , mReturnCollateral       :: !(Maybe TxOutShelleyBasedEra)
     -- ^ Return collateral
-  , mTotalCollateral        :: !(Maybe Lovelace)
+  , mTotalCollateral        :: !(Maybe Coin)
     -- ^ Total collateral
   , txouts                  :: ![TxOutAnyEra]
     -- ^ Normal outputs
@@ -114,7 +115,7 @@ data TransactionBuildCmdArgs era = TransactionBuildCmdArgs
     -- ^ Transaction validity upper bound
   , certificates            :: ![(CertificateFile, Maybe (ScriptWitnessFiles WitCtxStake))]
     -- ^ Certificates with potential script witness
-  , withdrawals             :: ![(StakeAddress, Lovelace, Maybe (ScriptWitnessFiles WitCtxStake))]
+  , withdrawals             :: ![(StakeAddress, Coin, Maybe (ScriptWitnessFiles WitCtxStake))]
     -- ^ Withdrawals with potential script witness
   , metadataSchema          :: !TxMetadataJsonSchema
   , scriptFiles             :: ![ScriptFile]

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
@@ -435,12 +435,12 @@ pFileInDirection l h =
     , Opt.completer (Opt.bashCompleter "file")
     ]
 
-parseLovelace :: Parsec.Parser Lovelace
+parseLovelace :: Parsec.Parser L.Coin
 parseLovelace = do
   i <- decimal
   if i > toInteger (maxBound :: Word64)
     then fail $ show i <> " lovelace exceeds the Word64 upper bound"
-    else return $ Lovelace i
+    else return $ L.Coin i
 
 -- | The first argument is the optional prefix.
 pStakePoolVerificationKeyOrFile :: Maybe String -> Parser (VerificationKeyOrFile StakePoolKey)
@@ -497,7 +497,7 @@ pMIRPot =
         ]
     ]
 
-pRewardAmt :: Parser Lovelace
+pRewardAmt :: Parser L.Coin
 pRewardAmt =
   Opt.option (readerFromParsecParser parseLovelace) $ mconcat
     [ Opt.long "reward"
@@ -505,7 +505,7 @@ pRewardAmt =
     , Opt.help "The reward for the relevant reward account."
     ]
 
-pTransferAmt :: Parser Lovelace
+pTransferAmt :: Parser L.Coin
 pTransferAmt =
   Opt.option (readerFromParsecParser parseLovelace) $ mconcat
     [ Opt.long "transfer"
@@ -915,7 +915,7 @@ pUrl l h =
                  , Opt.help h
                  ]
 
-pGovActionDeposit :: Parser Lovelace
+pGovActionDeposit :: Parser L.Coin
 pGovActionDeposit =
   Opt.option (readerFromParsecParser parseLovelace) $ mconcat
     [ Opt.long "governance-action-deposit"
@@ -923,7 +923,7 @@ pGovActionDeposit =
     , Opt.help "Deposit required to submit a governance action."
     ]
 
-pNewGovActionDeposit :: Parser Lovelace
+pNewGovActionDeposit :: Parser L.Coin
 pNewGovActionDeposit =
   Opt.option (readerFromParsecParser parseLovelace) $ mconcat
     [ Opt.long "new-governance-action-deposit"
@@ -1377,7 +1377,7 @@ pMetadataFile =
 pWithdrawal
   :: BalanceTxExecUnits
   -> Parser (StakeAddress,
-            Lovelace,
+            L.Coin,
             Maybe (ScriptWitnessFiles WitCtxStake))
 pWithdrawal balance =
     (\(stakeAddr,lovelace) maybeScriptFp -> (stakeAddr, lovelace, maybeScriptFp))
@@ -1404,7 +1404,7 @@ pWithdrawal balance =
     , "a script witness."
     ]
 
-  parseWithdrawal :: Parsec.Parser (StakeAddress, Lovelace)
+  parseWithdrawal :: Parsec.Parser (StakeAddress, L.Coin)
   parseWithdrawal =
     (,) <$> parseStakeAddress <* Parsec.char '+' <*> parseLovelace
 
@@ -1898,9 +1898,9 @@ pReturnCollateral =
     <*> pure TxOutDatumByNone -- TODO: Babbage era - we should be able to return these
     <*> pure ReferenceScriptAnyEraNone -- TODO: Babbage era - we should be able to return these
 
-pTotalCollateral :: Parser Lovelace
+pTotalCollateral :: Parser L.Coin
 pTotalCollateral =
-  Opt.option (Lovelace <$> readerFromParsecParser decimal) $ mconcat
+  Opt.option (L.Coin <$> readerFromParsecParser decimal) $ mconcat
   [ Opt.long "tx-total-collateral"
   , Opt.metavar "INTEGER"
   , Opt.help $ mconcat
@@ -2154,9 +2154,9 @@ pInvalidHereafter eon =
     ]
 
 
-pTxFee :: Parser Lovelace
+pTxFee :: Parser L.Coin
 pTxFee =
-  fmap (Lovelace . (fromIntegral :: Natural -> Integer)) $ Opt.option Opt.auto $ mconcat
+  fmap (L.Coin . (fromIntegral :: Natural -> Integer)) $ Opt.option Opt.auto $ mconcat
     [ Opt.long "fee"
     , Opt.metavar "LOVELACE"
     , Opt.help "The fee amount in Lovelace."
@@ -2441,7 +2441,7 @@ pPoolOwnerVerificationKeyOrFile =
     , VerificationKeyFilePath <$> pPoolOwnerVerificationKeyFile
     ]
 
-pPoolPledge :: Parser Lovelace
+pPoolPledge :: Parser L.Coin
 pPoolPledge =
   Opt.option (readerFromParsecParser parseLovelace) $ mconcat
     [ Opt.long "pool-pledge"
@@ -2449,7 +2449,7 @@ pPoolPledge =
     , Opt.help "The stake pool's pledge."
     ]
 
-pPoolCost :: Parser Lovelace
+pPoolCost :: Parser L.Coin
 pPoolCost =
   Opt.option (readerFromParsecParser parseLovelace) $ mconcat
     [ Opt.long "pool-cost"
@@ -2628,7 +2628,7 @@ pCostModels =
     , Opt.completer (Opt.bashCompleter "file")
     ]
 
-pMinFeePerByteFactor :: Parser Lovelace
+pMinFeePerByteFactor :: Parser L.Coin
 pMinFeePerByteFactor =
   Opt.option (readerFromParsecParser parseLovelace) $ mconcat
     [ Opt.long "min-fee-linear"
@@ -2636,7 +2636,7 @@ pMinFeePerByteFactor =
     , Opt.help "The linear factor per byte for the minimum fee calculation."
     ]
 
-pMinFeeConstantFactor :: Parser Lovelace
+pMinFeeConstantFactor :: Parser L.Coin
 pMinFeeConstantFactor =
   Opt.option (readerFromParsecParser parseLovelace) $ mconcat
     [ Opt.long "min-fee-constant"
@@ -2644,7 +2644,7 @@ pMinFeeConstantFactor =
     , Opt.help "The constant factor for the minimum fee calculation."
     ]
 
-pMinUTxOValue :: Parser Lovelace
+pMinUTxOValue :: Parser L.Coin
 pMinUTxOValue =
   Opt.option (readerFromParsecParser parseLovelace) $ mconcat
     [ Opt.long "min-utxo-value"
@@ -2652,7 +2652,7 @@ pMinUTxOValue =
     , Opt.help "The minimum allowed UTxO value (Shelley to Mary eras)."
     ]
 
-pMinPoolCost :: Parser Lovelace
+pMinPoolCost :: Parser L.Coin
 pMinPoolCost =
   Opt.option (readerFromParsecParser parseLovelace) $ mconcat
     [ Opt.long "min-pool-cost"
@@ -2684,7 +2684,7 @@ pMaxBlockHeaderSize =
    , Opt.help "Maximum block header size."
    ]
 
-pKeyRegistDeposit :: Parser Lovelace
+pKeyRegistDeposit :: Parser L.Coin
 pKeyRegistDeposit =
   Opt.option (readerFromParsecParser parseLovelace) $ mconcat
    [ Opt.long "key-reg-deposit-amt"
@@ -2692,7 +2692,7 @@ pKeyRegistDeposit =
    , Opt.help "Key registration deposit amount."
    ]
 
-pDrepDeposit :: Parser Lovelace
+pDrepDeposit :: Parser L.Coin
 pDrepDeposit =
   Opt.option (readerFromParsecParser parseLovelace) $ mconcat
    [ Opt.long "deposit-amt"
@@ -2700,7 +2700,7 @@ pDrepDeposit =
    , Opt.help "DRep deposit amount (same at registration and retirement)."
    ]
 
-pPoolDeposit :: Parser Lovelace
+pPoolDeposit :: Parser L.Coin
 pPoolDeposit =
   Opt.option (readerFromParsecParser parseLovelace) $ mconcat
    [ Opt.long "pool-reg-deposit"
@@ -2784,7 +2784,7 @@ pExtraEntropy =
                       . B16.decode . BSC.pack
                     =<< some Parsec.hexDigit
 
-pUTxOCostPerByte :: Parser Lovelace
+pUTxOCostPerByte :: Parser L.Coin
 pUTxOCostPerByte =
   Opt.option (readerFromParsecParser parseLovelace) $ mconcat
     [ Opt.long "utxo-cost-per-byte"
@@ -3035,7 +3035,7 @@ pGovActionLifetime =
     , Opt.help "Maximal lifetime of governance actions, in epochs."
     ]
 
-pDRepDeposit :: Parser Lovelace
+pDRepDeposit :: Parser L.Coin
 pDRepDeposit =
   Opt.option (readerFromParsecParser parseLovelace) $ mconcat
     [ Opt.long "drep-deposit"

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Genesis.hs
@@ -9,6 +9,7 @@ module Cardano.CLI.EraBased.Options.Genesis
   ) where
 
 import           Cardano.Api hiding (QueryInShelleyBasedEra (..))
+import           Cardano.Api.Ledger (Coin (..))
 
 import           Cardano.Chain.Common (BlockCount (BlockCount))
 import           Cardano.CLI.Environment (EnvCli (..))
@@ -281,9 +282,9 @@ pGenesisCreateTestNetData envCli =
         , Opt.help "The number of UTxO keys to make (default is 0)."
         , Opt.value 0
         ]
-    pSupply :: Parser (Maybe Lovelace)
+    pSupply :: Parser (Maybe Coin)
     pSupply =
-      Opt.optional $ fmap Lovelace $ Opt.option Opt.auto $ mconcat
+      Opt.optional $ fmap Coin $ Opt.option Opt.auto $ mconcat
         [ Opt.long "total-supply"
         , Opt.metavar "LOVELACE"
         , Opt.help $ mconcat [ "The maximum possible amount of Lovelace, which is evenly distributed across stake holders. Defaults to 1 million Ada (i.e. 10^12 Lovelace)."
@@ -291,9 +292,9 @@ pGenesisCreateTestNetData envCli =
                              ]
         , Opt.value 1_000_000_000_000
         ]
-    pSupplyDelegated :: Parser (Maybe Lovelace)
+    pSupplyDelegated :: Parser (Maybe Coin)
     pSupplyDelegated =
-      Opt.optional $ fmap Lovelace $ Opt.option Opt.auto $ mconcat
+      Opt.optional $ fmap Coin $ Opt.option Opt.auto $ mconcat
         [ Opt.long "delegated-supply"
         , Opt.metavar "LOVELACE"
         , Opt.help $ mconcat [ "The amount of the total supply which is evenly delegated. Defaults to 500 000 Ada (i.e. (10^12) / 2 Lovelace)."
@@ -383,17 +384,17 @@ pStuffedUtxoCount =
     , Opt.value 0
     ]
 
-pInitialSupplyNonDelegated :: Parser (Maybe Lovelace)
+pInitialSupplyNonDelegated :: Parser (Maybe Coin)
 pInitialSupplyNonDelegated =
-  Opt.optional $ fmap Lovelace $ Opt.option Opt.auto $ mconcat
+  Opt.optional $ fmap Coin $ Opt.option Opt.auto $ mconcat
     [ Opt.long "supply"
     , Opt.metavar "LOVELACE"
     , Opt.help "The initial coin supply in Lovelace which will be evenly distributed across initial, non-delegating stake holders."
     ]
 
-pInitialSupplyDelegated :: Parser Lovelace
+pInitialSupplyDelegated :: Parser Coin
 pInitialSupplyDelegated =
-  fmap (Lovelace . fromMaybe 0) $ Opt.optional $ Opt.option Opt.auto $ mconcat
+  fmap (Coin . fromMaybe 0) $ Opt.optional $ Opt.option Opt.auto $ mconcat
     [ Opt.long "supply-delegated"
     , Opt.metavar "LOVELACE"
     , Opt.help "The initial coin supply in Lovelace which will be evenly distributed across initial, delegating stake holders."

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Actions.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Actions.hs
@@ -240,25 +240,25 @@ mkProtocolVersionOrErr (majorProtVer, minorProtVer) =
 pCommonProtocolParameters :: Parser CommonProtocolParametersUpdate
 pCommonProtocolParameters =
   CommonProtocolParametersUpdate
-    <$> convertToLedger toShelleyLovelace (optional pMinFeeConstantFactor)
-    <*> convertToLedger toShelleyLovelace (optional pMinFeePerByteFactor)
+    <$> convertToLedger id (optional pMinFeeConstantFactor)
+    <*> convertToLedger id (optional pMinFeePerByteFactor)
     <*> convertToLedger id (optional pMaxBodySize)
     <*> convertToLedger id (optional pMaxTransactionSize)
     <*> convertToLedger id (optional pMaxBlockHeaderSize)
-    <*> convertToLedger toShelleyLovelace (optional pKeyRegistDeposit)
-    <*> convertToLedger toShelleyLovelace (optional pPoolDeposit)
+    <*> convertToLedger id (optional pKeyRegistDeposit)
+    <*> convertToLedger id (optional pPoolDeposit)
     <*> convertToLedger id (optional pEpochBoundRetirement)
     <*> convertToLedger id (optional pNumberOfPools)
     <*> convertToLedger toNonNegativeIntervalOrErr (optional pPoolInfluence)
     <*> convertToLedger toUnitIntervalOrErr (optional pTreasuryExpansion)
     <*> convertToLedger toUnitIntervalOrErr (optional pMonetaryExpansion)
-    <*> convertToLedger toShelleyLovelace (optional pMinPoolCost)
+    <*> convertToLedger id (optional pMinPoolCost)
 
 
 pDeprecatedAfterMaryPParams :: Parser (DeprecatedAfterMaryPParams ledgerera)
 pDeprecatedAfterMaryPParams =
   DeprecatedAfterMaryPParams
-    <$> convertToLedger toShelleyLovelace (optional pMinUTxOValue)
+    <$> convertToLedger id (optional pMinUTxOValue)
 
 pDeprecatedAfterBabbagePParams :: Parser (DeprecatedAfterBabbagePParams ledgerera)
 pDeprecatedAfterBabbagePParams =
@@ -286,7 +286,7 @@ pAlonzoOnwardsPParams =
 pIntroducedInBabbagePParams :: Parser (IntroducedInBabbagePParams ledgerera)
 pIntroducedInBabbagePParams =
   IntroducedInBabbagePParams
-    <$> convertToLedger (L.CoinPerByte . toShelleyLovelace) (optional pUTxOCostPerByte)
+    <$> convertToLedger L.CoinPerByte (optional pUTxOCostPerByte)
 
 pIntroducedInConwayPParams :: Parser (IntroducedInConwayPParams ledgerera)
 pIntroducedInConwayPParams =
@@ -296,8 +296,8 @@ pIntroducedInConwayPParams =
     <*> convertToLedger id (optional pMinCommitteeSize)
     <*> convertToLedger id (optional pCommitteeTermLength)
     <*> convertToLedger id (optional pGovActionLifetime)
-    <*> convertToLedger toShelleyLovelace (optional pNewGovActionDeposit)
-    <*> convertToLedger toShelleyLovelace (optional pDRepDeposit)
+    <*> convertToLedger id (optional pNewGovActionDeposit)
+    <*> convertToLedger id (optional pDRepDeposit)
     <*> convertToLedger id (optional pDRepActivity)
 
 -- Not necessary in Conway era onwards

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/CreateTestnetData.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/CreateTestnetData.hs
@@ -566,11 +566,11 @@ updateOutputTemplate
   :: forall m. MonadError GenesisCmdError m
   => SystemStart -- ^ System start time
   -> Map (Hash GenesisKey) (Hash GenesisDelegateKey, Hash VrfKey) -- ^ Genesis delegation (not stake-based)
-  -> Maybe Lovelace -- ^ Total amount of lovelace
+  -> Maybe L.Coin -- ^ Total amount of lovelace
   -> [AddressInEra ShelleyEra] -- ^ UTxO addresses that are not delegating
   -> [(L.KeyHash 'L.StakePool L.StandardCrypto, L.PoolParams L.StandardCrypto)] -- ^ Pool map
   -> [(L.KeyHash 'L.Staking L.StandardCrypto, L.KeyHash 'L.StakePool L.StandardCrypto)] -- ^ Delegaton map
-  -> Maybe Lovelace -- ^ Amount of lovelace to delegate
+  -> Maybe L.Coin -- ^ Amount of lovelace to delegate
   -> Int -- ^ Number of UTxO address for delegation
   -> [AddressInEra ShelleyEra] -- ^ UTxO address for delegation
   -> [AddressInEra ShelleyEra] -- ^ Stuffed UTxO addresses
@@ -588,7 +588,7 @@ updateOutputTemplate
           , sgMaxLovelaceSupply = totalSupply
           , sgGenDelegs = shelleyDelKeys
           , sgInitialFunds = ListMap.fromList
-                              [ (toShelleyAddr addr, toShelleyLovelace v)
+                              [ (toShelleyAddr addr, v)
                               | (addr, v) <-
                                 distribute nonDelegCoin nUtxoAddrsNonDeleg utxoAddrsNonDeleg
                                 ++ distribute delegCoin nUtxoAddrsDeleg utxoAddrsDeleg
@@ -624,14 +624,14 @@ updateOutputTemplate
     -- Since the user can specify total supply and delegated amount, the non-delegated amount is:
     nonDelegCoinRaw = totalSupply - delegCoinRaw
 
-    distribute :: Natural -> Int -> [AddressInEra ShelleyEra] -> [(AddressInEra ShelleyEra, Lovelace)]
+    distribute :: Natural -> Int -> [AddressInEra ShelleyEra] -> [(AddressInEra ShelleyEra, L.Coin)]
     distribute funds nAddrs addrs =
-      zip addrs $ Lovelace . toInteger <$> (coinPerAddr + remainder:repeat coinPerAddr)
+      zip addrs $ L.Coin . toInteger <$> (coinPerAddr + remainder:repeat coinPerAddr)
       where coinPerAddr, remainder :: Natural
             (coinPerAddr, remainder) = funds `divMod` fromIntegral nAddrs
 
-    mkStuffedUtxo :: [AddressInEra ShelleyEra] -> [(AddressInEra ShelleyEra, Lovelace)]
-    mkStuffedUtxo xs = (, Lovelace minUtxoVal) <$> xs
+    mkStuffedUtxo :: [AddressInEra ShelleyEra] -> [(AddressInEra ShelleyEra, L.Coin)]
+    mkStuffedUtxo xs = (, L.Coin minUtxoVal) <$> xs
       where L.Coin minUtxoVal = sgProtocolParams ^. L.ppMinUTxOValueL
     shelleyDelKeys = Map.fromList
       [ (gh, L.GenDelegPair gdh h)
@@ -639,8 +639,8 @@ updateOutputTemplate
           (GenesisDelegateKeyHash gdh, VrfKeyHash h)) <- Map.toList genDelegMap
       ]
 
-    unLovelace :: Integral a => Lovelace -> a
-    unLovelace (Lovelace coin) = fromIntegral coin
+    unLovelace :: Integral a => L.Coin -> a
+    unLovelace (L.Coin coin) = fromIntegral coin
 
 readAndDecodeShelleyGenesis
   :: FilePath

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance.hs
@@ -79,7 +79,7 @@ runGovernanceMIRCertificatePayStakeAddrs
   :: ShelleyToBabbageEra era
   -> L.MIRPot
   -> [StakeAddress] -- ^ Stake addresses
-  -> [Lovelace]     -- ^ Corresponding reward amounts (same length)
+  -> [L.Coin]     -- ^ Corresponding reward amounts (same length)
   -> File () Out
   -> ExceptT GovernanceCmdError IO ()
 runGovernanceMIRCertificatePayStakeAddrs w mirPot sAddrs rwdAmts oFp = do
@@ -89,7 +89,7 @@ runGovernanceMIRCertificatePayStakeAddrs w mirPot sAddrs rwdAmts oFp = do
 
   let sCreds  = map stakeAddressCredential sAddrs
       mirTarget = L.StakeAddressesMIR
-                    $ Map.fromList [ (toShelleyStakeCredential scred, L.toDeltaCoin (toShelleyLovelace rwdAmt))
+                    $ Map.fromList [ (toShelleyStakeCredential scred, L.toDeltaCoin rwdAmt)
                                     | (scred, rwdAmt) <- zip sCreds rwdAmts
                                     ]
   let mirCert = makeMIRCertificate
@@ -107,11 +107,11 @@ runGovernanceMIRCertificatePayStakeAddrs w mirPot sAddrs rwdAmts oFp = do
 
 runGovernanceCreateMirCertificateTransferToTreasuryCmd :: ()
   => ShelleyToBabbageEra era
-  -> Lovelace
+  -> L.Coin
   -> File () Out
   -> ExceptT GovernanceCmdError IO ()
 runGovernanceCreateMirCertificateTransferToTreasuryCmd w ll oFp = do
-  let mirTarget = L.SendToOppositePotMIR (toShelleyLovelace ll)
+  let mirTarget = L.SendToOppositePotMIR ll
 
   let mirCert = makeMIRCertificate $ MirCertificateRequirements w L.ReservesMIR mirTarget
 
@@ -126,11 +126,11 @@ runGovernanceCreateMirCertificateTransferToTreasuryCmd w ll oFp = do
 
 runGovernanceCreateMirCertificateTransferToReservesCmd :: ()
   => ShelleyToBabbageEra era
-  -> Lovelace
+  -> L.Coin
   -> File () Out
   -> ExceptT GovernanceCmdError IO ()
 runGovernanceCreateMirCertificateTransferToReservesCmd w ll oFp = do
-  let mirTarget = L.SendToOppositePotMIR (toShelleyLovelace ll)
+  let mirTarget = L.SendToOppositePotMIR ll
 
   let mirCert = makeMIRCertificate $ MirCertificateRequirements w L.TreasuryMIR mirTarget
 

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Query.hs
@@ -845,7 +845,7 @@ writeStakeAddressInfo
   :: ShelleyBasedEra era
   -> Maybe (File () Out)
   -> DelegationsAndRewards
-  -> Map StakeAddress Lovelace -- ^ deposits
+  -> Map StakeAddress L.Coin -- ^ deposits
   -> Map StakeAddress (L.DRep L.StandardCrypto) -- ^ vote delegatees
   -> ExceptT QueryCmdError IO ()
 writeStakeAddressInfo
@@ -890,7 +890,7 @@ writeStakeAddressInfo
   friendlyDRep (L.DRepCredential cred) =
     L.credToText cred -- this will pring "keyHash-..." or "scriptHash-...", depending on the type of credential
 
-  merged :: [(StakeAddress, Maybe Lovelace, Maybe PoolId, Maybe (L.DRep L.StandardCrypto), Maybe Lovelace)]
+  merged :: [(StakeAddress, Maybe L.Coin, Maybe PoolId, Maybe (L.DRep L.StandardCrypto), Maybe L.Coin)]
   merged =
     [ (addr, mBalance, mPoolId, mDRep, mDeposit)
     | addr <- Set.toList (Set.unions [ Map.keysSet stakeAccountBalances
@@ -1100,7 +1100,7 @@ utxoToText sbe txInOutTuple =
 
   printableValue :: TxOutValue era -> Text
   printableValue = \case
-    TxOutValueByron (Lovelace i) -> Text.pack $ show i
+    TxOutValueByron (L.Coin i) -> Text.pack $ show i
     TxOutValueShelleyBased sbe2 val -> renderValue $ Api.fromLedgerValue sbe2 val
 
 runQueryStakePoolsCmd :: ()

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/StakeAddress.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/StakeAddress.hs
@@ -115,7 +115,7 @@ runStakeAddressBuildCmd stakeVerifier network mOutputFp = do
 runStakeAddressRegistrationCertificateCmd :: ()
   => ShelleyBasedEra era
   -> StakeIdentifier
-  -> Maybe Lovelace -- ^ Deposit required in conway era
+  -> Maybe L.Coin -- ^ Deposit required in conway era
   -> File () Out
   -> ExceptT StakeAddressCmdError IO ()
 runStakeAddressRegistrationCertificateCmd sbe stakeIdentifier mDeposit oFp = do
@@ -141,7 +141,7 @@ runStakeAddressRegistrationCertificateCmd sbe stakeIdentifier mDeposit oFp = do
 createRegistrationCertRequirements :: ()
   => ShelleyBasedEra era
   -> StakeCredential
-  -> Maybe Lovelace -- ^ Deposit required in conway era
+  -> Maybe L.Coin -- ^ Deposit required in conway era
   -> Either StakeAddressRegistrationError (StakeAddressRequirements era)
 createRegistrationCertRequirements sbe stakeCred mdeposit =
   case sbe of
@@ -274,7 +274,7 @@ createStakeDelegationCertificate stakeCredential (StakePoolKeyHash poolStakeVKey
 runStakeAddressDeregistrationCertificateCmd :: ()
   => ShelleyBasedEra era
   -> StakeIdentifier
-  -> Maybe Lovelace -- ^ Deposit required in conway era
+  -> Maybe L.Coin -- ^ Deposit required in conway era
   -> File () Out
   -> ExceptT StakeAddressCmdError IO ()
 runStakeAddressDeregistrationCertificateCmd sbe stakeVerifier mDeposit oFp = do

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Transaction.hs
@@ -361,20 +361,20 @@ runTxBuildRaw :: ()
   -- ^ TxIn for collateral
   -> Maybe (TxOut CtxTx era)
   -- ^ Return collateral
-  -> Maybe Lovelace
+  -> Maybe L.Coin
   -- ^ Total collateral
   -> [TxOut CtxTx era]
   -> Maybe SlotNo
   -- ^ Tx lower bound
   -> TxValidityUpperBound era
   -- ^ Tx upper bound
-  -> Maybe Lovelace
+  -> Maybe L.Coin
   -- ^ Tx fee
   -> (Value, [ScriptWitness WitCtxMint era])
   -- ^ Multi-Asset value(s)
   -> [(Certificate era, Maybe (ScriptWitness WitCtxStake era))]
   -- ^ Certificate with potential script witness
-  -> [(StakeAddress, Lovelace, Maybe (ScriptWitness WitCtxStake era))]
+  -> [(StakeAddress, L.Coin, Maybe (ScriptWitness WitCtxStake era))]
   -> [Hash PaymentKey]
   -- ^ Required signers
   -> TxAuxScripts era
@@ -465,7 +465,7 @@ runTxBuild :: ()
   -- ^ TxIn for collateral
   -> Maybe (TxOut CtxTx era)
   -- ^ Return collateral
-  -> Maybe Lovelace
+  -> Maybe L.Coin
   -- ^ Total collateral
   -> [TxOut CtxTx era]
   -- ^ Normal outputs
@@ -479,7 +479,7 @@ runTxBuild :: ()
   -- ^ Tx upper bound
   -> [(Certificate era, Maybe (ScriptWitness WitCtxStake era))]
   -- ^ Certificate with potential script witness
-  -> [(StakeAddress, Lovelace, Maybe (ScriptWitness WitCtxStake era))]
+  -> [(StakeAddress, L.Coin, Maybe (ScriptWitness WitCtxStake era))]
   -> [Hash PaymentKey]
   -- ^ Required signers
   -> TxAuxScripts era
@@ -500,7 +500,7 @@ runTxBuild
   -- TODO: All functions should be parameterized by ShelleyBasedEra
   -- as it's not possible to call this function with ByronEra
   let era = shelleyBasedToCardanoEra sbe
-      dummyFee = Just $ Lovelace 0
+      dummyFee = Just $ L.Coin 0
       inputsThatRequireWitnessing = [input | (input,_) <- inputsAndMaybeScriptWits]
 
   let allReferenceInputs = getAllReferenceInputs
@@ -654,7 +654,7 @@ getAllReferenceInputs
  :: [(TxIn, Maybe (ScriptWitness WitCtxTxIn era))]
  -> [ScriptWitness WitCtxMint era]
  -> [(Certificate era, Maybe (ScriptWitness WitCtxStake era))]
- -> [(StakeAddress, Lovelace, Maybe (ScriptWitness WitCtxStake era))]
+ -> [(StakeAddress, L.Coin, Maybe (ScriptWitness WitCtxStake era))]
  -> [(VotingProcedures era, Maybe (ScriptWitness WitCtxStake era))]
  -> [(Proposal era, Maybe (ScriptWitness WitCtxStake era))]
  -> [TxIn] -- ^ Read only reference inputs
@@ -709,9 +709,6 @@ toAddressInShelleyBasedEra sbe sAddr = runExcept $
       pure (AddressInEra (ShelleyAddressInEra sbe) sAddr)
 
 
-lovelaceToCoin :: Lovelace -> L.Coin
-lovelaceToCoin (Lovelace ll) = L.Coin ll
-
 toTxOutValueInAnyEra
   :: ShelleyBasedEra era
   -> Value
@@ -719,7 +716,7 @@ toTxOutValueInAnyEra
 toTxOutValueInAnyEra era val =
   caseShelleyToAllegraOrMaryEraOnwards
     (\_ -> case valueToLovelace val of
-      Just l  -> return (TxOutValueShelleyBased era $ lovelaceToCoin l)
+      Just l  -> return (TxOutValueShelleyBased era l)
       Nothing -> txFeatureMismatchPure (toCardanoEra era) TxFeatureMultiAssetOutputs
     )
     (\w -> return (TxOutValueShelleyBased era (toLedgerValue w val))
@@ -733,7 +730,7 @@ toTxOutValueInShelleyBasedEra
 toTxOutValueInShelleyBasedEra sbe val =
   caseShelleyToAllegraOrMaryEraOnwards
     (\_ -> case valueToLovelace val of
-      Just l  -> return (TxOutValueShelleyBased sbe $ lovelaceToCoin l)
+      Just l  -> return (TxOutValueShelleyBased sbe l)
       Nothing -> txFeatureMismatchPure (toCardanoEra sbe) TxFeatureMultiAssetOutputs
     )
     (\w -> return (TxOutValueShelleyBased sbe (toLedgerValue w val))
@@ -1028,7 +1025,7 @@ runTransactionCalculateMinFeeCmd
       InAnyShelleyBasedEra sbe unwitTx <- pure anyTx
       let txbody =  getTxBody unwitTx
       let tx = makeSignedTransaction [] txbody
-          Lovelace fee = estimateTransactionFee sbe
+          L.Coin fee = estimateTransactionFee sbe
                             networkId
                             (protocolParamTxFeeFixed pparams)
                             (protocolParamTxFeePerByte pparams)
@@ -1042,7 +1039,7 @@ runTransactionCalculateMinFeeCmd
       InAnyShelleyBasedEra sbe txbody <- pure anyTxBody
 
       let tx = makeSignedTransaction [] txbody
-          Lovelace fee = estimateTransactionFee sbe
+          L.Coin fee = estimateTransactionFee sbe
                             networkId
                             (protocolParamTxFeeFixed pparams)
                             (protocolParamTxFeePerByte pparams)

--- a/cardano-cli/src/Cardano/CLI/Json/Friendly.hs
+++ b/cardano-cli/src/Cardano/CLI/Json/Friendly.hs
@@ -23,7 +23,7 @@ import qualified Cardano.Api.Ledger as L
 import           Cardano.Api.Shelley (Address (ShelleyAddress), Hash (..),
                    KeyWitness (ShelleyBootstrapWitness, ShelleyKeyWitness), Proposal (Proposal),
                    ShelleyLedgerEra, StakeAddress (..), fromShelleyPaymentCredential,
-                   fromShelleyStakeReference, toShelleyLovelace, toShelleyStakeCredential)
+                   fromShelleyStakeReference, toShelleyStakeCredential)
 
 import           Data.Aeson (Value (..), object, toJSON, (.=))
 import qualified Data.Aeson as Aeson
@@ -218,7 +218,7 @@ friendlyWithdrawals (TxWithdrawals _ withdrawals) =
   array
     [ object $
         "address" .= serialiseAddress addr :
-        "amount" .= friendlyLovelace (toShelleyLovelace amount) :
+        "amount" .= friendlyLovelace amount :
         friendlyStakeAddress addr
     | (addr, amount, _) <- withdrawals
     ]
@@ -319,12 +319,12 @@ friendlyProtocolParametersUpdate
     , protocolUpdateMaxTxSize <&> ("max transaction size" .=)
     , protocolUpdateTxFeeFixed <&> ("transaction fee constant" .=)
     , protocolUpdateTxFeePerByte <&> ("transaction fee linear per byte" .=)
-    , protocolUpdateMinUTxOValue <&> ("min UTxO value" .=) . friendlyLovelace . toShelleyLovelace
+    , protocolUpdateMinUTxOValue <&> ("min UTxO value" .=) . friendlyLovelace
     , protocolUpdateStakeAddressDeposit <&>
-        ("key registration deposit" .=) . friendlyLovelace . toShelleyLovelace
+        ("key registration deposit" .=) . friendlyLovelace
     , protocolUpdateStakePoolDeposit <&>
-        ("pool registration deposit" .=) . friendlyLovelace . toShelleyLovelace
-    , protocolUpdateMinPoolCost <&> ("min pool cost" .=) . friendlyLovelace . toShelleyLovelace
+        ("pool registration deposit" .=) . friendlyLovelace
+    , protocolUpdateMinPoolCost <&> ("min pool cost" .=) . friendlyLovelace
     , protocolUpdatePoolRetireMaxEpoch <&> ("pool retirement epoch boundary" .=)
     , protocolUpdateStakePoolTargetNum <&> ("number of pools" .=)
     , protocolUpdatePoolPledgeInfluence <&>
@@ -340,7 +340,7 @@ friendlyProtocolParametersUpdate
     , protocolUpdateMaxValueSize <&> ("max value size" .=)
     , protocolUpdatePrices <&> ("execution prices" .=) . friendlyPrices
     , protocolUpdateUTxOCostPerByte <&>
-        ("UTxO storage cost per byte" .=) . friendlyLovelace . toShelleyLovelace
+        ("UTxO storage cost per byte" .=) . friendlyLovelace
     ]
 
 friendlyPrices :: ExecutionUnitPrices -> Aeson.Value
@@ -504,7 +504,7 @@ friendlyMirTarget sbe = \case
     "target stake addresses" .=
       [ object
           [ friendlyStakeCredential credential
-          , "amount" .= friendlyLovelace (toShelleyLovelace (Lovelace 0) `L.addDeltaCoin` lovelace)
+          , "amount" .= friendlyLovelace (L.Coin 0 `L.addDeltaCoin` lovelace)
           ]
       | (credential, lovelace) <- Map.toList (shelleyBasedEraConstraints sbe addresses)
       ]
@@ -545,7 +545,7 @@ friendlyRational r =
 
 friendlyFee :: TxFee era -> Aeson.Value
 friendlyFee = \case
-  TxFeeExplicit _ fee -> friendlyLovelace $ toShelleyLovelace fee
+  TxFeeExplicit _ fee -> friendlyLovelace fee
 
 friendlyLovelace :: L.Coin -> Aeson.Value
 friendlyLovelace (L.Coin value) = String $ textShow value <> " Lovelace"
@@ -557,7 +557,7 @@ friendlyMintValue = \case
 
 friendlyTxOutValue :: TxOutValue era -> Aeson.Value
 friendlyTxOutValue = \case
-  TxOutValueByron lovelace -> friendlyLovelace $ toShelleyLovelace lovelace
+  TxOutValueByron lovelace -> friendlyLovelace lovelace
   TxOutValueShelleyBased sbe v -> friendlyLedgerValue sbe v
 
 friendlyLedgerValue :: ()

--- a/cardano-cli/src/Cardano/CLI/Legacy/Commands/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Commands/Genesis.hs
@@ -6,6 +6,7 @@ module Cardano.CLI.Legacy.Commands.Genesis
   , renderLegacyGenesisCmds
   ) where
 
+import           Cardano.Api.Ledger (Coin)
 import           Cardano.Api.Shelley
 
 import           Cardano.Chain.Common (BlockCount)
@@ -20,14 +21,14 @@ data LegacyGenesisCmds
       Word
       Word
       (Maybe SystemStart)
-      (Maybe Lovelace)
+      (Maybe Coin)
       NetworkId
   | GenesisCreateCardano
       GenesisDir
       Word
       Word
       (Maybe SystemStart)
-      (Maybe Lovelace)
+      (Maybe Coin)
       BlockCount
       Word
       Rational
@@ -45,8 +46,8 @@ data LegacyGenesisCmds
       Word
       Word
       (Maybe SystemStart)
-      (Maybe Lovelace)
-      Lovelace
+      (Maybe Coin)
+      Coin
       NetworkId
       Word
       Word

--- a/cardano-cli/src/Cardano/CLI/Legacy/Commands/Governance.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Commands/Governance.hs
@@ -5,6 +5,7 @@
 module Cardano.CLI.Legacy.Commands.Governance where
 
 import           Cardano.Api
+import           Cardano.Api.Ledger (Coin)
 import           Cardano.Api.Shelley
 
 import           Cardano.CLI.Types.Common
@@ -17,15 +18,15 @@ data LegacyGovernanceCmds
       (EraInEon ShelleyToBabbageEra)
       MIRPot
       [StakeAddress]
-      [Lovelace]
+      [Coin]
       (File () Out)
   | GovernanceCreateMirCertificateTransferToTreasuryCmd
       (EraInEon ShelleyToBabbageEra)
-      Lovelace
+      Coin
       (File () Out)
   | GovernanceCreateMirCertificateTransferToReservesCmd
       (EraInEon ShelleyToBabbageEra)
-      Lovelace
+      Coin
       (File () Out)
   | GovernanceGenesisKeyDelegationCertificate
       (EraInEon ShelleyToBabbageEra)

--- a/cardano-cli/src/Cardano/CLI/Legacy/Commands/StakeAddress.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Commands/StakeAddress.hs
@@ -7,6 +7,7 @@ module Cardano.CLI.Legacy.Commands.StakeAddress
   , renderLegacyStakeAddressCmds
   ) where
 
+import           Cardano.Api.Ledger (Coin)
 import           Cardano.Api.Shelley
 
 import           Cardano.CLI.Types.Common
@@ -31,7 +32,7 @@ data LegacyStakeAddressCmds
   | StakeAddressRegistrationCertificateCmd
       (EraInEon ShelleyBasedEra)
       StakeIdentifier
-      (Maybe Lovelace)
+      (Maybe Coin)
       (File () Out)
   | StakeAddressDelegationCertificateCmd
       (EraInEon ShelleyBasedEra)
@@ -41,7 +42,7 @@ data LegacyStakeAddressCmds
   | StakeAddressDeregistrationCertificateCmd
       (EraInEon ShelleyBasedEra)
       StakeIdentifier
-      (Maybe Lovelace)
+      (Maybe Coin)
       (File () Out)
   deriving Show
 

--- a/cardano-cli/src/Cardano/CLI/Legacy/Commands/StakePool.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Commands/StakePool.hs
@@ -6,6 +6,7 @@ module Cardano.CLI.Legacy.Commands.StakePool
   , renderLegacyStakePoolCmds
   ) where
 
+import           Cardano.Api.Ledger (Coin)
 import           Cardano.Api.Shelley hiding (QueryInShelleyBasedEra (..))
 
 import           Cardano.CLI.Types.Common
@@ -38,9 +39,9 @@ data LegacyStakePoolCmds
       -- ^ Stake pool verification key.
       (VerificationKeyOrFile VrfKey)
       -- ^ VRF Verification key.
-      Lovelace
+      Coin
       -- ^ Pool pledge.
-      Lovelace
+      Coin
       -- ^ Pool cost.
       Rational
       -- ^ Pool margin.

--- a/cardano-cli/src/Cardano/CLI/Legacy/Commands/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Commands/Transaction.hs
@@ -6,6 +6,7 @@ module Cardano.CLI.Legacy.Commands.Transaction
   , renderLegacyTransactionCmds
   ) where
 
+import           Cardano.Api.Ledger (Coin)
 import           Cardano.Api.Shelley
 
 import           Cardano.CLI.Types.Common
@@ -26,7 +27,7 @@ data LegacyTransactionCmds
       -- ^ Transaction inputs for collateral, only key witnesses, no scripts.
       (Maybe TxOutShelleyBasedEra)
       -- ^ Return collateral
-      (Maybe Lovelace)
+      (Maybe Coin)
       -- ^ Total collateral
       [RequiredSigner]
       -- ^ Required signers
@@ -37,11 +38,11 @@ data LegacyTransactionCmds
       -- ^ Transaction lower bound
       (Maybe SlotNo)
       -- ^ Transaction upper bound
-      (Maybe Lovelace)
+      (Maybe Coin)
       -- ^ Tx fee
       [(CertificateFile, Maybe (ScriptWitnessFiles WitCtxStake))]
       -- ^ Certificates with potential script witness
-      [(StakeAddress, Lovelace, Maybe (ScriptWitnessFiles WitCtxStake))]
+      [(StakeAddress, Coin, Maybe (ScriptWitnessFiles WitCtxStake))]
       TxMetadataJsonSchema
       [ScriptFile]
       -- ^ Auxiliary scripts
@@ -69,7 +70,7 @@ data LegacyTransactionCmds
       -- ^ Transaction inputs for collateral, only key witnesses, no scripts.
       (Maybe TxOutShelleyBasedEra)
       -- ^ Return collateral
-      (Maybe Lovelace)
+      (Maybe Coin)
       -- ^ Total collateral
       [TxOutAnyEra]
       -- ^ Normal outputs
@@ -83,7 +84,7 @@ data LegacyTransactionCmds
       -- ^ Transaction upper bound
       [(CertificateFile, Maybe (ScriptWitnessFiles WitCtxStake))]
       -- ^ Certificates with potential script witness
-      [(StakeAddress, Lovelace, Maybe (ScriptWitnessFiles WitCtxStake))]
+      [(StakeAddress, Coin, Maybe (ScriptWitnessFiles WitCtxStake))]
       -- ^ Withdrawals with potential script witness
       TxMetadataJsonSchema
       [ScriptFile]

--- a/cardano-cli/src/Cardano/CLI/Legacy/Options.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Options.hs
@@ -22,6 +22,7 @@ module Cardano.CLI.Legacy.Options
   ) where
 
 import           Cardano.Api hiding (QueryInShelleyBasedEra (..))
+import           Cardano.Api.Ledger (Coin (..))
 import           Cardano.Api.Shelley hiding (QueryInShelleyBasedEra (..))
 
 import           Cardano.Chain.Common (BlockCount (BlockCount))
@@ -1115,17 +1116,17 @@ pGenesisCmds envCli =
         , Opt.completer (Opt.bashCompleter "file")
         ]
 
-    pInitialSupplyNonDelegated :: Parser (Maybe Lovelace)
+    pInitialSupplyNonDelegated :: Parser (Maybe Coin)
     pInitialSupplyNonDelegated =
-      Opt.optional $ fmap Lovelace $ Opt.option Opt.auto $ mconcat
+      Opt.optional $ fmap Coin $ Opt.option Opt.auto $ mconcat
         [ Opt.long "supply"
         , Opt.metavar "LOVELACE"
         , Opt.help "The initial coin supply in Lovelace which will be evenly distributed across initial, non-delegating stake holders."
         ]
 
-    pInitialSupplyDelegated :: Parser Lovelace
+    pInitialSupplyDelegated :: Parser Coin
     pInitialSupplyDelegated =
-      fmap (Lovelace . fromMaybe 0) $ Opt.optional $ Opt.option Opt.auto $ mconcat
+      fmap (Coin . fromMaybe 0) $ Opt.optional $ Opt.option Opt.auto $ mconcat
         [ Opt.long "supply-delegated"
         , Opt.metavar "LOVELACE"
         , Opt.help "The initial coin supply in Lovelace which will be evenly distributed across initial, delegating stake holders."

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Genesis.hs
@@ -10,6 +10,7 @@ module Cardano.CLI.Legacy.Run.Genesis
   ) where
 
 import           Cardano.Api
+import           Cardano.Api.Ledger (Coin (..))
 
 import           Cardano.Chain.Common (BlockCount)
 import           Cardano.CLI.EraBased.Commands.Genesis
@@ -122,7 +123,7 @@ runLegacyGenesisCreateCmd :: ()
   -> Word  -- ^ num genesis & delegate keys to make
   -> Word  -- ^ num utxo keys to make
   -> Maybe SystemStart
-  -> Maybe Lovelace
+  -> Maybe Coin
   -> NetworkId
   -> ExceptT GenesisCmdError IO ()
 runLegacyGenesisCreateCmd fmt genDir nGenKeys nUTxOKeys mStart mSupply network =
@@ -142,7 +143,7 @@ runLegacyGenesisCreateCardanoCmd :: ()
   -> Word  -- ^ num genesis & delegate keys to make
   -> Word  -- ^ num utxo keys to make
   -> Maybe SystemStart
-  -> Maybe Lovelace
+  -> Maybe Coin
   -> BlockCount
   -> Word     -- ^ slot length in ms
   -> Rational
@@ -182,8 +183,8 @@ runLegacyGenesisCreateStakedCmd :: ()
   -> Word               -- ^ num pools to make
   -> Word               -- ^ num delegators to make
   -> Maybe SystemStart
-  -> Maybe Lovelace     -- ^ supply going to non-delegators
-  -> Lovelace           -- ^ supply going to delegators
+  -> Maybe Coin     -- ^ supply going to non-delegators
+  -> Coin           -- ^ supply going to delegators
   -> NetworkId
   -> Word               -- ^ bulk credential files to write
   -> Word               -- ^ pool credentials per bulk file

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Governance.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Governance.hs
@@ -96,7 +96,7 @@ runLegacyGovernanceMIRCertificatePayStakeAddrs
   :: EraInEon ShelleyToBabbageEra
   -> L.MIRPot
   -> [StakeAddress] -- ^ Stake addresses
-  -> [Lovelace]     -- ^ Corresponding reward amounts (same length)
+  -> [L.Coin]     -- ^ Corresponding reward amounts (same length)
   -> File () Out
   -> ExceptT GovernanceCmdError IO ()
 runLegacyGovernanceMIRCertificatePayStakeAddrs (EraInEon w) =
@@ -104,7 +104,7 @@ runLegacyGovernanceMIRCertificatePayStakeAddrs (EraInEon w) =
 
 runLegacyGovernanceCreateMirCertificateTransferToTreasuryCmd
   :: EraInEon ShelleyToBabbageEra
-  -> Lovelace
+  -> L.Coin
   -> File () Out
   -> ExceptT GovernanceCmdError IO ()
 runLegacyGovernanceCreateMirCertificateTransferToTreasuryCmd (EraInEon w) =
@@ -112,7 +112,7 @@ runLegacyGovernanceCreateMirCertificateTransferToTreasuryCmd (EraInEon w) =
 
 runLegacyGovernanceCreateMirCertificateTransferToReservesCmd
   :: EraInEon ShelleyToBabbageEra
-  -> Lovelace
+  -> L.Coin
   -> File () Out
   -> ExceptT GovernanceCmdError IO ()
 runLegacyGovernanceCreateMirCertificateTransferToReservesCmd (EraInEon w) =

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/StakeAddress.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/StakeAddress.hs
@@ -6,6 +6,7 @@ module Cardano.CLI.Legacy.Run.StakeAddress
   ) where
 
 import           Cardano.Api
+import           Cardano.Api.Ledger (Coin)
 import           Cardano.Api.Shelley
 
 import           Cardano.CLI.EraBased.Run.StakeAddress
@@ -57,7 +58,7 @@ runLegacyStakeAddressBuildCmd =
 runLegacyStakeAddressRegistrationCertificateCmd :: ()
   => EraInEon ShelleyBasedEra
   -> StakeIdentifier
-  -> Maybe Lovelace -- ^ Deposit required in conway era
+  -> Maybe Coin -- ^ Deposit required in conway era
   -> File () Out
   -> ExceptT StakeAddressCmdError IO ()
 runLegacyStakeAddressRegistrationCertificateCmd (EraInEon sbe) =
@@ -78,7 +79,7 @@ runLegacyStakeAddresslDelegationCertificateCmd (EraInEon sbe) =
 runLegacyStakeAddressDeregistrationCertificateCmd :: ()
   => EraInEon ShelleyBasedEra
   -> StakeIdentifier
-  -> Maybe Lovelace -- ^ Deposit required in conway era
+  -> Maybe Coin -- ^ Deposit required in conway era
   -> File () Out
   -> ExceptT StakeAddressCmdError IO ()
 runLegacyStakeAddressDeregistrationCertificateCmd (EraInEon sbe) =

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/StakePool.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/StakePool.hs
@@ -39,9 +39,9 @@ runLegacyStakePoolRegistrationCertificateCmd :: ()
   -- ^ Stake pool verification key.
   -> VerificationKeyOrFile VrfKey
   -- ^ VRF Verification key.
-  -> Lovelace
+  -> L.Coin
   -- ^ Pool pledge.
-  -> Lovelace
+  -> L.Coin
   -- ^ Pool cost.
   -> Rational
   -- ^ Pool margin.

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Transaction.hs
@@ -11,6 +11,7 @@ module Cardano.CLI.Legacy.Run.Transaction
 
 import           Cardano.Api
 import qualified Cardano.Api.Byron as Api
+import           Cardano.Api.Ledger (Coin)
 
 import qualified Cardano.CLI.EraBased.Commands.Transaction as Cmd
 import           Cardano.CLI.EraBased.Run.Transaction
@@ -75,14 +76,14 @@ runLegacyTransactionBuildCmd :: ()
   -> [RequiredSigner] -- ^ Required signers
   -> [TxIn] -- ^ Transaction inputs for collateral, only key witnesses, no scripts.
   -> Maybe TxOutShelleyBasedEra -- ^ Return collateral
-  -> Maybe Lovelace -- ^ Total collateral
+  -> Maybe Coin -- ^ Total collateral
   -> [TxOutAnyEra]
   -> TxOutChangeAddress
   -> Maybe (Value, [ScriptWitnessFiles WitCtxMint])
   -> Maybe SlotNo -- ^ Validity lower bound
   -> Maybe SlotNo -- ^ Validity upper bound
   -> [(CertificateFile, Maybe (ScriptWitnessFiles WitCtxStake))]
-  -> [(StakeAddress, Lovelace, Maybe (ScriptWitnessFiles WitCtxStake))] -- ^ Withdrawals with potential script witness
+  -> [(StakeAddress, Coin, Maybe (ScriptWitnessFiles WitCtxStake))] -- ^ Withdrawals with potential script witness
   -> TxMetadataJsonSchema
   -> [ScriptFile]
   -> [MetadataFile]
@@ -127,15 +128,15 @@ runLegacyTransactionBuildRawCmd :: ()
   -> [TxIn] -- ^ Read only reference inputs
   -> [TxIn] -- ^ Transaction inputs for collateral, only key witnesses, no scripts.
   -> Maybe TxOutShelleyBasedEra -- ^ Return collateral
-  -> Maybe Lovelace -- ^ Total collateral
+  -> Maybe Coin -- ^ Total collateral
   -> [RequiredSigner]
   -> [TxOutAnyEra]
   -> Maybe (Value, [ScriptWitnessFiles WitCtxMint]) -- ^ Multi-Asset value with script witness
   -> Maybe SlotNo -- ^ Validity lower bound
   -> Maybe SlotNo -- ^ Validity upper bound
-  -> Maybe Lovelace -- ^ Tx fee
+  -> Maybe Coin -- ^ Tx fee
   -> [(CertificateFile, Maybe (ScriptWitnessFiles WitCtxStake))]
-  -> [(StakeAddress, Lovelace, Maybe (ScriptWitnessFiles WitCtxStake))]
+  -> [(StakeAddress, Coin, Maybe (ScriptWitnessFiles WitCtxStake))]
   -> TxMetadataJsonSchema
   -> [ScriptFile]
   -> [MetadataFile]

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/TxValidationError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/TxValidationError.hs
@@ -82,7 +82,7 @@ instance Error TxFeeValidationError where
     "Explicit transaction fee not supported in " <> pretty era
 
 validateTxFee :: ShelleyBasedEra era
-              -> Maybe Lovelace -- TODO: Make this mandatory in the cli (Remove Maybe)
+              -> Maybe L.Coin -- TODO: Make this mandatory in the cli (Remove Maybe)
               -> Either TxFeeValidationError (TxFee era)
 validateTxFee era = \case
   Nothing ->
@@ -99,7 +99,7 @@ instance Error TxTotalCollateralValidationError where
     "Transaction collateral not supported in " <> pretty era
 
 validateTxTotalCollateral :: CardanoEra era
-                          -> Maybe Lovelace
+                          -> Maybe L.Coin
                           -> Either TxTotalCollateralValidationError (TxTotalCollateral era)
 validateTxTotalCollateral _ Nothing = return TxTotalCollateralNone
 validateTxTotalCollateral era (Just coll) = do
@@ -197,7 +197,7 @@ instance Error TxWithdrawalsValidationError where
 validateTxWithdrawals
   :: forall era.
      CardanoEra era
-  -> [(StakeAddress, Lovelace, Maybe (ScriptWitness WitCtxStake era))]
+  -> [(StakeAddress, L.Coin, Maybe (ScriptWitness WitCtxStake era))]
   -> Either TxWithdrawalsValidationError (TxWithdrawals BuildTx era)
 validateTxWithdrawals _ [] = return TxWithdrawalsNone
 validateTxWithdrawals era withdrawals = do
@@ -206,8 +206,8 @@ validateTxWithdrawals era withdrawals = do
   pure $ TxWithdrawals supported convWithdrawals
  where
   convert
-    :: (StakeAddress, Lovelace, Maybe (ScriptWitness WitCtxStake era))
-    -> (StakeAddress, Lovelace, BuildTxWith BuildTx (Witness WitCtxStake era))
+    :: (StakeAddress, L.Coin, Maybe (ScriptWitness WitCtxStake era))
+    -> (StakeAddress, L.Coin, BuildTxWith BuildTx (Witness WitCtxStake era))
   convert (sAddr, ll, mScriptWitnessFiles) =
     case mScriptWitnessFiles of
       Just sWit -> (sAddr, ll, BuildTxWith $ ScriptWitness ScriptWitnessForStakeAddr sWit)

--- a/cardano-cli/src/Cardano/CLI/Types/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Key.hs
@@ -136,9 +136,9 @@ data StakePoolRegistrationParserRequirements
      -- ^ Stake pool verification key.
      , sprVrfKey :: VerificationKeyOrFile VrfKey
      -- ^ VRF Verification key.
-     , sprPoolPledge :: Lovelace
+     , sprPoolPledge :: L.Coin
      -- ^ Pool pledge.
-     , sprPoolCost :: Lovelace
+     , sprPoolCost :: L.Coin
      -- ^ Pool cost.
      , sprPoolMargin :: Rational
      -- ^ Pool margin.

--- a/cardano-cli/src/Cardano/CLI/Types/Output.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Output.hs
@@ -248,7 +248,7 @@ data ScriptCostOutput =
   ScriptCostOutput
     { scScriptHash :: ScriptHash
     , scExecutionUnits :: ExecutionUnits
-    , scAda :: Lovelace
+    , scAda :: L.Coin
     }
 
 instance ToJSON ScriptCostOutput where

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1709638907,
-        "narHash": "sha256-kFgmpiV7U3h29zNwCRYLYBcUS7x3aPR185xFKK5zKb8=",
+        "lastModified": 1710408447,
+        "narHash": "sha256-zfERQOTVkZp4DDIrRE6V5xLMd5DRnXEdRn89WlLEJvI=",
         "owner": "input-output-hk",
         "repo": "cardano-haskell-packages",
-        "rev": "7901eee50274ca3f4b2121e7e5c6c50cd4193c37",
+        "rev": "37b94f464b015f4f5857c7c20f82347cb5f79af9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Update [cardano-api-8.40.0.0](https://github.com/IntersectMBO/cardano-api/blob/main/cardano-api/CHANGELOG.md#84000)
  type:
  - improvement
```

# Context

This PR updates `.cabal` file and removes `Lovelace` in favor of `Coin` since it was removed in `cardano-api-8.40.0.0`.

It still relies on a stanza because CHaP hasn't been updated at the time of writing. But it should be removed before merging it.

# How to trust this PR

This PR should be a refactoring, it shouldn't have any changes to functionality.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff

