### PR TITLE
query stake-distribution: add --output-{json,text} flags

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Query.hs
@@ -114,6 +114,7 @@ data QueryStakeDistributionCmdArgs = QueryStakeDistributionCmdArgs
   , consensusModeParams :: !ConsensusModeParams
   , networkId           :: !NetworkId
   , target              :: !(Consensus.Target ChainPoint)
+  , format              :: Maybe QueryOutputFormat
   , mOutFile            :: !(Maybe (File () Out))
   } deriving (Generic, Show)
 

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Query.hs
@@ -171,6 +171,7 @@ pQueryStakeDistributionCmd era envCli =
       <*> pConsensusModeParams
       <*> pNetworkId envCli
       <*> pTarget era
+      <*> (optional $ pQueryOutputFormat "stake-distribution")
       <*> pMaybeOutputFile
 
 pQueryStakeAddressInfoCmd :: CardanoEra era -> EnvCli -> Parser (QueryCmds era)

--- a/cardano-cli/src/Cardano/CLI/Legacy/Commands/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Commands/Query.hs
@@ -94,6 +94,7 @@ data LegacyQueryStakeDistributionCmdArgs = LegacyQueryStakeDistributionCmdArgs
   { nodeSocketPath      :: !SocketPath
   , consensusModeParams :: !ConsensusModeParams
   , networkId           :: !NetworkId
+  , format              :: Maybe QueryOutputFormat
   , mOutFile            :: !(Maybe (File () Out))
   } deriving (Generic, Show)
 

--- a/cardano-cli/src/Cardano/CLI/Legacy/Options.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Options.hs
@@ -671,6 +671,7 @@ pQueryCmds envCli =
         <$> pSocketPath envCli
         <*> pConsensusModeParams
         <*> pNetworkId envCli
+        <*> (optional $ pQueryOutputFormat "stake-distribution")
         <*> pMaybeOutputFile
 
     pQueryStakeAddressInfo :: Parser LegacyQueryCmds

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -495,6 +495,9 @@ Usage: cardano-cli shelley query stake-distribution --socket-path SOCKET_PATH
                                                       ( --mainnet
                                                       | --testnet-magic NATURAL
                                                       )
+                                                      [ --output-json
+                                                      | --output-text
+                                                      ]
                                                       [--out-file FILE]
 
   Get the node's current aggregated stake distribution
@@ -1687,6 +1690,9 @@ Usage: cardano-cli allegra query stake-distribution --socket-path SOCKET_PATH
                                                       ( --mainnet
                                                       | --testnet-magic NATURAL
                                                       )
+                                                      [ --output-json
+                                                      | --output-text
+                                                      ]
                                                       [--out-file FILE]
 
   Get the node's current aggregated stake distribution
@@ -2877,6 +2883,9 @@ Usage: cardano-cli mary query stake-distribution --socket-path SOCKET_PATH
                                                    ( --mainnet
                                                    | --testnet-magic NATURAL
                                                    )
+                                                   [ --output-json
+                                                   | --output-text
+                                                   ]
                                                    [--out-file FILE]
 
   Get the node's current aggregated stake distribution
@@ -4190,6 +4199,9 @@ Usage: cardano-cli alonzo query stake-distribution --socket-path SOCKET_PATH
                                                      ( --mainnet
                                                      | --testnet-magic NATURAL
                                                      )
+                                                     [ --output-json
+                                                     | --output-text
+                                                     ]
                                                      [--out-file FILE]
 
   Get the node's current aggregated stake distribution
@@ -5540,6 +5552,9 @@ Usage: cardano-cli babbage query stake-distribution --socket-path SOCKET_PATH
                                                       ( --mainnet
                                                       | --testnet-magic NATURAL
                                                       )
+                                                      [ --output-json
+                                                      | --output-text
+                                                      ]
                                                       [--out-file FILE]
 
   Get the node's current aggregated stake distribution
@@ -7154,6 +7169,9 @@ Usage: cardano-cli conway query stake-distribution --socket-path SOCKET_PATH
                                                      [ --volatile-tip
                                                      | --immutable-tip
                                                      ]
+                                                     [ --output-json
+                                                     | --output-text
+                                                     ]
                                                      [--out-file FILE]
 
   Get the node's current aggregated stake distribution
@@ -8703,6 +8721,9 @@ Usage: cardano-cli latest query stake-distribution --socket-path SOCKET_PATH
                                                      ( --mainnet
                                                      | --testnet-magic NATURAL
                                                      )
+                                                     [ --output-json
+                                                     | --output-text
+                                                     ]
                                                      [--out-file FILE]
 
   Get the node's current aggregated stake distribution
@@ -9874,6 +9895,9 @@ Usage: cardano-cli legacy query stake-distribution --socket-path SOCKET_PATH
                                                      ( --mainnet
                                                      | --testnet-magic NATURAL
                                                      )
+                                                     [ --output-json
+                                                     | --output-text
+                                                     ]
                                                      [--out-file FILE]
 
   Get the node's current aggregated stake distribution
@@ -11136,6 +11160,7 @@ Usage: cardano-cli query stake-distribution --socket-path SOCKET_PATH
                                               ( --mainnet
                                               | --testnet-magic NATURAL
                                               )
+                                              [--output-json | --output-text]
                                               [--out-file FILE]
 
   Get the node's current aggregated stake distribution

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_stake-distribution.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_stake-distribution.cli
@@ -4,6 +4,9 @@ Usage: cardano-cli allegra query stake-distribution --socket-path SOCKET_PATH
                                                       ( --mainnet
                                                       | --testnet-magic NATURAL
                                                       )
+                                                      [ --output-json
+                                                      | --output-text
+                                                      ]
                                                       [--out-file FILE]
 
   Get the node's current aggregated stake distribution
@@ -22,5 +25,9 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --output-json            Format stake-distribution query output to JSON.
+                           Default format when writing to a file
+  --output-text            Format stake-distribution query output to TEXT.
+                           Default format when writing to stdout
   --out-file FILE          Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_stake-distribution.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_stake-distribution.cli
@@ -4,6 +4,9 @@ Usage: cardano-cli alonzo query stake-distribution --socket-path SOCKET_PATH
                                                      ( --mainnet
                                                      | --testnet-magic NATURAL
                                                      )
+                                                     [ --output-json
+                                                     | --output-text
+                                                     ]
                                                      [--out-file FILE]
 
   Get the node's current aggregated stake distribution
@@ -22,5 +25,9 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --output-json            Format stake-distribution query output to JSON.
+                           Default format when writing to a file
+  --output-text            Format stake-distribution query output to TEXT.
+                           Default format when writing to stdout
   --out-file FILE          Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_stake-distribution.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_stake-distribution.cli
@@ -4,6 +4,9 @@ Usage: cardano-cli babbage query stake-distribution --socket-path SOCKET_PATH
                                                       ( --mainnet
                                                       | --testnet-magic NATURAL
                                                       )
+                                                      [ --output-json
+                                                      | --output-text
+                                                      ]
                                                       [--out-file FILE]
 
   Get the node's current aggregated stake distribution
@@ -22,5 +25,9 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --output-json            Format stake-distribution query output to JSON.
+                           Default format when writing to a file
+  --output-text            Format stake-distribution query output to TEXT.
+                           Default format when writing to stdout
   --out-file FILE          Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_stake-distribution.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_stake-distribution.cli
@@ -7,6 +7,9 @@ Usage: cardano-cli conway query stake-distribution --socket-path SOCKET_PATH
                                                      [ --volatile-tip
                                                      | --immutable-tip
                                                      ]
+                                                     [ --output-json
+                                                     | --output-text
+                                                     ]
                                                      [--out-file FILE]
 
   Get the node's current aggregated stake distribution
@@ -28,5 +31,9 @@ Available options:
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.
+  --output-json            Format stake-distribution query output to JSON.
+                           Default format when writing to a file
+  --output-text            Format stake-distribution query output to TEXT.
+                           Default format when writing to stdout
   --out-file FILE          Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_stake-distribution.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_stake-distribution.cli
@@ -4,6 +4,9 @@ Usage: cardano-cli latest query stake-distribution --socket-path SOCKET_PATH
                                                      ( --mainnet
                                                      | --testnet-magic NATURAL
                                                      )
