### PR TITLE
Provide a default value for `calculate-min-fee --reference-script-size`

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Transaction.hs
@@ -164,7 +164,7 @@ data TransactionCalculateMinFeeCmdArgs = TransactionCalculateMinFeeCmdArgs
   , txShelleyWitnessCount :: !TxShelleyWitnessCount
   , txByronWitnessCount   :: !TxByronWitnessCount
     -- | The total size in bytes of the transaction reference scripts.
-  , referenceScriptSize   :: !Int
+  , referenceScriptSize   :: !ReferenceScriptSize
   } deriving Show
 
 data TransactionCalculateMinValueCmdArgs era = TransactionCalculateMinValueCmdArgs

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
@@ -3308,12 +3308,13 @@ pNetworkIdForTestnetData envCli = asum $ mconcat
     pure <$> maybeToList (envCliNetworkId envCli)
   ]
 
-pReferenceScriptSize :: Parser Int
+pReferenceScriptSize :: Parser ReferenceScriptSize
 pReferenceScriptSize =
-  Opt.option auto $ mconcat
+  fmap ReferenceScriptSize $ Opt.option Opt.auto $ mconcat
     [ Opt.long "reference-script-size"
-    , Opt.metavar "INT"
-    , Opt.help "Total size in bytes of transaction reference scripts"
+    , Opt.metavar "NATURAL"
+    , Opt.help "Total size in bytes of transaction reference scripts (default is 0)."
+    , Opt.value 0
     ]
 
 --------------------------------------------------------------------------------

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Transaction.hs
@@ -1018,7 +1018,7 @@ runTransactionCalculateMinFeeCmd
       , protocolParamsFile = protocolParamsFile
       , txShelleyWitnessCount = TxShelleyWitnessCount nShelleyKeyWitnesses
       , txByronWitnessCount = TxByronWitnessCount nByronKeyWitnesses
-      , referenceScriptSize
+      , referenceScriptSize = ReferenceScriptSize sReferenceScript
       } = do
 
   txbodyFile <- liftIO $ fileOrPipe txbodyFilePath
@@ -1040,7 +1040,7 @@ runTransactionCalculateMinFeeCmd
 
   lpparams <- getLedgerPParams sbe pparams
 
-  let shelleyfee = evaluateTransactionFee sbe lpparams txbody nShelleyKeyWitW32 0 referenceScriptSize
+  let shelleyfee = evaluateTransactionFee sbe lpparams txbody nShelleyKeyWitW32 0 sReferenceScript
 
   let byronfee = calculateByronWitnessFees (protocolParamTxFeePerByte pparams) nByronKeyWitnesses
 

--- a/cardano-cli/src/Cardano/CLI/Legacy/Commands/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Commands/Transaction.hs
@@ -120,7 +120,7 @@ data LegacyTransactionCmds
       ProtocolParamsFile
       TxShelleyWitnessCount
       TxByronWitnessCount
-      Int
+      ReferenceScriptSize
       -- ^ The total size in bytes of the transaction reference scripts.
   | TransactionCalculateMinValueCmd
       (EraInEon ShelleyBasedEra)

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Transaction.hs
@@ -225,7 +225,7 @@ runLegacyTransactionCalculateMinFeeCmd :: ()
   -> ProtocolParamsFile
   -> TxShelleyWitnessCount
   -> TxByronWitnessCount
-  -> Int
+  -> ReferenceScriptSize
   -> ExceptT TxCmdError IO ()
 runLegacyTransactionCalculateMinFeeCmd
     txbodyFile

--- a/cardano-cli/src/Cardano/CLI/Types/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Common.hs
@@ -49,6 +49,7 @@ module Cardano.CLI.Types.Common
   , ProtocolParamsFile(..)
   , QueryOutputFormat(..)
   , ReferenceScriptAnyEra (..)
+  , ReferenceScriptSize (..)
   , RequiredSigner (..)
   , ScriptDataOrFile (..)
   , ScriptDatumOrFile (..)
@@ -504,6 +505,10 @@ newtype TxShelleyWitnessCount
 
 newtype TxByronWitnessCount
   = TxByronWitnessCount Int
+  deriving Show
+
+newtype ReferenceScriptSize
+  = ReferenceScriptSize Int
   deriving Show
 
 newtype BlockId

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -1139,7 +1139,7 @@ Usage: cardano-cli shelley transaction calculate-min-fee --tx-body-file FILE
                                                            --protocol-params-file FILE
                                                            --witness-count NATURAL
                                                            [--byron-witness-count NATURAL]
