### PR TITLE
Export friendly function that returns ByteString + export buildShelleyAddress

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Address.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Address.hs
@@ -10,6 +10,7 @@ module Cardano.CLI.EraBased.Run.Address
   , runAddressBuildCmd
   , runAddressKeyGenCmd
   , runAddressKeyHashCmd
+  , buildShelleyAddress
   , generateAndWriteKeyFiles
   ) where
 


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Export friendly function that returns ByteString + export buildShelleyAddress
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

* Continuation of https://github.com/IntersectMBO/cardano-cli/pull/745
* Required for updating [input-output-hk/cardano-faucet](https://github.com/input-output-hk/cardano-faucet) to cardano-cli 8.22.0.0 and cardano-api 8.44.0.0

# How to trust this PR

* Look at the prototype of `friendlyBS`, notice it plays well with the newly exported `*Impl` functions

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] Self-reviewed the diff