### PR TITLE
foldSomeAddressVerificationKey->mapSomeAddressVerificationKey

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Address.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Address.hs
@@ -139,7 +139,7 @@ runAddressKeyHashCmd vkeyTextOrFile mOutputFp = do
   vkey <- firstExceptT AddressCmdVerificationKeyTextOrFileError $
              newExceptT $ readVerificationKeyTextOrFileAnyOf vkeyTextOrFile
 
-  let hexKeyHash = foldSomeAddressVerificationKey
+  let hexKeyHash = mapSomeAddressVerificationKey
                      (serialiseToRawBytesHex . verificationKeyHash) vkey
 
   case mOutputFp of
@@ -218,27 +218,3 @@ buildShelleyAddress
   -> ExceptT AddressCmdError IO (Address ShelleyAddr)
 buildShelleyAddress vkey mbStakeVerifier nw =
   makeShelleyAddress nw (PaymentCredentialByKey (verificationKeyHash vkey)) <$> maybe (return NoStakeAddress) makeStakeAddressRef mbStakeVerifier
-
-
---
--- Handling the variety of address key types
---
-
-
-foldSomeAddressVerificationKey :: ()
-  => (forall keyrole. Key keyrole => VerificationKey keyrole -> a)
-  -> SomeAddressVerificationKey
-  -> a
-foldSomeAddressVerificationKey f = \case
-  AByronVerificationKey                   vk -> f vk
-  APaymentVerificationKey                 vk -> f vk
-  APaymentExtendedVerificationKey         vk -> f vk
-  AGenesisUTxOVerificationKey             vk -> f vk
-  AKesVerificationKey                     vk -> f vk
-  AGenesisDelegateExtendedVerificationKey vk -> f vk
-  AGenesisExtendedVerificationKey         vk -> f vk
-  AVrfVerificationKey                     vk -> f vk
-  AStakeVerificationKey                   vk -> f vk
-  AStakeExtendedVerificationKey           vk -> f vk
-  ADRepVerificationKey                    vk -> f vk
-  ADRepExtendedVerificationKey            vk -> f vk


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Use mapSomeAddressVerificationKey (provided by API) instead of foldSomeAddressVerificationKey
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# How to trust this PR

The [mapSomeAddressVerificationKey function from API](https://github.com/IntersectMBO/cardano-api/blob/03de67a58e044c41c62ab8683bffac52771bcd37/cardano-api/internal/Cardano/Api/DeserialiseAnyOf.hs#L277) has exactly the same behavior as `foldSomeAddressVerificationKey` that is being deleted.

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] Self-reviewed the diff