### PR TITLE
query leadership-schedule: add --output-[json,text] flag to control format of the output

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Query.hs
@@ -70,6 +70,7 @@ data QueryLeadershipScheduleCmdArgs = QueryLeadershipScheduleCmdArgs
   , vrkSkeyFp           :: !(SigningKeyFile In)
   , whichSchedule       :: !EpochLeadershipSchedule
   , target              :: !(Consensus.Target ChainPoint)
+  , format              :: Maybe QueryOutputFormat
   , mOutFile            :: !(Maybe (File () Out))
   } deriving (Generic, Show)
 

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Query.hs
@@ -264,6 +264,7 @@ pLeadershipScheduleCmd era envCli =
       <*> pVrfSigningKeyFile
       <*> pWhichLeadershipSchedule
       <*> pTarget era
+      <*> (optional $ pQueryOutputFormat "leadership-schedule")
       <*> pMaybeOutputFile
 
 pKesPeriodInfoCmd :: CardanoEra era -> EnvCli -> Parser (QueryCmds era)

--- a/cardano-cli/src/Cardano/CLI/Legacy/Commands/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Commands/Query.hs
@@ -57,6 +57,7 @@ data LegacyQueryLeadershipScheduleCmdArgs = LegacyQueryLeadershipScheduleCmdArgs
   , poolColdVerKeyFile  :: !(VerificationKeyOrHashOrFile StakePoolKey)
   , vrkSkeyFp           :: !(SigningKeyFile In)
   , whichSchedule       :: !EpochLeadershipSchedule
+  , format              :: Maybe QueryOutputFormat
   , mOutFile            :: !(Maybe (File () Out))
   } deriving (Generic, Show)
 

--- a/cardano-cli/src/Cardano/CLI/Legacy/Options.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Options.hs
@@ -762,6 +762,7 @@ pQueryCmds envCli =
           <*> pStakePoolVerificationKeyOrHashOrFile Nothing
           <*> pVrfSigningKeyFile
           <*> pWhichLeadershipSchedule
+          <*> (optional $ pQueryOutputFormat "leadership-schedule")
           <*> pMaybeOutputFile
 
     pKesPeriodInfo :: Parser LegacyQueryCmds

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -578,6 +578,9 @@ Usage: cardano-cli shelley query leadership-schedule --socket-path SOCKET_PATH
                                                        )
                                                        --vrf-signing-key-file FILE
                                                        (--current | --next)
+                                                       [ --output-json
+                                                       | --output-text
+                                                       ]
                                                        [--out-file FILE]
 
   Get the slots the node is expected to mint a block in (advanced command)
@@ -1743,6 +1746,9 @@ Usage: cardano-cli allegra query leadership-schedule --socket-path SOCKET_PATH
                                                        )
                                                        --vrf-signing-key-file FILE
                                                        (--current | --next)
+                                                       [ --output-json
+                                                       | --output-text
+                                                       ]
                                                        [--out-file FILE]
 
   Get the slots the node is expected to mint a block in (advanced command)
@@ -2906,6 +2912,9 @@ Usage: cardano-cli mary query leadership-schedule --socket-path SOCKET_PATH
                                                     )
                                                     --vrf-signing-key-file FILE
                                                     (--current | --next)
+                                                    [ --output-json
+                                                    | --output-text
+                                                    ]
                                                     [--out-file FILE]
 
   Get the slots the node is expected to mint a block in (advanced command)
@@ -4061,6 +4070,9 @@ Usage: cardano-cli alonzo query leadership-schedule --socket-path SOCKET_PATH
                                                       )
                                                       --vrf-signing-key-file FILE
                                                       (--current | --next)
+                                                      [ --output-json
+                                                      | --output-text
+                                                      ]
                                                       [--out-file FILE]
 
   Get the slots the node is expected to mint a block in (advanced command)
@@ -5251,6 +5263,9 @@ Usage: cardano-cli babbage query leadership-schedule --socket-path SOCKET_PATH
                                                        )
                                                        --vrf-signing-key-file FILE
                                                        (--current | --next)
+                                                       [ --output-json
+                                                       | --output-text
+                                                       ]
                                                        [--out-file FILE]
 
   Get the slots the node is expected to mint a block in (advanced command)
@@ -6711,6 +6726,9 @@ Usage: cardano-cli conway query leadership-schedule --socket-path SOCKET_PATH
                                                       [ --volatile-tip
                                                       | --immutable-tip
                                                       ]
+                                                      [ --output-json
+                                                      | --output-text
+                                                      ]
                                                       [--out-file FILE]
 
   Get the slots the node is expected to mint a block in (advanced command)
@@ -8065,6 +8083,9 @@ Usage: cardano-cli latest query leadership-schedule --socket-path SOCKET_PATH
                                                       )
                                                       --vrf-signing-key-file FILE
                                                       (--current | --next)
+                                                      [ --output-json
+                                                      | --output-text
+                                                      ]
                                                       [--out-file FILE]
 
   Get the slots the node is expected to mint a block in (advanced command)
@@ -9084,6 +9105,9 @@ Usage: cardano-cli legacy query leadership-schedule --socket-path SOCKET_PATH
                                                       )
                                                       --vrf-signing-key-file FILE
                                                       (--current | --next)
+                                                      [ --output-json
+                                                      | --output-text
+                                                      ]
                                                       [--out-file FILE]
 
   Get the slots the node is expected to mint a block in (advanced command)
@@ -10327,6 +10351,7 @@ Usage: cardano-cli query leadership-schedule --socket-path SOCKET_PATH
                                                )
                                                --vrf-signing-key-file FILE
                                                (--current | --next)
+                                               [--output-json | --output-text]
                                                [--out-file FILE]
 
   Get the slots the node is expected to mint a block in (advanced command)

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_leadership-schedule.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_leadership-schedule.cli
@@ -11,6 +11,9 @@ Usage: cardano-cli allegra query leadership-schedule --socket-path SOCKET_PATH
                                                        )
                                                        --vrf-signing-key-file FILE
                                                        (--current | --next)
+                                                       [ --output-json
+                                                       | --output-text
+                                                       ]
                                                        [--out-file FILE]
 
   Get the slots the node is expected to mint a block in (advanced command)
@@ -41,5 +44,9 @@ Available options:
                            Input filepath of the VRF signing key.
   --current                Get the leadership schedule for the current epoch.
   --next                   Get the leadership schedule for the following epoch.
+  --output-json            Format leadership-schedule query output to JSON.
+                           Default format when writing to a file
+  --output-text            Format leadership-schedule query output to TEXT.
+                           Default format when writing to stdout
   --out-file FILE          Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_leadership-schedule.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_leadership-schedule.cli
@@ -11,6 +11,9 @@ Usage: cardano-cli alonzo query leadership-schedule --socket-path SOCKET_PATH
                                                       )
                                                       --vrf-signing-key-file FILE
                                                       (--current | --next)
+                                                      [ --output-json
+                                                      | --output-text
+                                                      ]
                                                       [--out-file FILE]
 
   Get the slots the node is expected to mint a block in (advanced command)
@@ -41,5 +44,9 @@ Available options:
                            Input filepath of the VRF signing key.
   --current                Get the leadership schedule for the current epoch.
   --next                   Get the leadership schedule for the following epoch.
+  --output-json            Format leadership-schedule query output to JSON.
+                           Default format when writing to a file
+  --output-text            Format leadership-schedule query output to TEXT.
+                           Default format when writing to stdout
   --out-file FILE          Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_leadership-schedule.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_leadership-schedule.cli
@@ -11,6 +11,9 @@ Usage: cardano-cli babbage query leadership-schedule --socket-path SOCKET_PATH
                                                        )
                                                        --vrf-signing-key-file FILE
                                                        (--current | --next)
+                                                       [ --output-json
+                                                       | --output-text
+                                                       ]
                                                        [--out-file FILE]
 
   Get the slots the node is expected to mint a block in (advanced command)
@@ -41,5 +44,9 @@ Available options:
                            Input filepath of the VRF signing key.
   --current                Get the leadership schedule for the current epoch.
   --next                   Get the leadership schedule for the following epoch.
+  --output-json            Format leadership-schedule query output to JSON.
+                           Default format when writing to a file
+  --output-text            Format leadership-schedule query output to TEXT.
+                           Default format when writing to stdout
   --out-file FILE          Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_leadership-schedule.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_leadership-schedule.cli
@@ -14,6 +14,9 @@ Usage: cardano-cli conway query leadership-schedule --socket-path SOCKET_PATH
                                                       [ --volatile-tip
                                                       | --immutable-tip
                                                       ]
+                                                      [ --output-json
+                                                      | --output-text
+                                                      ]
                                                       [--out-file FILE]
 
   Get the slots the node is expected to mint a block in (advanced command)
@@ -47,5 +50,9 @@ Available options:
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.
+  --output-json            Format leadership-schedule query output to JSON.
+                           Default format when writing to a file
+  --output-text            Format leadership-schedule query output to TEXT.
+                           Default format when writing to stdout
   --out-file FILE          Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_leadership-schedule.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_leadership-schedule.cli
@@ -11,6 +11,9 @@ Usage: cardano-cli latest query leadership-schedule --socket-path SOCKET_PATH
                                                       )
                                                       --vrf-signing-key-file FILE
                                                       (--current | --next)
+                                                      [ --output-json
+                                                      | --output-text
+                                                      ]
                                                       [--out-file FILE]
 
   Get the slots the node is expected to mint a block in (advanced command)
