### PR TITLE
Enable both --cold-script-file and --cold-script-hash for committee auth and resig commands

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/Committee.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/Committee.hs
@@ -52,7 +52,7 @@ data GovernanceCommitteeKeyHashCmdArgs era =
 data GovernanceCommitteeCreateHotKeyAuthorizationCertificateCmdArgs era =
   GovernanceCommitteeCreateHotKeyAuthorizationCertificateCmdArgs
     { eon               :: !(ConwayEraOnwards era)
-    , vkeyColdKeySource :: !(VerificationKeyOrHashOrFileOrScript CommitteeColdKey)
+    , vkeyColdKeySource :: !(VerificationKeySource CommitteeColdKey)
     , vkeyHotKeySource  :: !(VerificationKeyOrHashOrFileOrScript CommitteeHotKey)
     , outFile           :: !(File () Out)
     } deriving Show
@@ -60,7 +60,7 @@ data GovernanceCommitteeCreateHotKeyAuthorizationCertificateCmdArgs era =
 data GovernanceCommitteeCreateColdKeyResignationCertificateCmdArgs era =
   GovernanceCommitteeCreateColdKeyResignationCertificateCmdArgs
     { eon               :: !(ConwayEraOnwards era)
-    , vkeyColdKeySource :: !(VerificationKeyOrHashOrFileOrScriptHash CommitteeColdKey)
+    , vkeyColdKeySource :: !(VerificationKeySource CommitteeColdKey)
     , anchor            :: !(Maybe (L.Anchor (L.EraCrypto (ShelleyLedgerEra era))))
     , outFile           :: !(File () Out)
     } deriving Show

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Committee.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Committee.hs
@@ -105,7 +105,7 @@ pGovernanceCommitteeCreateHotKeyAuthorizationCertificateCmd era = do
     $ Opt.info
         ( fmap GovernanceCommitteeCreateHotKeyAuthorizationCertificateCmd $
             GovernanceCommitteeCreateHotKeyAuthorizationCertificateCmdArgs w
-              <$> pColdVerificationKeyOrHashOrFileOrScript
+              <$> pColdCredential
               <*> pHotVerificationKeyOrHashOrFileOrScript
               <*> pOutputFile
         )
@@ -114,10 +114,6 @@ pGovernanceCommitteeCreateHotKeyAuthorizationCertificateCmd era = do
         [ "Create hot key authorization certificate for a Constitutional Committee Member"
         ]
   where
-    pColdVerificationKeyOrHashOrFileOrScript = asum
-      [ VkhfsKeyHashFile <$> pCommitteeColdVerificationKeyOrHashOrFile
-      , VkhfsScript <$> pScriptFor "cold-script-file" Nothing "Cold Native or Plutus script file"
-      ]
     pHotVerificationKeyOrHashOrFileOrScript = asum
       [ VkhfsKeyHashFile <$> pCommitteeHotKeyOrHashOrFile
       , VkhfsScript <$> pScriptFor "hot-script-file" Nothing "Hot Native or Plutus script file"
@@ -139,16 +135,19 @@ pGovernanceCommitteeCreateColdKeyResignationCertificateCmd era = do
   mkParser w =
     GovernanceCommitteeCreateColdKeyResignationCertificateCmd <$>
       (GovernanceCommitteeCreateColdKeyResignationCertificateCmdArgs w <$>
-        coldVKeyOrFileOrScriptHash <*> pAnchor <*> pOutputFile)
-  coldVKeyOrFileOrScriptHash =
-    asum
-      [ VkhfshKeyHashFile . VerificationKeyOrFile <$> pCommitteeColdVerificationKeyOrFile
-      , VkhfshKeyHashFile . VerificationKeyHash <$> pCommitteeColdVerificationKeyHash
-      , VkhfshScriptHash <$>
-          pScriptHash
-            "cold-script-hash"
-            "Cold Native or Plutus script file hash (hex-encoded). Obtain it with \"cardano-cli conway governance hash script ...\"."
-      ]
+        pColdCredential <*> pAnchor <*> pOutputFile)
+
+pColdCredential :: Parser (VerificationKeySource CommitteeColdKey)
+pColdCredential =
+  asum
+    [ VksKeyHashFile . VerificationKeyOrFile <$> pCommitteeColdVerificationKeyOrFile
+    , VksKeyHashFile . VerificationKeyHash <$> pCommitteeColdVerificationKeyHash
+    , VksScriptHash <$>
+        pScriptHash
+          "cold-script-hash"
+          "Committee cold Native or Plutus script file hash (hex-encoded). Obtain it with \"cardano-cli conway governance hash script ...\"."
+    , VksScript <$> pScriptFor "cold-script-file" Nothing "Cold Native or Plutus script file"
+    ]
 
 pAnchor :: Parser (Maybe (L.Anchor L.StandardCrypto))
 pAnchor =

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Committee.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Committee.hs
@@ -14,9 +14,9 @@ import           Cardano.Api.Shelley
 import           Cardano.CLI.EraBased.Commands.Governance.Committee
 import qualified Cardano.CLI.EraBased.Commands.Governance.Committee as Cmd
 import qualified Cardano.CLI.EraBased.Run.Key as Key
