### PR TITLE
conway governance committe key-hash: support extended CC keys

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Committee.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Committee.hs
@@ -81,7 +81,9 @@ runGovernanceCommitteeKeyGenHot
 
 data SomeCommitteeKey
   = ACommitteeHotKey  (VerificationKey CommitteeHotKey)
+  | ACommitteeHotExtendedKey  (VerificationKey CommitteeHotExtendedKey)
   | ACommitteeColdKey (VerificationKey CommitteeColdKey)
+  | ACommitteeColdExtendedKey (VerificationKey CommitteeColdExtendedKey)
 
 runGovernanceCommitteeKeyHash :: ()
   => Cmd.GovernanceCommitteeKeyHashCmdArgs era
@@ -94,15 +96,19 @@ runGovernanceCommitteeKeyHash
     case vkeySource of
       AnyVerificationKeySourceOfText vkText -> do
         let asTypes =
-              [ FromSomeType (AsVerificationKey AsCommitteeHotKey ) ACommitteeHotKey
-              , FromSomeType (AsVerificationKey AsCommitteeColdKey) ACommitteeColdKey
+              [ FromSomeType (AsVerificationKey AsCommitteeHotKey)          ACommitteeHotKey
+              , FromSomeType (AsVerificationKey AsCommitteeHotExtendedKey)  ACommitteeHotExtendedKey
+              , FromSomeType (AsVerificationKey AsCommitteeColdKey)         ACommitteeColdKey
+              , FromSomeType (AsVerificationKey AsCommitteeColdExtendedKey) ACommitteeColdExtendedKey
               ]
         pure (deserialiseAnyOfFromBech32 asTypes (unAnyVerificationKeyText vkText))
           & onLeft (left . GovernanceCommitteeCmdKeyDecodeError . InputBech32DecodeError)
       AnyVerificationKeySourceOfFile vkeyPath -> do
         let asTypes =
-              [ FromSomeType (AsVerificationKey AsCommitteeHotKey ) ACommitteeHotKey
-              , FromSomeType (AsVerificationKey AsCommitteeColdKey) ACommitteeColdKey
+              [ FromSomeType (AsVerificationKey AsCommitteeHotKey)          ACommitteeHotKey
+              , FromSomeType (AsVerificationKey AsCommitteeHotExtendedKey)  ACommitteeHotExtendedKey
+              , FromSomeType (AsVerificationKey AsCommitteeColdKey)         ACommitteeColdKey
+              , FromSomeType (AsVerificationKey AsCommitteeColdExtendedKey) ACommitteeColdExtendedKey
               ]
         readFileTextEnvelopeAnyOf asTypes vkeyPath
           & firstExceptT GovernanceCommitteeCmdTextEnvReadFileError . newExceptT
@@ -112,8 +118,10 @@ runGovernanceCommitteeKeyHash
   where
     renderKeyHash :: SomeCommitteeKey -> ByteString
     renderKeyHash = \case
-      ACommitteeHotKey  vk -> renderVerificationKeyHash vk
-      ACommitteeColdKey vk -> renderVerificationKeyHash vk
+      ACommitteeHotKey vk          -> renderVerificationKeyHash vk
+      ACommitteeHotExtendedKey vk  -> renderVerificationKeyHash vk
+      ACommitteeColdKey vk         -> renderVerificationKeyHash vk
+      ACommitteeColdExtendedKey vk -> renderVerificationKeyHash vk
 
     renderVerificationKeyHash :: Key keyrole => VerificationKey keyrole -> ByteString
     renderVerificationKeyHash = serialiseToRawBytesHex

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Governance/Committee.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Governance/Committee.hs
@@ -5,6 +5,7 @@
 module Test.Golden.Governance.Committee where
 
 import           Control.Monad (forM_, void)
+import           System.FilePath ((</>))
 
 import           Test.Cardano.CLI.Aeson (assertHasMappings)
 import           Test.Cardano.CLI.Util
@@ -12,6 +13,10 @@ import           Test.Cardano.CLI.Util
 import           Hedgehog (Property)
 import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.Golden as H
+
+goldenDir, inputDir :: FilePath
+goldenDir = "test/cardano-cli-golden/files/golden"
+inputDir  = "test/cardano-cli-golden/files/input"
 
 -- | Execute me with:
 -- @cabal test cardano-cli-golden --test-options '-p "/golden governance committee key gen/"'@
@@ -104,10 +109,10 @@ hprop_golden_governance_CommitteeCreateColdKeyResignationCertificate =
 hprop_golden_governance_UpdateCommittee :: Property
 hprop_golden_governance_UpdateCommittee =
   propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
-    stakeVkey <- noteInputFile "test/cardano-cli-golden/files/input/governance/stake-address.vkey"
-    ccProposal <- noteInputFile "test/cardano-cli-golden/files/input/governance/committee/cc-proposal.txt"
-    coldCCVkey1 <- noteInputFile "test/cardano-cli-golden/files/input/governance/committee/cc-cold1.vkey"
-    coldCCVkey2 <- noteInputFile "test/cardano-cli-golden/files/input/governance/committee/cc-cold2.vkey"
+    stakeVkey <- noteInputFile $ inputDir </> "governance/stake-address.vkey"
+    ccProposal <- noteInputFile $ inputDir </> "governance/committee/cc-proposal.txt"
+    coldCCVkey1 <- noteInputFile $ inputDir </> "governance/committee/cc-cold1.vkey"
+    coldCCVkey2 <- noteInputFile $ inputDir </> "governance/committee/cc-cold2.vkey"
 
     outFile <- H.noteTempFile tempDir "answer-file.json"
 
@@ -118,7 +123,7 @@ hprop_golden_governance_UpdateCommittee =
     H.note_ proposalHash
     H.note_ $ show $ length proposalHash
 
-    goldenAnswerFile <- H.note "test/cardano-cli-golden/files/golden/governance/committee/update-committee-answer.json"
+    goldenAnswerFile <- H.note $ goldenDir </> "governance/committee/update-committee-answer.json"
 
     void $ execCardanoCLI
       [ "conway", "governance", "action", "update-committee"
@@ -141,10 +146,10 @@ hprop_golden_governance_UpdateCommittee =
 hprop_golden_governance_committee_cold_extended_key_signing :: Property
 hprop_golden_governance_committee_cold_extended_key_signing =
   propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
-    skeyFile <- noteInputFile "test/cardano-cli-golden/files/input/governance/committee/cc.extended.cold.skey"
-    txBody <- noteInputFile "test/cardano-cli-golden/files/input/governance/drep/extended-key-signing/tx.body"
+    skeyFile <- noteInputFile $ inputDir </> "governance/committee/cc.extended.cold.skey"
+    txBody <- noteInputFile $ inputDir </> "governance/drep/extended-key-signing/tx.body"
 
-    outGold <- H.note "test/cardano-cli-golden/files/golden/governance/committee/tx.cold.extended.signed"
+    outGold <- H.note $ goldenDir </> "governance/committee/tx.cold.extended.signed"
     outFile <- H.noteTempFile tempDir "outFile"
 
     H.noteM_ $ execCardanoCLI
@@ -161,10 +166,10 @@ hprop_golden_governance_committee_cold_extended_key_signing =
 hprop_golden_governance_committee_hot_extended_key_signing :: Property
 hprop_golden_governance_committee_hot_extended_key_signing =
   propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
-    skeyFile <- noteInputFile "test/cardano-cli-golden/files/input/governance/committee/cc.extended.hot.skey"
-    txBody <- noteInputFile "test/cardano-cli-golden/files/input/governance/drep/extended-key-signing/tx.body"
+    skeyFile <- noteInputFile $ inputDir </> "governance/committee/cc.extended.hot.skey"
+    txBody <- noteInputFile $ inputDir </> "governance/drep/extended-key-signing/tx.body"
 
-    outGold <- H.note "test/cardano-cli-golden/files/golden/governance/committee/tx.hot.extended.signed"
+    outGold <- H.note $ goldenDir </> "governance/committee/tx.hot.extended.signed"
     outFile <- H.noteTempFile tempDir "outFile"
 
     H.noteM_ $ execCardanoCLI
@@ -180,12 +185,12 @@ hprop_golden_governance_committee_hot_extended_key_signing =
 -- @cabal test cardano-cli-golden --test-options '-p "/golden verification key committee/"'@
 hprop_golden_verification_key_committee :: Property
 hprop_golden_verification_key_committee = do
-  let values = [ ( "test/cardano-cli-golden/files/input/governance/committee/cc.extended.hot.skey"
-                 , "test/cardano-cli-golden/files/golden/governance/committee/cc.extended.hot.vkey"
+  let values = [ ( inputDir </> "governance/committee/cc.extended.hot.skey"
+                 , goldenDir </> "governance/committee/cc.extended.hot.vkey"
                  )
                  ,
-                 ( "test/cardano-cli-golden/files/input/governance/committee/cc.extended.cold.skey"
-                 , "test/cardano-cli-golden/files/golden/governance/committee/cc.extended.cold.vkey"
+                 ( inputDir </> "governance/committee/cc.extended.cold.skey"
+                 , goldenDir </> "governance/committee/cc.extended.cold.vkey"
                  )
                ]
 

--- a/cardano-cli/test/cardano-cli-golden/files/input/governance/committee/cc.extended.cold.vkey
+++ b/cardano-cli/test/cardano-cli-golden/files/input/governance/committee/cc.extended.cold.vkey
@@ -1,0 +1,5 @@
+{
+    "type": "ConstitutionalCommitteeColdExtendedVerificationKey_ed25519_bip32",
+    "description": "",
+    "cborHex": "58400a9d35aa5299580a67b1e43a3a4b6d43ef29c94e56c51ce4c17e9a53c1d0f39aa7f68837c38ef680b2dc8f047581707a32f6fcade23d4e02177d389002484798"
+}

--- a/cardano-cli/test/cardano-cli-golden/files/input/governance/committee/cc.extended.hot.vkey
+++ b/cardano-cli/test/cardano-cli-golden/files/input/governance/committee/cc.extended.hot.vkey
@@ -1,0 +1,5 @@
+{
+    "type": "ConstitutionalCommitteeHotExtendedVerificationKey_ed25519_bip32",
+    "description": "",
+    "cborHex": "5840f010c4332699c6ea1e43b427919860277169382d43d2969b28a110cfa08d955c4f178f20955541ce918a6a1352c32536f22677008f9f918d109663e4d2bdc084"
+}


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    conway governance committe key-hash: support extended CC keys
# uncomment types applicable to the change:
  type:
  - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Fixes https://github.com/IntersectMBO/cardano-cli/issues/706

# How to trust this PR

* Execute the new test before this PR, witness it fails: `cabal test cardano-cli-golden --test-options '-p "/golden governance extended committee key hash/"'`
* Execute the new test on this PR's HEAD, witness it works

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [X] Self-reviewed the diff