### PR TITLE
    Add Plutus script hash support in `update-committee`, `overnance committee create-cold-key-resignation-certificate` and `query committee-state` commands.

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -40,6 +40,12 @@ test-show-details: direct
 -- Always write GHC env files, because they are needed for ghci.
 write-ghc-environment-files: always
 
+-- FIXME: remove this when bumping ouroboros-consensus
+-- this is required to build with ouroboros-consensus-cardano-0.14.0.1
+allow-newer: 
+  cardano-git-rev
+
 -- IMPORTANT
 -- Do NOT add more source-repository-package stanzas here unless they are strictly
 -- temporary! Please read the section in CONTRIBUTING about updating dependencies.
+

--- a/cabal.project
+++ b/cabal.project
@@ -14,7 +14,7 @@ repository cardano-haskell-packages
 -- you need to run if you change them
 index-state:
   , hackage.haskell.org 2024-03-15T22:05:53Z
-  , cardano-haskell-packages 2024-03-15T18:07:40Z
+  , cardano-haskell-packages 2024-03-20T14:04:39Z
 
 packages:
   cardano-cli

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -195,7 +195,7 @@ library
                       , binary
                       , bytestring
                       , canonical-json
-                      , cardano-api ^>= 8.41.0.0
+                      , cardano-api ^>= 8.42.0.0
                       , cardano-binary
                       , cardano-crypto
                       , cardano-crypto-class ^>= 2.1.2

--- a/cardano-cli/src/Cardano/CLI/Byron/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Run.hs
@@ -154,7 +154,7 @@ runPrintSigningKeyAddress bKeyFormat networkid skF = do
 
 runKeygen :: NewSigningKeyFile -> ExceptT ByronClientCmdError IO ()
 runKeygen (NewSigningKeyFile skF)  = do
-  sK <- liftIO $ generateSigningKey AsByronKey
+  sK <- generateSigningKey AsByronKey
   firstExceptT ByronCmdHelpersError . ensureNewFileLBS skF $ serialiseToRawBytes sK
 
 runToVerification :: ByronKeyFormat -> SigningKeyFile In -> NewVerificationKeyFile -> ExceptT ByronClientCmdError IO ()

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/Actions.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/Actions.hs
@@ -8,7 +8,7 @@
 
 module Cardano.CLI.EraBased.Commands.Governance.Actions
   ( GovernanceActionCmds(..)
-  , GoveranceActionUpdateCommitteeCmdArgs(..)
+  , GovernanceActionUpdateCommitteeCmdArgs(..)
   , GovernanceActionCreateConstitutionCmdArgs(..)
   , GovernanceActionCreateNoConfidenceCmdArgs(..)
   , GovernanceActionInfoCmdArgs(..)
@@ -33,7 +33,7 @@ import           Data.Word
 
 data GovernanceActionCmds era
   = GovernanceActionCreateConstitutionCmd         !(GovernanceActionCreateConstitutionCmdArgs era)
-  | GoveranceActionUpdateCommitteeCmd             !(GoveranceActionUpdateCommitteeCmdArgs era)
+  | GovernanceActionUpdateCommitteeCmd            !(GovernanceActionUpdateCommitteeCmdArgs era)
   | GovernanceActionCreateNoConfidenceCmd         !(GovernanceActionCreateNoConfidenceCmdArgs era)
   | GovernanceActionProtocolParametersUpdateCmd   !(GovernanceActionProtocolParametersUpdateCmdArgs era)
   | GovernanceActionTreasuryWithdrawalCmd         !(GovernanceActionTreasuryWithdrawalCmdArgs era)
@@ -41,16 +41,16 @@ data GovernanceActionCmds era
   | GovernanceActionViewCmd                       !(GovernanceActionViewCmdArgs era)
   deriving Show
 
-data GoveranceActionUpdateCommitteeCmdArgs era
-  = GoveranceActionUpdateCommitteeCmdArgs
+data GovernanceActionUpdateCommitteeCmdArgs era
+  = GovernanceActionUpdateCommitteeCmdArgs
       { eon                     :: !(ConwayEraOnwards era)
       , networkId               :: !L.Network
       , deposit                 :: !L.Coin
       , returnAddress           :: !StakeIdentifier
       , proposalUrl             :: !ProposalUrl
       , proposalHash            :: !(L.SafeHash L.StandardCrypto L.AnchorData)
-      , oldCommitteeVkeySource  :: ![VerificationKeyOrHashOrFileOrScript CommitteeColdKey]
-      , newCommitteeVkeySource  :: ![(VerificationKeyOrHashOrFileOrScript CommitteeColdKey, EpochNo)]
+      , oldCommitteeVkeySource  :: ![VerificationKeyOrHashOrFileOrScriptHash CommitteeColdKey]
+      , newCommitteeVkeySource  :: ![(VerificationKeyOrHashOrFileOrScriptHash CommitteeColdKey, EpochNo)]
       , requiredQuorum          :: !Rational
       , mPrevGovernanceActionId :: !(Maybe (TxId, Word32))
       , outFile                 :: !(File () Out)
@@ -175,7 +175,7 @@ renderGovernanceActionCmds = ("governance action " <>) . \case
   GovernanceActionTreasuryWithdrawalCmd {} ->
     "create-treasury-withdrawal"
 
-  GoveranceActionUpdateCommitteeCmd {} ->
+  GovernanceActionUpdateCommitteeCmd {} ->
     "update-committee"
 
   GovernanceActionCreateNoConfidenceCmd {} ->

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/Actions.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/Actions.hs
@@ -49,8 +49,8 @@ data GoveranceActionUpdateCommitteeCmdArgs era
       , returnAddress           :: !StakeIdentifier
       , proposalUrl             :: !ProposalUrl
       , proposalHash            :: !(L.SafeHash L.StandardCrypto L.AnchorData)
-      , oldCommitteeVkeySource  :: ![VerificationKeyOrHashOrFile CommitteeColdKey]
-      , newCommitteeVkeySource  :: ![(VerificationKeyOrHashOrFile CommitteeColdKey, EpochNo)]
+      , oldCommitteeVkeySource  :: ![VerificationKeyOrHashOrFileOrScript CommitteeColdKey]
+      , newCommitteeVkeySource  :: ![(VerificationKeyOrHashOrFileOrScript CommitteeColdKey, EpochNo)]
       , requiredQuorum          :: !Rational
       , mPrevGovernanceActionId :: !(Maybe (TxId, Word32))
       , outFile                 :: !(File () Out)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/Committee.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/Committee.hs
@@ -60,7 +60,7 @@ data GovernanceCommitteeCreateHotKeyAuthorizationCertificateCmdArgs era =
 data GovernanceCommitteeCreateColdKeyResignationCertificateCmdArgs era =
   GovernanceCommitteeCreateColdKeyResignationCertificateCmdArgs
     { eon               :: !(ConwayEraOnwards era)
-    , vkeyColdKeySource :: !(VerificationKeyOrHashOrFile CommitteeColdKey)
+    , vkeyColdKeySource :: !(VerificationKeyOrHashOrFileOrScriptHash CommitteeColdKey)
     , anchor            :: !(Maybe (L.Anchor (L.EraCrypto (ShelleyLedgerEra era))))
     , outFile           :: !(File () Out)
     } deriving Show

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Query.hs
@@ -233,8 +233,8 @@ data QueryCommitteeMembersStateCmdArgs era = QueryCommitteeMembersStateCmdArgs
   , nodeSocketPath          :: !SocketPath
   , consensusModeParams     :: !ConsensusModeParams
   , networkId               :: !NetworkId
-  , committeeColdKeys       :: ![VerificationKeyOrHashOrFile CommitteeColdKey]
-  , committeeHotKeys        :: ![VerificationKeyOrHashOrFile CommitteeHotKey]
+  , committeeColdKeys       :: ![VerificationKeyOrHashOrFileOrScriptHash CommitteeColdKey]
+  , committeeHotKeys        :: ![VerificationKeyOrHashOrFileOrScriptHash CommitteeHotKey]
   , memberStatuses          :: ![MemberStatus]
   , target                  :: !(Consensus.Target ChainPoint)
   , mOutFile                :: !(Maybe (File () Out))

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
@@ -634,11 +634,12 @@ pOperatorCertIssueCounterFile =
 
 ---
 
-pAddCommitteeColdVerificationKeyOrHashOrFile :: Parser (VerificationKeyOrHashOrFile CommitteeColdKey)
+pAddCommitteeColdVerificationKeyOrHashOrFile :: Parser (VerificationKeyOrHashOrFileOrScript CommitteeColdKey)
 pAddCommitteeColdVerificationKeyOrHashOrFile =
   asum
-    [ VerificationKeyOrFile <$> pAddCommitteeColdVerificationKeyOrFile
-    , VerificationKeyHash <$> pAddCommitteeColdVerificationKeyHash
+    [ VkhfsKeyHashFile . VerificationKeyOrFile <$> pAddCommitteeColdVerificationKeyOrFile
+    , VkhfsKeyHashFile . VerificationKeyHash <$> pAddCommitteeColdVerificationKeyHash
+    , VkhfsScript <$> pScriptFor "add-cc-cold-script-file" Nothing "Cold Native or Plutus script file"
     ]
 
 pAddCommitteeColdVerificationKeyHash :: Parser (Hash CommitteeColdKey)
@@ -686,11 +687,12 @@ pAddCommitteeColdVerificationKeyFile =
     ]
 
 ---
-pRemoveCommitteeColdVerificationKeyOrHashOrFile :: Parser (VerificationKeyOrHashOrFile CommitteeColdKey)
+pRemoveCommitteeColdVerificationKeyOrHashOrFile :: Parser (VerificationKeyOrHashOrFileOrScript CommitteeColdKey)
 pRemoveCommitteeColdVerificationKeyOrHashOrFile =
   asum
-    [ VerificationKeyOrFile <$> pRemoveCommitteeColdVerificationKeyOrFile
-    , VerificationKeyHash <$> pRemoveCommitteeColdVerificationKeyHash
+    [ VkhfsKeyHashFile . VerificationKeyOrFile <$> pRemoveCommitteeColdVerificationKeyOrFile
+    , VkhfsKeyHashFile . VerificationKeyHash <$> pRemoveCommitteeColdVerificationKeyHash
+    , VkhfsScript <$> pScriptFor "remove-cc-cold-script-file" Nothing "Cold Native or Plutus script file"
     ]
 
 pRemoveCommitteeColdVerificationKeyHash :: Parser (Hash CommitteeColdKey)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
@@ -634,12 +634,15 @@ pOperatorCertIssueCounterFile =
 
 ---
 
-pAddCommitteeColdVerificationKeyOrHashOrFile :: Parser (VerificationKeyOrHashOrFileOrScript CommitteeColdKey)
+pAddCommitteeColdVerificationKeyOrHashOrFile :: Parser (VerificationKeyOrHashOrFileOrScriptHash CommitteeColdKey)
 pAddCommitteeColdVerificationKeyOrHashOrFile =
   asum
-    [ VkhfsKeyHashFile . VerificationKeyOrFile <$> pAddCommitteeColdVerificationKeyOrFile
-    , VkhfsKeyHashFile . VerificationKeyHash <$> pAddCommitteeColdVerificationKeyHash
-    , VkhfsScript <$> pScriptFor "add-cc-cold-script-file" Nothing "Cold Native or Plutus script file"
+    [ VkhfshKeyHashFile . VerificationKeyOrFile <$> pAddCommitteeColdVerificationKeyOrFile
+    , VkhfshKeyHashFile . VerificationKeyHash <$> pAddCommitteeColdVerificationKeyHash
+    , VkhfshScriptHash <$>
+        pScriptHash
+          "add-cc-cold-script-hash"
+          "Cold Native or Plutus script file hash (hex-encoded). Obtain it with \"cardano-cli conway governance hash script ...\"."
     ]
 
 pAddCommitteeColdVerificationKeyHash :: Parser (Hash CommitteeColdKey)
@@ -687,12 +690,26 @@ pAddCommitteeColdVerificationKeyFile =
     ]
 
 ---
-pRemoveCommitteeColdVerificationKeyOrHashOrFile :: Parser (VerificationKeyOrHashOrFileOrScript CommitteeColdKey)
+pRemoveCommitteeColdVerificationKeyOrHashOrFile :: Parser (VerificationKeyOrHashOrFileOrScriptHash CommitteeColdKey)
 pRemoveCommitteeColdVerificationKeyOrHashOrFile =
   asum
-    [ VkhfsKeyHashFile . VerificationKeyOrFile <$> pRemoveCommitteeColdVerificationKeyOrFile
-    , VkhfsKeyHashFile . VerificationKeyHash <$> pRemoveCommitteeColdVerificationKeyHash
-    , VkhfsScript <$> pScriptFor "remove-cc-cold-script-file" Nothing "Cold Native or Plutus script file"
+    [ VkhfshKeyHashFile . VerificationKeyOrFile <$> pRemoveCommitteeColdVerificationKeyOrFile
+    , VkhfshKeyHashFile . VerificationKeyHash <$> pRemoveCommitteeColdVerificationKeyHash
+    , VkhfshScriptHash <$>
+        pScriptHash
+          "remove-cc-cold-script-hash"
+          "Cold Native or Plutus script file hash (hex-encoded). Obtain it with \"cardano-cli conway governance hash script ...\"."
+    ]
+
+pScriptHash
+  :: String -- ^ long option name
+  -> String -- ^ help text
+  -> Parser ScriptHash
+pScriptHash longOptionName helpText =
+  Opt.option scriptHashReader $ mconcat
+    [ Opt.long longOptionName
+    , Opt.metavar "HASH"
+    , Opt.help helpText
     ]
 
 pRemoveCommitteeColdVerificationKeyHash :: Parser (Hash CommitteeColdKey)
@@ -3162,19 +3179,15 @@ pDRepHashSource =
 
 pDRepScriptHash :: Parser ScriptHash
 pDRepScriptHash =
-  Opt.option scriptHashReader $ mconcat
-    [ Opt.long "drep-script-hash"
-    , Opt.metavar "HASH"
-    , Opt.help "DRep script hash (hex-encoded). Obtain it with \"cardano-cli conway governance hash script ...\"."
-    ]
+  pScriptHash
+    "drep-script-hash"
+    "DRep script hash (hex-encoded). Obtain it with \"cardano-cli conway governance hash script ...\"."
 
 pConstitutionScriptHash :: Parser ScriptHash
 pConstitutionScriptHash =
-  Opt.option scriptHashReader $ mconcat
-    [ Opt.long "constitution-script-hash"
-    , Opt.metavar "HASH"
-    , Opt.help "Constitution script hash (hex-encoded). Obtain it with \"cardano-cli conway governance hash script ...\"."
-    ]
+  pScriptHash
+    "constitution-script-hash"
+    "Constitution script hash (hex-encoded). Obtain it with \"cardano-cli conway governance hash script ...\"."
 
 pDRepVerificationKeyOrHashOrFile
   :: Parser (VerificationKeyOrHashOrFile DRepKey)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
@@ -634,8 +634,8 @@ pOperatorCertIssueCounterFile =
 
 ---
 
-pAddCommitteeColdVerificationKeyOrHashOrFile :: Parser (VerificationKeyOrHashOrFileOrScriptHash CommitteeColdKey)
-pAddCommitteeColdVerificationKeyOrHashOrFile =
+pAddCommitteeColdVerificationKeySource :: Parser (VerificationKeyOrHashOrFileOrScriptHash CommitteeColdKey)
+pAddCommitteeColdVerificationKeySource =
   asum
     [ VkhfshKeyHashFile . VerificationKeyOrFile <$> pAddCommitteeColdVerificationKeyOrFile
     , VkhfshKeyHashFile . VerificationKeyHash <$> pAddCommitteeColdVerificationKeyHash
@@ -690,8 +690,8 @@ pAddCommitteeColdVerificationKeyFile =
     ]
 
 ---
-pRemoveCommitteeColdVerificationKeyOrHashOrFile :: Parser (VerificationKeyOrHashOrFileOrScriptHash CommitteeColdKey)
-pRemoveCommitteeColdVerificationKeyOrHashOrFile =
+pRemoveCommitteeColdVerificationKeySource :: Parser (VerificationKeyOrHashOrFileOrScriptHash CommitteeColdKey)
+pRemoveCommitteeColdVerificationKeySource =
   asum
     [ VkhfshKeyHashFile . VerificationKeyOrFile <$> pRemoveCommitteeColdVerificationKeyOrFile
     , VkhfshKeyHashFile . VerificationKeyHash <$> pRemoveCommitteeColdVerificationKeyHash

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Actions.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Actions.hs
@@ -120,10 +120,10 @@ pUpdateCommitteeCmd eon =
     <*> pStakeIdentifier (Just "deposit-return")
     <*> pAnchorUrl
     <*> pAnchorDataHash
-    <*> many pRemoveCommitteeColdVerificationKeyOrHashOrFile
+    <*> many pRemoveCommitteeColdVerificationKeySource
     <*> many
           ( (,)
-              <$> pAddCommitteeColdVerificationKeyOrHashOrFile
+              <$> pAddCommitteeColdVerificationKeySource
               <*> pEpochNo "Committee member expiry epoch")
     <*> pRational "quorum" "Quorum of the committee that is necessary for a successful vote."
     <*> pPreviousGovernanceAction

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Actions.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Actions.hs
@@ -105,16 +105,16 @@ pGovernanceActionUpdateCommitteeCmd era = do
   pure
     $ subParser "update-committee"
     $ Opt.info
-        ( Cmd.GoveranceActionUpdateCommitteeCmd
+        ( Cmd.GovernanceActionUpdateCommitteeCmd
             <$> pUpdateCommitteeCmd eon
         )
     $ Opt.progDesc "Create or update a new committee proposal."
 
 pUpdateCommitteeCmd :: ()
   => ConwayEraOnwards era
-  -> Parser (Cmd.GoveranceActionUpdateCommitteeCmdArgs era)
+  -> Parser (Cmd.GovernanceActionUpdateCommitteeCmdArgs era)
 pUpdateCommitteeCmd eon =
-  Cmd.GoveranceActionUpdateCommitteeCmdArgs eon
+  Cmd.GovernanceActionUpdateCommitteeCmdArgs eon
     <$> pNetwork
     <*> pGovActionDeposit
     <*> pStakeIdentifier (Just "deposit-return")

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Committee.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Committee.hs
@@ -136,13 +136,19 @@ pGovernanceCommitteeCreateColdKeyResignationCertificateCmd era = do
         [ "Create cold key resignation certificate for a Constitutional Committee Member"
         ]
  where
-  mkParser w = GovernanceCommitteeCreateColdKeyResignationCertificateCmd <$>
-    (
-      GovernanceCommitteeCreateColdKeyResignationCertificateCmdArgs w <$>
-        pCommitteeColdVerificationKeyOrHashOrFile <*>
-        pAnchor <*>
-        pOutputFile
-    )
+  mkParser w =
+    GovernanceCommitteeCreateColdKeyResignationCertificateCmd <$>
+      (GovernanceCommitteeCreateColdKeyResignationCertificateCmdArgs w <$>
+        coldVKeyOrFileOrScriptHash <*> pAnchor <*> pOutputFile)
+  coldVKeyOrFileOrScriptHash =
+    asum
+      [ VkhfshKeyHashFile . VerificationKeyOrFile <$> pCommitteeColdVerificationKeyOrFile
+      , VkhfshKeyHashFile . VerificationKeyHash <$> pCommitteeColdVerificationKeyHash
+      , VkhfshScriptHash <$>
+          pScriptHash
+            "cold-script-hash"
+            "Cold Native or Plutus script file hash (hex-encoded). Obtain it with \"cardano-cli conway governance hash script ...\"."
+      ]
 
 pAnchor :: Parser (Maybe (L.Anchor L.StandardCrypto))
 pAnchor =

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Query.hs
@@ -15,6 +15,7 @@ import           Cardano.CLI.Environment (EnvCli (..))
 import           Cardano.CLI.EraBased.Commands.Query
 import           Cardano.CLI.EraBased.Options.Common
 import           Cardano.CLI.Types.Common
+import           Cardano.CLI.Types.Key
 
 import           Data.Foldable
 import           Options.Applicative hiding (help, str)
@@ -388,11 +389,31 @@ pQueryGetCommitteeStateCmd era envCli = do
       <$> pSocketPath envCli
       <*> pConsensusModeParams
       <*> pNetworkId envCli
-      <*> many pCommitteeColdVerificationKeyOrHashOrFile
-      <*> many pCommitteeHotKeyOrHashOrFile
+      <*> many pCommitteeColdVerificationKeyOrHashOrFileOrScriptHash
+      <*> many pCommitteeHotKeyOrHashOrFileOrScriptHash
       <*> many pMemberStatus
       <*> pTarget era
       <*> optional pOutputFile
+
+    pCommitteeColdVerificationKeyOrHashOrFileOrScriptHash :: Parser (VerificationKeyOrHashOrFileOrScriptHash CommitteeColdKey)
+    pCommitteeColdVerificationKeyOrHashOrFileOrScriptHash =
+      asum
+        [ VkhfshKeyHashFile <$> pCommitteeColdVerificationKeyOrHashOrFile
+        , VkhfshScriptHash <$>
+            pScriptHash
+              "cold-script-hash"
+              "Cold Native or Plutus script file hash (hex-encoded). Obtain it with \"cardano-cli conway governance hash script ...\"."
+        ]
+
+    pCommitteeHotKeyOrHashOrFileOrScriptHash :: Parser (VerificationKeyOrHashOrFileOrScriptHash CommitteeHotKey)
+    pCommitteeHotKeyOrHashOrFileOrScriptHash =
+      asum
+        [ VkhfshKeyHashFile <$> pCommitteeHotKeyOrHashOrFile
+        , VkhfshScriptHash <$>
+            pScriptHash
+              "hot-script-hash"
+              "Hot Native or Plutus script file hash (hex-encoded). Obtain it with \"cardano-cli conway governance hash script ...\"."
+        ]
 
     pMemberStatus :: Parser MemberStatus
     pMemberStatus =

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Address.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Address.hs
@@ -197,9 +197,8 @@ makeStakeAddressRef stakeIdentifier =
     StakeIdentifierVerifier stakeVerifier ->
       case stakeVerifier of
         StakeVerifierKey stkVkeyOrFile -> do
-          stakeVKeyHash <- firstExceptT AddressCmdReadKeyFileError $
-            newExceptT $ readVerificationKeyOrHashOrFile AsStakeKey stkVkeyOrFile
-
+          stakeVKeyHash <- modifyError AddressCmdReadKeyFileError $
+            readVerificationKeyOrHashOrFile AsStakeKey stkVkeyOrFile
           return . StakeAddressByValue $ StakeCredentialByKey stakeVKeyHash
 
         StakeVerifierScriptFile (File fp) -> do

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/CreateTestnetData.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/CreateTestnetData.hs
@@ -97,7 +97,7 @@ runGenesisKeyGenGenesisCmd
     { Cmd.verificationKeyPath
     , Cmd.signingKeyPath
     } = do
-    skey <- liftIO $ generateSigningKey AsGenesisKey
+    skey <- generateSigningKey AsGenesisKey
     let vkey = getVerificationKey skey
     firstExceptT GenesisCmdGenesisFileError . newExceptT $ do
       void $ writeLazyByteStringFile signingKeyPath $ textEnvelopeToJSON (Just skeyDesc) skey
@@ -116,7 +116,7 @@ runGenesisKeyGenDelegateCmd
     , Cmd.signingKeyPath
     , Cmd.opCertCounterPath
     } = do
-    skey <- liftIO $ generateSigningKey AsGenesisDelegateKey
+    skey <- generateSigningKey AsGenesisDelegateKey
     let vkey = getVerificationKey skey
     firstExceptT GenesisCmdGenesisFileError . newExceptT $ do
       void $ writeLazyByteStringFile signingKeyPath
@@ -143,7 +143,7 @@ runGenesisKeyGenDelegateVRF ::
   -> SigningKeyFile Out
   -> ExceptT GenesisCmdError IO ()
 runGenesisKeyGenDelegateVRF vkeyPath skeyPath = do
-    skey <- liftIO $ generateSigningKey AsVrfKey
+    skey <- generateSigningKey AsVrfKey
     let vkey = getVerificationKey skey
     firstExceptT GenesisCmdGenesisFileError . newExceptT $ do
       void $ writeLazyByteStringFile skeyPath
@@ -163,7 +163,7 @@ runGenesisKeyGenUTxOCmd
     { Cmd.verificationKeyPath
     , Cmd.signingKeyPath
     } = do
-    skey <- liftIO $ generateSigningKey AsGenesisUTxOKey
+    skey <- generateSigningKey AsGenesisUTxOKey
     let vkey = getVerificationKey skey
     firstExceptT GenesisCmdGenesisFileError . newExceptT $ do
       void $ writeLazyByteStringFile signingKeyPath
@@ -334,7 +334,7 @@ runGenesisCreateTestNetDataCmd Cmd.GenesisCreateTestNetDataCmdArgs
 
       initialDReps :: L.Coin -> [VerificationKey DRepKey] -> ListMap (L.Credential L.DRepRole L.StandardCrypto) (L.DRepState L.StandardCrypto)
       initialDReps minDeposit = ListMap.fromList . map (\c -> ( verificationKeyToDRepCredential c
-                                                              , L.DRepState { L.drepExpiry = EpochNo 1000
+                                                              , L.DRepState { L.drepExpiry = EpochNo 1_000
                                                                             , L.drepAnchor = SNothing
                                                                             , L.drepDeposit = max (L.Coin 1_000_000) minDeposit
                                                                             }))

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Actions.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Actions.hs
@@ -218,11 +218,11 @@ runGovernanceActionUpdateCommitteeCmd
 
   oldCommitteeKeyHashes <- forM oldCommitteeVkeySource $ \vkeyOrHashOrTextFile ->
     modifyError GovernanceActionsCmdReadFileError $
-      readVerificaitonKeyOrHashOrFileOrScriptHash AsCommitteeColdKey unCommitteeColdKeyHash vkeyOrHashOrTextFile
+      readVerificationKeyOrHashOrFileOrScriptHash AsCommitteeColdKey unCommitteeColdKeyHash vkeyOrHashOrTextFile
 
   newCommitteeKeyHashes <- forM newCommitteeVkeySource $ \(vkeyOrHashOrTextFile, expEpoch) -> do
     kh <- modifyError GovernanceActionsCmdReadFileError $
-      readVerificaitonKeyOrHashOrFileOrScriptHash AsCommitteeColdKey unCommitteeColdKeyHash vkeyOrHashOrTextFile
+      readVerificationKeyOrHashOrFileOrScriptHash AsCommitteeColdKey unCommitteeColdKeyHash vkeyOrHashOrTextFile
     pure (kh, expEpoch)
 
   depositStakeCredential

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Actions.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Actions.hs
@@ -40,7 +40,7 @@ runGovernanceActionCmds = \case
   GovernanceActionTreasuryWithdrawalCmd args ->
     runGovernanceActionTreasuryWithdrawalCmd args
 
-  GoveranceActionUpdateCommitteeCmd args ->
+  GovernanceActionUpdateCommitteeCmd args ->
     runGovernanceActionUpdateCommitteeCmd args
 
   GovernanceActionCreateNoConfidenceCmd args ->
@@ -189,10 +189,10 @@ runGovernanceActionCreateConstitutionCmd
 -- TODO: Conway era - After ledger bump update this function
 -- with the new ledger types
 runGovernanceActionUpdateCommitteeCmd :: ()
-  => GoveranceActionUpdateCommitteeCmdArgs era
+  => GovernanceActionUpdateCommitteeCmdArgs era
   -> ExceptT GovernanceActionsError IO ()
 runGovernanceActionUpdateCommitteeCmd
-    Cmd.GoveranceActionUpdateCommitteeCmdArgs
+    Cmd.GovernanceActionUpdateCommitteeCmdArgs
       { Cmd.eon
       , Cmd.networkId
       , Cmd.deposit
@@ -215,15 +215,14 @@ runGovernanceActionUpdateCommitteeCmd
         { L.anchorUrl = unProposalUrl proposalUrl
         , L.anchorDataHash = proposalHash
         }
-      mapError' = modifyError $ either GovernanceActionsCmdScriptReadError GovernanceActionsCmdReadFileError
 
   oldCommitteeKeyHashes <- forM oldCommitteeVkeySource $ \vkeyOrHashOrTextFile ->
-    mapError' $
-      readVerificationKeyOrHashOrFileOrScript AsCommitteeColdKey unCommitteeColdKeyHash vkeyOrHashOrTextFile
+    modifyError GovernanceActionsCmdReadFileError $
+      readVerificaitonKeyOrHashOrFileOrScriptHash AsCommitteeColdKey unCommitteeColdKeyHash vkeyOrHashOrTextFile
 
   newCommitteeKeyHashes <- forM newCommitteeVkeySource $ \(vkeyOrHashOrTextFile, expEpoch) -> do
-    kh <- mapError' $
-      readVerificationKeyOrHashOrFileOrScript AsCommitteeColdKey unCommitteeColdKeyHash vkeyOrHashOrTextFile
+    kh <- modifyError GovernanceActionsCmdReadFileError $
+      readVerificaitonKeyOrHashOrFileOrScriptHash AsCommitteeColdKey unCommitteeColdKeyHash vkeyOrHashOrTextFile
     pure (kh, expEpoch)
 
   depositStakeCredential

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Committee.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Committee.hs
@@ -146,10 +146,10 @@ runGovernanceCommitteeCreateHotKeyAuthorizationCertificate
     let mapError' = modifyError $ either GovernanceCommitteeCmdScriptReadError  GovernanceCommitteeCmdKeyReadError
     hotCred <-
       mapError' $
-        readVerificationKeyOrHashOrFileOrScript AsCommitteeHotKey (\(CommitteeHotKeyHash kh) -> kh) vkeyHotKeySource
+        readVerificationKeyOrHashOrFileOrScript AsCommitteeHotKey unCommitteeHotKeyHash vkeyHotKeySource
     coldCred <-
       mapError' $
-        readVerificationKeyOrHashOrFileOrScript AsCommitteeColdKey (\(CommitteeColdKeyHash kh) -> kh) vkeyColdKeySource
+        readVerificationKeyOrHashOrFileOrScript AsCommitteeColdKey unCommitteeColdKeyHash vkeyColdKeySource
 
     makeCommitteeHotKeyAuthorizationCertificate (CommitteeHotKeyAuthorizationRequirements eon coldCred hotCred)
       & textEnvelopeToJSON (Just genKeyDelegCertDesc)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Committee.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Committee.hs
@@ -165,18 +165,18 @@ runGovernanceCommitteeColdKeyResignationCertificate :: ()
   -> ExceptT GovernanceCommitteeError IO ()
 runGovernanceCommitteeColdKeyResignationCertificate
     Cmd.GovernanceCommitteeCreateColdKeyResignationCertificateCmdArgs
-      { Cmd.eon               = w
-      , Cmd.vkeyColdKeySource = coldVkOrHashOrFp
-      , Cmd.anchor            = anchor
-      , Cmd.outFile           = oFp
+      { Cmd.eon
+      , Cmd.vkeyColdKeySource
+      , Cmd.anchor
+      , Cmd.outFile
       } =
-  conwayEraOnwardsConstraints w $ do
-    CommitteeColdKeyHash coldVKHash <- modifyError GovernanceCommitteeCmdKeyReadError $
-      readVerificationKeyOrHashOrTextEnvFile AsCommitteeColdKey coldVkOrHashOrFp
+  conwayEraOnwardsConstraints eon $ do
+    coldVKeyCred <- modifyError GovernanceCommitteeCmdKeyReadError $
+      readVerificaitonKeyOrHashOrFileOrScriptHash AsCommitteeColdKey unCommitteeColdKeyHash vkeyColdKeySource
 
-    makeCommitteeColdkeyResignationCertificate (CommitteeColdkeyResignationRequirements w coldVKHash anchor)
+    makeCommitteeColdkeyResignationCertificate (CommitteeColdkeyResignationRequirements eon coldVKeyCred anchor)
       & textEnvelopeToJSON (Just genKeyDelegCertDesc)
-      & writeLazyByteStringFile oFp
+      & writeLazyByteStringFile outFile
       & firstExceptT GovernanceCommitteeCmdTextEnvWriteError . newExceptT
 
   where

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Committee.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Committee.hs
@@ -172,7 +172,7 @@ runGovernanceCommitteeColdKeyResignationCertificate
       } =
   conwayEraOnwardsConstraints eon $ do
     coldVKeyCred <- modifyError GovernanceCommitteeCmdKeyReadError $
-      readVerificaitonKeyOrHashOrFileOrScriptHash AsCommitteeColdKey unCommitteeColdKeyHash vkeyColdKeySource
+      readVerificationKeyOrHashOrFileOrScriptHash AsCommitteeColdKey unCommitteeColdKeyHash vkeyColdKeySource
 
     makeCommitteeColdkeyResignationCertificate (CommitteeColdkeyResignationRequirements eon coldVKeyCred anchor)
       & textEnvelopeToJSON (Just genKeyDelegCertDesc)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Committee.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Committee.hs
@@ -45,7 +45,7 @@ runGovernanceCommitteeKeyGenCold
       { Cmd.vkeyOutFile = vkeyPath
       , Cmd.skeyOutFile = skeyPath
       } = do
-  skey <- liftIO $ generateSigningKey AsCommitteeColdKey
+  skey <- generateSigningKey AsCommitteeColdKey
 
   let vkey = getVerificationKey skey
 
@@ -71,7 +71,7 @@ runGovernanceCommitteeKeyGenHot
       , Cmd.vkeyOutFile = vkeyPath
       , Cmd.skeyOutFile = skeyPath
       } = do
-  skey <- liftIO $ generateSigningKey AsCommitteeHotKey
+  skey <- generateSigningKey AsCommitteeHotKey
 
   let vkey = getVerificationKey skey
 
@@ -171,9 +171,8 @@ runGovernanceCommitteeColdKeyResignationCertificate
       , Cmd.outFile           = oFp
       } =
   conwayEraOnwardsConstraints w $ do
-    CommitteeColdKeyHash coldVKHash <-
-      lift (readVerificationKeyOrHashOrTextEnvFile AsCommitteeColdKey coldVkOrHashOrFp)
-        & onLeft (left . GovernanceCommitteeCmdKeyReadError)
+    CommitteeColdKeyHash coldVKHash <- modifyError GovernanceCommitteeCmdKeyReadError $
+      readVerificationKeyOrHashOrTextEnvFile AsCommitteeColdKey coldVkOrHashOrFp
 
     makeCommitteeColdkeyResignationCertificate (CommitteeColdkeyResignationRequirements w coldVKHash anchor)
       & textEnvelopeToJSON (Just genKeyDelegCertDesc)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/DRep.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/DRep.hs
@@ -83,9 +83,8 @@ runGovernanceDRepIdCmd
       , idOutputFormat
       , mOutFile
       } = do
-  drepVerKey <-
-    lift (readVerificationKeyOrTextEnvFile AsDRepKey vkeySource)
-      & onLeft (left . ReadFileError)
+  drepVerKey <- modifyError ReadFileError $
+    readVerificationKeyOrTextEnvFile AsDRepKey vkeySource
 
   content <-
     pure $ case idOutputFormat of
@@ -134,7 +133,6 @@ runGovernanceDRepRetirementCertificateCmd
       } =
   conwayEraOnwardsConstraints w $ do
     DRepKeyHash drepKeyHash <- firstExceptT GovernanceCmdKeyReadError
-      . newExceptT
       $ readVerificationKeyOrHashOrFile AsDRepKey vkeyHashSource
     makeDrepUnregistrationCertificate (DRepUnregistrationRequirements w (KeyHashObj drepKeyHash) deposit)
       & writeFileTextEnvelope outFile (Just genKeyDelegCertDesc)
@@ -156,7 +154,6 @@ runGovernanceDRepUpdateCertificateCmd
       } =
   conwayEraOnwardsConstraints w $ do
     DRepKeyHash drepKeyHash <- firstExceptT GovernanceCmdKeyReadError
-      . newExceptT
       $ readVerificationKeyOrHashOrFile AsDRepKey drepVkeyHashSource
     makeDrepUpdateCertificate (DRepUpdateRequirements w (KeyHashObj drepKeyHash)) mAnchor
       & writeFileTextEnvelope outFile (Just "DRep Update Certificate")

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/GenesisKeyDelegationCertificate.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/GenesisKeyDelegationCertificate.hs
@@ -24,14 +24,11 @@ runGovernanceGenesisKeyDelegationCertificate stb
                                              genDelVkOrHashOrFp
                                              vrfVkOrHashOrFp
                                              oFp = do
-  genesisVkHash <- firstExceptT GovernanceCmdKeyReadError
-    . newExceptT
+  genesisVkHash <- modifyError GovernanceCmdKeyReadError
     $ readVerificationKeyOrHashOrTextEnvFile AsGenesisKey genVkOrHashOrFp
-  genesisDelVkHash <-firstExceptT GovernanceCmdKeyReadError
-    . newExceptT
+  genesisDelVkHash <- modifyError GovernanceCmdKeyReadError
     $ readVerificationKeyOrHashOrTextEnvFile AsGenesisDelegateKey genDelVkOrHashOrFp
-  vrfVkHash <- firstExceptT GovernanceCmdKeyReadError
-    . newExceptT
+  vrfVkHash <- modifyError GovernanceCmdKeyReadError
     $ readVerificationKeyOrHashOrFile AsVrfKey vrfVkOrHashOrFp
 
   let req = GenesisKeyDelegationRequirements stb genesisVkHash genesisDelVkHash vrfVkHash

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Vote.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Vote.hs
@@ -62,15 +62,15 @@ runGovernanceVoteCreateCmd
   shelleyBasedEraConstraints sbe $ do
     voter <- firstExceptT  GovernanceVoteCmdReadVerificationKeyError $ case votingStakeCredentialSource of
       AnyDRepVerificationKeyOrHashOrFile stake -> do
-        DRepKeyHash h <- newExceptT $ readVerificationKeyOrHashOrTextEnvFile AsDRepKey stake
+        DRepKeyHash h <- readVerificationKeyOrHashOrTextEnvFile AsDRepKey stake
         pure $ L.DRepVoter $ L.KeyHashObj h
 
       AnyStakePoolVerificationKeyOrHashOrFile stake -> do
-        StakePoolKeyHash h <- newExceptT $ readVerificationKeyOrHashOrTextEnvFile AsStakePoolKey stake
+        StakePoolKeyHash h <- readVerificationKeyOrHashOrTextEnvFile AsStakePoolKey stake
         pure $ L.StakePoolVoter h
 
       AnyCommitteeHotVerificationKeyOrHashOrFile stake -> do
-        CommitteeHotKeyHash h <-  newExceptT $ readVerificationKeyOrHashOrTextEnvFile AsCommitteeHotKey stake
+        CommitteeHotKeyHash h <- readVerificationKeyOrHashOrTextEnvFile AsCommitteeHotKey stake
         pure $ L.CommitteeVoter $ L.KeyHashObj h
 
     let govActIdentifier = createGovernanceActionId govActionTxId govActionIndex

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Node.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Node.hs
@@ -49,7 +49,7 @@ runNodeKeyGenColdCmd
       , skeyFile
       , operationalCertificateIssueCounter
       } = do
-  skey <- liftIO $ generateSigningKey AsStakePoolKey
+  skey <- generateSigningKey AsStakePoolKey
   let vkey = getVerificationKey skey
 
   case keyOutputFormat of
@@ -106,7 +106,7 @@ runNodeKeyGenKesCmd
       , vkeyFile
       , skeyFile
       } = do
