### PR TITLE
drep: registration-certificate, update-certificate: test anchors URLs of length > 64 and <= 128

### DIFF
--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -304,6 +304,7 @@ test-suite cardano-cli-test
   other-modules:        Test.Cli.AddCostModels
                         Test.Cli.CreateTestnetData
                         Test.Cli.FilePermissions
+                        Test.Cli.Governance.DRep
                         Test.Cli.Governance.Hash
                         Test.Cli.ITN
                         Test.Cli.JSON

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/Governance/DRep.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/Governance/DRep.hs
@@ -1,0 +1,60 @@
+
+{- HLINT ignore "Use camelCase" -}
+
+module Test.Cli.Governance.DRep where
+
+import           Control.Monad
+
+import           Test.Cardano.CLI.Util (execCardanoCLI, propertyOnce)
+
+import           Hedgehog
+import qualified Hedgehog.Extras.Test.Base as H
+
+metadataUrls :: [String]
+metadataUrls = [ "dummy-url"
+               , "length-84-here-we-goooooooooooooooooooooooooooooooooooooooooooooooooooooo-dummy-url"
+               , "exactly-128-chars-here-we-goooooooooooooooooooooooooooooooooooooooooooooooooooooo-dummy-url-ooooooooooooooooooooooooooooooooooo" ]
+
+-- | This is a test of https://github.com/IntersectMBO/cardano-cli/issues/552
+-- Execute me with:
+-- @cabal test cardano-cli-test --test-options '-p "/governance drep registration certificate script hash/"'@
+hprop_governance_drep_registration_certificate_script_hash :: Property
+hprop_governance_drep_registration_certificate_script_hash =
+  propertyOnce $ forM_ metadataUrls $ \metadataUrl -> do
+    H.moduleWorkspace "tmp" $ \tempDir -> do
+      outFile <- H.noteTempFile tempDir "drep-reg-cert.txt"
+
+      H.noteShowM_ $ execCardanoCLI
+        [ "conway", "governance", "drep", "registration-certificate"
+        , "--drep-script-hash", "00000000000000000000000000000000000000000000000000000003"
+        , "--key-reg-deposit-amt", "0"
+        , "--drep-metadata-url", metadataUrl
+        , "--drep-metadata-hash", "52e69500a92d80f2126c836a4903dc582006709f004cf7a28ed648f732dff8d2"
+        , "--out-file", outFile
+        ]
+
+-- | This is a test of https://github.com/IntersectMBO/cardano-cli/issues/552
+-- Execute me with:
+-- @cabal test cardano-cli-test --test-options '-p "/governance drep update certificate vkey file/"'@
+hprop_governance_drep_update_certificate_vkey_file :: Property
+hprop_governance_drep_update_certificate_vkey_file =
+  propertyOnce $ forM_ metadataUrls $ \metadataUrl -> do
+    H.moduleWorkspace "tmp" $ \tempDir -> do
+      drepVKeyFile <- H.noteTempFile tempDir "drep.vkey"
+      drepSKeyFile <- H.noteTempFile tempDir "drep.skey"
+
+      H.noteShowM_ $ execCardanoCLI
+        [  "conway", "governance", "drep", "key-gen"
+        , "--verification-key-file", drepVKeyFile
+        , "--signing-key-file", drepSKeyFile
+        ]
+
+      outFile <- H.noteTempFile tempDir "drep-upd-cert.txt"
+
+      H.noteShowM_ $ execCardanoCLI
+        [ "conway", "governance", "drep", "update-certificate"
+        , "--drep-verification-key-file", drepVKeyFile
+        , "--drep-metadata-url", metadataUrl
+        , "--drep-metadata-hash", "52e69500a92d80f2126c836a4903dc582006709f004cf7a28ed648f732dff8d2"
+        , "--out-file", outFile
+        ]


### PR DESCRIPTION

# Changelog

```yaml
- description: |
    drep: registration-certificate, update-certificate: test anchors URLs of length > 64 and <= 128
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

I wrote those tests to reproduce https://github.com/IntersectMBO/cardano-cli/issues/552. We can't reproduce it anymore, but since the bug was there at some point, and I wrote the tests anyway; I though "let's merge them".

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [X] Self-reviewed the diff