### PR TITLE
Support querying drep-state by script hash

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Query.hs
@@ -207,7 +207,7 @@ data QueryDRepStateCmdArgs era = QueryDRepStateCmdArgs
   , nodeSocketPath      :: !SocketPath
   , consensusModeParams :: !ConsensusModeParams
   , networkId           :: !NetworkId
-  , drepKeys            :: !(AllOrOnly (VerificationKeyOrHashOrFile DRepKey))
+  , drepHashSources     :: !(AllOrOnly DRepHashSource)
   , includeStake        :: !IncludeStake
   , target              :: !(Consensus.Target ChainPoint)
   , mOutFile            :: !(Maybe (File () Out))
@@ -223,7 +223,7 @@ data QueryDRepStakeDistributionCmdArgs era = QueryDRepStakeDistributionCmdArgs
   , nodeSocketPath      :: !SocketPath
   , consensusModeParams :: !ConsensusModeParams
   , networkId           :: !NetworkId
-  , drepKeys            :: !(AllOrOnly (VerificationKeyOrHashOrFile DRepKey))
+  , drepHashSources     :: !(AllOrOnly DRepHashSource)
   , target              :: !(Consensus.Target ChainPoint)
   , mOutFile            :: !(Maybe (File () Out))
   } deriving Show

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
@@ -3212,10 +3212,10 @@ pDRepVerificationKeyOrHashOrFileOrScriptHash =
           "Cold Native or Plutus script file hash (hex-encoded). Obtain it with \"cardano-cli conway governance hash script ...\"."
     ]
 
-pAllOrOnlyDRepVerificationKeyOrHashOrFile
-  :: Parser (AllOrOnly (VerificationKeyOrHashOrFile DRepKey))
-pAllOrOnlyDRepVerificationKeyOrHashOrFile = pAll <|> pOnly
-  where pOnly = Only <$> some pDRepVerificationKeyOrHashOrFile
+pAllOrOnlyDRepHashSoure
+  :: Parser (AllOrOnly DRepHashSource)
+pAllOrOnlyDRepHashSoure = pAll <|> pOnly
+  where pOnly = Only <$> some pDRepHashSource
         pAll = Opt.flag' All $ mconcat
           [ Opt.long "all-dreps"
           , Opt.help "Query for all DReps."

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Query.hs
@@ -339,7 +339,7 @@ pQueryDRepStateCmd era envCli = do
         <$> pSocketPath envCli
         <*> pConsensusModeParams
         <*> pNetworkId envCli
-        <*> pAllOrOnlyDRepVerificationKeyOrHashOrFile
+        <*> pAllOrOnlyDRepHashSoure
         <*> Opt.flag WithStake NoStake (mconcat
               [ Opt.long "include-stake"
               , Opt.help $ mconcat
@@ -369,7 +369,7 @@ pQueryDRepStakeDistributionCmd era envCli = do
       <$> pSocketPath envCli
       <*> pConsensusModeParams
       <*> pNetworkId envCli
-      <*> pAllOrOnlyDRepVerificationKeyOrHashOrFile
+      <*> pAllOrOnlyDRepHashSoure
       <*> pTarget era
       <*> optional pOutputFile
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -6859,7 +6859,8 @@ Usage: cardano-cli conway query drep-state --socket-path SOCKET_PATH
                                              )
                                              ( --all-dreps
                                              | 
-                                             ( --drep-verification-key STRING
+                                             ( --drep-script-hash HASH
+                                             | --drep-verification-key STRING
                                              | --drep-verification-key-file FILE
                                              | --drep-key-hash HASH
                                              )
@@ -6879,7 +6880,8 @@ Usage: cardano-cli conway query drep-stake-distribution
                                                           )
                                                           ( --all-dreps
                                                           | 
-                                                          ( --drep-verification-key STRING
+                                                          ( --drep-script-hash HASH
+                                                          | --drep-verification-key STRING
                                                           | --drep-verification-key-file FILE
                                                           | --drep-key-hash HASH
                                                           )

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_drep-stake-distribution.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_drep-stake-distribution.cli
@@ -7,7 +7,8 @@ Usage: cardano-cli conway query drep-stake-distribution
                                                           )
                                                           ( --all-dreps
                                                           | 
-                                                          ( --drep-verification-key STRING
+                                                          ( --drep-script-hash HASH
+                                                          | --drep-verification-key STRING
                                                           | --drep-verification-key-file FILE
                                                           | --drep-key-hash HASH
                                                           )
@@ -34,6 +35,8 @@ Available options:
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
   --all-dreps              Query for all DReps.
+  --drep-script-hash HASH  DRep script hash (hex-encoded). Obtain it with
+                           "cardano-cli conway governance hash script ...".
   --drep-verification-key STRING
                            DRep verification key (Bech32 or hex-encoded).
   --drep-verification-key-file FILE

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_drep-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_drep-state.cli
@@ -6,7 +6,8 @@ Usage: cardano-cli conway query drep-state --socket-path SOCKET_PATH
                                              )
                                              ( --all-dreps
                                              | 
-                                             ( --drep-verification-key STRING
+                                             ( --drep-script-hash HASH
+                                             | --drep-verification-key STRING
                                              | --drep-verification-key-file FILE
                                              | --drep-key-hash HASH
                                              )
@@ -32,6 +33,8 @@ Available options:
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
   --all-dreps              Query for all DReps.
+  --drep-script-hash HASH  DRep script hash (hex-encoded). Obtain it with
+                           "cardano-cli conway governance hash script ...".
   --drep-verification-key STRING
                            DRep verification key (Bech32 or hex-encoded).
   --drep-verification-key-file FILE


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Add support for querying drep state and stake distribution by script hash
  type:
  - feature        # introduces a new feature
```

# Context

Addresses [this issue](https://github.com/IntersectMBO/cardano-cli/issues/621), and it also adds the flag to stake distribution because it was using the same code.

# How to trust this PR

It is small, but probably check that the changes to the golden tests and see that the changes to the code make sense too. I just tested in sancho net and it seems to work, feel free to do the same.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