@@ -41,5 +44,9 @@ Available options:
                            Input filepath of the VRF signing key.
   --current                Get the leadership schedule for the current epoch.
   --next                   Get the leadership schedule for the following epoch.
+  --output-json            Format leadership-schedule query output to JSON.
+                           Default format when writing to a file
+  --output-text            Format leadership-schedule query output to TEXT.
+                           Default format when writing to stdout
   --out-file FILE          Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_query_leadership-schedule.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_query_leadership-schedule.cli
@@ -11,6 +11,9 @@ Usage: cardano-cli legacy query leadership-schedule --socket-path SOCKET_PATH
                                                       )
                                                       --vrf-signing-key-file FILE
                                                       (--current | --next)
+                                                      [ --output-json
+                                                      | --output-text
+                                                      ]
                                                       [--out-file FILE]
 
   Get the slots the node is expected to mint a block in (advanced command)
@@ -41,5 +44,9 @@ Available options:
                            Input filepath of the VRF signing key.
   --current                Get the leadership schedule for the current epoch.
   --next                   Get the leadership schedule for the following epoch.
+  --output-json            Format leadership-schedule query output to JSON.
+                           Default format when writing to a file
+  --output-text            Format leadership-schedule query output to TEXT.
+                           Default format when writing to stdout
   --out-file FILE          Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_leadership-schedule.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_leadership-schedule.cli
@@ -11,6 +11,9 @@ Usage: cardano-cli mary query leadership-schedule --socket-path SOCKET_PATH
                                                     )
                                                     --vrf-signing-key-file FILE
                                                     (--current | --next)
+                                                    [ --output-json
+                                                    | --output-text
+                                                    ]
                                                     [--out-file FILE]
 
   Get the slots the node is expected to mint a block in (advanced command)
@@ -41,5 +44,9 @@ Available options:
                            Input filepath of the VRF signing key.
   --current                Get the leadership schedule for the current epoch.
   --next                   Get the leadership schedule for the following epoch.
+  --output-json            Format leadership-schedule query output to JSON.
+                           Default format when writing to a file
+  --output-text            Format leadership-schedule query output to TEXT.
+                           Default format when writing to stdout
   --out-file FILE          Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/query_leadership-schedule.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/query_leadership-schedule.cli
@@ -11,6 +11,7 @@ Usage: cardano-cli query leadership-schedule --socket-path SOCKET_PATH
                                                )
                                                --vrf-signing-key-file FILE
                                                (--current | --next)
+                                               [--output-json | --output-text]
                                                [--out-file FILE]
 
   Get the slots the node is expected to mint a block in (advanced command)
@@ -41,5 +42,9 @@ Available options:
                            Input filepath of the VRF signing key.
   --current                Get the leadership schedule for the current epoch.
   --next                   Get the leadership schedule for the following epoch.
+  --output-json            Format leadership-schedule query output to JSON.
+                           Default format when writing to a file
+  --output-text            Format leadership-schedule query output to TEXT.
+                           Default format when writing to stdout
   --out-file FILE          Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_leadership-schedule.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_leadership-schedule.cli
@@ -11,6 +11,9 @@ Usage: cardano-cli shelley query leadership-schedule --socket-path SOCKET_PATH
                                                        )
                                                        --vrf-signing-key-file FILE
                                                        (--current | --next)
+                                                       [ --output-json
+                                                       | --output-text
+                                                       ]
                                                        [--out-file FILE]
 
   Get the slots the node is expected to mint a block in (advanced command)
@@ -41,5 +44,9 @@ Available options:
                            Input filepath of the VRF signing key.
   --current                Get the leadership schedule for the current epoch.
   --next                   Get the leadership schedule for the following epoch.
+  --output-json            Format leadership-schedule query output to JSON.
+                           Default format when writing to a file
+  --output-text            Format leadership-schedule query output to TEXT.
+                           Default format when writing to stdout
   --out-file FILE          Optional output file. Default is to write to stdout.
   -h,--help                Show this help text


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    query leadership: add --output-[json,text] flag to control format of the output. Previous behavior is preserved (write text to stdout, write json to file)
# uncomment types applicable to the change:
  type:
  - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

* It appears this is a longstanding request from users, as pointed out by @CarlosLopezDeLara to me
* Contributes to fixing https://github.com/IntersectMBO/cardano-cli/issues/566
* The design is the same as https://github.com/IntersectMBO/cardano-cli/pull/523 and https://github.com/IntersectMBO/cardano-cli/pull/611 to guarantee consistency

# How to trust this PR

* I tested this PR manually with [this test from cardano-node](https://github.com/IntersectMBO/cardano-node/blob/master/cardano-testnet/test/cardano-testnet-test/Cardano/Testnet/Test/Cli/Babbage/LeadershipSchedule.hs#L264). I tested all new behaviors.
* I checked manually that the historical behavior was preserved.

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff