### PR TITLE
Test PR for improving golden CI  (2/2)

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -144,6 +144,16 @@ jobs:
         CREATE_GOLDEN_FILES: 1
       run: cabal test all --enable-tests --test-show-details=direct -j1
 
+    - name: Check golden files are all being used
+      run: |
+        NB_UNUSED_GOLDEN_FILES=$(git ls-files -d | wc -l)
+        if [[ "$NB_UNUSED_GOLDEN_FILES" != "0" ]]; then
+          echo "⚠️ The following golden files are not used anymore:"
+          git ls-files -d
+          echo "Please delete them."
+          exit 1
+        fi
+
     - name: "Tar artifacts"
       run: |
         mkdir -p artifacts


### PR DESCRIPTION
Test to check that CI will catch golden files that are not being used anymore and should be removed. See e.g.:

![image](https://github.com/IntersectMBO/cardano-cli/assets/634720/e59b9d63-b6a4-4162-839d-82c6e69c7e68)