### PR TITLE
Query a node for a snapshot of big ledger peers

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Query.hs
@@ -28,6 +28,7 @@ module Cardano.CLI.EraBased.Commands.Query
   , QueryDRepStakeDistributionCmdArgs (..)
   , QuerySPOStakeDistributionCmdArgs (..)
   , QueryTreasuryValueCmdArgs (..)
+  , QueryLedgerPeerSnapshotCmdArgs (..)
   , renderQueryCmds
   , IncludeStake (..)
   )
@@ -69,6 +70,7 @@ data QueryCmds era
   | QueryCommitteeMembersStateCmd !(QueryCommitteeMembersStateCmdArgs era)
   | QueryTreasuryValueCmd !(QueryTreasuryValueCmdArgs era)
   | QueryProposalsCmd !(QueryProposalsCmdArgs era)
+  | QueryLedgerPeerSnapshotCmd !QueryLedgerPeerSnapshotCmdArgs
   deriving (Generic, Show)
 
 -- | Fields that are common to most queries
@@ -137,6 +139,12 @@ data QueryUTxOCmdArgs = QueryUTxOCmdArgs
 data QueryLedgerStateCmdArgs = QueryLedgerStateCmdArgs
   { commons :: !QueryCommons
   , mOutFile :: !(Maybe (File () Out))
+  }
+  deriving (Generic, Show)
+
+data QueryLedgerPeerSnapshotCmdArgs = QueryLedgerPeerSnapshotCmdArgs
+  { commons :: !QueryCommons
+  , outFile :: !(Maybe (File () Out))
   }
   deriving (Generic, Show)
 
@@ -266,6 +274,8 @@ renderQueryCmds = \case
     "query utxo"
   QueryLedgerStateCmd{} ->
     "query ledger-state"
+  QueryLedgerPeerSnapshotCmd{} ->
+    "query ledger-peer-snapshot"
   QueryProtocolStateCmd{} ->
     "query protocol-state"
   QueryStakeSnapshotCmd{} ->

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -218,6 +218,7 @@ Usage: cardano-cli query
                            | pool-state
                            | tx-mempool
                            | slot-number
+                           | ledger-peer-snapshot
                            )
 
   Node query commands. Will query the local node whose Unix domain socket is
@@ -400,6 +401,20 @@ Usage: cardano-cli query slot-number --socket-path SOCKET_PATH
                                        TIMESTAMP
 
   Query slot number for UTC timestamp
+
+Usage: cardano-cli query ledger-peer-snapshot --socket-path SOCKET_PATH
+                                                [--cardano-mode
+                                                  [--epoch-slots SLOTS]]
+                                                ( --mainnet
+                                                | --testnet-magic NATURAL
+                                                )
+                                                [ --volatile-tip
+                                                | --immutable-tip
+                                                ]
+                                                [--out-file FILEPATH]
+
+  Dump the current snapshot of big ledger peers. These are the largest pools
+  that cumulatively hold 90% of total stake.
 
 Usage: cardano-cli legacy Legacy commands
 
@@ -1360,6 +1375,7 @@ Usage: cardano-cli shelley query
                                    | stake-address-info
                                    | utxo
                                    | ledger-state
+                                   | ledger-peer-snapshot
                                    | protocol-state
                                    | stake-snapshot
                                    | leadership-schedule
@@ -1447,6 +1463,17 @@ Usage: cardano-cli shelley query ledger-state --socket-path SOCKET_PATH
 
   Dump the current ledger state of the node (Ledger.NewEpochState -- advanced
   command)
