### PR TITLE
Release 8.23.0.0 + upgrade cardano-api to 8.45.2.0

### DIFF
--- a/.github/workflows/release-upload.yaml
+++ b/.github/workflows/release-upload.yaml
@@ -58,6 +58,10 @@ jobs:
       DRY_RUN:    ${{ steps.store_target_tag.outputs.DRY_RUN }}
       FLAKE_REF:  ${{ steps.define_flake_ref.outputs.FLAKE_REF }}
     steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Because the target tag may not be HEAD
+          fetch-tags: true # So that tags are known to git commands
       - name: Define target tag (1/2)
         if: ${{ inputs.target_tag != '' }} # If a tag was specified manually as input, use it
         run: |
@@ -76,6 +80,7 @@ jobs:
         run: |
           if [[ "${{ env.TARGET_TAG }}" == "" ]]
           then
+            # Tag was not specified manually as input, and current commit has no tag.
             echo "Tag not yet defined, using current commit as reference."
             echo "TARGET_TAG=${{ github.ref_name }}" >> "$GITHUB_ENV"
           fi

--- a/.github/workflows/release-upload.yaml
+++ b/.github/workflows/release-upload.yaml
@@ -58,74 +58,74 @@ jobs:
       DRY_RUN:    ${{ steps.store_target_tag.outputs.DRY_RUN }}
       FLAKE_REF:  ${{ steps.define_flake_ref.outputs.FLAKE_REF }}
     steps:
-    - name: Define target tag (1/2)
-      if: ${{ inputs.target_tag != '' }} # If a tag was specified manually as input, use it
-      run: |
-        echo "TARGET_TAG=${{ inputs.target_tag }}" >> "$GITHUB_ENV"
-    - name: Define target tag (2/2)
-      if: ${{ inputs.target_tag == '' }} # If no tag was specified manually as input, take the tag from the current commit
-      run: |
-        current_tag=$(git tag --points-at HEAD | head -n 1)
-        if [[ "$current_tag" != "" ]]
-        then
-          # The workflow runs on a commit that has a tag, use this tag
-          echo "TARGET_TAG=$current_tag" >> "$GITHUB_ENV"
-        fi
-    - name: Default tag if needed and compute dryness
-      id: store_target_tag
-      run: |
-        if [[ "${{ env.TARGET_TAG }}" == "" ]]
-        then
-          echo "Tag not yet defined, using current commit as reference."
-          echo "TARGET_TAG=${{ github.ref_name }}" >> "$GITHUB_ENV"
-        fi
-        if [[ $(git tag --points-at ${{ env.TARGET_TAG }} | wc -l) == "0" ]]
-        then
-          echo "Run targets a commit that has no attached tag: no release will be published."
-          echo "DRY_RUN=true" >> "$GITHUB_OUTPUT"
-        else
-          echo "DRY_RUN=false" >> "$GITHUB_OUTPUT"
-        fi
-    - name: Define FLAKE_REF
-      id: define_flake_ref
-      run: |
-        flake_ref="github:${{ github.repository }}/${{ env.TARGET_TAG }}"
-        echo "FLAKE_REF=$flake_ref" >> "$GITHUB_ENV"
-        echo "FLAKE_REF=$flake_ref" >> "$GITHUB_OUTPUT"
-    - name: Get specific check run status
-      timeout-minutes: 120
-      run: |
-        while true; do
-          conclusion=$(gh api "repos/$GITHUB_REPOSITORY/commits/${{ env.TARGET_TAG }}/check-runs" --jq '.check_runs[] | select(.name | test("ci/hydra-build:.*\\.required")) | .conclusion')
-          # Here we are being careful, because we query the status of multiple jobs (once per line)
-          # But the only thing we are sure is that "success" means a green job. There
-          # could be unknown statuses, which is why we may retry when unsure (see 'sleep') below.
-          echo "ci/hydra-build:.*\\.required returned status: $conclusion"
-          # conclusion is of the form (note the newlines, which matter because we use 'wc -l' below)
-          # success
-          # failure
-          # success
-          # Because we care of the newlines, quoting $conclusion with "" is especially important below!
-          # (see https://stackoverflow.com/questions/22101778/how-to-preserve-line-breaks-when-storing-command-output-to-a-variable)
-
-          # shellcheck disable=SC2126
-          nb_failure=$(echo "$conclusion" | grep "^failure" | wc -l)
-          nb_statuses=$(echo "$conclusion" | wc -l)
-          # shellcheck disable=SC2126
-          nb_success=$(echo  "$conclusion" | grep "^success" | wc -l)
-          echo "nb_failure=$nb_failure nb_statuses=$nb_statuses nb_success=$nb_success"
-          if [[ "$nb_failure" != "0" ]]; then
-            echo "ci/hydra-build:required failed"
-            exit 1
-          elif [[ "$nb_statuses" == "$nb_success" ]]; then
-            echo "ci/hydra-build:required succeeded"
-            exit 0
-          else
-            # Unclear (some non-failure, non-success)
-            echo "ci/hydra-build:required pending with $conclusion. Waiting 30s..."
-            sleep 30
+      - name: Define target tag (1/2)
+        if: ${{ inputs.target_tag != '' }} # If a tag was specified manually as input, use it
+        run: |
+          echo "TARGET_TAG=${{ inputs.target_tag }}" >> "$GITHUB_ENV"
+      - name: Define target tag (2/2)
+        if: ${{ inputs.target_tag == '' }} # If no tag was specified manually as input, take the tag from the current commit
+        run: |
+          current_tag=$(git tag --points-at HEAD | head -n 1)
+          if [[ "$current_tag" != "" ]]
+          then
+            # The workflow runs on a commit that has a tag, use this tag
+            echo "TARGET_TAG=$current_tag" >> "$GITHUB_ENV"
           fi