-  skey <- liftIO $ generateSigningKey AsKesKey
+  skey <- generateSigningKey AsKesKey
 
   let vkey = getVerificationKey skey
 
@@ -150,7 +150,7 @@ runNodeKeyGenVrfCmd
       , vkeyFile
       , skeyFile
       } = do
-  skey <- liftIO $ generateSigningKey AsVrfKey
+  skey <- generateSigningKey AsVrfKey
 
   let vkey = getVerificationKey skey
 
@@ -191,7 +191,6 @@ runNodeKeyHashVrfCmd
       , mOutFile
       } = do
   vkey <- firstExceptT NodeCmdReadKeyFileError
-    . newExceptT
     $ readVerificationKeyOrFile AsVrfKey vkeySource
 
   let hexKeyHash = serialiseToRawBytesHex (verificationKeyHash vkey)
@@ -235,7 +234,6 @@ runNodeIssueOpCertCmd
     $ readFileTextEnvelope AsOperationalCertificateIssueCounter (onlyIn operationalCertificateCounterFile)
 
   verKeyKes <- firstExceptT NodeCmdReadKeyFileError
-    . newExceptT
     $ readVerificationKeyOrFile AsKesKey kesVkeySource
 
   signKey <- firstExceptT NodeCmdReadKeyFileError

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Query.hs
@@ -1223,14 +1223,14 @@ runQueryLeadershipScheduleCmd
     } = do
   let localNodeConnInfo = LocalNodeConnectInfo consensusModeParams networkId nodeSocketPath
 
