### PR TITLE
#667 Add ref-script-size query command

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Query.hs
@@ -21,6 +21,7 @@ module Cardano.CLI.EraBased.Commands.Query
   , QueryPoolStateCmdArgs(..)
   , QueryTxMempoolCmdArgs(..)
   , QuerySlotNumberCmdArgs(..)
+  , QueryRefScriptSizeCmdArgs(..)
   , QueryNoArgCmdArgs(..)
   , QueryDRepStateCmdArgs(..)
   , QueryDRepStakeDistributionCmdArgs(..)
@@ -34,6 +35,7 @@ import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Key
 import qualified Ouroboros.Network.Protocol.LocalStateQuery.Type as Consensus
 
+import           Data.Set (Set)
 import           Data.Text (Text)
 import           Data.Time.Clock
 import           GHC.Generics
@@ -54,6 +56,7 @@ data QueryCmds era
   | QueryPoolStateCmd               !QueryPoolStateCmdArgs
   | QueryTxMempoolCmd               !QueryTxMempoolCmdArgs
   | QuerySlotNumberCmd              !QuerySlotNumberCmdArgs
+  | QueryRefScriptSizeCmd           !QueryRefScriptSizeCmdArgs
   | QueryConstitutionCmd            !(QueryNoArgCmdArgs era)
   | QueryGovStateCmd                !(QueryNoArgCmdArgs era)
   | QueryDRepStateCmd               !(QueryDRepStateCmdArgs era)
@@ -193,6 +196,16 @@ data QuerySlotNumberCmdArgs = QuerySlotNumberCmdArgs
   , utcTime             :: !UTCTime
   } deriving (Generic, Show)
 
+data QueryRefScriptSizeCmdArgs = QueryRefScriptSizeCmdArgs
+  { nodeSocketPath      :: !SocketPath
+  , consensusModeParams :: !ConsensusModeParams
+  , transactionInputs   :: !(Set TxIn)
+  , networkId           :: !NetworkId
+  , target              :: !(Consensus.Target ChainPoint)
+  , format              :: Maybe QueryOutputFormat
+  , mOutFile            :: !(Maybe (File () Out))
+  } deriving (Generic, Show)
+
 data QueryNoArgCmdArgs era = QueryNoArgCmdArgs
   { eon                 :: !(ConwayEraOnwards era)
   , nodeSocketPath      :: !SocketPath
@@ -272,6 +285,8 @@ renderQueryCmds = \case
     "query tx-mempool" <> renderTxMempoolQuery q
   QuerySlotNumberCmd {} ->
     "query slot-number"
+  QueryRefScriptSizeCmd {} ->
+    "query ref-script-size"
   QueryConstitutionCmd {} ->
     "constitution"
   QueryGovStateCmd {} ->

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -452,6 +452,7 @@ Usage: cardano-cli shelley query
                                    | pool-state
                                    | tx-mempool
                                    | slot-number
+                                   | ref-script-size
                                    )
 
   Node query commands. Will query the local node whose Unix domain socket is
@@ -646,6 +647,21 @@ Usage: cardano-cli shelley query slot-number --socket-path SOCKET_PATH
                                                TIMESTAMP
 
   Query slot number for UTC timestamp
+
+Usage: cardano-cli shelley query ref-script-size --socket-path SOCKET_PATH
+                                                   [--cardano-mode
+                                                     [--epoch-slots SLOTS]]
+                                                   (--tx-in TX-IN)
+                                                   ( --mainnet
+                                                   | --testnet-magic NATURAL
+                                                   )
+                                                   [ --output-json
+                                                   | --output-text
+                                                   ]
+                                                   [--out-file FILE]
+
+  Calculate the reference input scripts size in bytes for provided transaction
+  inputs.
 
 Usage: cardano-cli shelley stake-address 
                                            ( key-gen
@@ -1625,6 +1641,7 @@ Usage: cardano-cli allegra query
                                    | pool-state
                                    | tx-mempool
                                    | slot-number
+                                   | ref-script-size
                                    )
 
   Node query commands. Will query the local node whose Unix domain socket is
