### PR TITLE
Add `--drep-script-hash` parameter to `conway governance drep retirement-certificate`

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/DRep.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/DRep.hs
@@ -59,7 +59,7 @@ data GovernanceDRepRegistrationCertificateCmdArgs era =
 data GovernanceDRepRetirementCertificateCmdArgs era =
   GovernanceDRepRetirementCertificateCmdArgs
     { eon             :: !(ConwayEraOnwards era)
-    , vkeyHashSource  :: !(VerificationKeyOrHashOrFile DRepKey)
+    , drepHashSource  :: !DRepHashSource
     , deposit         :: !L.Coin
     , outFile         :: !(File () Out)
     }

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/DRep.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/DRep.hs
@@ -136,7 +136,7 @@ pRetirementCertificateCmd era = do
     $ Opt.info
       ( fmap GovernanceDRepRetirementCertificateCmd $
           GovernanceDRepRetirementCertificateCmdArgs w
-            <$> pDRepVerificationKeyOrHashOrFile
+            <$> pDRepHashSource
             <*> pDrepDeposit
             <*> pOutputFile
       )

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/DRep.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/DRep.hs
@@ -127,16 +127,15 @@ runGovernanceDRepRetirementCertificateCmd :: ()
 runGovernanceDRepRetirementCertificateCmd
     Cmd.GovernanceDRepRetirementCertificateCmdArgs
       { eon = w
-      , vkeyHashSource
+      , drepHashSource
       , deposit
       , outFile
       } =
   conwayEraOnwardsConstraints w $ do
-    DRepKeyHash drepKeyHash <- firstExceptT GovernanceCmdKeyReadError
-      $ readVerificationKeyOrHashOrFile AsDRepKey vkeyHashSource
-    makeDrepUnregistrationCertificate (DRepUnregistrationRequirements w (KeyHashObj drepKeyHash) deposit)
+    drepCredential <- modifyError GovernanceCmdKeyReadError $ readDRepCredential drepHashSource
+    makeDrepUnregistrationCertificate (DRepUnregistrationRequirements w drepCredential deposit)
       & writeFileTextEnvelope outFile (Just genKeyDelegCertDesc)
-      & firstExceptT GovernanceCmdTextEnvWriteError . newExceptT
+      & modifyError GovernanceCmdTextEnvWriteError . newExceptT
 
   where
     genKeyDelegCertDesc :: TextEnvelopeDescr

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -6449,7 +6449,8 @@ Usage: cardano-cli conway governance drep registration-certificate
   Create a registration certificate.
 
 Usage: cardano-cli conway governance drep retirement-certificate 
-                                                                   ( --drep-verification-key STRING
+                                                                   ( --drep-script-hash HASH
+                                                                   | --drep-verification-key STRING
                                                                    | --drep-verification-key-file FILE
                                                                    | --drep-key-hash HASH
                                                                    )

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_drep_retirement-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_drep_retirement-certificate.cli
@@ -1,5 +1,6 @@
 Usage: cardano-cli conway governance drep retirement-certificate 
-                                                                   ( --drep-verification-key STRING
+                                                                   ( --drep-script-hash HASH
+                                                                   | --drep-verification-key STRING
                                                                    | --drep-verification-key-file FILE
                                                                    | --drep-key-hash HASH
                                                                    )
@@ -9,6 +10,8 @@ Usage: cardano-cli conway governance drep retirement-certificate
   Create a DRep retirement certificate.
 
 Available options:
+  --drep-script-hash HASH  DRep script hash (hex-encoded). Obtain it with
+                           "cardano-cli conway governance hash script ...".
   --drep-verification-key STRING
                            DRep verification key (Bech32 or hex-encoded).
   --drep-verification-key-file FILE


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Add `--drep-script-hash` parameter to `conway governance drep retirement-certificate`
  type:
  - feature        # introduces a new feature
```
# Context

This aims to solve issue [#659](https://github.com/IntersectMBO/cardano-cli/issues/659)

# How to trust this PR

It is small, but probably check that the changes to the golden tests and the changes to the code make sense too.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff

