### PR TITLE
Throw an error on identical action-ids in votes of one voter

### DIFF
--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -317,6 +317,7 @@ test-suite cardano-cli-test
                         Test.Cli.Pipes
                         Test.Cli.VerificationKey
                         Test.Cli.Shelley.Run.Query
+                        Test.Cli.Shelley.Transaction.Build
 
   ghc-options:          -threaded -rtsopts "-with-rtsopts=-N -T"
 

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Transaction.hs
@@ -429,6 +429,8 @@ runTxBuildRaw sbe
       <- createTxMintValue sbe valuesWithScriptWits
     validatedTxScriptValidity
       <- first TxCmdScriptValidityValidationError $ validateTxScriptValidity era mScriptValidity
+    validatedVotingProcedures
+      <- first TxCmdTxGovDuplicateVotes $ convertToTxVotingProcedures votingProcedures
     let txBodyContent =
           TxBodyContent
             { txIns = validatedTxIns
@@ -450,7 +452,7 @@ runTxBuildRaw sbe
             , txMintValue = validatedMintValue
             , txScriptValidity = validatedTxScriptValidity
             , txProposalProcedures = forEraInEonMaybe era (`Featured` (shelleyBasedEraConstraints sbe $ convToTxProposalProcedures proposals))
-            , txVotingProcedures = forEraInEonMaybe era (`Featured` convertToTxVotingProcedures votingProcedures)
+            , txVotingProcedures = forEraInEonMaybe era (`Featured` validatedVotingProcedures)
             }
     first TxCmdTxBodyError $ createAndValidateTransactionBody sbe txBodyContent
 
@@ -528,6 +530,7 @@ runTxBuild
   validatedTxCerts <- hoistEither (first TxCmdTxCertificatesValidationError $ validateTxCertificates era certsAndMaybeScriptWits)
   validatedMintValue <- hoistEither $ createTxMintValue sbe valuesWithScriptWits
   validatedTxScriptValidity <- hoistEither (first TxCmdScriptValidityValidationError $ validateTxScriptValidity era mScriptValidity)
+  validatedVotingProcedures <- hoistEither (first TxCmdTxGovDuplicateVotes $ convertToTxVotingProcedures votingProcedures)
 
   let allTxInputs = inputsThatRequireWitnessing ++ allReferenceInputs ++ txinsc
       localNodeConnInfo = LocalNodeConnectInfo
@@ -577,7 +580,7 @@ runTxBuild
           , txMintValue = validatedMintValue
           , txScriptValidity = validatedTxScriptValidity
           , txProposalProcedures = forEraInEonMaybe era (`Featured` convToTxProposalProcedures proposals)
-          , txVotingProcedures = forEraInEonMaybe era (`Featured` convertToTxVotingProcedures votingProcedures)
+          , txVotingProcedures = forEraInEonMaybe era (`Featured` validatedVotingProcedures)
           }
 
   firstExceptT TxCmdTxInsDoNotExist

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/TxCmdError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/TxCmdError.hs
@@ -93,6 +93,7 @@ data TxCmdError
   | TxCmdTxUpdateProposalValidationError TxUpdateProposalValidationError
   | TxCmdScriptValidityValidationError TxScriptValidityValidationError
   | TxCmdProtocolParamsConverstionError ProtocolParametersConversionError
+  | forall era. TxCmdTxGovDuplicateVotes (TxGovDuplicateVotes era)
 
 renderTxCmdError :: TxCmdError -> Doc ann
 renderTxCmdError = \case
@@ -232,6 +233,8 @@ renderTxCmdError = \case
   TxCmdTxUpdateProposalValidationError e ->
     prettyError e
   TxCmdScriptValidityValidationError e ->
+    prettyError e
+  TxCmdTxGovDuplicateVotes e ->
     prettyError e
 
 prettyPolicyIdList :: [PolicyId] -> Doc ann

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/Shelley/Transaction/Build.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/Shelley/Transaction/Build.hs
@@ -1,0 +1,34 @@
+module Test.Cli.Shelley.Transaction.Build where
+
+import           Data.List (isInfixOf)
+import           System.Exit (ExitCode (..))
+
+import           Test.Cardano.CLI.Util (execDetailCardanoCLI, propertyOnce)
+
+import           Hedgehog
+import qualified Hedgehog as H
+import qualified Hedgehog.Extras.Test.Base as H
+
+{- HLINT ignore "Use camelCase" -}
+{- HLINT ignore "Redundant bracket" -}
+
+-- | This is a test of https://github.com/IntersectMBO/cardano-cli/issues/662
+-- Execute me with:
+-- @cabal test cardano-cli-test --test-options '-p "/conway transaction build one voter many votes/"'@
+hprop_conway_transaction_build_one_voter_many_votes :: Property
+hprop_conway_transaction_build_one_voter_many_votes = propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir -> do
+  outFile <- H.noteTempFile tempDir "tx.traw"
+
+  (exitCode, _stdout, stderr) <- H.noteShowM $ execDetailCardanoCLI
+    [ "conway", "transaction", "build-raw"
+    , "--tx-in", "6e8c947816e82627aeccb55300074f2894a2051332f62a1c8954e7b588a18be7#0"
+    , "--tx-out", "addr_test1vpfwv0ezc5g8a4mkku8hhy3y3vp92t7s3ul8g778g5yegsgalc6gc+24910487859"
+    , "--invalid-hereafter", "24325742"
+    , "--fee" , "178569"
+    , "--vote-file", "test/cardano-cli-test/files/input/shelley/transaction/vote1.drep.json"
+    , "--vote-file", "test/cardano-cli-test/files/input/shelley/transaction/vote2.drep.json"
+    , "--out-file", outFile
+    ]
+
+  exitCode H.=== (ExitFailure 1)
+  H.assertWith stderr ("This would cause ignoring some of the votes" `isInfixOf`)

--- a/cardano-cli/test/cardano-cli-test/files/input/shelley/transaction/vote1.drep.json
+++ b/cardano-cli/test/cardano-cli-test/files/input/shelley/transaction/vote1.drep.json
@@ -1,0 +1,5 @@
+{
+    "type": "Governance voting procedures",
+    "description": "",
+    "cborHex": "a18202581c8f4fefcf28017a57b41517a67d56ef4c0dc04181a11d35178dd53f4ca1825820704e5c60c51dd0f3732991980b273402fbad0581c3407d682f8ea5b808a530fc008201f6"
+}

--- a/cardano-cli/test/cardano-cli-test/files/input/shelley/transaction/vote2.drep.json
+++ b/cardano-cli/test/cardano-cli-test/files/input/shelley/transaction/vote2.drep.json
@@ -1,0 +1,5 @@
+{
+    "type": "Governance voting procedures",
+    "description": "",
+    "cborHex": "a18202581c8f4fefcf28017a57b41517a67d56ef4c0dc04181a11d35178dd53f4ca1825820704e5c60c51dd0f3732991980b273402fbad0581c3407d682f8ea5b808a530fc008200f6"
+}


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    transaction build{,-raw}: throw an error on identical action-ids in votes files
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Fixes https://github.com/IntersectMBO/cardano-cli/issues/662

# How to trust this PR

* Run the new test before the main commit: `cabal test cardano-cli-test --test-options '-p "/conway transaction build one voter many votes/"'`
* Witness the test fails because the CLI returns `ExitSuccess`
* Run the same test after the main commit, witness the test passes: the CLI now fails.

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [X] Self-reviewed the diff