@@ -1819,6 +1836,21 @@ Usage: cardano-cli allegra query slot-number --socket-path SOCKET_PATH
                                                TIMESTAMP
 
   Query slot number for UTC timestamp
+
+Usage: cardano-cli allegra query ref-script-size --socket-path SOCKET_PATH
+                                                   [--cardano-mode
+                                                     [--epoch-slots SLOTS]]
+                                                   (--tx-in TX-IN)
+                                                   ( --mainnet
+                                                   | --testnet-magic NATURAL
+                                                   )
+                                                   [ --output-json
+                                                   | --output-text
+                                                   ]
+                                                   [--out-file FILE]
+
+  Calculate the reference input scripts size in bytes for provided transaction
+  inputs.
 
 Usage: cardano-cli allegra stake-address 
                                            ( key-gen
@@ -2796,6 +2828,7 @@ Usage: cardano-cli mary query
                                 | pool-state
                                 | tx-mempool
                                 | slot-number
+                                | ref-script-size
                                 )
 
   Node query commands. Will query the local node whose Unix domain socket is
@@ -2986,6 +3019,19 @@ Usage: cardano-cli mary query slot-number --socket-path SOCKET_PATH
                                             TIMESTAMP
 
   Query slot number for UTC timestamp
+
+Usage: cardano-cli mary query ref-script-size --socket-path SOCKET_PATH
+                                                [--cardano-mode
+                                                  [--epoch-slots SLOTS]]
+                                                (--tx-in TX-IN)
+                                                ( --mainnet
+                                                | --testnet-magic NATURAL
+                                                )
+                                                [--output-json | --output-text]
+                                                [--out-file FILE]
+
+  Calculate the reference input scripts size in bytes for provided transaction
+  inputs.
 
 Usage: cardano-cli mary stake-address 
                                         ( key-gen
@@ -3959,6 +4005,7 @@ Usage: cardano-cli alonzo query
                                   | pool-state
                                   | tx-mempool
                                   | slot-number
+                                  | ref-script-size
                                   )
 
   Node query commands. Will query the local node whose Unix domain socket is
@@ -4153,6 +4200,21 @@ Usage: cardano-cli alonzo query slot-number --socket-path SOCKET_PATH
                                               TIMESTAMP
 
   Query slot number for UTC timestamp
+
+Usage: cardano-cli alonzo query ref-script-size --socket-path SOCKET_PATH
+                                                  [--cardano-mode
+                                                    [--epoch-slots SLOTS]]
+                                                  (--tx-in TX-IN)
+                                                  ( --mainnet
+                                                  | --testnet-magic NATURAL
+                                                  )
+                                                  [ --output-json
+                                                  | --output-text
+                                                  ]
+                                                  [--out-file FILE]
+
+  Calculate the reference input scripts size in bytes for provided transaction
+  inputs.
 
 Usage: cardano-cli alonzo stake-address 
                                           ( key-gen
@@ -5157,6 +5219,7 @@ Usage: cardano-cli babbage query
                                    | pool-state
                                    | tx-mempool
                                    | slot-number
+                                   | ref-script-size
                                    )
 
   Node query commands. Will query the local node whose Unix domain socket is
@@ -5351,6 +5414,21 @@ Usage: cardano-cli babbage query slot-number --socket-path SOCKET_PATH
                                                TIMESTAMP
 
   Query slot number for UTC timestamp
