### PR TITLE
CI: add pipeline to create releases and attach binaries to releases

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -227,27 +227,3 @@ jobs:
         else
           echo 'Build complete'
         fi
-
-  release:
-    needs: [build]
-    if: ${{ startsWith(github.ref, 'refs/tags') }}
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-
-    - name: Create Release Tag
-      id: create_release_tag
-      run: |
-        echo "TAG=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
-
-    - name: Create Release
-      id: create_release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: ${{ github.ref }}
-        release_name: Release ${{ github.ref }}
-        draft: true
-        prerelease: false

--- a/.github/workflows/release-upload.yaml
+++ b/.github/workflows/release-upload.yaml
@@ -1,12 +1,37 @@
 name: Release Upload
-# This makes it easy to get download release binaries built using
-# a github action for any tagged commit.
+# Pipeline to download binaries from Hydra builds and create GitHub
+# releases out of them (or attaching the binaries to an already existing release)
 #
-# This workflow builds and uploads the macOS, win64 and linux
-# binary packages as github assets.
+# This pipeline is divided in three jobs:
 #
-# It uses `--builders "" --max-jobs 0` to ensure the assets are
-# from the IOG cache.
+# 1. The "wait_for_hydra" job looks up the status of the Hydra build corresponding to
+#    the tag for which we want to release. If the status is success, the pipeline
+#    continues. If the status cannot be determined or is a failure, the pipeline stops.
+# 2. The "pull" job downloads the binaries from the Hydra build and uploads them as artifacts.
+#    This job uses a matrix to handle all 3 platforms. Uploading as an artifact allows to
+#    do the last job without a matrix.
+#
+#    This job uses `--builders "" --max-jobs 0` to ensure the assets are downloaded
+#    from the IOG cache.
+# 3. The "create_release" job downloads the artifacts and attaches them to the target release.
+#
+# This pipeline is triggered in one of the following 3 ways:
+#
+# 1. When a release is published, this release's commit must have a tag for the pipeline to succeed
+# 2. When a tag is pushed. If this tag has a corresponding release, the release will be augmented.
+#    If there is no release, it will be created.
+# 3. By launching it manually, optionally specifying the tag to release:
+#      gh workflow run "Release Upload" -r $(git branch --show-current) -f target_tag=cardano-cli-8.22.0.0
+#    This mode is not supported by the pipeline of cardano-node (which was copied to create this pipeline),
+#    but we anticipate this mode to be useful when debugging, or releasing a posteriori.
+#
+#    If the tag is not specified, this pipeline will run, but skip the final "create_release" job,
+#    so no release will get created. This is useful for debugging or
+#    trying to build a release before tagging it.
+#
+# So far this pipeline only supports releasing Linux binaries. However everything is ready to support
+# other platforms. Please see the "TODO generalize" comments in this file to support new platforms.
+
 on:
   workflow_dispatch:
     inputs:
@@ -130,7 +155,7 @@ jobs:
           path: cardano-cli-* # Should match (1)
           retention-days: 1
 
-  create-release:
+  create_release:
     needs: [wait_for_hydra, pull]
     name: "Create Release"
     runs-on: ubuntu-latest

--- a/.github/workflows/release-upload.yaml
+++ b/.github/workflows/release-upload.yaml
@@ -1,0 +1,168 @@
+name: Release Upload
+# This makes it easy to get download release binaries built using
+# a github action for any tagged commit.
+#
+# This workflow builds and uploads the macOS, win64 and linux
+# binary packages as github assets.
+#
+# It uses `--builders "" --max-jobs 0` to ensure the assets are
+# from the IOG cache.
+on:
+  workflow_dispatch:
+    inputs:
+      target_tag:
+        description: 'The tag of the release to attach binaries to'
+        default: ''
+        required: false
+        type: string
+  release:
+    types:
+      - published
+  push:
+    tags:
+      - '**'
+env:
+  GH_TOKEN: ${{ github.token }}
+
+jobs:
+  wait_for_hydra:
+    name: "Wait for Hydra check-runs"
+    runs-on: ubuntu-latest
+    outputs:
+      TARGET_TAG: ${{ steps.store_target_tag.outputs.TARGET_TAG }}
+      DRY_RUN:    ${{ steps.store_target_tag.outputs.DRY_RUN }}
+      FLAKE_REF:  ${{ steps.define_flake_ref.outputs.FLAKE_REF }}
+    steps:
+    - name: Define target tag (1/2)
+      if: ${{ inputs.target_tag != '' }} # If a tag was specified manually as input, use it
+      run: |
+        echo "TARGET_TAG=${{ inputs.target_tag }}" >> "$GITHUB_ENV"
+    - name: Define target tag (2/2)
+      if: ${{ inputs.target_tag == '' }} # If no tag was specified manually as input, take the tag from the current commit
+      run: |
+        current_tag=$(git tag --points-to HEAD | head -n 1)
+        if [[ "$current_tag" != "" ]]
+        then
+          # The workflow runs on a commit that has a tag, use this tag
+          echo "TARGET_TAG=$current_tag" >> "$GITHUB_ENV"
+        fi
+    - name: Default tag if needed and store it in outputs
+      id: store_target_tag
+      run: |
+        if [[ "${{ env.TARGET_TAG }}" == "" ]]
+        then
+          echo "Tag not yet defined, using current commit as reference."
+          echo "No release will be created."
+          echo "TARGET_TAG=${{ github.ref_name }}" >> "$GITHUB_ENV"
+          echo "DRY_RUN=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "DRY_RUN=false" >> "$GITHUB_OUTPUT"
+        fi
+        echo "TARGET_TAG=${{ env.TARGET_TAG }}" >> "$GITHUB_OUTPUT"
+    - name: Define FLAKE_REF
+      id: define_flake_ref
+      run: |
+        flake_ref="github:${{ github.repository }}/${{ env.TARGET_TAG }}"
+        echo "FLAKE_REF=$flake_ref" >> "$GITHUB_ENV"
+        echo "FLAKE_REF=$flake_ref" >> "$GITHUB_OUTPUT"
+    - name: Get specific check run status
+      timeout-minutes: 120
+      run: |
+        while true; do
+          # When supporting other architectures than Linux, this query should be adapted:
+          conclusion=$(gh api "repos/$GITHUB_REPOSITORY/commits/${{ env.TARGET_TAG }}/check-runs" --jq '.check_runs[] | select(.name | test("ci/hydra-build:.*-linux.required")) | .conclusion')
+          case "$conclusion" in
+            success)
+              echo "ci/hydra-build:required succeeded"
+              exit 0;;
+            failure)
+              echo "ci/hydra-build:required failed"
+              exit 1;;
+            *)
+              echo "ci/hydra-build:required pending. Waiting 30s..."
+              sleep 30;;
+          esac
+        done
+    
+  pull:
+    needs: [wait_for_hydra]
+    strategy:
+      matrix:
+        arch: [linux]
+        # TODO generalize
+        # arch: [linux, macos, win64]
+    name: "Download Asset from the Cache"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install Nix with good defaults
+        uses: input-output-hk/install-nix-action@v20
+        with:
+          extra_nix_config: |
+            trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
+            substituters = https://cache.iog.io/ https://cache.nixos.org/
+          nix_path: nixpkgs=channel:nixos-unstable
+      - name: Display flake metadata
+        id: flake-metadata
+        run: |
+          nix flake metadata "${{ needs.wait_for_hydra.outputs.FLAKE_REF }}"
+          nix flake metadata "${{ needs.wait_for_hydra.outputs.FLAKE_REF }}" --json | jq -r '"LOCKED_URL=\(.url)"' >> "$GITHUB_ENV"
+      - name: Build
+        run: |
+          case ${{ matrix.arch }} in
+            linux)
+              nix build --builders "" --max-jobs 0 ${{ env.LOCKED_URL }}#cardano-cli:exe:cardano-cli
+              tree result
+              cp result/bin/cardano-cli cardano-cli-${{ matrix.arch }} # (1)
+              ;;
+            # TODO generalize
+            # macos)
+            #   nix build --builders "" --max-jobs 0 ${{ steps.flake-metadata.outputs.LOCKED_URL }}#cardano-cli:exe:cardano-cli
+            #   tree result
+            #   ;;
+            # win64)
+            #   nix build --builders "" --max-jobs 0 ${{ steps.flake-metadata.outputs.LOCKED_URL }}#x86_64-w64-mingw32:cardano-cli:exe:cardano-cli
+            #   tree result
+            #   ;;              
+          esac
+      - uses: actions/upload-artifact@v4
+        with:
+          name: cardano-cli-${{ matrix.arch }} # (2)
+          path: cardano-cli-* # Should match (1)
+          retention-days: 1
+
+  create-release:
+    needs: [wait_for_hydra, pull]
+    name: "Create Release"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: cardano-cli-linux # Should match (2)
+      # TODO generalize
+      # - uses: actions/download-artifact@v3
+      #   with:
+      #     name: cardano-cli-macos # Should match (2)
+      # - uses: actions/download-artifact@v3
+      #   with:
+      #     name: cardano-cli-win64 # Should match (2)
+      - name: Compress
+        run: |
+          # (3)
+          # TARGET_TAG is of the form cardano-cli-8.22.0, so we don't need to prefix the tar.gz's name
+          # with cardano-cli
+          tar -czf ${{ needs.wait_for_hydra.outputs.TARGET_TAG }}-linux.tar.gz cardano-cli-linux
+          # TODO generalize
+          # tar -czf ${{ needs.wait_for_hydra.outputs.TARGET_TAG }}-macos.tar.gz cardano-cli-macos
+          # zip ${{ needs.wait_for_hydra.outputs.TARGET_TAG }}-win64.zip cardano-cli-win64
+      - name: Create Release
+        uses: input-output-hk/action-gh-release@v1
+        if: ${{ needs.wait_for_hydra.outputs.DRY_RUN == 'false' }}
+        with:
+          draft: true
+          tag_name: ${{ needs.wait_for_hydra.outputs.TARGET_TAG }}
+          # TODO generalize
+          # cardano-cli-${{ needs.wait_for_hydra.outputs.TARGET_TAG }}-macos.tar.gz
+          # cardano-cli-${{ needs.wait_for_hydra.outputs.TARGET_TAG }}-win64.zip
+          # All entries in 'files' below should match (3)
+          files: |
+            ${{ needs.wait_for_hydra.outputs.TARGET_TAG }}-linux.tar.gz

--- a/flake.nix
+++ b/flake.nix
@@ -16,6 +16,7 @@
     supportedSystems = [
       "x86_64-linux"
       # disabling to reduce CI time initially. Uncomment later
+      # When you uncomment, lookup the "TODO generalize" comments in release-upload.yaml
       #"x86_64-darwin"
       #"aarch64-linux"
       #"aarch64-darwin"


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Add a pipeline named "Release Upload" that attaches binaries of cardano-cli to releases, creating the release if necessary
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

* We want to make the life of users easier, so let's give them easier access to binaries :tada: 
* We can generate the release's body automatically, by specifying the changelog; but I plan to do that in a follow-up PR.

Fixes https://github.com/IntersectMBO/cardano-cli/issues/725

# How to trust this PR

The asset attached to [this release](https://github.com/IntersectMBO/cardano-cli/releases/tag/cardano-cli-8.22.0.0) was created by triggering this pipeline manually as follows:

```shell
gh workflow run "Release Upload" -r smelc/automate-shipping-binaries-in-releases -f target_tag=cardano-cli-8.22.0.0
```

Generated asset is this one: 

![image](https://github.com/IntersectMBO/cardano-cli/assets/634720/8bfcccd4-f60b-4508-a4e1-20ec2af8bc8e)

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] Self-reviewed the diff