### PR TITLE
Display redeemers in `transaction view`

### DIFF
--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -208,6 +208,7 @@ library
                       , cardano-slotting ^>= 0.1
                       , cardano-strict-containers ^>= 0.1
                       , cborg >= 0.2.4 && < 0.3
+                      , cborg-json
                       , containers
                       , contra-tracer
                       , cryptonite

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -147,6 +147,7 @@ library
                         Cardano.CLI.Run.Ping
                         Cardano.CLI.TopHandler
                         Cardano.CLI.Types.Common
+                        Cardano.CLI.Types.MonadWarning
                         Cardano.CLI.Types.Errors.AddressCmdError
                         Cardano.CLI.Types.Errors.AddressInfoError
                         Cardano.CLI.Types.Errors.BootstrapWitnessError
@@ -299,6 +300,7 @@ test-suite cardano-cli-test
                       , tasty-hedgehog
                       , text
                       , time
+                      , transformers
 
   build-tool-depends:   tasty-discover:tasty-discover
 
@@ -309,6 +311,7 @@ test-suite cardano-cli-test
                         Test.Cli.Governance.Hash
                         Test.Cli.ITN
                         Test.Cli.JSON
+                        Test.Cli.MonadWarning
                         Test.Cli.Pioneers.Exercise1
                         Test.Cli.Pioneers.Exercise2
                         Test.Cli.Pioneers.Exercise3

--- a/cardano-cli/src/Cardano/CLI/Json/Friendly.hs
+++ b/cardano-cli/src/Cardano/CLI/Json/Friendly.hs
@@ -20,8 +20,7 @@ import           Cardano.Api.Shelley (Address (ShelleyAddress), Hash (..),
                    ShelleyLedgerEra, StakeAddress (..), fromShelleyPaymentCredential,
                    fromShelleyStakeReference, toShelleyStakeCredential)
 
-import           Cardano.CLI.Types.MonadWarning (MonadWarning, eitherToWarning,
-                   monadWarningInMonadIO)
+import           Cardano.CLI.Types.MonadWarning (MonadWarning, eitherToWarning, runWarningIO)
 import           Cardano.Prelude (first)
 
 import           Codec.CBOR.Encoding (Encoding)
@@ -71,7 +70,7 @@ friendlyTx ::
   -> Tx era
   -> m (Either (FileError e) ())
 friendlyTx format mOutFile era =
-  cardanoEraConstraints era (\tx -> do pairs <- monadWarningInMonadIO $ friendlyTxImpl era tx
+  cardanoEraConstraints era (\tx -> do pairs <- runWarningIO $ friendlyTxImpl era tx
                                        friendly format mOutFile $ object pairs)
 
 friendlyTxBody ::
@@ -82,7 +81,7 @@ friendlyTxBody ::
   -> TxBody era
   -> m (Either (FileError e) ())
 friendlyTxBody format mOutFile era =
-  cardanoEraConstraints era (\tx -> do pairs <- monadWarningInMonadIO $ friendlyTxBodyImpl era tx
+  cardanoEraConstraints era (\tx -> do pairs <- runWarningIO $ friendlyTxBodyImpl era tx
                                        friendly format mOutFile $ object pairs)
 
 friendlyProposal ::

--- a/cardano-cli/src/Cardano/CLI/Types/MonadWarning.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/MonadWarning.hs
@@ -1,0 +1,90 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  Cardano.CLI.Types.MonadWarning
+--
+-- This module defines the 'MonadWarning' type class, which provides a common
+-- interface for monads that support reporting warning messages without
+-- aborting the computation (unlike with exceptions, Either, or MonadFail,
+-- which either fail or return a value).
+--
+-- It also includes two functions that instantiate it into either a 'MonadIO'
+-- ('monadWarningInMonadIO') or a 'StateT' monad with a '[String]' as state
+-- ('monadWarningInStateT') respectively.
+--
+-- In the case of 'MonadIO', warnings are printed to 'stderr'.
+-- In the case of 'StateT', with a '[String]' state, warnings are added to the
+-- list in the state.
+--
+-- By using the 'MonadWarning' type class, users can write code that remains
+-- agnostic to the specific monad in which it operates, and to easily change
+-- it at a later stage if necessary.
+--
+-- Example usage:
+--
+-- @
+-- computeWithWarning :: (MonadWarning m) => Int -> m Int
+-- computeWithWarning x = do
+--   when (x < 0) $ reportIssue "Input value is negative!"
+--   return (x * 2)
+--
+-- -- Using 'IO' monad to perform computation and report warnings.
+-- main :: IO ()
+-- main = do
+--     result <- monadWarningInMonadIO $ computeWithWarning (-4)
+--     putStrLn $ "Result: " ++ show result
+-- @
+-----------------------------------------------------------------------------
+
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE InstanceSigs #-}
+
+module Cardano.CLI.Types.MonadWarning
+  ( MonadWarning(..)
+  , eitherToWarning
+  , monadWarningInMonadIO
+  , monadWarningInStateT
+  ) where
+
+import           Cardano.Prelude (MonadIO (liftIO), MonadState (state), Print (hPutStrLn), StateT,
+                   stderr)
+
+-- | Type class for monads that support reporting warnings.
+class Monad m => MonadWarning m where
+    -- | Report a warning issue.
+    reportIssue :: String -- ^ The warning message to report.
+                -> m ()   -- ^ The action that reports the warning.
+
+-- | Wrapper newtype for 'MonadIO' with 'MonadWarning' instance.
+-- We need to have wrapper to avoid overlapping instances.
+newtype WarningMonadIO m a = WarningMonadIO (m a)
+    deriving (Functor, Applicative, Monad, MonadIO)
+
+-- | This instance prints the issue to the 'stderr'.
+instance MonadIO m => MonadWarning (WarningMonadIO m) where
+    reportIssue :: String -> WarningMonadIO m ()
+    reportIssue issue = liftIO (hPutStrLn stderr issue)
+
+-- | Convert a 'MonadWarning' into a 'MonadIO' by reporting
+-- warnings to 'stderr'.
+monadWarningInMonadIO :: WarningMonadIO m a -> m a
+monadWarningInMonadIO (WarningMonadIO m) = m
+
+-- | Wrapper newtype for 'StateT [String]' with 'MonadWarning' instance.
+newtype WarningStateT m a = WarningState (StateT [String] m a)
+    deriving (Functor, Applicative, Monad, MonadState [String])
+
+-- | This instance adds the issue to the '[String]' in the state.
+instance Monad m => MonadWarning (WarningStateT m) where
+    reportIssue :: String -> WarningStateT m ()
+    reportIssue issue = state (\ x -> ((), issue : x))
+
+-- | Convert a 'MonadWarning' into a 'StateT [String]' monad,
+-- by accumulating warnings into the state.
+monadWarningInStateT :: WarningStateT m a -> StateT [String] m a
+monadWarningInStateT (WarningState m) = m
+
+-- | Convert an 'Either' into a 'MonadWarning'. If 'Either' is 'Left'
+-- it returns the default value (first parameter) and reports the value
+-- as an error. -- If 'Either' is 'Right' it just returns the value.
+eitherToWarning :: MonadWarning m => a -> Either String a -> m a
+eitherToWarning def = either (\issue -> do {reportIssue issue; return def}) return

--- a/cardano-cli/src/Cardano/CLI/Types/MonadWarning.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/MonadWarning.hs
@@ -45,8 +45,10 @@ module Cardano.CLI.Types.MonadWarning
   , monadWarningInStateT
   ) where
 
-import           Cardano.Prelude (MonadIO (liftIO), MonadState (state), Print (hPutStrLn), StateT,
-                   stderr)
+import           Control.Monad.IO.Class (MonadIO, liftIO)
+import           Control.Monad.State (MonadState (..))
+import           Control.Monad.Trans.State (StateT)
+import           System.IO (hPutStrLn, stderr)
 
 -- | Type class for monads that support reporting warnings.
 class Monad m => MonadWarning m where

--- a/cardano-cli/src/Cardano/CLI/Types/MonadWarning.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/MonadWarning.hs
@@ -30,8 +30,8 @@
 -- -- Using 'IO' monad to perform computation and report warnings.
 -- main :: IO ()
 -- main = do
---     result <- runWarningIO $ computeWithWarning (-4)
---     putStrLn $ "Result: " ++ show result
+--   result <- runWarningIO $ computeWithWarning (-4)
+--   putStrLn $ "Result: " ++ show result
 -- @
 -----------------------------------------------------------------------------
 
@@ -52,28 +52,28 @@ import           System.IO (hPutStrLn, stderr)
 
 -- | Type class for monads that support reporting warnings.
 class Monad m => MonadWarning m where
-    -- | Report a warning issue.
-    reportIssue :: String -- ^ The warning message to report.
-                -> m ()   -- ^ The action that reports the warning.
+  -- | Report a warning issue.
+  reportIssue :: String -- ^ The warning message to report.
+              -> m ()   -- ^ The action that reports the warning.
 
 -- | Wrapper newtype for 'MonadIO' with 'MonadWarning' instance.
 -- We need to have wrapper to avoid overlapping instances.
 newtype WarningIO m a = WarningIO { runWarningIO :: m a }
-    deriving (Functor, Applicative, Monad, MonadIO)
+  deriving (Functor, Applicative, Monad, MonadIO)
 
 -- | This instance prints the issue to the 'stderr'.
 instance MonadIO m => MonadWarning (WarningIO m) where
-    reportIssue :: String -> WarningIO m ()
-    reportIssue issue = liftIO (hPutStrLn stderr issue)
+  reportIssue :: String -> WarningIO m ()
+  reportIssue issue = liftIO (hPutStrLn stderr issue)
 
 -- | Wrapper newtype for 'StateT [String]' with 'MonadWarning' instance.
 newtype WarningStateT m a = WarningStateT { runWarningStateT :: StateT [String] m a }
-    deriving (Functor, Applicative, Monad, MonadState [String])
+  deriving (Functor, Applicative, Monad, MonadState [String])
 
 -- | This instance adds the issue to the '[String]' in the state.
 instance Monad m => MonadWarning (WarningStateT m) where
-    reportIssue :: String -> WarningStateT m ()
-    reportIssue issue = state (\ x -> ((), issue : x))
+  reportIssue :: String -> WarningStateT m ()
+  reportIssue issue = state (\ x -> ((), issue : x))
 
 -- | Convert an 'Either' into a 'MonadWarning'. If 'Either' is 'Left'
 -- it returns the default value (first parameter) and reports the value

--- a/cardano-cli/test/cardano-cli-golden/files/golden/allegra/transaction-view.out
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/allegra/transaction-view.out
@@ -17,6 +17,7 @@ outputs:
   reference script: null
   stake reference:
     stake credential key hash: c0a060899d6806f810547e2cb66f92d5c817a16af2a20f269e258ee0
+redeemers: null
 reference inputs: null
 required signers (payment key hashes needed for scripts): null
 return collateral: null

--- a/cardano-cli/test/cardano-cli-golden/files/golden/alonzo/signed-transaction-view.out
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/alonzo/signed-transaction-view.out
@@ -9,6 +9,7 @@ inputs:
 metadata: null
 mint: null
 outputs: []
+redeemers: []
 reference inputs: null
 required signers (payment key hashes needed for scripts):
 - 98717eaba8105a50a2a71831267552e337dfdc893bef5e40b8676d27

--- a/cardano-cli/test/cardano-cli-golden/files/golden/alonzo/transaction-view.out
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/alonzo/transaction-view.out
@@ -9,6 +9,7 @@ inputs:
 metadata: null
 mint: null
 outputs: []
+redeemers: []
 reference inputs: null
 required signers (payment key hashes needed for scripts):
 - 98717eaba8105a50a2a71831267552e337dfdc893bef5e40b8676d27

--- a/cardano-cli/test/cardano-cli-golden/files/golden/babbage/transaction-view-redeemer.out
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/babbage/transaction-view-redeemer.out
@@ -1,0 +1,26 @@
+auxiliary scripts: null
+certificates: null
+collateral inputs:
+- c9765d7d0e3955be8920e6d7a38e1f3f2032eac48c7c59b0b9193caa87727e7e#256
+era: Babbage
+fee: 213 Lovelace
+inputs:
+- ed7c8f68c194cc763ee65ad22ef0973e26481be058c65005fd39fb93f9c43a20#213
+metadata: null
+mint: null
+outputs: []
+redeemers:
+- - 0
+  - 0
+  - 42
+  - - 200
+    - 100
+reference inputs: []
+required signers (payment key hashes needed for scripts): null
+return collateral: null
+total collateral: null
+update proposal: null
+validity range:
+  lower bound: null
+  upper bound: null
+withdrawals: null

--- a/cardano-cli/test/cardano-cli-golden/files/golden/mary/transaction-view.out
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/mary/transaction-view.out
@@ -33,6 +33,7 @@ outputs:
   reference script: null
   stake reference:
     stake credential key hash: c0a060899d6806f810547e2cb66f92d5c817a16af2a20f269e258ee0
+redeemers: null
 reference inputs: null
 required signers (payment key hashes needed for scripts): null
 return collateral: null

--- a/cardano-cli/test/cardano-cli-golden/files/golden/shelley/transaction-view.out
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/shelley/transaction-view.out
@@ -46,6 +46,7 @@ outputs:
   payment credential key hash: bce78cb90f6da9ee778ef07ca881b489c38a188993e6870bd5a9ef77
   reference script: null
   stake reference: null
+redeemers: null
 reference inputs: null
 required signers (payment key hashes needed for scripts): null
 return collateral: null

--- a/cardano-cli/test/cardano-cli-golden/files/input/AlwaysSucceeds.plutus
+++ b/cardano-cli/test/cardano-cli-golden/files/input/AlwaysSucceeds.plutus
@@ -1,0 +1,5 @@
+{
+    "type": "PlutusScriptV1",
+    "description": "",
+    "cborHex": "4e4d01000033222220051200120011"
+}

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/MonadWarning.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/MonadWarning.hs
@@ -1,0 +1,26 @@
+module Test.Cli.MonadWarning
+  ( hprop_monad_warning
+  ) where
+
+import           Cardano.CLI.Types.MonadWarning (MonadWarning, monadWarningInStateT, reportIssue)
+
+import           Control.Monad (when)
+import           Control.Monad.Trans.State (State, runState)
+
+import           Hedgehog (Property, property, (===))
+
+hprop_monad_warning :: Property
+hprop_monad_warning = property $ do
+  (-8, [warning]) === duplicateNumber (-4)
+  (4, []) === duplicateNumber 2
+  where
+    duplicateNumber :: Int -> (Int, [String])
+    duplicateNumber n = runState (monadWarningInStateT $ computeWithWarning n :: State [String] Int) []
+
+    computeWithWarning :: (MonadWarning m) => Int -> m Int
+    computeWithWarning x = do
+      when (x < 0) $ reportIssue warning
+      return (x * 2)
+
+    warning :: String
+    warning = "Input value is negative!"

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/MonadWarning.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/MonadWarning.hs
@@ -2,7 +2,7 @@ module Test.Cli.MonadWarning
   ( hprop_monad_warning
   ) where
 
-import           Cardano.CLI.Types.MonadWarning (MonadWarning, monadWarningInStateT, reportIssue)
+import           Cardano.CLI.Types.MonadWarning (MonadWarning, reportIssue, runWarningStateT)
 
 import           Control.Monad (when)
 import           Control.Monad.Trans.State (State, runState)
@@ -15,7 +15,7 @@ hprop_monad_warning = property $ do
   (4, []) === duplicateNumber 2
   where
     duplicateNumber :: Int -> (Int, [String])
-    duplicateNumber n = runState (monadWarningInStateT $ computeWithWarning n :: State [String] Int) []
+    duplicateNumber n = runState (runWarningStateT $ computeWithWarning n :: State [String] Int) []
 
     computeWithWarning :: (MonadWarning m) => Int -> m Int
     computeWithWarning x = do


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Add info about redeemers to output of `transaction view` command.
  type:
  - feature        # introduces a new feature
```

# Context

It increases the amount of info displayed. It is only applicable to Shelley and after. It uses `cborg-json` to render the CBOR of the redeemer.

# How to trust this PR

I would check:
 - That the approach makes sense overall.
 - That it makes sense to return `null` when it does and it looks right in the changed tests.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