-  poolid <- lift (readVerificationKeyOrHashOrFile AsStakePoolKey poolColdVerKeyFile)
-    & onLeft (left . QueryCmdTextReadError)
+  poolid <- modifyError QueryCmdTextReadError $
+    readVerificationKeyOrHashOrFile AsStakePoolKey poolColdVerKeyFile
 
-  vrkSkey <- lift (readFileTextEnvelope (AsSigningKey AsVrfKey) vrkSkeyFp)
-    & onLeft (left . QueryCmdTextEnvelopeReadError)
+  vrkSkey <- modifyError QueryCmdTextEnvelopeReadError . hoistIOEither $
+    readFileTextEnvelope (AsSigningKey AsVrfKey) vrkSkeyFp
 
-  shelleyGenesis <- lift (readAndDecodeGenesisFile @(ShelleyGenesis StandardCrypto) genFile)
-    & onLeft (left . QueryCmdGenesisReadError)
+  shelleyGenesis <- modifyError QueryCmdGenesisReadError . hoistIOEither $
+    readAndDecodeGenesisFile @(ShelleyGenesis StandardCrypto) genFile
 
   join $ lift
     ( executeLocalStateQueryExpr localNodeConnInfo target $ runExceptT $ do

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Query.hs
@@ -1493,11 +1493,11 @@ runQueryCommitteeMembersState
   let localNodeConnInfo = LocalNodeConnectInfo consensusModeParams networkId nodeSocketPath
 
   let coldKeysFromVerKeyHashOrFile =
-        firstExceptT QueryCmdCommitteeColdKeyError . getCommitteeColdCredentialFromVerKeyHashOrFile
+        modifyError QueryCmdCommitteeColdKeyError . readVerificationKeyOrHashOrFileOrScriptHash AsCommitteeColdKey unCommitteeColdKeyHash
   coldKeys <- Set.fromList <$> mapM coldKeysFromVerKeyHashOrFile coldCredKeys
 
   let hotKeysFromVerKeyHashOrFile =
-        firstExceptT QueryCmdCommitteeHotKeyError . getCommitteeHotCredentialFromVerKeyHashOrFile
+        modifyError QueryCmdCommitteeHotKeyError . readVerificationKeyOrHashOrFileOrScriptHash AsCommitteeHotKey unCommitteeHotKeyHash
   hotKeys <- Set.fromList <$> mapM hotKeysFromVerKeyHashOrFile hotCredKeys
 
   committeeState <- runQuery localNodeConnInfo target $

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/StakePool.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/StakePool.hs
@@ -64,19 +64,16 @@ runStakePoolRegistrationCertificateCmd
     = shelleyBasedEraConstraints sbe $ do
     -- Pool verification key
     stakePoolVerKey <- firstExceptT StakePoolCmdReadKeyFileError
-      . newExceptT
       $ readVerificationKeyOrFile AsStakePoolKey poolVerificationKeyOrFile
     let stakePoolId' = verificationKeyHash stakePoolVerKey
 
     -- VRF verification key
     vrfVerKey <- firstExceptT StakePoolCmdReadKeyFileError
-      . newExceptT
       $ readVerificationKeyOrFile AsVrfKey vrfVerificationKeyOrFile
     let vrfKeyHash' = verificationKeyHash vrfVerKey
 
     -- Pool reward account
     rwdStakeVerKey <- firstExceptT StakePoolCmdReadKeyFileError
-      . newExceptT
       $ readVerificationKeyOrFile AsStakeKey rewardStakeVerificationKeyOrFile
     let stakeCred = StakeCredentialByKey (verificationKeyHash rwdStakeVerKey)
         rewardAccountAddr = makeStakeAddress network stakeCred
@@ -85,7 +82,6 @@ runStakePoolRegistrationCertificateCmd
     sPoolOwnerVkeys <-
       mapM
         (firstExceptT StakePoolCmdReadKeyFileError
-          . newExceptT
           . readVerificationKeyOrFile AsStakeKey
         )
         ownerStakeVerificationKeyOrFiles
@@ -150,7 +146,6 @@ runStakePoolDeregistrationCertificateCmd
   shelleyBasedEraConstraints sbe $ do
     -- Pool verification key
     stakePoolVerKey <- firstExceptT StakePoolCmdReadKeyFileError
-      . newExceptT
       $ readVerificationKeyOrFile AsStakePoolKey poolVerificationKeyOrFile
 
     let stakePoolId' = verificationKeyHash stakePoolVerKey
@@ -195,7 +190,6 @@ runStakePoolIdCmd
       , mOutFile
       } = do
   stakePoolVerKey <- firstExceptT StakePoolCmdReadKeyFileError
-    . newExceptT
     $ readVerificationKeyOrFile AsStakePoolKey poolVerificationKeyOrFile
 
   case outputFormat of

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Transaction.hs
@@ -149,7 +149,7 @@ runTransactionBuildCmd
         | (CertificateFile certFile, mSwit) <- certFilesAndMaybeScriptWits
         ]
   withdrawalsAndMaybeScriptWits <- firstExceptT TxCmdScriptWitnessError $
-    readScriptWitnessFilesThruple eon withdrawals
+    readScriptWitnessFilesTuple eon withdrawals
   txMetadata <- firstExceptT TxCmdMetadataError . newExceptT $
     readTxMetadata eon metadataSchema metadataFiles
   valuesWithScriptWits <- readValueScriptWitnesses eon $ fromMaybe mempty mValue
@@ -286,7 +286,7 @@ runTransactionBuildRawCmd
                                    $ readScriptWitnessFiles eon certificates
 
   withdrawalsAndMaybeScriptWits <- firstExceptT TxCmdScriptWitnessError
-                                     $ readScriptWitnessFilesThruple eon withdrawals
+                                     $ readScriptWitnessFilesTuple eon withdrawals
   txMetadata <- firstExceptT TxCmdMetadataError
                   . newExceptT $ readTxMetadata eon metadataSchema metadataFiles
   valuesWithScriptWits <- readValueScriptWitnesses eon $ fromMaybe mempty mValue

