### PR TITLE
Fix inversion in --include-stake parser + print "stake" field even when there is no stake (do not hide stake absence)

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
@@ -3212,9 +3212,9 @@ pDRepVerificationKeyOrHashOrFileOrScriptHash =
           "Cold Native or Plutus script file hash (hex-encoded). Obtain it with \"cardano-cli conway governance hash script ...\"."
     ]
 
-pAllOrOnlyDRepHashSoure
+pAllOrOnlyDRepHashSource
   :: Parser (AllOrOnly DRepHashSource)
-pAllOrOnlyDRepHashSoure = pAll <|> pOnly
+pAllOrOnlyDRepHashSource = pAll <|> pOnly
   where pOnly = Only <$> some pDRepHashSource
         pAll = Opt.flag' All $ mconcat
           [ Opt.long "all-dreps"

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Query.hs
@@ -365,13 +365,13 @@ pQueryDRepStateCmd era envCli = do
         <*> pConsensusModeParams
         <*> pNetworkId envCli
         <*> pAllOrOnlyDRepHashSoure
-        <*> Opt.flag WithStake NoStake (mconcat
+        <*> Opt.flag NoStake WithStake (mconcat
               [ Opt.long "include-stake"
               , Opt.help $ mconcat
                  [ "Also return the stake associated with each DRep. "
                  , "The result is the same as with \"drep-stake-distribution\"; "
                  , "this is a convenience option to obtain all information concerning a DRep at once. "
-                 , "This is a potentially expensive query."
+                 , "This is a potentially expensive query, so it's OFF by default."
                  ]
               ]
             )

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Query.hs
@@ -364,7 +364,7 @@ pQueryDRepStateCmd era envCli = do
         <$> pSocketPath envCli
         <*> pConsensusModeParams
         <*> pNetworkId envCli
-        <*> pAllOrOnlyDRepHashSoure
+        <*> pAllOrOnlyDRepHashSource
         <*> Opt.flag NoStake WithStake (mconcat
               [ Opt.long "include-stake"
               , Opt.help $ mconcat
@@ -394,7 +394,7 @@ pQueryDRepStakeDistributionCmd era envCli = do
       <$> pSocketPath envCli
       <*> pConsensusModeParams
       <*> pNetworkId envCli
-      <*> pAllOrOnlyDRepHashSoure
+      <*> pAllOrOnlyDRepHashSource
       <*> pTarget era
       <*> optional pOutputFile
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_drep-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_drep-state.cli
@@ -45,7 +45,7 @@ Available options:
                            result is the same as with "drep-stake-distribution";
                            this is a convenience option to obtain all
                            information concerning a DRep at once. This is a
-                           potentially expensive query.
+                           potentially expensive query, so it's OFF by default.
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Fixed `--include-stake` behavior in `query drep-state`
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Fixes https://github.com/IntersectMBO/cardano-cli/issues/623

# How to trust this PR

I've tested the behavior of this PR on this branch of `cardano-node`: see the HEAD of https://github.com/IntersectMBO/cardano-node/commits/smelc/test-of-cli-pull-698/

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- NA New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [X] Self-reviewed the diff