### PR TITLE
CI: run shellcheck

### DIFF
--- a/.github/workflows/shellcheck-exceptions.txt
+++ b/.github/workflows/shellcheck-exceptions.txt
@@ -1,0 +1,2 @@
+.github/bin/haddocks.sh
+scripts/ci/check-cabal-files.sh

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,39 @@
+name: Shellcheck
+# This pipeline runs shellcheck on all files with extension .sh,
+# except the ones listed in .github/workflows/shellcheck-exceptions.txt.
+#
+# This pipeline uses Nix, so that the shellcheck version used is the same
+# ones as used by developers in Nix shells. This ensures the CI's behavior
+# is consistent with the one of developers.
+
+on:
+  pull_request:
+
+jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Nix with good defaults
+        uses: input-output-hk/install-nix-action@v20
+        with:
+          extra_nix_config: |
+            trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
+            substituters = https://cache.iog.io/ https://cache.nixos.org/
+          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: cachix/install-nix-action@v18
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      # Make the Nix environment available to next steps
+      - uses: rrbutani/use-nix-shell-action@v1
+      - name: Shellcheck
+        run: |
+          for file in $(git ls-files "*.sh")
+          do
+            if grep -q "$file" ".github/workflows/shellcheck-exceptions.txt"
+            then
+              echo "⚠️ $file is ignored from shellcheck's verifications. Please consider fixing it."
+            else
+              shellcheck "$file"
+            fi
+          done


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    CI: add a job to run shellcheck
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

While working on https://github.com/IntersectMBO/cardano-cli/pull/733, I witnessed there was no check of the quality of shell scripts in this repo. This PR adds one.

You may think _hey all versioned `*.sh` scripts are being ignored right now_. That is correct: I didn't want to interleave fixing the existing scripts and adding this new check. The point is that this pipeline will automatically start checking new shell scripts, for example the one added by https://github.com/IntersectMBO/cardano-cli/pull/733.

So this pipeline will effectively start checking things when https://github.com/IntersectMBO/cardano-cli/pull/733 is merged. And it will also check future scripts we add (since, by default, we won't think of augmenting `.github/workflows/shellcheck-exceptions.txt` :wink:).

# How to trust this PR

Look at output of recent runs of the new pipeline: https://github.com/IntersectMBO/cardano-cli/actions/workflows/shellcheck.yml

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] Self-reviewed the diff