-                                                           --reference-script-size INT
+                                                           [--reference-script-size NATURAL]
                                                            [ --mainnet
                                                            | --testnet-magic NATURAL
                                                            ]
@@ -2331,7 +2331,7 @@ Usage: cardano-cli allegra transaction calculate-min-fee --tx-body-file FILE
                                                            --protocol-params-file FILE
                                                            --witness-count NATURAL
                                                            [--byron-witness-count NATURAL]
-                                                           --reference-script-size INT
+                                                           [--reference-script-size NATURAL]
                                                            [ --mainnet
                                                            | --testnet-magic NATURAL
                                                            ]
@@ -3507,7 +3507,7 @@ Usage: cardano-cli mary transaction calculate-min-fee --tx-body-file FILE
                                                         --protocol-params-file FILE
                                                         --witness-count NATURAL
                                                         [--byron-witness-count NATURAL]
-                                                        --reference-script-size INT
+                                                        [--reference-script-size NATURAL]
                                                         [ --mainnet
                                                         | --testnet-magic NATURAL
                                                         ]
@@ -4700,7 +4700,7 @@ Usage: cardano-cli alonzo transaction calculate-min-fee --tx-body-file FILE
                                                           --protocol-params-file FILE
                                                           --witness-count NATURAL
                                                           [--byron-witness-count NATURAL]
-                                                          --reference-script-size INT
+                                                          [--reference-script-size NATURAL]
                                                           [ --mainnet
                                                           | --testnet-magic NATURAL
                                                           ]
@@ -5918,7 +5918,7 @@ Usage: cardano-cli babbage transaction calculate-min-fee --tx-body-file FILE
                                                            --protocol-params-file FILE
                                                            --witness-count NATURAL
                                                            [--byron-witness-count NATURAL]
-                                                           --reference-script-size INT
+                                                           [--reference-script-size NATURAL]
                                                            [ --mainnet
                                                            | --testnet-magic NATURAL
                                                            ]
@@ -7587,7 +7587,7 @@ Usage: cardano-cli conway transaction calculate-min-fee --tx-body-file FILE
                                                           --protocol-params-file FILE
                                                           --witness-count NATURAL
                                                           [--byron-witness-count NATURAL]
-                                                          --reference-script-size INT
+                                                          [--reference-script-size NATURAL]
                                                           [ --mainnet
                                                           | --testnet-magic NATURAL
                                                           ]
@@ -8802,7 +8802,7 @@ Usage: cardano-cli latest transaction calculate-min-fee --tx-body-file FILE
                                                           --protocol-params-file FILE
                                                           --witness-count NATURAL
                                                           [--byron-witness-count NATURAL]
-                                                          --reference-script-size INT
+                                                          [--reference-script-size NATURAL]
                                                           [ --mainnet
                                                           | --testnet-magic NATURAL
                                                           ]
@@ -9839,7 +9839,7 @@ Usage: cardano-cli legacy transaction calculate-min-fee --tx-body-file FILE
                                                           --protocol-params-file FILE
                                                           --witness-count NATURAL
                                                           [--byron-witness-count NATURAL]
-                                                          --reference-script-size INT
+                                                          [--reference-script-size NATURAL]
                                                           [ --mainnet
                                                           | --testnet-magic NATURAL
                                                           ]
@@ -11059,7 +11059,7 @@ Usage: cardano-cli transaction calculate-min-fee --tx-body-file FILE
                                                    --protocol-params-file FILE
                                                    --witness-count NATURAL
                                                    [--byron-witness-count NATURAL]
-                                                   --reference-script-size INT
+                                                   [--reference-script-size NATURAL]
                                                    [ --mainnet
                                                    | --testnet-magic NATURAL
                                                    ]

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_transaction_calculate-min-fee.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_transaction_calculate-min-fee.cli
@@ -2,7 +2,7 @@ Usage: cardano-cli allegra transaction calculate-min-fee --tx-body-file FILE
                                                            --protocol-params-file FILE
                                                            --witness-count NATURAL
                                                            [--byron-witness-count NATURAL]
-                                                           --reference-script-size INT
+                                                           [--reference-script-size NATURAL]
                                                            [ --mainnet
                                                            | --testnet-magic NATURAL
                                                            ]
@@ -18,8 +18,9 @@ Available options:
   --witness-count NATURAL  The number of Shelley key witnesses.
   --byron-witness-count NATURAL
                            The number of Byron key witnesses (default is 0).
-  --reference-script-size INT
+  --reference-script-size NATURAL
                            Total size in bytes of transaction reference scripts
