### PR TITLE
CI: create release changelog automatically

### DIFF
--- a/.github/workflows/release-upload.yaml
+++ b/.github/workflows/release-upload.yaml
@@ -179,12 +179,20 @@ jobs:
           # TODO generalize
           # tar -czf ${{ needs.wait_for_hydra.outputs.TARGET_TAG }}-macos.tar.gz cardano-cli-macos
           # zip ${{ needs.wait_for_hydra.outputs.TARGET_TAG }}-win64.zip cardano-cli-win64
+      - name: Create short tag
+        run: |
+          # Transform the long tag (e.g. "cardano-cli-8.22.0.0")
+          # into the short version (e.g. "8.22.0.0")
+          long_tag=${{ needs.wait_for_hydra.outputs.TARGET_TAG }}
+          short_tag="${long_tag#cardano-cli-}"
+          echo "SHORT_TAG=$short_tag" >> "$GITHUB_ENV"
       - name: Create Release
         uses: input-output-hk/action-gh-release@v1
         if: ${{ needs.wait_for_hydra.outputs.DRY_RUN == 'false' }}
         with:
           draft: true
-          tag_name: ${{ needs.wait_for_hydra.outputs.TARGET_TAG }}
+          tag_name: ${{ needs.wait_for_hydra.outputs.TARGET_TAG }} # Git tag the release is attached to
+          name: ${{ env.SHORT_TAG }} # Release name in GitHub UI
           # TODO generalize
           # cardano-cli-${{ needs.wait_for_hydra.outputs.TARGET_TAG }}-macos.tar.gz
           # cardano-cli-${{ needs.wait_for_hydra.outputs.TARGET_TAG }}-win64.zip

--- a/.github/workflows/release-upload.yaml
+++ b/.github/workflows/release-upload.yaml
@@ -160,6 +160,7 @@ jobs:
     name: "Create Release"
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v4 # We need the repo to execute extract-changelog.sh  below
       - uses: actions/download-artifact@v4
         with:
           name: cardano-cli-linux # Should match (2)
@@ -186,6 +187,10 @@ jobs:
           long_tag=${{ needs.wait_for_hydra.outputs.TARGET_TAG }}
           short_tag="${long_tag#cardano-cli-}"
           echo "SHORT_TAG=$short_tag" >> "$GITHUB_ENV"
+      - name: Create changelog
+        run: |
+          echo -e "# Changelog\n" > RELEASE_CHANGELOG.md
+          ./scripts/ci/extract-changelog.sh ${{ env.SHORT_TAG }} >> RELEASE_CHANGELOG.md
       - name: Create Release
         uses: input-output-hk/action-gh-release@v1
         if: ${{ needs.wait_for_hydra.outputs.DRY_RUN == 'false' }}
@@ -199,3 +204,4 @@ jobs:
           # All entries in 'files' below should match (3)
           files: |
             ${{ needs.wait_for_hydra.outputs.TARGET_TAG }}-linux.tar.gz
+          body_path: RELEASE_CHANGELOG.md

--- a/scripts/ci/extract-changelog.sh
+++ b/scripts/ci/extract-changelog.sh
@@ -31,4 +31,8 @@ NUMBER_OF_LINES=$((NUMBER_OF_LINES - 1))
 # Uncomment to debug
 # echo "Found number of lines: $NUMBER_OF_LINES"
 
+# Piping tail doesn't play nice with "set -o pipefail" so turning it off
+# See https://superuser.com/questions/554855/how-can-i-fix-a-broken-pipe-error
+set +o pipefail
+
 tail -n "+$CHANGELOG_START_LINE" "$CHANGELOG" | head -n "$NUMBER_OF_LINES"

--- a/scripts/ci/extract-changelog.sh
+++ b/scripts/ci/extract-changelog.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#
+# Extracts the changelog of a specific version, by reading cardano-cli/CHANGELOG.md
+#
+# This script expects the version as first argument, for example "8.22.0.0"
+
+set -o pipefail # We want commands with pipes to fail if any command in the stream fails
+
+[[ -n "$1" ]] || { echo "This script expects a release version number as first and unique parameter. Please provide one (for example \"8.22.0\")"; exit 1; }
+
+declare -r CHANGELOG="cardano-cli/CHANGELOG.md"
+
+HEADER_LINE=$(grep -n "^## $1" "$CHANGELOG" | awk -F : '{print $1}')
+
+# shellcheck disable=SC2181
+[[ "$?" == "0" ]] || { echo "Release header not found (grep for \"^## $1\" failed)"; exit 1; }
+
+CHANGELOG_START_LINE=$((HEADER_LINE + 2))
+
+# Uncomment to debug
+# echo "Found changelog starting line: $CHANGELOG_START_LINE"
+
+AFTER_CHANGELOG_LINE=$((CHANGELOG_START_LINE + 1))
+NUMBER_OF_LINES=$(tail -n "+$AFTER_CHANGELOG_LINE" $CHANGELOG | grep -n '^##' | head -n 1 | awk -F : '{print $1}')
+
+# shellcheck disable=SC2181
+[[ "$?" == "0" ]] || { echo "Next release header not found (grep for \"^## $1\" failed), starting at line $AFTER_CHANGELOG_LINE"; exit 1; }
+
+NUMBER_OF_LINES=$((NUMBER_OF_LINES - 1))
+
+# Uncomment to debug
+# echo "Found number of lines: $NUMBER_OF_LINES"
+
+tail -n "+$CHANGELOG_START_LINE" "$CHANGELOG" | head -n "$NUMBER_OF_LINES"


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    CI: create release changelog automatically
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

We added automatic creation of releases in https://github.com/IntersectMBO/cardano-cli/pull/730. https://github.com/IntersectMBO/cardano-cli/pull/730, however, does not create the changelog, it uses placeholder text put by https://github.com/softprops/action-gh-release.

This improves on https://github.com/IntersectMBO/cardano-cli/pull/730 by populating the release changelog. See https://github.com/IntersectMBO/cardano-cli/releases/tag/untagged-6a3ce8a442ee33faf470 for an example of a release created by the pipeline of this PR.

This PR works by extracting the changelog from https://github.com/IntersectMBO/cardano-cli/blob/main/cardano-cli/CHANGELOG.md.

# How to trust this PR

Run the script extracting the changelog locally, and witness it outputs the correct subset of the changelog. E.g. try:

```shell
./scripts/ci/extract-changelog.sh 8.22.0.0
```

or

```shell
./scripts/ci/extract-changelog.sh 8.21.0.0
```

You can also try a failing call and witness that `$?` is non-zero:

```shell
./scripts/ci/extract-changelog.sh foobar
```

Try the pipeline on a unreleased tag, for example `8.20.3.0`:

```shell
gh workflow run "Release Upload" -r $(git branch --show-current) -f target_tag=cardano-cli-8.20.3.0
```

and look at the draft release that gets added here: https://github.com/IntersectMBO/cardano-cli/releases

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] Self-reviewed the diff