--- a/cardano-cli/src/Cardano/CLI/Read.hs
+++ b/cardano-cli/src/Cardano/CLI/Read.hs
@@ -81,10 +81,6 @@ module Cardano.CLI.Read
   -- * DRep credentials
   , getDRepCredentialFromVerKeyHashOrFile
 
-  -- * Committee credentials
-  , getCommitteeColdCredentialFromVerKeyHashOrFile
-  , getCommitteeHotCredentialFromVerKeyHashOrFile
-
   , ReadSafeHashError(..)
   , readHexAsSafeHash
   , readSafeHash
@@ -1089,28 +1085,6 @@ getDRepCredentialFromVerKeyHashOrFile = \case
     drepVerKey <- readVerificationKeyOrFile AsDRepKey verKeyOrFile
     pure . L.KeyHashObj . unDRepKeyHash $ verificationKeyHash drepVerKey
   VerificationKeyHash kh -> pure . L.KeyHashObj $ unDRepKeyHash kh
-
-getCommitteeColdCredentialFromVerKeyHashOrFile :: ()
-  => MonadIOTransError (FileError InputDecodeError) t m
-  => VerificationKeyOrHashOrFile CommitteeColdKey
-  -> t m (L.Credential L.ColdCommitteeRole L.StandardCrypto)
-getCommitteeColdCredentialFromVerKeyHashOrFile = \case
-  VerificationKeyOrFile verKeyOrFile -> do
-    commmitteeColdVerKey <- readVerificationKeyOrFile AsCommitteeColdKey verKeyOrFile
-    let CommitteeColdKeyHash kh = verificationKeyHash commmitteeColdVerKey
-    pure $ L.KeyHashObj kh
-  VerificationKeyHash (CommitteeColdKeyHash kh) -> pure $ L.KeyHashObj kh
-
-getCommitteeHotCredentialFromVerKeyHashOrFile :: ()
-  => MonadIOTransError (FileError InputDecodeError) t m
-  => VerificationKeyOrHashOrFile CommitteeHotKey
-  -> t m (L.Credential L.HotCommitteeRole L.StandardCrypto)
-getCommitteeHotCredentialFromVerKeyHashOrFile = \case
-  VerificationKeyOrFile verKeyOrFile -> do
-    commmitteeHotVerKey <- readVerificationKeyOrFile AsCommitteeHotKey verKeyOrFile
-    let CommitteeHotKeyHash kh = verificationKeyHash commmitteeHotVerKey
-    pure $ L.KeyHashObj kh
-  VerificationKeyHash (CommitteeHotKeyHash kh) -> pure $ L.KeyHashObj kh
 
 data ReadSafeHashError
   = ReadSafeHashErrorNotHex ByteString String

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/GovernanceActionsError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/GovernanceActionsError.hs
@@ -14,6 +14,7 @@ data GovernanceActionsError
   | GovernanceActionsCmdProposalError ProposalError
   | GovernanceActionsCmdCostModelsError CostModelsError
   | GovernanceActionsCmdReadFileError (FileError InputDecodeError)