+
+Usage: cardano-cli shelley query ledger-peer-snapshot --socket-path SOCKET_PATH
+                                                        [--cardano-mode
+                                                          [--epoch-slots SLOTS]]
+                                                        ( --mainnet
+                                                        | --testnet-magic NATURAL
+                                                        )
+                                                        [--out-file FILEPATH]
+
+  Dump the current snapshot of ledger peers.These are the largest pools that
+  cumulatively hold 90% of total stake.
 
 Usage: cardano-cli shelley query protocol-state --socket-path SOCKET_PATH
                                                   [--cardano-mode
@@ -2412,6 +2439,7 @@ Usage: cardano-cli allegra query
                                    | stake-address-info
                                    | utxo
                                    | ledger-state
+                                   | ledger-peer-snapshot
                                    | protocol-state
                                    | stake-snapshot
                                    | leadership-schedule
@@ -2499,6 +2527,17 @@ Usage: cardano-cli allegra query ledger-state --socket-path SOCKET_PATH
 
   Dump the current ledger state of the node (Ledger.NewEpochState -- advanced
   command)
+
+Usage: cardano-cli allegra query ledger-peer-snapshot --socket-path SOCKET_PATH
+                                                        [--cardano-mode
+                                                          [--epoch-slots SLOTS]]
+                                                        ( --mainnet
+                                                        | --testnet-magic NATURAL
+                                                        )
+                                                        [--out-file FILEPATH]
+
+  Dump the current snapshot of ledger peers.These are the largest pools that
+  cumulatively hold 90% of total stake.
 
 Usage: cardano-cli allegra query protocol-state --socket-path SOCKET_PATH
                                                   [--cardano-mode
@@ -3462,6 +3501,7 @@ Usage: cardano-cli mary query
                                 | stake-address-info
                                 | utxo
                                 | ledger-state
+                                | ledger-peer-snapshot
                                 | protocol-state
                                 | stake-snapshot
                                 | leadership-schedule
@@ -3549,6 +3589,17 @@ Usage: cardano-cli mary query ledger-state --socket-path SOCKET_PATH
 
   Dump the current ledger state of the node (Ledger.NewEpochState -- advanced
   command)
+
+Usage: cardano-cli mary query ledger-peer-snapshot --socket-path SOCKET_PATH
+                                                     [--cardano-mode
+                                                       [--epoch-slots SLOTS]]
+                                                     ( --mainnet
+                                                     | --testnet-magic NATURAL
+                                                     )
+                                                     [--out-file FILEPATH]
+
+  Dump the current snapshot of ledger peers.These are the largest pools that
+  cumulatively hold 90% of total stake.
 
 Usage: cardano-cli mary query protocol-state --socket-path SOCKET_PATH
                                                [--cardano-mode
@@ -4511,6 +4562,7 @@ Usage: cardano-cli alonzo query
                                   | stake-address-info
                                   | utxo
                                   | ledger-state
+                                  | ledger-peer-snapshot
                                   | protocol-state
                                   | stake-snapshot
                                   | leadership-schedule
@@ -4598,6 +4650,17 @@ Usage: cardano-cli alonzo query ledger-state --socket-path SOCKET_PATH
 
   Dump the current ledger state of the node (Ledger.NewEpochState -- advanced
   command)
+
+Usage: cardano-cli alonzo query ledger-peer-snapshot --socket-path SOCKET_PATH
+                                                       [--cardano-mode
+                                                         [--epoch-slots SLOTS]]
+                                                       ( --mainnet
+                                                       | --testnet-magic NATURAL
+                                                       )
+                                                       [--out-file FILEPATH]
+
+  Dump the current snapshot of ledger peers.These are the largest pools that
+  cumulatively hold 90% of total stake.
 
 Usage: cardano-cli alonzo query protocol-state --socket-path SOCKET_PATH
                                                  [--cardano-mode
@@ -5609,6 +5672,7 @@ Usage: cardano-cli babbage query
                                    | stake-address-info
                                    | utxo
                                    | ledger-state
+                                   | ledger-peer-snapshot
                                    | protocol-state
                                    | stake-snapshot
                                    | leadership-schedule
@@ -5696,6 +5760,17 @@ Usage: cardano-cli babbage query ledger-state --socket-path SOCKET_PATH
 
   Dump the current ledger state of the node (Ledger.NewEpochState -- advanced
   command)
+
+Usage: cardano-cli babbage query ledger-peer-snapshot --socket-path SOCKET_PATH
+                                                        [--cardano-mode
+                                                          [--epoch-slots SLOTS]]
+                                                        ( --mainnet
+                                                        | --testnet-magic NATURAL
+                                                        )
+                                                        [--out-file FILEPATH]
+
+  Dump the current snapshot of ledger peers.These are the largest pools that
+  cumulatively hold 90% of total stake.
 
 Usage: cardano-cli babbage query protocol-state --socket-path SOCKET_PATH
                                                   [--cardano-mode
@@ -7248,6 +7323,7 @@ Usage: cardano-cli conway query
                                   | stake-address-info
                                   | utxo
                                   | ledger-state
+                                  | ledger-peer-snapshot
                                   | protocol-state
                                   | stake-snapshot
                                   | leadership-schedule
@@ -7355,6 +7431,20 @@ Usage: cardano-cli conway query ledger-state --socket-path SOCKET_PATH
 
   Dump the current ledger state of the node (Ledger.NewEpochState -- advanced
   command)
+
+Usage: cardano-cli conway query ledger-peer-snapshot --socket-path SOCKET_PATH
+                                                       [--cardano-mode
+                                                         [--epoch-slots SLOTS]]
+                                                       ( --mainnet
+                                                       | --testnet-magic NATURAL
+                                                       )
+                                                       [ --volatile-tip
+                                                       | --immutable-tip
+                                                       ]
+                                                       [--out-file FILEPATH]
+
+  Dump the current snapshot of ledger peers.These are the largest pools that
+  cumulatively hold 90% of total stake.
 
 Usage: cardano-cli conway query protocol-state --socket-path SOCKET_PATH
                                                  [--cardano-mode
@@ -9270,6 +9360,7 @@ Usage: cardano-cli latest query
                                   | stake-address-info
                                   | utxo
                                   | ledger-state
+                                  | ledger-peer-snapshot
                                   | protocol-state
                                   | stake-snapshot
                                   | leadership-schedule
@@ -9377,6 +9468,20 @@ Usage: cardano-cli latest query ledger-state --socket-path SOCKET_PATH
 
   Dump the current ledger state of the node (Ledger.NewEpochState -- advanced
   command)
+
+Usage: cardano-cli latest query ledger-peer-snapshot --socket-path SOCKET_PATH
+                                                       [--cardano-mode
+                                                         [--epoch-slots SLOTS]]
+                                                       ( --mainnet
+                                                       | --testnet-magic NATURAL
+                                                       )
+                                                       [ --volatile-tip
+                                                       | --immutable-tip
+                                                       ]
+                                                       [--out-file FILEPATH]
+
+  Dump the current snapshot of ledger peers.These are the largest pools that
+  cumulatively hold 90% of total stake.
 
 Usage: cardano-cli latest query protocol-state --socket-path SOCKET_PATH
                                                  [--cardano-mode

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query.cli
@@ -6,6 +6,7 @@ Usage: cardano-cli allegra query
                                    | stake-address-info
                                    | utxo
                                    | ledger-state
+                                   | ledger-peer-snapshot
                                    | protocol-state
                                    | stake-snapshot
                                    | leadership-schedule
@@ -33,6 +34,9 @@ Available commands:
                            address or the whole.
   ledger-state             Dump the current ledger state of the node
                            (Ledger.NewEpochState -- advanced command)
+  ledger-peer-snapshot     Dump the current snapshot of ledger peers.These are
+                           the largest pools that cumulatively hold 90% of total
+                           stake.
   protocol-state           Dump the current protocol state of the node
                            (Ledger.ChainDepState -- advanced command)
   stake-snapshot           Obtain the three stake snapshots for a pool, plus the

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_ledger-peer-snapshot.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_ledger-peer-snapshot.cli
@@ -1,0 +1,27 @@
+Usage: cardano-cli allegra query ledger-peer-snapshot --socket-path SOCKET_PATH
+                                                        [--cardano-mode
+                                                          [--epoch-slots SLOTS]]
+                                                        ( --mainnet
+                                                        | --testnet-magic NATURAL
+                                                        )
+                                                        [--out-file FILEPATH]
+
+  Dump the current snapshot of ledger peers.These are the largest pools that
+  cumulatively hold 90% of total stake.
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILEPATH      Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query.cli
@@ -6,6 +6,7 @@ Usage: cardano-cli alonzo query
                                   | stake-address-info
                                   | utxo
                                   | ledger-state
+                                  | ledger-peer-snapshot
                                   | protocol-state
                                   | stake-snapshot
                                   | leadership-schedule
@@ -33,6 +34,9 @@ Available commands:
                            address or the whole.
   ledger-state             Dump the current ledger state of the node
                            (Ledger.NewEpochState -- advanced command)
+  ledger-peer-snapshot     Dump the current snapshot of ledger peers.These are
+                           the largest pools that cumulatively hold 90% of total
+                           stake.
   protocol-state           Dump the current protocol state of the node
                            (Ledger.ChainDepState -- advanced command)
   stake-snapshot           Obtain the three stake snapshots for a pool, plus the

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_ledger-peer-snapshot.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_ledger-peer-snapshot.cli
@@ -1,0 +1,27 @@
+Usage: cardano-cli alonzo query ledger-peer-snapshot --socket-path SOCKET_PATH
+                                                       [--cardano-mode
+                                                         [--epoch-slots SLOTS]]
+                                                       ( --mainnet
+                                                       | --testnet-magic NATURAL
+                                                       )
+                                                       [--out-file FILEPATH]
+
+  Dump the current snapshot of ledger peers.These are the largest pools that
+  cumulatively hold 90% of total stake.
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILEPATH      Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query.cli
@@ -6,6 +6,7 @@ Usage: cardano-cli babbage query
                                    | stake-address-info
                                    | utxo
                                    | ledger-state
+                                   | ledger-peer-snapshot
                                    | protocol-state
                                    | stake-snapshot
                                    | leadership-schedule
@@ -33,6 +34,9 @@ Available commands:
                            address or the whole.
   ledger-state             Dump the current ledger state of the node
                            (Ledger.NewEpochState -- advanced command)
+  ledger-peer-snapshot     Dump the current snapshot of ledger peers.These are
+                           the largest pools that cumulatively hold 90% of total
+                           stake.
   protocol-state           Dump the current protocol state of the node
                            (Ledger.ChainDepState -- advanced command)
   stake-snapshot           Obtain the three stake snapshots for a pool, plus the

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_ledger-peer-snapshot.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_ledger-peer-snapshot.cli
@@ -1,0 +1,27 @@
+Usage: cardano-cli babbage query ledger-peer-snapshot --socket-path SOCKET_PATH
+                                                        [--cardano-mode
+                                                          [--epoch-slots SLOTS]]
+                                                        ( --mainnet
+                                                        | --testnet-magic NATURAL
+                                                        )
+                                                        [--out-file FILEPATH]
+
+  Dump the current snapshot of ledger peers.These are the largest pools that
+  cumulatively hold 90% of total stake.
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILEPATH      Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query.cli
@@ -6,6 +6,7 @@ Usage: cardano-cli conway query
                                   | stake-address-info
                                   | utxo
                                   | ledger-state
+                                  | ledger-peer-snapshot
                                   | protocol-state
                                   | stake-snapshot
                                   | leadership-schedule
@@ -41,6 +42,9 @@ Available commands:
                            address or the whole.
   ledger-state             Dump the current ledger state of the node
                            (Ledger.NewEpochState -- advanced command)
+  ledger-peer-snapshot     Dump the current snapshot of ledger peers.These are
+                           the largest pools that cumulatively hold 90% of total
+                           stake.
   protocol-state           Dump the current protocol state of the node
                            (Ledger.ChainDepState -- advanced command)
   stake-snapshot           Obtain the three stake snapshots for a pool, plus the

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_ledger-peer-snapshot.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_ledger-peer-snapshot.cli
@@ -1,0 +1,33 @@
+Usage: cardano-cli conway query ledger-peer-snapshot --socket-path SOCKET_PATH
+                                                       [--cardano-mode
+                                                         [--epoch-slots SLOTS]]
+                                                       ( --mainnet
+                                                       | --testnet-magic NATURAL
+                                                       )
+                                                       [ --volatile-tip
+                                                       | --immutable-tip
+                                                       ]
+                                                       [--out-file FILEPATH]
+
+  Dump the current snapshot of ledger peers.These are the largest pools that
+  cumulatively hold 90% of total stake.
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --volatile-tip           Use the volatile tip as a target. (This is the
+                           default)
+  --immutable-tip          Use the immutable tip as a target.
+  --out-file FILEPATH      Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query.cli
@@ -6,6 +6,7 @@ Usage: cardano-cli latest query
                                   | stake-address-info
                                   | utxo
                                   | ledger-state
+                                  | ledger-peer-snapshot
                                   | protocol-state
                                   | stake-snapshot
                                   | leadership-schedule
@@ -41,6 +42,9 @@ Available commands:
                            address or the whole.
   ledger-state             Dump the current ledger state of the node
                            (Ledger.NewEpochState -- advanced command)
+  ledger-peer-snapshot     Dump the current snapshot of ledger peers.These are
+                           the largest pools that cumulatively hold 90% of total
+                           stake.
   protocol-state           Dump the current protocol state of the node
                            (Ledger.ChainDepState -- advanced command)
   stake-snapshot           Obtain the three stake snapshots for a pool, plus the

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_ledger-peer-snapshot.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_ledger-peer-snapshot.cli
@@ -1,0 +1,33 @@
+Usage: cardano-cli latest query ledger-peer-snapshot --socket-path SOCKET_PATH
+                                                       [--cardano-mode
+                                                         [--epoch-slots SLOTS]]
+                                                       ( --mainnet
+                                                       | --testnet-magic NATURAL
+                                                       )
+                                                       [ --volatile-tip
+                                                       | --immutable-tip
+                                                       ]
+                                                       [--out-file FILEPATH]
+
+  Dump the current snapshot of ledger peers.These are the largest pools that
+  cumulatively hold 90% of total stake.
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --volatile-tip           Use the volatile tip as a target. (This is the
+                           default)
+  --immutable-tip          Use the immutable tip as a target.
+  --out-file FILEPATH      Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query.cli
@@ -6,6 +6,7 @@ Usage: cardano-cli mary query
                                 | stake-address-info
                                 | utxo
                                 | ledger-state
+                                | ledger-peer-snapshot
                                 | protocol-state
                                 | stake-snapshot
                                 | leadership-schedule
@@ -33,6 +34,9 @@ Available commands:
                            address or the whole.
   ledger-state             Dump the current ledger state of the node
                            (Ledger.NewEpochState -- advanced command)
+  ledger-peer-snapshot     Dump the current snapshot of ledger peers.These are
+                           the largest pools that cumulatively hold 90% of total
+                           stake.
   protocol-state           Dump the current protocol state of the node
                            (Ledger.ChainDepState -- advanced command)
   stake-snapshot           Obtain the three stake snapshots for a pool, plus the

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_ledger-peer-snapshot.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_ledger-peer-snapshot.cli
@@ -1,0 +1,27 @@
+Usage: cardano-cli mary query ledger-peer-snapshot --socket-path SOCKET_PATH
+                                                     [--cardano-mode
+                                                       [--epoch-slots SLOTS]]
+                                                     ( --mainnet
+                                                     | --testnet-magic NATURAL
+                                                     )
+                                                     [--out-file FILEPATH]
+
+  Dump the current snapshot of ledger peers.These are the largest pools that
+  cumulatively hold 90% of total stake.
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILEPATH      Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/query.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/query.cli
@@ -13,6 +13,7 @@ Usage: cardano-cli query
                            | pool-state
                            | tx-mempool
                            | slot-number
+                           | ledger-peer-snapshot
                            )
 
   Node query commands. Will query the local node whose Unix domain socket is
@@ -47,3 +48,6 @@ Available commands:
   pool-state               Dump the pool state
   tx-mempool               Local Mempool info
   slot-number              Query slot number for UTC timestamp
+  ledger-peer-snapshot     Dump the current snapshot of big ledger peers. These
+                           are the largest pools that cumulatively hold 90% of
+                           total stake.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/query_ledger-peer-snapshot.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/query_ledger-peer-snapshot.cli
@@ -1,0 +1,33 @@
+Usage: cardano-cli query ledger-peer-snapshot --socket-path SOCKET_PATH
+                                                [--cardano-mode
+                                                  [--epoch-slots SLOTS]]
+                                                ( --mainnet
+                                                | --testnet-magic NATURAL
+                                                )
+                                                [ --volatile-tip
+                                                | --immutable-tip
+                                                ]
+                                                [--out-file FILEPATH]
+
+  Dump the current snapshot of big ledger peers. These are the largest pools
+  that cumulatively hold 90% of total stake.
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --volatile-tip           Use the volatile tip as a target. (This is the
+                           default)
+  --immutable-tip          Use the immutable tip as a target.
+  --out-file FILEPATH      Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query.cli
@@ -6,6 +6,7 @@ Usage: cardano-cli shelley query
                                    | stake-address-info
                                    | utxo
                                    | ledger-state
+                                   | ledger-peer-snapshot
                                    | protocol-state
                                    | stake-snapshot
                                    | leadership-schedule
@@ -33,6 +34,9 @@ Available commands:
                            address or the whole.
   ledger-state             Dump the current ledger state of the node
                            (Ledger.NewEpochState -- advanced command)
+  ledger-peer-snapshot     Dump the current snapshot of ledger peers.These are
+                           the largest pools that cumulatively hold 90% of total
+                           stake.
   protocol-state           Dump the current protocol state of the node
                            (Ledger.ChainDepState -- advanced command)
   stake-snapshot           Obtain the three stake snapshots for a pool, plus the

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_ledger-peer-snapshot.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_ledger-peer-snapshot.cli
@@ -1,0 +1,27 @@
+Usage: cardano-cli shelley query ledger-peer-snapshot --socket-path SOCKET_PATH
+                                                        [--cardano-mode
+                                                          [--epoch-slots SLOTS]]
+                                                        ( --mainnet
+                                                        | --testnet-magic NATURAL
+                                                        )
+                                                        [--out-file FILEPATH]
+
+  Dump the current snapshot of ledger peers.These are the largest pools that
+  cumulatively hold 90% of total stake.
+
+Available options:
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --out-file FILEPATH      Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text


### PR DESCRIPTION
# Changelog

```yaml
- description: |
   Add QueryLedgerPeerSnapshotCmd for a snapshot of big ledger peers used when syncing in Genesis
# uncomment types applicable to the change:
  type:
   - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

A new query subcommand ledger-peer-snapshot was introduced to serialize a snapshot of big ledger peers. These relays will be relied on by network layer when a node is syncing up in Genesis consensus mode, since a node may not have any or up to date information from its own ledger which are the big ledger peer relays. 

Closes #571 

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