-import           Cardano.CLI.Read (readVerificationKeyOrHashOrFileOrScript)
+import           Cardano.CLI.Read (readVerificationKeyOrHashOrFileOrScript,
+                   readVerificationKeySource)
 import           Cardano.CLI.Types.Errors.GovernanceCommitteeError
-import           Cardano.CLI.Types.Key
 import           Cardano.CLI.Types.Key.VerificationKey
 
 import           Data.ByteString (ByteString)
@@ -136,7 +136,7 @@ runGovernanceCommitteeCreateHotKeyAuthorizationCertificate
         readVerificationKeyOrHashOrFileOrScript AsCommitteeHotKey unCommitteeHotKeyHash vkeyHotKeySource
     coldCred <-
       mapError' $
-        readVerificationKeyOrHashOrFileOrScript AsCommitteeColdKey unCommitteeColdKeyHash vkeyColdKeySource
+        readVerificationKeySource AsCommitteeColdKey unCommitteeColdKeyHash vkeyColdKeySource
 
     makeCommitteeHotKeyAuthorizationCertificate (CommitteeHotKeyAuthorizationRequirements eon coldCred hotCred)
       & textEnvelopeToJSON (Just genKeyDelegCertDesc)
@@ -158,8 +158,9 @@ runGovernanceCommitteeColdKeyResignationCertificate
       , Cmd.outFile
       } =
   conwayEraOnwardsConstraints eon $ do
-    coldVKeyCred <- modifyError GovernanceCommitteeCmdKeyReadError $
-      readVerificationKeyOrHashOrFileOrScriptHash AsCommitteeColdKey unCommitteeColdKeyHash vkeyColdKeySource
+    let modifyError' = modifyError $ either GovernanceCommitteeCmdScriptReadError  GovernanceCommitteeCmdKeyReadError
+    coldVKeyCred <- modifyError' $
+      readVerificationKeySource AsCommitteeColdKey unCommitteeColdKeyHash vkeyColdKeySource
 
     makeCommitteeColdkeyResignationCertificate (CommitteeColdkeyResignationRequirements eon coldVKeyCred anchor)
       & textEnvelopeToJSON (Just genKeyDelegCertDesc)

--- a/cardano-cli/src/Cardano/CLI/Types/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Key.hs
@@ -25,6 +25,7 @@ module Cardano.CLI.Types.Key
 
   , VerificationKeyOrHashOrFileOrScript(..)
   , VerificationKeyOrHashOrFileOrScriptHash(..)
+  , VerificationKeySource(..)
   , readVerificationKeyOrHashOrFileOrScriptHash
 
   , PaymentVerifier(..)
@@ -344,15 +345,29 @@ data VerificationKeyOrHashOrFileOrScript keyrole
   = VkhfsKeyHashFile !(VerificationKeyOrHashOrFile keyrole)
   | VkhfsScript !(File ScriptInAnyLang In)
 
-deriving instance (Eq (VerificationKeyOrHashOrFile c)) => Eq (VerificationKeyOrHashOrFileOrScript c)
-deriving instance (Show (VerificationKeyOrHashOrFile c)) => Show (VerificationKeyOrHashOrFileOrScript c)
+deriving instance (Eq (VerificationKeyOrHashOrFile keyrole))
+  => Eq (VerificationKeyOrHashOrFileOrScript keyrole)
+deriving instance (Show (VerificationKeyOrHashOrFile keyrole))
+  => Show (VerificationKeyOrHashOrFileOrScript keyrole)
 
 data VerificationKeyOrHashOrFileOrScriptHash keyrole
   = VkhfshKeyHashFile !(VerificationKeyOrHashOrFile keyrole)
   | VkhfshScriptHash !ScriptHash
 