+  | GovernanceActionsCmdScriptReadError (FileError ScriptDecodeError)
   | GovernanceActionsReadStakeCredErrror StakeCredentialError
   | GovernanceActionsCmdReadTextEnvelopeFileError (FileError TextEnvelopeError)
   | GovernanceActionsCmdWriteFileError (FileError ())
@@ -30,14 +31,13 @@ instance Error GovernanceActionsError where
       "Cannot read constitution: " <> pshow e -- TODO Conway render this properly
     GovernanceActionsCmdReadFileError e ->
       "Cannot read file: " <> prettyError e
+    GovernanceActionsCmdScriptReadError e ->
+      "Cannot read script file: " <> prettyError e
     GovernanceActionsCmdReadTextEnvelopeFileError e ->
       "Cannot read text envelope file: " <> prettyError e
     GovernanceActionsCmdWriteFileError e ->
       "Cannot write file: " <> prettyError e
     GovernanceActionsValueUpdateProtocolParametersNotFound (AnyShelleyBasedEra expectedShelleyEra) ->
-      mconcat
-        [ "Protocol parameters update value for " <> pshow (toCardanoEra expectedShelleyEra)
-        , " was not found."
-        ]
+      "Protocol parameters update value for" <+> pretty expectedShelleyEra <+> "was not found."
     GovernanceActionsReadStakeCredErrror e ->
       prettyError e

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/GovernanceActionsError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/GovernanceActionsError.hs
@@ -14,7 +14,6 @@ data GovernanceActionsError
   | GovernanceActionsCmdProposalError ProposalError
   | GovernanceActionsCmdCostModelsError CostModelsError
   | GovernanceActionsCmdReadFileError (FileError InputDecodeError)
-  | GovernanceActionsCmdScriptReadError (FileError ScriptDecodeError)
   | GovernanceActionsReadStakeCredErrror StakeCredentialError
   | GovernanceActionsCmdReadTextEnvelopeFileError (FileError TextEnvelopeError)
   | GovernanceActionsCmdWriteFileError (FileError ())
@@ -31,8 +30,6 @@ instance Error GovernanceActionsError where
       "Cannot read constitution: " <> pshow e -- TODO Conway render this properly
     GovernanceActionsCmdReadFileError e ->
       "Cannot read file: " <> prettyError e
-    GovernanceActionsCmdScriptReadError e ->
-      "Cannot read script file: " <> prettyError e
     GovernanceActionsCmdReadTextEnvelopeFileError e ->
       "Cannot read text envelope file: " <> prettyError e
     GovernanceActionsCmdWriteFileError e ->

--- a/cardano-cli/src/Cardano/CLI/Types/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Key.hs
@@ -276,7 +276,7 @@ readVerificationKeyOrHashOrFile
   => AsType keyrole
   -> VerificationKeyOrHashOrFile keyrole
   -> t m (Hash keyrole)
-readVerificationKeyOrHashOrFile asType  =
+readVerificationKeyOrHashOrFile asType =
   \case
     VerificationKeyOrFile vkOrFile ->
       verificationKeyHash <$> readVerificationKeyOrFile asType vkOrFile
@@ -336,7 +336,7 @@ readDRepCredential
 readDRepCredential = \case
   DRepHashSourceScript (ScriptHash scriptHash) ->
     pure (L.ScriptHashObj scriptHash)
-  DRepHashSourceVerificationKey drepVKeyOrHashOrFile -> do
+  DRepHashSourceVerificationKey drepVKeyOrHashOrFile ->
     L.KeyHashObj . unDRepKeyHash <$>
       readVerificationKeyOrHashOrTextEnvFile AsDRepKey drepVKeyOrHashOrFile
 
@@ -364,7 +364,7 @@ readVerificationKeyOrHashOrFileOrScriptHash
 readVerificationKeyOrHashOrFileOrScriptHash asType extractHash = \case
   VkhfshScriptHash (ScriptHash scriptHash) ->
     pure (L.ScriptHashObj scriptHash)
-  VkhfshKeyHashFile vKeyOrHashOrFile -> do
+  VkhfshKeyHashFile vKeyOrHashOrFile ->
     L.KeyHashObj . extractHash <$>
       readVerificationKeyOrHashOrTextEnvFile asType vKeyOrHashOrFile
 

--- a/cardano-cli/src/Cardano/CLI/Types/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Key.hs
@@ -25,7 +25,7 @@ module Cardano.CLI.Types.Key
 
   , VerificationKeyOrHashOrFileOrScript(..)
   , VerificationKeyOrHashOrFileOrScriptHash(..)
-  , readVerificaitonKeyOrHashOrFileOrScriptHash
+  , readVerificationKeyOrHashOrFileOrScriptHash
 
   , PaymentVerifier(..)
   , StakeIdentifier(..)

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/EraBased/Governance/VerifyPoll.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/EraBased/Governance/VerifyPoll.hs
@@ -31,10 +31,10 @@ hprop_golden_governanceVerifyPoll = propertyOnce $ do
     , "--poll-file", pollFile
     , "--tx-file", txFile
     ]