+                           (default is 0).
   --mainnet                DEPRECATED. This argument has no effect.
   --testnet-magic NATURAL  DEPRECATED. This argument has no effect.
   --tx-in-count NATURAL    DEPRECATED. This argument has no effect.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_transaction_calculate-min-fee.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_transaction_calculate-min-fee.cli
@@ -2,7 +2,7 @@ Usage: cardano-cli alonzo transaction calculate-min-fee --tx-body-file FILE
                                                           --protocol-params-file FILE
                                                           --witness-count NATURAL
                                                           [--byron-witness-count NATURAL]
-                                                          --reference-script-size INT
+                                                          [--reference-script-size NATURAL]
                                                           [ --mainnet
                                                           | --testnet-magic NATURAL
                                                           ]
@@ -18,8 +18,9 @@ Available options:
   --witness-count NATURAL  The number of Shelley key witnesses.
   --byron-witness-count NATURAL
                            The number of Byron key witnesses (default is 0).
-  --reference-script-size INT
+  --reference-script-size NATURAL
                            Total size in bytes of transaction reference scripts
+                           (default is 0).
   --mainnet                DEPRECATED. This argument has no effect.
   --testnet-magic NATURAL  DEPRECATED. This argument has no effect.
   --tx-in-count NATURAL    DEPRECATED. This argument has no effect.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_transaction_calculate-min-fee.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_transaction_calculate-min-fee.cli
@@ -2,7 +2,7 @@ Usage: cardano-cli babbage transaction calculate-min-fee --tx-body-file FILE
                                                            --protocol-params-file FILE
                                                            --witness-count NATURAL
                                                            [--byron-witness-count NATURAL]
-                                                           --reference-script-size INT
+                                                           [--reference-script-size NATURAL]
                                                            [ --mainnet
                                                            | --testnet-magic NATURAL
                                                            ]
@@ -18,8 +18,9 @@ Available options:
   --witness-count NATURAL  The number of Shelley key witnesses.
   --byron-witness-count NATURAL
                            The number of Byron key witnesses (default is 0).
-  --reference-script-size INT
+  --reference-script-size NATURAL
                            Total size in bytes of transaction reference scripts
+                           (default is 0).
   --mainnet                DEPRECATED. This argument has no effect.
   --testnet-magic NATURAL  DEPRECATED. This argument has no effect.
   --tx-in-count NATURAL    DEPRECATED. This argument has no effect.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_calculate-min-fee.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_calculate-min-fee.cli
@@ -2,7 +2,7 @@ Usage: cardano-cli conway transaction calculate-min-fee --tx-body-file FILE
                                                           --protocol-params-file FILE
                                                           --witness-count NATURAL
                                                           [--byron-witness-count NATURAL]
-                                                          --reference-script-size INT
+                                                          [--reference-script-size NATURAL]
                                                           [ --mainnet
                                                           | --testnet-magic NATURAL
                                                           ]
@@ -18,8 +18,9 @@ Available options:
   --witness-count NATURAL  The number of Shelley key witnesses.
   --byron-witness-count NATURAL
                            The number of Byron key witnesses (default is 0).
-  --reference-script-size INT
+  --reference-script-size NATURAL
                            Total size in bytes of transaction reference scripts
+                           (default is 0).
   --mainnet                DEPRECATED. This argument has no effect.
   --testnet-magic NATURAL  DEPRECATED. This argument has no effect.
   --tx-in-count NATURAL    DEPRECATED. This argument has no effect.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_transaction_calculate-min-fee.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_transaction_calculate-min-fee.cli
@@ -2,7 +2,7 @@ Usage: cardano-cli latest transaction calculate-min-fee --tx-body-file FILE
                                                           --protocol-params-file FILE
                                                           --witness-count NATURAL
                                                           [--byron-witness-count NATURAL]
-                                                          --reference-script-size INT
+                                                          [--reference-script-size NATURAL]
                                                           [ --mainnet
                                                           | --testnet-magic NATURAL
                                                           ]
@@ -18,8 +18,9 @@ Available options:
   --witness-count NATURAL  The number of Shelley key witnesses.
   --byron-witness-count NATURAL
                            The number of Byron key witnesses (default is 0).
-  --reference-script-size INT
+  --reference-script-size NATURAL
                            Total size in bytes of transaction reference scripts
+                           (default is 0).
   --mainnet                DEPRECATED. This argument has no effect.
   --testnet-magic NATURAL  DEPRECATED. This argument has no effect.
   --tx-in-count NATURAL    DEPRECATED. This argument has no effect.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_transaction_calculate-min-fee.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_transaction_calculate-min-fee.cli