-        done
+      - name: Default tag if needed and compute dryness
+        id: store_target_tag
+        run: |
+          if [[ "${{ env.TARGET_TAG }}" == "" ]]
+          then
+            echo "Tag not yet defined, using current commit as reference."
+            echo "TARGET_TAG=${{ github.ref_name }}" >> "$GITHUB_ENV"
+          fi
+          if [[ $(git tag --points-at ${{ env.TARGET_TAG }} | wc -l) == "0" ]]
+          then
+            echo "Run targets a commit that has no attached tag: no release will be published."
+            echo "DRY_RUN=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "DRY_RUN=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Define FLAKE_REF
+        id: define_flake_ref
+        run: |
+          flake_ref="github:${{ github.repository }}/${{ env.TARGET_TAG }}"
+          echo "FLAKE_REF=$flake_ref" >> "$GITHUB_ENV"
+          echo "FLAKE_REF=$flake_ref" >> "$GITHUB_OUTPUT"
+      - name: Get specific check run status
+        timeout-minutes: 120
+        run: |
+          while true; do
+            conclusion=$(gh api "repos/$GITHUB_REPOSITORY/commits/${{ env.TARGET_TAG }}/check-runs" --jq '.check_runs[] | select(.name | test("ci/hydra-build:.*\\.required")) | .conclusion')
+            # Here we are being careful, because we query the status of multiple jobs (once per line)
+            # But the only thing we are sure is that "success" means a green job. There
+            # could be unknown statuses, which is why we may retry when unsure (see 'sleep') below.
+            echo "ci/hydra-build:.*\\.required returned status: $conclusion"
+            # conclusion is of the form (note the newlines, which matter because we use 'wc -l' below)
+            # success
+            # failure
+            # success
+            # Because we care of the newlines, quoting $conclusion with "" is especially important below!
+            # (see https://stackoverflow.com/questions/22101778/how-to-preserve-line-breaks-when-storing-command-output-to-a-variable)
+  
+            # shellcheck disable=SC2126
+            nb_failure=$(echo "$conclusion" | grep "^failure" | wc -l)
+            nb_statuses=$(echo "$conclusion" | wc -l)
+            # shellcheck disable=SC2126
+            nb_success=$(echo  "$conclusion" | grep "^success" | wc -l)
+            echo "nb_failure=$nb_failure nb_statuses=$nb_statuses nb_success=$nb_success"
+            if [[ "$nb_failure" != "0" ]]; then
+              echo "ci/hydra-build:required failed"
+              exit 1
+            elif [[ "$nb_statuses" == "$nb_success" ]]; then
+              echo "ci/hydra-build:required succeeded"
+              exit 0
+            else
+              # Unclear (some non-failure, non-success)
+              echo "ci/hydra-build:required pending with $conclusion. Waiting 30s..."
+              sleep 30
+            fi
+          done
     
   pull:
     needs: [wait_for_hydra]

--- a/.github/workflows/release-upload.yaml
+++ b/.github/workflows/release-upload.yaml
@@ -91,6 +91,7 @@ jobs:
           else
             echo "DRY_RUN=false" >> "$GITHUB_OUTPUT"
           fi
+          echo "TARGET_TAG=${{ env.TARGET_TAG }}" >> "$GITHUB_OUTPUT"
       - name: Define FLAKE_REF
         id: define_flake_ref
         run: |

--- a/cabal.project
+++ b/cabal.project
@@ -13,8 +13,9 @@ repository cardano-haskell-packages
 -- See CONTRIBUTING for information about these, including some Nix commands
 -- you need to run if you change them
 index-state:
-  , hackage.haskell.org 2024-04-15T08:36:34Z
-  , cardano-haskell-packages 	2024-04-24T22:24:37Z
+  , hackage.haskell.org 2024-05-02T11:03:23Z
+  , cardano-haskell-packages 2024-05-03T12:56:13Z
+
 packages:
   cardano-cli
 

--- a/cardano-cli/CHANGELOG.md
+++ b/cardano-cli/CHANGELOG.md
@@ -1,5 +1,56 @@
 # Changelog for cardano-cli
 