-
-  liftIO (readVerificationKeyOrTextEnvFile AsStakePoolKey goldenVkFile) >>= \case
-    Left e ->
-      H.failWith Nothing $ docToString $ prettyError e
+  H.evalIO (runExceptT $ readVerificationKeyOrTextEnvFile AsStakePoolKey goldenVkFile) >>= \case
+    Left e -> do
+      H.noteShow_ $ prettyError e
+      H.failure
     Right vk -> do
       let expected = prettyPrintJSON $ serialiseToRawBytesHexText <$> [verificationKeyHash vk]
       H.assert $ expected `BSC.isInfixOf` stdout

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -6211,11 +6211,13 @@ Usage: cardano-cli conway governance action update-committee
                                                                [ --remove-cc-cold-verification-key STRING
                                                                | --remove-cc-cold-verification-key-file FILE
                                                                | --remove-cc-cold-verification-key-hash STRING
+                                                               | --remove-cc-cold-script-file FILE
                                                                ]
                                                                [
                                                                  ( --add-cc-cold-verification-key STRING
                                                                  | --add-cc-cold-verification-key-file FILE
                                                                  | --add-cc-cold-verification-key-hash STRING
+                                                                 | --add-cc-cold-script-file FILE
                                                                  )
                                                                  --epoch NATURAL]
                                                                --quorum RATIONAL

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -6211,13 +6211,13 @@ Usage: cardano-cli conway governance action update-committee
                                                                [ --remove-cc-cold-verification-key STRING
                                                                | --remove-cc-cold-verification-key-file FILE
                                                                | --remove-cc-cold-verification-key-hash STRING
-                                                               | --remove-cc-cold-script-file FILE
+                                                               | --remove-cc-cold-script-hash HASH
                                                                ]
                                                                [
                                                                  ( --add-cc-cold-verification-key STRING
                                                                  | --add-cc-cold-verification-key-file FILE
                                                                  | --add-cc-cold-verification-key-hash STRING
-                                                                 | --add-cc-cold-script-file FILE
+                                                                 | --add-cc-cold-script-hash HASH
                                                                  )
                                                                  --epoch NATURAL]
                                                                --quorum RATIONAL

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -6898,10 +6898,12 @@ Usage: cardano-cli conway query committee-state --socket-path SOCKET_PATH
                                                   [ --cold-verification-key STRING
                                                   | --cold-verification-key-file FILE
                                                   | --cold-verification-key-hash STRING
+                                                  | --cold-script-hash HASH
                                                   ]
                                                   [ --hot-key STRING
                                                   | --hot-key-file FILE
                                                   | --hot-key-hash STRING
+                                                  | --hot-script-hash HASH
                                                   ]
                                                   [ --active
                                                   | --expired

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -6402,6 +6402,7 @@ Usage: cardano-cli conway governance committee create-cold-key-resignation-certi
                                                                                          ( --cold-verification-key STRING
                                                                                          | --cold-verification-key-file FILE
                                                                                          | --cold-verification-key-hash STRING
+                                                                                         | --cold-script-hash HASH
                                                                                          )
                                                                                          [--resignation-metadata-url TEXT
                                                                                            --resignation-metadata-hash HASH]

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_update-committee.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_update-committee.cli
@@ -14,13 +14,13 @@ Usage: cardano-cli conway governance action update-committee
                                                                [ --remove-cc-cold-verification-key STRING
                                                                | --remove-cc-cold-verification-key-file FILE
                                                                | --remove-cc-cold-verification-key-hash STRING
-                                                               | --remove-cc-cold-script-file FILE
+                                                               | --remove-cc-cold-script-hash HASH
                                                                ]
                                                                [
                                                                  ( --add-cc-cold-verification-key STRING
                                                                  | --add-cc-cold-verification-key-file FILE
                                                                  | --add-cc-cold-verification-key-hash STRING
-                                                                 | --add-cc-cold-script-file FILE
+                                                                 | --add-cc-cold-script-hash HASH
                                                                  )
                                                                  --epoch NATURAL]
                                                                --quorum RATIONAL
@@ -54,16 +54,20 @@ Available options:
                            Filepath of the Consitutional Committee cold key.
   --remove-cc-cold-verification-key-hash STRING
                            Constitutional Committee key hash (hex-encoded).
-  --remove-cc-cold-script-file FILE
-                           Cold Native or Plutus script file
+  --remove-cc-cold-script-hash HASH
+                           Cold Native or Plutus script file hash (hex-encoded).
+                           Obtain it with "cardano-cli conway governance hash
+                           script ...".
   --add-cc-cold-verification-key STRING
                            Constitutional Committee cold key (hex-encoded).
   --add-cc-cold-verification-key-file FILE
                            Filepath of the Consitutional Committee cold key.
   --add-cc-cold-verification-key-hash STRING
                            Constitutional Committee key hash (hex-encoded).
-  --add-cc-cold-script-file FILE
-                           Cold Native or Plutus script file
+  --add-cc-cold-script-hash HASH
+                           Cold Native or Plutus script file hash (hex-encoded).
+                           Obtain it with "cardano-cli conway governance hash
+                           script ...".
   --epoch NATURAL          Committee member expiry epoch
   --quorum RATIONAL        Quorum of the committee that is necessary for a
                            successful vote.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_update-committee.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_update-committee.cli
@@ -14,11 +14,13 @@ Usage: cardano-cli conway governance action update-committee
                                                                [ --remove-cc-cold-verification-key STRING
                                                                | --remove-cc-cold-verification-key-file FILE
                                                                | --remove-cc-cold-verification-key-hash STRING
+                                                               | --remove-cc-cold-script-file FILE
                                                                ]
                                                                [
                                                                  ( --add-cc-cold-verification-key STRING
                                                                  | --add-cc-cold-verification-key-file FILE
                                                                  | --add-cc-cold-verification-key-hash STRING
+                                                                 | --add-cc-cold-script-file FILE
                                                                  )
                                                                  --epoch NATURAL]
                                                                --quorum RATIONAL
@@ -52,12 +54,16 @@ Available options:
                            Filepath of the Consitutional Committee cold key.
   --remove-cc-cold-verification-key-hash STRING
                            Constitutional Committee key hash (hex-encoded).
+  --remove-cc-cold-script-file FILE
+                           Cold Native or Plutus script file
   --add-cc-cold-verification-key STRING
                            Constitutional Committee cold key (hex-encoded).
   --add-cc-cold-verification-key-file FILE
                            Filepath of the Consitutional Committee cold key.
   --add-cc-cold-verification-key-hash STRING
                            Constitutional Committee key hash (hex-encoded).
+  --add-cc-cold-script-file FILE
+                           Cold Native or Plutus script file
   --epoch NATURAL          Committee member expiry epoch
   --quorum RATIONAL        Quorum of the committee that is necessary for a
                            successful vote.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_committee_create-cold-key-resignation-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_committee_create-cold-key-resignation-certificate.cli
@@ -2,6 +2,7 @@ Usage: cardano-cli conway governance committee create-cold-key-resignation-certi
                                                                                          ( --cold-verification-key STRING
                                                                                          | --cold-verification-key-file FILE
                                                                                          | --cold-verification-key-hash STRING
+                                                                                         | --cold-script-hash HASH
                                                                                          )
                                                                                          [--resignation-metadata-url TEXT
                                                                                            --resignation-metadata-hash HASH]
@@ -16,6 +17,9 @@ Available options:
                            Filepath of the Consitutional Committee cold key.
   --cold-verification-key-hash STRING
                            Constitutional Committee key hash (hex-encoded).
+  --cold-script-hash HASH  Cold Native or Plutus script file hash (hex-encoded).
+                           Obtain it with "cardano-cli conway governance hash
+                           script ...".
   --resignation-metadata-url TEXT
                            Constitutional Committee cold key resignation
                            certificate URL

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_committee-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_committee-state.cli
@@ -7,10 +7,12 @@ Usage: cardano-cli conway query committee-state --socket-path SOCKET_PATH
                                                   [ --cold-verification-key STRING
                                                   | --cold-verification-key-file FILE
                                                   | --cold-verification-key-hash STRING
+                                                  | --cold-script-hash HASH
                                                   ]
                                                   [ --hot-key STRING
                                                   | --hot-key-file FILE
                                                   | --hot-key-hash STRING
+                                                  | --hot-script-hash HASH
                                                   ]
                                                   [ --active
                                                   | --expired
@@ -43,9 +45,15 @@ Available options:
                            Filepath of the Consitutional Committee cold key.
   --cold-verification-key-hash STRING
                            Constitutional Committee key hash (hex-encoded).
+  --cold-script-hash HASH  Cold Native or Plutus script file hash (hex-encoded).
+                           Obtain it with "cardano-cli conway governance hash
+                           script ...".
   --hot-key STRING         Constitutional Committee hot key (hex-encoded).
   --hot-key-file FILE      Filepath of the Consitutional Committee hot key.
   --hot-key-hash STRING    Constitutional Committee key hash (hex-encoded).
+  --hot-script-hash HASH   Hot Native or Plutus script file hash (hex-encoded).
+                           Obtain it with "cardano-cli conway governance hash
+                           script ...".
   --active                 Active committee members (members whose vote will
                            count during ratification)
   --expired                Expired committee members

--- a/flake.lock
+++ b/flake.lock
@@ -3,15 +3,15 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1710529033,
-        "narHash": "sha256-vcxum8uDTGEGV1/h8UWRJmdPXcLhrAqpty/N2LbxRb4=",
-        "owner": "input-output-hk",
+        "lastModified": 1710944230,
+        "narHash": "sha256-eWxTI0H/0S5WsYg4neL7KetFiF9qE6CYBB5UuBq4ZiQ=",
+        "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "a744b5fe534c57a42cbc2645b9211bb619c7c243",
+        "rev": "668b8aaa6c08e4f64f68718208b9c525861018de",
         "type": "github"
       },
       "original": {
-        "owner": "input-output-hk",
+        "owner": "intersectmbo",
         "ref": "repo",
         "repo": "cardano-haskell-packages",
         "type": "github"

--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,7 @@
     incl.url = "github:divnix/incl";
     flake-utils.url = "github:hamishmack/flake-utils/hkm/nested-hydraJobs";
 
-    CHaP.url = "github:input-output-hk/cardano-haskell-packages?ref=repo";
+    CHaP.url = "github:intersectmbo/cardano-haskell-packages?ref=repo";
     CHaP.flake = false;
   };
 


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Add Plutus script hash support in `update-committee`, `overnance committee create-cold-key-resignation-certificate` and `query committee-state` commands.
# uncomment types applicable to the change:
  type:
   - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
   - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

This PR consists of two commits:
1. Refactoring extending use of `MonadTransIOError`
2. Implementation of plutus script hash in `update-committee`.

It is better to review this PR commit-by-commit.

Requires changes from the following PR to compile successfully:
- https://github.com/IntersectMBO/cardano-api/pull/489

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
