### PR TITLE
proposal: disambiguate binary data from text data

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/Hash.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/Hash.hs
@@ -29,7 +29,7 @@ data GovernanceHashAnchorDataCmdArgs era
   } deriving Show
 
 data GovernanceAnchorDataHashSource
-  = GovernanceAnchorDataHashSourceBinaryFile (File ProposalText In)
+  = GovernanceAnchorDataHashSourceBinaryFile (File ProposalBinary In)
   | GovernanceAnchorDataHashSourceTextFile (File ProposalText In)
   | GovernanceAnchorDataHashSourceText Text
   deriving Show

--- a/cardano-cli/src/Cardano/CLI/Types/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Common.hs
@@ -42,6 +42,7 @@ module Cardano.CLI.Types.Common
   , ParserFileDirection (..)
   , IdOutputFormat (..)
   , PrivKeyFile(..)
+  , ProposalBinary(..)
   , ProposalFile
   , ProposalText(..)
   , ProposalUrl(..)
@@ -91,6 +92,7 @@ import qualified Cardano.Chain.Slotting as Byron
 
 import           Data.Aeson (FromJSON (..), ToJSON (..), object, pairs, (.=))
 import qualified Data.Aeson as Aeson
+import qualified Data.ByteString as BS
 import           Data.String (IsString)
 import           Data.Text (Text)
 import qualified Data.Text as Text
@@ -120,6 +122,10 @@ data ConstitutionHashSource
 
 newtype ProposalUrl = ProposalUrl
   { unProposalUrl :: L.Url
+  } deriving (Eq, Show)
+
+newtype ProposalBinary = ProposalBinary
+  { unProposalBinary :: BS.ByteString
   } deriving (Eq, Show)
 
 newtype ProposalText = ProposalText


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Introduce newtype to disambiguate binary data from text data
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Fixes https://github.com/IntersectMBO/cardano-cli/issues/568

I couldn't find other usages of `ProposalText` for binary data, so I think this is all there is to do to fix 568

# How to trust this PR

It is really harmless

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] Self-reviewed the diff