### PR TITLE
Enable manual specification of execution units for plutus voting and proposing scripts

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Transaction.hs
@@ -235,8 +235,8 @@ pTransactionBuildEstimateCmd era _envCli = do
                       "Filepath of auxiliary script(s)")
           <*> many pMetadataFile
           <*> pFeatured (shelleyBasedToCardanoEra sbe) (optional pUpdateProposalFile)
-          <*> pVoteFiles sbe AutoBalance
-          <*> pProposalFiles sbe AutoBalance
+          <*> pVoteFiles sbe ManualBalance
+          <*> pProposalFiles sbe ManualBalance
           <*> pTxBodyFileOut
 
 pChangeAddress :: Parser TxOutChangeAddress

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -8079,16 +8079,20 @@ Usage: cardano-cli conway transaction build-estimate
                                                        ]
                                                        [--vote-file FILE
                                                          [--vote-script-file FILE
-                                                           [ --vote-redeemer-cbor-file CBOR FILE
-                                                           | --vote-redeemer-file JSON FILE
-                                                           | --vote-redeemer-value JSON VALUE
-                                                           ]]]
+                                                           [
+                                                             ( --vote-redeemer-cbor-file CBOR FILE
+                                                             | --vote-redeemer-file JSON FILE
+                                                             | --vote-redeemer-value JSON VALUE
+                                                             )
+                                                             --vote-execution-units (INT, INT)]]]
                                                        [--proposal-file FILE
                                                          [--proposal-script-file FILE
-                                                           [ --proposal-redeemer-cbor-file CBOR FILE
-                                                           | --proposal-redeemer-file JSON FILE
-                                                           | --proposal-redeemer-value JSON VALUE
-                                                           ]]]
+                                                           [
+                                                             ( --proposal-redeemer-cbor-file CBOR FILE
+                                                             | --proposal-redeemer-file JSON FILE
+                                                             | --proposal-redeemer-value JSON VALUE
+                                                             )
+                                                             --proposal-execution-units (INT, INT)]]]
                                                        --out-file FILE
 
   Build a balanced transaction without access to a live node (automatically estimates fees)

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_build-estimate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_build-estimate.cli
@@ -125,16 +125,20 @@ Usage: cardano-cli conway transaction build-estimate
                                                        ]
                                                        [--vote-file FILE
                                                          [--vote-script-file FILE
-                                                           [ --vote-redeemer-cbor-file CBOR FILE
-                                                           | --vote-redeemer-file JSON FILE
-                                                           | --vote-redeemer-value JSON VALUE
-                                                           ]]]
+                                                           [
+                                                             ( --vote-redeemer-cbor-file CBOR FILE
+                                                             | --vote-redeemer-file JSON FILE
+                                                             | --vote-redeemer-value JSON VALUE
+                                                             )
+                                                             --vote-execution-units (INT, INT)]]]
                                                        [--proposal-file FILE
                                                          [--proposal-script-file FILE
-                                                           [ --proposal-redeemer-cbor-file CBOR FILE
-                                                           | --proposal-redeemer-file JSON FILE
-                                                           | --proposal-redeemer-value JSON VALUE
-                                                           ]]]
+                                                           [
+                                                             ( --proposal-redeemer-cbor-file CBOR FILE
+                                                             | --proposal-redeemer-file JSON FILE
+                                                             | --proposal-redeemer-value JSON VALUE
+                                                             )
+                                                             --proposal-execution-units (INT, INT)]]]
                                                        --out-file FILE
 
   Build a balanced transaction without access to a live node (automatically estimates fees)
@@ -430,6 +434,8 @@ Available options:
                            The script redeemer, in JSON syntax. There is no
                            schema: (almost) any JSON value is supported,
                            including top-level strings and numbers.
+  --vote-execution-units (INT, INT)
+                           The time and space units needed by the script.
   --proposal-file FILE     Filepath of the proposal.
   --proposal-script-file FILE
                            The file containing the script to witness a proposal
@@ -443,5 +449,7 @@ Available options:
                            The script redeemer, in JSON syntax. There is no
                            schema: (almost) any JSON value is supported,
                            including top-level strings and numbers.
+  --proposal-execution-units (INT, INT)
+                           The time and space units needed by the script.
   --out-file FILE          Output filepath of the JSON TxBody.
   -h,--help                Show this help text


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Enable manual specification of execution units for plutus voting and proposing scripts
# uncomment types applicable to the change:
  type:
  - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Additional context for the PR goes here. If the PR fixes a particular issue please provide a [link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=) to the issue.

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!-- 
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you. 
-->