+## 8.23.0.0
+
+- Introduces the `governance action create-hardfork` cmd.
+  (feature, test)
+  [PR 746](https://github.com/IntersectMBO/cardano-cli/pull/746)
+
+- Export friendly function that returns ByteString + export buildShelleyAddress
+  (compatible)
+  [PR 748](https://github.com/IntersectMBO/cardano-cli/pull/748)
+
+- Export toTxOutInAnyEra
+  (compatible)
+  [PR 745](https://github.com/IntersectMBO/cardano-cli/pull/745)
+
+- Enable manual specification of execution units for plutus voting and proposing scripts
+  (feature, breaking)
+  [PR 744](https://github.com/IntersectMBO/cardano-cli/pull/744)
+
+- query stake-distribution: add --output-{json,text} flags
+  (feature, breaking)
+  [PR 743](https://github.com/IntersectMBO/cardano-cli/pull/743)
+
+- Introduce new `cardano-cli latest transaction build-estimate` command which will
+  produce a balanced transaction body without requiring a connection to a live node
+  (feature)
+  [PR 728](https://github.com/IntersectMBO/cardano-cli/pull/728)
+
+- Add `minFeeRefScriptCostPerByte`  to create-protocol-parameter-update governance action command.
+  (feature)
+  [PR 736](https://github.com/IntersectMBO/cardano-cli/pull/736)
+
+- Fixed misunderstanding in generated README file by `genesis create-testnet-data`.
+  (bugfix)
+  [PR 726](https://github.com/IntersectMBO/cardano-cli/pull/726)
+
+- conway governance committe key-hash: support extended CC keys
+  (feature, compatible, bugfix)
+  [PR 717](https://github.com/IntersectMBO/cardano-cli/pull/717)
+
+- Defaulted `calculate-min-fee --reference-script-size`'s value to `0`
+  (improvement)
+  [PR 716](https://github.com/IntersectMBO/cardano-cli/pull/716)
+
+- Enable both `--cold-script-file` and `--cold-script-hash` for `governance committee create-hot-key-authorization-certificate` and `committee create-cold-key-resignation-certificate`
+  (feature, compatible)
+  [PR 699](https://github.com/IntersectMBO/cardano-cli/pull/699)
+
+- Fixed `--include-stake` behavior in `query drep-state`
+  (breaking, bugfix)
+  [PR 698](https://github.com/IntersectMBO/cardano-cli/pull/698)
+
 ## 8.22.0.0
 
 - Add `ref-script-size` query command

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -196,7 +196,7 @@ library
                       , binary
                       , bytestring
                       , canonical-json
-                      , cardano-api ^>= 8.45.1.0
+                      , cardano-api ^>= 8.45.2.0
                       , cardano-binary
                       , cardano-crypto
                       , cardano-crypto-class ^>= 2.1.2

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.4
 
 name:                   cardano-cli
-version:                8.22.0.0
+version:                8.23.0.0
 synopsis:               The Cardano command-line interface
 description:            The Cardano command-line interface.
 copyright:              2020-2023 Input Output Global Inc (IOG).

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1714001377,
-        "narHash": "sha256-FElLa99dH+HzG3tUkotgJhEB2T/ooyaIb5qwum/x8UE=",
+        "lastModified": 1714749809,
+        "narHash": "sha256-lIIwnXo+h0z5omBWTCe/FWsEcjpC50VfqO4TOwUFO00=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "a2e6e0cf123e35bc643ab2f33fcb5c4df5a8abe7",
+        "rev": "25684d60a9c139abc1c03b6938125f48f5996769",
         "type": "github"
       },
       "original": {
@@ -210,11 +210,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1713399842,
-        "narHash": "sha256-e2WgMXaoos+dJld+KcntBMqnS4tqtlKnXBFC+4KTuyA=",
+        "lastModified": 1714695883,
+        "narHash": "sha256-pWbXVMYs+EGX1n5obgey83gBswswK9/v/GtprhsdKWo=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "db08c82c5085b992f88f1dc48ab543b347496653",
+        "rev": "ee66164518012ffbf0e939c5ef65e4162137d947",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Release 8.23.0.0
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - improvement    # QoL changes e.g. refactoring
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

* Required for https://github.com/input-output-hk/cardano-faucet/pull/10
* Corresponding CHaP PR: https://github.com/IntersectMBO/cardano-haskell-packages/pull/754
* Corresponding GH release: https://github.com/IntersectMBO/cardano-cli/releases/tag/untagged-f4af8597894b0d9acbf1

# How to trust this PR (for the CI change)

:warning: You need to review the two CI-changing commits separately, because the first one fixes indentation, so it shows a big diff, but really it isn't :warning: 

When the release pipeline ran on the tagged commit here: 

![image](https://github.com/IntersectMBO/cardano-cli/assets/634720/871b80a7-4489-425f-87e9-583bad36100a)

It failed silently during the first steps, because the repo was not checked out yet:

![image](https://github.com/IntersectMBO/cardano-cli/assets/634720/c4a88a68-575a-484d-8baa-ea37703c68f0)

If you go to a later run (albeit triggered manually, because the HEAD wasn't the tag anymore), you can see the same step not failing anymore:

![image](https://github.com/IntersectMBO/cardano-cli/assets/634720/597267ce-1310-44af-9037-5867717f4907)