-deriving instance (Eq (VerificationKeyOrHashOrFile c)) => Eq (VerificationKeyOrHashOrFileOrScriptHash c)
-deriving instance (Show (VerificationKeyOrHashOrFile c)) => Show (VerificationKeyOrHashOrFileOrScriptHash c)
+deriving instance (Eq (VerificationKeyOrHashOrFile keyrole))
+  => Eq (VerificationKeyOrHashOrFileOrScriptHash keyrole)
+deriving instance (Show (VerificationKeyOrHashOrFile keyrole))
+  => Show (VerificationKeyOrHashOrFileOrScriptHash keyrole)
+
+data VerificationKeySource keyrole
+  = VksKeyHashFile !(VerificationKeyOrHashOrFile keyrole)
+  | VksScript !(File ScriptInAnyLang In)
+  | VksScriptHash !ScriptHash
+
+deriving instance (Eq (VerificationKeyOrHashOrFile keyrole))
+  => Eq (VerificationKeySource keyrole)
+deriving instance (Show (VerificationKeyOrHashOrFile keyrole))
+  => Show (VerificationKeySource keyrole)
 
 readVerificationKeyOrHashOrFileOrScriptHash
   :: MonadIOTransError (FileError InputDecodeError) t m

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -6488,6 +6488,7 @@ Usage: cardano-cli conway governance committee create-hot-key-authorization-cert
                                                                                           ( --cold-verification-key STRING
                                                                                           | --cold-verification-key-file FILE
                                                                                           | --cold-verification-key-hash STRING
+                                                                                          | --cold-script-hash HASH
                                                                                           | --cold-script-file FILE
                                                                                           )
                                                                                           ( --hot-key STRING
@@ -6504,6 +6505,7 @@ Usage: cardano-cli conway governance committee create-cold-key-resignation-certi
                                                                                          | --cold-verification-key-file FILE
                                                                                          | --cold-verification-key-hash STRING
                                                                                          | --cold-script-hash HASH
+                                                                                         | --cold-script-file FILE
                                                                                          )
                                                                                          [--resignation-metadata-url TEXT
                                                                                            --resignation-metadata-hash HASH]

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_committee_create-cold-key-resignation-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_committee_create-cold-key-resignation-certificate.cli
@@ -3,6 +3,7 @@ Usage: cardano-cli conway governance committee create-cold-key-resignation-certi
                                                                                          | --cold-verification-key-file FILE
                                                                                          | --cold-verification-key-hash STRING
                                                                                          | --cold-script-hash HASH
+                                                                                         | --cold-script-file FILE
                                                                                          )
                                                                                          [--resignation-metadata-url TEXT
                                                                                            --resignation-metadata-hash HASH]
@@ -17,9 +18,10 @@ Available options:
                            Filepath of the Consitutional Committee cold key.
   --cold-verification-key-hash STRING
                            Constitutional Committee key hash (hex-encoded).
-  --cold-script-hash HASH  Cold Native or Plutus script file hash (hex-encoded).
-                           Obtain it with "cardano-cli conway governance hash
-                           script ...".
+  --cold-script-hash HASH  Committee cold Native or Plutus script file hash
+                           (hex-encoded). Obtain it with "cardano-cli conway
+                           governance hash script ...".
+  --cold-script-file FILE  Cold Native or Plutus script file
   --resignation-metadata-url TEXT
                            Constitutional Committee cold key resignation
                            certificate URL

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_committee_create-hot-key-authorization-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_committee_create-hot-key-authorization-certificate.cli
@@ -2,6 +2,7 @@ Usage: cardano-cli conway governance committee create-hot-key-authorization-cert
                                                                                           ( --cold-verification-key STRING
                                                                                           | --cold-verification-key-file FILE
                                                                                           | --cold-verification-key-hash STRING
+                                                                                          | --cold-script-hash HASH
                                                                                           | --cold-script-file FILE
                                                                                           )
                                                                                           ( --hot-key STRING
@@ -20,6 +21,9 @@ Available options:
                            Filepath of the Consitutional Committee cold key.
   --cold-verification-key-hash STRING
                            Constitutional Committee key hash (hex-encoded).
+  --cold-script-hash HASH  Committee cold Native or Plutus script file hash
+                           (hex-encoded). Obtain it with "cardano-cli conway
+                           governance hash script ...".
   --cold-script-file FILE  Cold Native or Plutus script file
   --hot-key STRING         Constitutional Committee hot key (hex-encoded).
   --hot-key-file FILE      Filepath of the Consitutional Committee hot key.


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Enable both `--cold-script-file` and `--cold-script-hash` for `governance committee create-hot-key-authorization-certificate` and `committee create-cold-key-resignation-certificate`
# uncomment types applicable to the change:
  type:
   - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
   - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

na

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