+
+Usage: cardano-cli babbage query ref-script-size --socket-path SOCKET_PATH
+                                                   [--cardano-mode
+                                                     [--epoch-slots SLOTS]]
+                                                   (--tx-in TX-IN)
+                                                   ( --mainnet
+                                                   | --testnet-magic NATURAL
+                                                   )
+                                                   [ --output-json
+                                                   | --output-text
+                                                   ]
+                                                   [--out-file FILE]
+
+  Calculate the reference input scripts size in bytes for provided transaction
+  inputs.
 
 Usage: cardano-cli babbage stake-address 
                                            ( key-gen
@@ -6606,6 +6684,7 @@ Usage: cardano-cli conway query
                                   | pool-state
                                   | tx-mempool
                                   | slot-number
+                                  | ref-script-size
                                   | constitution
                                   | gov-state
                                   | drep-state
@@ -6832,6 +6911,24 @@ Usage: cardano-cli conway query slot-number --socket-path SOCKET_PATH
                                               TIMESTAMP
 
   Query slot number for UTC timestamp
+
+Usage: cardano-cli conway query ref-script-size --socket-path SOCKET_PATH
+                                                  [--cardano-mode
+                                                    [--epoch-slots SLOTS]]
+                                                  (--tx-in TX-IN)
+                                                  ( --mainnet
+                                                  | --testnet-magic NATURAL
+                                                  )
+                                                  [ --volatile-tip
+                                                  | --immutable-tip
+                                                  ]
+                                                  [ --output-json
+                                                  | --output-text
+                                                  ]
+                                                  [--out-file FILE]
+
+  Calculate the reference input scripts size in bytes for provided transaction
+  inputs.
 
 Usage: cardano-cli conway query constitution --socket-path SOCKET_PATH
                                                [--cardano-mode
@@ -7999,6 +8096,7 @@ Usage: cardano-cli latest query
                                   | pool-state
                                   | tx-mempool
                                   | slot-number
+                                  | ref-script-size
                                   )
 
   Node query commands. Will query the local node whose Unix domain socket is
@@ -8193,6 +8291,21 @@ Usage: cardano-cli latest query slot-number --socket-path SOCKET_PATH
                                               TIMESTAMP
 
   Query slot number for UTC timestamp
+
+Usage: cardano-cli latest query ref-script-size --socket-path SOCKET_PATH
+                                                  [--cardano-mode
+                                                    [--epoch-slots SLOTS]]
+                                                  (--tx-in TX-IN)
+                                                  ( --mainnet
+                                                  | --testnet-magic NATURAL
+                                                  )
+                                                  [ --output-json
+                                                  | --output-text
+                                                  ]
+                                                  [--out-file FILE]
+
+  Calculate the reference input scripts size in bytes for provided transaction
+  inputs.
 
 Usage: cardano-cli latest stake-address 
                                           ( key-gen

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query.cli
@@ -13,6 +13,7 @@ Usage: cardano-cli allegra query
                                    | pool-state
                                    | tx-mempool
                                    | slot-number
+                                   | ref-script-size
                                    )
 
   Node query commands. Will query the local node whose Unix domain socket is
@@ -47,3 +48,5 @@ Available commands:
   pool-state               Dump the pool state
   tx-mempool               Local Mempool info
   slot-number              Query slot number for UTC timestamp
+  ref-script-size          Calculate the reference input scripts size in bytes
+                           for provided transaction inputs.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_ref-script-size.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_ref-script-size.cli
@@ -1,0 +1,36 @@
+Usage: cardano-cli allegra query ref-script-size --socket-path SOCKET_PATH
+                                                   [--cardano-mode
+                                                     [--epoch-slots SLOTS]]
+                                                   (--tx-in TX-IN)
+                                                   ( --mainnet
+                                                   | --testnet-magic NATURAL
+                                                   )
+                                                   [ --output-json
+                                                   | --output-text
+                                                   ]
+                                                   [--out-file FILE]
+
+  Calculate the reference input scripts size in bytes for provided transaction
+  inputs.
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --tx-in TX-IN            Transaction input (TxId#TxIx).
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --output-json            Format reference inputs query output to JSON. Default
+                           format when writing to a file
+  --output-text            Format reference inputs query output to TEXT. Default
+                           format when writing to stdout
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query.cli
@@ -13,6 +13,7 @@ Usage: cardano-cli alonzo query
                                   | pool-state
                                   | tx-mempool
                                   | slot-number
+                                  | ref-script-size
                                   )
 
   Node query commands. Will query the local node whose Unix domain socket is
@@ -47,3 +48,5 @@ Available commands:
   pool-state               Dump the pool state
   tx-mempool               Local Mempool info
   slot-number              Query slot number for UTC timestamp
+  ref-script-size          Calculate the reference input scripts size in bytes
+                           for provided transaction inputs.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_ref-script-size.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_ref-script-size.cli
@@ -1,0 +1,36 @@
+Usage: cardano-cli alonzo query ref-script-size --socket-path SOCKET_PATH
+                                                  [--cardano-mode
+                                                    [--epoch-slots SLOTS]]
+                                                  (--tx-in TX-IN)
+                                                  ( --mainnet
+                                                  | --testnet-magic NATURAL
+                                                  )
+                                                  [ --output-json
+                                                  | --output-text
+                                                  ]
+                                                  [--out-file FILE]
+
+  Calculate the reference input scripts size in bytes for provided transaction
+  inputs.
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --tx-in TX-IN            Transaction input (TxId#TxIx).
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --output-json            Format reference inputs query output to JSON. Default
+                           format when writing to a file
+  --output-text            Format reference inputs query output to TEXT. Default
+                           format when writing to stdout
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query.cli
@@ -13,6 +13,7 @@ Usage: cardano-cli babbage query
                                    | pool-state
                                    | tx-mempool
                                    | slot-number
+                                   | ref-script-size
                                    )
 
   Node query commands. Will query the local node whose Unix domain socket is
@@ -47,3 +48,5 @@ Available commands:
   pool-state               Dump the pool state
   tx-mempool               Local Mempool info
   slot-number              Query slot number for UTC timestamp
+  ref-script-size          Calculate the reference input scripts size in bytes
+                           for provided transaction inputs.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_ref-script-size.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_ref-script-size.cli
@@ -1,0 +1,36 @@
+Usage: cardano-cli babbage query ref-script-size --socket-path SOCKET_PATH
+                                                   [--cardano-mode
+                                                     [--epoch-slots SLOTS]]
+                                                   (--tx-in TX-IN)
+                                                   ( --mainnet
+                                                   | --testnet-magic NATURAL
+                                                   )
+                                                   [ --output-json
+                                                   | --output-text
+                                                   ]
+                                                   [--out-file FILE]
+
+  Calculate the reference input scripts size in bytes for provided transaction
+  inputs.
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --tx-in TX-IN            Transaction input (TxId#TxIx).
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --output-json            Format reference inputs query output to JSON. Default
+                           format when writing to a file
+  --output-text            Format reference inputs query output to TEXT. Default
+                           format when writing to stdout
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query.cli
@@ -13,6 +13,7 @@ Usage: cardano-cli conway query
                                   | pool-state
                                   | tx-mempool
                                   | slot-number
+                                  | ref-script-size
                                   | constitution
                                   | gov-state
                                   | drep-state
@@ -52,6 +53,8 @@ Available commands:
   pool-state               Dump the pool state
   tx-mempool               Local Mempool info
   slot-number              Query slot number for UTC timestamp
+  ref-script-size          Calculate the reference input scripts size in bytes
+                           for provided transaction inputs.
   constitution             Get the constitution
   gov-state                Get the governance state
   drep-state               Get the DRep state.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_ref-script-size.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_ref-script-size.cli
@@ -1,0 +1,42 @@
+Usage: cardano-cli conway query ref-script-size --socket-path SOCKET_PATH
+                                                  [--cardano-mode
+                                                    [--epoch-slots SLOTS]]
+                                                  (--tx-in TX-IN)
+                                                  ( --mainnet
+                                                  | --testnet-magic NATURAL
+                                                  )
+                                                  [ --volatile-tip
+                                                  | --immutable-tip
+                                                  ]
+                                                  [ --output-json
+                                                  | --output-text
+                                                  ]
+                                                  [--out-file FILE]
+
+  Calculate the reference input scripts size in bytes for provided transaction
+  inputs.
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --tx-in TX-IN            Transaction input (TxId#TxIx).
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --volatile-tip           Use the volatile tip as a target. (This is the
+                           default)
+  --immutable-tip          Use the immutable tip as a target.
+  --output-json            Format reference inputs query output to JSON. Default
+                           format when writing to a file
+  --output-text            Format reference inputs query output to TEXT. Default
+                           format when writing to stdout
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query.cli
@@ -13,6 +13,7 @@ Usage: cardano-cli latest query
                                   | pool-state
                                   | tx-mempool
                                   | slot-number
+                                  | ref-script-size
                                   )
 
   Node query commands. Will query the local node whose Unix domain socket is
@@ -47,3 +48,5 @@ Available commands:
   pool-state               Dump the pool state
   tx-mempool               Local Mempool info
   slot-number              Query slot number for UTC timestamp
+  ref-script-size          Calculate the reference input scripts size in bytes
+                           for provided transaction inputs.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_ref-script-size.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_ref-script-size.cli
@@ -1,0 +1,36 @@
+Usage: cardano-cli latest query ref-script-size --socket-path SOCKET_PATH
+                                                  [--cardano-mode
+                                                    [--epoch-slots SLOTS]]
+                                                  (--tx-in TX-IN)
+                                                  ( --mainnet
+                                                  | --testnet-magic NATURAL
+                                                  )
+                                                  [ --output-json
+                                                  | --output-text
+                                                  ]
+                                                  [--out-file FILE]
+
+  Calculate the reference input scripts size in bytes for provided transaction
+  inputs.
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --tx-in TX-IN            Transaction input (TxId#TxIx).
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --output-json            Format reference inputs query output to JSON. Default
+                           format when writing to a file
+  --output-text            Format reference inputs query output to TEXT. Default
+                           format when writing to stdout
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query.cli
@@ -13,6 +13,7 @@ Usage: cardano-cli mary query
                                 | pool-state
                                 | tx-mempool
                                 | slot-number
+                                | ref-script-size
                                 )
 
   Node query commands. Will query the local node whose Unix domain socket is
@@ -47,3 +48,5 @@ Available commands:
   pool-state               Dump the pool state
   tx-mempool               Local Mempool info
   slot-number              Query slot number for UTC timestamp
+  ref-script-size          Calculate the reference input scripts size in bytes
+                           for provided transaction inputs.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_ref-script-size.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_ref-script-size.cli
@@ -1,0 +1,34 @@
+Usage: cardano-cli mary query ref-script-size --socket-path SOCKET_PATH
+                                                [--cardano-mode
+                                                  [--epoch-slots SLOTS]]
+                                                (--tx-in TX-IN)
+                                                ( --mainnet
+                                                | --testnet-magic NATURAL
+                                                )
+                                                [--output-json | --output-text]
+                                                [--out-file FILE]
+
+  Calculate the reference input scripts size in bytes for provided transaction
+  inputs.
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --tx-in TX-IN            Transaction input (TxId#TxIx).
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --output-json            Format reference inputs query output to JSON. Default
+                           format when writing to a file
+  --output-text            Format reference inputs query output to TEXT. Default
+                           format when writing to stdout
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query.cli
@@ -13,6 +13,7 @@ Usage: cardano-cli shelley query
                                    | pool-state
                                    | tx-mempool
                                    | slot-number
+                                   | ref-script-size
                                    )
 
   Node query commands. Will query the local node whose Unix domain socket is
@@ -47,3 +48,5 @@ Available commands:
   pool-state               Dump the pool state
   tx-mempool               Local Mempool info
   slot-number              Query slot number for UTC timestamp
+  ref-script-size          Calculate the reference input scripts size in bytes
+                           for provided transaction inputs.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_ref-script-size.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_ref-script-size.cli
@@ -1,0 +1,36 @@
+Usage: cardano-cli shelley query ref-script-size --socket-path SOCKET_PATH
+                                                   [--cardano-mode
+                                                     [--epoch-slots SLOTS]]
+                                                   (--tx-in TX-IN)
+                                                   ( --mainnet
+                                                   | --testnet-magic NATURAL
+                                                   )
+                                                   [ --output-json
+                                                   | --output-text
+                                                   ]
+                                                   [--out-file FILE]
+
+  Calculate the reference input scripts size in bytes for provided transaction
+  inputs.
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --tx-in TX-IN            Transaction input (TxId#TxIx).
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --output-json            Format reference inputs query output to JSON. Default
+                           format when writing to a file
+  --output-text            Format reference inputs query output to TEXT. Default
+                           format when writing to stdout
+  --out-file FILE          Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Add `ref-script-size` query command
# uncomment types applicable to the change:
  type:
   - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
   - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Requires:
* https://github.com/IntersectMBO/cardano-api/pull/495

This PR is rebased onto https://github.com/IntersectMBO/cardano-cli/pull/680/ - only `#667 Add ref-script-size query command` commit contains the changes related to this feature.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