+                                                     [ --output-json
+                                                     | --output-text
+                                                     ]
                                                      [--out-file FILE]
 
   Get the node's current aggregated stake distribution
@@ -22,5 +25,9 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --output-json            Format stake-distribution query output to JSON.
+                           Default format when writing to a file
+  --output-text            Format stake-distribution query output to TEXT.
+                           Default format when writing to stdout
   --out-file FILE          Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_query_stake-distribution.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_query_stake-distribution.cli
@@ -4,6 +4,9 @@ Usage: cardano-cli legacy query stake-distribution --socket-path SOCKET_PATH
                                                      ( --mainnet
                                                      | --testnet-magic NATURAL
                                                      )
+                                                     [ --output-json
+                                                     | --output-text
+                                                     ]
                                                      [--out-file FILE]
 
   Get the node's current aggregated stake distribution
@@ -22,5 +25,9 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --output-json            Format stake-distribution query output to JSON.
+                           Default format when writing to a file
+  --output-text            Format stake-distribution query output to TEXT.
+                           Default format when writing to stdout
   --out-file FILE          Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_stake-distribution.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_stake-distribution.cli
@@ -4,6 +4,9 @@ Usage: cardano-cli mary query stake-distribution --socket-path SOCKET_PATH
                                                    ( --mainnet
                                                    | --testnet-magic NATURAL
                                                    )
+                                                   [ --output-json
+                                                   | --output-text
+                                                   ]
                                                    [--out-file FILE]
 
   Get the node's current aggregated stake distribution
@@ -22,5 +25,9 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --output-json            Format stake-distribution query output to JSON.
+                           Default format when writing to a file
+  --output-text            Format stake-distribution query output to TEXT.
+                           Default format when writing to stdout
   --out-file FILE          Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/query_stake-distribution.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/query_stake-distribution.cli
@@ -4,6 +4,7 @@ Usage: cardano-cli query stake-distribution --socket-path SOCKET_PATH
                                               ( --mainnet
                                               | --testnet-magic NATURAL
                                               )
+                                              [--output-json | --output-text]
                                               [--out-file FILE]
 
   Get the node's current aggregated stake distribution
@@ -22,5 +23,9 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --output-json            Format stake-distribution query output to JSON.
+                           Default format when writing to a file
+  --output-text            Format stake-distribution query output to TEXT.
+                           Default format when writing to stdout
   --out-file FILE          Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_stake-distribution.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_stake-distribution.cli
@@ -4,6 +4,9 @@ Usage: cardano-cli shelley query stake-distribution --socket-path SOCKET_PATH
                                                       ( --mainnet
                                                       | --testnet-magic NATURAL
                                                       )
+                                                      [ --output-json
+                                                      | --output-text
+                                                      ]
                                                       [--out-file FILE]
 
   Get the node's current aggregated stake distribution
@@ -22,5 +25,9 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --output-json            Format stake-distribution query output to JSON.
+                           Default format when writing to a file
+  --output-text            Format stake-distribution query output to TEXT.
+                           Default format when writing to stdout
   --out-file FILE          Optional output file. Default is to write to stdout.
   -h,--help                Show this help text


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    query stake-distribution: add --output-{json,text} flags
# uncomment types applicable to the change:
  type:
  - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

* It appears this is a longstanding request from users, as pointed out by @CarlosLopezDeLara to me
* Contributes to fixing https://github.com/IntersectMBO/cardano-cli/issues/566
* The design is the same as https://github.com/IntersectMBO/cardano-cli/pull/649, https://github.com/IntersectMBO/cardano-cli/pull/611, and https://github.com/IntersectMBO/cardano-cli/pull/523 to guarantee consistency

Fixes https://github.com/IntersectMBO/cardano-cli/issues/739

# How to trust this PR

I tested this PR's behavior on https://github.com/IntersectMBO/cardano-node/pull/5803. You can see the comparison of the before/after states here: [test_743.zip](https://github.com/IntersectMBO/cardano-cli/files/15146726/test_743.zip)

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] Self-reviewed the diff