@@ -2,7 +2,7 @@ Usage: cardano-cli legacy transaction calculate-min-fee --tx-body-file FILE
                                                           --protocol-params-file FILE
                                                           --witness-count NATURAL
                                                           [--byron-witness-count NATURAL]
-                                                          --reference-script-size INT
+                                                          [--reference-script-size NATURAL]
                                                           [ --mainnet
                                                           | --testnet-magic NATURAL
                                                           ]
@@ -18,8 +18,9 @@ Available options:
   --witness-count NATURAL  The number of Shelley key witnesses.
   --byron-witness-count NATURAL
                            The number of Byron key witnesses (default is 0).
-  --reference-script-size INT
+  --reference-script-size NATURAL
                            Total size in bytes of transaction reference scripts
+                           (default is 0).
   --mainnet                DEPRECATED. This argument has no effect.
   --testnet-magic NATURAL  DEPRECATED. This argument has no effect.
   --tx-in-count NATURAL    DEPRECATED. This argument has no effect.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_transaction_calculate-min-fee.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_transaction_calculate-min-fee.cli
@@ -2,7 +2,7 @@ Usage: cardano-cli mary transaction calculate-min-fee --tx-body-file FILE
                                                         --protocol-params-file FILE
                                                         --witness-count NATURAL
                                                         [--byron-witness-count NATURAL]
-                                                        --reference-script-size INT
+                                                        [--reference-script-size NATURAL]
                                                         [ --mainnet
                                                         | --testnet-magic NATURAL
                                                         ]
@@ -18,8 +18,9 @@ Available options:
   --witness-count NATURAL  The number of Shelley key witnesses.
   --byron-witness-count NATURAL
                            The number of Byron key witnesses (default is 0).
-  --reference-script-size INT
+  --reference-script-size NATURAL
                            Total size in bytes of transaction reference scripts
+                           (default is 0).
   --mainnet                DEPRECATED. This argument has no effect.
   --testnet-magic NATURAL  DEPRECATED. This argument has no effect.
   --tx-in-count NATURAL    DEPRECATED. This argument has no effect.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_transaction_calculate-min-fee.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_transaction_calculate-min-fee.cli
@@ -2,7 +2,7 @@ Usage: cardano-cli shelley transaction calculate-min-fee --tx-body-file FILE
                                                            --protocol-params-file FILE
                                                            --witness-count NATURAL
                                                            [--byron-witness-count NATURAL]
-                                                           --reference-script-size INT
+                                                           [--reference-script-size NATURAL]
                                                            [ --mainnet
                                                            | --testnet-magic NATURAL
                                                            ]
@@ -18,8 +18,9 @@ Available options:
   --witness-count NATURAL  The number of Shelley key witnesses.
   --byron-witness-count NATURAL
                            The number of Byron key witnesses (default is 0).
-  --reference-script-size INT
+  --reference-script-size NATURAL
                            Total size in bytes of transaction reference scripts
+                           (default is 0).
   --mainnet                DEPRECATED. This argument has no effect.
   --testnet-magic NATURAL  DEPRECATED. This argument has no effect.
   --tx-in-count NATURAL    DEPRECATED. This argument has no effect.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/transaction_calculate-min-fee.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/transaction_calculate-min-fee.cli
@@ -2,7 +2,7 @@ Usage: cardano-cli transaction calculate-min-fee --tx-body-file FILE
                                                    --protocol-params-file FILE
                                                    --witness-count NATURAL
                                                    [--byron-witness-count NATURAL]
-                                                   --reference-script-size INT
+                                                   [--reference-script-size NATURAL]
                                                    [ --mainnet
                                                    | --testnet-magic NATURAL
                                                    ]
@@ -18,8 +18,9 @@ Available options:
   --witness-count NATURAL  The number of Shelley key witnesses.
   --byron-witness-count NATURAL
                            The number of Byron key witnesses (default is 0).
-  --reference-script-size INT
+  --reference-script-size NATURAL
                            Total size in bytes of transaction reference scripts
+                           (default is 0).
   --mainnet                DEPRECATED. This argument has no effect.
   --testnet-magic NATURAL  DEPRECATED. This argument has no effect.
   --tx-in-count NATURAL    DEPRECATED. This argument has no effect.


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Defaulted `calculate-min-fee --reference-script-size`'s value to `0`
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Fixes https://github.com/IntersectMBO/cardano-cli/issues/715

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
