### PR TITLE
Clarify help texts related to JSON and CBOR

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Transaction.hs
@@ -342,8 +342,8 @@ pTxHashScriptData =
     TransactionHashScriptDataCmdArgs
       <$> pScriptDataOrFile
             "script-data"
-            "The script data, in JSON syntax."
-            "The script data, in the given JSON file."
+            "The script data."
+            "The script data file."
 
 pTransactionId  :: Parser (TransactionCmds era)
 pTransactionId =

--- a/cardano-cli/src/Cardano/CLI/Legacy/Options.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Options.hs
@@ -435,8 +435,8 @@ pTransaction envCli =
     fmap TransactionHashScriptDataCmd
       $ pScriptDataOrFile
           "script-data"
-          "The script data, in JSON syntax."
-          "The script data, in the given JSON file."
+          "The script data."
+          "The script data file."
 
   pTransactionId  :: Parser LegacyTransactionCmds
   pTransactionId =

--- a/cardano-cli/src/Cardano/CLI/Read.hs
+++ b/cardano-cli/src/Cardano/CLI/Read.hs
@@ -385,7 +385,7 @@ renderScriptDataError = \case
     "Error validating script data at: " <> pshow fp <> ":\n" <> prettyError sDataRangeErr
   ScriptDataErrorMetadataDecode fp decoderErr->
     "Error decoding CBOR metadata at: " <> pshow fp <> " Error: " <> pshow decoderErr
-  ScriptDataErrorJsonBytes e->
+  ScriptDataErrorJsonBytes e ->
     prettyError e
 
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -845,27 +845,27 @@ Usage: cardano-cli shelley transaction build-raw
                                                        ( --spending-plutus-script-v2
                                                        | --spending-plutus-script-v3
                                                        )
-                                                       ( --spending-reference-tx-in-datum-cbor-file CBOR FILE
-                                                       | --spending-reference-tx-in-datum-file JSON FILE
-                                                       | --spending-reference-tx-in-datum-value JSON VALUE
+                                                       ( --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                                                       | --spending-reference-tx-in-datum-file JSON_FILE
+                                                       | --spending-reference-tx-in-datum-value JSON_VALUE
                                                        | --spending-reference-tx-in-inline-datum-present
                                                        )
-                                                       ( --spending-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                       | --spending-reference-tx-in-redeemer-file JSON FILE
-                                                       | --spending-reference-tx-in-redeemer-value JSON VALUE
+                                                       ( --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                       | --spending-reference-tx-in-redeemer-file JSON_FILE
+                                                       | --spending-reference-tx-in-redeemer-value JSON_VALUE
                                                        )
                                                        --spending-reference-tx-in-execution-units (INT, INT)
                                                      | --simple-script-tx-in-reference TX-IN
                                                      | --tx-in-script-file FILE
                                                        [
-                                                         ( --tx-in-datum-cbor-file CBOR FILE
-                                                         | --tx-in-datum-file JSON FILE
-                                                         | --tx-in-datum-value JSON VALUE
+                                                         ( --tx-in-datum-cbor-file CBOR_FILE
+                                                         | --tx-in-datum-file JSON_FILE
+                                                         | --tx-in-datum-value JSON_VALUE
                                                          | --tx-in-inline-datum-present
                                                          )
-                                                         ( --tx-in-redeemer-cbor-file CBOR FILE
-                                                         | --tx-in-redeemer-file JSON FILE
-                                                         | --tx-in-redeemer-value JSON VALUE
+                                                         ( --tx-in-redeemer-cbor-file CBOR_FILE
+                                                         | --tx-in-redeemer-file JSON_FILE
+                                                         | --tx-in-redeemer-value JSON_VALUE
                                                          )
                                                          --tx-in-execution-units (INT, INT)]
                                                      ])
@@ -878,23 +878,23 @@ Usage: cardano-cli shelley transaction build-raw
                                                    ]
                                                    [--tx-out ADDRESS VALUE
                                                      [ --tx-out-datum-hash HASH
-                                                     | --tx-out-datum-hash-cbor-file CBOR FILE
-                                                     | --tx-out-datum-hash-file JSON FILE
-                                                     | --tx-out-datum-hash-value JSON VALUE
-                                                     | --tx-out-datum-embed-cbor-file CBOR FILE
-                                                     | --tx-out-datum-embed-file JSON FILE
-                                                     | --tx-out-datum-embed-value JSON VALUE
-                                                     | --tx-out-inline-datum-cbor-file CBOR FILE
-                                                     | --tx-out-inline-datum-file JSON FILE
-                                                     | --tx-out-inline-datum-value JSON VALUE
+                                                     | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                     | --tx-out-datum-hash-file JSON_FILE
+                                                     | --tx-out-datum-hash-value JSON_VALUE
+                                                     | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                     | --tx-out-datum-embed-file JSON_FILE
+                                                     | --tx-out-datum-embed-value JSON_VALUE
+                                                     | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                     | --tx-out-inline-datum-file JSON_FILE
+                                                     | --tx-out-inline-datum-value JSON_VALUE
                                                      ]
                                                      [--tx-out-reference-script-file FILE]]
                                                    [--mint VALUE
                                                      ( --mint-script-file FILE
                                                        [
-                                                         ( --mint-redeemer-cbor-file CBOR FILE
-                                                         | --mint-redeemer-file JSON FILE
-                                                         | --mint-redeemer-value JSON VALUE
+                                                         ( --mint-redeemer-cbor-file CBOR_FILE
+                                                         | --mint-redeemer-file JSON_FILE
+                                                         | --mint-redeemer-value JSON_VALUE
                                                          )
                                                          --mint-execution-units (INT, INT)]
                                                      | --simple-minting-script-tx-in-reference TX-IN
@@ -903,9 +903,9 @@ Usage: cardano-cli shelley transaction build-raw
                                                        ( --mint-plutus-script-v2
                                                        | --mint-plutus-script-v3
                                                        )
-                                                       ( --mint-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                       | --mint-reference-tx-in-redeemer-file JSON FILE
-                                                       | --mint-reference-tx-in-redeemer-value JSON VALUE
+                                                       ( --mint-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                       | --mint-reference-tx-in-redeemer-file JSON_FILE
+                                                       | --mint-reference-tx-in-redeemer-value JSON_VALUE
                                                        )
                                                        --mint-reference-tx-in-execution-units (INT, INT)
                                                        --policy-id HASH
@@ -916,36 +916,36 @@ Usage: cardano-cli shelley transaction build-raw
                                                    [--certificate-file FILE
                                                      [ --certificate-script-file FILE
                                                        [
-                                                         ( --certificate-redeemer-cbor-file CBOR FILE
-                                                         | --certificate-redeemer-file JSON FILE
-                                                         | --certificate-redeemer-value JSON VALUE
+                                                         ( --certificate-redeemer-cbor-file CBOR_FILE
+                                                         | --certificate-redeemer-file JSON_FILE
+                                                         | --certificate-redeemer-value JSON_VALUE
                                                          )
                                                          --certificate-execution-units (INT, INT)]
                                                      | --certificate-tx-in-reference TX-IN
                                                        ( --certificate-plutus-script-v2
                                                        | --certificate-plutus-script-v3
                                                        )
-                                                       ( --certificate-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                       | --certificate-reference-tx-in-redeemer-file JSON FILE
-                                                       | --certificate-reference-tx-in-redeemer-value JSON VALUE
+                                                       ( --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                       | --certificate-reference-tx-in-redeemer-file JSON_FILE
+                                                       | --certificate-reference-tx-in-redeemer-value JSON_VALUE
                                                        )
                                                        --certificate-reference-tx-in-execution-units (INT, INT)
                                                      ]]
                                                    [--withdrawal WITHDRAWAL
                                                      [ --withdrawal-script-file FILE
                                                        [
-                                                         ( --withdrawal-redeemer-cbor-file CBOR FILE
-                                                         | --withdrawal-redeemer-file JSON FILE
-                                                         | --withdrawal-redeemer-value JSON VALUE
+                                                         ( --withdrawal-redeemer-cbor-file CBOR_FILE
+                                                         | --withdrawal-redeemer-file JSON_FILE
+                                                         | --withdrawal-redeemer-value JSON_VALUE
                                                          )
                                                          --withdrawal-execution-units (INT, INT)]
                                                      | --withdrawal-tx-in-reference TX-IN
                                                        ( --withdrawal-plutus-script-v2
                                                        | --withdrawal-plutus-script-v3
                                                        )
-                                                       ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                       | --withdrawal-reference-tx-in-redeemer-file JSON FILE
-                                                       | --withdrawal-reference-tx-in-redeemer-value JSON VALUE
+                                                       ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                       | --withdrawal-reference-tx-in-redeemer-file JSON_FILE
+                                                       | --withdrawal-reference-tx-in-redeemer-value JSON_VALUE
                                                        )
                                                        --withdrawal-reference-tx-in-execution-units (INT, INT)
                                                      ]]
@@ -979,26 +979,26 @@ Usage: cardano-cli shelley transaction build --socket-path SOCKET_PATH
                                                    ( --spending-plutus-script-v2
                                                    | --spending-plutus-script-v3
                                                    )
-                                                   ( --spending-reference-tx-in-datum-cbor-file CBOR FILE
-                                                   | --spending-reference-tx-in-datum-file JSON FILE
-                                                   | --spending-reference-tx-in-datum-value JSON VALUE
+                                                   ( --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                                                   | --spending-reference-tx-in-datum-file JSON_FILE
+                                                   | --spending-reference-tx-in-datum-value JSON_VALUE
                                                    | --spending-reference-tx-in-inline-datum-present
                                                    )
-                                                   ( --spending-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                   | --spending-reference-tx-in-redeemer-file JSON FILE
-                                                   | --spending-reference-tx-in-redeemer-value JSON VALUE
+                                                   ( --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                   | --spending-reference-tx-in-redeemer-file JSON_FILE
+                                                   | --spending-reference-tx-in-redeemer-value JSON_VALUE
                                                    )
                                                  | --simple-script-tx-in-reference TX-IN
                                                  | --tx-in-script-file FILE
                                                    [
-                                                     ( --tx-in-datum-cbor-file CBOR FILE
-                                                     | --tx-in-datum-file JSON FILE
-                                                     | --tx-in-datum-value JSON VALUE
+                                                     ( --tx-in-datum-cbor-file CBOR_FILE
+                                                     | --tx-in-datum-file JSON_FILE
+                                                     | --tx-in-datum-value JSON_VALUE
                                                      | --tx-in-inline-datum-present
                                                      )
-                                                     ( --tx-in-redeemer-cbor-file CBOR FILE
-                                                     | --tx-in-redeemer-file JSON FILE
-                                                     | --tx-in-redeemer-value JSON VALUE
+                                                     ( --tx-in-redeemer-cbor-file CBOR_FILE
+                                                     | --tx-in-redeemer-file JSON_FILE
+                                                     | --tx-in-redeemer-value JSON_VALUE
                                                      )]
                                                  ])
                                                [--read-only-tx-in-reference TX-IN]
@@ -1010,23 +1010,23 @@ Usage: cardano-cli shelley transaction build --socket-path SOCKET_PATH
                                                [--tx-total-collateral INTEGER]
                                                [--tx-out ADDRESS VALUE
                                                  [ --tx-out-datum-hash HASH
-                                                 | --tx-out-datum-hash-cbor-file CBOR FILE
-                                                 | --tx-out-datum-hash-file JSON FILE
-                                                 | --tx-out-datum-hash-value JSON VALUE
-                                                 | --tx-out-datum-embed-cbor-file CBOR FILE
-                                                 | --tx-out-datum-embed-file JSON FILE
-                                                 | --tx-out-datum-embed-value JSON VALUE
-                                                 | --tx-out-inline-datum-cbor-file CBOR FILE
-                                                 | --tx-out-inline-datum-file JSON FILE
-                                                 | --tx-out-inline-datum-value JSON VALUE
+                                                 | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                 | --tx-out-datum-hash-file JSON_FILE
+                                                 | --tx-out-datum-hash-value JSON_VALUE
+                                                 | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                 | --tx-out-datum-embed-file JSON_FILE
+                                                 | --tx-out-datum-embed-value JSON_VALUE
+                                                 | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                 | --tx-out-inline-datum-file JSON_FILE
+                                                 | --tx-out-inline-datum-value JSON_VALUE
                                                  ]
                                                  [--tx-out-reference-script-file FILE]]
                                                --change-address ADDRESS
                                                [--mint VALUE
                                                  ( --mint-script-file FILE
-                                                   [ --mint-redeemer-cbor-file CBOR FILE
-                                                   | --mint-redeemer-file JSON FILE
-                                                   | --mint-redeemer-value JSON VALUE
+                                                   [ --mint-redeemer-cbor-file CBOR_FILE
+                                                   | --mint-redeemer-file JSON_FILE
+                                                   | --mint-redeemer-value JSON_VALUE
                                                    ]
                                                  | --simple-minting-script-tx-in-reference TX-IN
                                                    --policy-id HASH
@@ -1034,9 +1034,9 @@ Usage: cardano-cli shelley transaction build --socket-path SOCKET_PATH
                                                    ( --mint-plutus-script-v2
                                                    | --mint-plutus-script-v3
                                                    )
-                                                   ( --mint-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                   | --mint-reference-tx-in-redeemer-file JSON FILE
-                                                   | --mint-reference-tx-in-redeemer-value JSON VALUE
+                                                   ( --mint-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                   | --mint-reference-tx-in-redeemer-file JSON_FILE
+                                                   | --mint-reference-tx-in-redeemer-value JSON_VALUE
                                                    )
                                                    --policy-id HASH
                                                  )]
@@ -1044,32 +1044,32 @@ Usage: cardano-cli shelley transaction build --socket-path SOCKET_PATH
                                                [--invalid-hereafter SLOT]
                                                [--certificate-file FILE
                                                  [ --certificate-script-file FILE
-                                                   [ --certificate-redeemer-cbor-file CBOR FILE
-                                                   | --certificate-redeemer-file JSON FILE
-                                                   | --certificate-redeemer-value JSON VALUE
+                                                   [ --certificate-redeemer-cbor-file CBOR_FILE
+                                                   | --certificate-redeemer-file JSON_FILE
+                                                   | --certificate-redeemer-value JSON_VALUE
                                                    ]
                                                  | --certificate-tx-in-reference TX-IN
                                                    ( --certificate-plutus-script-v2
                                                    | --certificate-plutus-script-v3
                                                    )
-                                                   ( --certificate-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                   | --certificate-reference-tx-in-redeemer-file JSON FILE
-                                                   | --certificate-reference-tx-in-redeemer-value JSON VALUE
+                                                   ( --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                   | --certificate-reference-tx-in-redeemer-file JSON_FILE
+                                                   | --certificate-reference-tx-in-redeemer-value JSON_VALUE
                                                    )
                                                  ]]
                                                [--withdrawal WITHDRAWAL
                                                  [ --withdrawal-script-file FILE
-                                                   [ --withdrawal-redeemer-cbor-file CBOR FILE
-                                                   | --withdrawal-redeemer-file JSON FILE
-                                                   | --withdrawal-redeemer-value JSON VALUE
+                                                   [ --withdrawal-redeemer-cbor-file CBOR_FILE
+                                                   | --withdrawal-redeemer-file JSON_FILE
+                                                   | --withdrawal-redeemer-value JSON_VALUE
                                                    ]
                                                  | --withdrawal-tx-in-reference TX-IN
                                                    ( --withdrawal-plutus-script-v2
                                                    | --withdrawal-plutus-script-v3
                                                    )
-                                                   ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                   | --withdrawal-reference-tx-in-redeemer-file JSON FILE
-                                                   | --withdrawal-reference-tx-in-redeemer-value JSON VALUE
+                                                   ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                   | --withdrawal-reference-tx-in-redeemer-file JSON_FILE
+                                                   | --withdrawal-reference-tx-in-redeemer-value JSON_VALUE
                                                    )
                                                  ]]
                                                [ --json-metadata-no-schema
@@ -1154,15 +1154,15 @@ Usage: cardano-cli shelley transaction calculate-min-fee --tx-body-file FILE
 Usage: cardano-cli shelley transaction calculate-min-required-utxo --protocol-params-file FILE
                                                                      --tx-out ADDRESS VALUE
                                                                      [ --tx-out-datum-hash HASH
-                                                                     | --tx-out-datum-hash-cbor-file CBOR FILE
-                                                                     | --tx-out-datum-hash-file JSON FILE
-                                                                     | --tx-out-datum-hash-value JSON VALUE
-                                                                     | --tx-out-datum-embed-cbor-file CBOR FILE
-                                                                     | --tx-out-datum-embed-file JSON FILE
-                                                                     | --tx-out-datum-embed-value JSON VALUE
-                                                                     | --tx-out-inline-datum-cbor-file CBOR FILE
-                                                                     | --tx-out-inline-datum-file JSON FILE
-                                                                     | --tx-out-inline-datum-value JSON VALUE
+                                                                     | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                                     | --tx-out-datum-hash-file JSON_FILE
+                                                                     | --tx-out-datum-hash-value JSON_VALUE
+                                                                     | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                                     | --tx-out-datum-embed-file JSON_FILE
+                                                                     | --tx-out-datum-embed-value JSON_VALUE
+                                                                     | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                                     | --tx-out-inline-datum-file JSON_FILE
+                                                                     | --tx-out-inline-datum-value JSON_VALUE
                                                                      ]
                                                                      [--tx-out-reference-script-file FILE]
 
@@ -1171,24 +1171,24 @@ Usage: cardano-cli shelley transaction calculate-min-required-utxo --protocol-pa
 Usage: cardano-cli shelley transaction calculate-min-value --protocol-params-file FILE
                                                              --tx-out ADDRESS VALUE
                                                              [ --tx-out-datum-hash HASH
-                                                             | --tx-out-datum-hash-cbor-file CBOR FILE
-                                                             | --tx-out-datum-hash-file JSON FILE
-                                                             | --tx-out-datum-hash-value JSON VALUE
-                                                             | --tx-out-datum-embed-cbor-file CBOR FILE
-                                                             | --tx-out-datum-embed-file JSON FILE
-                                                             | --tx-out-datum-embed-value JSON VALUE
-                                                             | --tx-out-inline-datum-cbor-file CBOR FILE
-                                                             | --tx-out-inline-datum-file JSON FILE
-                                                             | --tx-out-inline-datum-value JSON VALUE
+                                                             | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                             | --tx-out-datum-hash-file JSON_FILE
+                                                             | --tx-out-datum-hash-value JSON_VALUE
+                                                             | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                             | --tx-out-datum-embed-file JSON_FILE
+                                                             | --tx-out-datum-embed-value JSON_VALUE
+                                                             | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                             | --tx-out-inline-datum-file JSON_FILE
+                                                             | --tx-out-inline-datum-value JSON_VALUE
                                                              ]
                                                              [--tx-out-reference-script-file FILE]
 
   DEPRECATED: Use 'calculate-min-required-utxo' instead.
 
 Usage: cardano-cli shelley transaction hash-script-data 
-                                                          ( --script-data-cbor-file CBOR FILE
-                                                          | --script-data-file JSON FILE
-                                                          | --script-data-value JSON VALUE
+                                                          ( --script-data-cbor-file CBOR_FILE
+                                                          | --script-data-file JSON_FILE
+                                                          | --script-data-value JSON_VALUE
                                                           )
 
   Calculate the hash of script data.
@@ -2040,27 +2040,27 @@ Usage: cardano-cli allegra transaction build-raw
                                                        ( --spending-plutus-script-v2
                                                        | --spending-plutus-script-v3
                                                        )
-                                                       ( --spending-reference-tx-in-datum-cbor-file CBOR FILE
-                                                       | --spending-reference-tx-in-datum-file JSON FILE
-                                                       | --spending-reference-tx-in-datum-value JSON VALUE
+                                                       ( --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                                                       | --spending-reference-tx-in-datum-file JSON_FILE
+                                                       | --spending-reference-tx-in-datum-value JSON_VALUE
                                                        | --spending-reference-tx-in-inline-datum-present
                                                        )
-                                                       ( --spending-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                       | --spending-reference-tx-in-redeemer-file JSON FILE
-                                                       | --spending-reference-tx-in-redeemer-value JSON VALUE
+                                                       ( --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                       | --spending-reference-tx-in-redeemer-file JSON_FILE
+                                                       | --spending-reference-tx-in-redeemer-value JSON_VALUE
                                                        )
                                                        --spending-reference-tx-in-execution-units (INT, INT)
                                                      | --simple-script-tx-in-reference TX-IN
                                                      | --tx-in-script-file FILE
                                                        [
-                                                         ( --tx-in-datum-cbor-file CBOR FILE
-                                                         | --tx-in-datum-file JSON FILE
-                                                         | --tx-in-datum-value JSON VALUE
+                                                         ( --tx-in-datum-cbor-file CBOR_FILE
+                                                         | --tx-in-datum-file JSON_FILE
+                                                         | --tx-in-datum-value JSON_VALUE
                                                          | --tx-in-inline-datum-present
                                                          )
-                                                         ( --tx-in-redeemer-cbor-file CBOR FILE
-                                                         | --tx-in-redeemer-file JSON FILE
-                                                         | --tx-in-redeemer-value JSON VALUE
+                                                         ( --tx-in-redeemer-cbor-file CBOR_FILE
+                                                         | --tx-in-redeemer-file JSON_FILE
+                                                         | --tx-in-redeemer-value JSON_VALUE
                                                          )
                                                          --tx-in-execution-units (INT, INT)]
                                                      ])
@@ -2073,23 +2073,23 @@ Usage: cardano-cli allegra transaction build-raw
                                                    ]
                                                    [--tx-out ADDRESS VALUE
                                                      [ --tx-out-datum-hash HASH
-                                                     | --tx-out-datum-hash-cbor-file CBOR FILE
-                                                     | --tx-out-datum-hash-file JSON FILE
-                                                     | --tx-out-datum-hash-value JSON VALUE
-                                                     | --tx-out-datum-embed-cbor-file CBOR FILE
-                                                     | --tx-out-datum-embed-file JSON FILE
-                                                     | --tx-out-datum-embed-value JSON VALUE
-                                                     | --tx-out-inline-datum-cbor-file CBOR FILE
-                                                     | --tx-out-inline-datum-file JSON FILE
-                                                     | --tx-out-inline-datum-value JSON VALUE
+                                                     | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                     | --tx-out-datum-hash-file JSON_FILE
+                                                     | --tx-out-datum-hash-value JSON_VALUE
+                                                     | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                     | --tx-out-datum-embed-file JSON_FILE
+                                                     | --tx-out-datum-embed-value JSON_VALUE
+                                                     | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                     | --tx-out-inline-datum-file JSON_FILE
+                                                     | --tx-out-inline-datum-value JSON_VALUE
                                                      ]
                                                      [--tx-out-reference-script-file FILE]]
                                                    [--mint VALUE
                                                      ( --mint-script-file FILE
                                                        [
-                                                         ( --mint-redeemer-cbor-file CBOR FILE
-                                                         | --mint-redeemer-file JSON FILE
-                                                         | --mint-redeemer-value JSON VALUE
+                                                         ( --mint-redeemer-cbor-file CBOR_FILE
+                                                         | --mint-redeemer-file JSON_FILE
+                                                         | --mint-redeemer-value JSON_VALUE
                                                          )
                                                          --mint-execution-units (INT, INT)]
                                                      | --simple-minting-script-tx-in-reference TX-IN
@@ -2098,9 +2098,9 @@ Usage: cardano-cli allegra transaction build-raw
                                                        ( --mint-plutus-script-v2
                                                        | --mint-plutus-script-v3
                                                        )
-                                                       ( --mint-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                       | --mint-reference-tx-in-redeemer-file JSON FILE
-                                                       | --mint-reference-tx-in-redeemer-value JSON VALUE
+                                                       ( --mint-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                       | --mint-reference-tx-in-redeemer-file JSON_FILE
+                                                       | --mint-reference-tx-in-redeemer-value JSON_VALUE
                                                        )
                                                        --mint-reference-tx-in-execution-units (INT, INT)
                                                        --policy-id HASH
@@ -2111,36 +2111,36 @@ Usage: cardano-cli allegra transaction build-raw
                                                    [--certificate-file FILE
                                                      [ --certificate-script-file FILE
                                                        [
-                                                         ( --certificate-redeemer-cbor-file CBOR FILE
-                                                         | --certificate-redeemer-file JSON FILE
-                                                         | --certificate-redeemer-value JSON VALUE
+                                                         ( --certificate-redeemer-cbor-file CBOR_FILE
+                                                         | --certificate-redeemer-file JSON_FILE
+                                                         | --certificate-redeemer-value JSON_VALUE
                                                          )
                                                          --certificate-execution-units (INT, INT)]
                                                      | --certificate-tx-in-reference TX-IN
                                                        ( --certificate-plutus-script-v2
                                                        | --certificate-plutus-script-v3
                                                        )
-                                                       ( --certificate-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                       | --certificate-reference-tx-in-redeemer-file JSON FILE
-                                                       | --certificate-reference-tx-in-redeemer-value JSON VALUE
+                                                       ( --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                       | --certificate-reference-tx-in-redeemer-file JSON_FILE
+                                                       | --certificate-reference-tx-in-redeemer-value JSON_VALUE
                                                        )
                                                        --certificate-reference-tx-in-execution-units (INT, INT)
                                                      ]]
                                                    [--withdrawal WITHDRAWAL
                                                      [ --withdrawal-script-file FILE
                                                        [
-                                                         ( --withdrawal-redeemer-cbor-file CBOR FILE
-                                                         | --withdrawal-redeemer-file JSON FILE
-                                                         | --withdrawal-redeemer-value JSON VALUE
+                                                         ( --withdrawal-redeemer-cbor-file CBOR_FILE
+                                                         | --withdrawal-redeemer-file JSON_FILE
+                                                         | --withdrawal-redeemer-value JSON_VALUE
                                                          )
                                                          --withdrawal-execution-units (INT, INT)]
                                                      | --withdrawal-tx-in-reference TX-IN
                                                        ( --withdrawal-plutus-script-v2
                                                        | --withdrawal-plutus-script-v3
                                                        )
-                                                       ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                       | --withdrawal-reference-tx-in-redeemer-file JSON FILE
-                                                       | --withdrawal-reference-tx-in-redeemer-value JSON VALUE
+                                                       ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                       | --withdrawal-reference-tx-in-redeemer-file JSON_FILE
+                                                       | --withdrawal-reference-tx-in-redeemer-value JSON_VALUE
                                                        )
                                                        --withdrawal-reference-tx-in-execution-units (INT, INT)
                                                      ]]
@@ -2174,26 +2174,26 @@ Usage: cardano-cli allegra transaction build --socket-path SOCKET_PATH
                                                    ( --spending-plutus-script-v2
                                                    | --spending-plutus-script-v3
                                                    )
-                                                   ( --spending-reference-tx-in-datum-cbor-file CBOR FILE
-                                                   | --spending-reference-tx-in-datum-file JSON FILE
-                                                   | --spending-reference-tx-in-datum-value JSON VALUE
+                                                   ( --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                                                   | --spending-reference-tx-in-datum-file JSON_FILE
+                                                   | --spending-reference-tx-in-datum-value JSON_VALUE
                                                    | --spending-reference-tx-in-inline-datum-present
                                                    )
-                                                   ( --spending-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                   | --spending-reference-tx-in-redeemer-file JSON FILE
-                                                   | --spending-reference-tx-in-redeemer-value JSON VALUE
+                                                   ( --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                   | --spending-reference-tx-in-redeemer-file JSON_FILE
+                                                   | --spending-reference-tx-in-redeemer-value JSON_VALUE
                                                    )
                                                  | --simple-script-tx-in-reference TX-IN
                                                  | --tx-in-script-file FILE
                                                    [
-                                                     ( --tx-in-datum-cbor-file CBOR FILE
-                                                     | --tx-in-datum-file JSON FILE
-                                                     | --tx-in-datum-value JSON VALUE
+                                                     ( --tx-in-datum-cbor-file CBOR_FILE
+                                                     | --tx-in-datum-file JSON_FILE
+                                                     | --tx-in-datum-value JSON_VALUE
                                                      | --tx-in-inline-datum-present
                                                      )
-                                                     ( --tx-in-redeemer-cbor-file CBOR FILE
-                                                     | --tx-in-redeemer-file JSON FILE
-                                                     | --tx-in-redeemer-value JSON VALUE
+                                                     ( --tx-in-redeemer-cbor-file CBOR_FILE
+                                                     | --tx-in-redeemer-file JSON_FILE
+                                                     | --tx-in-redeemer-value JSON_VALUE
                                                      )]
                                                  ])
                                                [--read-only-tx-in-reference TX-IN]
@@ -2205,23 +2205,23 @@ Usage: cardano-cli allegra transaction build --socket-path SOCKET_PATH
                                                [--tx-total-collateral INTEGER]
                                                [--tx-out ADDRESS VALUE
                                                  [ --tx-out-datum-hash HASH
-                                                 | --tx-out-datum-hash-cbor-file CBOR FILE
-                                                 | --tx-out-datum-hash-file JSON FILE
-                                                 | --tx-out-datum-hash-value JSON VALUE
-                                                 | --tx-out-datum-embed-cbor-file CBOR FILE
-                                                 | --tx-out-datum-embed-file JSON FILE
-                                                 | --tx-out-datum-embed-value JSON VALUE
-                                                 | --tx-out-inline-datum-cbor-file CBOR FILE
-                                                 | --tx-out-inline-datum-file JSON FILE
-                                                 | --tx-out-inline-datum-value JSON VALUE
+                                                 | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                 | --tx-out-datum-hash-file JSON_FILE
+                                                 | --tx-out-datum-hash-value JSON_VALUE
+                                                 | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                 | --tx-out-datum-embed-file JSON_FILE
+                                                 | --tx-out-datum-embed-value JSON_VALUE
+                                                 | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                 | --tx-out-inline-datum-file JSON_FILE
+                                                 | --tx-out-inline-datum-value JSON_VALUE
                                                  ]
                                                  [--tx-out-reference-script-file FILE]]
                                                --change-address ADDRESS
                                                [--mint VALUE
                                                  ( --mint-script-file FILE
-                                                   [ --mint-redeemer-cbor-file CBOR FILE
-                                                   | --mint-redeemer-file JSON FILE
-                                                   | --mint-redeemer-value JSON VALUE
+                                                   [ --mint-redeemer-cbor-file CBOR_FILE
+                                                   | --mint-redeemer-file JSON_FILE
+                                                   | --mint-redeemer-value JSON_VALUE
                                                    ]
                                                  | --simple-minting-script-tx-in-reference TX-IN
                                                    --policy-id HASH
@@ -2229,9 +2229,9 @@ Usage: cardano-cli allegra transaction build --socket-path SOCKET_PATH
                                                    ( --mint-plutus-script-v2
                                                    | --mint-plutus-script-v3
                                                    )
-                                                   ( --mint-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                   | --mint-reference-tx-in-redeemer-file JSON FILE
-                                                   | --mint-reference-tx-in-redeemer-value JSON VALUE
+                                                   ( --mint-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                   | --mint-reference-tx-in-redeemer-file JSON_FILE
+                                                   | --mint-reference-tx-in-redeemer-value JSON_VALUE
                                                    )
                                                    --policy-id HASH
                                                  )]
@@ -2239,32 +2239,32 @@ Usage: cardano-cli allegra transaction build --socket-path SOCKET_PATH
                                                [--invalid-hereafter SLOT]
                                                [--certificate-file FILE
                                                  [ --certificate-script-file FILE
-                                                   [ --certificate-redeemer-cbor-file CBOR FILE
-                                                   | --certificate-redeemer-file JSON FILE
-                                                   | --certificate-redeemer-value JSON VALUE
+                                                   [ --certificate-redeemer-cbor-file CBOR_FILE
+                                                   | --certificate-redeemer-file JSON_FILE
+                                                   | --certificate-redeemer-value JSON_VALUE
                                                    ]
                                                  | --certificate-tx-in-reference TX-IN
                                                    ( --certificate-plutus-script-v2
                                                    | --certificate-plutus-script-v3
                                                    )
-                                                   ( --certificate-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                   | --certificate-reference-tx-in-redeemer-file JSON FILE
-                                                   | --certificate-reference-tx-in-redeemer-value JSON VALUE
+                                                   ( --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                   | --certificate-reference-tx-in-redeemer-file JSON_FILE
+                                                   | --certificate-reference-tx-in-redeemer-value JSON_VALUE
                                                    )
                                                  ]]
                                                [--withdrawal WITHDRAWAL
                                                  [ --withdrawal-script-file FILE
-                                                   [ --withdrawal-redeemer-cbor-file CBOR FILE
-                                                   | --withdrawal-redeemer-file JSON FILE
-                                                   | --withdrawal-redeemer-value JSON VALUE
+                                                   [ --withdrawal-redeemer-cbor-file CBOR_FILE
+                                                   | --withdrawal-redeemer-file JSON_FILE
+                                                   | --withdrawal-redeemer-value JSON_VALUE
                                                    ]
                                                  | --withdrawal-tx-in-reference TX-IN
                                                    ( --withdrawal-plutus-script-v2
                                                    | --withdrawal-plutus-script-v3
                                                    )
-                                                   ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                   | --withdrawal-reference-tx-in-redeemer-file JSON FILE
-                                                   | --withdrawal-reference-tx-in-redeemer-value JSON VALUE
+                                                   ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                   | --withdrawal-reference-tx-in-redeemer-file JSON_FILE
+                                                   | --withdrawal-reference-tx-in-redeemer-value JSON_VALUE
                                                    )
                                                  ]]
                                                [ --json-metadata-no-schema
@@ -2349,15 +2349,15 @@ Usage: cardano-cli allegra transaction calculate-min-fee --tx-body-file FILE
 Usage: cardano-cli allegra transaction calculate-min-required-utxo --protocol-params-file FILE
                                                                      --tx-out ADDRESS VALUE
                                                                      [ --tx-out-datum-hash HASH
-                                                                     | --tx-out-datum-hash-cbor-file CBOR FILE
-                                                                     | --tx-out-datum-hash-file JSON FILE
-                                                                     | --tx-out-datum-hash-value JSON VALUE
-                                                                     | --tx-out-datum-embed-cbor-file CBOR FILE
-                                                                     | --tx-out-datum-embed-file JSON FILE
-                                                                     | --tx-out-datum-embed-value JSON VALUE
-                                                                     | --tx-out-inline-datum-cbor-file CBOR FILE
-                                                                     | --tx-out-inline-datum-file JSON FILE
-                                                                     | --tx-out-inline-datum-value JSON VALUE
+                                                                     | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                                     | --tx-out-datum-hash-file JSON_FILE
+                                                                     | --tx-out-datum-hash-value JSON_VALUE
+                                                                     | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                                     | --tx-out-datum-embed-file JSON_FILE
+                                                                     | --tx-out-datum-embed-value JSON_VALUE
+                                                                     | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                                     | --tx-out-inline-datum-file JSON_FILE
+                                                                     | --tx-out-inline-datum-value JSON_VALUE
                                                                      ]
                                                                      [--tx-out-reference-script-file FILE]
 
@@ -2366,24 +2366,24 @@ Usage: cardano-cli allegra transaction calculate-min-required-utxo --protocol-pa
 Usage: cardano-cli allegra transaction calculate-min-value --protocol-params-file FILE
                                                              --tx-out ADDRESS VALUE
                                                              [ --tx-out-datum-hash HASH
-                                                             | --tx-out-datum-hash-cbor-file CBOR FILE
-                                                             | --tx-out-datum-hash-file JSON FILE
-                                                             | --tx-out-datum-hash-value JSON VALUE
-                                                             | --tx-out-datum-embed-cbor-file CBOR FILE
-                                                             | --tx-out-datum-embed-file JSON FILE
-                                                             | --tx-out-datum-embed-value JSON VALUE
-                                                             | --tx-out-inline-datum-cbor-file CBOR FILE
-                                                             | --tx-out-inline-datum-file JSON FILE
-                                                             | --tx-out-inline-datum-value JSON VALUE
+                                                             | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                             | --tx-out-datum-hash-file JSON_FILE
+                                                             | --tx-out-datum-hash-value JSON_VALUE
+                                                             | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                             | --tx-out-datum-embed-file JSON_FILE
+                                                             | --tx-out-datum-embed-value JSON_VALUE
+                                                             | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                             | --tx-out-inline-datum-file JSON_FILE
+                                                             | --tx-out-inline-datum-value JSON_VALUE
                                                              ]
                                                              [--tx-out-reference-script-file FILE]
 
   DEPRECATED: Use 'calculate-min-required-utxo' instead.
 
 Usage: cardano-cli allegra transaction hash-script-data 
-                                                          ( --script-data-cbor-file CBOR FILE
-                                                          | --script-data-file JSON FILE
-                                                          | --script-data-value JSON VALUE
+                                                          ( --script-data-cbor-file CBOR_FILE
+                                                          | --script-data-file JSON_FILE
+                                                          | --script-data-value JSON_VALUE
                                                           )
 
   Calculate the hash of script data.
@@ -3227,27 +3227,27 @@ Usage: cardano-cli mary transaction build-raw
                                                     ( --spending-plutus-script-v2
                                                     | --spending-plutus-script-v3
                                                     )
-                                                    ( --spending-reference-tx-in-datum-cbor-file CBOR FILE
-                                                    | --spending-reference-tx-in-datum-file JSON FILE
-                                                    | --spending-reference-tx-in-datum-value JSON VALUE
+                                                    ( --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                                                    | --spending-reference-tx-in-datum-file JSON_FILE
+                                                    | --spending-reference-tx-in-datum-value JSON_VALUE
                                                     | --spending-reference-tx-in-inline-datum-present
                                                     )
-                                                    ( --spending-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                    | --spending-reference-tx-in-redeemer-file JSON FILE
-                                                    | --spending-reference-tx-in-redeemer-value JSON VALUE
+                                                    ( --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                    | --spending-reference-tx-in-redeemer-file JSON_FILE
+                                                    | --spending-reference-tx-in-redeemer-value JSON_VALUE
                                                     )
                                                     --spending-reference-tx-in-execution-units (INT, INT)
                                                   | --simple-script-tx-in-reference TX-IN
                                                   | --tx-in-script-file FILE
                                                     [
-                                                      ( --tx-in-datum-cbor-file CBOR FILE
-                                                      | --tx-in-datum-file JSON FILE
-                                                      | --tx-in-datum-value JSON VALUE
+                                                      ( --tx-in-datum-cbor-file CBOR_FILE
+                                                      | --tx-in-datum-file JSON_FILE
+                                                      | --tx-in-datum-value JSON_VALUE
                                                       | --tx-in-inline-datum-present
                                                       )
-                                                      ( --tx-in-redeemer-cbor-file CBOR FILE
-                                                      | --tx-in-redeemer-file JSON FILE
-                                                      | --tx-in-redeemer-value JSON VALUE
+                                                      ( --tx-in-redeemer-cbor-file CBOR_FILE
+                                                      | --tx-in-redeemer-file JSON_FILE
+                                                      | --tx-in-redeemer-value JSON_VALUE
                                                       )
                                                       --tx-in-execution-units (INT, INT)]
                                                   ])
@@ -3260,23 +3260,23 @@ Usage: cardano-cli mary transaction build-raw
                                                 ]
                                                 [--tx-out ADDRESS VALUE
                                                   [ --tx-out-datum-hash HASH
-                                                  | --tx-out-datum-hash-cbor-file CBOR FILE
-                                                  | --tx-out-datum-hash-file JSON FILE
-                                                  | --tx-out-datum-hash-value JSON VALUE
-                                                  | --tx-out-datum-embed-cbor-file CBOR FILE
-                                                  | --tx-out-datum-embed-file JSON FILE
-                                                  | --tx-out-datum-embed-value JSON VALUE
-                                                  | --tx-out-inline-datum-cbor-file CBOR FILE
-                                                  | --tx-out-inline-datum-file JSON FILE
-                                                  | --tx-out-inline-datum-value JSON VALUE
+                                                  | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                  | --tx-out-datum-hash-file JSON_FILE
+                                                  | --tx-out-datum-hash-value JSON_VALUE
+                                                  | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                  | --tx-out-datum-embed-file JSON_FILE
+                                                  | --tx-out-datum-embed-value JSON_VALUE
+                                                  | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                  | --tx-out-inline-datum-file JSON_FILE
+                                                  | --tx-out-inline-datum-value JSON_VALUE
                                                   ]
                                                   [--tx-out-reference-script-file FILE]]
                                                 [--mint VALUE
                                                   ( --mint-script-file FILE
                                                     [
-                                                      ( --mint-redeemer-cbor-file CBOR FILE
-                                                      | --mint-redeemer-file JSON FILE
-                                                      | --mint-redeemer-value JSON VALUE
+                                                      ( --mint-redeemer-cbor-file CBOR_FILE
+                                                      | --mint-redeemer-file JSON_FILE
+                                                      | --mint-redeemer-value JSON_VALUE
                                                       )
                                                       --mint-execution-units (INT, INT)]
                                                   | --simple-minting-script-tx-in-reference TX-IN
@@ -3285,9 +3285,9 @@ Usage: cardano-cli mary transaction build-raw
                                                     ( --mint-plutus-script-v2
                                                     | --mint-plutus-script-v3
                                                     )
-                                                    ( --mint-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                    | --mint-reference-tx-in-redeemer-file JSON FILE
-                                                    | --mint-reference-tx-in-redeemer-value JSON VALUE
+                                                    ( --mint-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                    | --mint-reference-tx-in-redeemer-file JSON_FILE
+                                                    | --mint-reference-tx-in-redeemer-value JSON_VALUE
                                                     )
                                                     --mint-reference-tx-in-execution-units (INT, INT)
                                                     --policy-id HASH
@@ -3298,36 +3298,36 @@ Usage: cardano-cli mary transaction build-raw
                                                 [--certificate-file FILE
                                                   [ --certificate-script-file FILE
                                                     [
-                                                      ( --certificate-redeemer-cbor-file CBOR FILE
-                                                      | --certificate-redeemer-file JSON FILE
-                                                      | --certificate-redeemer-value JSON VALUE
+                                                      ( --certificate-redeemer-cbor-file CBOR_FILE
+                                                      | --certificate-redeemer-file JSON_FILE
+                                                      | --certificate-redeemer-value JSON_VALUE
                                                       )
                                                       --certificate-execution-units (INT, INT)]
                                                   | --certificate-tx-in-reference TX-IN
                                                     ( --certificate-plutus-script-v2
                                                     | --certificate-plutus-script-v3
                                                     )
-                                                    ( --certificate-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                    | --certificate-reference-tx-in-redeemer-file JSON FILE
-                                                    | --certificate-reference-tx-in-redeemer-value JSON VALUE
+                                                    ( --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                    | --certificate-reference-tx-in-redeemer-file JSON_FILE
+                                                    | --certificate-reference-tx-in-redeemer-value JSON_VALUE
                                                     )
                                                     --certificate-reference-tx-in-execution-units (INT, INT)
                                                   ]]
                                                 [--withdrawal WITHDRAWAL
                                                   [ --withdrawal-script-file FILE
                                                     [
-                                                      ( --withdrawal-redeemer-cbor-file CBOR FILE
-                                                      | --withdrawal-redeemer-file JSON FILE
-                                                      | --withdrawal-redeemer-value JSON VALUE
+                                                      ( --withdrawal-redeemer-cbor-file CBOR_FILE
+                                                      | --withdrawal-redeemer-file JSON_FILE
+                                                      | --withdrawal-redeemer-value JSON_VALUE
                                                       )
                                                       --withdrawal-execution-units (INT, INT)]
                                                   | --withdrawal-tx-in-reference TX-IN
                                                     ( --withdrawal-plutus-script-v2
                                                     | --withdrawal-plutus-script-v3
                                                     )
-                                                    ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                    | --withdrawal-reference-tx-in-redeemer-file JSON FILE
-                                                    | --withdrawal-reference-tx-in-redeemer-value JSON VALUE
+                                                    ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                    | --withdrawal-reference-tx-in-redeemer-file JSON_FILE
+                                                    | --withdrawal-reference-tx-in-redeemer-value JSON_VALUE
                                                     )
                                                     --withdrawal-reference-tx-in-execution-units (INT, INT)
                                                   ]]
@@ -3359,26 +3359,26 @@ Usage: cardano-cli mary transaction build --socket-path SOCKET_PATH
                                                 ( --spending-plutus-script-v2
                                                 | --spending-plutus-script-v3
                                                 )
-                                                ( --spending-reference-tx-in-datum-cbor-file CBOR FILE
-                                                | --spending-reference-tx-in-datum-file JSON FILE
-                                                | --spending-reference-tx-in-datum-value JSON VALUE
+                                                ( --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                                                | --spending-reference-tx-in-datum-file JSON_FILE
+                                                | --spending-reference-tx-in-datum-value JSON_VALUE
                                                 | --spending-reference-tx-in-inline-datum-present
                                                 )
-                                                ( --spending-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                | --spending-reference-tx-in-redeemer-file JSON FILE
-                                                | --spending-reference-tx-in-redeemer-value JSON VALUE
+                                                ( --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                | --spending-reference-tx-in-redeemer-file JSON_FILE
+                                                | --spending-reference-tx-in-redeemer-value JSON_VALUE
                                                 )
                                               | --simple-script-tx-in-reference TX-IN
                                               | --tx-in-script-file FILE
                                                 [
-                                                  ( --tx-in-datum-cbor-file CBOR FILE
-                                                  | --tx-in-datum-file JSON FILE
-                                                  | --tx-in-datum-value JSON VALUE
+                                                  ( --tx-in-datum-cbor-file CBOR_FILE
+                                                  | --tx-in-datum-file JSON_FILE
+                                                  | --tx-in-datum-value JSON_VALUE
                                                   | --tx-in-inline-datum-present
                                                   )
-                                                  ( --tx-in-redeemer-cbor-file CBOR FILE
-                                                  | --tx-in-redeemer-file JSON FILE
-                                                  | --tx-in-redeemer-value JSON VALUE
+                                                  ( --tx-in-redeemer-cbor-file CBOR_FILE
+                                                  | --tx-in-redeemer-file JSON_FILE
+                                                  | --tx-in-redeemer-value JSON_VALUE
                                                   )]
                                               ])
                                             [--read-only-tx-in-reference TX-IN]
@@ -3390,23 +3390,23 @@ Usage: cardano-cli mary transaction build --socket-path SOCKET_PATH
                                             [--tx-total-collateral INTEGER]
                                             [--tx-out ADDRESS VALUE
                                               [ --tx-out-datum-hash HASH
-                                              | --tx-out-datum-hash-cbor-file CBOR FILE
-                                              | --tx-out-datum-hash-file JSON FILE
-                                              | --tx-out-datum-hash-value JSON VALUE
-                                              | --tx-out-datum-embed-cbor-file CBOR FILE
-                                              | --tx-out-datum-embed-file JSON FILE
-                                              | --tx-out-datum-embed-value JSON VALUE
-                                              | --tx-out-inline-datum-cbor-file CBOR FILE
-                                              | --tx-out-inline-datum-file JSON FILE
-                                              | --tx-out-inline-datum-value JSON VALUE
+                                              | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                              | --tx-out-datum-hash-file JSON_FILE
+                                              | --tx-out-datum-hash-value JSON_VALUE
+                                              | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                              | --tx-out-datum-embed-file JSON_FILE
+                                              | --tx-out-datum-embed-value JSON_VALUE
+                                              | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                              | --tx-out-inline-datum-file JSON_FILE
+                                              | --tx-out-inline-datum-value JSON_VALUE
                                               ]
                                               [--tx-out-reference-script-file FILE]]
                                             --change-address ADDRESS
                                             [--mint VALUE
                                               ( --mint-script-file FILE
-                                                [ --mint-redeemer-cbor-file CBOR FILE
-                                                | --mint-redeemer-file JSON FILE
-                                                | --mint-redeemer-value JSON VALUE
+                                                [ --mint-redeemer-cbor-file CBOR_FILE
+                                                | --mint-redeemer-file JSON_FILE
+                                                | --mint-redeemer-value JSON_VALUE
                                                 ]
                                               | --simple-minting-script-tx-in-reference TX-IN
                                                 --policy-id HASH
@@ -3414,9 +3414,9 @@ Usage: cardano-cli mary transaction build --socket-path SOCKET_PATH
                                                 ( --mint-plutus-script-v2
                                                 | --mint-plutus-script-v3
                                                 )
-                                                ( --mint-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                | --mint-reference-tx-in-redeemer-file JSON FILE
-                                                | --mint-reference-tx-in-redeemer-value JSON VALUE
+                                                ( --mint-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                | --mint-reference-tx-in-redeemer-file JSON_FILE
+                                                | --mint-reference-tx-in-redeemer-value JSON_VALUE
                                                 )
                                                 --policy-id HASH
                                               )]
@@ -3424,32 +3424,32 @@ Usage: cardano-cli mary transaction build --socket-path SOCKET_PATH
                                             [--invalid-hereafter SLOT]
                                             [--certificate-file FILE
                                               [ --certificate-script-file FILE
-                                                [ --certificate-redeemer-cbor-file CBOR FILE
-                                                | --certificate-redeemer-file JSON FILE
-                                                | --certificate-redeemer-value JSON VALUE
+                                                [ --certificate-redeemer-cbor-file CBOR_FILE
+                                                | --certificate-redeemer-file JSON_FILE
+                                                | --certificate-redeemer-value JSON_VALUE
                                                 ]
                                               | --certificate-tx-in-reference TX-IN
                                                 ( --certificate-plutus-script-v2
                                                 | --certificate-plutus-script-v3
                                                 )
-                                                ( --certificate-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                | --certificate-reference-tx-in-redeemer-file JSON FILE
-                                                | --certificate-reference-tx-in-redeemer-value JSON VALUE
+                                                ( --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                | --certificate-reference-tx-in-redeemer-file JSON_FILE
+                                                | --certificate-reference-tx-in-redeemer-value JSON_VALUE
                                                 )
                                               ]]
                                             [--withdrawal WITHDRAWAL
                                               [ --withdrawal-script-file FILE
-                                                [ --withdrawal-redeemer-cbor-file CBOR FILE
-                                                | --withdrawal-redeemer-file JSON FILE
-                                                | --withdrawal-redeemer-value JSON VALUE
+                                                [ --withdrawal-redeemer-cbor-file CBOR_FILE
+                                                | --withdrawal-redeemer-file JSON_FILE
+                                                | --withdrawal-redeemer-value JSON_VALUE
                                                 ]
                                               | --withdrawal-tx-in-reference TX-IN
                                                 ( --withdrawal-plutus-script-v2
                                                 | --withdrawal-plutus-script-v3
                                                 )
-                                                ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                | --withdrawal-reference-tx-in-redeemer-file JSON FILE
-                                                | --withdrawal-reference-tx-in-redeemer-value JSON VALUE
+                                                ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                | --withdrawal-reference-tx-in-redeemer-file JSON_FILE
+                                                | --withdrawal-reference-tx-in-redeemer-value JSON_VALUE
                                                 )
                                               ]]
                                             [ --json-metadata-no-schema
@@ -3481,27 +3481,27 @@ Usage: cardano-cli mary transaction build-estimate
                                                          ( --spending-plutus-script-v2
                                                          | --spending-plutus-script-v3
                                                          )
-                                                         ( --spending-reference-tx-in-datum-cbor-file CBOR FILE
-                                                         | --spending-reference-tx-in-datum-file JSON FILE
-                                                         | --spending-reference-tx-in-datum-value JSON VALUE
+                                                         ( --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                                                         | --spending-reference-tx-in-datum-file JSON_FILE
+                                                         | --spending-reference-tx-in-datum-value JSON_VALUE
                                                          | --spending-reference-tx-in-inline-datum-present
                                                          )
-                                                         ( --spending-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                         | --spending-reference-tx-in-redeemer-file JSON FILE
-                                                         | --spending-reference-tx-in-redeemer-value JSON VALUE
+                                                         ( --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                         | --spending-reference-tx-in-redeemer-file JSON_FILE
+                                                         | --spending-reference-tx-in-redeemer-value JSON_VALUE
                                                          )
                                                          --spending-reference-tx-in-execution-units (INT, INT)
                                                        | --simple-script-tx-in-reference TX-IN
                                                        | --tx-in-script-file FILE
                                                          [
-                                                           ( --tx-in-datum-cbor-file CBOR FILE
-                                                           | --tx-in-datum-file JSON FILE
-                                                           | --tx-in-datum-value JSON VALUE
+                                                           ( --tx-in-datum-cbor-file CBOR_FILE
+                                                           | --tx-in-datum-file JSON_FILE
+                                                           | --tx-in-datum-value JSON_VALUE
                                                            | --tx-in-inline-datum-present
                                                            )
-                                                           ( --tx-in-redeemer-cbor-file CBOR FILE
-                                                           | --tx-in-redeemer-file JSON FILE
-                                                           | --tx-in-redeemer-value JSON VALUE
+                                                           ( --tx-in-redeemer-cbor-file CBOR_FILE
+                                                           | --tx-in-redeemer-file JSON_FILE
+                                                           | --tx-in-redeemer-value JSON_VALUE
                                                            )
                                                            --tx-in-execution-units (INT, INT)]
                                                        ])
@@ -3513,24 +3513,24 @@ Usage: cardano-cli mary transaction build-estimate
                                                      [--tx-out-return-collateral ADDRESS VALUE]
                                                      [--tx-out ADDRESS VALUE
                                                        [ --tx-out-datum-hash HASH
-                                                       | --tx-out-datum-hash-cbor-file CBOR FILE
-                                                       | --tx-out-datum-hash-file JSON FILE
-                                                       | --tx-out-datum-hash-value JSON VALUE
-                                                       | --tx-out-datum-embed-cbor-file CBOR FILE
-                                                       | --tx-out-datum-embed-file JSON FILE
-                                                       | --tx-out-datum-embed-value JSON VALUE
-                                                       | --tx-out-inline-datum-cbor-file CBOR FILE
-                                                       | --tx-out-inline-datum-file JSON FILE
-                                                       | --tx-out-inline-datum-value JSON VALUE
+                                                       | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                       | --tx-out-datum-hash-file JSON_FILE
+                                                       | --tx-out-datum-hash-value JSON_VALUE
+                                                       | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                       | --tx-out-datum-embed-file JSON_FILE
+                                                       | --tx-out-datum-embed-value JSON_VALUE
+                                                       | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                       | --tx-out-inline-datum-file JSON_FILE
+                                                       | --tx-out-inline-datum-value JSON_VALUE
                                                        ]
                                                        [--tx-out-reference-script-file FILE]]
                                                      --change-address ADDRESS
                                                      [--mint VALUE
                                                        ( --mint-script-file FILE
                                                          [
-                                                           ( --mint-redeemer-cbor-file CBOR FILE
-                                                           | --mint-redeemer-file JSON FILE
-                                                           | --mint-redeemer-value JSON VALUE
+                                                           ( --mint-redeemer-cbor-file CBOR_FILE
+                                                           | --mint-redeemer-file JSON_FILE
+                                                           | --mint-redeemer-value JSON_VALUE
                                                            )
                                                            --mint-execution-units (INT, INT)]
                                                        | --simple-minting-script-tx-in-reference TX-IN
@@ -3539,9 +3539,9 @@ Usage: cardano-cli mary transaction build-estimate
                                                          ( --mint-plutus-script-v2
                                                          | --mint-plutus-script-v3
                                                          )
-                                                         ( --mint-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                         | --mint-reference-tx-in-redeemer-file JSON FILE
-                                                         | --mint-reference-tx-in-redeemer-value JSON VALUE
+                                                         ( --mint-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                         | --mint-reference-tx-in-redeemer-file JSON_FILE
+                                                         | --mint-reference-tx-in-redeemer-value JSON_VALUE
                                                          )
                                                          --mint-reference-tx-in-execution-units (INT, INT)
                                                          --policy-id HASH
@@ -3551,36 +3551,36 @@ Usage: cardano-cli mary transaction build-estimate
                                                      [--certificate-file FILE
                                                        [ --certificate-script-file FILE
                                                          [
-                                                           ( --certificate-redeemer-cbor-file CBOR FILE
-                                                           | --certificate-redeemer-file JSON FILE
-                                                           | --certificate-redeemer-value JSON VALUE
+                                                           ( --certificate-redeemer-cbor-file CBOR_FILE
+                                                           | --certificate-redeemer-file JSON_FILE
+                                                           | --certificate-redeemer-value JSON_VALUE
                                                            )
                                                            --certificate-execution-units (INT, INT)]
                                                        | --certificate-tx-in-reference TX-IN
                                                          ( --certificate-plutus-script-v2
                                                          | --certificate-plutus-script-v3
                                                          )
-                                                         ( --certificate-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                         | --certificate-reference-tx-in-redeemer-file JSON FILE
-                                                         | --certificate-reference-tx-in-redeemer-value JSON VALUE
+                                                         ( --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                         | --certificate-reference-tx-in-redeemer-file JSON_FILE
+                                                         | --certificate-reference-tx-in-redeemer-value JSON_VALUE
                                                          )
                                                          --certificate-reference-tx-in-execution-units (INT, INT)
                                                        ]]
                                                      [--withdrawal WITHDRAWAL
                                                        [ --withdrawal-script-file FILE
                                                          [
-                                                           ( --withdrawal-redeemer-cbor-file CBOR FILE
-                                                           | --withdrawal-redeemer-file JSON FILE
-                                                           | --withdrawal-redeemer-value JSON VALUE
+                                                           ( --withdrawal-redeemer-cbor-file CBOR_FILE
+                                                           | --withdrawal-redeemer-file JSON_FILE
+                                                           | --withdrawal-redeemer-value JSON_VALUE
                                                            )
                                                            --withdrawal-execution-units (INT, INT)]
                                                        | --withdrawal-tx-in-reference TX-IN
                                                          ( --withdrawal-plutus-script-v2
                                                          | --withdrawal-plutus-script-v3
                                                          )
-                                                         ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                         | --withdrawal-reference-tx-in-redeemer-file JSON FILE
-                                                         | --withdrawal-reference-tx-in-redeemer-value JSON VALUE
+                                                         ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                         | --withdrawal-reference-tx-in-redeemer-file JSON_FILE
+                                                         | --withdrawal-reference-tx-in-redeemer-value JSON_VALUE
                                                          )
                                                          --withdrawal-reference-tx-in-execution-units (INT, INT)
                                                        ]]
@@ -3661,15 +3661,15 @@ Usage: cardano-cli mary transaction calculate-min-fee --tx-body-file FILE
 Usage: cardano-cli mary transaction calculate-min-required-utxo --protocol-params-file FILE
                                                                   --tx-out ADDRESS VALUE
                                                                   [ --tx-out-datum-hash HASH
-                                                                  | --tx-out-datum-hash-cbor-file CBOR FILE
-                                                                  | --tx-out-datum-hash-file JSON FILE
-                                                                  | --tx-out-datum-hash-value JSON VALUE
-                                                                  | --tx-out-datum-embed-cbor-file CBOR FILE
-                                                                  | --tx-out-datum-embed-file JSON FILE
-                                                                  | --tx-out-datum-embed-value JSON VALUE
-                                                                  | --tx-out-inline-datum-cbor-file CBOR FILE
-                                                                  | --tx-out-inline-datum-file JSON FILE
-                                                                  | --tx-out-inline-datum-value JSON VALUE
+                                                                  | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                                  | --tx-out-datum-hash-file JSON_FILE
+                                                                  | --tx-out-datum-hash-value JSON_VALUE
+                                                                  | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                                  | --tx-out-datum-embed-file JSON_FILE
+                                                                  | --tx-out-datum-embed-value JSON_VALUE
+                                                                  | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                                  | --tx-out-inline-datum-file JSON_FILE
+                                                                  | --tx-out-inline-datum-value JSON_VALUE
                                                                   ]
                                                                   [--tx-out-reference-script-file FILE]
 
@@ -3678,24 +3678,24 @@ Usage: cardano-cli mary transaction calculate-min-required-utxo --protocol-param
 Usage: cardano-cli mary transaction calculate-min-value --protocol-params-file FILE
                                                           --tx-out ADDRESS VALUE
                                                           [ --tx-out-datum-hash HASH
-                                                          | --tx-out-datum-hash-cbor-file CBOR FILE
-                                                          | --tx-out-datum-hash-file JSON FILE
-                                                          | --tx-out-datum-hash-value JSON VALUE
-                                                          | --tx-out-datum-embed-cbor-file CBOR FILE
-                                                          | --tx-out-datum-embed-file JSON FILE
-                                                          | --tx-out-datum-embed-value JSON VALUE
-                                                          | --tx-out-inline-datum-cbor-file CBOR FILE
-                                                          | --tx-out-inline-datum-file JSON FILE
-                                                          | --tx-out-inline-datum-value JSON VALUE
+                                                          | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                          | --tx-out-datum-hash-file JSON_FILE
+                                                          | --tx-out-datum-hash-value JSON_VALUE
+                                                          | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                          | --tx-out-datum-embed-file JSON_FILE
+                                                          | --tx-out-datum-embed-value JSON_VALUE
+                                                          | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                          | --tx-out-inline-datum-file JSON_FILE
+                                                          | --tx-out-inline-datum-value JSON_VALUE
                                                           ]
                                                           [--tx-out-reference-script-file FILE]
 
   DEPRECATED: Use 'calculate-min-required-utxo' instead.
 
 Usage: cardano-cli mary transaction hash-script-data 
-                                                       ( --script-data-cbor-file CBOR FILE
-                                                       | --script-data-file JSON FILE
-                                                       | --script-data-value JSON VALUE
+                                                       ( --script-data-cbor-file CBOR_FILE
+                                                       | --script-data-file JSON_FILE
+                                                       | --script-data-value JSON_VALUE
                                                        )
 
   Calculate the hash of script data.
@@ -4549,27 +4549,27 @@ Usage: cardano-cli alonzo transaction build-raw
                                                       ( --spending-plutus-script-v2
                                                       | --spending-plutus-script-v3
                                                       )
-                                                      ( --spending-reference-tx-in-datum-cbor-file CBOR FILE
-                                                      | --spending-reference-tx-in-datum-file JSON FILE
-                                                      | --spending-reference-tx-in-datum-value JSON VALUE
+                                                      ( --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                                                      | --spending-reference-tx-in-datum-file JSON_FILE
+                                                      | --spending-reference-tx-in-datum-value JSON_VALUE
                                                       | --spending-reference-tx-in-inline-datum-present
                                                       )
-                                                      ( --spending-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                      | --spending-reference-tx-in-redeemer-file JSON FILE
-                                                      | --spending-reference-tx-in-redeemer-value JSON VALUE
+                                                      ( --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                      | --spending-reference-tx-in-redeemer-file JSON_FILE
+                                                      | --spending-reference-tx-in-redeemer-value JSON_VALUE
                                                       )
                                                       --spending-reference-tx-in-execution-units (INT, INT)
                                                     | --simple-script-tx-in-reference TX-IN
                                                     | --tx-in-script-file FILE
                                                       [
-                                                        ( --tx-in-datum-cbor-file CBOR FILE
-                                                        | --tx-in-datum-file JSON FILE
-                                                        | --tx-in-datum-value JSON VALUE
+                                                        ( --tx-in-datum-cbor-file CBOR_FILE
+                                                        | --tx-in-datum-file JSON_FILE
+                                                        | --tx-in-datum-value JSON_VALUE
                                                         | --tx-in-inline-datum-present
                                                         )
-                                                        ( --tx-in-redeemer-cbor-file CBOR FILE
-                                                        | --tx-in-redeemer-file JSON FILE
-                                                        | --tx-in-redeemer-value JSON VALUE
+                                                        ( --tx-in-redeemer-cbor-file CBOR_FILE
+                                                        | --tx-in-redeemer-file JSON_FILE
+                                                        | --tx-in-redeemer-value JSON_VALUE
                                                         )
                                                         --tx-in-execution-units (INT, INT)]
                                                     ])
@@ -4582,23 +4582,23 @@ Usage: cardano-cli alonzo transaction build-raw
                                                   ]
                                                   [--tx-out ADDRESS VALUE
                                                     [ --tx-out-datum-hash HASH
-                                                    | --tx-out-datum-hash-cbor-file CBOR FILE
-                                                    | --tx-out-datum-hash-file JSON FILE
-                                                    | --tx-out-datum-hash-value JSON VALUE
-                                                    | --tx-out-datum-embed-cbor-file CBOR FILE
-                                                    | --tx-out-datum-embed-file JSON FILE
-                                                    | --tx-out-datum-embed-value JSON VALUE
-                                                    | --tx-out-inline-datum-cbor-file CBOR FILE
-                                                    | --tx-out-inline-datum-file JSON FILE
-                                                    | --tx-out-inline-datum-value JSON VALUE
+                                                    | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                    | --tx-out-datum-hash-file JSON_FILE
+                                                    | --tx-out-datum-hash-value JSON_VALUE
+                                                    | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                    | --tx-out-datum-embed-file JSON_FILE
+                                                    | --tx-out-datum-embed-value JSON_VALUE
+                                                    | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                    | --tx-out-inline-datum-file JSON_FILE
+                                                    | --tx-out-inline-datum-value JSON_VALUE
                                                     ]
                                                     [--tx-out-reference-script-file FILE]]
                                                   [--mint VALUE
                                                     ( --mint-script-file FILE
                                                       [
-                                                        ( --mint-redeemer-cbor-file CBOR FILE
-                                                        | --mint-redeemer-file JSON FILE
-                                                        | --mint-redeemer-value JSON VALUE
+                                                        ( --mint-redeemer-cbor-file CBOR_FILE
+                                                        | --mint-redeemer-file JSON_FILE
+                                                        | --mint-redeemer-value JSON_VALUE
                                                         )
                                                         --mint-execution-units (INT, INT)]
                                                     | --simple-minting-script-tx-in-reference TX-IN
@@ -4607,9 +4607,9 @@ Usage: cardano-cli alonzo transaction build-raw
                                                       ( --mint-plutus-script-v2
                                                       | --mint-plutus-script-v3
                                                       )
-                                                      ( --mint-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                      | --mint-reference-tx-in-redeemer-file JSON FILE
-                                                      | --mint-reference-tx-in-redeemer-value JSON VALUE
+                                                      ( --mint-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                      | --mint-reference-tx-in-redeemer-file JSON_FILE
+                                                      | --mint-reference-tx-in-redeemer-value JSON_VALUE
                                                       )
                                                       --mint-reference-tx-in-execution-units (INT, INT)
                                                       --policy-id HASH
@@ -4620,36 +4620,36 @@ Usage: cardano-cli alonzo transaction build-raw
                                                   [--certificate-file FILE
                                                     [ --certificate-script-file FILE
                                                       [
-                                                        ( --certificate-redeemer-cbor-file CBOR FILE
-                                                        | --certificate-redeemer-file JSON FILE
-                                                        | --certificate-redeemer-value JSON VALUE
+                                                        ( --certificate-redeemer-cbor-file CBOR_FILE
+                                                        | --certificate-redeemer-file JSON_FILE
+                                                        | --certificate-redeemer-value JSON_VALUE
                                                         )
                                                         --certificate-execution-units (INT, INT)]
                                                     | --certificate-tx-in-reference TX-IN
                                                       ( --certificate-plutus-script-v2
                                                       | --certificate-plutus-script-v3
                                                       )
-                                                      ( --certificate-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                      | --certificate-reference-tx-in-redeemer-file JSON FILE
-                                                      | --certificate-reference-tx-in-redeemer-value JSON VALUE
+                                                      ( --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                      | --certificate-reference-tx-in-redeemer-file JSON_FILE
+                                                      | --certificate-reference-tx-in-redeemer-value JSON_VALUE
                                                       )
                                                       --certificate-reference-tx-in-execution-units (INT, INT)
                                                     ]]
                                                   [--withdrawal WITHDRAWAL
                                                     [ --withdrawal-script-file FILE
                                                       [
-                                                        ( --withdrawal-redeemer-cbor-file CBOR FILE
-                                                        | --withdrawal-redeemer-file JSON FILE
-                                                        | --withdrawal-redeemer-value JSON VALUE
+                                                        ( --withdrawal-redeemer-cbor-file CBOR_FILE
+                                                        | --withdrawal-redeemer-file JSON_FILE
+                                                        | --withdrawal-redeemer-value JSON_VALUE
                                                         )
                                                         --withdrawal-execution-units (INT, INT)]
                                                     | --withdrawal-tx-in-reference TX-IN
                                                       ( --withdrawal-plutus-script-v2
                                                       | --withdrawal-plutus-script-v3
                                                       )
-                                                      ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                      | --withdrawal-reference-tx-in-redeemer-file JSON FILE
-                                                      | --withdrawal-reference-tx-in-redeemer-value JSON VALUE
+                                                      ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                      | --withdrawal-reference-tx-in-redeemer-file JSON_FILE
+                                                      | --withdrawal-reference-tx-in-redeemer-value JSON_VALUE
                                                       )
                                                       --withdrawal-reference-tx-in-execution-units (INT, INT)
                                                     ]]
@@ -4683,26 +4683,26 @@ Usage: cardano-cli alonzo transaction build --socket-path SOCKET_PATH
                                                   ( --spending-plutus-script-v2
                                                   | --spending-plutus-script-v3
                                                   )
-                                                  ( --spending-reference-tx-in-datum-cbor-file CBOR FILE
-                                                  | --spending-reference-tx-in-datum-file JSON FILE
-                                                  | --spending-reference-tx-in-datum-value JSON VALUE
+                                                  ( --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                                                  | --spending-reference-tx-in-datum-file JSON_FILE
+                                                  | --spending-reference-tx-in-datum-value JSON_VALUE
                                                   | --spending-reference-tx-in-inline-datum-present
                                                   )
-                                                  ( --spending-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                  | --spending-reference-tx-in-redeemer-file JSON FILE
-                                                  | --spending-reference-tx-in-redeemer-value JSON VALUE
+                                                  ( --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                  | --spending-reference-tx-in-redeemer-file JSON_FILE
+                                                  | --spending-reference-tx-in-redeemer-value JSON_VALUE
                                                   )
                                                 | --simple-script-tx-in-reference TX-IN
                                                 | --tx-in-script-file FILE
                                                   [
-                                                    ( --tx-in-datum-cbor-file CBOR FILE
-                                                    | --tx-in-datum-file JSON FILE
-                                                    | --tx-in-datum-value JSON VALUE
+                                                    ( --tx-in-datum-cbor-file CBOR_FILE
+                                                    | --tx-in-datum-file JSON_FILE
+                                                    | --tx-in-datum-value JSON_VALUE
                                                     | --tx-in-inline-datum-present
                                                     )
-                                                    ( --tx-in-redeemer-cbor-file CBOR FILE
-                                                    | --tx-in-redeemer-file JSON FILE
-                                                    | --tx-in-redeemer-value JSON VALUE
+                                                    ( --tx-in-redeemer-cbor-file CBOR_FILE
+                                                    | --tx-in-redeemer-file JSON_FILE
+                                                    | --tx-in-redeemer-value JSON_VALUE
                                                     )]
                                                 ])
                                               [--read-only-tx-in-reference TX-IN]
@@ -4714,23 +4714,23 @@ Usage: cardano-cli alonzo transaction build --socket-path SOCKET_PATH
                                               [--tx-total-collateral INTEGER]
                                               [--tx-out ADDRESS VALUE
                                                 [ --tx-out-datum-hash HASH
-                                                | --tx-out-datum-hash-cbor-file CBOR FILE
-                                                | --tx-out-datum-hash-file JSON FILE
-                                                | --tx-out-datum-hash-value JSON VALUE
-                                                | --tx-out-datum-embed-cbor-file CBOR FILE
-                                                | --tx-out-datum-embed-file JSON FILE
-                                                | --tx-out-datum-embed-value JSON VALUE
-                                                | --tx-out-inline-datum-cbor-file CBOR FILE
-                                                | --tx-out-inline-datum-file JSON FILE
-                                                | --tx-out-inline-datum-value JSON VALUE
+                                                | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                | --tx-out-datum-hash-file JSON_FILE
+                                                | --tx-out-datum-hash-value JSON_VALUE
+                                                | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                | --tx-out-datum-embed-file JSON_FILE
+                                                | --tx-out-datum-embed-value JSON_VALUE
+                                                | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                | --tx-out-inline-datum-file JSON_FILE
+                                                | --tx-out-inline-datum-value JSON_VALUE
                                                 ]
                                                 [--tx-out-reference-script-file FILE]]
                                               --change-address ADDRESS
                                               [--mint VALUE
                                                 ( --mint-script-file FILE
-                                                  [ --mint-redeemer-cbor-file CBOR FILE
-                                                  | --mint-redeemer-file JSON FILE
-                                                  | --mint-redeemer-value JSON VALUE
+                                                  [ --mint-redeemer-cbor-file CBOR_FILE
+                                                  | --mint-redeemer-file JSON_FILE
+                                                  | --mint-redeemer-value JSON_VALUE
                                                   ]
                                                 | --simple-minting-script-tx-in-reference TX-IN
                                                   --policy-id HASH
@@ -4738,9 +4738,9 @@ Usage: cardano-cli alonzo transaction build --socket-path SOCKET_PATH
                                                   ( --mint-plutus-script-v2
                                                   | --mint-plutus-script-v3
                                                   )
-                                                  ( --mint-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                  | --mint-reference-tx-in-redeemer-file JSON FILE
-                                                  | --mint-reference-tx-in-redeemer-value JSON VALUE
+                                                  ( --mint-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                  | --mint-reference-tx-in-redeemer-file JSON_FILE
+                                                  | --mint-reference-tx-in-redeemer-value JSON_VALUE
                                                   )
                                                   --policy-id HASH
                                                 )]
@@ -4748,32 +4748,32 @@ Usage: cardano-cli alonzo transaction build --socket-path SOCKET_PATH
                                               [--invalid-hereafter SLOT]
                                               [--certificate-file FILE
                                                 [ --certificate-script-file FILE
-                                                  [ --certificate-redeemer-cbor-file CBOR FILE
-                                                  | --certificate-redeemer-file JSON FILE
-                                                  | --certificate-redeemer-value JSON VALUE
+                                                  [ --certificate-redeemer-cbor-file CBOR_FILE
+                                                  | --certificate-redeemer-file JSON_FILE
+                                                  | --certificate-redeemer-value JSON_VALUE
                                                   ]
                                                 | --certificate-tx-in-reference TX-IN
                                                   ( --certificate-plutus-script-v2
                                                   | --certificate-plutus-script-v3
                                                   )
-                                                  ( --certificate-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                  | --certificate-reference-tx-in-redeemer-file JSON FILE
-                                                  | --certificate-reference-tx-in-redeemer-value JSON VALUE
+                                                  ( --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                  | --certificate-reference-tx-in-redeemer-file JSON_FILE
+                                                  | --certificate-reference-tx-in-redeemer-value JSON_VALUE
                                                   )
                                                 ]]
                                               [--withdrawal WITHDRAWAL
                                                 [ --withdrawal-script-file FILE
-                                                  [ --withdrawal-redeemer-cbor-file CBOR FILE
-                                                  | --withdrawal-redeemer-file JSON FILE
-                                                  | --withdrawal-redeemer-value JSON VALUE
+                                                  [ --withdrawal-redeemer-cbor-file CBOR_FILE
+                                                  | --withdrawal-redeemer-file JSON_FILE
+                                                  | --withdrawal-redeemer-value JSON_VALUE
                                                   ]
                                                 | --withdrawal-tx-in-reference TX-IN
                                                   ( --withdrawal-plutus-script-v2
                                                   | --withdrawal-plutus-script-v3
                                                   )
-                                                  ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                  | --withdrawal-reference-tx-in-redeemer-file JSON FILE
-                                                  | --withdrawal-reference-tx-in-redeemer-value JSON VALUE
+                                                  ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                  | --withdrawal-reference-tx-in-redeemer-file JSON_FILE
+                                                  | --withdrawal-reference-tx-in-redeemer-value JSON_VALUE
                                                   )
                                                 ]]
                                               [ --json-metadata-no-schema
@@ -4805,27 +4805,27 @@ Usage: cardano-cli alonzo transaction build-estimate
                                                            ( --spending-plutus-script-v2
                                                            | --spending-plutus-script-v3
                                                            )
-                                                           ( --spending-reference-tx-in-datum-cbor-file CBOR FILE
-                                                           | --spending-reference-tx-in-datum-file JSON FILE
-                                                           | --spending-reference-tx-in-datum-value JSON VALUE
+                                                           ( --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                                                           | --spending-reference-tx-in-datum-file JSON_FILE
+                                                           | --spending-reference-tx-in-datum-value JSON_VALUE
                                                            | --spending-reference-tx-in-inline-datum-present
                                                            )
-                                                           ( --spending-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                           | --spending-reference-tx-in-redeemer-file JSON FILE
-                                                           | --spending-reference-tx-in-redeemer-value JSON VALUE
+                                                           ( --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                           | --spending-reference-tx-in-redeemer-file JSON_FILE
+                                                           | --spending-reference-tx-in-redeemer-value JSON_VALUE
                                                            )
                                                            --spending-reference-tx-in-execution-units (INT, INT)
                                                          | --simple-script-tx-in-reference TX-IN
                                                          | --tx-in-script-file FILE
                                                            [
-                                                             ( --tx-in-datum-cbor-file CBOR FILE
-                                                             | --tx-in-datum-file JSON FILE
-                                                             | --tx-in-datum-value JSON VALUE
+                                                             ( --tx-in-datum-cbor-file CBOR_FILE
+                                                             | --tx-in-datum-file JSON_FILE
+                                                             | --tx-in-datum-value JSON_VALUE
                                                              | --tx-in-inline-datum-present
                                                              )
-                                                             ( --tx-in-redeemer-cbor-file CBOR FILE
-                                                             | --tx-in-redeemer-file JSON FILE
-                                                             | --tx-in-redeemer-value JSON VALUE
+                                                             ( --tx-in-redeemer-cbor-file CBOR_FILE
+                                                             | --tx-in-redeemer-file JSON_FILE
+                                                             | --tx-in-redeemer-value JSON_VALUE
                                                              )
                                                              --tx-in-execution-units (INT, INT)]
                                                          ])
@@ -4837,24 +4837,24 @@ Usage: cardano-cli alonzo transaction build-estimate
                                                        [--tx-out-return-collateral ADDRESS VALUE]
                                                        [--tx-out ADDRESS VALUE
                                                          [ --tx-out-datum-hash HASH
-                                                         | --tx-out-datum-hash-cbor-file CBOR FILE
-                                                         | --tx-out-datum-hash-file JSON FILE
-                                                         | --tx-out-datum-hash-value JSON VALUE
-                                                         | --tx-out-datum-embed-cbor-file CBOR FILE
-                                                         | --tx-out-datum-embed-file JSON FILE
-                                                         | --tx-out-datum-embed-value JSON VALUE
-                                                         | --tx-out-inline-datum-cbor-file CBOR FILE
-                                                         | --tx-out-inline-datum-file JSON FILE
-                                                         | --tx-out-inline-datum-value JSON VALUE
+                                                         | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                         | --tx-out-datum-hash-file JSON_FILE
+                                                         | --tx-out-datum-hash-value JSON_VALUE
+                                                         | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                         | --tx-out-datum-embed-file JSON_FILE
+                                                         | --tx-out-datum-embed-value JSON_VALUE
+                                                         | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                         | --tx-out-inline-datum-file JSON_FILE
+                                                         | --tx-out-inline-datum-value JSON_VALUE
                                                          ]
                                                          [--tx-out-reference-script-file FILE]]
                                                        --change-address ADDRESS
                                                        [--mint VALUE
                                                          ( --mint-script-file FILE
                                                            [
-                                                             ( --mint-redeemer-cbor-file CBOR FILE
-                                                             | --mint-redeemer-file JSON FILE
-                                                             | --mint-redeemer-value JSON VALUE
+                                                             ( --mint-redeemer-cbor-file CBOR_FILE
+                                                             | --mint-redeemer-file JSON_FILE
+                                                             | --mint-redeemer-value JSON_VALUE
                                                              )
                                                              --mint-execution-units (INT, INT)]
                                                          | --simple-minting-script-tx-in-reference TX-IN
@@ -4863,9 +4863,9 @@ Usage: cardano-cli alonzo transaction build-estimate
                                                            ( --mint-plutus-script-v2
                                                            | --mint-plutus-script-v3
                                                            )
-                                                           ( --mint-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                           | --mint-reference-tx-in-redeemer-file JSON FILE
-                                                           | --mint-reference-tx-in-redeemer-value JSON VALUE
+                                                           ( --mint-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                           | --mint-reference-tx-in-redeemer-file JSON_FILE
+                                                           | --mint-reference-tx-in-redeemer-value JSON_VALUE
                                                            )
                                                            --mint-reference-tx-in-execution-units (INT, INT)
                                                            --policy-id HASH
@@ -4875,36 +4875,36 @@ Usage: cardano-cli alonzo transaction build-estimate
                                                        [--certificate-file FILE
                                                          [ --certificate-script-file FILE
                                                            [
-                                                             ( --certificate-redeemer-cbor-file CBOR FILE
-                                                             | --certificate-redeemer-file JSON FILE
-                                                             | --certificate-redeemer-value JSON VALUE
+                                                             ( --certificate-redeemer-cbor-file CBOR_FILE
+                                                             | --certificate-redeemer-file JSON_FILE
+                                                             | --certificate-redeemer-value JSON_VALUE
                                                              )
                                                              --certificate-execution-units (INT, INT)]
                                                          | --certificate-tx-in-reference TX-IN
                                                            ( --certificate-plutus-script-v2
                                                            | --certificate-plutus-script-v3
                                                            )
-                                                           ( --certificate-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                           | --certificate-reference-tx-in-redeemer-file JSON FILE
-                                                           | --certificate-reference-tx-in-redeemer-value JSON VALUE
+                                                           ( --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                           | --certificate-reference-tx-in-redeemer-file JSON_FILE
+                                                           | --certificate-reference-tx-in-redeemer-value JSON_VALUE
                                                            )
                                                            --certificate-reference-tx-in-execution-units (INT, INT)
                                                          ]]
                                                        [--withdrawal WITHDRAWAL
                                                          [ --withdrawal-script-file FILE
                                                            [
-                                                             ( --withdrawal-redeemer-cbor-file CBOR FILE
-                                                             | --withdrawal-redeemer-file JSON FILE
-                                                             | --withdrawal-redeemer-value JSON VALUE
+                                                             ( --withdrawal-redeemer-cbor-file CBOR_FILE
+                                                             | --withdrawal-redeemer-file JSON_FILE
+                                                             | --withdrawal-redeemer-value JSON_VALUE
                                                              )
                                                              --withdrawal-execution-units (INT, INT)]
                                                          | --withdrawal-tx-in-reference TX-IN
                                                            ( --withdrawal-plutus-script-v2
                                                            | --withdrawal-plutus-script-v3
                                                            )
-                                                           ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                           | --withdrawal-reference-tx-in-redeemer-file JSON FILE
-                                                           | --withdrawal-reference-tx-in-redeemer-value JSON VALUE
+                                                           ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                           | --withdrawal-reference-tx-in-redeemer-file JSON_FILE
+                                                           | --withdrawal-reference-tx-in-redeemer-value JSON_VALUE
                                                            )
                                                            --withdrawal-reference-tx-in-execution-units (INT, INT)
                                                          ]]
@@ -4990,15 +4990,15 @@ Usage: cardano-cli alonzo transaction calculate-min-fee --tx-body-file FILE
 Usage: cardano-cli alonzo transaction calculate-min-required-utxo --protocol-params-file FILE
                                                                     --tx-out ADDRESS VALUE
                                                                     [ --tx-out-datum-hash HASH
-                                                                    | --tx-out-datum-hash-cbor-file CBOR FILE
-                                                                    | --tx-out-datum-hash-file JSON FILE
-                                                                    | --tx-out-datum-hash-value JSON VALUE
-                                                                    | --tx-out-datum-embed-cbor-file CBOR FILE
-                                                                    | --tx-out-datum-embed-file JSON FILE
-                                                                    | --tx-out-datum-embed-value JSON VALUE
-                                                                    | --tx-out-inline-datum-cbor-file CBOR FILE
-                                                                    | --tx-out-inline-datum-file JSON FILE
-                                                                    | --tx-out-inline-datum-value JSON VALUE
+                                                                    | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                                    | --tx-out-datum-hash-file JSON_FILE
+                                                                    | --tx-out-datum-hash-value JSON_VALUE
+                                                                    | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                                    | --tx-out-datum-embed-file JSON_FILE
+                                                                    | --tx-out-datum-embed-value JSON_VALUE
+                                                                    | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                                    | --tx-out-inline-datum-file JSON_FILE
+                                                                    | --tx-out-inline-datum-value JSON_VALUE
                                                                     ]
                                                                     [--tx-out-reference-script-file FILE]
 
@@ -5007,24 +5007,24 @@ Usage: cardano-cli alonzo transaction calculate-min-required-utxo --protocol-par
 Usage: cardano-cli alonzo transaction calculate-min-value --protocol-params-file FILE
                                                             --tx-out ADDRESS VALUE
                                                             [ --tx-out-datum-hash HASH
-                                                            | --tx-out-datum-hash-cbor-file CBOR FILE
-                                                            | --tx-out-datum-hash-file JSON FILE
-                                                            | --tx-out-datum-hash-value JSON VALUE
-                                                            | --tx-out-datum-embed-cbor-file CBOR FILE
-                                                            | --tx-out-datum-embed-file JSON FILE
-                                                            | --tx-out-datum-embed-value JSON VALUE
-                                                            | --tx-out-inline-datum-cbor-file CBOR FILE
-                                                            | --tx-out-inline-datum-file JSON FILE
-                                                            | --tx-out-inline-datum-value JSON VALUE
+                                                            | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                            | --tx-out-datum-hash-file JSON_FILE
+                                                            | --tx-out-datum-hash-value JSON_VALUE
+                                                            | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                            | --tx-out-datum-embed-file JSON_FILE
+                                                            | --tx-out-datum-embed-value JSON_VALUE
+                                                            | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                            | --tx-out-inline-datum-file JSON_FILE
+                                                            | --tx-out-inline-datum-value JSON_VALUE
                                                             ]
                                                             [--tx-out-reference-script-file FILE]
 
   DEPRECATED: Use 'calculate-min-required-utxo' instead.
 
 Usage: cardano-cli alonzo transaction hash-script-data 
-                                                         ( --script-data-cbor-file CBOR FILE
-                                                         | --script-data-file JSON FILE
-                                                         | --script-data-value JSON VALUE
+                                                         ( --script-data-cbor-file CBOR_FILE
+                                                         | --script-data-file JSON_FILE
+                                                         | --script-data-value JSON_VALUE
                                                          )
 
   Calculate the hash of script data.
@@ -5903,27 +5903,27 @@ Usage: cardano-cli babbage transaction build-raw
                                                        ( --spending-plutus-script-v2
                                                        | --spending-plutus-script-v3
                                                        )
-                                                       ( --spending-reference-tx-in-datum-cbor-file CBOR FILE
-                                                       | --spending-reference-tx-in-datum-file JSON FILE
-                                                       | --spending-reference-tx-in-datum-value JSON VALUE
+                                                       ( --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                                                       | --spending-reference-tx-in-datum-file JSON_FILE
+                                                       | --spending-reference-tx-in-datum-value JSON_VALUE
                                                        | --spending-reference-tx-in-inline-datum-present
                                                        )
-                                                       ( --spending-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                       | --spending-reference-tx-in-redeemer-file JSON FILE
-                                                       | --spending-reference-tx-in-redeemer-value JSON VALUE
+                                                       ( --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                       | --spending-reference-tx-in-redeemer-file JSON_FILE
+                                                       | --spending-reference-tx-in-redeemer-value JSON_VALUE
                                                        )
                                                        --spending-reference-tx-in-execution-units (INT, INT)
                                                      | --simple-script-tx-in-reference TX-IN
                                                      | --tx-in-script-file FILE
                                                        [
-                                                         ( --tx-in-datum-cbor-file CBOR FILE
-                                                         | --tx-in-datum-file JSON FILE
-                                                         | --tx-in-datum-value JSON VALUE
+                                                         ( --tx-in-datum-cbor-file CBOR_FILE
+                                                         | --tx-in-datum-file JSON_FILE
+                                                         | --tx-in-datum-value JSON_VALUE
                                                          | --tx-in-inline-datum-present
                                                          )
-                                                         ( --tx-in-redeemer-cbor-file CBOR FILE
-                                                         | --tx-in-redeemer-file JSON FILE
-                                                         | --tx-in-redeemer-value JSON VALUE
+                                                         ( --tx-in-redeemer-cbor-file CBOR_FILE
+                                                         | --tx-in-redeemer-file JSON_FILE
+                                                         | --tx-in-redeemer-value JSON_VALUE
                                                          )
                                                          --tx-in-execution-units (INT, INT)]
                                                      ])
@@ -5936,23 +5936,23 @@ Usage: cardano-cli babbage transaction build-raw
                                                    ]
                                                    [--tx-out ADDRESS VALUE
                                                      [ --tx-out-datum-hash HASH
-                                                     | --tx-out-datum-hash-cbor-file CBOR FILE
-                                                     | --tx-out-datum-hash-file JSON FILE
-                                                     | --tx-out-datum-hash-value JSON VALUE
-                                                     | --tx-out-datum-embed-cbor-file CBOR FILE
-                                                     | --tx-out-datum-embed-file JSON FILE
-                                                     | --tx-out-datum-embed-value JSON VALUE
-                                                     | --tx-out-inline-datum-cbor-file CBOR FILE
-                                                     | --tx-out-inline-datum-file JSON FILE
-                                                     | --tx-out-inline-datum-value JSON VALUE
+                                                     | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                     | --tx-out-datum-hash-file JSON_FILE
+                                                     | --tx-out-datum-hash-value JSON_VALUE
+                                                     | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                     | --tx-out-datum-embed-file JSON_FILE
+                                                     | --tx-out-datum-embed-value JSON_VALUE
+                                                     | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                     | --tx-out-inline-datum-file JSON_FILE
+                                                     | --tx-out-inline-datum-value JSON_VALUE
                                                      ]
                                                      [--tx-out-reference-script-file FILE]]
                                                    [--mint VALUE
                                                      ( --mint-script-file FILE
                                                        [
-                                                         ( --mint-redeemer-cbor-file CBOR FILE
-                                                         | --mint-redeemer-file JSON FILE
-                                                         | --mint-redeemer-value JSON VALUE
+                                                         ( --mint-redeemer-cbor-file CBOR_FILE
+                                                         | --mint-redeemer-file JSON_FILE
+                                                         | --mint-redeemer-value JSON_VALUE
                                                          )
                                                          --mint-execution-units (INT, INT)]
                                                      | --simple-minting-script-tx-in-reference TX-IN
@@ -5961,9 +5961,9 @@ Usage: cardano-cli babbage transaction build-raw
                                                        ( --mint-plutus-script-v2
                                                        | --mint-plutus-script-v3
                                                        )
-                                                       ( --mint-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                       | --mint-reference-tx-in-redeemer-file JSON FILE
-                                                       | --mint-reference-tx-in-redeemer-value JSON VALUE
+                                                       ( --mint-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                       | --mint-reference-tx-in-redeemer-file JSON_FILE
+                                                       | --mint-reference-tx-in-redeemer-value JSON_VALUE
                                                        )
                                                        --mint-reference-tx-in-execution-units (INT, INT)
                                                        --policy-id HASH
@@ -5974,36 +5974,36 @@ Usage: cardano-cli babbage transaction build-raw
                                                    [--certificate-file FILE
                                                      [ --certificate-script-file FILE
                                                        [
-                                                         ( --certificate-redeemer-cbor-file CBOR FILE
-                                                         | --certificate-redeemer-file JSON FILE
-                                                         | --certificate-redeemer-value JSON VALUE
+                                                         ( --certificate-redeemer-cbor-file CBOR_FILE
+                                                         | --certificate-redeemer-file JSON_FILE
+                                                         | --certificate-redeemer-value JSON_VALUE
                                                          )
                                                          --certificate-execution-units (INT, INT)]
                                                      | --certificate-tx-in-reference TX-IN
                                                        ( --certificate-plutus-script-v2
                                                        | --certificate-plutus-script-v3
                                                        )
-                                                       ( --certificate-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                       | --certificate-reference-tx-in-redeemer-file JSON FILE
-                                                       | --certificate-reference-tx-in-redeemer-value JSON VALUE
+                                                       ( --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                       | --certificate-reference-tx-in-redeemer-file JSON_FILE
+                                                       | --certificate-reference-tx-in-redeemer-value JSON_VALUE
                                                        )
                                                        --certificate-reference-tx-in-execution-units (INT, INT)
                                                      ]]
                                                    [--withdrawal WITHDRAWAL
                                                      [ --withdrawal-script-file FILE
                                                        [
-                                                         ( --withdrawal-redeemer-cbor-file CBOR FILE
-                                                         | --withdrawal-redeemer-file JSON FILE
-                                                         | --withdrawal-redeemer-value JSON VALUE
+                                                         ( --withdrawal-redeemer-cbor-file CBOR_FILE
+                                                         | --withdrawal-redeemer-file JSON_FILE
+                                                         | --withdrawal-redeemer-value JSON_VALUE
                                                          )
                                                          --withdrawal-execution-units (INT, INT)]
                                                      | --withdrawal-tx-in-reference TX-IN
                                                        ( --withdrawal-plutus-script-v2
                                                        | --withdrawal-plutus-script-v3
                                                        )
-                                                       ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                       | --withdrawal-reference-tx-in-redeemer-file JSON FILE
-                                                       | --withdrawal-reference-tx-in-redeemer-value JSON VALUE
+                                                       ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                       | --withdrawal-reference-tx-in-redeemer-file JSON_FILE
+                                                       | --withdrawal-reference-tx-in-redeemer-value JSON_VALUE
                                                        )
                                                        --withdrawal-reference-tx-in-execution-units (INT, INT)
                                                      ]]
@@ -6037,26 +6037,26 @@ Usage: cardano-cli babbage transaction build --socket-path SOCKET_PATH
                                                    ( --spending-plutus-script-v2
                                                    | --spending-plutus-script-v3
                                                    )
-                                                   ( --spending-reference-tx-in-datum-cbor-file CBOR FILE
-                                                   | --spending-reference-tx-in-datum-file JSON FILE
-                                                   | --spending-reference-tx-in-datum-value JSON VALUE
+                                                   ( --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                                                   | --spending-reference-tx-in-datum-file JSON_FILE
+                                                   | --spending-reference-tx-in-datum-value JSON_VALUE
                                                    | --spending-reference-tx-in-inline-datum-present
                                                    )
-                                                   ( --spending-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                   | --spending-reference-tx-in-redeemer-file JSON FILE
-                                                   | --spending-reference-tx-in-redeemer-value JSON VALUE
+                                                   ( --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                   | --spending-reference-tx-in-redeemer-file JSON_FILE
+                                                   | --spending-reference-tx-in-redeemer-value JSON_VALUE
                                                    )
                                                  | --simple-script-tx-in-reference TX-IN
                                                  | --tx-in-script-file FILE
                                                    [
-                                                     ( --tx-in-datum-cbor-file CBOR FILE
-                                                     | --tx-in-datum-file JSON FILE
-                                                     | --tx-in-datum-value JSON VALUE
+                                                     ( --tx-in-datum-cbor-file CBOR_FILE
+                                                     | --tx-in-datum-file JSON_FILE
+                                                     | --tx-in-datum-value JSON_VALUE
                                                      | --tx-in-inline-datum-present
                                                      )
-                                                     ( --tx-in-redeemer-cbor-file CBOR FILE
-                                                     | --tx-in-redeemer-file JSON FILE
-                                                     | --tx-in-redeemer-value JSON VALUE
+                                                     ( --tx-in-redeemer-cbor-file CBOR_FILE
+                                                     | --tx-in-redeemer-file JSON_FILE
+                                                     | --tx-in-redeemer-value JSON_VALUE
                                                      )]
                                                  ])
                                                [--read-only-tx-in-reference TX-IN]
@@ -6068,23 +6068,23 @@ Usage: cardano-cli babbage transaction build --socket-path SOCKET_PATH
                                                [--tx-total-collateral INTEGER]
                                                [--tx-out ADDRESS VALUE
                                                  [ --tx-out-datum-hash HASH
-                                                 | --tx-out-datum-hash-cbor-file CBOR FILE
-                                                 | --tx-out-datum-hash-file JSON FILE
-                                                 | --tx-out-datum-hash-value JSON VALUE
-                                                 | --tx-out-datum-embed-cbor-file CBOR FILE
-                                                 | --tx-out-datum-embed-file JSON FILE
-                                                 | --tx-out-datum-embed-value JSON VALUE
-                                                 | --tx-out-inline-datum-cbor-file CBOR FILE
-                                                 | --tx-out-inline-datum-file JSON FILE
-                                                 | --tx-out-inline-datum-value JSON VALUE
+                                                 | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                 | --tx-out-datum-hash-file JSON_FILE
+                                                 | --tx-out-datum-hash-value JSON_VALUE
+                                                 | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                 | --tx-out-datum-embed-file JSON_FILE
+                                                 | --tx-out-datum-embed-value JSON_VALUE
+                                                 | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                 | --tx-out-inline-datum-file JSON_FILE
+                                                 | --tx-out-inline-datum-value JSON_VALUE
                                                  ]
                                                  [--tx-out-reference-script-file FILE]]
                                                --change-address ADDRESS
                                                [--mint VALUE
                                                  ( --mint-script-file FILE
-                                                   [ --mint-redeemer-cbor-file CBOR FILE
-                                                   | --mint-redeemer-file JSON FILE
-                                                   | --mint-redeemer-value JSON VALUE
+                                                   [ --mint-redeemer-cbor-file CBOR_FILE
+                                                   | --mint-redeemer-file JSON_FILE
+                                                   | --mint-redeemer-value JSON_VALUE
                                                    ]
                                                  | --simple-minting-script-tx-in-reference TX-IN
                                                    --policy-id HASH
@@ -6092,9 +6092,9 @@ Usage: cardano-cli babbage transaction build --socket-path SOCKET_PATH
                                                    ( --mint-plutus-script-v2
                                                    | --mint-plutus-script-v3
                                                    )
-                                                   ( --mint-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                   | --mint-reference-tx-in-redeemer-file JSON FILE
-                                                   | --mint-reference-tx-in-redeemer-value JSON VALUE
+                                                   ( --mint-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                   | --mint-reference-tx-in-redeemer-file JSON_FILE
+                                                   | --mint-reference-tx-in-redeemer-value JSON_VALUE
                                                    )
                                                    --policy-id HASH
                                                  )]
@@ -6102,32 +6102,32 @@ Usage: cardano-cli babbage transaction build --socket-path SOCKET_PATH
                                                [--invalid-hereafter SLOT]
                                                [--certificate-file FILE
                                                  [ --certificate-script-file FILE
-                                                   [ --certificate-redeemer-cbor-file CBOR FILE
-                                                   | --certificate-redeemer-file JSON FILE
-                                                   | --certificate-redeemer-value JSON VALUE
+                                                   [ --certificate-redeemer-cbor-file CBOR_FILE
+                                                   | --certificate-redeemer-file JSON_FILE
+                                                   | --certificate-redeemer-value JSON_VALUE
                                                    ]
                                                  | --certificate-tx-in-reference TX-IN
                                                    ( --certificate-plutus-script-v2
                                                    | --certificate-plutus-script-v3
                                                    )
-                                                   ( --certificate-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                   | --certificate-reference-tx-in-redeemer-file JSON FILE
-                                                   | --certificate-reference-tx-in-redeemer-value JSON VALUE
+                                                   ( --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                   | --certificate-reference-tx-in-redeemer-file JSON_FILE
+                                                   | --certificate-reference-tx-in-redeemer-value JSON_VALUE
                                                    )
                                                  ]]
                                                [--withdrawal WITHDRAWAL
                                                  [ --withdrawal-script-file FILE
-                                                   [ --withdrawal-redeemer-cbor-file CBOR FILE
-                                                   | --withdrawal-redeemer-file JSON FILE
-                                                   | --withdrawal-redeemer-value JSON VALUE
+                                                   [ --withdrawal-redeemer-cbor-file CBOR_FILE
+                                                   | --withdrawal-redeemer-file JSON_FILE
+                                                   | --withdrawal-redeemer-value JSON_VALUE
                                                    ]
                                                  | --withdrawal-tx-in-reference TX-IN
                                                    ( --withdrawal-plutus-script-v2
                                                    | --withdrawal-plutus-script-v3
                                                    )
-                                                   ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                   | --withdrawal-reference-tx-in-redeemer-file JSON FILE
-                                                   | --withdrawal-reference-tx-in-redeemer-value JSON VALUE
+                                                   ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                   | --withdrawal-reference-tx-in-redeemer-file JSON_FILE
+                                                   | --withdrawal-reference-tx-in-redeemer-value JSON_VALUE
                                                    )
                                                  ]]
                                                [ --json-metadata-no-schema
@@ -6159,27 +6159,27 @@ Usage: cardano-cli babbage transaction build-estimate
                                                             ( --spending-plutus-script-v2
                                                             | --spending-plutus-script-v3
                                                             )
-                                                            ( --spending-reference-tx-in-datum-cbor-file CBOR FILE
-                                                            | --spending-reference-tx-in-datum-file JSON FILE
-                                                            | --spending-reference-tx-in-datum-value JSON VALUE
+                                                            ( --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                                                            | --spending-reference-tx-in-datum-file JSON_FILE
+                                                            | --spending-reference-tx-in-datum-value JSON_VALUE
                                                             | --spending-reference-tx-in-inline-datum-present
                                                             )
-                                                            ( --spending-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                            | --spending-reference-tx-in-redeemer-file JSON FILE
-                                                            | --spending-reference-tx-in-redeemer-value JSON VALUE
+                                                            ( --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                            | --spending-reference-tx-in-redeemer-file JSON_FILE
+                                                            | --spending-reference-tx-in-redeemer-value JSON_VALUE
                                                             )
                                                             --spending-reference-tx-in-execution-units (INT, INT)
                                                           | --simple-script-tx-in-reference TX-IN
                                                           | --tx-in-script-file FILE
                                                             [
-                                                              ( --tx-in-datum-cbor-file CBOR FILE
-                                                              | --tx-in-datum-file JSON FILE
-                                                              | --tx-in-datum-value JSON VALUE
+                                                              ( --tx-in-datum-cbor-file CBOR_FILE
+                                                              | --tx-in-datum-file JSON_FILE
+                                                              | --tx-in-datum-value JSON_VALUE
                                                               | --tx-in-inline-datum-present
                                                               )
-                                                              ( --tx-in-redeemer-cbor-file CBOR FILE
-                                                              | --tx-in-redeemer-file JSON FILE
-                                                              | --tx-in-redeemer-value JSON VALUE
+                                                              ( --tx-in-redeemer-cbor-file CBOR_FILE
+                                                              | --tx-in-redeemer-file JSON_FILE
+                                                              | --tx-in-redeemer-value JSON_VALUE
                                                               )
                                                               --tx-in-execution-units (INT, INT)]
                                                           ])
@@ -6191,24 +6191,24 @@ Usage: cardano-cli babbage transaction build-estimate
                                                         [--tx-out-return-collateral ADDRESS VALUE]
                                                         [--tx-out ADDRESS VALUE
                                                           [ --tx-out-datum-hash HASH
-                                                          | --tx-out-datum-hash-cbor-file CBOR FILE
-                                                          | --tx-out-datum-hash-file JSON FILE
-                                                          | --tx-out-datum-hash-value JSON VALUE
-                                                          | --tx-out-datum-embed-cbor-file CBOR FILE
-                                                          | --tx-out-datum-embed-file JSON FILE
-                                                          | --tx-out-datum-embed-value JSON VALUE
-                                                          | --tx-out-inline-datum-cbor-file CBOR FILE
-                                                          | --tx-out-inline-datum-file JSON FILE
-                                                          | --tx-out-inline-datum-value JSON VALUE
+                                                          | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                          | --tx-out-datum-hash-file JSON_FILE
+                                                          | --tx-out-datum-hash-value JSON_VALUE
+                                                          | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                          | --tx-out-datum-embed-file JSON_FILE
+                                                          | --tx-out-datum-embed-value JSON_VALUE
+                                                          | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                          | --tx-out-inline-datum-file JSON_FILE
+                                                          | --tx-out-inline-datum-value JSON_VALUE
                                                           ]
                                                           [--tx-out-reference-script-file FILE]]
                                                         --change-address ADDRESS
                                                         [--mint VALUE
                                                           ( --mint-script-file FILE
                                                             [
-                                                              ( --mint-redeemer-cbor-file CBOR FILE
-                                                              | --mint-redeemer-file JSON FILE
-                                                              | --mint-redeemer-value JSON VALUE
+                                                              ( --mint-redeemer-cbor-file CBOR_FILE
+                                                              | --mint-redeemer-file JSON_FILE
+                                                              | --mint-redeemer-value JSON_VALUE
                                                               )
                                                               --mint-execution-units (INT, INT)]
                                                           | --simple-minting-script-tx-in-reference TX-IN
@@ -6217,9 +6217,9 @@ Usage: cardano-cli babbage transaction build-estimate
                                                             ( --mint-plutus-script-v2
                                                             | --mint-plutus-script-v3
                                                             )
-                                                            ( --mint-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                            | --mint-reference-tx-in-redeemer-file JSON FILE
-                                                            | --mint-reference-tx-in-redeemer-value JSON VALUE
+                                                            ( --mint-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                            | --mint-reference-tx-in-redeemer-file JSON_FILE
+                                                            | --mint-reference-tx-in-redeemer-value JSON_VALUE
                                                             )
                                                             --mint-reference-tx-in-execution-units (INT, INT)
                                                             --policy-id HASH
@@ -6229,36 +6229,36 @@ Usage: cardano-cli babbage transaction build-estimate
                                                         [--certificate-file FILE
                                                           [ --certificate-script-file FILE
                                                             [
-                                                              ( --certificate-redeemer-cbor-file CBOR FILE
-                                                              | --certificate-redeemer-file JSON FILE
-                                                              | --certificate-redeemer-value JSON VALUE
+                                                              ( --certificate-redeemer-cbor-file CBOR_FILE
+                                                              | --certificate-redeemer-file JSON_FILE
+                                                              | --certificate-redeemer-value JSON_VALUE
                                                               )
                                                               --certificate-execution-units (INT, INT)]
                                                           | --certificate-tx-in-reference TX-IN
                                                             ( --certificate-plutus-script-v2
                                                             | --certificate-plutus-script-v3
                                                             )
-                                                            ( --certificate-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                            | --certificate-reference-tx-in-redeemer-file JSON FILE
-                                                            | --certificate-reference-tx-in-redeemer-value JSON VALUE
+                                                            ( --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                            | --certificate-reference-tx-in-redeemer-file JSON_FILE
+                                                            | --certificate-reference-tx-in-redeemer-value JSON_VALUE
                                                             )
                                                             --certificate-reference-tx-in-execution-units (INT, INT)
                                                           ]]
                                                         [--withdrawal WITHDRAWAL
                                                           [ --withdrawal-script-file FILE
                                                             [
-                                                              ( --withdrawal-redeemer-cbor-file CBOR FILE
-                                                              | --withdrawal-redeemer-file JSON FILE
-                                                              | --withdrawal-redeemer-value JSON VALUE
+                                                              ( --withdrawal-redeemer-cbor-file CBOR_FILE
+                                                              | --withdrawal-redeemer-file JSON_FILE
+                                                              | --withdrawal-redeemer-value JSON_VALUE
                                                               )
                                                               --withdrawal-execution-units (INT, INT)]
                                                           | --withdrawal-tx-in-reference TX-IN
                                                             ( --withdrawal-plutus-script-v2
                                                             | --withdrawal-plutus-script-v3
                                                             )
-                                                            ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                            | --withdrawal-reference-tx-in-redeemer-file JSON FILE
-                                                            | --withdrawal-reference-tx-in-redeemer-value JSON VALUE
+                                                            ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                            | --withdrawal-reference-tx-in-redeemer-file JSON_FILE
+                                                            | --withdrawal-reference-tx-in-redeemer-value JSON_VALUE
                                                             )
                                                             --withdrawal-reference-tx-in-execution-units (INT, INT)
                                                           ]]
@@ -6344,15 +6344,15 @@ Usage: cardano-cli babbage transaction calculate-min-fee --tx-body-file FILE
 Usage: cardano-cli babbage transaction calculate-min-required-utxo --protocol-params-file FILE
                                                                      --tx-out ADDRESS VALUE
                                                                      [ --tx-out-datum-hash HASH
-                                                                     | --tx-out-datum-hash-cbor-file CBOR FILE
-                                                                     | --tx-out-datum-hash-file JSON FILE
-                                                                     | --tx-out-datum-hash-value JSON VALUE
-                                                                     | --tx-out-datum-embed-cbor-file CBOR FILE
-                                                                     | --tx-out-datum-embed-file JSON FILE
-                                                                     | --tx-out-datum-embed-value JSON VALUE
-                                                                     | --tx-out-inline-datum-cbor-file CBOR FILE
-                                                                     | --tx-out-inline-datum-file JSON FILE
-                                                                     | --tx-out-inline-datum-value JSON VALUE
+                                                                     | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                                     | --tx-out-datum-hash-file JSON_FILE
+                                                                     | --tx-out-datum-hash-value JSON_VALUE
+                                                                     | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                                     | --tx-out-datum-embed-file JSON_FILE
+                                                                     | --tx-out-datum-embed-value JSON_VALUE
+                                                                     | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                                     | --tx-out-inline-datum-file JSON_FILE
+                                                                     | --tx-out-inline-datum-value JSON_VALUE
                                                                      ]
                                                                      [--tx-out-reference-script-file FILE]
 
@@ -6361,24 +6361,24 @@ Usage: cardano-cli babbage transaction calculate-min-required-utxo --protocol-pa
 Usage: cardano-cli babbage transaction calculate-min-value --protocol-params-file FILE
                                                              --tx-out ADDRESS VALUE
                                                              [ --tx-out-datum-hash HASH
-                                                             | --tx-out-datum-hash-cbor-file CBOR FILE
-                                                             | --tx-out-datum-hash-file JSON FILE
-                                                             | --tx-out-datum-hash-value JSON VALUE
-                                                             | --tx-out-datum-embed-cbor-file CBOR FILE
-                                                             | --tx-out-datum-embed-file JSON FILE
-                                                             | --tx-out-datum-embed-value JSON VALUE
-                                                             | --tx-out-inline-datum-cbor-file CBOR FILE
-                                                             | --tx-out-inline-datum-file JSON FILE
-                                                             | --tx-out-inline-datum-value JSON VALUE
+                                                             | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                             | --tx-out-datum-hash-file JSON_FILE
+                                                             | --tx-out-datum-hash-value JSON_VALUE
+                                                             | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                             | --tx-out-datum-embed-file JSON_FILE
+                                                             | --tx-out-datum-embed-value JSON_VALUE
+                                                             | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                             | --tx-out-inline-datum-file JSON_FILE
+                                                             | --tx-out-inline-datum-value JSON_VALUE
                                                              ]
                                                              [--tx-out-reference-script-file FILE]
 
   DEPRECATED: Use 'calculate-min-required-utxo' instead.
 
 Usage: cardano-cli babbage transaction hash-script-data 
-                                                          ( --script-data-cbor-file CBOR FILE
-                                                          | --script-data-file JSON FILE
-                                                          | --script-data-value JSON VALUE
+                                                          ( --script-data-cbor-file CBOR_FILE
+                                                          | --script-data-file JSON_FILE
+                                                          | --script-data-value JSON_VALUE
                                                           )
 
   Calculate the hash of script data.
@@ -7705,27 +7705,27 @@ Usage: cardano-cli conway transaction build-raw
                                                       ( --spending-plutus-script-v2
                                                       | --spending-plutus-script-v3
                                                       )
-                                                      ( --spending-reference-tx-in-datum-cbor-file CBOR FILE
-                                                      | --spending-reference-tx-in-datum-file JSON FILE
-                                                      | --spending-reference-tx-in-datum-value JSON VALUE
+                                                      ( --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                                                      | --spending-reference-tx-in-datum-file JSON_FILE
+                                                      | --spending-reference-tx-in-datum-value JSON_VALUE
                                                       | --spending-reference-tx-in-inline-datum-present
                                                       )
-                                                      ( --spending-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                      | --spending-reference-tx-in-redeemer-file JSON FILE
-                                                      | --spending-reference-tx-in-redeemer-value JSON VALUE
+                                                      ( --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                      | --spending-reference-tx-in-redeemer-file JSON_FILE
+                                                      | --spending-reference-tx-in-redeemer-value JSON_VALUE
                                                       )
                                                       --spending-reference-tx-in-execution-units (INT, INT)
                                                     | --simple-script-tx-in-reference TX-IN
                                                     | --tx-in-script-file FILE
                                                       [
-                                                        ( --tx-in-datum-cbor-file CBOR FILE
-                                                        | --tx-in-datum-file JSON FILE
-                                                        | --tx-in-datum-value JSON VALUE
+                                                        ( --tx-in-datum-cbor-file CBOR_FILE
+                                                        | --tx-in-datum-file JSON_FILE
+                                                        | --tx-in-datum-value JSON_VALUE
                                                         | --tx-in-inline-datum-present
                                                         )
-                                                        ( --tx-in-redeemer-cbor-file CBOR FILE
-                                                        | --tx-in-redeemer-file JSON FILE
-                                                        | --tx-in-redeemer-value JSON VALUE
+                                                        ( --tx-in-redeemer-cbor-file CBOR_FILE
+                                                        | --tx-in-redeemer-file JSON_FILE
+                                                        | --tx-in-redeemer-value JSON_VALUE
                                                         )
                                                         --tx-in-execution-units (INT, INT)]
                                                     ])
@@ -7738,23 +7738,23 @@ Usage: cardano-cli conway transaction build-raw
                                                   ]
                                                   [--tx-out ADDRESS VALUE
                                                     [ --tx-out-datum-hash HASH
-                                                    | --tx-out-datum-hash-cbor-file CBOR FILE
-                                                    | --tx-out-datum-hash-file JSON FILE
-                                                    | --tx-out-datum-hash-value JSON VALUE
-                                                    | --tx-out-datum-embed-cbor-file CBOR FILE
-                                                    | --tx-out-datum-embed-file JSON FILE
-                                                    | --tx-out-datum-embed-value JSON VALUE
-                                                    | --tx-out-inline-datum-cbor-file CBOR FILE
-                                                    | --tx-out-inline-datum-file JSON FILE
-                                                    | --tx-out-inline-datum-value JSON VALUE
+                                                    | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                    | --tx-out-datum-hash-file JSON_FILE
+                                                    | --tx-out-datum-hash-value JSON_VALUE
+                                                    | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                    | --tx-out-datum-embed-file JSON_FILE
+                                                    | --tx-out-datum-embed-value JSON_VALUE
+                                                    | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                    | --tx-out-inline-datum-file JSON_FILE
+                                                    | --tx-out-inline-datum-value JSON_VALUE
                                                     ]
                                                     [--tx-out-reference-script-file FILE]]
                                                   [--mint VALUE
                                                     ( --mint-script-file FILE
                                                       [
-                                                        ( --mint-redeemer-cbor-file CBOR FILE
-                                                        | --mint-redeemer-file JSON FILE
-                                                        | --mint-redeemer-value JSON VALUE
+                                                        ( --mint-redeemer-cbor-file CBOR_FILE
+                                                        | --mint-redeemer-file JSON_FILE
+                                                        | --mint-redeemer-value JSON_VALUE
                                                         )
                                                         --mint-execution-units (INT, INT)]
                                                     | --simple-minting-script-tx-in-reference TX-IN
@@ -7763,9 +7763,9 @@ Usage: cardano-cli conway transaction build-raw
                                                       ( --mint-plutus-script-v2
                                                       | --mint-plutus-script-v3
                                                       )
-                                                      ( --mint-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                      | --mint-reference-tx-in-redeemer-file JSON FILE
-                                                      | --mint-reference-tx-in-redeemer-value JSON VALUE
+                                                      ( --mint-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                      | --mint-reference-tx-in-redeemer-file JSON_FILE
+                                                      | --mint-reference-tx-in-redeemer-value JSON_VALUE
                                                       )
                                                       --mint-reference-tx-in-execution-units (INT, INT)
                                                       --policy-id HASH
@@ -7776,36 +7776,36 @@ Usage: cardano-cli conway transaction build-raw
                                                   [--certificate-file FILE
                                                     [ --certificate-script-file FILE
                                                       [
-                                                        ( --certificate-redeemer-cbor-file CBOR FILE
-                                                        | --certificate-redeemer-file JSON FILE
-                                                        | --certificate-redeemer-value JSON VALUE
+                                                        ( --certificate-redeemer-cbor-file CBOR_FILE
+                                                        | --certificate-redeemer-file JSON_FILE
+                                                        | --certificate-redeemer-value JSON_VALUE
                                                         )
                                                         --certificate-execution-units (INT, INT)]
                                                     | --certificate-tx-in-reference TX-IN
                                                       ( --certificate-plutus-script-v2
                                                       | --certificate-plutus-script-v3
                                                       )
-                                                      ( --certificate-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                      | --certificate-reference-tx-in-redeemer-file JSON FILE
-                                                      | --certificate-reference-tx-in-redeemer-value JSON VALUE
+                                                      ( --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                      | --certificate-reference-tx-in-redeemer-file JSON_FILE
+                                                      | --certificate-reference-tx-in-redeemer-value JSON_VALUE
                                                       )
                                                       --certificate-reference-tx-in-execution-units (INT, INT)
                                                     ]]
                                                   [--withdrawal WITHDRAWAL
                                                     [ --withdrawal-script-file FILE
                                                       [
-                                                        ( --withdrawal-redeemer-cbor-file CBOR FILE
-                                                        | --withdrawal-redeemer-file JSON FILE
-                                                        | --withdrawal-redeemer-value JSON VALUE
+                                                        ( --withdrawal-redeemer-cbor-file CBOR_FILE
+                                                        | --withdrawal-redeemer-file JSON_FILE
+                                                        | --withdrawal-redeemer-value JSON_VALUE
                                                         )
                                                         --withdrawal-execution-units (INT, INT)]
                                                     | --withdrawal-tx-in-reference TX-IN
                                                       ( --withdrawal-plutus-script-v2
                                                       | --withdrawal-plutus-script-v3
                                                       )
-                                                      ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                      | --withdrawal-reference-tx-in-redeemer-file JSON FILE
-                                                      | --withdrawal-reference-tx-in-redeemer-value JSON VALUE
+                                                      ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                      | --withdrawal-reference-tx-in-redeemer-file JSON_FILE
+                                                      | --withdrawal-reference-tx-in-redeemer-value JSON_VALUE
                                                       )
                                                       --withdrawal-reference-tx-in-execution-units (INT, INT)
                                                     ]]
@@ -7820,17 +7820,17 @@ Usage: cardano-cli conway transaction build-raw
                                                   [--vote-file FILE
                                                     [--vote-script-file FILE
                                                       [
-                                                        ( --vote-redeemer-cbor-file CBOR FILE
-                                                        | --vote-redeemer-file JSON FILE
-                                                        | --vote-redeemer-value JSON VALUE
+                                                        ( --vote-redeemer-cbor-file CBOR_FILE
+                                                        | --vote-redeemer-file JSON_FILE
+                                                        | --vote-redeemer-value JSON_VALUE
                                                         )
                                                         --vote-execution-units (INT, INT)]]]
                                                   [--proposal-file FILE
                                                     [--proposal-script-file FILE
                                                       [
-                                                        ( --proposal-redeemer-cbor-file CBOR FILE
-                                                        | --proposal-redeemer-file JSON FILE
-                                                        | --proposal-redeemer-value JSON VALUE
+                                                        ( --proposal-redeemer-cbor-file CBOR_FILE
+                                                        | --proposal-redeemer-file JSON_FILE
+                                                        | --proposal-redeemer-value JSON_VALUE
                                                         )
                                                         --proposal-execution-units (INT, INT)]]]
                                                   --out-file FILE
@@ -7854,26 +7854,26 @@ Usage: cardano-cli conway transaction build --socket-path SOCKET_PATH
                                                   ( --spending-plutus-script-v2
                                                   | --spending-plutus-script-v3
                                                   )
-                                                  ( --spending-reference-tx-in-datum-cbor-file CBOR FILE
-                                                  | --spending-reference-tx-in-datum-file JSON FILE
-                                                  | --spending-reference-tx-in-datum-value JSON VALUE
+                                                  ( --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                                                  | --spending-reference-tx-in-datum-file JSON_FILE
+                                                  | --spending-reference-tx-in-datum-value JSON_VALUE
                                                   | --spending-reference-tx-in-inline-datum-present
                                                   )
-                                                  ( --spending-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                  | --spending-reference-tx-in-redeemer-file JSON FILE
-                                                  | --spending-reference-tx-in-redeemer-value JSON VALUE
+                                                  ( --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                  | --spending-reference-tx-in-redeemer-file JSON_FILE
+                                                  | --spending-reference-tx-in-redeemer-value JSON_VALUE
                                                   )
                                                 | --simple-script-tx-in-reference TX-IN
                                                 | --tx-in-script-file FILE
                                                   [
-                                                    ( --tx-in-datum-cbor-file CBOR FILE
-                                                    | --tx-in-datum-file JSON FILE
-                                                    | --tx-in-datum-value JSON VALUE
+                                                    ( --tx-in-datum-cbor-file CBOR_FILE
+                                                    | --tx-in-datum-file JSON_FILE
+                                                    | --tx-in-datum-value JSON_VALUE
                                                     | --tx-in-inline-datum-present
                                                     )
-                                                    ( --tx-in-redeemer-cbor-file CBOR FILE
-                                                    | --tx-in-redeemer-file JSON FILE
-                                                    | --tx-in-redeemer-value JSON VALUE
+                                                    ( --tx-in-redeemer-cbor-file CBOR_FILE
+                                                    | --tx-in-redeemer-file JSON_FILE
+                                                    | --tx-in-redeemer-value JSON_VALUE
                                                     )]
                                                 ])
                                               [--read-only-tx-in-reference TX-IN]
@@ -7885,23 +7885,23 @@ Usage: cardano-cli conway transaction build --socket-path SOCKET_PATH
                                               [--tx-total-collateral INTEGER]
                                               [--tx-out ADDRESS VALUE
                                                 [ --tx-out-datum-hash HASH
-                                                | --tx-out-datum-hash-cbor-file CBOR FILE
-                                                | --tx-out-datum-hash-file JSON FILE
-                                                | --tx-out-datum-hash-value JSON VALUE
-                                                | --tx-out-datum-embed-cbor-file CBOR FILE
-                                                | --tx-out-datum-embed-file JSON FILE
-                                                | --tx-out-datum-embed-value JSON VALUE
-                                                | --tx-out-inline-datum-cbor-file CBOR FILE
-                                                | --tx-out-inline-datum-file JSON FILE
-                                                | --tx-out-inline-datum-value JSON VALUE
+                                                | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                | --tx-out-datum-hash-file JSON_FILE
+                                                | --tx-out-datum-hash-value JSON_VALUE
+                                                | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                | --tx-out-datum-embed-file JSON_FILE
+                                                | --tx-out-datum-embed-value JSON_VALUE
+                                                | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                | --tx-out-inline-datum-file JSON_FILE
+                                                | --tx-out-inline-datum-value JSON_VALUE
                                                 ]
                                                 [--tx-out-reference-script-file FILE]]
                                               --change-address ADDRESS
                                               [--mint VALUE
                                                 ( --mint-script-file FILE
-                                                  [ --mint-redeemer-cbor-file CBOR FILE
-                                                  | --mint-redeemer-file JSON FILE
-                                                  | --mint-redeemer-value JSON VALUE
+                                                  [ --mint-redeemer-cbor-file CBOR_FILE
+                                                  | --mint-redeemer-file JSON_FILE
+                                                  | --mint-redeemer-value JSON_VALUE
                                                   ]
                                                 | --simple-minting-script-tx-in-reference TX-IN
                                                   --policy-id HASH
@@ -7909,9 +7909,9 @@ Usage: cardano-cli conway transaction build --socket-path SOCKET_PATH
                                                   ( --mint-plutus-script-v2
                                                   | --mint-plutus-script-v3
                                                   )
-                                                  ( --mint-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                  | --mint-reference-tx-in-redeemer-file JSON FILE
-                                                  | --mint-reference-tx-in-redeemer-value JSON VALUE
+                                                  ( --mint-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                  | --mint-reference-tx-in-redeemer-file JSON_FILE
+                                                  | --mint-reference-tx-in-redeemer-value JSON_VALUE
                                                   )
                                                   --policy-id HASH
                                                 )]
@@ -7919,32 +7919,32 @@ Usage: cardano-cli conway transaction build --socket-path SOCKET_PATH
                                               [--invalid-hereafter SLOT]
                                               [--certificate-file FILE
                                                 [ --certificate-script-file FILE
-                                                  [ --certificate-redeemer-cbor-file CBOR FILE
-                                                  | --certificate-redeemer-file JSON FILE
-                                                  | --certificate-redeemer-value JSON VALUE
+                                                  [ --certificate-redeemer-cbor-file CBOR_FILE
+                                                  | --certificate-redeemer-file JSON_FILE
+                                                  | --certificate-redeemer-value JSON_VALUE
                                                   ]
                                                 | --certificate-tx-in-reference TX-IN
                                                   ( --certificate-plutus-script-v2
                                                   | --certificate-plutus-script-v3
                                                   )
-                                                  ( --certificate-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                  | --certificate-reference-tx-in-redeemer-file JSON FILE
-                                                  | --certificate-reference-tx-in-redeemer-value JSON VALUE
+                                                  ( --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                  | --certificate-reference-tx-in-redeemer-file JSON_FILE
+                                                  | --certificate-reference-tx-in-redeemer-value JSON_VALUE
                                                   )
                                                 ]]
                                               [--withdrawal WITHDRAWAL
                                                 [ --withdrawal-script-file FILE
-                                                  [ --withdrawal-redeemer-cbor-file CBOR FILE
-                                                  | --withdrawal-redeemer-file JSON FILE
-                                                  | --withdrawal-redeemer-value JSON VALUE
+                                                  [ --withdrawal-redeemer-cbor-file CBOR_FILE
+                                                  | --withdrawal-redeemer-file JSON_FILE
+                                                  | --withdrawal-redeemer-value JSON_VALUE
                                                   ]
                                                 | --withdrawal-tx-in-reference TX-IN
                                                   ( --withdrawal-plutus-script-v2
                                                   | --withdrawal-plutus-script-v3
                                                   )
-                                                  ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                  | --withdrawal-reference-tx-in-redeemer-file JSON FILE
-                                                  | --withdrawal-reference-tx-in-redeemer-value JSON VALUE
+                                                  ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                  | --withdrawal-reference-tx-in-redeemer-file JSON_FILE
+                                                  | --withdrawal-reference-tx-in-redeemer-value JSON_VALUE
                                                   )
                                                 ]]
                                               [ --json-metadata-no-schema
@@ -7956,15 +7956,15 @@ Usage: cardano-cli conway transaction build --socket-path SOCKET_PATH
                                               ]
                                               [--vote-file FILE
                                                 [--vote-script-file FILE
-                                                  [ --vote-redeemer-cbor-file CBOR FILE
-                                                  | --vote-redeemer-file JSON FILE
-                                                  | --vote-redeemer-value JSON VALUE
+                                                  [ --vote-redeemer-cbor-file CBOR_FILE
+                                                  | --vote-redeemer-file JSON_FILE
+                                                  | --vote-redeemer-value JSON_VALUE
                                                   ]]]
                                               [--proposal-file FILE
                                                 [--proposal-script-file FILE
-                                                  [ --proposal-redeemer-cbor-file CBOR FILE
-                                                  | --proposal-redeemer-file JSON FILE
-                                                  | --proposal-redeemer-value JSON VALUE
+                                                  [ --proposal-redeemer-cbor-file CBOR_FILE
+                                                  | --proposal-redeemer-file JSON_FILE
+                                                  | --proposal-redeemer-value JSON_VALUE
                                                   ]]]
                                               ( --out-file FILE
                                               | --calculate-plutus-script-cost FILE
@@ -7987,27 +7987,27 @@ Usage: cardano-cli conway transaction build-estimate
                                                            ( --spending-plutus-script-v2
                                                            | --spending-plutus-script-v3
                                                            )
-                                                           ( --spending-reference-tx-in-datum-cbor-file CBOR FILE
-                                                           | --spending-reference-tx-in-datum-file JSON FILE
-                                                           | --spending-reference-tx-in-datum-value JSON VALUE
+                                                           ( --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                                                           | --spending-reference-tx-in-datum-file JSON_FILE
+                                                           | --spending-reference-tx-in-datum-value JSON_VALUE
                                                            | --spending-reference-tx-in-inline-datum-present
                                                            )
-                                                           ( --spending-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                           | --spending-reference-tx-in-redeemer-file JSON FILE
-                                                           | --spending-reference-tx-in-redeemer-value JSON VALUE
+                                                           ( --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                           | --spending-reference-tx-in-redeemer-file JSON_FILE
+                                                           | --spending-reference-tx-in-redeemer-value JSON_VALUE
                                                            )
                                                            --spending-reference-tx-in-execution-units (INT, INT)
                                                          | --simple-script-tx-in-reference TX-IN
                                                          | --tx-in-script-file FILE
                                                            [
-                                                             ( --tx-in-datum-cbor-file CBOR FILE
-                                                             | --tx-in-datum-file JSON FILE
-                                                             | --tx-in-datum-value JSON VALUE
+                                                             ( --tx-in-datum-cbor-file CBOR_FILE
+                                                             | --tx-in-datum-file JSON_FILE
+                                                             | --tx-in-datum-value JSON_VALUE
                                                              | --tx-in-inline-datum-present
                                                              )
-                                                             ( --tx-in-redeemer-cbor-file CBOR FILE
-                                                             | --tx-in-redeemer-file JSON FILE
-                                                             | --tx-in-redeemer-value JSON VALUE
+                                                             ( --tx-in-redeemer-cbor-file CBOR_FILE
+                                                             | --tx-in-redeemer-file JSON_FILE
+                                                             | --tx-in-redeemer-value JSON_VALUE
                                                              )
                                                              --tx-in-execution-units (INT, INT)]
                                                          ])
@@ -8019,24 +8019,24 @@ Usage: cardano-cli conway transaction build-estimate
                                                        [--tx-out-return-collateral ADDRESS VALUE]
                                                        [--tx-out ADDRESS VALUE
                                                          [ --tx-out-datum-hash HASH
-                                                         | --tx-out-datum-hash-cbor-file CBOR FILE
-                                                         | --tx-out-datum-hash-file JSON FILE
-                                                         | --tx-out-datum-hash-value JSON VALUE
-                                                         | --tx-out-datum-embed-cbor-file CBOR FILE
-                                                         | --tx-out-datum-embed-file JSON FILE
-                                                         | --tx-out-datum-embed-value JSON VALUE
-                                                         | --tx-out-inline-datum-cbor-file CBOR FILE
-                                                         | --tx-out-inline-datum-file JSON FILE
-                                                         | --tx-out-inline-datum-value JSON VALUE
+                                                         | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                         | --tx-out-datum-hash-file JSON_FILE
+                                                         | --tx-out-datum-hash-value JSON_VALUE
+                                                         | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                         | --tx-out-datum-embed-file JSON_FILE
+                                                         | --tx-out-datum-embed-value JSON_VALUE
+                                                         | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                         | --tx-out-inline-datum-file JSON_FILE
+                                                         | --tx-out-inline-datum-value JSON_VALUE
                                                          ]
                                                          [--tx-out-reference-script-file FILE]]
                                                        --change-address ADDRESS
                                                        [--mint VALUE
                                                          ( --mint-script-file FILE
                                                            [
-                                                             ( --mint-redeemer-cbor-file CBOR FILE
-                                                             | --mint-redeemer-file JSON FILE
-                                                             | --mint-redeemer-value JSON VALUE
+                                                             ( --mint-redeemer-cbor-file CBOR_FILE
+                                                             | --mint-redeemer-file JSON_FILE
+                                                             | --mint-redeemer-value JSON_VALUE
                                                              )
                                                              --mint-execution-units (INT, INT)]
                                                          | --simple-minting-script-tx-in-reference TX-IN
@@ -8045,9 +8045,9 @@ Usage: cardano-cli conway transaction build-estimate
                                                            ( --mint-plutus-script-v2
                                                            | --mint-plutus-script-v3
                                                            )
-                                                           ( --mint-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                           | --mint-reference-tx-in-redeemer-file JSON FILE
-                                                           | --mint-reference-tx-in-redeemer-value JSON VALUE
+                                                           ( --mint-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                           | --mint-reference-tx-in-redeemer-file JSON_FILE
+                                                           | --mint-reference-tx-in-redeemer-value JSON_VALUE
                                                            )
                                                            --mint-reference-tx-in-execution-units (INT, INT)
                                                            --policy-id HASH
@@ -8057,36 +8057,36 @@ Usage: cardano-cli conway transaction build-estimate
                                                        [--certificate-file FILE
                                                          [ --certificate-script-file FILE
                                                            [
-                                                             ( --certificate-redeemer-cbor-file CBOR FILE
-                                                             | --certificate-redeemer-file JSON FILE
-                                                             | --certificate-redeemer-value JSON VALUE
+                                                             ( --certificate-redeemer-cbor-file CBOR_FILE
+                                                             | --certificate-redeemer-file JSON_FILE
+                                                             | --certificate-redeemer-value JSON_VALUE
                                                              )
                                                              --certificate-execution-units (INT, INT)]
                                                          | --certificate-tx-in-reference TX-IN
                                                            ( --certificate-plutus-script-v2
                                                            | --certificate-plutus-script-v3
                                                            )
-                                                           ( --certificate-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                           | --certificate-reference-tx-in-redeemer-file JSON FILE
-                                                           | --certificate-reference-tx-in-redeemer-value JSON VALUE
+                                                           ( --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                           | --certificate-reference-tx-in-redeemer-file JSON_FILE
+                                                           | --certificate-reference-tx-in-redeemer-value JSON_VALUE
                                                            )
                                                            --certificate-reference-tx-in-execution-units (INT, INT)
                                                          ]]
                                                        [--withdrawal WITHDRAWAL
                                                          [ --withdrawal-script-file FILE
                                                            [
-                                                             ( --withdrawal-redeemer-cbor-file CBOR FILE
-                                                             | --withdrawal-redeemer-file JSON FILE
-                                                             | --withdrawal-redeemer-value JSON VALUE
+                                                             ( --withdrawal-redeemer-cbor-file CBOR_FILE
+                                                             | --withdrawal-redeemer-file JSON_FILE
+                                                             | --withdrawal-redeemer-value JSON_VALUE
                                                              )
                                                              --withdrawal-execution-units (INT, INT)]
                                                          | --withdrawal-tx-in-reference TX-IN
                                                            ( --withdrawal-plutus-script-v2
                                                            | --withdrawal-plutus-script-v3
                                                            )
-                                                           ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                           | --withdrawal-reference-tx-in-redeemer-file JSON FILE
-                                                           | --withdrawal-reference-tx-in-redeemer-value JSON VALUE
+                                                           ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                           | --withdrawal-reference-tx-in-redeemer-file JSON_FILE
+                                                           | --withdrawal-reference-tx-in-redeemer-value JSON_VALUE
                                                            )
                                                            --withdrawal-reference-tx-in-execution-units (INT, INT)
                                                          ]]
@@ -8102,17 +8102,17 @@ Usage: cardano-cli conway transaction build-estimate
                                                        [--vote-file FILE
                                                          [--vote-script-file FILE
                                                            [
-                                                             ( --vote-redeemer-cbor-file CBOR FILE
-                                                             | --vote-redeemer-file JSON FILE
-                                                             | --vote-redeemer-value JSON VALUE
+                                                             ( --vote-redeemer-cbor-file CBOR_FILE
+                                                             | --vote-redeemer-file JSON_FILE
+                                                             | --vote-redeemer-value JSON_VALUE
                                                              )
                                                              --vote-execution-units (INT, INT)]]]
                                                        [--proposal-file FILE
                                                          [--proposal-script-file FILE
                                                            [
-                                                             ( --proposal-redeemer-cbor-file CBOR FILE
-                                                             | --proposal-redeemer-file JSON FILE
-                                                             | --proposal-redeemer-value JSON VALUE
+                                                             ( --proposal-redeemer-cbor-file CBOR_FILE
+                                                             | --proposal-redeemer-file JSON_FILE
+                                                             | --proposal-redeemer-value JSON_VALUE
                                                              )
                                                              --proposal-execution-units (INT, INT)]]]
                                                        --out-file FILE
@@ -8187,15 +8187,15 @@ Usage: cardano-cli conway transaction calculate-min-fee --tx-body-file FILE
 Usage: cardano-cli conway transaction calculate-min-required-utxo --protocol-params-file FILE
                                                                     --tx-out ADDRESS VALUE
                                                                     [ --tx-out-datum-hash HASH
-                                                                    | --tx-out-datum-hash-cbor-file CBOR FILE
-                                                                    | --tx-out-datum-hash-file JSON FILE
-                                                                    | --tx-out-datum-hash-value JSON VALUE
-                                                                    | --tx-out-datum-embed-cbor-file CBOR FILE
-                                                                    | --tx-out-datum-embed-file JSON FILE
-                                                                    | --tx-out-datum-embed-value JSON VALUE
-                                                                    | --tx-out-inline-datum-cbor-file CBOR FILE
-                                                                    | --tx-out-inline-datum-file JSON FILE
-                                                                    | --tx-out-inline-datum-value JSON VALUE
+                                                                    | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                                    | --tx-out-datum-hash-file JSON_FILE
+                                                                    | --tx-out-datum-hash-value JSON_VALUE
+                                                                    | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                                    | --tx-out-datum-embed-file JSON_FILE
+                                                                    | --tx-out-datum-embed-value JSON_VALUE
+                                                                    | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                                    | --tx-out-inline-datum-file JSON_FILE
+                                                                    | --tx-out-inline-datum-value JSON_VALUE
                                                                     ]
                                                                     [--tx-out-reference-script-file FILE]
 
@@ -8204,24 +8204,24 @@ Usage: cardano-cli conway transaction calculate-min-required-utxo --protocol-par
 Usage: cardano-cli conway transaction calculate-min-value --protocol-params-file FILE
                                                             --tx-out ADDRESS VALUE
                                                             [ --tx-out-datum-hash HASH
-                                                            | --tx-out-datum-hash-cbor-file CBOR FILE
-                                                            | --tx-out-datum-hash-file JSON FILE
-                                                            | --tx-out-datum-hash-value JSON VALUE
-                                                            | --tx-out-datum-embed-cbor-file CBOR FILE
-                                                            | --tx-out-datum-embed-file JSON FILE
-                                                            | --tx-out-datum-embed-value JSON VALUE
-                                                            | --tx-out-inline-datum-cbor-file CBOR FILE
-                                                            | --tx-out-inline-datum-file JSON FILE
-                                                            | --tx-out-inline-datum-value JSON VALUE
+                                                            | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                            | --tx-out-datum-hash-file JSON_FILE
+                                                            | --tx-out-datum-hash-value JSON_VALUE
+                                                            | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                            | --tx-out-datum-embed-file JSON_FILE
+                                                            | --tx-out-datum-embed-value JSON_VALUE
+                                                            | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                            | --tx-out-inline-datum-file JSON_FILE
+                                                            | --tx-out-inline-datum-value JSON_VALUE
                                                             ]
                                                             [--tx-out-reference-script-file FILE]
 
   DEPRECATED: Use 'calculate-min-required-utxo' instead.
 
 Usage: cardano-cli conway transaction hash-script-data 
-                                                         ( --script-data-cbor-file CBOR FILE
-                                                         | --script-data-file JSON FILE
-                                                         | --script-data-value JSON VALUE
+                                                         ( --script-data-cbor-file CBOR_FILE
+                                                         | --script-data-file JSON_FILE
+                                                         | --script-data-value JSON_VALUE
                                                          )
 
   Calculate the hash of script data.
@@ -9097,27 +9097,27 @@ Usage: cardano-cli latest transaction build-raw
                                                       ( --spending-plutus-script-v2
                                                       | --spending-plutus-script-v3
                                                       )
-                                                      ( --spending-reference-tx-in-datum-cbor-file CBOR FILE
-                                                      | --spending-reference-tx-in-datum-file JSON FILE
-                                                      | --spending-reference-tx-in-datum-value JSON VALUE
+                                                      ( --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                                                      | --spending-reference-tx-in-datum-file JSON_FILE
+                                                      | --spending-reference-tx-in-datum-value JSON_VALUE
                                                       | --spending-reference-tx-in-inline-datum-present
                                                       )
-                                                      ( --spending-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                      | --spending-reference-tx-in-redeemer-file JSON FILE
-                                                      | --spending-reference-tx-in-redeemer-value JSON VALUE
+                                                      ( --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                      | --spending-reference-tx-in-redeemer-file JSON_FILE
+                                                      | --spending-reference-tx-in-redeemer-value JSON_VALUE
                                                       )
                                                       --spending-reference-tx-in-execution-units (INT, INT)
                                                     | --simple-script-tx-in-reference TX-IN
                                                     | --tx-in-script-file FILE
                                                       [
-                                                        ( --tx-in-datum-cbor-file CBOR FILE
-                                                        | --tx-in-datum-file JSON FILE
-                                                        | --tx-in-datum-value JSON VALUE
+                                                        ( --tx-in-datum-cbor-file CBOR_FILE
+                                                        | --tx-in-datum-file JSON_FILE
+                                                        | --tx-in-datum-value JSON_VALUE
                                                         | --tx-in-inline-datum-present
                                                         )
-                                                        ( --tx-in-redeemer-cbor-file CBOR FILE
-                                                        | --tx-in-redeemer-file JSON FILE
-                                                        | --tx-in-redeemer-value JSON VALUE
+                                                        ( --tx-in-redeemer-cbor-file CBOR_FILE
+                                                        | --tx-in-redeemer-file JSON_FILE
+                                                        | --tx-in-redeemer-value JSON_VALUE
                                                         )
                                                         --tx-in-execution-units (INT, INT)]
                                                     ])
@@ -9130,23 +9130,23 @@ Usage: cardano-cli latest transaction build-raw
                                                   ]
                                                   [--tx-out ADDRESS VALUE
                                                     [ --tx-out-datum-hash HASH
-                                                    | --tx-out-datum-hash-cbor-file CBOR FILE
-                                                    | --tx-out-datum-hash-file JSON FILE
-                                                    | --tx-out-datum-hash-value JSON VALUE
-                                                    | --tx-out-datum-embed-cbor-file CBOR FILE
-                                                    | --tx-out-datum-embed-file JSON FILE
-                                                    | --tx-out-datum-embed-value JSON VALUE
-                                                    | --tx-out-inline-datum-cbor-file CBOR FILE
-                                                    | --tx-out-inline-datum-file JSON FILE
-                                                    | --tx-out-inline-datum-value JSON VALUE
+                                                    | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                    | --tx-out-datum-hash-file JSON_FILE
+                                                    | --tx-out-datum-hash-value JSON_VALUE
+                                                    | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                    | --tx-out-datum-embed-file JSON_FILE
+                                                    | --tx-out-datum-embed-value JSON_VALUE
+                                                    | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                    | --tx-out-inline-datum-file JSON_FILE
+                                                    | --tx-out-inline-datum-value JSON_VALUE
                                                     ]
                                                     [--tx-out-reference-script-file FILE]]
                                                   [--mint VALUE
                                                     ( --mint-script-file FILE
                                                       [
-                                                        ( --mint-redeemer-cbor-file CBOR FILE
-                                                        | --mint-redeemer-file JSON FILE
-                                                        | --mint-redeemer-value JSON VALUE
+                                                        ( --mint-redeemer-cbor-file CBOR_FILE
+                                                        | --mint-redeemer-file JSON_FILE
+                                                        | --mint-redeemer-value JSON_VALUE
                                                         )
                                                         --mint-execution-units (INT, INT)]
                                                     | --simple-minting-script-tx-in-reference TX-IN
@@ -9155,9 +9155,9 @@ Usage: cardano-cli latest transaction build-raw
                                                       ( --mint-plutus-script-v2
                                                       | --mint-plutus-script-v3
                                                       )
-                                                      ( --mint-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                      | --mint-reference-tx-in-redeemer-file JSON FILE
-                                                      | --mint-reference-tx-in-redeemer-value JSON VALUE
+                                                      ( --mint-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                      | --mint-reference-tx-in-redeemer-file JSON_FILE
+                                                      | --mint-reference-tx-in-redeemer-value JSON_VALUE
                                                       )
                                                       --mint-reference-tx-in-execution-units (INT, INT)
                                                       --policy-id HASH
@@ -9168,36 +9168,36 @@ Usage: cardano-cli latest transaction build-raw
                                                   [--certificate-file FILE
                                                     [ --certificate-script-file FILE
                                                       [
-                                                        ( --certificate-redeemer-cbor-file CBOR FILE
-                                                        | --certificate-redeemer-file JSON FILE
-                                                        | --certificate-redeemer-value JSON VALUE
+                                                        ( --certificate-redeemer-cbor-file CBOR_FILE
+                                                        | --certificate-redeemer-file JSON_FILE
+                                                        | --certificate-redeemer-value JSON_VALUE
                                                         )
                                                         --certificate-execution-units (INT, INT)]
                                                     | --certificate-tx-in-reference TX-IN
                                                       ( --certificate-plutus-script-v2
                                                       | --certificate-plutus-script-v3
                                                       )
-                                                      ( --certificate-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                      | --certificate-reference-tx-in-redeemer-file JSON FILE
-                                                      | --certificate-reference-tx-in-redeemer-value JSON VALUE
+                                                      ( --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                      | --certificate-reference-tx-in-redeemer-file JSON_FILE
+                                                      | --certificate-reference-tx-in-redeemer-value JSON_VALUE
                                                       )
                                                       --certificate-reference-tx-in-execution-units (INT, INT)
                                                     ]]
                                                   [--withdrawal WITHDRAWAL
                                                     [ --withdrawal-script-file FILE
                                                       [
-                                                        ( --withdrawal-redeemer-cbor-file CBOR FILE
-                                                        | --withdrawal-redeemer-file JSON FILE
-                                                        | --withdrawal-redeemer-value JSON VALUE
+                                                        ( --withdrawal-redeemer-cbor-file CBOR_FILE
+                                                        | --withdrawal-redeemer-file JSON_FILE
+                                                        | --withdrawal-redeemer-value JSON_VALUE
                                                         )
                                                         --withdrawal-execution-units (INT, INT)]
                                                     | --withdrawal-tx-in-reference TX-IN
                                                       ( --withdrawal-plutus-script-v2
                                                       | --withdrawal-plutus-script-v3
                                                       )
-                                                      ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                      | --withdrawal-reference-tx-in-redeemer-file JSON FILE
-                                                      | --withdrawal-reference-tx-in-redeemer-value JSON VALUE
+                                                      ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                      | --withdrawal-reference-tx-in-redeemer-file JSON_FILE
+                                                      | --withdrawal-reference-tx-in-redeemer-value JSON_VALUE
                                                       )
                                                       --withdrawal-reference-tx-in-execution-units (INT, INT)
                                                     ]]
@@ -9231,26 +9231,26 @@ Usage: cardano-cli latest transaction build --socket-path SOCKET_PATH
                                                   ( --spending-plutus-script-v2
                                                   | --spending-plutus-script-v3
                                                   )
-                                                  ( --spending-reference-tx-in-datum-cbor-file CBOR FILE
-                                                  | --spending-reference-tx-in-datum-file JSON FILE
-                                                  | --spending-reference-tx-in-datum-value JSON VALUE
+                                                  ( --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                                                  | --spending-reference-tx-in-datum-file JSON_FILE
+                                                  | --spending-reference-tx-in-datum-value JSON_VALUE
                                                   | --spending-reference-tx-in-inline-datum-present
                                                   )
-                                                  ( --spending-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                  | --spending-reference-tx-in-redeemer-file JSON FILE
-                                                  | --spending-reference-tx-in-redeemer-value JSON VALUE
+                                                  ( --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                  | --spending-reference-tx-in-redeemer-file JSON_FILE
+                                                  | --spending-reference-tx-in-redeemer-value JSON_VALUE
                                                   )
                                                 | --simple-script-tx-in-reference TX-IN
                                                 | --tx-in-script-file FILE
                                                   [
-                                                    ( --tx-in-datum-cbor-file CBOR FILE
-                                                    | --tx-in-datum-file JSON FILE
-                                                    | --tx-in-datum-value JSON VALUE
+                                                    ( --tx-in-datum-cbor-file CBOR_FILE
+                                                    | --tx-in-datum-file JSON_FILE
+                                                    | --tx-in-datum-value JSON_VALUE
                                                     | --tx-in-inline-datum-present
                                                     )
-                                                    ( --tx-in-redeemer-cbor-file CBOR FILE
-                                                    | --tx-in-redeemer-file JSON FILE
-                                                    | --tx-in-redeemer-value JSON VALUE
+                                                    ( --tx-in-redeemer-cbor-file CBOR_FILE
+                                                    | --tx-in-redeemer-file JSON_FILE
+                                                    | --tx-in-redeemer-value JSON_VALUE
                                                     )]
                                                 ])
                                               [--read-only-tx-in-reference TX-IN]
@@ -9262,23 +9262,23 @@ Usage: cardano-cli latest transaction build --socket-path SOCKET_PATH
                                               [--tx-total-collateral INTEGER]
                                               [--tx-out ADDRESS VALUE
                                                 [ --tx-out-datum-hash HASH
-                                                | --tx-out-datum-hash-cbor-file CBOR FILE
-                                                | --tx-out-datum-hash-file JSON FILE
-                                                | --tx-out-datum-hash-value JSON VALUE
-                                                | --tx-out-datum-embed-cbor-file CBOR FILE
-                                                | --tx-out-datum-embed-file JSON FILE
-                                                | --tx-out-datum-embed-value JSON VALUE
-                                                | --tx-out-inline-datum-cbor-file CBOR FILE
-                                                | --tx-out-inline-datum-file JSON FILE
-                                                | --tx-out-inline-datum-value JSON VALUE
+                                                | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                | --tx-out-datum-hash-file JSON_FILE
+                                                | --tx-out-datum-hash-value JSON_VALUE
+                                                | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                | --tx-out-datum-embed-file JSON_FILE
+                                                | --tx-out-datum-embed-value JSON_VALUE
+                                                | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                | --tx-out-inline-datum-file JSON_FILE
+                                                | --tx-out-inline-datum-value JSON_VALUE
                                                 ]
                                                 [--tx-out-reference-script-file FILE]]
                                               --change-address ADDRESS
                                               [--mint VALUE
                                                 ( --mint-script-file FILE
-                                                  [ --mint-redeemer-cbor-file CBOR FILE
-                                                  | --mint-redeemer-file JSON FILE
-                                                  | --mint-redeemer-value JSON VALUE
+                                                  [ --mint-redeemer-cbor-file CBOR_FILE
+                                                  | --mint-redeemer-file JSON_FILE
+                                                  | --mint-redeemer-value JSON_VALUE
                                                   ]
                                                 | --simple-minting-script-tx-in-reference TX-IN
                                                   --policy-id HASH
@@ -9286,9 +9286,9 @@ Usage: cardano-cli latest transaction build --socket-path SOCKET_PATH
                                                   ( --mint-plutus-script-v2
                                                   | --mint-plutus-script-v3
                                                   )
-                                                  ( --mint-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                  | --mint-reference-tx-in-redeemer-file JSON FILE
-                                                  | --mint-reference-tx-in-redeemer-value JSON VALUE
+                                                  ( --mint-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                  | --mint-reference-tx-in-redeemer-file JSON_FILE
+                                                  | --mint-reference-tx-in-redeemer-value JSON_VALUE
                                                   )
                                                   --policy-id HASH
                                                 )]
@@ -9296,32 +9296,32 @@ Usage: cardano-cli latest transaction build --socket-path SOCKET_PATH
                                               [--invalid-hereafter SLOT]
                                               [--certificate-file FILE
                                                 [ --certificate-script-file FILE
-                                                  [ --certificate-redeemer-cbor-file CBOR FILE
-                                                  | --certificate-redeemer-file JSON FILE
-                                                  | --certificate-redeemer-value JSON VALUE
+                                                  [ --certificate-redeemer-cbor-file CBOR_FILE
+                                                  | --certificate-redeemer-file JSON_FILE
+                                                  | --certificate-redeemer-value JSON_VALUE
                                                   ]
                                                 | --certificate-tx-in-reference TX-IN
                                                   ( --certificate-plutus-script-v2
                                                   | --certificate-plutus-script-v3
                                                   )
-                                                  ( --certificate-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                  | --certificate-reference-tx-in-redeemer-file JSON FILE
-                                                  | --certificate-reference-tx-in-redeemer-value JSON VALUE
+                                                  ( --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                  | --certificate-reference-tx-in-redeemer-file JSON_FILE
+                                                  | --certificate-reference-tx-in-redeemer-value JSON_VALUE
                                                   )
                                                 ]]
                                               [--withdrawal WITHDRAWAL
                                                 [ --withdrawal-script-file FILE
-                                                  [ --withdrawal-redeemer-cbor-file CBOR FILE
-                                                  | --withdrawal-redeemer-file JSON FILE
-                                                  | --withdrawal-redeemer-value JSON VALUE
+                                                  [ --withdrawal-redeemer-cbor-file CBOR_FILE
+                                                  | --withdrawal-redeemer-file JSON_FILE
+                                                  | --withdrawal-redeemer-value JSON_VALUE
                                                   ]
                                                 | --withdrawal-tx-in-reference TX-IN
                                                   ( --withdrawal-plutus-script-v2
                                                   | --withdrawal-plutus-script-v3
                                                   )
-                                                  ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                  | --withdrawal-reference-tx-in-redeemer-file JSON FILE
-                                                  | --withdrawal-reference-tx-in-redeemer-value JSON VALUE
+                                                  ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                  | --withdrawal-reference-tx-in-redeemer-file JSON_FILE
+                                                  | --withdrawal-reference-tx-in-redeemer-value JSON_VALUE
                                                   )
                                                 ]]
                                               [ --json-metadata-no-schema
@@ -9353,27 +9353,27 @@ Usage: cardano-cli latest transaction build-estimate
                                                            ( --spending-plutus-script-v2
                                                            | --spending-plutus-script-v3
                                                            )
-                                                           ( --spending-reference-tx-in-datum-cbor-file CBOR FILE
-                                                           | --spending-reference-tx-in-datum-file JSON FILE
-                                                           | --spending-reference-tx-in-datum-value JSON VALUE
+                                                           ( --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                                                           | --spending-reference-tx-in-datum-file JSON_FILE
+                                                           | --spending-reference-tx-in-datum-value JSON_VALUE
                                                            | --spending-reference-tx-in-inline-datum-present
                                                            )
-                                                           ( --spending-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                           | --spending-reference-tx-in-redeemer-file JSON FILE
-                                                           | --spending-reference-tx-in-redeemer-value JSON VALUE
+                                                           ( --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                           | --spending-reference-tx-in-redeemer-file JSON_FILE
+                                                           | --spending-reference-tx-in-redeemer-value JSON_VALUE
                                                            )
                                                            --spending-reference-tx-in-execution-units (INT, INT)
                                                          | --simple-script-tx-in-reference TX-IN
                                                          | --tx-in-script-file FILE
                                                            [
-                                                             ( --tx-in-datum-cbor-file CBOR FILE
-                                                             | --tx-in-datum-file JSON FILE
-                                                             | --tx-in-datum-value JSON VALUE
+                                                             ( --tx-in-datum-cbor-file CBOR_FILE
+                                                             | --tx-in-datum-file JSON_FILE
+                                                             | --tx-in-datum-value JSON_VALUE
                                                              | --tx-in-inline-datum-present
                                                              )
-                                                             ( --tx-in-redeemer-cbor-file CBOR FILE
-                                                             | --tx-in-redeemer-file JSON FILE
-                                                             | --tx-in-redeemer-value JSON VALUE
+                                                             ( --tx-in-redeemer-cbor-file CBOR_FILE
+                                                             | --tx-in-redeemer-file JSON_FILE
+                                                             | --tx-in-redeemer-value JSON_VALUE
                                                              )
                                                              --tx-in-execution-units (INT, INT)]
                                                          ])
@@ -9385,24 +9385,24 @@ Usage: cardano-cli latest transaction build-estimate
                                                        [--tx-out-return-collateral ADDRESS VALUE]
                                                        [--tx-out ADDRESS VALUE
                                                          [ --tx-out-datum-hash HASH
-                                                         | --tx-out-datum-hash-cbor-file CBOR FILE
-                                                         | --tx-out-datum-hash-file JSON FILE
-                                                         | --tx-out-datum-hash-value JSON VALUE
-                                                         | --tx-out-datum-embed-cbor-file CBOR FILE
-                                                         | --tx-out-datum-embed-file JSON FILE
-                                                         | --tx-out-datum-embed-value JSON VALUE
-                                                         | --tx-out-inline-datum-cbor-file CBOR FILE
-                                                         | --tx-out-inline-datum-file JSON FILE
-                                                         | --tx-out-inline-datum-value JSON VALUE
+                                                         | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                         | --tx-out-datum-hash-file JSON_FILE
+                                                         | --tx-out-datum-hash-value JSON_VALUE
+                                                         | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                         | --tx-out-datum-embed-file JSON_FILE
+                                                         | --tx-out-datum-embed-value JSON_VALUE
+                                                         | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                         | --tx-out-inline-datum-file JSON_FILE
+                                                         | --tx-out-inline-datum-value JSON_VALUE
                                                          ]
                                                          [--tx-out-reference-script-file FILE]]
                                                        --change-address ADDRESS
                                                        [--mint VALUE
                                                          ( --mint-script-file FILE
                                                            [
-                                                             ( --mint-redeemer-cbor-file CBOR FILE
-                                                             | --mint-redeemer-file JSON FILE
-                                                             | --mint-redeemer-value JSON VALUE
+                                                             ( --mint-redeemer-cbor-file CBOR_FILE
+                                                             | --mint-redeemer-file JSON_FILE
+                                                             | --mint-redeemer-value JSON_VALUE
                                                              )
                                                              --mint-execution-units (INT, INT)]
                                                          | --simple-minting-script-tx-in-reference TX-IN
@@ -9411,9 +9411,9 @@ Usage: cardano-cli latest transaction build-estimate
                                                            ( --mint-plutus-script-v2
                                                            | --mint-plutus-script-v3
                                                            )
-                                                           ( --mint-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                           | --mint-reference-tx-in-redeemer-file JSON FILE
-                                                           | --mint-reference-tx-in-redeemer-value JSON VALUE
+                                                           ( --mint-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                           | --mint-reference-tx-in-redeemer-file JSON_FILE
+                                                           | --mint-reference-tx-in-redeemer-value JSON_VALUE
                                                            )
                                                            --mint-reference-tx-in-execution-units (INT, INT)
                                                            --policy-id HASH
@@ -9423,36 +9423,36 @@ Usage: cardano-cli latest transaction build-estimate
                                                        [--certificate-file FILE
                                                          [ --certificate-script-file FILE
                                                            [
-                                                             ( --certificate-redeemer-cbor-file CBOR FILE
-                                                             | --certificate-redeemer-file JSON FILE
-                                                             | --certificate-redeemer-value JSON VALUE
+                                                             ( --certificate-redeemer-cbor-file CBOR_FILE
+                                                             | --certificate-redeemer-file JSON_FILE
+                                                             | --certificate-redeemer-value JSON_VALUE
                                                              )
                                                              --certificate-execution-units (INT, INT)]
                                                          | --certificate-tx-in-reference TX-IN
                                                            ( --certificate-plutus-script-v2
                                                            | --certificate-plutus-script-v3
                                                            )
-                                                           ( --certificate-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                           | --certificate-reference-tx-in-redeemer-file JSON FILE
-                                                           | --certificate-reference-tx-in-redeemer-value JSON VALUE
+                                                           ( --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                           | --certificate-reference-tx-in-redeemer-file JSON_FILE
+                                                           | --certificate-reference-tx-in-redeemer-value JSON_VALUE
                                                            )
                                                            --certificate-reference-tx-in-execution-units (INT, INT)
                                                          ]]
                                                        [--withdrawal WITHDRAWAL
                                                          [ --withdrawal-script-file FILE
                                                            [
-                                                             ( --withdrawal-redeemer-cbor-file CBOR FILE
-                                                             | --withdrawal-redeemer-file JSON FILE
-                                                             | --withdrawal-redeemer-value JSON VALUE
+                                                             ( --withdrawal-redeemer-cbor-file CBOR_FILE
+                                                             | --withdrawal-redeemer-file JSON_FILE
+                                                             | --withdrawal-redeemer-value JSON_VALUE
                                                              )
                                                              --withdrawal-execution-units (INT, INT)]
                                                          | --withdrawal-tx-in-reference TX-IN
                                                            ( --withdrawal-plutus-script-v2
                                                            | --withdrawal-plutus-script-v3
                                                            )
-                                                           ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                           | --withdrawal-reference-tx-in-redeemer-file JSON FILE
-                                                           | --withdrawal-reference-tx-in-redeemer-value JSON VALUE
+                                                           ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                           | --withdrawal-reference-tx-in-redeemer-file JSON_FILE
+                                                           | --withdrawal-reference-tx-in-redeemer-value JSON_VALUE
                                                            )
                                                            --withdrawal-reference-tx-in-execution-units (INT, INT)
                                                          ]]
@@ -9538,15 +9538,15 @@ Usage: cardano-cli latest transaction calculate-min-fee --tx-body-file FILE
 Usage: cardano-cli latest transaction calculate-min-required-utxo --protocol-params-file FILE
                                                                     --tx-out ADDRESS VALUE
                                                                     [ --tx-out-datum-hash HASH
-                                                                    | --tx-out-datum-hash-cbor-file CBOR FILE
-                                                                    | --tx-out-datum-hash-file JSON FILE
-                                                                    | --tx-out-datum-hash-value JSON VALUE
-                                                                    | --tx-out-datum-embed-cbor-file CBOR FILE
-                                                                    | --tx-out-datum-embed-file JSON FILE
-                                                                    | --tx-out-datum-embed-value JSON VALUE
-                                                                    | --tx-out-inline-datum-cbor-file CBOR FILE
-                                                                    | --tx-out-inline-datum-file JSON FILE
-                                                                    | --tx-out-inline-datum-value JSON VALUE
+                                                                    | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                                    | --tx-out-datum-hash-file JSON_FILE
+                                                                    | --tx-out-datum-hash-value JSON_VALUE
+                                                                    | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                                    | --tx-out-datum-embed-file JSON_FILE
+                                                                    | --tx-out-datum-embed-value JSON_VALUE
+                                                                    | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                                    | --tx-out-inline-datum-file JSON_FILE
+                                                                    | --tx-out-inline-datum-value JSON_VALUE
                                                                     ]
                                                                     [--tx-out-reference-script-file FILE]
 
@@ -9555,24 +9555,24 @@ Usage: cardano-cli latest transaction calculate-min-required-utxo --protocol-par
 Usage: cardano-cli latest transaction calculate-min-value --protocol-params-file FILE
                                                             --tx-out ADDRESS VALUE
                                                             [ --tx-out-datum-hash HASH
-                                                            | --tx-out-datum-hash-cbor-file CBOR FILE
-                                                            | --tx-out-datum-hash-file JSON FILE
-                                                            | --tx-out-datum-hash-value JSON VALUE
-                                                            | --tx-out-datum-embed-cbor-file CBOR FILE
-                                                            | --tx-out-datum-embed-file JSON FILE
-                                                            | --tx-out-datum-embed-value JSON VALUE
-                                                            | --tx-out-inline-datum-cbor-file CBOR FILE
-                                                            | --tx-out-inline-datum-file JSON FILE
-                                                            | --tx-out-inline-datum-value JSON VALUE
+                                                            | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                            | --tx-out-datum-hash-file JSON_FILE
+                                                            | --tx-out-datum-hash-value JSON_VALUE
+                                                            | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                            | --tx-out-datum-embed-file JSON_FILE
+                                                            | --tx-out-datum-embed-value JSON_VALUE
+                                                            | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                            | --tx-out-inline-datum-file JSON_FILE
+                                                            | --tx-out-inline-datum-value JSON_VALUE
                                                             ]
                                                             [--tx-out-reference-script-file FILE]
 
   DEPRECATED: Use 'calculate-min-required-utxo' instead.
 
 Usage: cardano-cli latest transaction hash-script-data 
-                                                         ( --script-data-cbor-file CBOR FILE
-                                                         | --script-data-file JSON FILE
-                                                         | --script-data-value JSON VALUE
+                                                         ( --script-data-cbor-file CBOR_FILE
+                                                         | --script-data-file JSON_FILE
+                                                         | --script-data-value JSON_VALUE
                                                          )
 
   Calculate the hash of script data.
@@ -10251,27 +10251,27 @@ Usage: cardano-cli legacy transaction build-raw
                                                       ( --spending-plutus-script-v2
                                                       | --spending-plutus-script-v3
                                                       )
-                                                      ( --spending-reference-tx-in-datum-cbor-file CBOR FILE
-                                                      | --spending-reference-tx-in-datum-file JSON FILE
-                                                      | --spending-reference-tx-in-datum-value JSON VALUE
+                                                      ( --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                                                      | --spending-reference-tx-in-datum-file JSON_FILE
+                                                      | --spending-reference-tx-in-datum-value JSON_VALUE
                                                       | --spending-reference-tx-in-inline-datum-present
                                                       )
-                                                      ( --spending-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                      | --spending-reference-tx-in-redeemer-file JSON FILE
-                                                      | --spending-reference-tx-in-redeemer-value JSON VALUE
+                                                      ( --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                      | --spending-reference-tx-in-redeemer-file JSON_FILE
+                                                      | --spending-reference-tx-in-redeemer-value JSON_VALUE
                                                       )
                                                       --spending-reference-tx-in-execution-units (INT, INT)
                                                     | --simple-script-tx-in-reference TX-IN
                                                     | --tx-in-script-file FILE
                                                       [
-                                                        ( --tx-in-datum-cbor-file CBOR FILE
-                                                        | --tx-in-datum-file JSON FILE
-                                                        | --tx-in-datum-value JSON VALUE
+                                                        ( --tx-in-datum-cbor-file CBOR_FILE
+                                                        | --tx-in-datum-file JSON_FILE
+                                                        | --tx-in-datum-value JSON_VALUE
                                                         | --tx-in-inline-datum-present
                                                         )
-                                                        ( --tx-in-redeemer-cbor-file CBOR FILE
-                                                        | --tx-in-redeemer-file JSON FILE
-                                                        | --tx-in-redeemer-value JSON VALUE
+                                                        ( --tx-in-redeemer-cbor-file CBOR_FILE
+                                                        | --tx-in-redeemer-file JSON_FILE
+                                                        | --tx-in-redeemer-value JSON_VALUE
                                                         )
                                                         --tx-in-execution-units (INT, INT)]
                                                     ])
@@ -10284,23 +10284,23 @@ Usage: cardano-cli legacy transaction build-raw
                                                   ]
                                                   [--tx-out ADDRESS VALUE
                                                     [ --tx-out-datum-hash HASH
-                                                    | --tx-out-datum-hash-cbor-file CBOR FILE
-                                                    | --tx-out-datum-hash-file JSON FILE
-                                                    | --tx-out-datum-hash-value JSON VALUE
-                                                    | --tx-out-datum-embed-cbor-file CBOR FILE
-                                                    | --tx-out-datum-embed-file JSON FILE
-                                                    | --tx-out-datum-embed-value JSON VALUE
-                                                    | --tx-out-inline-datum-cbor-file CBOR FILE
-                                                    | --tx-out-inline-datum-file JSON FILE
-                                                    | --tx-out-inline-datum-value JSON VALUE
+                                                    | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                    | --tx-out-datum-hash-file JSON_FILE
+                                                    | --tx-out-datum-hash-value JSON_VALUE
+                                                    | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                    | --tx-out-datum-embed-file JSON_FILE
+                                                    | --tx-out-datum-embed-value JSON_VALUE
+                                                    | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                    | --tx-out-inline-datum-file JSON_FILE
+                                                    | --tx-out-inline-datum-value JSON_VALUE
                                                     ]
                                                     [--tx-out-reference-script-file FILE]]
                                                   [--mint VALUE
                                                     ( --mint-script-file FILE
                                                       [
-                                                        ( --mint-redeemer-cbor-file CBOR FILE
-                                                        | --mint-redeemer-file JSON FILE
-                                                        | --mint-redeemer-value JSON VALUE
+                                                        ( --mint-redeemer-cbor-file CBOR_FILE
+                                                        | --mint-redeemer-file JSON_FILE
+                                                        | --mint-redeemer-value JSON_VALUE
                                                         )
                                                         --mint-execution-units (INT, INT)]
                                                     | --simple-minting-script-tx-in-reference TX-IN
@@ -10309,9 +10309,9 @@ Usage: cardano-cli legacy transaction build-raw
                                                       ( --mint-plutus-script-v2
                                                       | --mint-plutus-script-v3
                                                       )
-                                                      ( --mint-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                      | --mint-reference-tx-in-redeemer-file JSON FILE
-                                                      | --mint-reference-tx-in-redeemer-value JSON VALUE
+                                                      ( --mint-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                      | --mint-reference-tx-in-redeemer-file JSON_FILE
+                                                      | --mint-reference-tx-in-redeemer-value JSON_VALUE
                                                       )
                                                       --mint-reference-tx-in-execution-units (INT, INT)
                                                       --policy-id HASH
@@ -10322,36 +10322,36 @@ Usage: cardano-cli legacy transaction build-raw
                                                   [--certificate-file FILE
                                                     [ --certificate-script-file FILE
                                                       [
-                                                        ( --certificate-redeemer-cbor-file CBOR FILE
-                                                        | --certificate-redeemer-file JSON FILE
-                                                        | --certificate-redeemer-value JSON VALUE
+                                                        ( --certificate-redeemer-cbor-file CBOR_FILE
+                                                        | --certificate-redeemer-file JSON_FILE
+                                                        | --certificate-redeemer-value JSON_VALUE
                                                         )
                                                         --certificate-execution-units (INT, INT)]
                                                     | --certificate-tx-in-reference TX-IN
                                                       ( --certificate-plutus-script-v2
                                                       | --certificate-plutus-script-v3
                                                       )
-                                                      ( --certificate-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                      | --certificate-reference-tx-in-redeemer-file JSON FILE
-                                                      | --certificate-reference-tx-in-redeemer-value JSON VALUE
+                                                      ( --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                      | --certificate-reference-tx-in-redeemer-file JSON_FILE
+                                                      | --certificate-reference-tx-in-redeemer-value JSON_VALUE
                                                       )
                                                       --certificate-reference-tx-in-execution-units (INT, INT)
                                                     ]]
                                                   [--withdrawal WITHDRAWAL
                                                     [ --withdrawal-script-file FILE
                                                       [
-                                                        ( --withdrawal-redeemer-cbor-file CBOR FILE
-                                                        | --withdrawal-redeemer-file JSON FILE
-                                                        | --withdrawal-redeemer-value JSON VALUE
+                                                        ( --withdrawal-redeemer-cbor-file CBOR_FILE
+                                                        | --withdrawal-redeemer-file JSON_FILE
+                                                        | --withdrawal-redeemer-value JSON_VALUE
                                                         )
                                                         --withdrawal-execution-units (INT, INT)]
                                                     | --withdrawal-tx-in-reference TX-IN
                                                       ( --withdrawal-plutus-script-v2
                                                       | --withdrawal-plutus-script-v3
                                                       )
-                                                      ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                      | --withdrawal-reference-tx-in-redeemer-file JSON FILE
-                                                      | --withdrawal-reference-tx-in-redeemer-value JSON VALUE
+                                                      ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                      | --withdrawal-reference-tx-in-redeemer-file JSON_FILE
+                                                      | --withdrawal-reference-tx-in-redeemer-value JSON_VALUE
                                                       )
                                                       --withdrawal-reference-tx-in-execution-units (INT, INT)
                                                     ]]
@@ -10391,26 +10391,26 @@ Usage: cardano-cli legacy transaction build --socket-path SOCKET_PATH
                                                   ( --spending-plutus-script-v2
                                                   | --spending-plutus-script-v3
                                                   )
-                                                  ( --spending-reference-tx-in-datum-cbor-file CBOR FILE
-                                                  | --spending-reference-tx-in-datum-file JSON FILE
-                                                  | --spending-reference-tx-in-datum-value JSON VALUE
+                                                  ( --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                                                  | --spending-reference-tx-in-datum-file JSON_FILE
+                                                  | --spending-reference-tx-in-datum-value JSON_VALUE
                                                   | --spending-reference-tx-in-inline-datum-present
                                                   )
-                                                  ( --spending-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                  | --spending-reference-tx-in-redeemer-file JSON FILE
-                                                  | --spending-reference-tx-in-redeemer-value JSON VALUE
+                                                  ( --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                  | --spending-reference-tx-in-redeemer-file JSON_FILE
+                                                  | --spending-reference-tx-in-redeemer-value JSON_VALUE
                                                   )
                                                 | --simple-script-tx-in-reference TX-IN
                                                 | --tx-in-script-file FILE
                                                   [
-                                                    ( --tx-in-datum-cbor-file CBOR FILE
-                                                    | --tx-in-datum-file JSON FILE
-                                                    | --tx-in-datum-value JSON VALUE
+                                                    ( --tx-in-datum-cbor-file CBOR_FILE
+                                                    | --tx-in-datum-file JSON_FILE
+                                                    | --tx-in-datum-value JSON_VALUE
                                                     | --tx-in-inline-datum-present
                                                     )
-                                                    ( --tx-in-redeemer-cbor-file CBOR FILE
-                                                    | --tx-in-redeemer-file JSON FILE
-                                                    | --tx-in-redeemer-value JSON VALUE
+                                                    ( --tx-in-redeemer-cbor-file CBOR_FILE
+                                                    | --tx-in-redeemer-file JSON_FILE
+                                                    | --tx-in-redeemer-value JSON_VALUE
                                                     )]
                                                 ])
                                               [--read-only-tx-in-reference TX-IN]
@@ -10422,23 +10422,23 @@ Usage: cardano-cli legacy transaction build --socket-path SOCKET_PATH
                                               [--tx-total-collateral INTEGER]
                                               [--tx-out ADDRESS VALUE
                                                 [ --tx-out-datum-hash HASH
-                                                | --tx-out-datum-hash-cbor-file CBOR FILE
-                                                | --tx-out-datum-hash-file JSON FILE
-                                                | --tx-out-datum-hash-value JSON VALUE
-                                                | --tx-out-datum-embed-cbor-file CBOR FILE
-                                                | --tx-out-datum-embed-file JSON FILE
-                                                | --tx-out-datum-embed-value JSON VALUE
-                                                | --tx-out-inline-datum-cbor-file CBOR FILE
-                                                | --tx-out-inline-datum-file JSON FILE
-                                                | --tx-out-inline-datum-value JSON VALUE
+                                                | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                | --tx-out-datum-hash-file JSON_FILE
+                                                | --tx-out-datum-hash-value JSON_VALUE
+                                                | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                | --tx-out-datum-embed-file JSON_FILE
+                                                | --tx-out-datum-embed-value JSON_VALUE
+                                                | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                | --tx-out-inline-datum-file JSON_FILE
+                                                | --tx-out-inline-datum-value JSON_VALUE
                                                 ]
                                                 [--tx-out-reference-script-file FILE]]
                                               --change-address ADDRESS
                                               [--mint VALUE
                                                 ( --mint-script-file FILE
-                                                  [ --mint-redeemer-cbor-file CBOR FILE
-                                                  | --mint-redeemer-file JSON FILE
-                                                  | --mint-redeemer-value JSON VALUE
+                                                  [ --mint-redeemer-cbor-file CBOR_FILE
+                                                  | --mint-redeemer-file JSON_FILE
+                                                  | --mint-redeemer-value JSON_VALUE
                                                   ]
                                                 | --simple-minting-script-tx-in-reference TX-IN
                                                   --policy-id HASH
@@ -10446,9 +10446,9 @@ Usage: cardano-cli legacy transaction build --socket-path SOCKET_PATH
                                                   ( --mint-plutus-script-v2
                                                   | --mint-plutus-script-v3
                                                   )
-                                                  ( --mint-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                  | --mint-reference-tx-in-redeemer-file JSON FILE
-                                                  | --mint-reference-tx-in-redeemer-value JSON VALUE
+                                                  ( --mint-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                  | --mint-reference-tx-in-redeemer-file JSON_FILE
+                                                  | --mint-reference-tx-in-redeemer-value JSON_VALUE
                                                   )
                                                   --policy-id HASH
                                                 )]
@@ -10456,32 +10456,32 @@ Usage: cardano-cli legacy transaction build --socket-path SOCKET_PATH
                                               [--invalid-hereafter SLOT]
                                               [--certificate-file FILE
                                                 [ --certificate-script-file FILE
-                                                  [ --certificate-redeemer-cbor-file CBOR FILE
-                                                  | --certificate-redeemer-file JSON FILE
-                                                  | --certificate-redeemer-value JSON VALUE
+                                                  [ --certificate-redeemer-cbor-file CBOR_FILE
+                                                  | --certificate-redeemer-file JSON_FILE
+                                                  | --certificate-redeemer-value JSON_VALUE
                                                   ]
                                                 | --certificate-tx-in-reference TX-IN
                                                   ( --certificate-plutus-script-v2
                                                   | --certificate-plutus-script-v3
                                                   )
-                                                  ( --certificate-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                  | --certificate-reference-tx-in-redeemer-file JSON FILE
-                                                  | --certificate-reference-tx-in-redeemer-value JSON VALUE
+                                                  ( --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                  | --certificate-reference-tx-in-redeemer-file JSON_FILE
+                                                  | --certificate-reference-tx-in-redeemer-value JSON_VALUE
                                                   )
                                                 ]]
                                               [--withdrawal WITHDRAWAL
                                                 [ --withdrawal-script-file FILE
-                                                  [ --withdrawal-redeemer-cbor-file CBOR FILE
-                                                  | --withdrawal-redeemer-file JSON FILE
-                                                  | --withdrawal-redeemer-value JSON VALUE
+                                                  [ --withdrawal-redeemer-cbor-file CBOR_FILE
+                                                  | --withdrawal-redeemer-file JSON_FILE
+                                                  | --withdrawal-redeemer-value JSON_VALUE
                                                   ]
                                                 | --withdrawal-tx-in-reference TX-IN
                                                   ( --withdrawal-plutus-script-v2
                                                   | --withdrawal-plutus-script-v3
                                                   )
-                                                  ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                  | --withdrawal-reference-tx-in-redeemer-file JSON FILE
-                                                  | --withdrawal-reference-tx-in-redeemer-value JSON VALUE
+                                                  ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                  | --withdrawal-reference-tx-in-redeemer-file JSON_FILE
+                                                  | --withdrawal-reference-tx-in-redeemer-value JSON_VALUE
                                                   )
                                                 ]]
                                               [ --json-metadata-no-schema
@@ -10494,15 +10494,15 @@ Usage: cardano-cli legacy transaction build --socket-path SOCKET_PATH
                                               [--update-proposal-file FILE]
                                               [--vote-file FILE
                                                 [--vote-script-file FILE
-                                                  [ --vote-redeemer-cbor-file CBOR FILE
-                                                  | --vote-redeemer-file JSON FILE
-                                                  | --vote-redeemer-value JSON VALUE
+                                                  [ --vote-redeemer-cbor-file CBOR_FILE
+                                                  | --vote-redeemer-file JSON_FILE
+                                                  | --vote-redeemer-value JSON_VALUE
                                                   ]]]
                                               [--proposal-file FILE
                                                 [--proposal-script-file FILE
-                                                  [ --proposal-redeemer-cbor-file CBOR FILE
-                                                  | --proposal-redeemer-file JSON FILE
-                                                  | --proposal-redeemer-value JSON VALUE
+                                                  [ --proposal-redeemer-cbor-file CBOR_FILE
+                                                  | --proposal-redeemer-file JSON_FILE
+                                                  | --proposal-redeemer-value JSON_VALUE
                                                   ]]]
                                               ( --out-file FILE
                                               | --calculate-plutus-script-cost FILE
@@ -10586,15 +10586,15 @@ Usage: cardano-cli legacy transaction calculate-min-required-utxo
                                                                     --protocol-params-file FILE
                                                                     --tx-out ADDRESS VALUE
                                                                     [ --tx-out-datum-hash HASH
-                                                                    | --tx-out-datum-hash-cbor-file CBOR FILE
-                                                                    | --tx-out-datum-hash-file JSON FILE
-                                                                    | --tx-out-datum-hash-value JSON VALUE
-                                                                    | --tx-out-datum-embed-cbor-file CBOR FILE
-                                                                    | --tx-out-datum-embed-file JSON FILE
-                                                                    | --tx-out-datum-embed-value JSON VALUE
-                                                                    | --tx-out-inline-datum-cbor-file CBOR FILE
-                                                                    | --tx-out-inline-datum-file JSON FILE
-                                                                    | --tx-out-inline-datum-value JSON VALUE
+                                                                    | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                                    | --tx-out-datum-hash-file JSON_FILE
+                                                                    | --tx-out-datum-hash-value JSON_VALUE
+                                                                    | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                                    | --tx-out-datum-embed-file JSON_FILE
+                                                                    | --tx-out-datum-embed-value JSON_VALUE
+                                                                    | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                                    | --tx-out-inline-datum-file JSON_FILE
+                                                                    | --tx-out-inline-datum-value JSON_VALUE
                                                                     ]
                                                                     [--tx-out-reference-script-file FILE]
 
@@ -10611,24 +10611,24 @@ Usage: cardano-cli legacy transaction calculate-min-value
                                                             --protocol-params-file FILE
                                                             --tx-out ADDRESS VALUE
                                                             [ --tx-out-datum-hash HASH
-                                                            | --tx-out-datum-hash-cbor-file CBOR FILE
-                                                            | --tx-out-datum-hash-file JSON FILE
-                                                            | --tx-out-datum-hash-value JSON VALUE
-                                                            | --tx-out-datum-embed-cbor-file CBOR FILE
-                                                            | --tx-out-datum-embed-file JSON FILE
-                                                            | --tx-out-datum-embed-value JSON VALUE
-                                                            | --tx-out-inline-datum-cbor-file CBOR FILE
-                                                            | --tx-out-inline-datum-file JSON FILE
-                                                            | --tx-out-inline-datum-value JSON VALUE
+                                                            | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                            | --tx-out-datum-hash-file JSON_FILE
+                                                            | --tx-out-datum-hash-value JSON_VALUE
+                                                            | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                            | --tx-out-datum-embed-file JSON_FILE
+                                                            | --tx-out-datum-embed-value JSON_VALUE
+                                                            | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                            | --tx-out-inline-datum-file JSON_FILE
+                                                            | --tx-out-inline-datum-value JSON_VALUE
                                                             ]
                                                             [--tx-out-reference-script-file FILE]
 
   DEPRECATED: Use 'calculate-min-required-utxo' instead.
 
 Usage: cardano-cli legacy transaction hash-script-data 
-                                                         ( --script-data-cbor-file CBOR FILE
-                                                         | --script-data-file JSON FILE
-                                                         | --script-data-value JSON VALUE
+                                                         ( --script-data-cbor-file CBOR_FILE
+                                                         | --script-data-file JSON_FILE
+                                                         | --script-data-value JSON_VALUE
                                                          )
 
   Calculate the hash of script data.
@@ -11487,27 +11487,27 @@ Usage: cardano-cli transaction build-raw
                                                ( --spending-plutus-script-v2
                                                | --spending-plutus-script-v3
                                                )
-                                               ( --spending-reference-tx-in-datum-cbor-file CBOR FILE
-                                               | --spending-reference-tx-in-datum-file JSON FILE
-                                               | --spending-reference-tx-in-datum-value JSON VALUE
+                                               ( --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                                               | --spending-reference-tx-in-datum-file JSON_FILE
+                                               | --spending-reference-tx-in-datum-value JSON_VALUE
                                                | --spending-reference-tx-in-inline-datum-present
                                                )
-                                               ( --spending-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                               | --spending-reference-tx-in-redeemer-file JSON FILE
-                                               | --spending-reference-tx-in-redeemer-value JSON VALUE
+                                               ( --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                               | --spending-reference-tx-in-redeemer-file JSON_FILE
+                                               | --spending-reference-tx-in-redeemer-value JSON_VALUE
                                                )
                                                --spending-reference-tx-in-execution-units (INT, INT)
                                              | --simple-script-tx-in-reference TX-IN
                                              | --tx-in-script-file FILE
                                                [
-                                                 ( --tx-in-datum-cbor-file CBOR FILE
-                                                 | --tx-in-datum-file JSON FILE
-                                                 | --tx-in-datum-value JSON VALUE
+                                                 ( --tx-in-datum-cbor-file CBOR_FILE
+                                                 | --tx-in-datum-file JSON_FILE
+                                                 | --tx-in-datum-value JSON_VALUE
                                                  | --tx-in-inline-datum-present
                                                  )
-                                                 ( --tx-in-redeemer-cbor-file CBOR FILE
-                                                 | --tx-in-redeemer-file JSON FILE
-                                                 | --tx-in-redeemer-value JSON VALUE
+                                                 ( --tx-in-redeemer-cbor-file CBOR_FILE
+                                                 | --tx-in-redeemer-file JSON_FILE
+                                                 | --tx-in-redeemer-value JSON_VALUE
                                                  )
                                                  --tx-in-execution-units (INT, INT)]
                                              ])
@@ -11520,23 +11520,23 @@ Usage: cardano-cli transaction build-raw
                                            ]
                                            [--tx-out ADDRESS VALUE
                                              [ --tx-out-datum-hash HASH
-                                             | --tx-out-datum-hash-cbor-file CBOR FILE
-                                             | --tx-out-datum-hash-file JSON FILE
-                                             | --tx-out-datum-hash-value JSON VALUE
-                                             | --tx-out-datum-embed-cbor-file CBOR FILE
-                                             | --tx-out-datum-embed-file JSON FILE
-                                             | --tx-out-datum-embed-value JSON VALUE
-                                             | --tx-out-inline-datum-cbor-file CBOR FILE
-                                             | --tx-out-inline-datum-file JSON FILE
-                                             | --tx-out-inline-datum-value JSON VALUE
+                                             | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                             | --tx-out-datum-hash-file JSON_FILE
+                                             | --tx-out-datum-hash-value JSON_VALUE
+                                             | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                             | --tx-out-datum-embed-file JSON_FILE
+                                             | --tx-out-datum-embed-value JSON_VALUE
+                                             | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                             | --tx-out-inline-datum-file JSON_FILE
+                                             | --tx-out-inline-datum-value JSON_VALUE
                                              ]
                                              [--tx-out-reference-script-file FILE]]
                                            [--mint VALUE
                                              ( --mint-script-file FILE
                                                [
-                                                 ( --mint-redeemer-cbor-file CBOR FILE
-                                                 | --mint-redeemer-file JSON FILE
-                                                 | --mint-redeemer-value JSON VALUE
+                                                 ( --mint-redeemer-cbor-file CBOR_FILE
+                                                 | --mint-redeemer-file JSON_FILE
+                                                 | --mint-redeemer-value JSON_VALUE
                                                  )
                                                  --mint-execution-units (INT, INT)]
                                              | --simple-minting-script-tx-in-reference TX-IN
@@ -11545,9 +11545,9 @@ Usage: cardano-cli transaction build-raw
                                                ( --mint-plutus-script-v2
                                                | --mint-plutus-script-v3
                                                )
-                                               ( --mint-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                               | --mint-reference-tx-in-redeemer-file JSON FILE
-                                               | --mint-reference-tx-in-redeemer-value JSON VALUE
+                                               ( --mint-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                               | --mint-reference-tx-in-redeemer-file JSON_FILE
+                                               | --mint-reference-tx-in-redeemer-value JSON_VALUE
                                                )
                                                --mint-reference-tx-in-execution-units (INT, INT)
                                                --policy-id HASH
@@ -11558,36 +11558,36 @@ Usage: cardano-cli transaction build-raw
                                            [--certificate-file FILE
                                              [ --certificate-script-file FILE
                                                [
-                                                 ( --certificate-redeemer-cbor-file CBOR FILE
-                                                 | --certificate-redeemer-file JSON FILE
-                                                 | --certificate-redeemer-value JSON VALUE
+                                                 ( --certificate-redeemer-cbor-file CBOR_FILE
+                                                 | --certificate-redeemer-file JSON_FILE
+                                                 | --certificate-redeemer-value JSON_VALUE
                                                  )
                                                  --certificate-execution-units (INT, INT)]
                                              | --certificate-tx-in-reference TX-IN
                                                ( --certificate-plutus-script-v2
                                                | --certificate-plutus-script-v3
                                                )
-                                               ( --certificate-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                               | --certificate-reference-tx-in-redeemer-file JSON FILE
-                                               | --certificate-reference-tx-in-redeemer-value JSON VALUE
+                                               ( --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                               | --certificate-reference-tx-in-redeemer-file JSON_FILE
+                                               | --certificate-reference-tx-in-redeemer-value JSON_VALUE
                                                )
                                                --certificate-reference-tx-in-execution-units (INT, INT)
                                              ]]
                                            [--withdrawal WITHDRAWAL
                                              [ --withdrawal-script-file FILE
                                                [
-                                                 ( --withdrawal-redeemer-cbor-file CBOR FILE
-                                                 | --withdrawal-redeemer-file JSON FILE
-                                                 | --withdrawal-redeemer-value JSON VALUE
+                                                 ( --withdrawal-redeemer-cbor-file CBOR_FILE
+                                                 | --withdrawal-redeemer-file JSON_FILE
+                                                 | --withdrawal-redeemer-value JSON_VALUE
                                                  )
                                                  --withdrawal-execution-units (INT, INT)]
                                              | --withdrawal-tx-in-reference TX-IN
                                                ( --withdrawal-plutus-script-v2
                                                | --withdrawal-plutus-script-v3
                                                )
-                                               ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                               | --withdrawal-reference-tx-in-redeemer-file JSON FILE
-                                               | --withdrawal-reference-tx-in-redeemer-value JSON VALUE
+                                               ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                               | --withdrawal-reference-tx-in-redeemer-file JSON_FILE
+                                               | --withdrawal-reference-tx-in-redeemer-value JSON_VALUE
                                                )
                                                --withdrawal-reference-tx-in-execution-units (INT, INT)
                                              ]]
@@ -11622,26 +11622,26 @@ Usage: cardano-cli transaction build --socket-path SOCKET_PATH
                                            ( --spending-plutus-script-v2
                                            | --spending-plutus-script-v3
                                            )
-                                           ( --spending-reference-tx-in-datum-cbor-file CBOR FILE
-                                           | --spending-reference-tx-in-datum-file JSON FILE
-                                           | --spending-reference-tx-in-datum-value JSON VALUE
+                                           ( --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                                           | --spending-reference-tx-in-datum-file JSON_FILE
+                                           | --spending-reference-tx-in-datum-value JSON_VALUE
                                            | --spending-reference-tx-in-inline-datum-present
                                            )
-                                           ( --spending-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                           | --spending-reference-tx-in-redeemer-file JSON FILE
-                                           | --spending-reference-tx-in-redeemer-value JSON VALUE
+                                           ( --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                           | --spending-reference-tx-in-redeemer-file JSON_FILE
+                                           | --spending-reference-tx-in-redeemer-value JSON_VALUE
                                            )
                                          | --simple-script-tx-in-reference TX-IN
                                          | --tx-in-script-file FILE
                                            [
-                                             ( --tx-in-datum-cbor-file CBOR FILE
-                                             | --tx-in-datum-file JSON FILE
-                                             | --tx-in-datum-value JSON VALUE
+                                             ( --tx-in-datum-cbor-file CBOR_FILE
+                                             | --tx-in-datum-file JSON_FILE
+                                             | --tx-in-datum-value JSON_VALUE
                                              | --tx-in-inline-datum-present
                                              )
-                                             ( --tx-in-redeemer-cbor-file CBOR FILE
-                                             | --tx-in-redeemer-file JSON FILE
-                                             | --tx-in-redeemer-value JSON VALUE
+                                             ( --tx-in-redeemer-cbor-file CBOR_FILE
+                                             | --tx-in-redeemer-file JSON_FILE
+                                             | --tx-in-redeemer-value JSON_VALUE
                                              )]
                                          ])
                                        [--read-only-tx-in-reference TX-IN]
@@ -11653,23 +11653,23 @@ Usage: cardano-cli transaction build --socket-path SOCKET_PATH
                                        [--tx-total-collateral INTEGER]
                                        [--tx-out ADDRESS VALUE
                                          [ --tx-out-datum-hash HASH
-                                         | --tx-out-datum-hash-cbor-file CBOR FILE
-                                         | --tx-out-datum-hash-file JSON FILE
-                                         | --tx-out-datum-hash-value JSON VALUE
-                                         | --tx-out-datum-embed-cbor-file CBOR FILE
-                                         | --tx-out-datum-embed-file JSON FILE
-                                         | --tx-out-datum-embed-value JSON VALUE
-                                         | --tx-out-inline-datum-cbor-file CBOR FILE
-                                         | --tx-out-inline-datum-file JSON FILE
-                                         | --tx-out-inline-datum-value JSON VALUE
+                                         | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                         | --tx-out-datum-hash-file JSON_FILE
+                                         | --tx-out-datum-hash-value JSON_VALUE
+                                         | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                         | --tx-out-datum-embed-file JSON_FILE
+                                         | --tx-out-datum-embed-value JSON_VALUE
+                                         | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                         | --tx-out-inline-datum-file JSON_FILE
+                                         | --tx-out-inline-datum-value JSON_VALUE
                                          ]
                                          [--tx-out-reference-script-file FILE]]
                                        --change-address ADDRESS
                                        [--mint VALUE
                                          ( --mint-script-file FILE
-                                           [ --mint-redeemer-cbor-file CBOR FILE
-                                           | --mint-redeemer-file JSON FILE
-                                           | --mint-redeemer-value JSON VALUE
+                                           [ --mint-redeemer-cbor-file CBOR_FILE
+                                           | --mint-redeemer-file JSON_FILE
+                                           | --mint-redeemer-value JSON_VALUE
                                            ]
                                          | --simple-minting-script-tx-in-reference TX-IN
                                            --policy-id HASH
@@ -11677,9 +11677,9 @@ Usage: cardano-cli transaction build --socket-path SOCKET_PATH
                                            ( --mint-plutus-script-v2
                                            | --mint-plutus-script-v3
                                            )
-                                           ( --mint-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                           | --mint-reference-tx-in-redeemer-file JSON FILE
-                                           | --mint-reference-tx-in-redeemer-value JSON VALUE
+                                           ( --mint-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                           | --mint-reference-tx-in-redeemer-file JSON_FILE
+                                           | --mint-reference-tx-in-redeemer-value JSON_VALUE
                                            )
                                            --policy-id HASH
                                          )]
@@ -11687,32 +11687,32 @@ Usage: cardano-cli transaction build --socket-path SOCKET_PATH
                                        [--invalid-hereafter SLOT]
                                        [--certificate-file FILE
                                          [ --certificate-script-file FILE
-                                           [ --certificate-redeemer-cbor-file CBOR FILE
-                                           | --certificate-redeemer-file JSON FILE
-                                           | --certificate-redeemer-value JSON VALUE
+                                           [ --certificate-redeemer-cbor-file CBOR_FILE
+                                           | --certificate-redeemer-file JSON_FILE
+                                           | --certificate-redeemer-value JSON_VALUE
                                            ]
                                          | --certificate-tx-in-reference TX-IN
                                            ( --certificate-plutus-script-v2
                                            | --certificate-plutus-script-v3
                                            )
-                                           ( --certificate-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                           | --certificate-reference-tx-in-redeemer-file JSON FILE
-                                           | --certificate-reference-tx-in-redeemer-value JSON VALUE
+                                           ( --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                           | --certificate-reference-tx-in-redeemer-file JSON_FILE
+                                           | --certificate-reference-tx-in-redeemer-value JSON_VALUE
                                            )
                                          ]]
                                        [--withdrawal WITHDRAWAL
                                          [ --withdrawal-script-file FILE
-                                           [ --withdrawal-redeemer-cbor-file CBOR FILE
-                                           | --withdrawal-redeemer-file JSON FILE
-                                           | --withdrawal-redeemer-value JSON VALUE
+                                           [ --withdrawal-redeemer-cbor-file CBOR_FILE
+                                           | --withdrawal-redeemer-file JSON_FILE
+                                           | --withdrawal-redeemer-value JSON_VALUE
                                            ]
                                          | --withdrawal-tx-in-reference TX-IN
                                            ( --withdrawal-plutus-script-v2
                                            | --withdrawal-plutus-script-v3
                                            )
-                                           ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                           | --withdrawal-reference-tx-in-redeemer-file JSON FILE
-                                           | --withdrawal-reference-tx-in-redeemer-value JSON VALUE
+                                           ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                           | --withdrawal-reference-tx-in-redeemer-file JSON_FILE
+                                           | --withdrawal-reference-tx-in-redeemer-value JSON_VALUE
                                            )
                                          ]]
                                        [ --json-metadata-no-schema
@@ -11725,15 +11725,15 @@ Usage: cardano-cli transaction build --socket-path SOCKET_PATH
                                        [--update-proposal-file FILE]
                                        [--vote-file FILE
                                          [--vote-script-file FILE
-                                           [ --vote-redeemer-cbor-file CBOR FILE
-                                           | --vote-redeemer-file JSON FILE
-                                           | --vote-redeemer-value JSON VALUE
+                                           [ --vote-redeemer-cbor-file CBOR_FILE
+                                           | --vote-redeemer-file JSON_FILE
+                                           | --vote-redeemer-value JSON_VALUE
                                            ]]]
                                        [--proposal-file FILE
                                          [--proposal-script-file FILE
-                                           [ --proposal-redeemer-cbor-file CBOR FILE
-                                           | --proposal-redeemer-file JSON FILE
-                                           | --proposal-redeemer-value JSON VALUE
+                                           [ --proposal-redeemer-cbor-file CBOR_FILE
+                                           | --proposal-redeemer-file JSON_FILE
+                                           | --proposal-redeemer-value JSON_VALUE
                                            ]]]
                                        ( --out-file FILE
                                        | --calculate-plutus-script-cost FILE
@@ -11807,15 +11807,15 @@ Usage: cardano-cli transaction calculate-min-required-utxo
                                                              --protocol-params-file FILE
                                                              --tx-out ADDRESS VALUE
                                                              [ --tx-out-datum-hash HASH
-                                                             | --tx-out-datum-hash-cbor-file CBOR FILE
-                                                             | --tx-out-datum-hash-file JSON FILE
-                                                             | --tx-out-datum-hash-value JSON VALUE
-                                                             | --tx-out-datum-embed-cbor-file CBOR FILE
-                                                             | --tx-out-datum-embed-file JSON FILE
-                                                             | --tx-out-datum-embed-value JSON VALUE
-                                                             | --tx-out-inline-datum-cbor-file CBOR FILE
-                                                             | --tx-out-inline-datum-file JSON FILE
-                                                             | --tx-out-inline-datum-value JSON VALUE
+                                                             | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                             | --tx-out-datum-hash-file JSON_FILE
+                                                             | --tx-out-datum-hash-value JSON_VALUE
+                                                             | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                             | --tx-out-datum-embed-file JSON_FILE
+                                                             | --tx-out-datum-embed-value JSON_VALUE
+                                                             | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                             | --tx-out-inline-datum-file JSON_FILE
+                                                             | --tx-out-inline-datum-value JSON_VALUE
                                                              ]
                                                              [--tx-out-reference-script-file FILE]
 
@@ -11832,24 +11832,24 @@ Usage: cardano-cli transaction calculate-min-value
                                                      --protocol-params-file FILE
                                                      --tx-out ADDRESS VALUE
                                                      [ --tx-out-datum-hash HASH
-                                                     | --tx-out-datum-hash-cbor-file CBOR FILE
-                                                     | --tx-out-datum-hash-file JSON FILE
-                                                     | --tx-out-datum-hash-value JSON VALUE
-                                                     | --tx-out-datum-embed-cbor-file CBOR FILE
-                                                     | --tx-out-datum-embed-file JSON FILE
-                                                     | --tx-out-datum-embed-value JSON VALUE
-                                                     | --tx-out-inline-datum-cbor-file CBOR FILE
-                                                     | --tx-out-inline-datum-file JSON FILE
-                                                     | --tx-out-inline-datum-value JSON VALUE
+                                                     | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                     | --tx-out-datum-hash-file JSON_FILE
+                                                     | --tx-out-datum-hash-value JSON_VALUE
+                                                     | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                     | --tx-out-datum-embed-file JSON_FILE
+                                                     | --tx-out-datum-embed-value JSON_VALUE
+                                                     | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                     | --tx-out-inline-datum-file JSON_FILE
+                                                     | --tx-out-inline-datum-value JSON_VALUE
                                                      ]
                                                      [--tx-out-reference-script-file FILE]
 
   DEPRECATED: Use 'calculate-min-required-utxo' instead.
 
 Usage: cardano-cli transaction hash-script-data 
-                                                  ( --script-data-cbor-file CBOR FILE
-                                                  | --script-data-file JSON FILE
-                                                  | --script-data-value JSON VALUE
+                                                  ( --script-data-cbor-file CBOR_FILE
+                                                  | --script-data-file JSON_FILE
+                                                  | --script-data-value JSON_VALUE
                                                   )
 
   Calculate the hash of script data.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_transaction_build-raw.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_transaction_build-raw.cli
@@ -7,27 +7,27 @@ Usage: cardano-cli allegra transaction build-raw
                                                        ( --spending-plutus-script-v2
                                                        | --spending-plutus-script-v3
                                                        )
-                                                       ( --spending-reference-tx-in-datum-cbor-file CBOR FILE
-                                                       | --spending-reference-tx-in-datum-file JSON FILE
-                                                       | --spending-reference-tx-in-datum-value JSON VALUE
+                                                       ( --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                                                       | --spending-reference-tx-in-datum-file JSON_FILE
+                                                       | --spending-reference-tx-in-datum-value JSON_VALUE
                                                        | --spending-reference-tx-in-inline-datum-present
                                                        )
-                                                       ( --spending-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                       | --spending-reference-tx-in-redeemer-file JSON FILE
-                                                       | --spending-reference-tx-in-redeemer-value JSON VALUE
+                                                       ( --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                       | --spending-reference-tx-in-redeemer-file JSON_FILE
+                                                       | --spending-reference-tx-in-redeemer-value JSON_VALUE
                                                        )
                                                        --spending-reference-tx-in-execution-units (INT, INT)
                                                      | --simple-script-tx-in-reference TX-IN
                                                      | --tx-in-script-file FILE
                                                        [
-                                                         ( --tx-in-datum-cbor-file CBOR FILE
-                                                         | --tx-in-datum-file JSON FILE
-                                                         | --tx-in-datum-value JSON VALUE
+                                                         ( --tx-in-datum-cbor-file CBOR_FILE
+                                                         | --tx-in-datum-file JSON_FILE
+                                                         | --tx-in-datum-value JSON_VALUE
                                                          | --tx-in-inline-datum-present
                                                          )
-                                                         ( --tx-in-redeemer-cbor-file CBOR FILE
-                                                         | --tx-in-redeemer-file JSON FILE
-                                                         | --tx-in-redeemer-value JSON VALUE
+                                                         ( --tx-in-redeemer-cbor-file CBOR_FILE
+                                                         | --tx-in-redeemer-file JSON_FILE
+                                                         | --tx-in-redeemer-value JSON_VALUE
                                                          )
                                                          --tx-in-execution-units (INT, INT)]
                                                      ])
@@ -40,23 +40,23 @@ Usage: cardano-cli allegra transaction build-raw
                                                    ]
                                                    [--tx-out ADDRESS VALUE
                                                      [ --tx-out-datum-hash HASH
-                                                     | --tx-out-datum-hash-cbor-file CBOR FILE
-                                                     | --tx-out-datum-hash-file JSON FILE
-                                                     | --tx-out-datum-hash-value JSON VALUE
-                                                     | --tx-out-datum-embed-cbor-file CBOR FILE
-                                                     | --tx-out-datum-embed-file JSON FILE
-                                                     | --tx-out-datum-embed-value JSON VALUE
-                                                     | --tx-out-inline-datum-cbor-file CBOR FILE
-                                                     | --tx-out-inline-datum-file JSON FILE
-                                                     | --tx-out-inline-datum-value JSON VALUE
+                                                     | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                     | --tx-out-datum-hash-file JSON_FILE
+                                                     | --tx-out-datum-hash-value JSON_VALUE
+                                                     | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                     | --tx-out-datum-embed-file JSON_FILE
+                                                     | --tx-out-datum-embed-value JSON_VALUE
+                                                     | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                     | --tx-out-inline-datum-file JSON_FILE
+                                                     | --tx-out-inline-datum-value JSON_VALUE
                                                      ]
                                                      [--tx-out-reference-script-file FILE]]
                                                    [--mint VALUE
                                                      ( --mint-script-file FILE
                                                        [
-                                                         ( --mint-redeemer-cbor-file CBOR FILE
-                                                         | --mint-redeemer-file JSON FILE
-                                                         | --mint-redeemer-value JSON VALUE
+                                                         ( --mint-redeemer-cbor-file CBOR_FILE
+                                                         | --mint-redeemer-file JSON_FILE
+                                                         | --mint-redeemer-value JSON_VALUE
                                                          )
                                                          --mint-execution-units (INT, INT)]
                                                      | --simple-minting-script-tx-in-reference TX-IN
@@ -65,9 +65,9 @@ Usage: cardano-cli allegra transaction build-raw
                                                        ( --mint-plutus-script-v2
                                                        | --mint-plutus-script-v3
                                                        )
-                                                       ( --mint-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                       | --mint-reference-tx-in-redeemer-file JSON FILE
-                                                       | --mint-reference-tx-in-redeemer-value JSON VALUE
+                                                       ( --mint-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                       | --mint-reference-tx-in-redeemer-file JSON_FILE
+                                                       | --mint-reference-tx-in-redeemer-value JSON_VALUE
                                                        )
                                                        --mint-reference-tx-in-execution-units (INT, INT)
                                                        --policy-id HASH
@@ -78,36 +78,36 @@ Usage: cardano-cli allegra transaction build-raw
                                                    [--certificate-file FILE
                                                      [ --certificate-script-file FILE
                                                        [
-                                                         ( --certificate-redeemer-cbor-file CBOR FILE
-                                                         | --certificate-redeemer-file JSON FILE
-                                                         | --certificate-redeemer-value JSON VALUE
+                                                         ( --certificate-redeemer-cbor-file CBOR_FILE
+                                                         | --certificate-redeemer-file JSON_FILE
+                                                         | --certificate-redeemer-value JSON_VALUE
                                                          )
                                                          --certificate-execution-units (INT, INT)]
                                                      | --certificate-tx-in-reference TX-IN
                                                        ( --certificate-plutus-script-v2
                                                        | --certificate-plutus-script-v3
                                                        )
-                                                       ( --certificate-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                       | --certificate-reference-tx-in-redeemer-file JSON FILE
-                                                       | --certificate-reference-tx-in-redeemer-value JSON VALUE
+                                                       ( --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                       | --certificate-reference-tx-in-redeemer-file JSON_FILE
+                                                       | --certificate-reference-tx-in-redeemer-value JSON_VALUE
                                                        )
                                                        --certificate-reference-tx-in-execution-units (INT, INT)
                                                      ]]
                                                    [--withdrawal WITHDRAWAL
                                                      [ --withdrawal-script-file FILE
                                                        [
-                                                         ( --withdrawal-redeemer-cbor-file CBOR FILE
-                                                         | --withdrawal-redeemer-file JSON FILE
-                                                         | --withdrawal-redeemer-value JSON VALUE
+                                                         ( --withdrawal-redeemer-cbor-file CBOR_FILE
+                                                         | --withdrawal-redeemer-file JSON_FILE
+                                                         | --withdrawal-redeemer-value JSON_VALUE
                                                          )
                                                          --withdrawal-execution-units (INT, INT)]
                                                      | --withdrawal-tx-in-reference TX-IN
                                                        ( --withdrawal-plutus-script-v2
                                                        | --withdrawal-plutus-script-v3
                                                        )
-                                                       ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                       | --withdrawal-reference-tx-in-redeemer-file JSON FILE
-                                                       | --withdrawal-reference-tx-in-redeemer-value JSON VALUE
+                                                       ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                       | --withdrawal-reference-tx-in-redeemer-file JSON_FILE
+                                                       | --withdrawal-reference-tx-in-redeemer-value JSON_VALUE
                                                        )
                                                        --withdrawal-reference-tx-in-execution-units (INT, INT)
                                                      ]]
@@ -139,28 +139,28 @@ Available options:
                            Specify a plutus script v2 reference script.
   --spending-plutus-script-v3
                            Specify a plutus script v3 reference script.
-  --spending-reference-tx-in-datum-cbor-file CBOR FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-datum-file JSON FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-datum-value JSON VALUE
-                           The script datum, in JSON syntax. There is no schema:
-                           (almost) any JSON value is supported, including
-                           top-level strings and numbers.
+  --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                           The script datum file. The file has to be in CBOR
+                           format.
+  --spending-reference-tx-in-datum-file JSON_FILE
+                           The script datum file. The file must follow the
+                           detailed JSON schema for script data.
+  --spending-reference-tx-in-datum-value JSON_VALUE
+                           The script datum. There is no schema: (almost) any
+                           JSON value is supported, including top-level strings
+                           and numbers.
   --spending-reference-tx-in-inline-datum-present
                            Inline datum present at transaction input.
-  --spending-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --spending-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --spending-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --spending-reference-tx-in-execution-units (INT, INT)
                            The time and space units needed by the script.
   --simple-script-tx-in-reference TX-IN
@@ -168,28 +168,28 @@ Available options:
                            input must have a simple reference script attached.
   --tx-in-script-file FILE The file containing the script to witness the
                            spending of the transaction input.
-  --tx-in-datum-cbor-file CBOR FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-datum-file JSON FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-datum-value JSON VALUE
-                           The script datum, in JSON syntax. There is no schema:
-                           (almost) any JSON value is supported, including
-                           top-level strings and numbers.
+  --tx-in-datum-cbor-file CBOR_FILE
+                           The script datum file. The file has to be in CBOR
+                           format.
+  --tx-in-datum-file JSON_FILE
+                           The script datum file. The file must follow the
+                           detailed JSON schema for script data.
+  --tx-in-datum-value JSON_VALUE
+                           The script datum. There is no schema: (almost) any
+                           JSON value is supported, including top-level strings
+                           and numbers.
   --tx-in-inline-datum-present
                            Inline datum present at transaction input.
-  --tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --tx-in-execution-units (INT, INT)
                            The time and space units needed by the script.
   --read-only-tx-in-reference TX-IN
@@ -220,61 +220,60 @@ Available options:
                            Lovelace).
   --tx-out-datum-hash HASH The script datum hash for this tx output, as the raw
                            datum hash (in hex).
-  --tx-out-datum-hash-cbor-file CBOR FILE
+  --tx-out-datum-hash-cbor-file CBOR_FILE
                            The script datum hash for this tx output, by hashing
-                           the script datum in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-out-datum-hash-file JSON FILE
+                           the script datum in the file. The file has to be in
+                           CBOR format.
+  --tx-out-datum-hash-file JSON_FILE
                            The script datum hash for this tx output, by hashing
-                           the script datum in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-out-datum-hash-value JSON VALUE
+                           the script datum in the file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-datum-hash-value JSON_VALUE
                            The script datum hash for this tx output, by hashing
-                           the script datum given here in JSON syntax. There is
-                           no schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
-  --tx-out-datum-embed-cbor-file CBOR FILE
-                           The script datum to embed in the tx for this output,
-                           in the given JSON file. The file must follow the
-                           special JSON schema for script data.
-  --tx-out-datum-embed-file JSON FILE
-                           The script datum to embed in the tx for this output,
-                           in the given JSON file. The file must follow the
-                           special JSON schema for script data.
-  --tx-out-datum-embed-value JSON VALUE
-                           The script datum to embed in the tx for this output,
-                           given here in JSON syntax. There is no schema:
+                           the script datum given here. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
-  --tx-out-inline-datum-cbor-file CBOR FILE
+  --tx-out-datum-embed-cbor-file CBOR_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file has to be in CBOR format.
+  --tx-out-datum-embed-file JSON_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file must follow the detailed
+                           JSON schema for script data.
+  --tx-out-datum-embed-value JSON_VALUE
+                           The script datum to embed in the tx for this output,
+                           given here. There is no schema: (almost) any JSON
+                           value is supported, including top-level strings and
+                           numbers.
+  --tx-out-inline-datum-cbor-file CBOR_FILE
                            The script datum to embed in the tx output as an
-                           inline datum, in the given JSON file. The file must
-                           follow the special JSON schema for script data.
-  --tx-out-inline-datum-file JSON FILE
+                           inline datum, in the given file. The file has to be
+                           in CBOR format.
+  --tx-out-inline-datum-file JSON_FILE
                            The script datum to embed in the tx output as an
-                           inline datum, in the given JSON file. The file must
-                           follow the special JSON schema for script data.
-  --tx-out-inline-datum-value JSON VALUE
+                           inline datum, in the given file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-inline-datum-value JSON_VALUE
                            The script datum to embed in the tx output as an
-                           inline datum, given here in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+                           inline datum, given here. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --tx-out-reference-script-file FILE
                            Reference script input file.
   --mint VALUE             Mint multi-asset value(s) with the multi-asset cli
                            syntax. You must specify a script witness.
   --mint-script-file FILE  The file containing the script to witness the minting
                            of assets for a particular policy Id.
-  --mint-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --mint-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --mint-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --mint-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --mint-execution-units (INT, INT)
                            The time and space units needed by the script.
   --simple-minting-script-tx-in-reference TX-IN
@@ -286,16 +285,16 @@ Available options:
                            input must have a plutus reference script attached.
   --mint-plutus-script-v2  Specify a plutus script v2 reference script.
   --mint-plutus-script-v3  Specify a plutus script v3 reference script.
-  --mint-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --mint-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --mint-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --mint-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --mint-reference-tx-in-execution-units (INT, INT)
                            The time and space units needed by the script.
   --policy-id HASH         Policy id of minting script.
@@ -309,16 +308,16 @@ Available options:
   --certificate-script-file FILE
                            The file containing the script to witness the use of
                            the certificate.
-  --certificate-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --certificate-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --certificate-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --certificate-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --certificate-execution-units (INT, INT)
                            The time and space units needed by the script.
   --certificate-tx-in-reference TX-IN
@@ -328,16 +327,16 @@ Available options:
                            Specify a plutus script v2 reference script.
   --certificate-plutus-script-v3
                            Specify a plutus script v3 reference script.
-  --certificate-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --certificate-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --certificate-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --certificate-reference-tx-in-execution-units (INT, INT)
                            The time and space units needed by the script.
   --withdrawal WITHDRAWAL  The reward withdrawal as StakeAddress+Lovelace where
@@ -347,16 +346,16 @@ Available options:
   --withdrawal-script-file FILE
                            The file containing the script to witness the
                            withdrawal of rewards.
-  --withdrawal-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --withdrawal-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --withdrawal-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --withdrawal-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --withdrawal-execution-units (INT, INT)
                            The time and space units needed by the script.
   --withdrawal-tx-in-reference TX-IN
@@ -366,16 +365,16 @@ Available options:
                            Specify a plutus script v2 reference script.
   --withdrawal-plutus-script-v3
                            Specify a plutus script v3 reference script.
-  --withdrawal-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --withdrawal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --withdrawal-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --withdrawal-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --withdrawal-reference-tx-in-execution-units (INT, INT)
                            The time and space units needed by the script.
   --json-metadata-no-schema

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_transaction_build.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_transaction_build.cli
@@ -13,26 +13,26 @@ Usage: cardano-cli allegra transaction build --socket-path SOCKET_PATH
                                                    ( --spending-plutus-script-v2
                                                    | --spending-plutus-script-v3
                                                    )
-                                                   ( --spending-reference-tx-in-datum-cbor-file CBOR FILE
-                                                   | --spending-reference-tx-in-datum-file JSON FILE
-                                                   | --spending-reference-tx-in-datum-value JSON VALUE
+                                                   ( --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                                                   | --spending-reference-tx-in-datum-file JSON_FILE
+                                                   | --spending-reference-tx-in-datum-value JSON_VALUE
                                                    | --spending-reference-tx-in-inline-datum-present
                                                    )
-                                                   ( --spending-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                   | --spending-reference-tx-in-redeemer-file JSON FILE
-                                                   | --spending-reference-tx-in-redeemer-value JSON VALUE
+                                                   ( --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                   | --spending-reference-tx-in-redeemer-file JSON_FILE
+                                                   | --spending-reference-tx-in-redeemer-value JSON_VALUE
                                                    )
                                                  | --simple-script-tx-in-reference TX-IN
                                                  | --tx-in-script-file FILE
                                                    [
-                                                     ( --tx-in-datum-cbor-file CBOR FILE
-                                                     | --tx-in-datum-file JSON FILE
-                                                     | --tx-in-datum-value JSON VALUE
+                                                     ( --tx-in-datum-cbor-file CBOR_FILE
+                                                     | --tx-in-datum-file JSON_FILE
+                                                     | --tx-in-datum-value JSON_VALUE
                                                      | --tx-in-inline-datum-present
                                                      )
-                                                     ( --tx-in-redeemer-cbor-file CBOR FILE
-                                                     | --tx-in-redeemer-file JSON FILE
-                                                     | --tx-in-redeemer-value JSON VALUE
+                                                     ( --tx-in-redeemer-cbor-file CBOR_FILE
+                                                     | --tx-in-redeemer-file JSON_FILE
+                                                     | --tx-in-redeemer-value JSON_VALUE
                                                      )]
                                                  ])
                                                [--read-only-tx-in-reference TX-IN]
@@ -44,23 +44,23 @@ Usage: cardano-cli allegra transaction build --socket-path SOCKET_PATH
                                                [--tx-total-collateral INTEGER]
                                                [--tx-out ADDRESS VALUE
                                                  [ --tx-out-datum-hash HASH
-                                                 | --tx-out-datum-hash-cbor-file CBOR FILE
-                                                 | --tx-out-datum-hash-file JSON FILE
-                                                 | --tx-out-datum-hash-value JSON VALUE
-                                                 | --tx-out-datum-embed-cbor-file CBOR FILE
-                                                 | --tx-out-datum-embed-file JSON FILE
-                                                 | --tx-out-datum-embed-value JSON VALUE
-                                                 | --tx-out-inline-datum-cbor-file CBOR FILE
-                                                 | --tx-out-inline-datum-file JSON FILE
-                                                 | --tx-out-inline-datum-value JSON VALUE
+                                                 | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                 | --tx-out-datum-hash-file JSON_FILE
+                                                 | --tx-out-datum-hash-value JSON_VALUE
+                                                 | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                 | --tx-out-datum-embed-file JSON_FILE
+                                                 | --tx-out-datum-embed-value JSON_VALUE
+                                                 | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                 | --tx-out-inline-datum-file JSON_FILE
+                                                 | --tx-out-inline-datum-value JSON_VALUE
                                                  ]
                                                  [--tx-out-reference-script-file FILE]]
                                                --change-address ADDRESS
                                                [--mint VALUE
                                                  ( --mint-script-file FILE
-                                                   [ --mint-redeemer-cbor-file CBOR FILE
-                                                   | --mint-redeemer-file JSON FILE
-                                                   | --mint-redeemer-value JSON VALUE
+                                                   [ --mint-redeemer-cbor-file CBOR_FILE
+                                                   | --mint-redeemer-file JSON_FILE
+                                                   | --mint-redeemer-value JSON_VALUE
                                                    ]
                                                  | --simple-minting-script-tx-in-reference TX-IN
                                                    --policy-id HASH
@@ -68,9 +68,9 @@ Usage: cardano-cli allegra transaction build --socket-path SOCKET_PATH
                                                    ( --mint-plutus-script-v2
                                                    | --mint-plutus-script-v3
                                                    )
-                                                   ( --mint-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                   | --mint-reference-tx-in-redeemer-file JSON FILE
-                                                   | --mint-reference-tx-in-redeemer-value JSON VALUE
+                                                   ( --mint-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                   | --mint-reference-tx-in-redeemer-file JSON_FILE
+                                                   | --mint-reference-tx-in-redeemer-value JSON_VALUE
                                                    )
                                                    --policy-id HASH
                                                  )]
@@ -78,32 +78,32 @@ Usage: cardano-cli allegra transaction build --socket-path SOCKET_PATH
                                                [--invalid-hereafter SLOT]
                                                [--certificate-file FILE
                                                  [ --certificate-script-file FILE
-                                                   [ --certificate-redeemer-cbor-file CBOR FILE
-                                                   | --certificate-redeemer-file JSON FILE
-                                                   | --certificate-redeemer-value JSON VALUE
+                                                   [ --certificate-redeemer-cbor-file CBOR_FILE
+                                                   | --certificate-redeemer-file JSON_FILE
+                                                   | --certificate-redeemer-value JSON_VALUE
                                                    ]
                                                  | --certificate-tx-in-reference TX-IN
                                                    ( --certificate-plutus-script-v2
                                                    | --certificate-plutus-script-v3
                                                    )
-                                                   ( --certificate-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                   | --certificate-reference-tx-in-redeemer-file JSON FILE
-                                                   | --certificate-reference-tx-in-redeemer-value JSON VALUE
+                                                   ( --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                   | --certificate-reference-tx-in-redeemer-file JSON_FILE
+                                                   | --certificate-reference-tx-in-redeemer-value JSON_VALUE
                                                    )
                                                  ]]
                                                [--withdrawal WITHDRAWAL
                                                  [ --withdrawal-script-file FILE
-                                                   [ --withdrawal-redeemer-cbor-file CBOR FILE
-                                                   | --withdrawal-redeemer-file JSON FILE
-                                                   | --withdrawal-redeemer-value JSON VALUE
+                                                   [ --withdrawal-redeemer-cbor-file CBOR_FILE
+                                                   | --withdrawal-redeemer-file JSON_FILE
+                                                   | --withdrawal-redeemer-value JSON_VALUE
                                                    ]
                                                  | --withdrawal-tx-in-reference TX-IN
                                                    ( --withdrawal-plutus-script-v2
                                                    | --withdrawal-plutus-script-v3
                                                    )
-                                                   ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                   | --withdrawal-reference-tx-in-redeemer-file JSON FILE
-                                                   | --withdrawal-reference-tx-in-redeemer-value JSON VALUE
+                                                   ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                   | --withdrawal-reference-tx-in-redeemer-file JSON_FILE
+                                                   | --withdrawal-reference-tx-in-redeemer-value JSON_VALUE
                                                    )
                                                  ]]
                                                [ --json-metadata-no-schema
@@ -150,55 +150,55 @@ Available options:
                            Specify a plutus script v2 reference script.
   --spending-plutus-script-v3
                            Specify a plutus script v3 reference script.
-  --spending-reference-tx-in-datum-cbor-file CBOR FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-datum-file JSON FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-datum-value JSON VALUE
-                           The script datum, in JSON syntax. There is no schema:
-                           (almost) any JSON value is supported, including
-                           top-level strings and numbers.
+  --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                           The script datum file. The file has to be in CBOR
+                           format.
+  --spending-reference-tx-in-datum-file JSON_FILE
+                           The script datum file. The file must follow the
+                           detailed JSON schema for script data.
+  --spending-reference-tx-in-datum-value JSON_VALUE
+                           The script datum. There is no schema: (almost) any
+                           JSON value is supported, including top-level strings
+                           and numbers.
   --spending-reference-tx-in-inline-datum-present
                            Inline datum present at transaction input.
-  --spending-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --spending-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --spending-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --simple-script-tx-in-reference TX-IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a simple reference script attached.
   --tx-in-script-file FILE The file containing the script to witness the
                            spending of the transaction input.
-  --tx-in-datum-cbor-file CBOR FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-datum-file JSON FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-datum-value JSON VALUE
-                           The script datum, in JSON syntax. There is no schema:
-                           (almost) any JSON value is supported, including
-                           top-level strings and numbers.
+  --tx-in-datum-cbor-file CBOR_FILE
+                           The script datum file. The file has to be in CBOR
+                           format.
+  --tx-in-datum-file JSON_FILE
+                           The script datum file. The file must follow the
+                           detailed JSON schema for script data.
+  --tx-in-datum-value JSON_VALUE
+                           The script datum. There is no schema: (almost) any
+                           JSON value is supported, including top-level strings
+                           and numbers.
   --tx-in-inline-datum-present
                            Inline datum present at transaction input.
-  --tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --read-only-tx-in-reference TX-IN
                            Specify a read only reference input. This reference
                            input is not witnessing anything it is simply
@@ -227,45 +227,44 @@ Available options:
                            Lovelace).
   --tx-out-datum-hash HASH The script datum hash for this tx output, as the raw
                            datum hash (in hex).
-  --tx-out-datum-hash-cbor-file CBOR FILE
+  --tx-out-datum-hash-cbor-file CBOR_FILE
                            The script datum hash for this tx output, by hashing
-                           the script datum in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-out-datum-hash-file JSON FILE
+                           the script datum in the file. The file has to be in
+                           CBOR format.
+  --tx-out-datum-hash-file JSON_FILE
                            The script datum hash for this tx output, by hashing
-                           the script datum in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-out-datum-hash-value JSON VALUE
+                           the script datum in the file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-datum-hash-value JSON_VALUE
                            The script datum hash for this tx output, by hashing
-                           the script datum given here in JSON syntax. There is
-                           no schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
-  --tx-out-datum-embed-cbor-file CBOR FILE
-                           The script datum to embed in the tx for this output,
-                           in the given JSON file. The file must follow the
-                           special JSON schema for script data.
-  --tx-out-datum-embed-file JSON FILE
-                           The script datum to embed in the tx for this output,
-                           in the given JSON file. The file must follow the
-                           special JSON schema for script data.
-  --tx-out-datum-embed-value JSON VALUE
-                           The script datum to embed in the tx for this output,
-                           given here in JSON syntax. There is no schema:
+                           the script datum given here. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
-  --tx-out-inline-datum-cbor-file CBOR FILE
+  --tx-out-datum-embed-cbor-file CBOR_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file has to be in CBOR format.
+  --tx-out-datum-embed-file JSON_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file must follow the detailed
+                           JSON schema for script data.
+  --tx-out-datum-embed-value JSON_VALUE
+                           The script datum to embed in the tx for this output,
+                           given here. There is no schema: (almost) any JSON
+                           value is supported, including top-level strings and
+                           numbers.
+  --tx-out-inline-datum-cbor-file CBOR_FILE
                            The script datum to embed in the tx output as an
-                           inline datum, in the given JSON file. The file must
-                           follow the special JSON schema for script data.
-  --tx-out-inline-datum-file JSON FILE
+                           inline datum, in the given file. The file has to be
+                           in CBOR format.
+  --tx-out-inline-datum-file JSON_FILE
                            The script datum to embed in the tx output as an
-                           inline datum, in the given JSON file. The file must
-                           follow the special JSON schema for script data.
-  --tx-out-inline-datum-value JSON VALUE
+                           inline datum, in the given file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-inline-datum-value JSON_VALUE
                            The script datum to embed in the tx output as an
-                           inline datum, given here in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+                           inline datum, given here. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --tx-out-reference-script-file FILE
                            Reference script input file.
   --change-address ADDRESS Address where ADA in excess of the tx fee will go to.
@@ -273,16 +272,16 @@ Available options:
                            syntax. You must specify a script witness.
   --mint-script-file FILE  The file containing the script to witness the minting
                            of assets for a particular policy Id.
-  --mint-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --mint-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --mint-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --mint-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --simple-minting-script-tx-in-reference TX-IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a simple reference script attached.
@@ -292,16 +291,16 @@ Available options:
                            input must have a plutus reference script attached.
   --mint-plutus-script-v2  Specify a plutus script v2 reference script.
   --mint-plutus-script-v3  Specify a plutus script v3 reference script.
-  --mint-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --mint-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --mint-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --mint-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --policy-id HASH         Policy id of minting script.
   --invalid-before SLOT    Time that transaction is valid from (in slots).
   --invalid-hereafter SLOT Time that transaction is valid until (in slots).
@@ -312,16 +311,16 @@ Available options:
   --certificate-script-file FILE
                            The file containing the script to witness the use of
                            the certificate.
-  --certificate-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --certificate-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --certificate-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --certificate-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --certificate-tx-in-reference TX-IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a plutus reference script attached.
@@ -329,16 +328,16 @@ Available options:
                            Specify a plutus script v2 reference script.
   --certificate-plutus-script-v3
                            Specify a plutus script v3 reference script.
-  --certificate-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --certificate-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --certificate-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --withdrawal WITHDRAWAL  The reward withdrawal as StakeAddress+Lovelace where
                            StakeAddress is the Bech32-encoded stake address
                            followed by the amount in Lovelace. Optionally
@@ -346,16 +345,16 @@ Available options:
   --withdrawal-script-file FILE
                            The file containing the script to witness the
                            withdrawal of rewards.
-  --withdrawal-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --withdrawal-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --withdrawal-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --withdrawal-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --withdrawal-tx-in-reference TX-IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a plutus reference script attached.
@@ -363,16 +362,16 @@ Available options:
                            Specify a plutus script v2 reference script.
   --withdrawal-plutus-script-v3
                            Specify a plutus script v3 reference script.
-  --withdrawal-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --withdrawal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --withdrawal-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --withdrawal-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --json-metadata-no-schema
                            Use the "no schema" conversion from JSON to tx
                            metadata (default).

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_transaction_calculate-min-required-utxo.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_transaction_calculate-min-required-utxo.cli
@@ -1,15 +1,15 @@
 Usage: cardano-cli allegra transaction calculate-min-required-utxo --protocol-params-file FILE
                                                                      --tx-out ADDRESS VALUE
                                                                      [ --tx-out-datum-hash HASH
-                                                                     | --tx-out-datum-hash-cbor-file CBOR FILE
-                                                                     | --tx-out-datum-hash-file JSON FILE
-                                                                     | --tx-out-datum-hash-value JSON VALUE
-                                                                     | --tx-out-datum-embed-cbor-file CBOR FILE
-                                                                     | --tx-out-datum-embed-file JSON FILE
-                                                                     | --tx-out-datum-embed-value JSON VALUE
-                                                                     | --tx-out-inline-datum-cbor-file CBOR FILE
-                                                                     | --tx-out-inline-datum-file JSON FILE
-                                                                     | --tx-out-inline-datum-value JSON VALUE
+                                                                     | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                                     | --tx-out-datum-hash-file JSON_FILE
+                                                                     | --tx-out-datum-hash-value JSON_VALUE
+                                                                     | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                                     | --tx-out-datum-embed-file JSON_FILE
+                                                                     | --tx-out-datum-embed-value JSON_VALUE
+                                                                     | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                                     | --tx-out-inline-datum-file JSON_FILE
+                                                                     | --tx-out-inline-datum-value JSON_VALUE
                                                                      ]
                                                                      [--tx-out-reference-script-file FILE]
 
@@ -24,45 +24,44 @@ Available options:
                            Lovelace).
   --tx-out-datum-hash HASH The script datum hash for this tx output, as the raw
                            datum hash (in hex).
-  --tx-out-datum-hash-cbor-file CBOR FILE
+  --tx-out-datum-hash-cbor-file CBOR_FILE
                            The script datum hash for this tx output, by hashing
-                           the script datum in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-out-datum-hash-file JSON FILE
+                           the script datum in the file. The file has to be in
+                           CBOR format.
+  --tx-out-datum-hash-file JSON_FILE
                            The script datum hash for this tx output, by hashing
-                           the script datum in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-out-datum-hash-value JSON VALUE
+                           the script datum in the file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-datum-hash-value JSON_VALUE
                            The script datum hash for this tx output, by hashing
-                           the script datum given here in JSON syntax. There is
-                           no schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
-  --tx-out-datum-embed-cbor-file CBOR FILE
-                           The script datum to embed in the tx for this output,
-                           in the given JSON file. The file must follow the
-                           special JSON schema for script data.
-  --tx-out-datum-embed-file JSON FILE
-                           The script datum to embed in the tx for this output,
-                           in the given JSON file. The file must follow the
-                           special JSON schema for script data.
-  --tx-out-datum-embed-value JSON VALUE
-                           The script datum to embed in the tx for this output,
-                           given here in JSON syntax. There is no schema:
+                           the script datum given here. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
-  --tx-out-inline-datum-cbor-file CBOR FILE
+  --tx-out-datum-embed-cbor-file CBOR_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file has to be in CBOR format.
+  --tx-out-datum-embed-file JSON_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file must follow the detailed
+                           JSON schema for script data.
+  --tx-out-datum-embed-value JSON_VALUE
+                           The script datum to embed in the tx for this output,
+                           given here. There is no schema: (almost) any JSON
+                           value is supported, including top-level strings and
+                           numbers.
+  --tx-out-inline-datum-cbor-file CBOR_FILE
                            The script datum to embed in the tx output as an
-                           inline datum, in the given JSON file. The file must
-                           follow the special JSON schema for script data.
-  --tx-out-inline-datum-file JSON FILE
+                           inline datum, in the given file. The file has to be
+                           in CBOR format.
+  --tx-out-inline-datum-file JSON_FILE
                            The script datum to embed in the tx output as an
-                           inline datum, in the given JSON file. The file must
-                           follow the special JSON schema for script data.
-  --tx-out-inline-datum-value JSON VALUE
+                           inline datum, in the given file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-inline-datum-value JSON_VALUE
                            The script datum to embed in the tx output as an
-                           inline datum, given here in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+                           inline datum, given here. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --tx-out-reference-script-file FILE
                            Reference script input file.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_transaction_calculate-min-value.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_transaction_calculate-min-value.cli
@@ -1,15 +1,15 @@
 Usage: cardano-cli allegra transaction calculate-min-value --protocol-params-file FILE
                                                              --tx-out ADDRESS VALUE
                                                              [ --tx-out-datum-hash HASH
-                                                             | --tx-out-datum-hash-cbor-file CBOR FILE
-                                                             | --tx-out-datum-hash-file JSON FILE
-                                                             | --tx-out-datum-hash-value JSON VALUE
-                                                             | --tx-out-datum-embed-cbor-file CBOR FILE
-                                                             | --tx-out-datum-embed-file JSON FILE
-                                                             | --tx-out-datum-embed-value JSON VALUE
-                                                             | --tx-out-inline-datum-cbor-file CBOR FILE
-                                                             | --tx-out-inline-datum-file JSON FILE
-                                                             | --tx-out-inline-datum-value JSON VALUE
+                                                             | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                             | --tx-out-datum-hash-file JSON_FILE
+                                                             | --tx-out-datum-hash-value JSON_VALUE
+                                                             | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                             | --tx-out-datum-embed-file JSON_FILE
+                                                             | --tx-out-datum-embed-value JSON_VALUE
+                                                             | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                             | --tx-out-inline-datum-file JSON_FILE
+                                                             | --tx-out-inline-datum-value JSON_VALUE
                                                              ]
                                                              [--tx-out-reference-script-file FILE]
 
@@ -24,44 +24,43 @@ Available options:
                            Lovelace).
   --tx-out-datum-hash HASH The script datum hash for this tx output, as the raw
                            datum hash (in hex).
-  --tx-out-datum-hash-cbor-file CBOR FILE
+  --tx-out-datum-hash-cbor-file CBOR_FILE
                            The script datum hash for this tx output, by hashing
-                           the script datum in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-out-datum-hash-file JSON FILE
+                           the script datum in the file. The file has to be in
+                           CBOR format.
+  --tx-out-datum-hash-file JSON_FILE
                            The script datum hash for this tx output, by hashing
-                           the script datum in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-out-datum-hash-value JSON VALUE
+                           the script datum in the file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-datum-hash-value JSON_VALUE
                            The script datum hash for this tx output, by hashing
-                           the script datum given here in JSON syntax. There is
-                           no schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
-  --tx-out-datum-embed-cbor-file CBOR FILE
-                           The script datum to embed in the tx for this output,
-                           in the given JSON file. The file must follow the
-                           special JSON schema for script data.
-  --tx-out-datum-embed-file JSON FILE
-                           The script datum to embed in the tx for this output,
-                           in the given JSON file. The file must follow the
-                           special JSON schema for script data.
-  --tx-out-datum-embed-value JSON VALUE
-                           The script datum to embed in the tx for this output,
-                           given here in JSON syntax. There is no schema:
+                           the script datum given here. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
-  --tx-out-inline-datum-cbor-file CBOR FILE
+  --tx-out-datum-embed-cbor-file CBOR_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file has to be in CBOR format.
+  --tx-out-datum-embed-file JSON_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file must follow the detailed
+                           JSON schema for script data.
+  --tx-out-datum-embed-value JSON_VALUE
+                           The script datum to embed in the tx for this output,
+                           given here. There is no schema: (almost) any JSON
+                           value is supported, including top-level strings and
+                           numbers.
+  --tx-out-inline-datum-cbor-file CBOR_FILE
                            The script datum to embed in the tx output as an
-                           inline datum, in the given JSON file. The file must
-                           follow the special JSON schema for script data.
-  --tx-out-inline-datum-file JSON FILE
+                           inline datum, in the given file. The file has to be
+                           in CBOR format.
+  --tx-out-inline-datum-file JSON_FILE
                            The script datum to embed in the tx output as an
-                           inline datum, in the given JSON file. The file must
-                           follow the special JSON schema for script data.
-  --tx-out-inline-datum-value JSON VALUE
+                           inline datum, in the given file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-inline-datum-value JSON_VALUE
                            The script datum to embed in the tx output as an
-                           inline datum, given here in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+                           inline datum, given here. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --tx-out-reference-script-file FILE
                            Reference script input file.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_transaction_hash-script-data.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_transaction_hash-script-data.cli
@@ -1,20 +1,20 @@
 Usage: cardano-cli allegra transaction hash-script-data 
-                                                          ( --script-data-cbor-file CBOR FILE
-                                                          | --script-data-file JSON FILE
-                                                          | --script-data-value JSON VALUE
+                                                          ( --script-data-cbor-file CBOR_FILE
+                                                          | --script-data-file JSON_FILE
+                                                          | --script-data-value JSON_VALUE
                                                           )
 
   Calculate the hash of script data.
 
 Available options:
-  --script-data-cbor-file CBOR FILE
-                           The script data, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --script-data-file JSON FILE
-                           The script data, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --script-data-value JSON VALUE
-                           The script data, in JSON syntax. There is no schema:
-                           (almost) any JSON value is supported, including
-                           top-level strings and numbers.
+  --script-data-cbor-file CBOR_FILE
+                           The script data file. The file has to be in CBOR
+                           format.
+  --script-data-file JSON_FILE
+                           The script data file. The file must follow the
+                           detailed JSON schema for script data.
+  --script-data-value JSON_VALUE
+                           The script data. There is no schema: (almost) any
+                           JSON value is supported, including top-level strings
+                           and numbers.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_transaction_build-estimate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_transaction_build-estimate.cli
@@ -11,27 +11,27 @@ Usage: cardano-cli alonzo transaction build-estimate
                                                            ( --spending-plutus-script-v2
                                                            | --spending-plutus-script-v3
                                                            )
-                                                           ( --spending-reference-tx-in-datum-cbor-file CBOR FILE
-                                                           | --spending-reference-tx-in-datum-file JSON FILE
-                                                           | --spending-reference-tx-in-datum-value JSON VALUE
+                                                           ( --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                                                           | --spending-reference-tx-in-datum-file JSON_FILE
+                                                           | --spending-reference-tx-in-datum-value JSON_VALUE
                                                            | --spending-reference-tx-in-inline-datum-present
                                                            )
-                                                           ( --spending-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                           | --spending-reference-tx-in-redeemer-file JSON FILE
-                                                           | --spending-reference-tx-in-redeemer-value JSON VALUE
+                                                           ( --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                           | --spending-reference-tx-in-redeemer-file JSON_FILE
+                                                           | --spending-reference-tx-in-redeemer-value JSON_VALUE
                                                            )
                                                            --spending-reference-tx-in-execution-units (INT, INT)
                                                          | --simple-script-tx-in-reference TX-IN
                                                          | --tx-in-script-file FILE
                                                            [
-                                                             ( --tx-in-datum-cbor-file CBOR FILE
-                                                             | --tx-in-datum-file JSON FILE
-                                                             | --tx-in-datum-value JSON VALUE
+                                                             ( --tx-in-datum-cbor-file CBOR_FILE
+                                                             | --tx-in-datum-file JSON_FILE
+                                                             | --tx-in-datum-value JSON_VALUE
                                                              | --tx-in-inline-datum-present
                                                              )
-                                                             ( --tx-in-redeemer-cbor-file CBOR FILE
-                                                             | --tx-in-redeemer-file JSON FILE
-                                                             | --tx-in-redeemer-value JSON VALUE
+                                                             ( --tx-in-redeemer-cbor-file CBOR_FILE
+                                                             | --tx-in-redeemer-file JSON_FILE
+                                                             | --tx-in-redeemer-value JSON_VALUE
                                                              )
                                                              --tx-in-execution-units (INT, INT)]
                                                          ])
@@ -43,24 +43,24 @@ Usage: cardano-cli alonzo transaction build-estimate
                                                        [--tx-out-return-collateral ADDRESS VALUE]
                                                        [--tx-out ADDRESS VALUE
                                                          [ --tx-out-datum-hash HASH
-                                                         | --tx-out-datum-hash-cbor-file CBOR FILE
-                                                         | --tx-out-datum-hash-file JSON FILE
-                                                         | --tx-out-datum-hash-value JSON VALUE
-                                                         | --tx-out-datum-embed-cbor-file CBOR FILE
-                                                         | --tx-out-datum-embed-file JSON FILE
-                                                         | --tx-out-datum-embed-value JSON VALUE
-                                                         | --tx-out-inline-datum-cbor-file CBOR FILE
-                                                         | --tx-out-inline-datum-file JSON FILE
-                                                         | --tx-out-inline-datum-value JSON VALUE
+                                                         | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                         | --tx-out-datum-hash-file JSON_FILE
+                                                         | --tx-out-datum-hash-value JSON_VALUE
+                                                         | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                         | --tx-out-datum-embed-file JSON_FILE
+                                                         | --tx-out-datum-embed-value JSON_VALUE
+                                                         | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                         | --tx-out-inline-datum-file JSON_FILE
+                                                         | --tx-out-inline-datum-value JSON_VALUE
                                                          ]
                                                          [--tx-out-reference-script-file FILE]]
                                                        --change-address ADDRESS
                                                        [--mint VALUE
                                                          ( --mint-script-file FILE
                                                            [
-                                                             ( --mint-redeemer-cbor-file CBOR FILE
-                                                             | --mint-redeemer-file JSON FILE
-                                                             | --mint-redeemer-value JSON VALUE
+                                                             ( --mint-redeemer-cbor-file CBOR_FILE
+                                                             | --mint-redeemer-file JSON_FILE
+                                                             | --mint-redeemer-value JSON_VALUE
                                                              )
                                                              --mint-execution-units (INT, INT)]
                                                          | --simple-minting-script-tx-in-reference TX-IN
@@ -69,9 +69,9 @@ Usage: cardano-cli alonzo transaction build-estimate
                                                            ( --mint-plutus-script-v2
                                                            | --mint-plutus-script-v3
                                                            )
-                                                           ( --mint-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                           | --mint-reference-tx-in-redeemer-file JSON FILE
-                                                           | --mint-reference-tx-in-redeemer-value JSON VALUE
+                                                           ( --mint-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                           | --mint-reference-tx-in-redeemer-file JSON_FILE
+                                                           | --mint-reference-tx-in-redeemer-value JSON_VALUE
                                                            )
                                                            --mint-reference-tx-in-execution-units (INT, INT)
                                                            --policy-id HASH
@@ -81,36 +81,36 @@ Usage: cardano-cli alonzo transaction build-estimate
                                                        [--certificate-file FILE
                                                          [ --certificate-script-file FILE
                                                            [
-                                                             ( --certificate-redeemer-cbor-file CBOR FILE
-                                                             | --certificate-redeemer-file JSON FILE
-                                                             | --certificate-redeemer-value JSON VALUE
+                                                             ( --certificate-redeemer-cbor-file CBOR_FILE
+                                                             | --certificate-redeemer-file JSON_FILE
+                                                             | --certificate-redeemer-value JSON_VALUE
                                                              )
                                                              --certificate-execution-units (INT, INT)]
                                                          | --certificate-tx-in-reference TX-IN
                                                            ( --certificate-plutus-script-v2
                                                            | --certificate-plutus-script-v3
                                                            )
-                                                           ( --certificate-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                           | --certificate-reference-tx-in-redeemer-file JSON FILE
-                                                           | --certificate-reference-tx-in-redeemer-value JSON VALUE
+                                                           ( --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                           | --certificate-reference-tx-in-redeemer-file JSON_FILE
+                                                           | --certificate-reference-tx-in-redeemer-value JSON_VALUE
                                                            )
                                                            --certificate-reference-tx-in-execution-units (INT, INT)
                                                          ]]
                                                        [--withdrawal WITHDRAWAL
                                                          [ --withdrawal-script-file FILE
                                                            [
-                                                             ( --withdrawal-redeemer-cbor-file CBOR FILE
-                                                             | --withdrawal-redeemer-file JSON FILE
-                                                             | --withdrawal-redeemer-value JSON VALUE
+                                                             ( --withdrawal-redeemer-cbor-file CBOR_FILE
+                                                             | --withdrawal-redeemer-file JSON_FILE
+                                                             | --withdrawal-redeemer-value JSON_VALUE
                                                              )
                                                              --withdrawal-execution-units (INT, INT)]
                                                          | --withdrawal-tx-in-reference TX-IN
                                                            ( --withdrawal-plutus-script-v2
                                                            | --withdrawal-plutus-script-v3
                                                            )
-                                                           ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                           | --withdrawal-reference-tx-in-redeemer-file JSON FILE
-                                                           | --withdrawal-reference-tx-in-redeemer-value JSON VALUE
+                                                           ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                           | --withdrawal-reference-tx-in-redeemer-file JSON_FILE
+                                                           | --withdrawal-reference-tx-in-redeemer-value JSON_VALUE
                                                            )
                                                            --withdrawal-reference-tx-in-execution-units (INT, INT)
                                                          ]]
@@ -153,28 +153,28 @@ Available options:
                            Specify a plutus script v2 reference script.
   --spending-plutus-script-v3
                            Specify a plutus script v3 reference script.
-  --spending-reference-tx-in-datum-cbor-file CBOR FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-datum-file JSON FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-datum-value JSON VALUE
-                           The script datum, in JSON syntax. There is no schema:
-                           (almost) any JSON value is supported, including
-                           top-level strings and numbers.
+  --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                           The script datum file. The file has to be in CBOR
+                           format.
+  --spending-reference-tx-in-datum-file JSON_FILE
+                           The script datum file. The file must follow the
+                           detailed JSON schema for script data.
+  --spending-reference-tx-in-datum-value JSON_VALUE
+                           The script datum. There is no schema: (almost) any
+                           JSON value is supported, including top-level strings
+                           and numbers.
   --spending-reference-tx-in-inline-datum-present
                            Inline datum present at transaction input.
-  --spending-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --spending-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --spending-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --spending-reference-tx-in-execution-units (INT, INT)
                            The time and space units needed by the script.
   --simple-script-tx-in-reference TX-IN
@@ -182,28 +182,28 @@ Available options:
                            input must have a simple reference script attached.
   --tx-in-script-file FILE The file containing the script to witness the
                            spending of the transaction input.
-  --tx-in-datum-cbor-file CBOR FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-datum-file JSON FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-datum-value JSON VALUE
-                           The script datum, in JSON syntax. There is no schema:
-                           (almost) any JSON value is supported, including
-                           top-level strings and numbers.
+  --tx-in-datum-cbor-file CBOR_FILE
+                           The script datum file. The file has to be in CBOR
+                           format.
+  --tx-in-datum-file JSON_FILE
+                           The script datum file. The file must follow the
+                           detailed JSON schema for script data.
+  --tx-in-datum-value JSON_VALUE
+                           The script datum. There is no schema: (almost) any
+                           JSON value is supported, including top-level strings
+                           and numbers.
   --tx-in-inline-datum-present
                            Inline datum present at transaction input.
-  --tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --tx-in-execution-units (INT, INT)
                            The time and space units needed by the script.
   --read-only-tx-in-reference TX-IN
@@ -229,45 +229,44 @@ Available options:
                            Lovelace).
   --tx-out-datum-hash HASH The script datum hash for this tx output, as the raw
                            datum hash (in hex).
-  --tx-out-datum-hash-cbor-file CBOR FILE
+  --tx-out-datum-hash-cbor-file CBOR_FILE
                            The script datum hash for this tx output, by hashing
-                           the script datum in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-out-datum-hash-file JSON FILE
+                           the script datum in the file. The file has to be in
+                           CBOR format.
+  --tx-out-datum-hash-file JSON_FILE
                            The script datum hash for this tx output, by hashing
-                           the script datum in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-out-datum-hash-value JSON VALUE
+                           the script datum in the file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-datum-hash-value JSON_VALUE
                            The script datum hash for this tx output, by hashing
-                           the script datum given here in JSON syntax. There is
-                           no schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
-  --tx-out-datum-embed-cbor-file CBOR FILE
-                           The script datum to embed in the tx for this output,
-                           in the given JSON file. The file must follow the
-                           special JSON schema for script data.
-  --tx-out-datum-embed-file JSON FILE
-                           The script datum to embed in the tx for this output,
-                           in the given JSON file. The file must follow the
-                           special JSON schema for script data.
-  --tx-out-datum-embed-value JSON VALUE
-                           The script datum to embed in the tx for this output,
-                           given here in JSON syntax. There is no schema:
+                           the script datum given here. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
-  --tx-out-inline-datum-cbor-file CBOR FILE
+  --tx-out-datum-embed-cbor-file CBOR_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file has to be in CBOR format.
+  --tx-out-datum-embed-file JSON_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file must follow the detailed
+                           JSON schema for script data.
+  --tx-out-datum-embed-value JSON_VALUE
+                           The script datum to embed in the tx for this output,
+                           given here. There is no schema: (almost) any JSON
+                           value is supported, including top-level strings and
+                           numbers.
+  --tx-out-inline-datum-cbor-file CBOR_FILE
                            The script datum to embed in the tx output as an
-                           inline datum, in the given JSON file. The file must
-                           follow the special JSON schema for script data.
-  --tx-out-inline-datum-file JSON FILE
+                           inline datum, in the given file. The file has to be
+                           in CBOR format.
+  --tx-out-inline-datum-file JSON_FILE
                            The script datum to embed in the tx output as an
-                           inline datum, in the given JSON file. The file must
-                           follow the special JSON schema for script data.
-  --tx-out-inline-datum-value JSON VALUE
+                           inline datum, in the given file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-inline-datum-value JSON_VALUE
                            The script datum to embed in the tx output as an
-                           inline datum, given here in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+                           inline datum, given here. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --tx-out-reference-script-file FILE
                            Reference script input file.
   --change-address ADDRESS Address where ADA in excess of the tx fee will go to.
@@ -275,16 +274,16 @@ Available options:
                            syntax. You must specify a script witness.
   --mint-script-file FILE  The file containing the script to witness the minting
                            of assets for a particular policy Id.
-  --mint-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --mint-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --mint-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --mint-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --mint-execution-units (INT, INT)
                            The time and space units needed by the script.
   --simple-minting-script-tx-in-reference TX-IN
@@ -296,16 +295,16 @@ Available options:
                            input must have a plutus reference script attached.
   --mint-plutus-script-v2  Specify a plutus script v2 reference script.
   --mint-plutus-script-v3  Specify a plutus script v3 reference script.
-  --mint-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --mint-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --mint-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --mint-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --mint-reference-tx-in-execution-units (INT, INT)
                            The time and space units needed by the script.
   --policy-id HASH         Policy id of minting script.
@@ -318,16 +317,16 @@ Available options:
   --certificate-script-file FILE
                            The file containing the script to witness the use of
                            the certificate.
-  --certificate-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --certificate-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --certificate-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --certificate-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --certificate-execution-units (INT, INT)
                            The time and space units needed by the script.
   --certificate-tx-in-reference TX-IN
@@ -337,16 +336,16 @@ Available options:
                            Specify a plutus script v2 reference script.
   --certificate-plutus-script-v3
                            Specify a plutus script v3 reference script.
-  --certificate-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --certificate-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --certificate-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --certificate-reference-tx-in-execution-units (INT, INT)
                            The time and space units needed by the script.
   --withdrawal WITHDRAWAL  The reward withdrawal as StakeAddress+Lovelace where
@@ -356,16 +355,16 @@ Available options:
   --withdrawal-script-file FILE
                            The file containing the script to witness the
                            withdrawal of rewards.
-  --withdrawal-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --withdrawal-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --withdrawal-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --withdrawal-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --withdrawal-execution-units (INT, INT)
                            The time and space units needed by the script.
   --withdrawal-tx-in-reference TX-IN
@@ -375,16 +374,16 @@ Available options:
                            Specify a plutus script v2 reference script.
   --withdrawal-plutus-script-v3
                            Specify a plutus script v3 reference script.
-  --withdrawal-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --withdrawal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --withdrawal-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --withdrawal-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --withdrawal-reference-tx-in-execution-units (INT, INT)
                            The time and space units needed by the script.
   --tx-total-collateral INTEGER

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_transaction_build-raw.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_transaction_build-raw.cli
@@ -7,27 +7,27 @@ Usage: cardano-cli alonzo transaction build-raw
                                                       ( --spending-plutus-script-v2
                                                       | --spending-plutus-script-v3
                                                       )
-                                                      ( --spending-reference-tx-in-datum-cbor-file CBOR FILE
-                                                      | --spending-reference-tx-in-datum-file JSON FILE
-                                                      | --spending-reference-tx-in-datum-value JSON VALUE
+                                                      ( --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                                                      | --spending-reference-tx-in-datum-file JSON_FILE
+                                                      | --spending-reference-tx-in-datum-value JSON_VALUE
                                                       | --spending-reference-tx-in-inline-datum-present
                                                       )
-                                                      ( --spending-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                      | --spending-reference-tx-in-redeemer-file JSON FILE
-                                                      | --spending-reference-tx-in-redeemer-value JSON VALUE
+                                                      ( --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                      | --spending-reference-tx-in-redeemer-file JSON_FILE
+                                                      | --spending-reference-tx-in-redeemer-value JSON_VALUE
                                                       )
                                                       --spending-reference-tx-in-execution-units (INT, INT)
                                                     | --simple-script-tx-in-reference TX-IN
                                                     | --tx-in-script-file FILE
                                                       [
-                                                        ( --tx-in-datum-cbor-file CBOR FILE
-                                                        | --tx-in-datum-file JSON FILE
-                                                        | --tx-in-datum-value JSON VALUE
+                                                        ( --tx-in-datum-cbor-file CBOR_FILE
+                                                        | --tx-in-datum-file JSON_FILE
+                                                        | --tx-in-datum-value JSON_VALUE
                                                         | --tx-in-inline-datum-present
                                                         )
-                                                        ( --tx-in-redeemer-cbor-file CBOR FILE
-                                                        | --tx-in-redeemer-file JSON FILE
-                                                        | --tx-in-redeemer-value JSON VALUE
+                                                        ( --tx-in-redeemer-cbor-file CBOR_FILE
+                                                        | --tx-in-redeemer-file JSON_FILE
+                                                        | --tx-in-redeemer-value JSON_VALUE
                                                         )
                                                         --tx-in-execution-units (INT, INT)]
                                                     ])
@@ -40,23 +40,23 @@ Usage: cardano-cli alonzo transaction build-raw
                                                   ]
                                                   [--tx-out ADDRESS VALUE
                                                     [ --tx-out-datum-hash HASH
-                                                    | --tx-out-datum-hash-cbor-file CBOR FILE
-                                                    | --tx-out-datum-hash-file JSON FILE
-                                                    | --tx-out-datum-hash-value JSON VALUE
-                                                    | --tx-out-datum-embed-cbor-file CBOR FILE
-                                                    | --tx-out-datum-embed-file JSON FILE
-                                                    | --tx-out-datum-embed-value JSON VALUE
-                                                    | --tx-out-inline-datum-cbor-file CBOR FILE
-                                                    | --tx-out-inline-datum-file JSON FILE
-                                                    | --tx-out-inline-datum-value JSON VALUE
+                                                    | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                    | --tx-out-datum-hash-file JSON_FILE
+                                                    | --tx-out-datum-hash-value JSON_VALUE
+                                                    | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                    | --tx-out-datum-embed-file JSON_FILE
+                                                    | --tx-out-datum-embed-value JSON_VALUE
+                                                    | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                    | --tx-out-inline-datum-file JSON_FILE
+                                                    | --tx-out-inline-datum-value JSON_VALUE
                                                     ]
                                                     [--tx-out-reference-script-file FILE]]
                                                   [--mint VALUE
                                                     ( --mint-script-file FILE
                                                       [
-                                                        ( --mint-redeemer-cbor-file CBOR FILE
-                                                        | --mint-redeemer-file JSON FILE
-                                                        | --mint-redeemer-value JSON VALUE
+                                                        ( --mint-redeemer-cbor-file CBOR_FILE
+                                                        | --mint-redeemer-file JSON_FILE
+                                                        | --mint-redeemer-value JSON_VALUE
                                                         )
                                                         --mint-execution-units (INT, INT)]
                                                     | --simple-minting-script-tx-in-reference TX-IN
@@ -65,9 +65,9 @@ Usage: cardano-cli alonzo transaction build-raw
                                                       ( --mint-plutus-script-v2
                                                       | --mint-plutus-script-v3
                                                       )
-                                                      ( --mint-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                      | --mint-reference-tx-in-redeemer-file JSON FILE
-                                                      | --mint-reference-tx-in-redeemer-value JSON VALUE
+                                                      ( --mint-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                      | --mint-reference-tx-in-redeemer-file JSON_FILE
+                                                      | --mint-reference-tx-in-redeemer-value JSON_VALUE
                                                       )
                                                       --mint-reference-tx-in-execution-units (INT, INT)
                                                       --policy-id HASH
@@ -78,36 +78,36 @@ Usage: cardano-cli alonzo transaction build-raw
                                                   [--certificate-file FILE
                                                     [ --certificate-script-file FILE
                                                       [
-                                                        ( --certificate-redeemer-cbor-file CBOR FILE
-                                                        | --certificate-redeemer-file JSON FILE
-                                                        | --certificate-redeemer-value JSON VALUE
+                                                        ( --certificate-redeemer-cbor-file CBOR_FILE
+                                                        | --certificate-redeemer-file JSON_FILE
+                                                        | --certificate-redeemer-value JSON_VALUE
                                                         )
                                                         --certificate-execution-units (INT, INT)]
                                                     | --certificate-tx-in-reference TX-IN
                                                       ( --certificate-plutus-script-v2
                                                       | --certificate-plutus-script-v3
                                                       )
-                                                      ( --certificate-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                      | --certificate-reference-tx-in-redeemer-file JSON FILE
-                                                      | --certificate-reference-tx-in-redeemer-value JSON VALUE
+                                                      ( --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                      | --certificate-reference-tx-in-redeemer-file JSON_FILE
+                                                      | --certificate-reference-tx-in-redeemer-value JSON_VALUE
                                                       )
                                                       --certificate-reference-tx-in-execution-units (INT, INT)
                                                     ]]
                                                   [--withdrawal WITHDRAWAL
                                                     [ --withdrawal-script-file FILE
                                                       [
-                                                        ( --withdrawal-redeemer-cbor-file CBOR FILE
-                                                        | --withdrawal-redeemer-file JSON FILE
-                                                        | --withdrawal-redeemer-value JSON VALUE
+                                                        ( --withdrawal-redeemer-cbor-file CBOR_FILE
+                                                        | --withdrawal-redeemer-file JSON_FILE
+                                                        | --withdrawal-redeemer-value JSON_VALUE
                                                         )
                                                         --withdrawal-execution-units (INT, INT)]
                                                     | --withdrawal-tx-in-reference TX-IN
                                                       ( --withdrawal-plutus-script-v2
                                                       | --withdrawal-plutus-script-v3
                                                       )
-                                                      ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                      | --withdrawal-reference-tx-in-redeemer-file JSON FILE
-                                                      | --withdrawal-reference-tx-in-redeemer-value JSON VALUE
+                                                      ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                      | --withdrawal-reference-tx-in-redeemer-file JSON_FILE
+                                                      | --withdrawal-reference-tx-in-redeemer-value JSON_VALUE
                                                       )
                                                       --withdrawal-reference-tx-in-execution-units (INT, INT)
                                                     ]]
@@ -139,28 +139,28 @@ Available options:
                            Specify a plutus script v2 reference script.
   --spending-plutus-script-v3
                            Specify a plutus script v3 reference script.
-  --spending-reference-tx-in-datum-cbor-file CBOR FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-datum-file JSON FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-datum-value JSON VALUE
-                           The script datum, in JSON syntax. There is no schema:
-                           (almost) any JSON value is supported, including
-                           top-level strings and numbers.
+  --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                           The script datum file. The file has to be in CBOR
+                           format.
+  --spending-reference-tx-in-datum-file JSON_FILE
+                           The script datum file. The file must follow the
+                           detailed JSON schema for script data.
+  --spending-reference-tx-in-datum-value JSON_VALUE
+                           The script datum. There is no schema: (almost) any
+                           JSON value is supported, including top-level strings
+                           and numbers.
   --spending-reference-tx-in-inline-datum-present
                            Inline datum present at transaction input.
-  --spending-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --spending-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --spending-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --spending-reference-tx-in-execution-units (INT, INT)
                            The time and space units needed by the script.
   --simple-script-tx-in-reference TX-IN
@@ -168,28 +168,28 @@ Available options:
                            input must have a simple reference script attached.
   --tx-in-script-file FILE The file containing the script to witness the
                            spending of the transaction input.
-  --tx-in-datum-cbor-file CBOR FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-datum-file JSON FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-datum-value JSON VALUE
-                           The script datum, in JSON syntax. There is no schema:
-                           (almost) any JSON value is supported, including
-                           top-level strings and numbers.
+  --tx-in-datum-cbor-file CBOR_FILE
+                           The script datum file. The file has to be in CBOR
+                           format.
+  --tx-in-datum-file JSON_FILE
+                           The script datum file. The file must follow the
+                           detailed JSON schema for script data.
+  --tx-in-datum-value JSON_VALUE
+                           The script datum. There is no schema: (almost) any
+                           JSON value is supported, including top-level strings
+                           and numbers.
   --tx-in-inline-datum-present
                            Inline datum present at transaction input.
-  --tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --tx-in-execution-units (INT, INT)
                            The time and space units needed by the script.
   --read-only-tx-in-reference TX-IN
@@ -220,61 +220,60 @@ Available options:
                            Lovelace).
   --tx-out-datum-hash HASH The script datum hash for this tx output, as the raw
                            datum hash (in hex).
-  --tx-out-datum-hash-cbor-file CBOR FILE
+  --tx-out-datum-hash-cbor-file CBOR_FILE
                            The script datum hash for this tx output, by hashing
-                           the script datum in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-out-datum-hash-file JSON FILE
+                           the script datum in the file. The file has to be in
+                           CBOR format.
+  --tx-out-datum-hash-file JSON_FILE
                            The script datum hash for this tx output, by hashing
-                           the script datum in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-out-datum-hash-value JSON VALUE
+                           the script datum in the file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-datum-hash-value JSON_VALUE
                            The script datum hash for this tx output, by hashing
-                           the script datum given here in JSON syntax. There is
-                           no schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
-  --tx-out-datum-embed-cbor-file CBOR FILE
-                           The script datum to embed in the tx for this output,
-                           in the given JSON file. The file must follow the
-                           special JSON schema for script data.
-  --tx-out-datum-embed-file JSON FILE
-                           The script datum to embed in the tx for this output,
-                           in the given JSON file. The file must follow the
-                           special JSON schema for script data.
-  --tx-out-datum-embed-value JSON VALUE
-                           The script datum to embed in the tx for this output,
-                           given here in JSON syntax. There is no schema:
+                           the script datum given here. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
-  --tx-out-inline-datum-cbor-file CBOR FILE
+  --tx-out-datum-embed-cbor-file CBOR_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file has to be in CBOR format.
+  --tx-out-datum-embed-file JSON_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file must follow the detailed
+                           JSON schema for script data.
+  --tx-out-datum-embed-value JSON_VALUE
+                           The script datum to embed in the tx for this output,
+                           given here. There is no schema: (almost) any JSON
+                           value is supported, including top-level strings and
+                           numbers.
+  --tx-out-inline-datum-cbor-file CBOR_FILE
                            The script datum to embed in the tx output as an
-                           inline datum, in the given JSON file. The file must
-                           follow the special JSON schema for script data.
-  --tx-out-inline-datum-file JSON FILE
+                           inline datum, in the given file. The file has to be
+                           in CBOR format.
+  --tx-out-inline-datum-file JSON_FILE
                            The script datum to embed in the tx output as an
-                           inline datum, in the given JSON file. The file must
-                           follow the special JSON schema for script data.
-  --tx-out-inline-datum-value JSON VALUE
+                           inline datum, in the given file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-inline-datum-value JSON_VALUE
                            The script datum to embed in the tx output as an
-                           inline datum, given here in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+                           inline datum, given here. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --tx-out-reference-script-file FILE
                            Reference script input file.
   --mint VALUE             Mint multi-asset value(s) with the multi-asset cli
                            syntax. You must specify a script witness.
   --mint-script-file FILE  The file containing the script to witness the minting
                            of assets for a particular policy Id.
-  --mint-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --mint-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --mint-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --mint-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --mint-execution-units (INT, INT)
                            The time and space units needed by the script.
   --simple-minting-script-tx-in-reference TX-IN
@@ -286,16 +285,16 @@ Available options:
                            input must have a plutus reference script attached.
   --mint-plutus-script-v2  Specify a plutus script v2 reference script.
   --mint-plutus-script-v3  Specify a plutus script v3 reference script.
-  --mint-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --mint-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --mint-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --mint-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --mint-reference-tx-in-execution-units (INT, INT)
                            The time and space units needed by the script.
   --policy-id HASH         Policy id of minting script.
@@ -309,16 +308,16 @@ Available options:
   --certificate-script-file FILE
                            The file containing the script to witness the use of
                            the certificate.
-  --certificate-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --certificate-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --certificate-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --certificate-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --certificate-execution-units (INT, INT)
                            The time and space units needed by the script.
   --certificate-tx-in-reference TX-IN
@@ -328,16 +327,16 @@ Available options:
                            Specify a plutus script v2 reference script.
   --certificate-plutus-script-v3
                            Specify a plutus script v3 reference script.
-  --certificate-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --certificate-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --certificate-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --certificate-reference-tx-in-execution-units (INT, INT)
                            The time and space units needed by the script.
   --withdrawal WITHDRAWAL  The reward withdrawal as StakeAddress+Lovelace where
@@ -347,16 +346,16 @@ Available options:
   --withdrawal-script-file FILE
                            The file containing the script to witness the
                            withdrawal of rewards.
-  --withdrawal-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --withdrawal-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --withdrawal-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --withdrawal-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --withdrawal-execution-units (INT, INT)
                            The time and space units needed by the script.
   --withdrawal-tx-in-reference TX-IN
@@ -366,16 +365,16 @@ Available options:
                            Specify a plutus script v2 reference script.
   --withdrawal-plutus-script-v3
                            Specify a plutus script v3 reference script.
-  --withdrawal-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --withdrawal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --withdrawal-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --withdrawal-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --withdrawal-reference-tx-in-execution-units (INT, INT)
                            The time and space units needed by the script.
   --json-metadata-no-schema

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_transaction_build.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_transaction_build.cli
@@ -13,26 +13,26 @@ Usage: cardano-cli alonzo transaction build --socket-path SOCKET_PATH
                                                   ( --spending-plutus-script-v2
                                                   | --spending-plutus-script-v3
                                                   )
-                                                  ( --spending-reference-tx-in-datum-cbor-file CBOR FILE
-                                                  | --spending-reference-tx-in-datum-file JSON FILE
-                                                  | --spending-reference-tx-in-datum-value JSON VALUE
+                                                  ( --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                                                  | --spending-reference-tx-in-datum-file JSON_FILE
+                                                  | --spending-reference-tx-in-datum-value JSON_VALUE
                                                   | --spending-reference-tx-in-inline-datum-present
                                                   )
-                                                  ( --spending-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                  | --spending-reference-tx-in-redeemer-file JSON FILE
-                                                  | --spending-reference-tx-in-redeemer-value JSON VALUE
+                                                  ( --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                  | --spending-reference-tx-in-redeemer-file JSON_FILE
+                                                  | --spending-reference-tx-in-redeemer-value JSON_VALUE
                                                   )
                                                 | --simple-script-tx-in-reference TX-IN
                                                 | --tx-in-script-file FILE
                                                   [
-                                                    ( --tx-in-datum-cbor-file CBOR FILE
-                                                    | --tx-in-datum-file JSON FILE
-                                                    | --tx-in-datum-value JSON VALUE
+                                                    ( --tx-in-datum-cbor-file CBOR_FILE
+                                                    | --tx-in-datum-file JSON_FILE
+                                                    | --tx-in-datum-value JSON_VALUE
                                                     | --tx-in-inline-datum-present
                                                     )
-                                                    ( --tx-in-redeemer-cbor-file CBOR FILE
-                                                    | --tx-in-redeemer-file JSON FILE
-                                                    | --tx-in-redeemer-value JSON VALUE
+                                                    ( --tx-in-redeemer-cbor-file CBOR_FILE
+                                                    | --tx-in-redeemer-file JSON_FILE
+                                                    | --tx-in-redeemer-value JSON_VALUE
                                                     )]
                                                 ])
                                               [--read-only-tx-in-reference TX-IN]
@@ -44,23 +44,23 @@ Usage: cardano-cli alonzo transaction build --socket-path SOCKET_PATH
                                               [--tx-total-collateral INTEGER]
                                               [--tx-out ADDRESS VALUE
                                                 [ --tx-out-datum-hash HASH
-                                                | --tx-out-datum-hash-cbor-file CBOR FILE
-                                                | --tx-out-datum-hash-file JSON FILE
-                                                | --tx-out-datum-hash-value JSON VALUE
-                                                | --tx-out-datum-embed-cbor-file CBOR FILE
-                                                | --tx-out-datum-embed-file JSON FILE
-                                                | --tx-out-datum-embed-value JSON VALUE
-                                                | --tx-out-inline-datum-cbor-file CBOR FILE
-                                                | --tx-out-inline-datum-file JSON FILE
-                                                | --tx-out-inline-datum-value JSON VALUE
+                                                | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                | --tx-out-datum-hash-file JSON_FILE
+                                                | --tx-out-datum-hash-value JSON_VALUE
+                                                | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                | --tx-out-datum-embed-file JSON_FILE
+                                                | --tx-out-datum-embed-value JSON_VALUE
+                                                | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                | --tx-out-inline-datum-file JSON_FILE
+                                                | --tx-out-inline-datum-value JSON_VALUE
                                                 ]
                                                 [--tx-out-reference-script-file FILE]]
                                               --change-address ADDRESS
                                               [--mint VALUE
                                                 ( --mint-script-file FILE
-                                                  [ --mint-redeemer-cbor-file CBOR FILE
-                                                  | --mint-redeemer-file JSON FILE
-                                                  | --mint-redeemer-value JSON VALUE
+                                                  [ --mint-redeemer-cbor-file CBOR_FILE
+                                                  | --mint-redeemer-file JSON_FILE
+                                                  | --mint-redeemer-value JSON_VALUE
                                                   ]
                                                 | --simple-minting-script-tx-in-reference TX-IN
                                                   --policy-id HASH
@@ -68,9 +68,9 @@ Usage: cardano-cli alonzo transaction build --socket-path SOCKET_PATH
                                                   ( --mint-plutus-script-v2
                                                   | --mint-plutus-script-v3
                                                   )
-                                                  ( --mint-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                  | --mint-reference-tx-in-redeemer-file JSON FILE
-                                                  | --mint-reference-tx-in-redeemer-value JSON VALUE
+                                                  ( --mint-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                  | --mint-reference-tx-in-redeemer-file JSON_FILE
+                                                  | --mint-reference-tx-in-redeemer-value JSON_VALUE
                                                   )
                                                   --policy-id HASH
                                                 )]
@@ -78,32 +78,32 @@ Usage: cardano-cli alonzo transaction build --socket-path SOCKET_PATH
                                               [--invalid-hereafter SLOT]
                                               [--certificate-file FILE
                                                 [ --certificate-script-file FILE
-                                                  [ --certificate-redeemer-cbor-file CBOR FILE
-                                                  | --certificate-redeemer-file JSON FILE
-                                                  | --certificate-redeemer-value JSON VALUE
+                                                  [ --certificate-redeemer-cbor-file CBOR_FILE
+                                                  | --certificate-redeemer-file JSON_FILE
+                                                  | --certificate-redeemer-value JSON_VALUE
                                                   ]
                                                 | --certificate-tx-in-reference TX-IN
                                                   ( --certificate-plutus-script-v2
                                                   | --certificate-plutus-script-v3
                                                   )
-                                                  ( --certificate-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                  | --certificate-reference-tx-in-redeemer-file JSON FILE
-                                                  | --certificate-reference-tx-in-redeemer-value JSON VALUE
+                                                  ( --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                  | --certificate-reference-tx-in-redeemer-file JSON_FILE
+                                                  | --certificate-reference-tx-in-redeemer-value JSON_VALUE
                                                   )
                                                 ]]
                                               [--withdrawal WITHDRAWAL
                                                 [ --withdrawal-script-file FILE
-                                                  [ --withdrawal-redeemer-cbor-file CBOR FILE
-                                                  | --withdrawal-redeemer-file JSON FILE
-                                                  | --withdrawal-redeemer-value JSON VALUE
+                                                  [ --withdrawal-redeemer-cbor-file CBOR_FILE
+                                                  | --withdrawal-redeemer-file JSON_FILE
+                                                  | --withdrawal-redeemer-value JSON_VALUE
                                                   ]
                                                 | --withdrawal-tx-in-reference TX-IN
                                                   ( --withdrawal-plutus-script-v2
                                                   | --withdrawal-plutus-script-v3
                                                   )
-                                                  ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                  | --withdrawal-reference-tx-in-redeemer-file JSON FILE
-                                                  | --withdrawal-reference-tx-in-redeemer-value JSON VALUE
+                                                  ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                  | --withdrawal-reference-tx-in-redeemer-file JSON_FILE
+                                                  | --withdrawal-reference-tx-in-redeemer-value JSON_VALUE
                                                   )
                                                 ]]
                                               [ --json-metadata-no-schema
@@ -150,55 +150,55 @@ Available options:
                            Specify a plutus script v2 reference script.
   --spending-plutus-script-v3
                            Specify a plutus script v3 reference script.
-  --spending-reference-tx-in-datum-cbor-file CBOR FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-datum-file JSON FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-datum-value JSON VALUE
-                           The script datum, in JSON syntax. There is no schema:
-                           (almost) any JSON value is supported, including
-                           top-level strings and numbers.
+  --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                           The script datum file. The file has to be in CBOR
+                           format.
+  --spending-reference-tx-in-datum-file JSON_FILE
+                           The script datum file. The file must follow the
+                           detailed JSON schema for script data.
+  --spending-reference-tx-in-datum-value JSON_VALUE
+                           The script datum. There is no schema: (almost) any
+                           JSON value is supported, including top-level strings
+                           and numbers.
   --spending-reference-tx-in-inline-datum-present
                            Inline datum present at transaction input.
-  --spending-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --spending-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --spending-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --simple-script-tx-in-reference TX-IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a simple reference script attached.
   --tx-in-script-file FILE The file containing the script to witness the
                            spending of the transaction input.
-  --tx-in-datum-cbor-file CBOR FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-datum-file JSON FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-datum-value JSON VALUE
-                           The script datum, in JSON syntax. There is no schema:
-                           (almost) any JSON value is supported, including
-                           top-level strings and numbers.
+  --tx-in-datum-cbor-file CBOR_FILE
+                           The script datum file. The file has to be in CBOR
+                           format.
+  --tx-in-datum-file JSON_FILE
+                           The script datum file. The file must follow the
+                           detailed JSON schema for script data.
+  --tx-in-datum-value JSON_VALUE
+                           The script datum. There is no schema: (almost) any
+                           JSON value is supported, including top-level strings
+                           and numbers.
   --tx-in-inline-datum-present
                            Inline datum present at transaction input.
-  --tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --read-only-tx-in-reference TX-IN
                            Specify a read only reference input. This reference
                            input is not witnessing anything it is simply
@@ -227,45 +227,44 @@ Available options:
                            Lovelace).
   --tx-out-datum-hash HASH The script datum hash for this tx output, as the raw
                            datum hash (in hex).
-  --tx-out-datum-hash-cbor-file CBOR FILE
+  --tx-out-datum-hash-cbor-file CBOR_FILE
                            The script datum hash for this tx output, by hashing
-                           the script datum in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-out-datum-hash-file JSON FILE
+                           the script datum in the file. The file has to be in
+                           CBOR format.
+  --tx-out-datum-hash-file JSON_FILE
                            The script datum hash for this tx output, by hashing
-                           the script datum in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-out-datum-hash-value JSON VALUE
+                           the script datum in the file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-datum-hash-value JSON_VALUE
                            The script datum hash for this tx output, by hashing
-                           the script datum given here in JSON syntax. There is
-                           no schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
-  --tx-out-datum-embed-cbor-file CBOR FILE
-                           The script datum to embed in the tx for this output,
-                           in the given JSON file. The file must follow the
-                           special JSON schema for script data.
-  --tx-out-datum-embed-file JSON FILE
-                           The script datum to embed in the tx for this output,
-                           in the given JSON file. The file must follow the
-                           special JSON schema for script data.
-  --tx-out-datum-embed-value JSON VALUE
-                           The script datum to embed in the tx for this output,
-                           given here in JSON syntax. There is no schema:
+                           the script datum given here. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
-  --tx-out-inline-datum-cbor-file CBOR FILE
+  --tx-out-datum-embed-cbor-file CBOR_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file has to be in CBOR format.
+  --tx-out-datum-embed-file JSON_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file must follow the detailed
+                           JSON schema for script data.
+  --tx-out-datum-embed-value JSON_VALUE
+                           The script datum to embed in the tx for this output,
+                           given here. There is no schema: (almost) any JSON
+                           value is supported, including top-level strings and
+                           numbers.
+  --tx-out-inline-datum-cbor-file CBOR_FILE
                            The script datum to embed in the tx output as an
-                           inline datum, in the given JSON file. The file must
-                           follow the special JSON schema for script data.
-  --tx-out-inline-datum-file JSON FILE
+                           inline datum, in the given file. The file has to be
+                           in CBOR format.
+  --tx-out-inline-datum-file JSON_FILE
                            The script datum to embed in the tx output as an
-                           inline datum, in the given JSON file. The file must
-                           follow the special JSON schema for script data.
-  --tx-out-inline-datum-value JSON VALUE
+                           inline datum, in the given file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-inline-datum-value JSON_VALUE
                            The script datum to embed in the tx output as an
-                           inline datum, given here in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+                           inline datum, given here. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --tx-out-reference-script-file FILE
                            Reference script input file.
   --change-address ADDRESS Address where ADA in excess of the tx fee will go to.
@@ -273,16 +272,16 @@ Available options:
                            syntax. You must specify a script witness.
   --mint-script-file FILE  The file containing the script to witness the minting
                            of assets for a particular policy Id.
-  --mint-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --mint-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --mint-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --mint-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --simple-minting-script-tx-in-reference TX-IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a simple reference script attached.
@@ -292,16 +291,16 @@ Available options:
                            input must have a plutus reference script attached.
   --mint-plutus-script-v2  Specify a plutus script v2 reference script.
   --mint-plutus-script-v3  Specify a plutus script v3 reference script.
-  --mint-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --mint-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --mint-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --mint-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --policy-id HASH         Policy id of minting script.
   --invalid-before SLOT    Time that transaction is valid from (in slots).
   --invalid-hereafter SLOT Time that transaction is valid until (in slots).
@@ -312,16 +311,16 @@ Available options:
   --certificate-script-file FILE
                            The file containing the script to witness the use of
                            the certificate.
-  --certificate-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --certificate-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --certificate-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --certificate-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --certificate-tx-in-reference TX-IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a plutus reference script attached.
@@ -329,16 +328,16 @@ Available options:
                            Specify a plutus script v2 reference script.
   --certificate-plutus-script-v3
                            Specify a plutus script v3 reference script.
-  --certificate-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --certificate-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --certificate-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --withdrawal WITHDRAWAL  The reward withdrawal as StakeAddress+Lovelace where
                            StakeAddress is the Bech32-encoded stake address
                            followed by the amount in Lovelace. Optionally
@@ -346,16 +345,16 @@ Available options:
   --withdrawal-script-file FILE
                            The file containing the script to witness the
                            withdrawal of rewards.
-  --withdrawal-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --withdrawal-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --withdrawal-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --withdrawal-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --withdrawal-tx-in-reference TX-IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a plutus reference script attached.
@@ -363,16 +362,16 @@ Available options:
                            Specify a plutus script v2 reference script.
   --withdrawal-plutus-script-v3
                            Specify a plutus script v3 reference script.
-  --withdrawal-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --withdrawal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --withdrawal-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --withdrawal-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --json-metadata-no-schema
                            Use the "no schema" conversion from JSON to tx
                            metadata (default).

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_transaction_calculate-min-required-utxo.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_transaction_calculate-min-required-utxo.cli
@@ -1,15 +1,15 @@
 Usage: cardano-cli alonzo transaction calculate-min-required-utxo --protocol-params-file FILE
                                                                     --tx-out ADDRESS VALUE
                                                                     [ --tx-out-datum-hash HASH
-                                                                    | --tx-out-datum-hash-cbor-file CBOR FILE
-                                                                    | --tx-out-datum-hash-file JSON FILE
-                                                                    | --tx-out-datum-hash-value JSON VALUE
-                                                                    | --tx-out-datum-embed-cbor-file CBOR FILE
-                                                                    | --tx-out-datum-embed-file JSON FILE
-                                                                    | --tx-out-datum-embed-value JSON VALUE
-                                                                    | --tx-out-inline-datum-cbor-file CBOR FILE
-                                                                    | --tx-out-inline-datum-file JSON FILE
-                                                                    | --tx-out-inline-datum-value JSON VALUE
+                                                                    | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                                    | --tx-out-datum-hash-file JSON_FILE
+                                                                    | --tx-out-datum-hash-value JSON_VALUE
+                                                                    | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                                    | --tx-out-datum-embed-file JSON_FILE
+                                                                    | --tx-out-datum-embed-value JSON_VALUE
+                                                                    | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                                    | --tx-out-inline-datum-file JSON_FILE
+                                                                    | --tx-out-inline-datum-value JSON_VALUE
                                                                     ]
                                                                     [--tx-out-reference-script-file FILE]
 
@@ -24,45 +24,44 @@ Available options:
                            Lovelace).
   --tx-out-datum-hash HASH The script datum hash for this tx output, as the raw
                            datum hash (in hex).
-  --tx-out-datum-hash-cbor-file CBOR FILE
+  --tx-out-datum-hash-cbor-file CBOR_FILE
                            The script datum hash for this tx output, by hashing
-                           the script datum in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-out-datum-hash-file JSON FILE
+                           the script datum in the file. The file has to be in
+                           CBOR format.
+  --tx-out-datum-hash-file JSON_FILE
                            The script datum hash for this tx output, by hashing
-                           the script datum in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-out-datum-hash-value JSON VALUE
+                           the script datum in the file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-datum-hash-value JSON_VALUE
                            The script datum hash for this tx output, by hashing
-                           the script datum given here in JSON syntax. There is
-                           no schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
-  --tx-out-datum-embed-cbor-file CBOR FILE
-                           The script datum to embed in the tx for this output,
-                           in the given JSON file. The file must follow the
-                           special JSON schema for script data.
-  --tx-out-datum-embed-file JSON FILE
-                           The script datum to embed in the tx for this output,
-                           in the given JSON file. The file must follow the
-                           special JSON schema for script data.
-  --tx-out-datum-embed-value JSON VALUE
-                           The script datum to embed in the tx for this output,
-                           given here in JSON syntax. There is no schema:
+                           the script datum given here. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
-  --tx-out-inline-datum-cbor-file CBOR FILE
+  --tx-out-datum-embed-cbor-file CBOR_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file has to be in CBOR format.
+  --tx-out-datum-embed-file JSON_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file must follow the detailed
+                           JSON schema for script data.
+  --tx-out-datum-embed-value JSON_VALUE
+                           The script datum to embed in the tx for this output,
+                           given here. There is no schema: (almost) any JSON
+                           value is supported, including top-level strings and
+                           numbers.
+  --tx-out-inline-datum-cbor-file CBOR_FILE
                            The script datum to embed in the tx output as an
-                           inline datum, in the given JSON file. The file must
-                           follow the special JSON schema for script data.
-  --tx-out-inline-datum-file JSON FILE
+                           inline datum, in the given file. The file has to be
+                           in CBOR format.
+  --tx-out-inline-datum-file JSON_FILE
                            The script datum to embed in the tx output as an
-                           inline datum, in the given JSON file. The file must
-                           follow the special JSON schema for script data.
-  --tx-out-inline-datum-value JSON VALUE
+                           inline datum, in the given file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-inline-datum-value JSON_VALUE
                            The script datum to embed in the tx output as an
-                           inline datum, given here in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+                           inline datum, given here. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --tx-out-reference-script-file FILE
                            Reference script input file.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_transaction_calculate-min-value.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_transaction_calculate-min-value.cli
@@ -1,15 +1,15 @@
 Usage: cardano-cli alonzo transaction calculate-min-value --protocol-params-file FILE
                                                             --tx-out ADDRESS VALUE
                                                             [ --tx-out-datum-hash HASH
-                                                            | --tx-out-datum-hash-cbor-file CBOR FILE
-                                                            | --tx-out-datum-hash-file JSON FILE
-                                                            | --tx-out-datum-hash-value JSON VALUE
-                                                            | --tx-out-datum-embed-cbor-file CBOR FILE
-                                                            | --tx-out-datum-embed-file JSON FILE
-                                                            | --tx-out-datum-embed-value JSON VALUE
-                                                            | --tx-out-inline-datum-cbor-file CBOR FILE
-                                                            | --tx-out-inline-datum-file JSON FILE
-                                                            | --tx-out-inline-datum-value JSON VALUE
+                                                            | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                            | --tx-out-datum-hash-file JSON_FILE
+                                                            | --tx-out-datum-hash-value JSON_VALUE
+                                                            | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                            | --tx-out-datum-embed-file JSON_FILE
+                                                            | --tx-out-datum-embed-value JSON_VALUE
+                                                            | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                            | --tx-out-inline-datum-file JSON_FILE
+                                                            | --tx-out-inline-datum-value JSON_VALUE
                                                             ]
                                                             [--tx-out-reference-script-file FILE]
 
@@ -24,44 +24,43 @@ Available options:
                            Lovelace).
   --tx-out-datum-hash HASH The script datum hash for this tx output, as the raw
                            datum hash (in hex).
-  --tx-out-datum-hash-cbor-file CBOR FILE
+  --tx-out-datum-hash-cbor-file CBOR_FILE
                            The script datum hash for this tx output, by hashing
-                           the script datum in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-out-datum-hash-file JSON FILE
+                           the script datum in the file. The file has to be in
+                           CBOR format.
+  --tx-out-datum-hash-file JSON_FILE
                            The script datum hash for this tx output, by hashing
-                           the script datum in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-out-datum-hash-value JSON VALUE
+                           the script datum in the file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-datum-hash-value JSON_VALUE
                            The script datum hash for this tx output, by hashing
-                           the script datum given here in JSON syntax. There is
-                           no schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
-  --tx-out-datum-embed-cbor-file CBOR FILE
-                           The script datum to embed in the tx for this output,
-                           in the given JSON file. The file must follow the
-                           special JSON schema for script data.
-  --tx-out-datum-embed-file JSON FILE
-                           The script datum to embed in the tx for this output,
-                           in the given JSON file. The file must follow the
-                           special JSON schema for script data.
-  --tx-out-datum-embed-value JSON VALUE
-                           The script datum to embed in the tx for this output,
-                           given here in JSON syntax. There is no schema:
+                           the script datum given here. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
-  --tx-out-inline-datum-cbor-file CBOR FILE
+  --tx-out-datum-embed-cbor-file CBOR_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file has to be in CBOR format.
+  --tx-out-datum-embed-file JSON_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file must follow the detailed
+                           JSON schema for script data.
+  --tx-out-datum-embed-value JSON_VALUE
+                           The script datum to embed in the tx for this output,
+                           given here. There is no schema: (almost) any JSON
+                           value is supported, including top-level strings and
+                           numbers.
+  --tx-out-inline-datum-cbor-file CBOR_FILE
                            The script datum to embed in the tx output as an
-                           inline datum, in the given JSON file. The file must
-                           follow the special JSON schema for script data.
-  --tx-out-inline-datum-file JSON FILE
+                           inline datum, in the given file. The file has to be
+                           in CBOR format.
+  --tx-out-inline-datum-file JSON_FILE
                            The script datum to embed in the tx output as an
-                           inline datum, in the given JSON file. The file must
-                           follow the special JSON schema for script data.
-  --tx-out-inline-datum-value JSON VALUE
+                           inline datum, in the given file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-inline-datum-value JSON_VALUE
                            The script datum to embed in the tx output as an
-                           inline datum, given here in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+                           inline datum, given here. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --tx-out-reference-script-file FILE
                            Reference script input file.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_transaction_hash-script-data.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_transaction_hash-script-data.cli
@@ -1,20 +1,20 @@
 Usage: cardano-cli alonzo transaction hash-script-data 
-                                                         ( --script-data-cbor-file CBOR FILE
-                                                         | --script-data-file JSON FILE
-                                                         | --script-data-value JSON VALUE
+                                                         ( --script-data-cbor-file CBOR_FILE
+                                                         | --script-data-file JSON_FILE
+                                                         | --script-data-value JSON_VALUE
                                                          )
 
   Calculate the hash of script data.
 
 Available options:
-  --script-data-cbor-file CBOR FILE
-                           The script data, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --script-data-file JSON FILE
-                           The script data, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --script-data-value JSON VALUE
-                           The script data, in JSON syntax. There is no schema:
-                           (almost) any JSON value is supported, including
-                           top-level strings and numbers.
+  --script-data-cbor-file CBOR_FILE
+                           The script data file. The file has to be in CBOR
+                           format.
+  --script-data-file JSON_FILE
+                           The script data file. The file must follow the
+                           detailed JSON schema for script data.
+  --script-data-value JSON_VALUE
+                           The script data. There is no schema: (almost) any
+                           JSON value is supported, including top-level strings
+                           and numbers.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_transaction_build-estimate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_transaction_build-estimate.cli
@@ -11,27 +11,27 @@ Usage: cardano-cli babbage transaction build-estimate
                                                             ( --spending-plutus-script-v2
                                                             | --spending-plutus-script-v3
                                                             )
-                                                            ( --spending-reference-tx-in-datum-cbor-file CBOR FILE
-                                                            | --spending-reference-tx-in-datum-file JSON FILE
-                                                            | --spending-reference-tx-in-datum-value JSON VALUE
+                                                            ( --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                                                            | --spending-reference-tx-in-datum-file JSON_FILE
+                                                            | --spending-reference-tx-in-datum-value JSON_VALUE
                                                             | --spending-reference-tx-in-inline-datum-present
                                                             )
-                                                            ( --spending-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                            | --spending-reference-tx-in-redeemer-file JSON FILE
-                                                            | --spending-reference-tx-in-redeemer-value JSON VALUE
+                                                            ( --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                            | --spending-reference-tx-in-redeemer-file JSON_FILE
+                                                            | --spending-reference-tx-in-redeemer-value JSON_VALUE
                                                             )
                                                             --spending-reference-tx-in-execution-units (INT, INT)
                                                           | --simple-script-tx-in-reference TX-IN
                                                           | --tx-in-script-file FILE
                                                             [
-                                                              ( --tx-in-datum-cbor-file CBOR FILE
-                                                              | --tx-in-datum-file JSON FILE
-                                                              | --tx-in-datum-value JSON VALUE
+                                                              ( --tx-in-datum-cbor-file CBOR_FILE
+                                                              | --tx-in-datum-file JSON_FILE
+                                                              | --tx-in-datum-value JSON_VALUE
                                                               | --tx-in-inline-datum-present
                                                               )
-                                                              ( --tx-in-redeemer-cbor-file CBOR FILE
-                                                              | --tx-in-redeemer-file JSON FILE
-                                                              | --tx-in-redeemer-value JSON VALUE
+                                                              ( --tx-in-redeemer-cbor-file CBOR_FILE
+                                                              | --tx-in-redeemer-file JSON_FILE
+                                                              | --tx-in-redeemer-value JSON_VALUE
                                                               )
                                                               --tx-in-execution-units (INT, INT)]
                                                           ])
@@ -43,24 +43,24 @@ Usage: cardano-cli babbage transaction build-estimate
                                                         [--tx-out-return-collateral ADDRESS VALUE]
                                                         [--tx-out ADDRESS VALUE
                                                           [ --tx-out-datum-hash HASH
-                                                          | --tx-out-datum-hash-cbor-file CBOR FILE
-                                                          | --tx-out-datum-hash-file JSON FILE
-                                                          | --tx-out-datum-hash-value JSON VALUE
-                                                          | --tx-out-datum-embed-cbor-file CBOR FILE
-                                                          | --tx-out-datum-embed-file JSON FILE
-                                                          | --tx-out-datum-embed-value JSON VALUE
-                                                          | --tx-out-inline-datum-cbor-file CBOR FILE
-                                                          | --tx-out-inline-datum-file JSON FILE
-                                                          | --tx-out-inline-datum-value JSON VALUE
+                                                          | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                          | --tx-out-datum-hash-file JSON_FILE
+                                                          | --tx-out-datum-hash-value JSON_VALUE
+                                                          | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                          | --tx-out-datum-embed-file JSON_FILE
+                                                          | --tx-out-datum-embed-value JSON_VALUE
+                                                          | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                          | --tx-out-inline-datum-file JSON_FILE
+                                                          | --tx-out-inline-datum-value JSON_VALUE
                                                           ]
                                                           [--tx-out-reference-script-file FILE]]
                                                         --change-address ADDRESS
                                                         [--mint VALUE
                                                           ( --mint-script-file FILE
                                                             [
-                                                              ( --mint-redeemer-cbor-file CBOR FILE
-                                                              | --mint-redeemer-file JSON FILE
-                                                              | --mint-redeemer-value JSON VALUE
+                                                              ( --mint-redeemer-cbor-file CBOR_FILE
+                                                              | --mint-redeemer-file JSON_FILE
+                                                              | --mint-redeemer-value JSON_VALUE
                                                               )
                                                               --mint-execution-units (INT, INT)]
                                                           | --simple-minting-script-tx-in-reference TX-IN
@@ -69,9 +69,9 @@ Usage: cardano-cli babbage transaction build-estimate
                                                             ( --mint-plutus-script-v2
                                                             | --mint-plutus-script-v3
                                                             )
-                                                            ( --mint-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                            | --mint-reference-tx-in-redeemer-file JSON FILE
-                                                            | --mint-reference-tx-in-redeemer-value JSON VALUE
+                                                            ( --mint-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                            | --mint-reference-tx-in-redeemer-file JSON_FILE
+                                                            | --mint-reference-tx-in-redeemer-value JSON_VALUE
                                                             )
                                                             --mint-reference-tx-in-execution-units (INT, INT)
                                                             --policy-id HASH
@@ -81,36 +81,36 @@ Usage: cardano-cli babbage transaction build-estimate
                                                         [--certificate-file FILE
                                                           [ --certificate-script-file FILE
                                                             [
-                                                              ( --certificate-redeemer-cbor-file CBOR FILE
-                                                              | --certificate-redeemer-file JSON FILE
-                                                              | --certificate-redeemer-value JSON VALUE
+                                                              ( --certificate-redeemer-cbor-file CBOR_FILE
+                                                              | --certificate-redeemer-file JSON_FILE
+                                                              | --certificate-redeemer-value JSON_VALUE
                                                               )
                                                               --certificate-execution-units (INT, INT)]
                                                           | --certificate-tx-in-reference TX-IN
                                                             ( --certificate-plutus-script-v2
                                                             | --certificate-plutus-script-v3
                                                             )
-                                                            ( --certificate-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                            | --certificate-reference-tx-in-redeemer-file JSON FILE
-                                                            | --certificate-reference-tx-in-redeemer-value JSON VALUE
+                                                            ( --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                            | --certificate-reference-tx-in-redeemer-file JSON_FILE
+                                                            | --certificate-reference-tx-in-redeemer-value JSON_VALUE
                                                             )
                                                             --certificate-reference-tx-in-execution-units (INT, INT)
                                                           ]]
                                                         [--withdrawal WITHDRAWAL
                                                           [ --withdrawal-script-file FILE
                                                             [
-                                                              ( --withdrawal-redeemer-cbor-file CBOR FILE
-                                                              | --withdrawal-redeemer-file JSON FILE
-                                                              | --withdrawal-redeemer-value JSON VALUE
+                                                              ( --withdrawal-redeemer-cbor-file CBOR_FILE
+                                                              | --withdrawal-redeemer-file JSON_FILE
+                                                              | --withdrawal-redeemer-value JSON_VALUE
                                                               )
                                                               --withdrawal-execution-units (INT, INT)]
                                                           | --withdrawal-tx-in-reference TX-IN
                                                             ( --withdrawal-plutus-script-v2
                                                             | --withdrawal-plutus-script-v3
                                                             )
-                                                            ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                            | --withdrawal-reference-tx-in-redeemer-file JSON FILE
-                                                            | --withdrawal-reference-tx-in-redeemer-value JSON VALUE
+                                                            ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                            | --withdrawal-reference-tx-in-redeemer-file JSON_FILE
+                                                            | --withdrawal-reference-tx-in-redeemer-value JSON_VALUE
                                                             )
                                                             --withdrawal-reference-tx-in-execution-units (INT, INT)
                                                           ]]
@@ -153,28 +153,28 @@ Available options:
                            Specify a plutus script v2 reference script.
   --spending-plutus-script-v3
                            Specify a plutus script v3 reference script.
-  --spending-reference-tx-in-datum-cbor-file CBOR FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-datum-file JSON FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-datum-value JSON VALUE
-                           The script datum, in JSON syntax. There is no schema:
-                           (almost) any JSON value is supported, including
-                           top-level strings and numbers.
+  --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                           The script datum file. The file has to be in CBOR
+                           format.
+  --spending-reference-tx-in-datum-file JSON_FILE
+                           The script datum file. The file must follow the
+                           detailed JSON schema for script data.
+  --spending-reference-tx-in-datum-value JSON_VALUE
+                           The script datum. There is no schema: (almost) any
+                           JSON value is supported, including top-level strings
+                           and numbers.
   --spending-reference-tx-in-inline-datum-present
                            Inline datum present at transaction input.
-  --spending-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --spending-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --spending-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --spending-reference-tx-in-execution-units (INT, INT)
                            The time and space units needed by the script.
   --simple-script-tx-in-reference TX-IN
@@ -182,28 +182,28 @@ Available options:
                            input must have a simple reference script attached.
   --tx-in-script-file FILE The file containing the script to witness the
                            spending of the transaction input.
-  --tx-in-datum-cbor-file CBOR FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-datum-file JSON FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-datum-value JSON VALUE
-                           The script datum, in JSON syntax. There is no schema:
-                           (almost) any JSON value is supported, including
-                           top-level strings and numbers.
+  --tx-in-datum-cbor-file CBOR_FILE
+                           The script datum file. The file has to be in CBOR
+                           format.
+  --tx-in-datum-file JSON_FILE
+                           The script datum file. The file must follow the
+                           detailed JSON schema for script data.
+  --tx-in-datum-value JSON_VALUE
+                           The script datum. There is no schema: (almost) any
+                           JSON value is supported, including top-level strings
+                           and numbers.
   --tx-in-inline-datum-present
                            Inline datum present at transaction input.
-  --tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --tx-in-execution-units (INT, INT)
                            The time and space units needed by the script.
   --read-only-tx-in-reference TX-IN
@@ -229,45 +229,44 @@ Available options:
                            Lovelace).
   --tx-out-datum-hash HASH The script datum hash for this tx output, as the raw
                            datum hash (in hex).
-  --tx-out-datum-hash-cbor-file CBOR FILE
+  --tx-out-datum-hash-cbor-file CBOR_FILE
                            The script datum hash for this tx output, by hashing
-                           the script datum in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-out-datum-hash-file JSON FILE
+                           the script datum in the file. The file has to be in
+                           CBOR format.
+  --tx-out-datum-hash-file JSON_FILE
                            The script datum hash for this tx output, by hashing
-                           the script datum in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-out-datum-hash-value JSON VALUE
+                           the script datum in the file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-datum-hash-value JSON_VALUE
                            The script datum hash for this tx output, by hashing
-                           the script datum given here in JSON syntax. There is
-                           no schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
-  --tx-out-datum-embed-cbor-file CBOR FILE
-                           The script datum to embed in the tx for this output,
-                           in the given JSON file. The file must follow the
-                           special JSON schema for script data.
-  --tx-out-datum-embed-file JSON FILE
-                           The script datum to embed in the tx for this output,
-                           in the given JSON file. The file must follow the
-                           special JSON schema for script data.
-  --tx-out-datum-embed-value JSON VALUE
-                           The script datum to embed in the tx for this output,
-                           given here in JSON syntax. There is no schema:
+                           the script datum given here. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
-  --tx-out-inline-datum-cbor-file CBOR FILE
+  --tx-out-datum-embed-cbor-file CBOR_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file has to be in CBOR format.
+  --tx-out-datum-embed-file JSON_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file must follow the detailed
+                           JSON schema for script data.
+  --tx-out-datum-embed-value JSON_VALUE
+                           The script datum to embed in the tx for this output,
+                           given here. There is no schema: (almost) any JSON
+                           value is supported, including top-level strings and
+                           numbers.
+  --tx-out-inline-datum-cbor-file CBOR_FILE
                            The script datum to embed in the tx output as an
-                           inline datum, in the given JSON file. The file must
-                           follow the special JSON schema for script data.
-  --tx-out-inline-datum-file JSON FILE
+                           inline datum, in the given file. The file has to be
+                           in CBOR format.
+  --tx-out-inline-datum-file JSON_FILE
                            The script datum to embed in the tx output as an
-                           inline datum, in the given JSON file. The file must
-                           follow the special JSON schema for script data.
-  --tx-out-inline-datum-value JSON VALUE
+                           inline datum, in the given file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-inline-datum-value JSON_VALUE
                            The script datum to embed in the tx output as an
-                           inline datum, given here in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+                           inline datum, given here. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --tx-out-reference-script-file FILE
                            Reference script input file.
   --change-address ADDRESS Address where ADA in excess of the tx fee will go to.
@@ -275,16 +274,16 @@ Available options:
                            syntax. You must specify a script witness.
   --mint-script-file FILE  The file containing the script to witness the minting
                            of assets for a particular policy Id.
-  --mint-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --mint-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --mint-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --mint-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --mint-execution-units (INT, INT)
                            The time and space units needed by the script.
   --simple-minting-script-tx-in-reference TX-IN
@@ -296,16 +295,16 @@ Available options:
                            input must have a plutus reference script attached.
   --mint-plutus-script-v2  Specify a plutus script v2 reference script.
   --mint-plutus-script-v3  Specify a plutus script v3 reference script.
-  --mint-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --mint-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --mint-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --mint-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --mint-reference-tx-in-execution-units (INT, INT)
                            The time and space units needed by the script.
   --policy-id HASH         Policy id of minting script.
@@ -318,16 +317,16 @@ Available options:
   --certificate-script-file FILE
                            The file containing the script to witness the use of
                            the certificate.
-  --certificate-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --certificate-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --certificate-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --certificate-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --certificate-execution-units (INT, INT)
                            The time and space units needed by the script.
   --certificate-tx-in-reference TX-IN
@@ -337,16 +336,16 @@ Available options:
                            Specify a plutus script v2 reference script.
   --certificate-plutus-script-v3
                            Specify a plutus script v3 reference script.
-  --certificate-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --certificate-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --certificate-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --certificate-reference-tx-in-execution-units (INT, INT)
                            The time and space units needed by the script.
   --withdrawal WITHDRAWAL  The reward withdrawal as StakeAddress+Lovelace where
@@ -356,16 +355,16 @@ Available options:
   --withdrawal-script-file FILE
                            The file containing the script to witness the
                            withdrawal of rewards.
-  --withdrawal-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --withdrawal-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --withdrawal-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --withdrawal-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --withdrawal-execution-units (INT, INT)
                            The time and space units needed by the script.
   --withdrawal-tx-in-reference TX-IN
@@ -375,16 +374,16 @@ Available options:
                            Specify a plutus script v2 reference script.
   --withdrawal-plutus-script-v3
                            Specify a plutus script v3 reference script.
-  --withdrawal-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --withdrawal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --withdrawal-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --withdrawal-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --withdrawal-reference-tx-in-execution-units (INT, INT)
                            The time and space units needed by the script.
   --tx-total-collateral INTEGER

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_transaction_build-raw.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_transaction_build-raw.cli
@@ -7,27 +7,27 @@ Usage: cardano-cli babbage transaction build-raw
                                                        ( --spending-plutus-script-v2
                                                        | --spending-plutus-script-v3
                                                        )
-                                                       ( --spending-reference-tx-in-datum-cbor-file CBOR FILE
-                                                       | --spending-reference-tx-in-datum-file JSON FILE
-                                                       | --spending-reference-tx-in-datum-value JSON VALUE
+                                                       ( --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                                                       | --spending-reference-tx-in-datum-file JSON_FILE
+                                                       | --spending-reference-tx-in-datum-value JSON_VALUE
                                                        | --spending-reference-tx-in-inline-datum-present
                                                        )
-                                                       ( --spending-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                       | --spending-reference-tx-in-redeemer-file JSON FILE
-                                                       | --spending-reference-tx-in-redeemer-value JSON VALUE
+                                                       ( --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                       | --spending-reference-tx-in-redeemer-file JSON_FILE
+                                                       | --spending-reference-tx-in-redeemer-value JSON_VALUE
                                                        )
                                                        --spending-reference-tx-in-execution-units (INT, INT)
                                                      | --simple-script-tx-in-reference TX-IN
                                                      | --tx-in-script-file FILE
                                                        [
-                                                         ( --tx-in-datum-cbor-file CBOR FILE
-                                                         | --tx-in-datum-file JSON FILE
-                                                         | --tx-in-datum-value JSON VALUE
+                                                         ( --tx-in-datum-cbor-file CBOR_FILE
+                                                         | --tx-in-datum-file JSON_FILE
+                                                         | --tx-in-datum-value JSON_VALUE
                                                          | --tx-in-inline-datum-present
                                                          )
-                                                         ( --tx-in-redeemer-cbor-file CBOR FILE
-                                                         | --tx-in-redeemer-file JSON FILE
-                                                         | --tx-in-redeemer-value JSON VALUE
+                                                         ( --tx-in-redeemer-cbor-file CBOR_FILE
+                                                         | --tx-in-redeemer-file JSON_FILE
+                                                         | --tx-in-redeemer-value JSON_VALUE
                                                          )
                                                          --tx-in-execution-units (INT, INT)]
                                                      ])
@@ -40,23 +40,23 @@ Usage: cardano-cli babbage transaction build-raw
                                                    ]
                                                    [--tx-out ADDRESS VALUE
                                                      [ --tx-out-datum-hash HASH
-                                                     | --tx-out-datum-hash-cbor-file CBOR FILE
-                                                     | --tx-out-datum-hash-file JSON FILE
-                                                     | --tx-out-datum-hash-value JSON VALUE
-                                                     | --tx-out-datum-embed-cbor-file CBOR FILE
-                                                     | --tx-out-datum-embed-file JSON FILE
-                                                     | --tx-out-datum-embed-value JSON VALUE
-                                                     | --tx-out-inline-datum-cbor-file CBOR FILE
-                                                     | --tx-out-inline-datum-file JSON FILE
-                                                     | --tx-out-inline-datum-value JSON VALUE
+                                                     | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                     | --tx-out-datum-hash-file JSON_FILE
+                                                     | --tx-out-datum-hash-value JSON_VALUE
+                                                     | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                     | --tx-out-datum-embed-file JSON_FILE
+                                                     | --tx-out-datum-embed-value JSON_VALUE
+                                                     | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                     | --tx-out-inline-datum-file JSON_FILE
+                                                     | --tx-out-inline-datum-value JSON_VALUE
                                                      ]
                                                      [--tx-out-reference-script-file FILE]]
                                                    [--mint VALUE
                                                      ( --mint-script-file FILE
                                                        [
-                                                         ( --mint-redeemer-cbor-file CBOR FILE
-                                                         | --mint-redeemer-file JSON FILE
-                                                         | --mint-redeemer-value JSON VALUE
+                                                         ( --mint-redeemer-cbor-file CBOR_FILE
+                                                         | --mint-redeemer-file JSON_FILE
+                                                         | --mint-redeemer-value JSON_VALUE
                                                          )
                                                          --mint-execution-units (INT, INT)]
                                                      | --simple-minting-script-tx-in-reference TX-IN
@@ -65,9 +65,9 @@ Usage: cardano-cli babbage transaction build-raw
                                                        ( --mint-plutus-script-v2
                                                        | --mint-plutus-script-v3
                                                        )
-                                                       ( --mint-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                       | --mint-reference-tx-in-redeemer-file JSON FILE
-                                                       | --mint-reference-tx-in-redeemer-value JSON VALUE
+                                                       ( --mint-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                       | --mint-reference-tx-in-redeemer-file JSON_FILE
+                                                       | --mint-reference-tx-in-redeemer-value JSON_VALUE
                                                        )
                                                        --mint-reference-tx-in-execution-units (INT, INT)
                                                        --policy-id HASH
@@ -78,36 +78,36 @@ Usage: cardano-cli babbage transaction build-raw
                                                    [--certificate-file FILE
                                                      [ --certificate-script-file FILE
                                                        [
-                                                         ( --certificate-redeemer-cbor-file CBOR FILE
-                                                         | --certificate-redeemer-file JSON FILE
-                                                         | --certificate-redeemer-value JSON VALUE
+                                                         ( --certificate-redeemer-cbor-file CBOR_FILE
+                                                         | --certificate-redeemer-file JSON_FILE
+                                                         | --certificate-redeemer-value JSON_VALUE
                                                          )
                                                          --certificate-execution-units (INT, INT)]
                                                      | --certificate-tx-in-reference TX-IN
                                                        ( --certificate-plutus-script-v2
                                                        | --certificate-plutus-script-v3
                                                        )
-                                                       ( --certificate-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                       | --certificate-reference-tx-in-redeemer-file JSON FILE
-                                                       | --certificate-reference-tx-in-redeemer-value JSON VALUE
+                                                       ( --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                       | --certificate-reference-tx-in-redeemer-file JSON_FILE
+                                                       | --certificate-reference-tx-in-redeemer-value JSON_VALUE
                                                        )
                                                        --certificate-reference-tx-in-execution-units (INT, INT)
                                                      ]]
                                                    [--withdrawal WITHDRAWAL
                                                      [ --withdrawal-script-file FILE
                                                        [
-                                                         ( --withdrawal-redeemer-cbor-file CBOR FILE
-                                                         | --withdrawal-redeemer-file JSON FILE
-                                                         | --withdrawal-redeemer-value JSON VALUE
+                                                         ( --withdrawal-redeemer-cbor-file CBOR_FILE
+                                                         | --withdrawal-redeemer-file JSON_FILE
+                                                         | --withdrawal-redeemer-value JSON_VALUE
                                                          )
                                                          --withdrawal-execution-units (INT, INT)]
                                                      | --withdrawal-tx-in-reference TX-IN
                                                        ( --withdrawal-plutus-script-v2
                                                        | --withdrawal-plutus-script-v3
                                                        )
-                                                       ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                       | --withdrawal-reference-tx-in-redeemer-file JSON FILE
-                                                       | --withdrawal-reference-tx-in-redeemer-value JSON VALUE
+                                                       ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                       | --withdrawal-reference-tx-in-redeemer-file JSON_FILE
+                                                       | --withdrawal-reference-tx-in-redeemer-value JSON_VALUE
                                                        )
                                                        --withdrawal-reference-tx-in-execution-units (INT, INT)
                                                      ]]
@@ -139,28 +139,28 @@ Available options:
                            Specify a plutus script v2 reference script.
   --spending-plutus-script-v3
                            Specify a plutus script v3 reference script.
-  --spending-reference-tx-in-datum-cbor-file CBOR FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-datum-file JSON FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-datum-value JSON VALUE
-                           The script datum, in JSON syntax. There is no schema:
-                           (almost) any JSON value is supported, including
-                           top-level strings and numbers.
+  --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                           The script datum file. The file has to be in CBOR
+                           format.
+  --spending-reference-tx-in-datum-file JSON_FILE
+                           The script datum file. The file must follow the
+                           detailed JSON schema for script data.
+  --spending-reference-tx-in-datum-value JSON_VALUE
+                           The script datum. There is no schema: (almost) any
+                           JSON value is supported, including top-level strings
+                           and numbers.
   --spending-reference-tx-in-inline-datum-present
                            Inline datum present at transaction input.
-  --spending-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --spending-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --spending-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --spending-reference-tx-in-execution-units (INT, INT)
                            The time and space units needed by the script.
   --simple-script-tx-in-reference TX-IN
@@ -168,28 +168,28 @@ Available options:
                            input must have a simple reference script attached.
   --tx-in-script-file FILE The file containing the script to witness the
                            spending of the transaction input.
-  --tx-in-datum-cbor-file CBOR FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-datum-file JSON FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-datum-value JSON VALUE
-                           The script datum, in JSON syntax. There is no schema:
-                           (almost) any JSON value is supported, including
-                           top-level strings and numbers.
+  --tx-in-datum-cbor-file CBOR_FILE
+                           The script datum file. The file has to be in CBOR
+                           format.
+  --tx-in-datum-file JSON_FILE
+                           The script datum file. The file must follow the
+                           detailed JSON schema for script data.
+  --tx-in-datum-value JSON_VALUE
+                           The script datum. There is no schema: (almost) any
+                           JSON value is supported, including top-level strings
+                           and numbers.
   --tx-in-inline-datum-present
                            Inline datum present at transaction input.
-  --tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --tx-in-execution-units (INT, INT)
                            The time and space units needed by the script.
   --read-only-tx-in-reference TX-IN
@@ -220,61 +220,60 @@ Available options:
                            Lovelace).
   --tx-out-datum-hash HASH The script datum hash for this tx output, as the raw
                            datum hash (in hex).
-  --tx-out-datum-hash-cbor-file CBOR FILE
+  --tx-out-datum-hash-cbor-file CBOR_FILE
                            The script datum hash for this tx output, by hashing
-                           the script datum in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-out-datum-hash-file JSON FILE
+                           the script datum in the file. The file has to be in
+                           CBOR format.
+  --tx-out-datum-hash-file JSON_FILE
                            The script datum hash for this tx output, by hashing
-                           the script datum in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-out-datum-hash-value JSON VALUE
+                           the script datum in the file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-datum-hash-value JSON_VALUE
                            The script datum hash for this tx output, by hashing
-                           the script datum given here in JSON syntax. There is
-                           no schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
-  --tx-out-datum-embed-cbor-file CBOR FILE
-                           The script datum to embed in the tx for this output,
-                           in the given JSON file. The file must follow the
-                           special JSON schema for script data.
-  --tx-out-datum-embed-file JSON FILE
-                           The script datum to embed in the tx for this output,
-                           in the given JSON file. The file must follow the
-                           special JSON schema for script data.
-  --tx-out-datum-embed-value JSON VALUE
-                           The script datum to embed in the tx for this output,
-                           given here in JSON syntax. There is no schema:
+                           the script datum given here. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
-  --tx-out-inline-datum-cbor-file CBOR FILE
+  --tx-out-datum-embed-cbor-file CBOR_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file has to be in CBOR format.
+  --tx-out-datum-embed-file JSON_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file must follow the detailed
+                           JSON schema for script data.
+  --tx-out-datum-embed-value JSON_VALUE
+                           The script datum to embed in the tx for this output,
+                           given here. There is no schema: (almost) any JSON
+                           value is supported, including top-level strings and
+                           numbers.
+  --tx-out-inline-datum-cbor-file CBOR_FILE
                            The script datum to embed in the tx output as an
-                           inline datum, in the given JSON file. The file must
-                           follow the special JSON schema for script data.
-  --tx-out-inline-datum-file JSON FILE
+                           inline datum, in the given file. The file has to be
+                           in CBOR format.
+  --tx-out-inline-datum-file JSON_FILE
                            The script datum to embed in the tx output as an
-                           inline datum, in the given JSON file. The file must
-                           follow the special JSON schema for script data.
-  --tx-out-inline-datum-value JSON VALUE
+                           inline datum, in the given file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-inline-datum-value JSON_VALUE
                            The script datum to embed in the tx output as an
-                           inline datum, given here in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+                           inline datum, given here. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --tx-out-reference-script-file FILE
                            Reference script input file.
   --mint VALUE             Mint multi-asset value(s) with the multi-asset cli
                            syntax. You must specify a script witness.
   --mint-script-file FILE  The file containing the script to witness the minting
                            of assets for a particular policy Id.
-  --mint-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --mint-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --mint-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --mint-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --mint-execution-units (INT, INT)
                            The time and space units needed by the script.
   --simple-minting-script-tx-in-reference TX-IN
@@ -286,16 +285,16 @@ Available options:
                            input must have a plutus reference script attached.
   --mint-plutus-script-v2  Specify a plutus script v2 reference script.
   --mint-plutus-script-v3  Specify a plutus script v3 reference script.
-  --mint-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --mint-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --mint-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --mint-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --mint-reference-tx-in-execution-units (INT, INT)
                            The time and space units needed by the script.
   --policy-id HASH         Policy id of minting script.
@@ -309,16 +308,16 @@ Available options:
   --certificate-script-file FILE
                            The file containing the script to witness the use of
                            the certificate.
-  --certificate-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --certificate-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --certificate-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --certificate-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --certificate-execution-units (INT, INT)
                            The time and space units needed by the script.
   --certificate-tx-in-reference TX-IN
@@ -328,16 +327,16 @@ Available options:
                            Specify a plutus script v2 reference script.
   --certificate-plutus-script-v3
                            Specify a plutus script v3 reference script.
-  --certificate-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --certificate-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --certificate-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --certificate-reference-tx-in-execution-units (INT, INT)
                            The time and space units needed by the script.
   --withdrawal WITHDRAWAL  The reward withdrawal as StakeAddress+Lovelace where
@@ -347,16 +346,16 @@ Available options:
   --withdrawal-script-file FILE
                            The file containing the script to witness the
                            withdrawal of rewards.
-  --withdrawal-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --withdrawal-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --withdrawal-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --withdrawal-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --withdrawal-execution-units (INT, INT)
                            The time and space units needed by the script.
   --withdrawal-tx-in-reference TX-IN
@@ -366,16 +365,16 @@ Available options:
                            Specify a plutus script v2 reference script.
   --withdrawal-plutus-script-v3
                            Specify a plutus script v3 reference script.
-  --withdrawal-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --withdrawal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --withdrawal-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --withdrawal-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --withdrawal-reference-tx-in-execution-units (INT, INT)
                            The time and space units needed by the script.
   --json-metadata-no-schema

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_transaction_build.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_transaction_build.cli
@@ -13,26 +13,26 @@ Usage: cardano-cli babbage transaction build --socket-path SOCKET_PATH
                                                    ( --spending-plutus-script-v2
                                                    | --spending-plutus-script-v3
                                                    )
-                                                   ( --spending-reference-tx-in-datum-cbor-file CBOR FILE
-                                                   | --spending-reference-tx-in-datum-file JSON FILE
-                                                   | --spending-reference-tx-in-datum-value JSON VALUE
+                                                   ( --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                                                   | --spending-reference-tx-in-datum-file JSON_FILE
+                                                   | --spending-reference-tx-in-datum-value JSON_VALUE
                                                    | --spending-reference-tx-in-inline-datum-present
                                                    )
-                                                   ( --spending-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                   | --spending-reference-tx-in-redeemer-file JSON FILE
-                                                   | --spending-reference-tx-in-redeemer-value JSON VALUE
+                                                   ( --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                   | --spending-reference-tx-in-redeemer-file JSON_FILE
+                                                   | --spending-reference-tx-in-redeemer-value JSON_VALUE
                                                    )
                                                  | --simple-script-tx-in-reference TX-IN
                                                  | --tx-in-script-file FILE
                                                    [
-                                                     ( --tx-in-datum-cbor-file CBOR FILE
-                                                     | --tx-in-datum-file JSON FILE
-                                                     | --tx-in-datum-value JSON VALUE
+                                                     ( --tx-in-datum-cbor-file CBOR_FILE
+                                                     | --tx-in-datum-file JSON_FILE
+                                                     | --tx-in-datum-value JSON_VALUE
                                                      | --tx-in-inline-datum-present
                                                      )
-                                                     ( --tx-in-redeemer-cbor-file CBOR FILE
-                                                     | --tx-in-redeemer-file JSON FILE
-                                                     | --tx-in-redeemer-value JSON VALUE
+                                                     ( --tx-in-redeemer-cbor-file CBOR_FILE
+                                                     | --tx-in-redeemer-file JSON_FILE
+                                                     | --tx-in-redeemer-value JSON_VALUE
                                                      )]
                                                  ])
                                                [--read-only-tx-in-reference TX-IN]
@@ -44,23 +44,23 @@ Usage: cardano-cli babbage transaction build --socket-path SOCKET_PATH
                                                [--tx-total-collateral INTEGER]
                                                [--tx-out ADDRESS VALUE
                                                  [ --tx-out-datum-hash HASH
-                                                 | --tx-out-datum-hash-cbor-file CBOR FILE
-                                                 | --tx-out-datum-hash-file JSON FILE
-                                                 | --tx-out-datum-hash-value JSON VALUE
-                                                 | --tx-out-datum-embed-cbor-file CBOR FILE
-                                                 | --tx-out-datum-embed-file JSON FILE
-                                                 | --tx-out-datum-embed-value JSON VALUE
-                                                 | --tx-out-inline-datum-cbor-file CBOR FILE
-                                                 | --tx-out-inline-datum-file JSON FILE
-                                                 | --tx-out-inline-datum-value JSON VALUE
+                                                 | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                 | --tx-out-datum-hash-file JSON_FILE
+                                                 | --tx-out-datum-hash-value JSON_VALUE
+                                                 | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                 | --tx-out-datum-embed-file JSON_FILE
+                                                 | --tx-out-datum-embed-value JSON_VALUE
+                                                 | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                 | --tx-out-inline-datum-file JSON_FILE
+                                                 | --tx-out-inline-datum-value JSON_VALUE
                                                  ]
                                                  [--tx-out-reference-script-file FILE]]
                                                --change-address ADDRESS
                                                [--mint VALUE
                                                  ( --mint-script-file FILE
-                                                   [ --mint-redeemer-cbor-file CBOR FILE
-                                                   | --mint-redeemer-file JSON FILE
-                                                   | --mint-redeemer-value JSON VALUE
+                                                   [ --mint-redeemer-cbor-file CBOR_FILE
+                                                   | --mint-redeemer-file JSON_FILE
+                                                   | --mint-redeemer-value JSON_VALUE
                                                    ]
                                                  | --simple-minting-script-tx-in-reference TX-IN
                                                    --policy-id HASH
@@ -68,9 +68,9 @@ Usage: cardano-cli babbage transaction build --socket-path SOCKET_PATH
                                                    ( --mint-plutus-script-v2
                                                    | --mint-plutus-script-v3
                                                    )
-                                                   ( --mint-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                   | --mint-reference-tx-in-redeemer-file JSON FILE
-                                                   | --mint-reference-tx-in-redeemer-value JSON VALUE
+                                                   ( --mint-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                   | --mint-reference-tx-in-redeemer-file JSON_FILE
+                                                   | --mint-reference-tx-in-redeemer-value JSON_VALUE
                                                    )
                                                    --policy-id HASH
                                                  )]
@@ -78,32 +78,32 @@ Usage: cardano-cli babbage transaction build --socket-path SOCKET_PATH
                                                [--invalid-hereafter SLOT]
                                                [--certificate-file FILE
                                                  [ --certificate-script-file FILE
-                                                   [ --certificate-redeemer-cbor-file CBOR FILE
-                                                   | --certificate-redeemer-file JSON FILE
-                                                   | --certificate-redeemer-value JSON VALUE
+                                                   [ --certificate-redeemer-cbor-file CBOR_FILE
+                                                   | --certificate-redeemer-file JSON_FILE
+                                                   | --certificate-redeemer-value JSON_VALUE
                                                    ]
                                                  | --certificate-tx-in-reference TX-IN
                                                    ( --certificate-plutus-script-v2
                                                    | --certificate-plutus-script-v3
                                                    )
-                                                   ( --certificate-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                   | --certificate-reference-tx-in-redeemer-file JSON FILE
-                                                   | --certificate-reference-tx-in-redeemer-value JSON VALUE
+                                                   ( --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                   | --certificate-reference-tx-in-redeemer-file JSON_FILE
+                                                   | --certificate-reference-tx-in-redeemer-value JSON_VALUE
                                                    )
                                                  ]]
                                                [--withdrawal WITHDRAWAL
                                                  [ --withdrawal-script-file FILE
-                                                   [ --withdrawal-redeemer-cbor-file CBOR FILE
-                                                   | --withdrawal-redeemer-file JSON FILE
-                                                   | --withdrawal-redeemer-value JSON VALUE
+                                                   [ --withdrawal-redeemer-cbor-file CBOR_FILE
+                                                   | --withdrawal-redeemer-file JSON_FILE
+                                                   | --withdrawal-redeemer-value JSON_VALUE
                                                    ]
                                                  | --withdrawal-tx-in-reference TX-IN
                                                    ( --withdrawal-plutus-script-v2
                                                    | --withdrawal-plutus-script-v3
                                                    )
-                                                   ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                   | --withdrawal-reference-tx-in-redeemer-file JSON FILE
-                                                   | --withdrawal-reference-tx-in-redeemer-value JSON VALUE
+                                                   ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                   | --withdrawal-reference-tx-in-redeemer-file JSON_FILE
+                                                   | --withdrawal-reference-tx-in-redeemer-value JSON_VALUE
                                                    )
                                                  ]]
                                                [ --json-metadata-no-schema
@@ -150,55 +150,55 @@ Available options:
                            Specify a plutus script v2 reference script.
   --spending-plutus-script-v3
                            Specify a plutus script v3 reference script.
-  --spending-reference-tx-in-datum-cbor-file CBOR FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-datum-file JSON FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-datum-value JSON VALUE
-                           The script datum, in JSON syntax. There is no schema:
-                           (almost) any JSON value is supported, including
-                           top-level strings and numbers.
+  --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                           The script datum file. The file has to be in CBOR
+                           format.
+  --spending-reference-tx-in-datum-file JSON_FILE
+                           The script datum file. The file must follow the
+                           detailed JSON schema for script data.
+  --spending-reference-tx-in-datum-value JSON_VALUE
+                           The script datum. There is no schema: (almost) any
+                           JSON value is supported, including top-level strings
+                           and numbers.
   --spending-reference-tx-in-inline-datum-present
                            Inline datum present at transaction input.
-  --spending-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --spending-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --spending-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --simple-script-tx-in-reference TX-IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a simple reference script attached.
   --tx-in-script-file FILE The file containing the script to witness the
                            spending of the transaction input.
-  --tx-in-datum-cbor-file CBOR FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-datum-file JSON FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-datum-value JSON VALUE
-                           The script datum, in JSON syntax. There is no schema:
-                           (almost) any JSON value is supported, including
-                           top-level strings and numbers.
+  --tx-in-datum-cbor-file CBOR_FILE
+                           The script datum file. The file has to be in CBOR
+                           format.
+  --tx-in-datum-file JSON_FILE
+                           The script datum file. The file must follow the
+                           detailed JSON schema for script data.
+  --tx-in-datum-value JSON_VALUE
+                           The script datum. There is no schema: (almost) any
+                           JSON value is supported, including top-level strings
+                           and numbers.
   --tx-in-inline-datum-present
                            Inline datum present at transaction input.
-  --tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --read-only-tx-in-reference TX-IN
                            Specify a read only reference input. This reference
                            input is not witnessing anything it is simply
@@ -227,45 +227,44 @@ Available options:
                            Lovelace).
   --tx-out-datum-hash HASH The script datum hash for this tx output, as the raw
                            datum hash (in hex).
-  --tx-out-datum-hash-cbor-file CBOR FILE
+  --tx-out-datum-hash-cbor-file CBOR_FILE
                            The script datum hash for this tx output, by hashing
-                           the script datum in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-out-datum-hash-file JSON FILE
+                           the script datum in the file. The file has to be in
+                           CBOR format.
+  --tx-out-datum-hash-file JSON_FILE
                            The script datum hash for this tx output, by hashing
-                           the script datum in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-out-datum-hash-value JSON VALUE
+                           the script datum in the file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-datum-hash-value JSON_VALUE
                            The script datum hash for this tx output, by hashing
-                           the script datum given here in JSON syntax. There is
-                           no schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
-  --tx-out-datum-embed-cbor-file CBOR FILE
-                           The script datum to embed in the tx for this output,
-                           in the given JSON file. The file must follow the
-                           special JSON schema for script data.
-  --tx-out-datum-embed-file JSON FILE
-                           The script datum to embed in the tx for this output,
-                           in the given JSON file. The file must follow the
-                           special JSON schema for script data.
-  --tx-out-datum-embed-value JSON VALUE
-                           The script datum to embed in the tx for this output,
-                           given here in JSON syntax. There is no schema:
+                           the script datum given here. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
-  --tx-out-inline-datum-cbor-file CBOR FILE
+  --tx-out-datum-embed-cbor-file CBOR_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file has to be in CBOR format.
+  --tx-out-datum-embed-file JSON_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file must follow the detailed
+                           JSON schema for script data.
+  --tx-out-datum-embed-value JSON_VALUE
+                           The script datum to embed in the tx for this output,
+                           given here. There is no schema: (almost) any JSON
+                           value is supported, including top-level strings and
+                           numbers.
+  --tx-out-inline-datum-cbor-file CBOR_FILE
                            The script datum to embed in the tx output as an
-                           inline datum, in the given JSON file. The file must
-                           follow the special JSON schema for script data.
-  --tx-out-inline-datum-file JSON FILE
+                           inline datum, in the given file. The file has to be
+                           in CBOR format.
+  --tx-out-inline-datum-file JSON_FILE
                            The script datum to embed in the tx output as an
-                           inline datum, in the given JSON file. The file must
-                           follow the special JSON schema for script data.
-  --tx-out-inline-datum-value JSON VALUE
+                           inline datum, in the given file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-inline-datum-value JSON_VALUE
                            The script datum to embed in the tx output as an
-                           inline datum, given here in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+                           inline datum, given here. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --tx-out-reference-script-file FILE
                            Reference script input file.
   --change-address ADDRESS Address where ADA in excess of the tx fee will go to.
@@ -273,16 +272,16 @@ Available options:
                            syntax. You must specify a script witness.
   --mint-script-file FILE  The file containing the script to witness the minting
                            of assets for a particular policy Id.
-  --mint-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --mint-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --mint-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --mint-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --simple-minting-script-tx-in-reference TX-IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a simple reference script attached.
@@ -292,16 +291,16 @@ Available options:
                            input must have a plutus reference script attached.
   --mint-plutus-script-v2  Specify a plutus script v2 reference script.
   --mint-plutus-script-v3  Specify a plutus script v3 reference script.
-  --mint-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --mint-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --mint-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --mint-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --policy-id HASH         Policy id of minting script.
   --invalid-before SLOT    Time that transaction is valid from (in slots).
   --invalid-hereafter SLOT Time that transaction is valid until (in slots).
@@ -312,16 +311,16 @@ Available options:
   --certificate-script-file FILE
                            The file containing the script to witness the use of
                            the certificate.
-  --certificate-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --certificate-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --certificate-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --certificate-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --certificate-tx-in-reference TX-IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a plutus reference script attached.
@@ -329,16 +328,16 @@ Available options:
                            Specify a plutus script v2 reference script.
   --certificate-plutus-script-v3
                            Specify a plutus script v3 reference script.
-  --certificate-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --certificate-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --certificate-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --withdrawal WITHDRAWAL  The reward withdrawal as StakeAddress+Lovelace where
                            StakeAddress is the Bech32-encoded stake address
                            followed by the amount in Lovelace. Optionally
@@ -346,16 +345,16 @@ Available options:
   --withdrawal-script-file FILE
                            The file containing the script to witness the
                            withdrawal of rewards.
-  --withdrawal-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --withdrawal-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --withdrawal-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --withdrawal-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --withdrawal-tx-in-reference TX-IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a plutus reference script attached.
@@ -363,16 +362,16 @@ Available options:
                            Specify a plutus script v2 reference script.
   --withdrawal-plutus-script-v3
                            Specify a plutus script v3 reference script.
-  --withdrawal-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --withdrawal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --withdrawal-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --withdrawal-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --json-metadata-no-schema
                            Use the "no schema" conversion from JSON to tx
                            metadata (default).

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_transaction_calculate-min-required-utxo.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_transaction_calculate-min-required-utxo.cli
@@ -1,15 +1,15 @@
 Usage: cardano-cli babbage transaction calculate-min-required-utxo --protocol-params-file FILE
                                                                      --tx-out ADDRESS VALUE
                                                                      [ --tx-out-datum-hash HASH
-                                                                     | --tx-out-datum-hash-cbor-file CBOR FILE
-                                                                     | --tx-out-datum-hash-file JSON FILE
-                                                                     | --tx-out-datum-hash-value JSON VALUE
-                                                                     | --tx-out-datum-embed-cbor-file CBOR FILE
-                                                                     | --tx-out-datum-embed-file JSON FILE
-                                                                     | --tx-out-datum-embed-value JSON VALUE
-                                                                     | --tx-out-inline-datum-cbor-file CBOR FILE
-                                                                     | --tx-out-inline-datum-file JSON FILE
-                                                                     | --tx-out-inline-datum-value JSON VALUE
+                                                                     | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                                     | --tx-out-datum-hash-file JSON_FILE
+                                                                     | --tx-out-datum-hash-value JSON_VALUE
+                                                                     | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                                     | --tx-out-datum-embed-file JSON_FILE
+                                                                     | --tx-out-datum-embed-value JSON_VALUE
+                                                                     | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                                     | --tx-out-inline-datum-file JSON_FILE
+                                                                     | --tx-out-inline-datum-value JSON_VALUE
                                                                      ]
                                                                      [--tx-out-reference-script-file FILE]
 
@@ -24,45 +24,44 @@ Available options:
                            Lovelace).
   --tx-out-datum-hash HASH The script datum hash for this tx output, as the raw
                            datum hash (in hex).
-  --tx-out-datum-hash-cbor-file CBOR FILE
+  --tx-out-datum-hash-cbor-file CBOR_FILE
                            The script datum hash for this tx output, by hashing
-                           the script datum in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-out-datum-hash-file JSON FILE
+                           the script datum in the file. The file has to be in
+                           CBOR format.
+  --tx-out-datum-hash-file JSON_FILE
                            The script datum hash for this tx output, by hashing
-                           the script datum in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-out-datum-hash-value JSON VALUE
+                           the script datum in the file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-datum-hash-value JSON_VALUE
                            The script datum hash for this tx output, by hashing
-                           the script datum given here in JSON syntax. There is
-                           no schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
-  --tx-out-datum-embed-cbor-file CBOR FILE
-                           The script datum to embed in the tx for this output,
-                           in the given JSON file. The file must follow the
-                           special JSON schema for script data.
-  --tx-out-datum-embed-file JSON FILE
-                           The script datum to embed in the tx for this output,
-                           in the given JSON file. The file must follow the
-                           special JSON schema for script data.
-  --tx-out-datum-embed-value JSON VALUE
-                           The script datum to embed in the tx for this output,
-                           given here in JSON syntax. There is no schema:
+                           the script datum given here. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
-  --tx-out-inline-datum-cbor-file CBOR FILE
+  --tx-out-datum-embed-cbor-file CBOR_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file has to be in CBOR format.
+  --tx-out-datum-embed-file JSON_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file must follow the detailed
+                           JSON schema for script data.
+  --tx-out-datum-embed-value JSON_VALUE
+                           The script datum to embed in the tx for this output,
+                           given here. There is no schema: (almost) any JSON
+                           value is supported, including top-level strings and
+                           numbers.
+  --tx-out-inline-datum-cbor-file CBOR_FILE
                            The script datum to embed in the tx output as an
-                           inline datum, in the given JSON file. The file must
-                           follow the special JSON schema for script data.
-  --tx-out-inline-datum-file JSON FILE
+                           inline datum, in the given file. The file has to be
+                           in CBOR format.
+  --tx-out-inline-datum-file JSON_FILE
                            The script datum to embed in the tx output as an
-                           inline datum, in the given JSON file. The file must
-                           follow the special JSON schema for script data.
-  --tx-out-inline-datum-value JSON VALUE
+                           inline datum, in the given file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-inline-datum-value JSON_VALUE
                            The script datum to embed in the tx output as an
-                           inline datum, given here in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+                           inline datum, given here. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --tx-out-reference-script-file FILE
                            Reference script input file.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_transaction_calculate-min-value.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_transaction_calculate-min-value.cli
@@ -1,15 +1,15 @@
 Usage: cardano-cli babbage transaction calculate-min-value --protocol-params-file FILE
                                                              --tx-out ADDRESS VALUE
                                                              [ --tx-out-datum-hash HASH
-                                                             | --tx-out-datum-hash-cbor-file CBOR FILE
-                                                             | --tx-out-datum-hash-file JSON FILE
-                                                             | --tx-out-datum-hash-value JSON VALUE
-                                                             | --tx-out-datum-embed-cbor-file CBOR FILE
-                                                             | --tx-out-datum-embed-file JSON FILE
-                                                             | --tx-out-datum-embed-value JSON VALUE
-                                                             | --tx-out-inline-datum-cbor-file CBOR FILE
-                                                             | --tx-out-inline-datum-file JSON FILE
-                                                             | --tx-out-inline-datum-value JSON VALUE
+                                                             | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                             | --tx-out-datum-hash-file JSON_FILE
+                                                             | --tx-out-datum-hash-value JSON_VALUE
+                                                             | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                             | --tx-out-datum-embed-file JSON_FILE
+                                                             | --tx-out-datum-embed-value JSON_VALUE
+                                                             | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                             | --tx-out-inline-datum-file JSON_FILE
+                                                             | --tx-out-inline-datum-value JSON_VALUE
                                                              ]
                                                              [--tx-out-reference-script-file FILE]
 
@@ -24,44 +24,43 @@ Available options:
                            Lovelace).
   --tx-out-datum-hash HASH The script datum hash for this tx output, as the raw
                            datum hash (in hex).
-  --tx-out-datum-hash-cbor-file CBOR FILE
+  --tx-out-datum-hash-cbor-file CBOR_FILE
                            The script datum hash for this tx output, by hashing
-                           the script datum in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-out-datum-hash-file JSON FILE
+                           the script datum in the file. The file has to be in
+                           CBOR format.
+  --tx-out-datum-hash-file JSON_FILE
                            The script datum hash for this tx output, by hashing
-                           the script datum in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-out-datum-hash-value JSON VALUE
+                           the script datum in the file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-datum-hash-value JSON_VALUE
                            The script datum hash for this tx output, by hashing
-                           the script datum given here in JSON syntax. There is
-                           no schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
-  --tx-out-datum-embed-cbor-file CBOR FILE
-                           The script datum to embed in the tx for this output,
-                           in the given JSON file. The file must follow the
-                           special JSON schema for script data.
-  --tx-out-datum-embed-file JSON FILE
-                           The script datum to embed in the tx for this output,
-                           in the given JSON file. The file must follow the
-                           special JSON schema for script data.
-  --tx-out-datum-embed-value JSON VALUE
-                           The script datum to embed in the tx for this output,
-                           given here in JSON syntax. There is no schema:
+                           the script datum given here. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
-  --tx-out-inline-datum-cbor-file CBOR FILE
+  --tx-out-datum-embed-cbor-file CBOR_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file has to be in CBOR format.
+  --tx-out-datum-embed-file JSON_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file must follow the detailed
+                           JSON schema for script data.
+  --tx-out-datum-embed-value JSON_VALUE
+                           The script datum to embed in the tx for this output,
+                           given here. There is no schema: (almost) any JSON
+                           value is supported, including top-level strings and
+                           numbers.
+  --tx-out-inline-datum-cbor-file CBOR_FILE
                            The script datum to embed in the tx output as an
-                           inline datum, in the given JSON file. The file must
-                           follow the special JSON schema for script data.
-  --tx-out-inline-datum-file JSON FILE
+                           inline datum, in the given file. The file has to be
+                           in CBOR format.
+  --tx-out-inline-datum-file JSON_FILE
                            The script datum to embed in the tx output as an
-                           inline datum, in the given JSON file. The file must
-                           follow the special JSON schema for script data.
-  --tx-out-inline-datum-value JSON VALUE
+                           inline datum, in the given file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-inline-datum-value JSON_VALUE
                            The script datum to embed in the tx output as an
-                           inline datum, given here in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+                           inline datum, given here. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --tx-out-reference-script-file FILE
                            Reference script input file.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_transaction_hash-script-data.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_transaction_hash-script-data.cli
@@ -1,20 +1,20 @@
 Usage: cardano-cli babbage transaction hash-script-data 
-                                                          ( --script-data-cbor-file CBOR FILE
-                                                          | --script-data-file JSON FILE
-                                                          | --script-data-value JSON VALUE
+                                                          ( --script-data-cbor-file CBOR_FILE
+                                                          | --script-data-file JSON_FILE
+                                                          | --script-data-value JSON_VALUE
                                                           )
 
   Calculate the hash of script data.
 
 Available options:
-  --script-data-cbor-file CBOR FILE
-                           The script data, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --script-data-file JSON FILE
-                           The script data, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --script-data-value JSON VALUE
-                           The script data, in JSON syntax. There is no schema:
-                           (almost) any JSON value is supported, including
-                           top-level strings and numbers.
+  --script-data-cbor-file CBOR_FILE
+                           The script data file. The file has to be in CBOR
+                           format.
+  --script-data-file JSON_FILE
+                           The script data file. The file must follow the
+                           detailed JSON schema for script data.
+  --script-data-value JSON_VALUE
+                           The script data. There is no schema: (almost) any
+                           JSON value is supported, including top-level strings
+                           and numbers.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_build-estimate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_build-estimate.cli
@@ -11,27 +11,27 @@ Usage: cardano-cli conway transaction build-estimate
                                                            ( --spending-plutus-script-v2
                                                            | --spending-plutus-script-v3
                                                            )
-                                                           ( --spending-reference-tx-in-datum-cbor-file CBOR FILE
-                                                           | --spending-reference-tx-in-datum-file JSON FILE
-                                                           | --spending-reference-tx-in-datum-value JSON VALUE
+                                                           ( --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                                                           | --spending-reference-tx-in-datum-file JSON_FILE
+                                                           | --spending-reference-tx-in-datum-value JSON_VALUE
                                                            | --spending-reference-tx-in-inline-datum-present
                                                            )
-                                                           ( --spending-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                           | --spending-reference-tx-in-redeemer-file JSON FILE
-                                                           | --spending-reference-tx-in-redeemer-value JSON VALUE
+                                                           ( --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                           | --spending-reference-tx-in-redeemer-file JSON_FILE
+                                                           | --spending-reference-tx-in-redeemer-value JSON_VALUE
                                                            )
                                                            --spending-reference-tx-in-execution-units (INT, INT)
                                                          | --simple-script-tx-in-reference TX-IN
                                                          | --tx-in-script-file FILE
                                                            [
-                                                             ( --tx-in-datum-cbor-file CBOR FILE
-                                                             | --tx-in-datum-file JSON FILE
-                                                             | --tx-in-datum-value JSON VALUE
+                                                             ( --tx-in-datum-cbor-file CBOR_FILE
+                                                             | --tx-in-datum-file JSON_FILE
+                                                             | --tx-in-datum-value JSON_VALUE
                                                              | --tx-in-inline-datum-present
                                                              )
-                                                             ( --tx-in-redeemer-cbor-file CBOR FILE
-                                                             | --tx-in-redeemer-file JSON FILE
-                                                             | --tx-in-redeemer-value JSON VALUE
+                                                             ( --tx-in-redeemer-cbor-file CBOR_FILE
+                                                             | --tx-in-redeemer-file JSON_FILE
+                                                             | --tx-in-redeemer-value JSON_VALUE
                                                              )
                                                              --tx-in-execution-units (INT, INT)]
                                                          ])
@@ -43,24 +43,24 @@ Usage: cardano-cli conway transaction build-estimate
                                                        [--tx-out-return-collateral ADDRESS VALUE]
                                                        [--tx-out ADDRESS VALUE
                                                          [ --tx-out-datum-hash HASH
-                                                         | --tx-out-datum-hash-cbor-file CBOR FILE
-                                                         | --tx-out-datum-hash-file JSON FILE
-                                                         | --tx-out-datum-hash-value JSON VALUE
-                                                         | --tx-out-datum-embed-cbor-file CBOR FILE
-                                                         | --tx-out-datum-embed-file JSON FILE
-                                                         | --tx-out-datum-embed-value JSON VALUE
-                                                         | --tx-out-inline-datum-cbor-file CBOR FILE
-                                                         | --tx-out-inline-datum-file JSON FILE
-                                                         | --tx-out-inline-datum-value JSON VALUE
+                                                         | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                         | --tx-out-datum-hash-file JSON_FILE
+                                                         | --tx-out-datum-hash-value JSON_VALUE
+                                                         | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                         | --tx-out-datum-embed-file JSON_FILE
+                                                         | --tx-out-datum-embed-value JSON_VALUE
+                                                         | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                         | --tx-out-inline-datum-file JSON_FILE
+                                                         | --tx-out-inline-datum-value JSON_VALUE
                                                          ]
                                                          [--tx-out-reference-script-file FILE]]
                                                        --change-address ADDRESS
                                                        [--mint VALUE
                                                          ( --mint-script-file FILE
                                                            [
-                                                             ( --mint-redeemer-cbor-file CBOR FILE
-                                                             | --mint-redeemer-file JSON FILE
-                                                             | --mint-redeemer-value JSON VALUE
+                                                             ( --mint-redeemer-cbor-file CBOR_FILE
+                                                             | --mint-redeemer-file JSON_FILE
+                                                             | --mint-redeemer-value JSON_VALUE
                                                              )
                                                              --mint-execution-units (INT, INT)]
                                                          | --simple-minting-script-tx-in-reference TX-IN
@@ -69,9 +69,9 @@ Usage: cardano-cli conway transaction build-estimate
                                                            ( --mint-plutus-script-v2
                                                            | --mint-plutus-script-v3
                                                            )
-                                                           ( --mint-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                           | --mint-reference-tx-in-redeemer-file JSON FILE
-                                                           | --mint-reference-tx-in-redeemer-value JSON VALUE
+                                                           ( --mint-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                           | --mint-reference-tx-in-redeemer-file JSON_FILE
+                                                           | --mint-reference-tx-in-redeemer-value JSON_VALUE
                                                            )
                                                            --mint-reference-tx-in-execution-units (INT, INT)
                                                            --policy-id HASH
@@ -81,36 +81,36 @@ Usage: cardano-cli conway transaction build-estimate
                                                        [--certificate-file FILE
                                                          [ --certificate-script-file FILE
                                                            [
-                                                             ( --certificate-redeemer-cbor-file CBOR FILE
-                                                             | --certificate-redeemer-file JSON FILE
-                                                             | --certificate-redeemer-value JSON VALUE
+                                                             ( --certificate-redeemer-cbor-file CBOR_FILE
+                                                             | --certificate-redeemer-file JSON_FILE
+                                                             | --certificate-redeemer-value JSON_VALUE
                                                              )
                                                              --certificate-execution-units (INT, INT)]
                                                          | --certificate-tx-in-reference TX-IN
                                                            ( --certificate-plutus-script-v2
                                                            | --certificate-plutus-script-v3
                                                            )
-                                                           ( --certificate-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                           | --certificate-reference-tx-in-redeemer-file JSON FILE
-                                                           | --certificate-reference-tx-in-redeemer-value JSON VALUE
+                                                           ( --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                           | --certificate-reference-tx-in-redeemer-file JSON_FILE
+                                                           | --certificate-reference-tx-in-redeemer-value JSON_VALUE
                                                            )
                                                            --certificate-reference-tx-in-execution-units (INT, INT)
                                                          ]]
                                                        [--withdrawal WITHDRAWAL
                                                          [ --withdrawal-script-file FILE
                                                            [
-                                                             ( --withdrawal-redeemer-cbor-file CBOR FILE
-                                                             | --withdrawal-redeemer-file JSON FILE
-                                                             | --withdrawal-redeemer-value JSON VALUE
+                                                             ( --withdrawal-redeemer-cbor-file CBOR_FILE
+                                                             | --withdrawal-redeemer-file JSON_FILE
+                                                             | --withdrawal-redeemer-value JSON_VALUE
                                                              )
                                                              --withdrawal-execution-units (INT, INT)]
                                                          | --withdrawal-tx-in-reference TX-IN
                                                            ( --withdrawal-plutus-script-v2
                                                            | --withdrawal-plutus-script-v3
                                                            )
-                                                           ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                           | --withdrawal-reference-tx-in-redeemer-file JSON FILE
-                                                           | --withdrawal-reference-tx-in-redeemer-value JSON VALUE
+                                                           ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                           | --withdrawal-reference-tx-in-redeemer-file JSON_FILE
+                                                           | --withdrawal-reference-tx-in-redeemer-value JSON_VALUE
                                                            )
                                                            --withdrawal-reference-tx-in-execution-units (INT, INT)
                                                          ]]
@@ -126,17 +126,17 @@ Usage: cardano-cli conway transaction build-estimate
                                                        [--vote-file FILE
                                                          [--vote-script-file FILE
                                                            [
-                                                             ( --vote-redeemer-cbor-file CBOR FILE
-                                                             | --vote-redeemer-file JSON FILE
-                                                             | --vote-redeemer-value JSON VALUE
+                                                             ( --vote-redeemer-cbor-file CBOR_FILE
+                                                             | --vote-redeemer-file JSON_FILE
+                                                             | --vote-redeemer-value JSON_VALUE
                                                              )
                                                              --vote-execution-units (INT, INT)]]]
                                                        [--proposal-file FILE
                                                          [--proposal-script-file FILE
                                                            [
-                                                             ( --proposal-redeemer-cbor-file CBOR FILE
-                                                             | --proposal-redeemer-file JSON FILE
-                                                             | --proposal-redeemer-value JSON VALUE
+                                                             ( --proposal-redeemer-cbor-file CBOR_FILE
+                                                             | --proposal-redeemer-file JSON_FILE
+                                                             | --proposal-redeemer-value JSON_VALUE
                                                              )
                                                              --proposal-execution-units (INT, INT)]]]
                                                        --out-file FILE
@@ -168,28 +168,28 @@ Available options:
                            Specify a plutus script v2 reference script.
   --spending-plutus-script-v3
                            Specify a plutus script v3 reference script.
-  --spending-reference-tx-in-datum-cbor-file CBOR FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-datum-file JSON FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-datum-value JSON VALUE
-                           The script datum, in JSON syntax. There is no schema:
-                           (almost) any JSON value is supported, including
-                           top-level strings and numbers.
+  --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                           The script datum file. The file has to be in CBOR
+                           format.
+  --spending-reference-tx-in-datum-file JSON_FILE
+                           The script datum file. The file must follow the
+                           detailed JSON schema for script data.
+  --spending-reference-tx-in-datum-value JSON_VALUE
+                           The script datum. There is no schema: (almost) any
+                           JSON value is supported, including top-level strings
+                           and numbers.
   --spending-reference-tx-in-inline-datum-present
                            Inline datum present at transaction input.
-  --spending-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --spending-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --spending-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --spending-reference-tx-in-execution-units (INT, INT)
                            The time and space units needed by the script.
   --simple-script-tx-in-reference TX-IN
@@ -197,28 +197,28 @@ Available options:
                            input must have a simple reference script attached.
   --tx-in-script-file FILE The file containing the script to witness the
                            spending of the transaction input.
-  --tx-in-datum-cbor-file CBOR FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-datum-file JSON FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-datum-value JSON VALUE
-                           The script datum, in JSON syntax. There is no schema:
-                           (almost) any JSON value is supported, including
-                           top-level strings and numbers.
+  --tx-in-datum-cbor-file CBOR_FILE
+                           The script datum file. The file has to be in CBOR
+                           format.
+  --tx-in-datum-file JSON_FILE
+                           The script datum file. The file must follow the
+                           detailed JSON schema for script data.
+  --tx-in-datum-value JSON_VALUE
+                           The script datum. There is no schema: (almost) any
+                           JSON value is supported, including top-level strings
+                           and numbers.
   --tx-in-inline-datum-present
                            Inline datum present at transaction input.
-  --tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --tx-in-execution-units (INT, INT)
                            The time and space units needed by the script.
   --read-only-tx-in-reference TX-IN
@@ -244,45 +244,44 @@ Available options:
                            Lovelace).
   --tx-out-datum-hash HASH The script datum hash for this tx output, as the raw
                            datum hash (in hex).
-  --tx-out-datum-hash-cbor-file CBOR FILE
+  --tx-out-datum-hash-cbor-file CBOR_FILE
                            The script datum hash for this tx output, by hashing
-                           the script datum in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-out-datum-hash-file JSON FILE
+                           the script datum in the file. The file has to be in
+                           CBOR format.
+  --tx-out-datum-hash-file JSON_FILE
                            The script datum hash for this tx output, by hashing
-                           the script datum in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-out-datum-hash-value JSON VALUE
+                           the script datum in the file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-datum-hash-value JSON_VALUE
                            The script datum hash for this tx output, by hashing
-                           the script datum given here in JSON syntax. There is
-                           no schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
-  --tx-out-datum-embed-cbor-file CBOR FILE
-                           The script datum to embed in the tx for this output,
-                           in the given JSON file. The file must follow the
-                           special JSON schema for script data.
-  --tx-out-datum-embed-file JSON FILE
-                           The script datum to embed in the tx for this output,
-                           in the given JSON file. The file must follow the
-                           special JSON schema for script data.
-  --tx-out-datum-embed-value JSON VALUE
-                           The script datum to embed in the tx for this output,
-                           given here in JSON syntax. There is no schema:
+                           the script datum given here. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
-  --tx-out-inline-datum-cbor-file CBOR FILE
+  --tx-out-datum-embed-cbor-file CBOR_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file has to be in CBOR format.
+  --tx-out-datum-embed-file JSON_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file must follow the detailed
+                           JSON schema for script data.
+  --tx-out-datum-embed-value JSON_VALUE
+                           The script datum to embed in the tx for this output,
+                           given here. There is no schema: (almost) any JSON
+                           value is supported, including top-level strings and
+                           numbers.
+  --tx-out-inline-datum-cbor-file CBOR_FILE
                            The script datum to embed in the tx output as an
-                           inline datum, in the given JSON file. The file must
-                           follow the special JSON schema for script data.
-  --tx-out-inline-datum-file JSON FILE
+                           inline datum, in the given file. The file has to be
+                           in CBOR format.
+  --tx-out-inline-datum-file JSON_FILE
                            The script datum to embed in the tx output as an
-                           inline datum, in the given JSON file. The file must
-                           follow the special JSON schema for script data.
-  --tx-out-inline-datum-value JSON VALUE
+                           inline datum, in the given file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-inline-datum-value JSON_VALUE
                            The script datum to embed in the tx output as an
-                           inline datum, given here in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+                           inline datum, given here. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --tx-out-reference-script-file FILE
                            Reference script input file.
   --change-address ADDRESS Address where ADA in excess of the tx fee will go to.
@@ -290,16 +289,16 @@ Available options:
                            syntax. You must specify a script witness.
   --mint-script-file FILE  The file containing the script to witness the minting
                            of assets for a particular policy Id.
-  --mint-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --mint-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --mint-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --mint-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --mint-execution-units (INT, INT)
                            The time and space units needed by the script.
   --simple-minting-script-tx-in-reference TX-IN
@@ -311,16 +310,16 @@ Available options:
                            input must have a plutus reference script attached.
   --mint-plutus-script-v2  Specify a plutus script v2 reference script.
   --mint-plutus-script-v3  Specify a plutus script v3 reference script.
-  --mint-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --mint-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --mint-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --mint-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --mint-reference-tx-in-execution-units (INT, INT)
                            The time and space units needed by the script.
   --policy-id HASH         Policy id of minting script.
@@ -333,16 +332,16 @@ Available options:
   --certificate-script-file FILE
                            The file containing the script to witness the use of
                            the certificate.
-  --certificate-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --certificate-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --certificate-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --certificate-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --certificate-execution-units (INT, INT)
                            The time and space units needed by the script.
   --certificate-tx-in-reference TX-IN
@@ -352,16 +351,16 @@ Available options:
                            Specify a plutus script v2 reference script.
   --certificate-plutus-script-v3
                            Specify a plutus script v3 reference script.
-  --certificate-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --certificate-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --certificate-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --certificate-reference-tx-in-execution-units (INT, INT)
                            The time and space units needed by the script.
   --withdrawal WITHDRAWAL  The reward withdrawal as StakeAddress+Lovelace where
@@ -371,16 +370,16 @@ Available options:
   --withdrawal-script-file FILE
                            The file containing the script to witness the
                            withdrawal of rewards.
-  --withdrawal-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --withdrawal-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --withdrawal-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --withdrawal-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --withdrawal-execution-units (INT, INT)
                            The time and space units needed by the script.
   --withdrawal-tx-in-reference TX-IN
@@ -390,16 +389,16 @@ Available options:
                            Specify a plutus script v2 reference script.
   --withdrawal-plutus-script-v3
                            Specify a plutus script v3 reference script.
-  --withdrawal-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --withdrawal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --withdrawal-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --withdrawal-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --withdrawal-reference-tx-in-execution-units (INT, INT)
                            The time and space units needed by the script.
   --tx-total-collateral INTEGER
@@ -424,31 +423,31 @@ Available options:
                            Filepath of the metadata, in raw CBOR format.
   --vote-file FILE         Filepath of the vote.
   --vote-script-file FILE  The file containing the script to witness a vote
-  --vote-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --vote-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --vote-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --vote-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --vote-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --vote-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --vote-execution-units (INT, INT)
                            The time and space units needed by the script.
   --proposal-file FILE     Filepath of the proposal.
   --proposal-script-file FILE
                            The file containing the script to witness a proposal
-  --proposal-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --proposal-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --proposal-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --proposal-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --proposal-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --proposal-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --proposal-execution-units (INT, INT)
                            The time and space units needed by the script.
   --out-file FILE          Output filepath of the JSON TxBody.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_build-raw.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_build-raw.cli
@@ -7,27 +7,27 @@ Usage: cardano-cli conway transaction build-raw
                                                       ( --spending-plutus-script-v2
                                                       | --spending-plutus-script-v3
                                                       )
-                                                      ( --spending-reference-tx-in-datum-cbor-file CBOR FILE
-                                                      | --spending-reference-tx-in-datum-file JSON FILE
-                                                      | --spending-reference-tx-in-datum-value JSON VALUE
+                                                      ( --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                                                      | --spending-reference-tx-in-datum-file JSON_FILE
+                                                      | --spending-reference-tx-in-datum-value JSON_VALUE
                                                       | --spending-reference-tx-in-inline-datum-present
                                                       )
-                                                      ( --spending-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                      | --spending-reference-tx-in-redeemer-file JSON FILE
-                                                      | --spending-reference-tx-in-redeemer-value JSON VALUE
+                                                      ( --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                      | --spending-reference-tx-in-redeemer-file JSON_FILE
+                                                      | --spending-reference-tx-in-redeemer-value JSON_VALUE
                                                       )
                                                       --spending-reference-tx-in-execution-units (INT, INT)
                                                     | --simple-script-tx-in-reference TX-IN
                                                     | --tx-in-script-file FILE
                                                       [
-                                                        ( --tx-in-datum-cbor-file CBOR FILE
-                                                        | --tx-in-datum-file JSON FILE
-                                                        | --tx-in-datum-value JSON VALUE
+                                                        ( --tx-in-datum-cbor-file CBOR_FILE
+                                                        | --tx-in-datum-file JSON_FILE
+                                                        | --tx-in-datum-value JSON_VALUE
                                                         | --tx-in-inline-datum-present
                                                         )
-                                                        ( --tx-in-redeemer-cbor-file CBOR FILE
-                                                        | --tx-in-redeemer-file JSON FILE
-                                                        | --tx-in-redeemer-value JSON VALUE
+                                                        ( --tx-in-redeemer-cbor-file CBOR_FILE
+                                                        | --tx-in-redeemer-file JSON_FILE
+                                                        | --tx-in-redeemer-value JSON_VALUE
                                                         )
                                                         --tx-in-execution-units (INT, INT)]
                                                     ])
@@ -40,23 +40,23 @@ Usage: cardano-cli conway transaction build-raw
                                                   ]
                                                   [--tx-out ADDRESS VALUE
                                                     [ --tx-out-datum-hash HASH
-                                                    | --tx-out-datum-hash-cbor-file CBOR FILE
-                                                    | --tx-out-datum-hash-file JSON FILE
-                                                    | --tx-out-datum-hash-value JSON VALUE
-                                                    | --tx-out-datum-embed-cbor-file CBOR FILE
-                                                    | --tx-out-datum-embed-file JSON FILE
-                                                    | --tx-out-datum-embed-value JSON VALUE
-                                                    | --tx-out-inline-datum-cbor-file CBOR FILE
-                                                    | --tx-out-inline-datum-file JSON FILE
-                                                    | --tx-out-inline-datum-value JSON VALUE
+                                                    | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                    | --tx-out-datum-hash-file JSON_FILE
+                                                    | --tx-out-datum-hash-value JSON_VALUE
+                                                    | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                    | --tx-out-datum-embed-file JSON_FILE
+                                                    | --tx-out-datum-embed-value JSON_VALUE
+                                                    | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                    | --tx-out-inline-datum-file JSON_FILE
+                                                    | --tx-out-inline-datum-value JSON_VALUE
                                                     ]
                                                     [--tx-out-reference-script-file FILE]]
                                                   [--mint VALUE
                                                     ( --mint-script-file FILE
                                                       [
-                                                        ( --mint-redeemer-cbor-file CBOR FILE
-                                                        | --mint-redeemer-file JSON FILE
-                                                        | --mint-redeemer-value JSON VALUE
+                                                        ( --mint-redeemer-cbor-file CBOR_FILE
+                                                        | --mint-redeemer-file JSON_FILE
+                                                        | --mint-redeemer-value JSON_VALUE
                                                         )
                                                         --mint-execution-units (INT, INT)]
                                                     | --simple-minting-script-tx-in-reference TX-IN
@@ -65,9 +65,9 @@ Usage: cardano-cli conway transaction build-raw
                                                       ( --mint-plutus-script-v2
                                                       | --mint-plutus-script-v3
                                                       )
-                                                      ( --mint-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                      | --mint-reference-tx-in-redeemer-file JSON FILE
-                                                      | --mint-reference-tx-in-redeemer-value JSON VALUE
+                                                      ( --mint-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                      | --mint-reference-tx-in-redeemer-file JSON_FILE
+                                                      | --mint-reference-tx-in-redeemer-value JSON_VALUE
                                                       )
                                                       --mint-reference-tx-in-execution-units (INT, INT)
                                                       --policy-id HASH
@@ -78,36 +78,36 @@ Usage: cardano-cli conway transaction build-raw
                                                   [--certificate-file FILE
                                                     [ --certificate-script-file FILE
                                                       [
-                                                        ( --certificate-redeemer-cbor-file CBOR FILE
-                                                        | --certificate-redeemer-file JSON FILE
-                                                        | --certificate-redeemer-value JSON VALUE
+                                                        ( --certificate-redeemer-cbor-file CBOR_FILE
+                                                        | --certificate-redeemer-file JSON_FILE
+                                                        | --certificate-redeemer-value JSON_VALUE
                                                         )
                                                         --certificate-execution-units (INT, INT)]
                                                     | --certificate-tx-in-reference TX-IN
                                                       ( --certificate-plutus-script-v2
                                                       | --certificate-plutus-script-v3
                                                       )
-                                                      ( --certificate-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                      | --certificate-reference-tx-in-redeemer-file JSON FILE
-                                                      | --certificate-reference-tx-in-redeemer-value JSON VALUE
+                                                      ( --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                      | --certificate-reference-tx-in-redeemer-file JSON_FILE
+                                                      | --certificate-reference-tx-in-redeemer-value JSON_VALUE
                                                       )
                                                       --certificate-reference-tx-in-execution-units (INT, INT)
                                                     ]]
                                                   [--withdrawal WITHDRAWAL
                                                     [ --withdrawal-script-file FILE
                                                       [
-                                                        ( --withdrawal-redeemer-cbor-file CBOR FILE
-                                                        | --withdrawal-redeemer-file JSON FILE
-                                                        | --withdrawal-redeemer-value JSON VALUE
+                                                        ( --withdrawal-redeemer-cbor-file CBOR_FILE
+                                                        | --withdrawal-redeemer-file JSON_FILE
+                                                        | --withdrawal-redeemer-value JSON_VALUE
                                                         )
                                                         --withdrawal-execution-units (INT, INT)]
                                                     | --withdrawal-tx-in-reference TX-IN
                                                       ( --withdrawal-plutus-script-v2
                                                       | --withdrawal-plutus-script-v3
                                                       )
-                                                      ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                      | --withdrawal-reference-tx-in-redeemer-file JSON FILE
-                                                      | --withdrawal-reference-tx-in-redeemer-value JSON VALUE
+                                                      ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                      | --withdrawal-reference-tx-in-redeemer-file JSON_FILE
+                                                      | --withdrawal-reference-tx-in-redeemer-value JSON_VALUE
                                                       )
                                                       --withdrawal-reference-tx-in-execution-units (INT, INT)
                                                     ]]
@@ -122,17 +122,17 @@ Usage: cardano-cli conway transaction build-raw
                                                   [--vote-file FILE
                                                     [--vote-script-file FILE
                                                       [
-                                                        ( --vote-redeemer-cbor-file CBOR FILE
-                                                        | --vote-redeemer-file JSON FILE
-                                                        | --vote-redeemer-value JSON VALUE
+                                                        ( --vote-redeemer-cbor-file CBOR_FILE
+                                                        | --vote-redeemer-file JSON_FILE
+                                                        | --vote-redeemer-value JSON_VALUE
                                                         )
                                                         --vote-execution-units (INT, INT)]]]
                                                   [--proposal-file FILE
                                                     [--proposal-script-file FILE
                                                       [
-                                                        ( --proposal-redeemer-cbor-file CBOR FILE
-                                                        | --proposal-redeemer-file JSON FILE
-                                                        | --proposal-redeemer-value JSON VALUE
+                                                        ( --proposal-redeemer-cbor-file CBOR_FILE
+                                                        | --proposal-redeemer-file JSON_FILE
+                                                        | --proposal-redeemer-value JSON_VALUE
                                                         )
                                                         --proposal-execution-units (INT, INT)]]]
                                                   --out-file FILE
@@ -154,28 +154,28 @@ Available options:
                            Specify a plutus script v2 reference script.
   --spending-plutus-script-v3
                            Specify a plutus script v3 reference script.
-  --spending-reference-tx-in-datum-cbor-file CBOR FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-datum-file JSON FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-datum-value JSON VALUE
-                           The script datum, in JSON syntax. There is no schema:
-                           (almost) any JSON value is supported, including
-                           top-level strings and numbers.
+  --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                           The script datum file. The file has to be in CBOR
+                           format.
+  --spending-reference-tx-in-datum-file JSON_FILE
+                           The script datum file. The file must follow the
+                           detailed JSON schema for script data.
+  --spending-reference-tx-in-datum-value JSON_VALUE
+                           The script datum. There is no schema: (almost) any
+                           JSON value is supported, including top-level strings
+                           and numbers.
   --spending-reference-tx-in-inline-datum-present
                            Inline datum present at transaction input.
-  --spending-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --spending-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --spending-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --spending-reference-tx-in-execution-units (INT, INT)
                            The time and space units needed by the script.
   --simple-script-tx-in-reference TX-IN
@@ -183,28 +183,28 @@ Available options:
                            input must have a simple reference script attached.
   --tx-in-script-file FILE The file containing the script to witness the
                            spending of the transaction input.
-  --tx-in-datum-cbor-file CBOR FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-datum-file JSON FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-datum-value JSON VALUE
-                           The script datum, in JSON syntax. There is no schema:
-                           (almost) any JSON value is supported, including
-                           top-level strings and numbers.
+  --tx-in-datum-cbor-file CBOR_FILE
+                           The script datum file. The file has to be in CBOR
+                           format.
+  --tx-in-datum-file JSON_FILE
+                           The script datum file. The file must follow the
+                           detailed JSON schema for script data.
+  --tx-in-datum-value JSON_VALUE
+                           The script datum. There is no schema: (almost) any
+                           JSON value is supported, including top-level strings
+                           and numbers.
   --tx-in-inline-datum-present
                            Inline datum present at transaction input.
-  --tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --tx-in-execution-units (INT, INT)
                            The time and space units needed by the script.
   --read-only-tx-in-reference TX-IN
@@ -235,61 +235,60 @@ Available options:
                            Lovelace).
   --tx-out-datum-hash HASH The script datum hash for this tx output, as the raw
                            datum hash (in hex).
-  --tx-out-datum-hash-cbor-file CBOR FILE
+  --tx-out-datum-hash-cbor-file CBOR_FILE
                            The script datum hash for this tx output, by hashing
-                           the script datum in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-out-datum-hash-file JSON FILE
+                           the script datum in the file. The file has to be in
+                           CBOR format.
+  --tx-out-datum-hash-file JSON_FILE
                            The script datum hash for this tx output, by hashing
-                           the script datum in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-out-datum-hash-value JSON VALUE
+                           the script datum in the file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-datum-hash-value JSON_VALUE
                            The script datum hash for this tx output, by hashing
-                           the script datum given here in JSON syntax. There is
-                           no schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
-  --tx-out-datum-embed-cbor-file CBOR FILE
-                           The script datum to embed in the tx for this output,
-                           in the given JSON file. The file must follow the
-                           special JSON schema for script data.
-  --tx-out-datum-embed-file JSON FILE
-                           The script datum to embed in the tx for this output,
-                           in the given JSON file. The file must follow the
-                           special JSON schema for script data.
-  --tx-out-datum-embed-value JSON VALUE
-                           The script datum to embed in the tx for this output,
-                           given here in JSON syntax. There is no schema:
+                           the script datum given here. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
-  --tx-out-inline-datum-cbor-file CBOR FILE
+  --tx-out-datum-embed-cbor-file CBOR_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file has to be in CBOR format.
+  --tx-out-datum-embed-file JSON_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file must follow the detailed
+                           JSON schema for script data.
+  --tx-out-datum-embed-value JSON_VALUE
+                           The script datum to embed in the tx for this output,
+                           given here. There is no schema: (almost) any JSON
+                           value is supported, including top-level strings and
+                           numbers.
+  --tx-out-inline-datum-cbor-file CBOR_FILE
                            The script datum to embed in the tx output as an
-                           inline datum, in the given JSON file. The file must
-                           follow the special JSON schema for script data.
-  --tx-out-inline-datum-file JSON FILE
+                           inline datum, in the given file. The file has to be
+                           in CBOR format.
+  --tx-out-inline-datum-file JSON_FILE
                            The script datum to embed in the tx output as an
-                           inline datum, in the given JSON file. The file must
-                           follow the special JSON schema for script data.
-  --tx-out-inline-datum-value JSON VALUE
+                           inline datum, in the given file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-inline-datum-value JSON_VALUE
                            The script datum to embed in the tx output as an
-                           inline datum, given here in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+                           inline datum, given here. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --tx-out-reference-script-file FILE
                            Reference script input file.
   --mint VALUE             Mint multi-asset value(s) with the multi-asset cli
                            syntax. You must specify a script witness.
   --mint-script-file FILE  The file containing the script to witness the minting
                            of assets for a particular policy Id.
-  --mint-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --mint-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --mint-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --mint-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --mint-execution-units (INT, INT)
                            The time and space units needed by the script.
   --simple-minting-script-tx-in-reference TX-IN
@@ -301,16 +300,16 @@ Available options:
                            input must have a plutus reference script attached.
   --mint-plutus-script-v2  Specify a plutus script v2 reference script.
   --mint-plutus-script-v3  Specify a plutus script v3 reference script.
-  --mint-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --mint-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --mint-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --mint-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --mint-reference-tx-in-execution-units (INT, INT)
                            The time and space units needed by the script.
   --policy-id HASH         Policy id of minting script.
@@ -324,16 +323,16 @@ Available options:
   --certificate-script-file FILE
                            The file containing the script to witness the use of
                            the certificate.
-  --certificate-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --certificate-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --certificate-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --certificate-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --certificate-execution-units (INT, INT)
                            The time and space units needed by the script.
   --certificate-tx-in-reference TX-IN
@@ -343,16 +342,16 @@ Available options:
                            Specify a plutus script v2 reference script.
   --certificate-plutus-script-v3
                            Specify a plutus script v3 reference script.
-  --certificate-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --certificate-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --certificate-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --certificate-reference-tx-in-execution-units (INT, INT)
                            The time and space units needed by the script.
   --withdrawal WITHDRAWAL  The reward withdrawal as StakeAddress+Lovelace where
@@ -362,16 +361,16 @@ Available options:
   --withdrawal-script-file FILE
                            The file containing the script to witness the
                            withdrawal of rewards.
-  --withdrawal-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --withdrawal-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --withdrawal-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --withdrawal-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --withdrawal-execution-units (INT, INT)
                            The time and space units needed by the script.
   --withdrawal-tx-in-reference TX-IN
@@ -381,16 +380,16 @@ Available options:
                            Specify a plutus script v2 reference script.
   --withdrawal-plutus-script-v3
                            Specify a plutus script v3 reference script.
-  --withdrawal-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --withdrawal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --withdrawal-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --withdrawal-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --withdrawal-reference-tx-in-execution-units (INT, INT)
                            The time and space units needed by the script.
   --json-metadata-no-schema
@@ -409,31 +408,31 @@ Available options:
                            Filepath of the JSON-encoded protocol parameters file
   --vote-file FILE         Filepath of the vote.
   --vote-script-file FILE  The file containing the script to witness a vote
-  --vote-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --vote-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --vote-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --vote-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --vote-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --vote-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --vote-execution-units (INT, INT)
                            The time and space units needed by the script.
   --proposal-file FILE     Filepath of the proposal.
   --proposal-script-file FILE
                            The file containing the script to witness a proposal
-  --proposal-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --proposal-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --proposal-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --proposal-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --proposal-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --proposal-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --proposal-execution-units (INT, INT)
                            The time and space units needed by the script.
   --out-file FILE          Output filepath of the JSON TxBody.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_build.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_build.cli
@@ -13,26 +13,26 @@ Usage: cardano-cli conway transaction build --socket-path SOCKET_PATH
                                                   ( --spending-plutus-script-v2
                                                   | --spending-plutus-script-v3
                                                   )
-                                                  ( --spending-reference-tx-in-datum-cbor-file CBOR FILE
-                                                  | --spending-reference-tx-in-datum-file JSON FILE
-                                                  | --spending-reference-tx-in-datum-value JSON VALUE
+                                                  ( --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                                                  | --spending-reference-tx-in-datum-file JSON_FILE
+                                                  | --spending-reference-tx-in-datum-value JSON_VALUE
                                                   | --spending-reference-tx-in-inline-datum-present
                                                   )
-                                                  ( --spending-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                  | --spending-reference-tx-in-redeemer-file JSON FILE
-                                                  | --spending-reference-tx-in-redeemer-value JSON VALUE
+                                                  ( --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                  | --spending-reference-tx-in-redeemer-file JSON_FILE
+                                                  | --spending-reference-tx-in-redeemer-value JSON_VALUE
                                                   )
                                                 | --simple-script-tx-in-reference TX-IN
                                                 | --tx-in-script-file FILE
                                                   [
-                                                    ( --tx-in-datum-cbor-file CBOR FILE
-                                                    | --tx-in-datum-file JSON FILE
-                                                    | --tx-in-datum-value JSON VALUE
+                                                    ( --tx-in-datum-cbor-file CBOR_FILE
+                                                    | --tx-in-datum-file JSON_FILE
+                                                    | --tx-in-datum-value JSON_VALUE
                                                     | --tx-in-inline-datum-present
                                                     )
-                                                    ( --tx-in-redeemer-cbor-file CBOR FILE
-                                                    | --tx-in-redeemer-file JSON FILE
-                                                    | --tx-in-redeemer-value JSON VALUE
+                                                    ( --tx-in-redeemer-cbor-file CBOR_FILE
+                                                    | --tx-in-redeemer-file JSON_FILE
+                                                    | --tx-in-redeemer-value JSON_VALUE
                                                     )]
                                                 ])
                                               [--read-only-tx-in-reference TX-IN]
@@ -44,23 +44,23 @@ Usage: cardano-cli conway transaction build --socket-path SOCKET_PATH
                                               [--tx-total-collateral INTEGER]
                                               [--tx-out ADDRESS VALUE
                                                 [ --tx-out-datum-hash HASH
-                                                | --tx-out-datum-hash-cbor-file CBOR FILE
-                                                | --tx-out-datum-hash-file JSON FILE
-                                                | --tx-out-datum-hash-value JSON VALUE
-                                                | --tx-out-datum-embed-cbor-file CBOR FILE
-                                                | --tx-out-datum-embed-file JSON FILE
-                                                | --tx-out-datum-embed-value JSON VALUE
-                                                | --tx-out-inline-datum-cbor-file CBOR FILE
-                                                | --tx-out-inline-datum-file JSON FILE
-                                                | --tx-out-inline-datum-value JSON VALUE
+                                                | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                | --tx-out-datum-hash-file JSON_FILE
+                                                | --tx-out-datum-hash-value JSON_VALUE
+                                                | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                | --tx-out-datum-embed-file JSON_FILE
+                                                | --tx-out-datum-embed-value JSON_VALUE
+                                                | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                | --tx-out-inline-datum-file JSON_FILE
+                                                | --tx-out-inline-datum-value JSON_VALUE
                                                 ]
                                                 [--tx-out-reference-script-file FILE]]
                                               --change-address ADDRESS
                                               [--mint VALUE
                                                 ( --mint-script-file FILE
-                                                  [ --mint-redeemer-cbor-file CBOR FILE
-                                                  | --mint-redeemer-file JSON FILE
-                                                  | --mint-redeemer-value JSON VALUE
+                                                  [ --mint-redeemer-cbor-file CBOR_FILE
+                                                  | --mint-redeemer-file JSON_FILE
+                                                  | --mint-redeemer-value JSON_VALUE
                                                   ]
                                                 | --simple-minting-script-tx-in-reference TX-IN
                                                   --policy-id HASH
@@ -68,9 +68,9 @@ Usage: cardano-cli conway transaction build --socket-path SOCKET_PATH
                                                   ( --mint-plutus-script-v2
                                                   | --mint-plutus-script-v3
                                                   )
-                                                  ( --mint-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                  | --mint-reference-tx-in-redeemer-file JSON FILE
-                                                  | --mint-reference-tx-in-redeemer-value JSON VALUE
+                                                  ( --mint-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                  | --mint-reference-tx-in-redeemer-file JSON_FILE
+                                                  | --mint-reference-tx-in-redeemer-value JSON_VALUE
                                                   )
                                                   --policy-id HASH
                                                 )]
@@ -78,32 +78,32 @@ Usage: cardano-cli conway transaction build --socket-path SOCKET_PATH
                                               [--invalid-hereafter SLOT]
                                               [--certificate-file FILE
                                                 [ --certificate-script-file FILE
-                                                  [ --certificate-redeemer-cbor-file CBOR FILE
-                                                  | --certificate-redeemer-file JSON FILE
-                                                  | --certificate-redeemer-value JSON VALUE
+                                                  [ --certificate-redeemer-cbor-file CBOR_FILE
+                                                  | --certificate-redeemer-file JSON_FILE
+                                                  | --certificate-redeemer-value JSON_VALUE
                                                   ]
                                                 | --certificate-tx-in-reference TX-IN
                                                   ( --certificate-plutus-script-v2
                                                   | --certificate-plutus-script-v3
                                                   )
-                                                  ( --certificate-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                  | --certificate-reference-tx-in-redeemer-file JSON FILE
-                                                  | --certificate-reference-tx-in-redeemer-value JSON VALUE
+                                                  ( --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                  | --certificate-reference-tx-in-redeemer-file JSON_FILE
+                                                  | --certificate-reference-tx-in-redeemer-value JSON_VALUE
                                                   )
                                                 ]]
                                               [--withdrawal WITHDRAWAL
                                                 [ --withdrawal-script-file FILE
-                                                  [ --withdrawal-redeemer-cbor-file CBOR FILE
-                                                  | --withdrawal-redeemer-file JSON FILE
-                                                  | --withdrawal-redeemer-value JSON VALUE
+                                                  [ --withdrawal-redeemer-cbor-file CBOR_FILE
+                                                  | --withdrawal-redeemer-file JSON_FILE
+                                                  | --withdrawal-redeemer-value JSON_VALUE
                                                   ]
                                                 | --withdrawal-tx-in-reference TX-IN
                                                   ( --withdrawal-plutus-script-v2
                                                   | --withdrawal-plutus-script-v3
                                                   )
-                                                  ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                  | --withdrawal-reference-tx-in-redeemer-file JSON FILE
-                                                  | --withdrawal-reference-tx-in-redeemer-value JSON VALUE
+                                                  ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                  | --withdrawal-reference-tx-in-redeemer-file JSON_FILE
+                                                  | --withdrawal-reference-tx-in-redeemer-value JSON_VALUE
                                                   )
                                                 ]]
                                               [ --json-metadata-no-schema
@@ -115,15 +115,15 @@ Usage: cardano-cli conway transaction build --socket-path SOCKET_PATH
                                               ]
                                               [--vote-file FILE
                                                 [--vote-script-file FILE
-                                                  [ --vote-redeemer-cbor-file CBOR FILE
-                                                  | --vote-redeemer-file JSON FILE
-                                                  | --vote-redeemer-value JSON VALUE
+                                                  [ --vote-redeemer-cbor-file CBOR_FILE
+                                                  | --vote-redeemer-file JSON_FILE
+                                                  | --vote-redeemer-value JSON_VALUE
                                                   ]]]
                                               [--proposal-file FILE
                                                 [--proposal-script-file FILE
-                                                  [ --proposal-redeemer-cbor-file CBOR FILE
-                                                  | --proposal-redeemer-file JSON FILE
-                                                  | --proposal-redeemer-value JSON VALUE
+                                                  [ --proposal-redeemer-cbor-file CBOR_FILE
+                                                  | --proposal-redeemer-file JSON_FILE
+                                                  | --proposal-redeemer-value JSON_VALUE
                                                   ]]]
                                               ( --out-file FILE
                                               | --calculate-plutus-script-cost FILE
@@ -161,55 +161,55 @@ Available options:
                            Specify a plutus script v2 reference script.
   --spending-plutus-script-v3
                            Specify a plutus script v3 reference script.
-  --spending-reference-tx-in-datum-cbor-file CBOR FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-datum-file JSON FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-datum-value JSON VALUE
-                           The script datum, in JSON syntax. There is no schema:
-                           (almost) any JSON value is supported, including
-                           top-level strings and numbers.
+  --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                           The script datum file. The file has to be in CBOR
+                           format.
+  --spending-reference-tx-in-datum-file JSON_FILE
+                           The script datum file. The file must follow the
+                           detailed JSON schema for script data.
+  --spending-reference-tx-in-datum-value JSON_VALUE
+                           The script datum. There is no schema: (almost) any
+                           JSON value is supported, including top-level strings
+                           and numbers.
   --spending-reference-tx-in-inline-datum-present
                            Inline datum present at transaction input.
-  --spending-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --spending-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --spending-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --simple-script-tx-in-reference TX-IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a simple reference script attached.
   --tx-in-script-file FILE The file containing the script to witness the
                            spending of the transaction input.
-  --tx-in-datum-cbor-file CBOR FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-datum-file JSON FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-datum-value JSON VALUE
-                           The script datum, in JSON syntax. There is no schema:
-                           (almost) any JSON value is supported, including
-                           top-level strings and numbers.
+  --tx-in-datum-cbor-file CBOR_FILE
+                           The script datum file. The file has to be in CBOR
+                           format.
+  --tx-in-datum-file JSON_FILE
+                           The script datum file. The file must follow the
+                           detailed JSON schema for script data.
+  --tx-in-datum-value JSON_VALUE
+                           The script datum. There is no schema: (almost) any
+                           JSON value is supported, including top-level strings
+                           and numbers.
   --tx-in-inline-datum-present
                            Inline datum present at transaction input.
-  --tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --read-only-tx-in-reference TX-IN
                            Specify a read only reference input. This reference
                            input is not witnessing anything it is simply
@@ -238,45 +238,44 @@ Available options:
                            Lovelace).
   --tx-out-datum-hash HASH The script datum hash for this tx output, as the raw
                            datum hash (in hex).
-  --tx-out-datum-hash-cbor-file CBOR FILE
+  --tx-out-datum-hash-cbor-file CBOR_FILE
                            The script datum hash for this tx output, by hashing
-                           the script datum in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-out-datum-hash-file JSON FILE
+                           the script datum in the file. The file has to be in
+                           CBOR format.
+  --tx-out-datum-hash-file JSON_FILE
                            The script datum hash for this tx output, by hashing
-                           the script datum in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-out-datum-hash-value JSON VALUE
+                           the script datum in the file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-datum-hash-value JSON_VALUE
                            The script datum hash for this tx output, by hashing
-                           the script datum given here in JSON syntax. There is
-                           no schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
-  --tx-out-datum-embed-cbor-file CBOR FILE
-                           The script datum to embed in the tx for this output,
-                           in the given JSON file. The file must follow the
-                           special JSON schema for script data.
-  --tx-out-datum-embed-file JSON FILE
-                           The script datum to embed in the tx for this output,
-                           in the given JSON file. The file must follow the
-                           special JSON schema for script data.
-  --tx-out-datum-embed-value JSON VALUE
-                           The script datum to embed in the tx for this output,
-                           given here in JSON syntax. There is no schema:
+                           the script datum given here. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
-  --tx-out-inline-datum-cbor-file CBOR FILE
+  --tx-out-datum-embed-cbor-file CBOR_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file has to be in CBOR format.
+  --tx-out-datum-embed-file JSON_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file must follow the detailed
+                           JSON schema for script data.
+  --tx-out-datum-embed-value JSON_VALUE
+                           The script datum to embed in the tx for this output,
+                           given here. There is no schema: (almost) any JSON
+                           value is supported, including top-level strings and
+                           numbers.
+  --tx-out-inline-datum-cbor-file CBOR_FILE
                            The script datum to embed in the tx output as an
-                           inline datum, in the given JSON file. The file must
-                           follow the special JSON schema for script data.
-  --tx-out-inline-datum-file JSON FILE
+                           inline datum, in the given file. The file has to be
+                           in CBOR format.
+  --tx-out-inline-datum-file JSON_FILE
                            The script datum to embed in the tx output as an
-                           inline datum, in the given JSON file. The file must
-                           follow the special JSON schema for script data.
-  --tx-out-inline-datum-value JSON VALUE
+                           inline datum, in the given file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-inline-datum-value JSON_VALUE
                            The script datum to embed in the tx output as an
-                           inline datum, given here in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+                           inline datum, given here. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --tx-out-reference-script-file FILE
                            Reference script input file.
   --change-address ADDRESS Address where ADA in excess of the tx fee will go to.
@@ -284,16 +283,16 @@ Available options:
                            syntax. You must specify a script witness.
   --mint-script-file FILE  The file containing the script to witness the minting
                            of assets for a particular policy Id.
-  --mint-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --mint-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --mint-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --mint-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --simple-minting-script-tx-in-reference TX-IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a simple reference script attached.
@@ -303,16 +302,16 @@ Available options:
                            input must have a plutus reference script attached.
   --mint-plutus-script-v2  Specify a plutus script v2 reference script.
   --mint-plutus-script-v3  Specify a plutus script v3 reference script.
-  --mint-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --mint-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --mint-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --mint-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --policy-id HASH         Policy id of minting script.
   --invalid-before SLOT    Time that transaction is valid from (in slots).
   --invalid-hereafter SLOT Time that transaction is valid until (in slots).
@@ -323,16 +322,16 @@ Available options:
   --certificate-script-file FILE
                            The file containing the script to witness the use of
                            the certificate.
-  --certificate-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --certificate-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --certificate-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --certificate-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --certificate-tx-in-reference TX-IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a plutus reference script attached.
@@ -340,16 +339,16 @@ Available options:
                            Specify a plutus script v2 reference script.
   --certificate-plutus-script-v3
                            Specify a plutus script v3 reference script.
-  --certificate-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --certificate-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --certificate-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --withdrawal WITHDRAWAL  The reward withdrawal as StakeAddress+Lovelace where
                            StakeAddress is the Bech32-encoded stake address
                            followed by the amount in Lovelace. Optionally
@@ -357,16 +356,16 @@ Available options:
   --withdrawal-script-file FILE
                            The file containing the script to witness the
                            withdrawal of rewards.
-  --withdrawal-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --withdrawal-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --withdrawal-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --withdrawal-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --withdrawal-tx-in-reference TX-IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a plutus reference script attached.
@@ -374,16 +373,16 @@ Available options:
                            Specify a plutus script v2 reference script.
   --withdrawal-plutus-script-v3
                            Specify a plutus script v3 reference script.
-  --withdrawal-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --withdrawal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --withdrawal-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --withdrawal-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --json-metadata-no-schema
                            Use the "no schema" conversion from JSON to tx
                            metadata (default).
@@ -398,29 +397,29 @@ Available options:
                            Filepath of the metadata, in raw CBOR format.
   --vote-file FILE         Filepath of the vote.
   --vote-script-file FILE  The file containing the script to witness a vote
-  --vote-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --vote-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --vote-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --vote-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --vote-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --vote-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --proposal-file FILE     Filepath of the proposal.
   --proposal-script-file FILE
                            The file containing the script to witness a proposal
-  --proposal-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --proposal-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --proposal-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --proposal-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --proposal-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --proposal-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --out-file FILE          Output filepath of the JSON TxBody.
   --calculate-plutus-script-cost FILE
                            (File () Out) filepath of the script cost

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_calculate-min-required-utxo.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_calculate-min-required-utxo.cli
@@ -1,15 +1,15 @@
 Usage: cardano-cli conway transaction calculate-min-required-utxo --protocol-params-file FILE
                                                                     --tx-out ADDRESS VALUE
                                                                     [ --tx-out-datum-hash HASH
-                                                                    | --tx-out-datum-hash-cbor-file CBOR FILE
-                                                                    | --tx-out-datum-hash-file JSON FILE
-                                                                    | --tx-out-datum-hash-value JSON VALUE
-                                                                    | --tx-out-datum-embed-cbor-file CBOR FILE
-                                                                    | --tx-out-datum-embed-file JSON FILE
-                                                                    | --tx-out-datum-embed-value JSON VALUE
-                                                                    | --tx-out-inline-datum-cbor-file CBOR FILE
-                                                                    | --tx-out-inline-datum-file JSON FILE
-                                                                    | --tx-out-inline-datum-value JSON VALUE
+                                                                    | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                                    | --tx-out-datum-hash-file JSON_FILE
+                                                                    | --tx-out-datum-hash-value JSON_VALUE
+                                                                    | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                                    | --tx-out-datum-embed-file JSON_FILE
+                                                                    | --tx-out-datum-embed-value JSON_VALUE
+                                                                    | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                                    | --tx-out-inline-datum-file JSON_FILE
+                                                                    | --tx-out-inline-datum-value JSON_VALUE
                                                                     ]
                                                                     [--tx-out-reference-script-file FILE]
 
@@ -24,45 +24,44 @@ Available options:
                            Lovelace).
   --tx-out-datum-hash HASH The script datum hash for this tx output, as the raw
                            datum hash (in hex).
-  --tx-out-datum-hash-cbor-file CBOR FILE
+  --tx-out-datum-hash-cbor-file CBOR_FILE
                            The script datum hash for this tx output, by hashing
-                           the script datum in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-out-datum-hash-file JSON FILE
+                           the script datum in the file. The file has to be in
+                           CBOR format.
+  --tx-out-datum-hash-file JSON_FILE
                            The script datum hash for this tx output, by hashing
-                           the script datum in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-out-datum-hash-value JSON VALUE
+                           the script datum in the file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-datum-hash-value JSON_VALUE
                            The script datum hash for this tx output, by hashing
-                           the script datum given here in JSON syntax. There is
-                           no schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
-  --tx-out-datum-embed-cbor-file CBOR FILE
-                           The script datum to embed in the tx for this output,
-                           in the given JSON file. The file must follow the
-                           special JSON schema for script data.
-  --tx-out-datum-embed-file JSON FILE
-                           The script datum to embed in the tx for this output,
-                           in the given JSON file. The file must follow the
-                           special JSON schema for script data.
-  --tx-out-datum-embed-value JSON VALUE
-                           The script datum to embed in the tx for this output,
-                           given here in JSON syntax. There is no schema:
+                           the script datum given here. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
-  --tx-out-inline-datum-cbor-file CBOR FILE
+  --tx-out-datum-embed-cbor-file CBOR_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file has to be in CBOR format.
+  --tx-out-datum-embed-file JSON_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file must follow the detailed
+                           JSON schema for script data.
+  --tx-out-datum-embed-value JSON_VALUE
+                           The script datum to embed in the tx for this output,
+                           given here. There is no schema: (almost) any JSON
+                           value is supported, including top-level strings and
+                           numbers.
+  --tx-out-inline-datum-cbor-file CBOR_FILE
                            The script datum to embed in the tx output as an
-                           inline datum, in the given JSON file. The file must
-                           follow the special JSON schema for script data.
-  --tx-out-inline-datum-file JSON FILE
+                           inline datum, in the given file. The file has to be
+                           in CBOR format.
+  --tx-out-inline-datum-file JSON_FILE
                            The script datum to embed in the tx output as an
-                           inline datum, in the given JSON file. The file must
-                           follow the special JSON schema for script data.
-  --tx-out-inline-datum-value JSON VALUE
+                           inline datum, in the given file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-inline-datum-value JSON_VALUE
                            The script datum to embed in the tx output as an
-                           inline datum, given here in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+                           inline datum, given here. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --tx-out-reference-script-file FILE
                            Reference script input file.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_calculate-min-value.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_calculate-min-value.cli
@@ -1,15 +1,15 @@
 Usage: cardano-cli conway transaction calculate-min-value --protocol-params-file FILE
                                                             --tx-out ADDRESS VALUE
                                                             [ --tx-out-datum-hash HASH
-                                                            | --tx-out-datum-hash-cbor-file CBOR FILE
-                                                            | --tx-out-datum-hash-file JSON FILE
-                                                            | --tx-out-datum-hash-value JSON VALUE
-                                                            | --tx-out-datum-embed-cbor-file CBOR FILE
-                                                            | --tx-out-datum-embed-file JSON FILE
-                                                            | --tx-out-datum-embed-value JSON VALUE
-                                                            | --tx-out-inline-datum-cbor-file CBOR FILE
-                                                            | --tx-out-inline-datum-file JSON FILE
-                                                            | --tx-out-inline-datum-value JSON VALUE
+                                                            | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                            | --tx-out-datum-hash-file JSON_FILE
+                                                            | --tx-out-datum-hash-value JSON_VALUE
+                                                            | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                            | --tx-out-datum-embed-file JSON_FILE
+                                                            | --tx-out-datum-embed-value JSON_VALUE
+                                                            | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                            | --tx-out-inline-datum-file JSON_FILE
+                                                            | --tx-out-inline-datum-value JSON_VALUE
                                                             ]
                                                             [--tx-out-reference-script-file FILE]
 
@@ -24,44 +24,43 @@ Available options:
                            Lovelace).
   --tx-out-datum-hash HASH The script datum hash for this tx output, as the raw
                            datum hash (in hex).
-  --tx-out-datum-hash-cbor-file CBOR FILE
+  --tx-out-datum-hash-cbor-file CBOR_FILE
                            The script datum hash for this tx output, by hashing
-                           the script datum in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-out-datum-hash-file JSON FILE
+                           the script datum in the file. The file has to be in
+                           CBOR format.
+  --tx-out-datum-hash-file JSON_FILE
                            The script datum hash for this tx output, by hashing
-                           the script datum in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-out-datum-hash-value JSON VALUE
+                           the script datum in the file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-datum-hash-value JSON_VALUE
                            The script datum hash for this tx output, by hashing
-                           the script datum given here in JSON syntax. There is
-                           no schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
-  --tx-out-datum-embed-cbor-file CBOR FILE
-                           The script datum to embed in the tx for this output,
-                           in the given JSON file. The file must follow the
-                           special JSON schema for script data.
-  --tx-out-datum-embed-file JSON FILE
-                           The script datum to embed in the tx for this output,
-                           in the given JSON file. The file must follow the
-                           special JSON schema for script data.
-  --tx-out-datum-embed-value JSON VALUE
-                           The script datum to embed in the tx for this output,
-                           given here in JSON syntax. There is no schema:
+                           the script datum given here. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
-  --tx-out-inline-datum-cbor-file CBOR FILE
+  --tx-out-datum-embed-cbor-file CBOR_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file has to be in CBOR format.
+  --tx-out-datum-embed-file JSON_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file must follow the detailed
+                           JSON schema for script data.
+  --tx-out-datum-embed-value JSON_VALUE
+                           The script datum to embed in the tx for this output,
+                           given here. There is no schema: (almost) any JSON
+                           value is supported, including top-level strings and
+                           numbers.
+  --tx-out-inline-datum-cbor-file CBOR_FILE
                            The script datum to embed in the tx output as an
-                           inline datum, in the given JSON file. The file must
-                           follow the special JSON schema for script data.
-  --tx-out-inline-datum-file JSON FILE
+                           inline datum, in the given file. The file has to be
+                           in CBOR format.
+  --tx-out-inline-datum-file JSON_FILE
                            The script datum to embed in the tx output as an
-                           inline datum, in the given JSON file. The file must
-                           follow the special JSON schema for script data.
-  --tx-out-inline-datum-value JSON VALUE
+                           inline datum, in the given file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-inline-datum-value JSON_VALUE
                            The script datum to embed in the tx output as an
-                           inline datum, given here in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+                           inline datum, given here. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --tx-out-reference-script-file FILE
                            Reference script input file.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_hash-script-data.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_hash-script-data.cli
@@ -1,20 +1,20 @@
 Usage: cardano-cli conway transaction hash-script-data 
-                                                         ( --script-data-cbor-file CBOR FILE
-                                                         | --script-data-file JSON FILE
-                                                         | --script-data-value JSON VALUE
+                                                         ( --script-data-cbor-file CBOR_FILE
+                                                         | --script-data-file JSON_FILE
+                                                         | --script-data-value JSON_VALUE
                                                          )
 
   Calculate the hash of script data.
 
 Available options:
-  --script-data-cbor-file CBOR FILE
-                           The script data, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --script-data-file JSON FILE
-                           The script data, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --script-data-value JSON VALUE
-                           The script data, in JSON syntax. There is no schema:
-                           (almost) any JSON value is supported, including
-                           top-level strings and numbers.
+  --script-data-cbor-file CBOR_FILE
+                           The script data file. The file has to be in CBOR
+                           format.
+  --script-data-file JSON_FILE
+                           The script data file. The file must follow the
+                           detailed JSON schema for script data.
+  --script-data-value JSON_VALUE
+                           The script data. There is no schema: (almost) any
+                           JSON value is supported, including top-level strings
+                           and numbers.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_transaction_build-estimate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_transaction_build-estimate.cli
@@ -11,27 +11,27 @@ Usage: cardano-cli latest transaction build-estimate
                                                            ( --spending-plutus-script-v2
                                                            | --spending-plutus-script-v3
                                                            )
-                                                           ( --spending-reference-tx-in-datum-cbor-file CBOR FILE
-                                                           | --spending-reference-tx-in-datum-file JSON FILE
-                                                           | --spending-reference-tx-in-datum-value JSON VALUE
+                                                           ( --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                                                           | --spending-reference-tx-in-datum-file JSON_FILE
+                                                           | --spending-reference-tx-in-datum-value JSON_VALUE
                                                            | --spending-reference-tx-in-inline-datum-present
                                                            )
-                                                           ( --spending-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                           | --spending-reference-tx-in-redeemer-file JSON FILE
-                                                           | --spending-reference-tx-in-redeemer-value JSON VALUE
+                                                           ( --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                           | --spending-reference-tx-in-redeemer-file JSON_FILE
+                                                           | --spending-reference-tx-in-redeemer-value JSON_VALUE
                                                            )
                                                            --spending-reference-tx-in-execution-units (INT, INT)
                                                          | --simple-script-tx-in-reference TX-IN
                                                          | --tx-in-script-file FILE
                                                            [
-                                                             ( --tx-in-datum-cbor-file CBOR FILE
-                                                             | --tx-in-datum-file JSON FILE
-                                                             | --tx-in-datum-value JSON VALUE
+                                                             ( --tx-in-datum-cbor-file CBOR_FILE
+                                                             | --tx-in-datum-file JSON_FILE
+                                                             | --tx-in-datum-value JSON_VALUE
                                                              | --tx-in-inline-datum-present
                                                              )
-                                                             ( --tx-in-redeemer-cbor-file CBOR FILE
-                                                             | --tx-in-redeemer-file JSON FILE
-                                                             | --tx-in-redeemer-value JSON VALUE
+                                                             ( --tx-in-redeemer-cbor-file CBOR_FILE
+                                                             | --tx-in-redeemer-file JSON_FILE
+                                                             | --tx-in-redeemer-value JSON_VALUE
                                                              )
                                                              --tx-in-execution-units (INT, INT)]
                                                          ])
@@ -43,24 +43,24 @@ Usage: cardano-cli latest transaction build-estimate
                                                        [--tx-out-return-collateral ADDRESS VALUE]
                                                        [--tx-out ADDRESS VALUE
                                                          [ --tx-out-datum-hash HASH
-                                                         | --tx-out-datum-hash-cbor-file CBOR FILE
-                                                         | --tx-out-datum-hash-file JSON FILE
-                                                         | --tx-out-datum-hash-value JSON VALUE
-                                                         | --tx-out-datum-embed-cbor-file CBOR FILE
-                                                         | --tx-out-datum-embed-file JSON FILE
-                                                         | --tx-out-datum-embed-value JSON VALUE
-                                                         | --tx-out-inline-datum-cbor-file CBOR FILE
-                                                         | --tx-out-inline-datum-file JSON FILE
-                                                         | --tx-out-inline-datum-value JSON VALUE
+                                                         | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                         | --tx-out-datum-hash-file JSON_FILE
+                                                         | --tx-out-datum-hash-value JSON_VALUE
+                                                         | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                         | --tx-out-datum-embed-file JSON_FILE
+                                                         | --tx-out-datum-embed-value JSON_VALUE
+                                                         | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                         | --tx-out-inline-datum-file JSON_FILE
+                                                         | --tx-out-inline-datum-value JSON_VALUE
                                                          ]
                                                          [--tx-out-reference-script-file FILE]]
                                                        --change-address ADDRESS
                                                        [--mint VALUE
                                                          ( --mint-script-file FILE
                                                            [
-                                                             ( --mint-redeemer-cbor-file CBOR FILE
-                                                             | --mint-redeemer-file JSON FILE
-                                                             | --mint-redeemer-value JSON VALUE
+                                                             ( --mint-redeemer-cbor-file CBOR_FILE
+                                                             | --mint-redeemer-file JSON_FILE
+                                                             | --mint-redeemer-value JSON_VALUE
                                                              )
                                                              --mint-execution-units (INT, INT)]
                                                          | --simple-minting-script-tx-in-reference TX-IN
@@ -69,9 +69,9 @@ Usage: cardano-cli latest transaction build-estimate
                                                            ( --mint-plutus-script-v2
                                                            | --mint-plutus-script-v3
                                                            )
-                                                           ( --mint-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                           | --mint-reference-tx-in-redeemer-file JSON FILE
-                                                           | --mint-reference-tx-in-redeemer-value JSON VALUE
+                                                           ( --mint-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                           | --mint-reference-tx-in-redeemer-file JSON_FILE
+                                                           | --mint-reference-tx-in-redeemer-value JSON_VALUE
                                                            )
                                                            --mint-reference-tx-in-execution-units (INT, INT)
                                                            --policy-id HASH
@@ -81,36 +81,36 @@ Usage: cardano-cli latest transaction build-estimate
                                                        [--certificate-file FILE
                                                          [ --certificate-script-file FILE
                                                            [
-                                                             ( --certificate-redeemer-cbor-file CBOR FILE
-                                                             | --certificate-redeemer-file JSON FILE
-                                                             | --certificate-redeemer-value JSON VALUE
+                                                             ( --certificate-redeemer-cbor-file CBOR_FILE
+                                                             | --certificate-redeemer-file JSON_FILE
+                                                             | --certificate-redeemer-value JSON_VALUE
                                                              )
                                                              --certificate-execution-units (INT, INT)]
                                                          | --certificate-tx-in-reference TX-IN
                                                            ( --certificate-plutus-script-v2
                                                            | --certificate-plutus-script-v3
                                                            )
-                                                           ( --certificate-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                           | --certificate-reference-tx-in-redeemer-file JSON FILE
-                                                           | --certificate-reference-tx-in-redeemer-value JSON VALUE
+                                                           ( --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                           | --certificate-reference-tx-in-redeemer-file JSON_FILE
+                                                           | --certificate-reference-tx-in-redeemer-value JSON_VALUE
                                                            )
                                                            --certificate-reference-tx-in-execution-units (INT, INT)
                                                          ]]
                                                        [--withdrawal WITHDRAWAL
                                                          [ --withdrawal-script-file FILE
                                                            [
-                                                             ( --withdrawal-redeemer-cbor-file CBOR FILE
-                                                             | --withdrawal-redeemer-file JSON FILE
-                                                             | --withdrawal-redeemer-value JSON VALUE
+                                                             ( --withdrawal-redeemer-cbor-file CBOR_FILE
+                                                             | --withdrawal-redeemer-file JSON_FILE
+                                                             | --withdrawal-redeemer-value JSON_VALUE
                                                              )
                                                              --withdrawal-execution-units (INT, INT)]
                                                          | --withdrawal-tx-in-reference TX-IN
                                                            ( --withdrawal-plutus-script-v2
                                                            | --withdrawal-plutus-script-v3
                                                            )
-                                                           ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                           | --withdrawal-reference-tx-in-redeemer-file JSON FILE
-                                                           | --withdrawal-reference-tx-in-redeemer-value JSON VALUE
+                                                           ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                           | --withdrawal-reference-tx-in-redeemer-file JSON_FILE
+                                                           | --withdrawal-reference-tx-in-redeemer-value JSON_VALUE
                                                            )
                                                            --withdrawal-reference-tx-in-execution-units (INT, INT)
                                                          ]]
@@ -153,28 +153,28 @@ Available options:
                            Specify a plutus script v2 reference script.
   --spending-plutus-script-v3
                            Specify a plutus script v3 reference script.
-  --spending-reference-tx-in-datum-cbor-file CBOR FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-datum-file JSON FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-datum-value JSON VALUE
-                           The script datum, in JSON syntax. There is no schema:
-                           (almost) any JSON value is supported, including
-                           top-level strings and numbers.
+  --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                           The script datum file. The file has to be in CBOR
+                           format.
+  --spending-reference-tx-in-datum-file JSON_FILE
+                           The script datum file. The file must follow the
+                           detailed JSON schema for script data.
+  --spending-reference-tx-in-datum-value JSON_VALUE
+                           The script datum. There is no schema: (almost) any
+                           JSON value is supported, including top-level strings
+                           and numbers.
   --spending-reference-tx-in-inline-datum-present
                            Inline datum present at transaction input.
-  --spending-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --spending-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --spending-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --spending-reference-tx-in-execution-units (INT, INT)
                            The time and space units needed by the script.
   --simple-script-tx-in-reference TX-IN
@@ -182,28 +182,28 @@ Available options:
                            input must have a simple reference script attached.
   --tx-in-script-file FILE The file containing the script to witness the
                            spending of the transaction input.
-  --tx-in-datum-cbor-file CBOR FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-datum-file JSON FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-datum-value JSON VALUE
-                           The script datum, in JSON syntax. There is no schema:
-                           (almost) any JSON value is supported, including
-                           top-level strings and numbers.
+  --tx-in-datum-cbor-file CBOR_FILE
+                           The script datum file. The file has to be in CBOR
+                           format.
+  --tx-in-datum-file JSON_FILE
+                           The script datum file. The file must follow the
+                           detailed JSON schema for script data.
+  --tx-in-datum-value JSON_VALUE
+                           The script datum. There is no schema: (almost) any
+                           JSON value is supported, including top-level strings
+                           and numbers.
   --tx-in-inline-datum-present
                            Inline datum present at transaction input.
-  --tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --tx-in-execution-units (INT, INT)
                            The time and space units needed by the script.
   --read-only-tx-in-reference TX-IN
@@ -229,45 +229,44 @@ Available options:
                            Lovelace).
   --tx-out-datum-hash HASH The script datum hash for this tx output, as the raw
                            datum hash (in hex).
-  --tx-out-datum-hash-cbor-file CBOR FILE
+  --tx-out-datum-hash-cbor-file CBOR_FILE
                            The script datum hash for this tx output, by hashing
-                           the script datum in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-out-datum-hash-file JSON FILE
+                           the script datum in the file. The file has to be in
+                           CBOR format.
+  --tx-out-datum-hash-file JSON_FILE
                            The script datum hash for this tx output, by hashing
-                           the script datum in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-out-datum-hash-value JSON VALUE
+                           the script datum in the file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-datum-hash-value JSON_VALUE
                            The script datum hash for this tx output, by hashing
-                           the script datum given here in JSON syntax. There is
-                           no schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
-  --tx-out-datum-embed-cbor-file CBOR FILE
-                           The script datum to embed in the tx for this output,
-                           in the given JSON file. The file must follow the
-                           special JSON schema for script data.
-  --tx-out-datum-embed-file JSON FILE
-                           The script datum to embed in the tx for this output,
-                           in the given JSON file. The file must follow the
-                           special JSON schema for script data.
-  --tx-out-datum-embed-value JSON VALUE
-                           The script datum to embed in the tx for this output,
-                           given here in JSON syntax. There is no schema:
+                           the script datum given here. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
-  --tx-out-inline-datum-cbor-file CBOR FILE
+  --tx-out-datum-embed-cbor-file CBOR_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file has to be in CBOR format.
+  --tx-out-datum-embed-file JSON_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file must follow the detailed
+                           JSON schema for script data.
+  --tx-out-datum-embed-value JSON_VALUE
+                           The script datum to embed in the tx for this output,
+                           given here. There is no schema: (almost) any JSON
+                           value is supported, including top-level strings and
+                           numbers.
+  --tx-out-inline-datum-cbor-file CBOR_FILE
                            The script datum to embed in the tx output as an
-                           inline datum, in the given JSON file. The file must
-                           follow the special JSON schema for script data.
-  --tx-out-inline-datum-file JSON FILE
+                           inline datum, in the given file. The file has to be
+                           in CBOR format.
+  --tx-out-inline-datum-file JSON_FILE
                            The script datum to embed in the tx output as an
-                           inline datum, in the given JSON file. The file must
-                           follow the special JSON schema for script data.
-  --tx-out-inline-datum-value JSON VALUE
+                           inline datum, in the given file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-inline-datum-value JSON_VALUE
                            The script datum to embed in the tx output as an
-                           inline datum, given here in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+                           inline datum, given here. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --tx-out-reference-script-file FILE
                            Reference script input file.
   --change-address ADDRESS Address where ADA in excess of the tx fee will go to.
@@ -275,16 +274,16 @@ Available options:
                            syntax. You must specify a script witness.
   --mint-script-file FILE  The file containing the script to witness the minting
                            of assets for a particular policy Id.
-  --mint-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --mint-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --mint-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --mint-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --mint-execution-units (INT, INT)
                            The time and space units needed by the script.
   --simple-minting-script-tx-in-reference TX-IN
@@ -296,16 +295,16 @@ Available options:
                            input must have a plutus reference script attached.
   --mint-plutus-script-v2  Specify a plutus script v2 reference script.
   --mint-plutus-script-v3  Specify a plutus script v3 reference script.
-  --mint-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --mint-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --mint-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --mint-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --mint-reference-tx-in-execution-units (INT, INT)
                            The time and space units needed by the script.
   --policy-id HASH         Policy id of minting script.
@@ -318,16 +317,16 @@ Available options:
   --certificate-script-file FILE
                            The file containing the script to witness the use of
                            the certificate.
-  --certificate-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --certificate-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --certificate-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --certificate-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --certificate-execution-units (INT, INT)
                            The time and space units needed by the script.
   --certificate-tx-in-reference TX-IN
@@ -337,16 +336,16 @@ Available options:
                            Specify a plutus script v2 reference script.
   --certificate-plutus-script-v3
                            Specify a plutus script v3 reference script.
-  --certificate-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --certificate-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --certificate-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --certificate-reference-tx-in-execution-units (INT, INT)
                            The time and space units needed by the script.
   --withdrawal WITHDRAWAL  The reward withdrawal as StakeAddress+Lovelace where
@@ -356,16 +355,16 @@ Available options:
   --withdrawal-script-file FILE
                            The file containing the script to witness the
                            withdrawal of rewards.
-  --withdrawal-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --withdrawal-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --withdrawal-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --withdrawal-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --withdrawal-execution-units (INT, INT)
                            The time and space units needed by the script.
   --withdrawal-tx-in-reference TX-IN
@@ -375,16 +374,16 @@ Available options:
                            Specify a plutus script v2 reference script.
   --withdrawal-plutus-script-v3
                            Specify a plutus script v3 reference script.
-  --withdrawal-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --withdrawal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --withdrawal-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --withdrawal-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --withdrawal-reference-tx-in-execution-units (INT, INT)
                            The time and space units needed by the script.
   --tx-total-collateral INTEGER

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_transaction_build-raw.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_transaction_build-raw.cli
@@ -7,27 +7,27 @@ Usage: cardano-cli latest transaction build-raw
                                                       ( --spending-plutus-script-v2
                                                       | --spending-plutus-script-v3
                                                       )
-                                                      ( --spending-reference-tx-in-datum-cbor-file CBOR FILE
-                                                      | --spending-reference-tx-in-datum-file JSON FILE
-                                                      | --spending-reference-tx-in-datum-value JSON VALUE
+                                                      ( --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                                                      | --spending-reference-tx-in-datum-file JSON_FILE
+                                                      | --spending-reference-tx-in-datum-value JSON_VALUE
                                                       | --spending-reference-tx-in-inline-datum-present
                                                       )
-                                                      ( --spending-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                      | --spending-reference-tx-in-redeemer-file JSON FILE
-                                                      | --spending-reference-tx-in-redeemer-value JSON VALUE
+                                                      ( --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                      | --spending-reference-tx-in-redeemer-file JSON_FILE
+                                                      | --spending-reference-tx-in-redeemer-value JSON_VALUE
                                                       )
                                                       --spending-reference-tx-in-execution-units (INT, INT)
                                                     | --simple-script-tx-in-reference TX-IN
                                                     | --tx-in-script-file FILE
                                                       [
-                                                        ( --tx-in-datum-cbor-file CBOR FILE
-                                                        | --tx-in-datum-file JSON FILE
-                                                        | --tx-in-datum-value JSON VALUE
+                                                        ( --tx-in-datum-cbor-file CBOR_FILE
+                                                        | --tx-in-datum-file JSON_FILE
+                                                        | --tx-in-datum-value JSON_VALUE
                                                         | --tx-in-inline-datum-present
                                                         )
-                                                        ( --tx-in-redeemer-cbor-file CBOR FILE
-                                                        | --tx-in-redeemer-file JSON FILE
-                                                        | --tx-in-redeemer-value JSON VALUE
+                                                        ( --tx-in-redeemer-cbor-file CBOR_FILE
+                                                        | --tx-in-redeemer-file JSON_FILE
+                                                        | --tx-in-redeemer-value JSON_VALUE
                                                         )
                                                         --tx-in-execution-units (INT, INT)]
                                                     ])
@@ -40,23 +40,23 @@ Usage: cardano-cli latest transaction build-raw
                                                   ]
                                                   [--tx-out ADDRESS VALUE
                                                     [ --tx-out-datum-hash HASH
-                                                    | --tx-out-datum-hash-cbor-file CBOR FILE
-                                                    | --tx-out-datum-hash-file JSON FILE
-                                                    | --tx-out-datum-hash-value JSON VALUE
-                                                    | --tx-out-datum-embed-cbor-file CBOR FILE
-                                                    | --tx-out-datum-embed-file JSON FILE
-                                                    | --tx-out-datum-embed-value JSON VALUE
-                                                    | --tx-out-inline-datum-cbor-file CBOR FILE
-                                                    | --tx-out-inline-datum-file JSON FILE
-                                                    | --tx-out-inline-datum-value JSON VALUE
+                                                    | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                    | --tx-out-datum-hash-file JSON_FILE
+                                                    | --tx-out-datum-hash-value JSON_VALUE
+                                                    | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                    | --tx-out-datum-embed-file JSON_FILE
+                                                    | --tx-out-datum-embed-value JSON_VALUE
+                                                    | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                    | --tx-out-inline-datum-file JSON_FILE
+                                                    | --tx-out-inline-datum-value JSON_VALUE
                                                     ]
                                                     [--tx-out-reference-script-file FILE]]
                                                   [--mint VALUE
                                                     ( --mint-script-file FILE
                                                       [
-                                                        ( --mint-redeemer-cbor-file CBOR FILE
-                                                        | --mint-redeemer-file JSON FILE
-                                                        | --mint-redeemer-value JSON VALUE
+                                                        ( --mint-redeemer-cbor-file CBOR_FILE
+                                                        | --mint-redeemer-file JSON_FILE
+                                                        | --mint-redeemer-value JSON_VALUE
                                                         )
                                                         --mint-execution-units (INT, INT)]
                                                     | --simple-minting-script-tx-in-reference TX-IN
@@ -65,9 +65,9 @@ Usage: cardano-cli latest transaction build-raw
                                                       ( --mint-plutus-script-v2
                                                       | --mint-plutus-script-v3
                                                       )
-                                                      ( --mint-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                      | --mint-reference-tx-in-redeemer-file JSON FILE
-                                                      | --mint-reference-tx-in-redeemer-value JSON VALUE
+                                                      ( --mint-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                      | --mint-reference-tx-in-redeemer-file JSON_FILE
+                                                      | --mint-reference-tx-in-redeemer-value JSON_VALUE
                                                       )
                                                       --mint-reference-tx-in-execution-units (INT, INT)
                                                       --policy-id HASH
@@ -78,36 +78,36 @@ Usage: cardano-cli latest transaction build-raw
                                                   [--certificate-file FILE
                                                     [ --certificate-script-file FILE
                                                       [
-                                                        ( --certificate-redeemer-cbor-file CBOR FILE
-                                                        | --certificate-redeemer-file JSON FILE
-                                                        | --certificate-redeemer-value JSON VALUE
+                                                        ( --certificate-redeemer-cbor-file CBOR_FILE
+                                                        | --certificate-redeemer-file JSON_FILE
+                                                        | --certificate-redeemer-value JSON_VALUE
                                                         )
                                                         --certificate-execution-units (INT, INT)]
                                                     | --certificate-tx-in-reference TX-IN
                                                       ( --certificate-plutus-script-v2
                                                       | --certificate-plutus-script-v3
                                                       )
-                                                      ( --certificate-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                      | --certificate-reference-tx-in-redeemer-file JSON FILE
-                                                      | --certificate-reference-tx-in-redeemer-value JSON VALUE
+                                                      ( --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                      | --certificate-reference-tx-in-redeemer-file JSON_FILE
+                                                      | --certificate-reference-tx-in-redeemer-value JSON_VALUE
                                                       )
                                                       --certificate-reference-tx-in-execution-units (INT, INT)
                                                     ]]
                                                   [--withdrawal WITHDRAWAL
                                                     [ --withdrawal-script-file FILE
                                                       [
-                                                        ( --withdrawal-redeemer-cbor-file CBOR FILE
-                                                        | --withdrawal-redeemer-file JSON FILE
-                                                        | --withdrawal-redeemer-value JSON VALUE
+                                                        ( --withdrawal-redeemer-cbor-file CBOR_FILE
+                                                        | --withdrawal-redeemer-file JSON_FILE
+                                                        | --withdrawal-redeemer-value JSON_VALUE
                                                         )
                                                         --withdrawal-execution-units (INT, INT)]
                                                     | --withdrawal-tx-in-reference TX-IN
                                                       ( --withdrawal-plutus-script-v2
                                                       | --withdrawal-plutus-script-v3
                                                       )
-                                                      ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                      | --withdrawal-reference-tx-in-redeemer-file JSON FILE
-                                                      | --withdrawal-reference-tx-in-redeemer-value JSON VALUE
+                                                      ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                      | --withdrawal-reference-tx-in-redeemer-file JSON_FILE
+                                                      | --withdrawal-reference-tx-in-redeemer-value JSON_VALUE
                                                       )
                                                       --withdrawal-reference-tx-in-execution-units (INT, INT)
                                                     ]]
@@ -139,28 +139,28 @@ Available options:
                            Specify a plutus script v2 reference script.
   --spending-plutus-script-v3
                            Specify a plutus script v3 reference script.
-  --spending-reference-tx-in-datum-cbor-file CBOR FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-datum-file JSON FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-datum-value JSON VALUE
-                           The script datum, in JSON syntax. There is no schema:
-                           (almost) any JSON value is supported, including
-                           top-level strings and numbers.
+  --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                           The script datum file. The file has to be in CBOR
+                           format.
+  --spending-reference-tx-in-datum-file JSON_FILE
+                           The script datum file. The file must follow the
+                           detailed JSON schema for script data.
+  --spending-reference-tx-in-datum-value JSON_VALUE
+                           The script datum. There is no schema: (almost) any
+                           JSON value is supported, including top-level strings
+                           and numbers.
   --spending-reference-tx-in-inline-datum-present
                            Inline datum present at transaction input.
-  --spending-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --spending-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --spending-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --spending-reference-tx-in-execution-units (INT, INT)
                            The time and space units needed by the script.
   --simple-script-tx-in-reference TX-IN
@@ -168,28 +168,28 @@ Available options:
                            input must have a simple reference script attached.
   --tx-in-script-file FILE The file containing the script to witness the
                            spending of the transaction input.
-  --tx-in-datum-cbor-file CBOR FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-datum-file JSON FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-datum-value JSON VALUE
-                           The script datum, in JSON syntax. There is no schema:
-                           (almost) any JSON value is supported, including
-                           top-level strings and numbers.
+  --tx-in-datum-cbor-file CBOR_FILE
+                           The script datum file. The file has to be in CBOR
+                           format.
+  --tx-in-datum-file JSON_FILE
+                           The script datum file. The file must follow the
+                           detailed JSON schema for script data.
+  --tx-in-datum-value JSON_VALUE
+                           The script datum. There is no schema: (almost) any
+                           JSON value is supported, including top-level strings
+                           and numbers.
   --tx-in-inline-datum-present
                            Inline datum present at transaction input.
-  --tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --tx-in-execution-units (INT, INT)
                            The time and space units needed by the script.
   --read-only-tx-in-reference TX-IN
@@ -220,61 +220,60 @@ Available options:
                            Lovelace).
   --tx-out-datum-hash HASH The script datum hash for this tx output, as the raw
                            datum hash (in hex).
-  --tx-out-datum-hash-cbor-file CBOR FILE
+  --tx-out-datum-hash-cbor-file CBOR_FILE
                            The script datum hash for this tx output, by hashing
-                           the script datum in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-out-datum-hash-file JSON FILE
+                           the script datum in the file. The file has to be in
+                           CBOR format.
+  --tx-out-datum-hash-file JSON_FILE
                            The script datum hash for this tx output, by hashing
-                           the script datum in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-out-datum-hash-value JSON VALUE
+                           the script datum in the file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-datum-hash-value JSON_VALUE
                            The script datum hash for this tx output, by hashing
-                           the script datum given here in JSON syntax. There is
-                           no schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
-  --tx-out-datum-embed-cbor-file CBOR FILE
-                           The script datum to embed in the tx for this output,
-                           in the given JSON file. The file must follow the
-                           special JSON schema for script data.
-  --tx-out-datum-embed-file JSON FILE
-                           The script datum to embed in the tx for this output,
-                           in the given JSON file. The file must follow the
-                           special JSON schema for script data.
-  --tx-out-datum-embed-value JSON VALUE
-                           The script datum to embed in the tx for this output,
-                           given here in JSON syntax. There is no schema:
+                           the script datum given here. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
-  --tx-out-inline-datum-cbor-file CBOR FILE
+  --tx-out-datum-embed-cbor-file CBOR_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file has to be in CBOR format.
+  --tx-out-datum-embed-file JSON_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file must follow the detailed
+                           JSON schema for script data.
+  --tx-out-datum-embed-value JSON_VALUE
+                           The script datum to embed in the tx for this output,
+                           given here. There is no schema: (almost) any JSON
+                           value is supported, including top-level strings and
+                           numbers.
+  --tx-out-inline-datum-cbor-file CBOR_FILE
                            The script datum to embed in the tx output as an
-                           inline datum, in the given JSON file. The file must
-                           follow the special JSON schema for script data.
-  --tx-out-inline-datum-file JSON FILE
+                           inline datum, in the given file. The file has to be
+                           in CBOR format.
+  --tx-out-inline-datum-file JSON_FILE
                            The script datum to embed in the tx output as an
-                           inline datum, in the given JSON file. The file must
-                           follow the special JSON schema for script data.
-  --tx-out-inline-datum-value JSON VALUE
+                           inline datum, in the given file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-inline-datum-value JSON_VALUE
                            The script datum to embed in the tx output as an
-                           inline datum, given here in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+                           inline datum, given here. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --tx-out-reference-script-file FILE
                            Reference script input file.
   --mint VALUE             Mint multi-asset value(s) with the multi-asset cli
                            syntax. You must specify a script witness.
   --mint-script-file FILE  The file containing the script to witness the minting
                            of assets for a particular policy Id.
-  --mint-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --mint-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --mint-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --mint-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --mint-execution-units (INT, INT)
                            The time and space units needed by the script.
   --simple-minting-script-tx-in-reference TX-IN
@@ -286,16 +285,16 @@ Available options:
                            input must have a plutus reference script attached.
   --mint-plutus-script-v2  Specify a plutus script v2 reference script.
   --mint-plutus-script-v3  Specify a plutus script v3 reference script.
-  --mint-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --mint-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --mint-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --mint-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --mint-reference-tx-in-execution-units (INT, INT)
                            The time and space units needed by the script.
   --policy-id HASH         Policy id of minting script.
@@ -309,16 +308,16 @@ Available options:
   --certificate-script-file FILE
                            The file containing the script to witness the use of
                            the certificate.
-  --certificate-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --certificate-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --certificate-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --certificate-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --certificate-execution-units (INT, INT)
                            The time and space units needed by the script.
   --certificate-tx-in-reference TX-IN
@@ -328,16 +327,16 @@ Available options:
                            Specify a plutus script v2 reference script.
   --certificate-plutus-script-v3
                            Specify a plutus script v3 reference script.
-  --certificate-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --certificate-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --certificate-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --certificate-reference-tx-in-execution-units (INT, INT)
                            The time and space units needed by the script.
   --withdrawal WITHDRAWAL  The reward withdrawal as StakeAddress+Lovelace where
@@ -347,16 +346,16 @@ Available options:
   --withdrawal-script-file FILE
                            The file containing the script to witness the
                            withdrawal of rewards.
-  --withdrawal-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --withdrawal-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --withdrawal-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --withdrawal-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --withdrawal-execution-units (INT, INT)
                            The time and space units needed by the script.
   --withdrawal-tx-in-reference TX-IN
@@ -366,16 +365,16 @@ Available options:
                            Specify a plutus script v2 reference script.
   --withdrawal-plutus-script-v3
                            Specify a plutus script v3 reference script.
-  --withdrawal-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --withdrawal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --withdrawal-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --withdrawal-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --withdrawal-reference-tx-in-execution-units (INT, INT)
                            The time and space units needed by the script.
   --json-metadata-no-schema

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_transaction_build.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_transaction_build.cli
@@ -13,26 +13,26 @@ Usage: cardano-cli latest transaction build --socket-path SOCKET_PATH
                                                   ( --spending-plutus-script-v2
                                                   | --spending-plutus-script-v3
                                                   )
-                                                  ( --spending-reference-tx-in-datum-cbor-file CBOR FILE
-                                                  | --spending-reference-tx-in-datum-file JSON FILE
-                                                  | --spending-reference-tx-in-datum-value JSON VALUE
+                                                  ( --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                                                  | --spending-reference-tx-in-datum-file JSON_FILE
+                                                  | --spending-reference-tx-in-datum-value JSON_VALUE
                                                   | --spending-reference-tx-in-inline-datum-present
                                                   )
-                                                  ( --spending-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                  | --spending-reference-tx-in-redeemer-file JSON FILE
-                                                  | --spending-reference-tx-in-redeemer-value JSON VALUE
+                                                  ( --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                  | --spending-reference-tx-in-redeemer-file JSON_FILE
+                                                  | --spending-reference-tx-in-redeemer-value JSON_VALUE
                                                   )
                                                 | --simple-script-tx-in-reference TX-IN
                                                 | --tx-in-script-file FILE
                                                   [
-                                                    ( --tx-in-datum-cbor-file CBOR FILE
-                                                    | --tx-in-datum-file JSON FILE
-                                                    | --tx-in-datum-value JSON VALUE
+                                                    ( --tx-in-datum-cbor-file CBOR_FILE
+                                                    | --tx-in-datum-file JSON_FILE
+                                                    | --tx-in-datum-value JSON_VALUE
                                                     | --tx-in-inline-datum-present
                                                     )
-                                                    ( --tx-in-redeemer-cbor-file CBOR FILE
-                                                    | --tx-in-redeemer-file JSON FILE
-                                                    | --tx-in-redeemer-value JSON VALUE
+                                                    ( --tx-in-redeemer-cbor-file CBOR_FILE
+                                                    | --tx-in-redeemer-file JSON_FILE
+                                                    | --tx-in-redeemer-value JSON_VALUE
                                                     )]
                                                 ])
                                               [--read-only-tx-in-reference TX-IN]
@@ -44,23 +44,23 @@ Usage: cardano-cli latest transaction build --socket-path SOCKET_PATH
                                               [--tx-total-collateral INTEGER]
                                               [--tx-out ADDRESS VALUE
                                                 [ --tx-out-datum-hash HASH
-                                                | --tx-out-datum-hash-cbor-file CBOR FILE
-                                                | --tx-out-datum-hash-file JSON FILE
-                                                | --tx-out-datum-hash-value JSON VALUE
-                                                | --tx-out-datum-embed-cbor-file CBOR FILE
-                                                | --tx-out-datum-embed-file JSON FILE
-                                                | --tx-out-datum-embed-value JSON VALUE
-                                                | --tx-out-inline-datum-cbor-file CBOR FILE
-                                                | --tx-out-inline-datum-file JSON FILE
-                                                | --tx-out-inline-datum-value JSON VALUE
+                                                | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                | --tx-out-datum-hash-file JSON_FILE
+                                                | --tx-out-datum-hash-value JSON_VALUE
+                                                | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                | --tx-out-datum-embed-file JSON_FILE
+                                                | --tx-out-datum-embed-value JSON_VALUE
+                                                | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                | --tx-out-inline-datum-file JSON_FILE
+                                                | --tx-out-inline-datum-value JSON_VALUE
                                                 ]
                                                 [--tx-out-reference-script-file FILE]]
                                               --change-address ADDRESS
                                               [--mint VALUE
                                                 ( --mint-script-file FILE
-                                                  [ --mint-redeemer-cbor-file CBOR FILE
-                                                  | --mint-redeemer-file JSON FILE
-                                                  | --mint-redeemer-value JSON VALUE
+                                                  [ --mint-redeemer-cbor-file CBOR_FILE
+                                                  | --mint-redeemer-file JSON_FILE
+                                                  | --mint-redeemer-value JSON_VALUE
                                                   ]
                                                 | --simple-minting-script-tx-in-reference TX-IN
                                                   --policy-id HASH
@@ -68,9 +68,9 @@ Usage: cardano-cli latest transaction build --socket-path SOCKET_PATH
                                                   ( --mint-plutus-script-v2
                                                   | --mint-plutus-script-v3
                                                   )
-                                                  ( --mint-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                  | --mint-reference-tx-in-redeemer-file JSON FILE
-                                                  | --mint-reference-tx-in-redeemer-value JSON VALUE
+                                                  ( --mint-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                  | --mint-reference-tx-in-redeemer-file JSON_FILE
+                                                  | --mint-reference-tx-in-redeemer-value JSON_VALUE
                                                   )
                                                   --policy-id HASH
                                                 )]
@@ -78,32 +78,32 @@ Usage: cardano-cli latest transaction build --socket-path SOCKET_PATH
                                               [--invalid-hereafter SLOT]
                                               [--certificate-file FILE
                                                 [ --certificate-script-file FILE
-                                                  [ --certificate-redeemer-cbor-file CBOR FILE
-                                                  | --certificate-redeemer-file JSON FILE
-                                                  | --certificate-redeemer-value JSON VALUE
+                                                  [ --certificate-redeemer-cbor-file CBOR_FILE
+                                                  | --certificate-redeemer-file JSON_FILE
+                                                  | --certificate-redeemer-value JSON_VALUE
                                                   ]
                                                 | --certificate-tx-in-reference TX-IN
                                                   ( --certificate-plutus-script-v2
                                                   | --certificate-plutus-script-v3
                                                   )
-                                                  ( --certificate-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                  | --certificate-reference-tx-in-redeemer-file JSON FILE
-                                                  | --certificate-reference-tx-in-redeemer-value JSON VALUE
+                                                  ( --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                  | --certificate-reference-tx-in-redeemer-file JSON_FILE
+                                                  | --certificate-reference-tx-in-redeemer-value JSON_VALUE
                                                   )
                                                 ]]
                                               [--withdrawal WITHDRAWAL
                                                 [ --withdrawal-script-file FILE
-                                                  [ --withdrawal-redeemer-cbor-file CBOR FILE
-                                                  | --withdrawal-redeemer-file JSON FILE
-                                                  | --withdrawal-redeemer-value JSON VALUE
+                                                  [ --withdrawal-redeemer-cbor-file CBOR_FILE
+                                                  | --withdrawal-redeemer-file JSON_FILE
+                                                  | --withdrawal-redeemer-value JSON_VALUE
                                                   ]
                                                 | --withdrawal-tx-in-reference TX-IN
                                                   ( --withdrawal-plutus-script-v2
                                                   | --withdrawal-plutus-script-v3
                                                   )
-                                                  ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                  | --withdrawal-reference-tx-in-redeemer-file JSON FILE
-                                                  | --withdrawal-reference-tx-in-redeemer-value JSON VALUE
+                                                  ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                  | --withdrawal-reference-tx-in-redeemer-file JSON_FILE
+                                                  | --withdrawal-reference-tx-in-redeemer-value JSON_VALUE
                                                   )
                                                 ]]
                                               [ --json-metadata-no-schema
@@ -150,55 +150,55 @@ Available options:
                            Specify a plutus script v2 reference script.
   --spending-plutus-script-v3
                            Specify a plutus script v3 reference script.
-  --spending-reference-tx-in-datum-cbor-file CBOR FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-datum-file JSON FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-datum-value JSON VALUE
-                           The script datum, in JSON syntax. There is no schema:
-                           (almost) any JSON value is supported, including
-                           top-level strings and numbers.
+  --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                           The script datum file. The file has to be in CBOR
+                           format.
+  --spending-reference-tx-in-datum-file JSON_FILE
+                           The script datum file. The file must follow the
+                           detailed JSON schema for script data.
+  --spending-reference-tx-in-datum-value JSON_VALUE
+                           The script datum. There is no schema: (almost) any
+                           JSON value is supported, including top-level strings
+                           and numbers.
   --spending-reference-tx-in-inline-datum-present
                            Inline datum present at transaction input.
-  --spending-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --spending-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --spending-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --simple-script-tx-in-reference TX-IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a simple reference script attached.
   --tx-in-script-file FILE The file containing the script to witness the
                            spending of the transaction input.
-  --tx-in-datum-cbor-file CBOR FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-datum-file JSON FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-datum-value JSON VALUE
-                           The script datum, in JSON syntax. There is no schema:
-                           (almost) any JSON value is supported, including
-                           top-level strings and numbers.
+  --tx-in-datum-cbor-file CBOR_FILE
+                           The script datum file. The file has to be in CBOR
+                           format.
+  --tx-in-datum-file JSON_FILE
+                           The script datum file. The file must follow the
+                           detailed JSON schema for script data.
+  --tx-in-datum-value JSON_VALUE
+                           The script datum. There is no schema: (almost) any
+                           JSON value is supported, including top-level strings
+                           and numbers.
   --tx-in-inline-datum-present
                            Inline datum present at transaction input.
-  --tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --read-only-tx-in-reference TX-IN
                            Specify a read only reference input. This reference
                            input is not witnessing anything it is simply
@@ -227,45 +227,44 @@ Available options:
                            Lovelace).
   --tx-out-datum-hash HASH The script datum hash for this tx output, as the raw
                            datum hash (in hex).
-  --tx-out-datum-hash-cbor-file CBOR FILE
+  --tx-out-datum-hash-cbor-file CBOR_FILE
                            The script datum hash for this tx output, by hashing
-                           the script datum in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-out-datum-hash-file JSON FILE
+                           the script datum in the file. The file has to be in
+                           CBOR format.
+  --tx-out-datum-hash-file JSON_FILE
                            The script datum hash for this tx output, by hashing
-                           the script datum in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-out-datum-hash-value JSON VALUE
+                           the script datum in the file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-datum-hash-value JSON_VALUE
                            The script datum hash for this tx output, by hashing
-                           the script datum given here in JSON syntax. There is
-                           no schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
-  --tx-out-datum-embed-cbor-file CBOR FILE
-                           The script datum to embed in the tx for this output,
-                           in the given JSON file. The file must follow the
-                           special JSON schema for script data.
-  --tx-out-datum-embed-file JSON FILE
-                           The script datum to embed in the tx for this output,
-                           in the given JSON file. The file must follow the
-                           special JSON schema for script data.
-  --tx-out-datum-embed-value JSON VALUE
-                           The script datum to embed in the tx for this output,
-                           given here in JSON syntax. There is no schema:
+                           the script datum given here. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
-  --tx-out-inline-datum-cbor-file CBOR FILE
+  --tx-out-datum-embed-cbor-file CBOR_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file has to be in CBOR format.
+  --tx-out-datum-embed-file JSON_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file must follow the detailed
+                           JSON schema for script data.
+  --tx-out-datum-embed-value JSON_VALUE
+                           The script datum to embed in the tx for this output,
+                           given here. There is no schema: (almost) any JSON
+                           value is supported, including top-level strings and
+                           numbers.
+  --tx-out-inline-datum-cbor-file CBOR_FILE
                            The script datum to embed in the tx output as an
-                           inline datum, in the given JSON file. The file must
-                           follow the special JSON schema for script data.
-  --tx-out-inline-datum-file JSON FILE
+                           inline datum, in the given file. The file has to be
+                           in CBOR format.
+  --tx-out-inline-datum-file JSON_FILE
                            The script datum to embed in the tx output as an
-                           inline datum, in the given JSON file. The file must
-                           follow the special JSON schema for script data.
-  --tx-out-inline-datum-value JSON VALUE
+                           inline datum, in the given file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-inline-datum-value JSON_VALUE
                            The script datum to embed in the tx output as an
-                           inline datum, given here in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+                           inline datum, given here. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --tx-out-reference-script-file FILE
                            Reference script input file.
   --change-address ADDRESS Address where ADA in excess of the tx fee will go to.
@@ -273,16 +272,16 @@ Available options:
                            syntax. You must specify a script witness.
   --mint-script-file FILE  The file containing the script to witness the minting
                            of assets for a particular policy Id.
-  --mint-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --mint-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --mint-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --mint-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --simple-minting-script-tx-in-reference TX-IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a simple reference script attached.
@@ -292,16 +291,16 @@ Available options:
                            input must have a plutus reference script attached.
   --mint-plutus-script-v2  Specify a plutus script v2 reference script.
   --mint-plutus-script-v3  Specify a plutus script v3 reference script.
-  --mint-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --mint-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --mint-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --mint-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --policy-id HASH         Policy id of minting script.
   --invalid-before SLOT    Time that transaction is valid from (in slots).
   --invalid-hereafter SLOT Time that transaction is valid until (in slots).
@@ -312,16 +311,16 @@ Available options:
   --certificate-script-file FILE
                            The file containing the script to witness the use of
                            the certificate.
-  --certificate-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --certificate-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --certificate-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --certificate-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --certificate-tx-in-reference TX-IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a plutus reference script attached.
@@ -329,16 +328,16 @@ Available options:
                            Specify a plutus script v2 reference script.
   --certificate-plutus-script-v3
                            Specify a plutus script v3 reference script.
-  --certificate-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --certificate-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --certificate-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --withdrawal WITHDRAWAL  The reward withdrawal as StakeAddress+Lovelace where
                            StakeAddress is the Bech32-encoded stake address
                            followed by the amount in Lovelace. Optionally
@@ -346,16 +345,16 @@ Available options:
   --withdrawal-script-file FILE
                            The file containing the script to witness the
                            withdrawal of rewards.
-  --withdrawal-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --withdrawal-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --withdrawal-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --withdrawal-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --withdrawal-tx-in-reference TX-IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a plutus reference script attached.
@@ -363,16 +362,16 @@ Available options:
                            Specify a plutus script v2 reference script.
   --withdrawal-plutus-script-v3
                            Specify a plutus script v3 reference script.
-  --withdrawal-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --withdrawal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --withdrawal-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --withdrawal-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --json-metadata-no-schema
                            Use the "no schema" conversion from JSON to tx
                            metadata (default).

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_transaction_calculate-min-required-utxo.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_transaction_calculate-min-required-utxo.cli
@@ -1,15 +1,15 @@
 Usage: cardano-cli latest transaction calculate-min-required-utxo --protocol-params-file FILE
                                                                     --tx-out ADDRESS VALUE
                                                                     [ --tx-out-datum-hash HASH
-                                                                    | --tx-out-datum-hash-cbor-file CBOR FILE
-                                                                    | --tx-out-datum-hash-file JSON FILE
-                                                                    | --tx-out-datum-hash-value JSON VALUE
-                                                                    | --tx-out-datum-embed-cbor-file CBOR FILE
-                                                                    | --tx-out-datum-embed-file JSON FILE
-                                                                    | --tx-out-datum-embed-value JSON VALUE
-                                                                    | --tx-out-inline-datum-cbor-file CBOR FILE
-                                                                    | --tx-out-inline-datum-file JSON FILE
-                                                                    | --tx-out-inline-datum-value JSON VALUE
+                                                                    | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                                    | --tx-out-datum-hash-file JSON_FILE
+                                                                    | --tx-out-datum-hash-value JSON_VALUE
+                                                                    | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                                    | --tx-out-datum-embed-file JSON_FILE
+                                                                    | --tx-out-datum-embed-value JSON_VALUE
+                                                                    | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                                    | --tx-out-inline-datum-file JSON_FILE
+                                                                    | --tx-out-inline-datum-value JSON_VALUE
                                                                     ]
                                                                     [--tx-out-reference-script-file FILE]
 
@@ -24,45 +24,44 @@ Available options:
                            Lovelace).
   --tx-out-datum-hash HASH The script datum hash for this tx output, as the raw
                            datum hash (in hex).
-  --tx-out-datum-hash-cbor-file CBOR FILE
+  --tx-out-datum-hash-cbor-file CBOR_FILE
                            The script datum hash for this tx output, by hashing
-                           the script datum in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-out-datum-hash-file JSON FILE
+                           the script datum in the file. The file has to be in
+                           CBOR format.
+  --tx-out-datum-hash-file JSON_FILE
                            The script datum hash for this tx output, by hashing
-                           the script datum in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-out-datum-hash-value JSON VALUE
+                           the script datum in the file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-datum-hash-value JSON_VALUE
                            The script datum hash for this tx output, by hashing
-                           the script datum given here in JSON syntax. There is
-                           no schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
-  --tx-out-datum-embed-cbor-file CBOR FILE
-                           The script datum to embed in the tx for this output,
-                           in the given JSON file. The file must follow the
-                           special JSON schema for script data.
-  --tx-out-datum-embed-file JSON FILE
-                           The script datum to embed in the tx for this output,
-                           in the given JSON file. The file must follow the
-                           special JSON schema for script data.
-  --tx-out-datum-embed-value JSON VALUE
-                           The script datum to embed in the tx for this output,
-                           given here in JSON syntax. There is no schema:
+                           the script datum given here. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
-  --tx-out-inline-datum-cbor-file CBOR FILE
+  --tx-out-datum-embed-cbor-file CBOR_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file has to be in CBOR format.
+  --tx-out-datum-embed-file JSON_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file must follow the detailed
+                           JSON schema for script data.
+  --tx-out-datum-embed-value JSON_VALUE
+                           The script datum to embed in the tx for this output,
+                           given here. There is no schema: (almost) any JSON
+                           value is supported, including top-level strings and
+                           numbers.
+  --tx-out-inline-datum-cbor-file CBOR_FILE
                            The script datum to embed in the tx output as an
-                           inline datum, in the given JSON file. The file must
-                           follow the special JSON schema for script data.
-  --tx-out-inline-datum-file JSON FILE
+                           inline datum, in the given file. The file has to be
+                           in CBOR format.
+  --tx-out-inline-datum-file JSON_FILE
                            The script datum to embed in the tx output as an
-                           inline datum, in the given JSON file. The file must
-                           follow the special JSON schema for script data.
-  --tx-out-inline-datum-value JSON VALUE
+                           inline datum, in the given file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-inline-datum-value JSON_VALUE
                            The script datum to embed in the tx output as an
-                           inline datum, given here in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+                           inline datum, given here. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --tx-out-reference-script-file FILE
                            Reference script input file.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_transaction_calculate-min-value.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_transaction_calculate-min-value.cli
@@ -1,15 +1,15 @@
 Usage: cardano-cli latest transaction calculate-min-value --protocol-params-file FILE
                                                             --tx-out ADDRESS VALUE
                                                             [ --tx-out-datum-hash HASH
-                                                            | --tx-out-datum-hash-cbor-file CBOR FILE
-                                                            | --tx-out-datum-hash-file JSON FILE
-                                                            | --tx-out-datum-hash-value JSON VALUE
-                                                            | --tx-out-datum-embed-cbor-file CBOR FILE
-                                                            | --tx-out-datum-embed-file JSON FILE
-                                                            | --tx-out-datum-embed-value JSON VALUE
-                                                            | --tx-out-inline-datum-cbor-file CBOR FILE
-                                                            | --tx-out-inline-datum-file JSON FILE
-                                                            | --tx-out-inline-datum-value JSON VALUE
+                                                            | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                            | --tx-out-datum-hash-file JSON_FILE
+                                                            | --tx-out-datum-hash-value JSON_VALUE
+                                                            | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                            | --tx-out-datum-embed-file JSON_FILE
+                                                            | --tx-out-datum-embed-value JSON_VALUE
+                                                            | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                            | --tx-out-inline-datum-file JSON_FILE
+                                                            | --tx-out-inline-datum-value JSON_VALUE
                                                             ]
                                                             [--tx-out-reference-script-file FILE]
 
@@ -24,44 +24,43 @@ Available options:
                            Lovelace).
   --tx-out-datum-hash HASH The script datum hash for this tx output, as the raw
                            datum hash (in hex).
-  --tx-out-datum-hash-cbor-file CBOR FILE
+  --tx-out-datum-hash-cbor-file CBOR_FILE
                            The script datum hash for this tx output, by hashing
-                           the script datum in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-out-datum-hash-file JSON FILE
+                           the script datum in the file. The file has to be in
+                           CBOR format.
+  --tx-out-datum-hash-file JSON_FILE
                            The script datum hash for this tx output, by hashing
-                           the script datum in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-out-datum-hash-value JSON VALUE
+                           the script datum in the file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-datum-hash-value JSON_VALUE
                            The script datum hash for this tx output, by hashing
-                           the script datum given here in JSON syntax. There is
-                           no schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
-  --tx-out-datum-embed-cbor-file CBOR FILE
-                           The script datum to embed in the tx for this output,
-                           in the given JSON file. The file must follow the
-                           special JSON schema for script data.
-  --tx-out-datum-embed-file JSON FILE
-                           The script datum to embed in the tx for this output,
-                           in the given JSON file. The file must follow the
-                           special JSON schema for script data.
-  --tx-out-datum-embed-value JSON VALUE
-                           The script datum to embed in the tx for this output,
-                           given here in JSON syntax. There is no schema:
+                           the script datum given here. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
-  --tx-out-inline-datum-cbor-file CBOR FILE
+  --tx-out-datum-embed-cbor-file CBOR_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file has to be in CBOR format.
+  --tx-out-datum-embed-file JSON_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file must follow the detailed
+                           JSON schema for script data.
+  --tx-out-datum-embed-value JSON_VALUE
+                           The script datum to embed in the tx for this output,
+                           given here. There is no schema: (almost) any JSON
+                           value is supported, including top-level strings and
+                           numbers.
+  --tx-out-inline-datum-cbor-file CBOR_FILE
                            The script datum to embed in the tx output as an
-                           inline datum, in the given JSON file. The file must
-                           follow the special JSON schema for script data.
-  --tx-out-inline-datum-file JSON FILE
+                           inline datum, in the given file. The file has to be
+                           in CBOR format.
+  --tx-out-inline-datum-file JSON_FILE
                            The script datum to embed in the tx output as an
-                           inline datum, in the given JSON file. The file must
-                           follow the special JSON schema for script data.
-  --tx-out-inline-datum-value JSON VALUE
+                           inline datum, in the given file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-inline-datum-value JSON_VALUE
                            The script datum to embed in the tx output as an
-                           inline datum, given here in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+                           inline datum, given here. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --tx-out-reference-script-file FILE
                            Reference script input file.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_transaction_hash-script-data.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_transaction_hash-script-data.cli
@@ -1,20 +1,20 @@
 Usage: cardano-cli latest transaction hash-script-data 
-                                                         ( --script-data-cbor-file CBOR FILE
-                                                         | --script-data-file JSON FILE
-                                                         | --script-data-value JSON VALUE
+                                                         ( --script-data-cbor-file CBOR_FILE
+                                                         | --script-data-file JSON_FILE
+                                                         | --script-data-value JSON_VALUE
                                                          )
 
   Calculate the hash of script data.
 
 Available options:
-  --script-data-cbor-file CBOR FILE
-                           The script data, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --script-data-file JSON FILE
-                           The script data, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --script-data-value JSON VALUE
-                           The script data, in JSON syntax. There is no schema:
-                           (almost) any JSON value is supported, including
-                           top-level strings and numbers.
+  --script-data-cbor-file CBOR_FILE
+                           The script data file. The file has to be in CBOR
+                           format.
+  --script-data-file JSON_FILE
+                           The script data file. The file must follow the
+                           detailed JSON schema for script data.
+  --script-data-value JSON_VALUE
+                           The script data. There is no schema: (almost) any
+                           JSON value is supported, including top-level strings
+                           and numbers.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_transaction_build-raw.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_transaction_build-raw.cli
@@ -14,27 +14,27 @@ Usage: cardano-cli legacy transaction build-raw
                                                       ( --spending-plutus-script-v2
                                                       | --spending-plutus-script-v3
                                                       )
-                                                      ( --spending-reference-tx-in-datum-cbor-file CBOR FILE
-                                                      | --spending-reference-tx-in-datum-file JSON FILE
-                                                      | --spending-reference-tx-in-datum-value JSON VALUE
+                                                      ( --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                                                      | --spending-reference-tx-in-datum-file JSON_FILE
+                                                      | --spending-reference-tx-in-datum-value JSON_VALUE
                                                       | --spending-reference-tx-in-inline-datum-present
                                                       )
-                                                      ( --spending-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                      | --spending-reference-tx-in-redeemer-file JSON FILE
-                                                      | --spending-reference-tx-in-redeemer-value JSON VALUE
+                                                      ( --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                      | --spending-reference-tx-in-redeemer-file JSON_FILE
+                                                      | --spending-reference-tx-in-redeemer-value JSON_VALUE
                                                       )
                                                       --spending-reference-tx-in-execution-units (INT, INT)
                                                     | --simple-script-tx-in-reference TX-IN
                                                     | --tx-in-script-file FILE
                                                       [
-                                                        ( --tx-in-datum-cbor-file CBOR FILE
-                                                        | --tx-in-datum-file JSON FILE
-                                                        | --tx-in-datum-value JSON VALUE
+                                                        ( --tx-in-datum-cbor-file CBOR_FILE
+                                                        | --tx-in-datum-file JSON_FILE
+                                                        | --tx-in-datum-value JSON_VALUE
                                                         | --tx-in-inline-datum-present
                                                         )
-                                                        ( --tx-in-redeemer-cbor-file CBOR FILE
-                                                        | --tx-in-redeemer-file JSON FILE
-                                                        | --tx-in-redeemer-value JSON VALUE
+                                                        ( --tx-in-redeemer-cbor-file CBOR_FILE
+                                                        | --tx-in-redeemer-file JSON_FILE
+                                                        | --tx-in-redeemer-value JSON_VALUE
                                                         )
                                                         --tx-in-execution-units (INT, INT)]
                                                     ])
@@ -47,23 +47,23 @@ Usage: cardano-cli legacy transaction build-raw
                                                   ]
                                                   [--tx-out ADDRESS VALUE
                                                     [ --tx-out-datum-hash HASH
-                                                    | --tx-out-datum-hash-cbor-file CBOR FILE
-                                                    | --tx-out-datum-hash-file JSON FILE
-                                                    | --tx-out-datum-hash-value JSON VALUE
-                                                    | --tx-out-datum-embed-cbor-file CBOR FILE
-                                                    | --tx-out-datum-embed-file JSON FILE
-                                                    | --tx-out-datum-embed-value JSON VALUE
-                                                    | --tx-out-inline-datum-cbor-file CBOR FILE
-                                                    | --tx-out-inline-datum-file JSON FILE
-                                                    | --tx-out-inline-datum-value JSON VALUE
+                                                    | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                    | --tx-out-datum-hash-file JSON_FILE
+                                                    | --tx-out-datum-hash-value JSON_VALUE
+                                                    | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                    | --tx-out-datum-embed-file JSON_FILE
+                                                    | --tx-out-datum-embed-value JSON_VALUE
+                                                    | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                    | --tx-out-inline-datum-file JSON_FILE
+                                                    | --tx-out-inline-datum-value JSON_VALUE
                                                     ]
                                                     [--tx-out-reference-script-file FILE]]
                                                   [--mint VALUE
                                                     ( --mint-script-file FILE
                                                       [
-                                                        ( --mint-redeemer-cbor-file CBOR FILE
-                                                        | --mint-redeemer-file JSON FILE
-                                                        | --mint-redeemer-value JSON VALUE
+                                                        ( --mint-redeemer-cbor-file CBOR_FILE
+                                                        | --mint-redeemer-file JSON_FILE
+                                                        | --mint-redeemer-value JSON_VALUE
                                                         )
                                                         --mint-execution-units (INT, INT)]
                                                     | --simple-minting-script-tx-in-reference TX-IN
@@ -72,9 +72,9 @@ Usage: cardano-cli legacy transaction build-raw
                                                       ( --mint-plutus-script-v2
                                                       | --mint-plutus-script-v3
                                                       )
-                                                      ( --mint-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                      | --mint-reference-tx-in-redeemer-file JSON FILE
-                                                      | --mint-reference-tx-in-redeemer-value JSON VALUE
+                                                      ( --mint-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                      | --mint-reference-tx-in-redeemer-file JSON_FILE
+                                                      | --mint-reference-tx-in-redeemer-value JSON_VALUE
                                                       )
                                                       --mint-reference-tx-in-execution-units (INT, INT)
                                                       --policy-id HASH
@@ -85,36 +85,36 @@ Usage: cardano-cli legacy transaction build-raw
                                                   [--certificate-file FILE
                                                     [ --certificate-script-file FILE
                                                       [
-                                                        ( --certificate-redeemer-cbor-file CBOR FILE
-                                                        | --certificate-redeemer-file JSON FILE
-                                                        | --certificate-redeemer-value JSON VALUE
+                                                        ( --certificate-redeemer-cbor-file CBOR_FILE
+                                                        | --certificate-redeemer-file JSON_FILE
+                                                        | --certificate-redeemer-value JSON_VALUE
                                                         )
                                                         --certificate-execution-units (INT, INT)]
                                                     | --certificate-tx-in-reference TX-IN
                                                       ( --certificate-plutus-script-v2
                                                       | --certificate-plutus-script-v3
                                                       )
-                                                      ( --certificate-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                      | --certificate-reference-tx-in-redeemer-file JSON FILE
-                                                      | --certificate-reference-tx-in-redeemer-value JSON VALUE
+                                                      ( --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                      | --certificate-reference-tx-in-redeemer-file JSON_FILE
+                                                      | --certificate-reference-tx-in-redeemer-value JSON_VALUE
                                                       )
                                                       --certificate-reference-tx-in-execution-units (INT, INT)
                                                     ]]
                                                   [--withdrawal WITHDRAWAL
                                                     [ --withdrawal-script-file FILE
                                                       [
-                                                        ( --withdrawal-redeemer-cbor-file CBOR FILE
-                                                        | --withdrawal-redeemer-file JSON FILE
-                                                        | --withdrawal-redeemer-value JSON VALUE
+                                                        ( --withdrawal-redeemer-cbor-file CBOR_FILE
+                                                        | --withdrawal-redeemer-file JSON_FILE
+                                                        | --withdrawal-redeemer-value JSON_VALUE
                                                         )
                                                         --withdrawal-execution-units (INT, INT)]
                                                     | --withdrawal-tx-in-reference TX-IN
                                                       ( --withdrawal-plutus-script-v2
                                                       | --withdrawal-plutus-script-v3
                                                       )
-                                                      ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                      | --withdrawal-reference-tx-in-redeemer-file JSON FILE
-                                                      | --withdrawal-reference-tx-in-redeemer-value JSON VALUE
+                                                      ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                      | --withdrawal-reference-tx-in-redeemer-file JSON_FILE
+                                                      | --withdrawal-reference-tx-in-redeemer-value JSON_VALUE
                                                       )
                                                       --withdrawal-reference-tx-in-execution-units (INT, INT)
                                                     ]]
@@ -152,28 +152,28 @@ Available options:
                            Specify a plutus script v2 reference script.
   --spending-plutus-script-v3
                            Specify a plutus script v3 reference script.
-  --spending-reference-tx-in-datum-cbor-file CBOR FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-datum-file JSON FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-datum-value JSON VALUE
-                           The script datum, in JSON syntax. There is no schema:
-                           (almost) any JSON value is supported, including
-                           top-level strings and numbers.
+  --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                           The script datum file. The file has to be in CBOR
+                           format.
+  --spending-reference-tx-in-datum-file JSON_FILE
+                           The script datum file. The file must follow the
+                           detailed JSON schema for script data.
+  --spending-reference-tx-in-datum-value JSON_VALUE
+                           The script datum. There is no schema: (almost) any
+                           JSON value is supported, including top-level strings
+                           and numbers.
   --spending-reference-tx-in-inline-datum-present
                            Inline datum present at transaction input.
-  --spending-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --spending-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --spending-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --spending-reference-tx-in-execution-units (INT, INT)
                            The time and space units needed by the script.
   --simple-script-tx-in-reference TX-IN
@@ -181,28 +181,28 @@ Available options:
                            input must have a simple reference script attached.
   --tx-in-script-file FILE The file containing the script to witness the
                            spending of the transaction input.
-  --tx-in-datum-cbor-file CBOR FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-datum-file JSON FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-datum-value JSON VALUE
-                           The script datum, in JSON syntax. There is no schema:
-                           (almost) any JSON value is supported, including
-                           top-level strings and numbers.
+  --tx-in-datum-cbor-file CBOR_FILE
+                           The script datum file. The file has to be in CBOR
+                           format.
+  --tx-in-datum-file JSON_FILE
+                           The script datum file. The file must follow the
+                           detailed JSON schema for script data.
+  --tx-in-datum-value JSON_VALUE
+                           The script datum. There is no schema: (almost) any
+                           JSON value is supported, including top-level strings
+                           and numbers.
   --tx-in-inline-datum-present
                            Inline datum present at transaction input.
-  --tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --tx-in-execution-units (INT, INT)
                            The time and space units needed by the script.
   --read-only-tx-in-reference TX-IN
@@ -233,61 +233,60 @@ Available options:
                            Lovelace).
   --tx-out-datum-hash HASH The script datum hash for this tx output, as the raw
                            datum hash (in hex).
-  --tx-out-datum-hash-cbor-file CBOR FILE
+  --tx-out-datum-hash-cbor-file CBOR_FILE
                            The script datum hash for this tx output, by hashing
-                           the script datum in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-out-datum-hash-file JSON FILE
+                           the script datum in the file. The file has to be in
+                           CBOR format.
+  --tx-out-datum-hash-file JSON_FILE
                            The script datum hash for this tx output, by hashing
-                           the script datum in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-out-datum-hash-value JSON VALUE
+                           the script datum in the file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-datum-hash-value JSON_VALUE
                            The script datum hash for this tx output, by hashing
-                           the script datum given here in JSON syntax. There is
-                           no schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
-  --tx-out-datum-embed-cbor-file CBOR FILE
-                           The script datum to embed in the tx for this output,
-                           in the given JSON file. The file must follow the
-                           special JSON schema for script data.
-  --tx-out-datum-embed-file JSON FILE
-                           The script datum to embed in the tx for this output,
-                           in the given JSON file. The file must follow the
-                           special JSON schema for script data.
-  --tx-out-datum-embed-value JSON VALUE
-                           The script datum to embed in the tx for this output,
-                           given here in JSON syntax. There is no schema:
+                           the script datum given here. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
-  --tx-out-inline-datum-cbor-file CBOR FILE
+  --tx-out-datum-embed-cbor-file CBOR_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file has to be in CBOR format.
+  --tx-out-datum-embed-file JSON_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file must follow the detailed
+                           JSON schema for script data.
+  --tx-out-datum-embed-value JSON_VALUE
+                           The script datum to embed in the tx for this output,
+                           given here. There is no schema: (almost) any JSON
+                           value is supported, including top-level strings and
+                           numbers.
+  --tx-out-inline-datum-cbor-file CBOR_FILE
                            The script datum to embed in the tx output as an
-                           inline datum, in the given JSON file. The file must
-                           follow the special JSON schema for script data.
-  --tx-out-inline-datum-file JSON FILE
+                           inline datum, in the given file. The file has to be
+                           in CBOR format.
+  --tx-out-inline-datum-file JSON_FILE
                            The script datum to embed in the tx output as an
-                           inline datum, in the given JSON file. The file must
-                           follow the special JSON schema for script data.
-  --tx-out-inline-datum-value JSON VALUE
+                           inline datum, in the given file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-inline-datum-value JSON_VALUE
                            The script datum to embed in the tx output as an
-                           inline datum, given here in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+                           inline datum, given here. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --tx-out-reference-script-file FILE
                            Reference script input file.
   --mint VALUE             Mint multi-asset value(s) with the multi-asset cli
                            syntax. You must specify a script witness.
   --mint-script-file FILE  The file containing the script to witness the minting
                            of assets for a particular policy Id.
-  --mint-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --mint-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --mint-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --mint-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --mint-execution-units (INT, INT)
                            The time and space units needed by the script.
   --simple-minting-script-tx-in-reference TX-IN
@@ -299,16 +298,16 @@ Available options:
                            input must have a plutus reference script attached.
   --mint-plutus-script-v2  Specify a plutus script v2 reference script.
   --mint-plutus-script-v3  Specify a plutus script v3 reference script.
-  --mint-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --mint-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --mint-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --mint-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --mint-reference-tx-in-execution-units (INT, INT)
                            The time and space units needed by the script.
   --policy-id HASH         Policy id of minting script.
@@ -322,16 +321,16 @@ Available options:
   --certificate-script-file FILE
                            The file containing the script to witness the use of
                            the certificate.
-  --certificate-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --certificate-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --certificate-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --certificate-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --certificate-execution-units (INT, INT)
                            The time and space units needed by the script.
   --certificate-tx-in-reference TX-IN
@@ -341,16 +340,16 @@ Available options:
                            Specify a plutus script v2 reference script.
   --certificate-plutus-script-v3
                            Specify a plutus script v3 reference script.
-  --certificate-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --certificate-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --certificate-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --certificate-reference-tx-in-execution-units (INT, INT)
                            The time and space units needed by the script.
   --withdrawal WITHDRAWAL  The reward withdrawal as StakeAddress+Lovelace where
@@ -360,16 +359,16 @@ Available options:
   --withdrawal-script-file FILE
                            The file containing the script to witness the
                            withdrawal of rewards.
-  --withdrawal-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --withdrawal-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --withdrawal-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --withdrawal-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --withdrawal-execution-units (INT, INT)
                            The time and space units needed by the script.
   --withdrawal-tx-in-reference TX-IN
@@ -379,16 +378,16 @@ Available options:
                            Specify a plutus script v2 reference script.
   --withdrawal-plutus-script-v3
                            Specify a plutus script v3 reference script.
-  --withdrawal-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --withdrawal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --withdrawal-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --withdrawal-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --withdrawal-reference-tx-in-execution-units (INT, INT)
                            The time and space units needed by the script.
   --json-metadata-no-schema

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_transaction_build.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_transaction_build.cli
@@ -19,26 +19,26 @@ Usage: cardano-cli legacy transaction build --socket-path SOCKET_PATH
                                                   ( --spending-plutus-script-v2
                                                   | --spending-plutus-script-v3
                                                   )
-                                                  ( --spending-reference-tx-in-datum-cbor-file CBOR FILE
-                                                  | --spending-reference-tx-in-datum-file JSON FILE
-                                                  | --spending-reference-tx-in-datum-value JSON VALUE
+                                                  ( --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                                                  | --spending-reference-tx-in-datum-file JSON_FILE
+                                                  | --spending-reference-tx-in-datum-value JSON_VALUE
                                                   | --spending-reference-tx-in-inline-datum-present
                                                   )
-                                                  ( --spending-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                  | --spending-reference-tx-in-redeemer-file JSON FILE
-                                                  | --spending-reference-tx-in-redeemer-value JSON VALUE
+                                                  ( --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                  | --spending-reference-tx-in-redeemer-file JSON_FILE
+                                                  | --spending-reference-tx-in-redeemer-value JSON_VALUE
                                                   )
                                                 | --simple-script-tx-in-reference TX-IN
                                                 | --tx-in-script-file FILE
                                                   [
-                                                    ( --tx-in-datum-cbor-file CBOR FILE
-                                                    | --tx-in-datum-file JSON FILE
-                                                    | --tx-in-datum-value JSON VALUE
+                                                    ( --tx-in-datum-cbor-file CBOR_FILE
+                                                    | --tx-in-datum-file JSON_FILE
+                                                    | --tx-in-datum-value JSON_VALUE
                                                     | --tx-in-inline-datum-present
                                                     )
-                                                    ( --tx-in-redeemer-cbor-file CBOR FILE
-                                                    | --tx-in-redeemer-file JSON FILE
-                                                    | --tx-in-redeemer-value JSON VALUE
+                                                    ( --tx-in-redeemer-cbor-file CBOR_FILE
+                                                    | --tx-in-redeemer-file JSON_FILE
+                                                    | --tx-in-redeemer-value JSON_VALUE
                                                     )]
                                                 ])
                                               [--read-only-tx-in-reference TX-IN]
@@ -50,23 +50,23 @@ Usage: cardano-cli legacy transaction build --socket-path SOCKET_PATH
                                               [--tx-total-collateral INTEGER]
                                               [--tx-out ADDRESS VALUE
                                                 [ --tx-out-datum-hash HASH
-                                                | --tx-out-datum-hash-cbor-file CBOR FILE
-                                                | --tx-out-datum-hash-file JSON FILE
-                                                | --tx-out-datum-hash-value JSON VALUE
-                                                | --tx-out-datum-embed-cbor-file CBOR FILE
-                                                | --tx-out-datum-embed-file JSON FILE
-                                                | --tx-out-datum-embed-value JSON VALUE
-                                                | --tx-out-inline-datum-cbor-file CBOR FILE
-                                                | --tx-out-inline-datum-file JSON FILE
-                                                | --tx-out-inline-datum-value JSON VALUE
+                                                | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                | --tx-out-datum-hash-file JSON_FILE
+                                                | --tx-out-datum-hash-value JSON_VALUE
+                                                | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                | --tx-out-datum-embed-file JSON_FILE
+                                                | --tx-out-datum-embed-value JSON_VALUE
+                                                | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                | --tx-out-inline-datum-file JSON_FILE
+                                                | --tx-out-inline-datum-value JSON_VALUE
                                                 ]
                                                 [--tx-out-reference-script-file FILE]]
                                               --change-address ADDRESS
                                               [--mint VALUE
                                                 ( --mint-script-file FILE
-                                                  [ --mint-redeemer-cbor-file CBOR FILE
-                                                  | --mint-redeemer-file JSON FILE
-                                                  | --mint-redeemer-value JSON VALUE
+                                                  [ --mint-redeemer-cbor-file CBOR_FILE
+                                                  | --mint-redeemer-file JSON_FILE
+                                                  | --mint-redeemer-value JSON_VALUE
                                                   ]
                                                 | --simple-minting-script-tx-in-reference TX-IN
                                                   --policy-id HASH
@@ -74,9 +74,9 @@ Usage: cardano-cli legacy transaction build --socket-path SOCKET_PATH
                                                   ( --mint-plutus-script-v2
                                                   | --mint-plutus-script-v3
                                                   )
-                                                  ( --mint-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                  | --mint-reference-tx-in-redeemer-file JSON FILE
-                                                  | --mint-reference-tx-in-redeemer-value JSON VALUE
+                                                  ( --mint-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                  | --mint-reference-tx-in-redeemer-file JSON_FILE
+                                                  | --mint-reference-tx-in-redeemer-value JSON_VALUE
                                                   )
                                                   --policy-id HASH
                                                 )]
@@ -84,32 +84,32 @@ Usage: cardano-cli legacy transaction build --socket-path SOCKET_PATH
                                               [--invalid-hereafter SLOT]
                                               [--certificate-file FILE
                                                 [ --certificate-script-file FILE
-                                                  [ --certificate-redeemer-cbor-file CBOR FILE
-                                                  | --certificate-redeemer-file JSON FILE
-                                                  | --certificate-redeemer-value JSON VALUE
+                                                  [ --certificate-redeemer-cbor-file CBOR_FILE
+                                                  | --certificate-redeemer-file JSON_FILE
+                                                  | --certificate-redeemer-value JSON_VALUE
                                                   ]
                                                 | --certificate-tx-in-reference TX-IN
                                                   ( --certificate-plutus-script-v2
                                                   | --certificate-plutus-script-v3
                                                   )
-                                                  ( --certificate-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                  | --certificate-reference-tx-in-redeemer-file JSON FILE
-                                                  | --certificate-reference-tx-in-redeemer-value JSON VALUE
+                                                  ( --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                  | --certificate-reference-tx-in-redeemer-file JSON_FILE
+                                                  | --certificate-reference-tx-in-redeemer-value JSON_VALUE
                                                   )
                                                 ]]
                                               [--withdrawal WITHDRAWAL
                                                 [ --withdrawal-script-file FILE
-                                                  [ --withdrawal-redeemer-cbor-file CBOR FILE
-                                                  | --withdrawal-redeemer-file JSON FILE
-                                                  | --withdrawal-redeemer-value JSON VALUE
+                                                  [ --withdrawal-redeemer-cbor-file CBOR_FILE
+                                                  | --withdrawal-redeemer-file JSON_FILE
+                                                  | --withdrawal-redeemer-value JSON_VALUE
                                                   ]
                                                 | --withdrawal-tx-in-reference TX-IN
                                                   ( --withdrawal-plutus-script-v2
                                                   | --withdrawal-plutus-script-v3
                                                   )
-                                                  ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                  | --withdrawal-reference-tx-in-redeemer-file JSON FILE
-                                                  | --withdrawal-reference-tx-in-redeemer-value JSON VALUE
+                                                  ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                  | --withdrawal-reference-tx-in-redeemer-file JSON_FILE
+                                                  | --withdrawal-reference-tx-in-redeemer-value JSON_VALUE
                                                   )
                                                 ]]
                                               [ --json-metadata-no-schema
@@ -122,15 +122,15 @@ Usage: cardano-cli legacy transaction build --socket-path SOCKET_PATH
                                               [--update-proposal-file FILE]
                                               [--vote-file FILE
                                                 [--vote-script-file FILE
-                                                  [ --vote-redeemer-cbor-file CBOR FILE
-                                                  | --vote-redeemer-file JSON FILE
-                                                  | --vote-redeemer-value JSON VALUE
+                                                  [ --vote-redeemer-cbor-file CBOR_FILE
+                                                  | --vote-redeemer-file JSON_FILE
+                                                  | --vote-redeemer-value JSON_VALUE
                                                   ]]]
                                               [--proposal-file FILE
                                                 [--proposal-script-file FILE
-                                                  [ --proposal-redeemer-cbor-file CBOR FILE
-                                                  | --proposal-redeemer-file JSON FILE
-                                                  | --proposal-redeemer-value JSON VALUE
+                                                  [ --proposal-redeemer-cbor-file CBOR_FILE
+                                                  | --proposal-redeemer-file JSON_FILE
+                                                  | --proposal-redeemer-value JSON_VALUE
                                                   ]]]
                                               ( --out-file FILE
                                               | --calculate-plutus-script-cost FILE
@@ -173,55 +173,55 @@ Available options:
                            Specify a plutus script v2 reference script.
   --spending-plutus-script-v3
                            Specify a plutus script v3 reference script.
-  --spending-reference-tx-in-datum-cbor-file CBOR FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-datum-file JSON FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-datum-value JSON VALUE
-                           The script datum, in JSON syntax. There is no schema:
-                           (almost) any JSON value is supported, including
-                           top-level strings and numbers.
+  --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                           The script datum file. The file has to be in CBOR
+                           format.
+  --spending-reference-tx-in-datum-file JSON_FILE
+                           The script datum file. The file must follow the
+                           detailed JSON schema for script data.
+  --spending-reference-tx-in-datum-value JSON_VALUE
+                           The script datum. There is no schema: (almost) any
+                           JSON value is supported, including top-level strings
+                           and numbers.
   --spending-reference-tx-in-inline-datum-present
                            Inline datum present at transaction input.
-  --spending-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --spending-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --spending-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --simple-script-tx-in-reference TX-IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a simple reference script attached.
   --tx-in-script-file FILE The file containing the script to witness the
                            spending of the transaction input.
-  --tx-in-datum-cbor-file CBOR FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-datum-file JSON FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-datum-value JSON VALUE
-                           The script datum, in JSON syntax. There is no schema:
-                           (almost) any JSON value is supported, including
-                           top-level strings and numbers.
+  --tx-in-datum-cbor-file CBOR_FILE
+                           The script datum file. The file has to be in CBOR
+                           format.
+  --tx-in-datum-file JSON_FILE
+                           The script datum file. The file must follow the
+                           detailed JSON schema for script data.
+  --tx-in-datum-value JSON_VALUE
+                           The script datum. There is no schema: (almost) any
+                           JSON value is supported, including top-level strings
+                           and numbers.
   --tx-in-inline-datum-present
                            Inline datum present at transaction input.
-  --tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --read-only-tx-in-reference TX-IN
                            Specify a read only reference input. This reference
                            input is not witnessing anything it is simply
@@ -250,45 +250,44 @@ Available options:
                            Lovelace).
   --tx-out-datum-hash HASH The script datum hash for this tx output, as the raw
                            datum hash (in hex).
-  --tx-out-datum-hash-cbor-file CBOR FILE
+  --tx-out-datum-hash-cbor-file CBOR_FILE
                            The script datum hash for this tx output, by hashing
-                           the script datum in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-out-datum-hash-file JSON FILE
+                           the script datum in the file. The file has to be in
+                           CBOR format.
+  --tx-out-datum-hash-file JSON_FILE
                            The script datum hash for this tx output, by hashing
-                           the script datum in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-out-datum-hash-value JSON VALUE
+                           the script datum in the file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-datum-hash-value JSON_VALUE
                            The script datum hash for this tx output, by hashing
-                           the script datum given here in JSON syntax. There is
-                           no schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
-  --tx-out-datum-embed-cbor-file CBOR FILE
-                           The script datum to embed in the tx for this output,
-                           in the given JSON file. The file must follow the
-                           special JSON schema for script data.
-  --tx-out-datum-embed-file JSON FILE
-                           The script datum to embed in the tx for this output,
-                           in the given JSON file. The file must follow the
-                           special JSON schema for script data.
-  --tx-out-datum-embed-value JSON VALUE
-                           The script datum to embed in the tx for this output,
-                           given here in JSON syntax. There is no schema:
+                           the script datum given here. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
-  --tx-out-inline-datum-cbor-file CBOR FILE
+  --tx-out-datum-embed-cbor-file CBOR_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file has to be in CBOR format.
+  --tx-out-datum-embed-file JSON_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file must follow the detailed
+                           JSON schema for script data.
+  --tx-out-datum-embed-value JSON_VALUE
+                           The script datum to embed in the tx for this output,
+                           given here. There is no schema: (almost) any JSON
+                           value is supported, including top-level strings and
+                           numbers.
+  --tx-out-inline-datum-cbor-file CBOR_FILE
                            The script datum to embed in the tx output as an
-                           inline datum, in the given JSON file. The file must
-                           follow the special JSON schema for script data.
-  --tx-out-inline-datum-file JSON FILE
+                           inline datum, in the given file. The file has to be
+                           in CBOR format.
+  --tx-out-inline-datum-file JSON_FILE
                            The script datum to embed in the tx output as an
-                           inline datum, in the given JSON file. The file must
-                           follow the special JSON schema for script data.
-  --tx-out-inline-datum-value JSON VALUE
+                           inline datum, in the given file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-inline-datum-value JSON_VALUE
                            The script datum to embed in the tx output as an
-                           inline datum, given here in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+                           inline datum, given here. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --tx-out-reference-script-file FILE
                            Reference script input file.
   --change-address ADDRESS Address where ADA in excess of the tx fee will go to.
@@ -296,16 +295,16 @@ Available options:
                            syntax. You must specify a script witness.
   --mint-script-file FILE  The file containing the script to witness the minting
                            of assets for a particular policy Id.
-  --mint-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --mint-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --mint-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --mint-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --simple-minting-script-tx-in-reference TX-IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a simple reference script attached.
@@ -315,16 +314,16 @@ Available options:
                            input must have a plutus reference script attached.
   --mint-plutus-script-v2  Specify a plutus script v2 reference script.
   --mint-plutus-script-v3  Specify a plutus script v3 reference script.
-  --mint-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --mint-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --mint-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --mint-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --policy-id HASH         Policy id of minting script.
   --invalid-before SLOT    Time that transaction is valid from (in slots).
   --invalid-hereafter SLOT Time that transaction is valid until (in slots).
@@ -335,16 +334,16 @@ Available options:
   --certificate-script-file FILE
                            The file containing the script to witness the use of
                            the certificate.
-  --certificate-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --certificate-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --certificate-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --certificate-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --certificate-tx-in-reference TX-IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a plutus reference script attached.
@@ -352,16 +351,16 @@ Available options:
                            Specify a plutus script v2 reference script.
   --certificate-plutus-script-v3
                            Specify a plutus script v3 reference script.
-  --certificate-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --certificate-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --certificate-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --withdrawal WITHDRAWAL  The reward withdrawal as StakeAddress+Lovelace where
                            StakeAddress is the Bech32-encoded stake address
                            followed by the amount in Lovelace. Optionally
@@ -369,16 +368,16 @@ Available options:
   --withdrawal-script-file FILE
                            The file containing the script to witness the
                            withdrawal of rewards.
-  --withdrawal-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --withdrawal-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --withdrawal-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --withdrawal-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --withdrawal-tx-in-reference TX-IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a plutus reference script attached.
@@ -386,16 +385,16 @@ Available options:
                            Specify a plutus script v2 reference script.
   --withdrawal-plutus-script-v3
                            Specify a plutus script v3 reference script.
-  --withdrawal-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --withdrawal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --withdrawal-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --withdrawal-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --json-metadata-no-schema
                            Use the "no schema" conversion from JSON to tx
                            metadata (default).
@@ -412,29 +411,29 @@ Available options:
                            Filepath of the update proposal.
   --vote-file FILE         Filepath of the vote.
   --vote-script-file FILE  The file containing the script to witness a vote
-  --vote-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --vote-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --vote-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --vote-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --vote-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --vote-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --proposal-file FILE     Filepath of the proposal.
   --proposal-script-file FILE
                            The file containing the script to witness a proposal
-  --proposal-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --proposal-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --proposal-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --proposal-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --proposal-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --proposal-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --out-file FILE          Output filepath of the JSON TxBody.
   --calculate-plutus-script-cost FILE
                            (File () Out) filepath of the script cost

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_transaction_calculate-min-required-utxo.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_transaction_calculate-min-required-utxo.cli
@@ -9,15 +9,15 @@ Usage: cardano-cli legacy transaction calculate-min-required-utxo
                                                                     --protocol-params-file FILE
                                                                     --tx-out ADDRESS VALUE
                                                                     [ --tx-out-datum-hash HASH
-                                                                    | --tx-out-datum-hash-cbor-file CBOR FILE
-                                                                    | --tx-out-datum-hash-file JSON FILE
-                                                                    | --tx-out-datum-hash-value JSON VALUE
-                                                                    | --tx-out-datum-embed-cbor-file CBOR FILE
-                                                                    | --tx-out-datum-embed-file JSON FILE
-                                                                    | --tx-out-datum-embed-value JSON VALUE
-                                                                    | --tx-out-inline-datum-cbor-file CBOR FILE
-                                                                    | --tx-out-inline-datum-file JSON FILE
-                                                                    | --tx-out-inline-datum-value JSON VALUE
+                                                                    | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                                    | --tx-out-datum-hash-file JSON_FILE
+                                                                    | --tx-out-datum-hash-value JSON_VALUE
+                                                                    | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                                    | --tx-out-datum-embed-file JSON_FILE
+                                                                    | --tx-out-datum-embed-value JSON_VALUE
+                                                                    | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                                    | --tx-out-inline-datum-file JSON_FILE
+                                                                    | --tx-out-inline-datum-value JSON_VALUE
                                                                     ]
                                                                     [--tx-out-reference-script-file FILE]
 
@@ -38,45 +38,44 @@ Available options:
                            Lovelace).
   --tx-out-datum-hash HASH The script datum hash for this tx output, as the raw
                            datum hash (in hex).
-  --tx-out-datum-hash-cbor-file CBOR FILE
+  --tx-out-datum-hash-cbor-file CBOR_FILE
                            The script datum hash for this tx output, by hashing
-                           the script datum in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-out-datum-hash-file JSON FILE
+                           the script datum in the file. The file has to be in
+                           CBOR format.
+  --tx-out-datum-hash-file JSON_FILE
                            The script datum hash for this tx output, by hashing
-                           the script datum in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-out-datum-hash-value JSON VALUE
+                           the script datum in the file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-datum-hash-value JSON_VALUE
                            The script datum hash for this tx output, by hashing
-                           the script datum given here in JSON syntax. There is
-                           no schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
-  --tx-out-datum-embed-cbor-file CBOR FILE
-                           The script datum to embed in the tx for this output,
-                           in the given JSON file. The file must follow the
-                           special JSON schema for script data.
-  --tx-out-datum-embed-file JSON FILE
-                           The script datum to embed in the tx for this output,
-                           in the given JSON file. The file must follow the
-                           special JSON schema for script data.
-  --tx-out-datum-embed-value JSON VALUE
-                           The script datum to embed in the tx for this output,
-                           given here in JSON syntax. There is no schema:
+                           the script datum given here. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
-  --tx-out-inline-datum-cbor-file CBOR FILE
+  --tx-out-datum-embed-cbor-file CBOR_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file has to be in CBOR format.
+  --tx-out-datum-embed-file JSON_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file must follow the detailed
+                           JSON schema for script data.
+  --tx-out-datum-embed-value JSON_VALUE
+                           The script datum to embed in the tx for this output,
+                           given here. There is no schema: (almost) any JSON
+                           value is supported, including top-level strings and
+                           numbers.
+  --tx-out-inline-datum-cbor-file CBOR_FILE
                            The script datum to embed in the tx output as an
-                           inline datum, in the given JSON file. The file must
-                           follow the special JSON schema for script data.
-  --tx-out-inline-datum-file JSON FILE
+                           inline datum, in the given file. The file has to be
+                           in CBOR format.
+  --tx-out-inline-datum-file JSON_FILE
                            The script datum to embed in the tx output as an
-                           inline datum, in the given JSON file. The file must
-                           follow the special JSON schema for script data.
-  --tx-out-inline-datum-value JSON VALUE
+                           inline datum, in the given file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-inline-datum-value JSON_VALUE
                            The script datum to embed in the tx output as an
-                           inline datum, given here in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+                           inline datum, given here. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --tx-out-reference-script-file FILE
                            Reference script input file.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_transaction_calculate-min-value.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_transaction_calculate-min-value.cli
@@ -9,15 +9,15 @@ Usage: cardano-cli legacy transaction calculate-min-value
                                                             --protocol-params-file FILE
                                                             --tx-out ADDRESS VALUE
                                                             [ --tx-out-datum-hash HASH
-                                                            | --tx-out-datum-hash-cbor-file CBOR FILE
-                                                            | --tx-out-datum-hash-file JSON FILE
-                                                            | --tx-out-datum-hash-value JSON VALUE
-                                                            | --tx-out-datum-embed-cbor-file CBOR FILE
-                                                            | --tx-out-datum-embed-file JSON FILE
-                                                            | --tx-out-datum-embed-value JSON VALUE
-                                                            | --tx-out-inline-datum-cbor-file CBOR FILE
-                                                            | --tx-out-inline-datum-file JSON FILE
-                                                            | --tx-out-inline-datum-value JSON VALUE
+                                                            | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                            | --tx-out-datum-hash-file JSON_FILE
+                                                            | --tx-out-datum-hash-value JSON_VALUE
+                                                            | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                            | --tx-out-datum-embed-file JSON_FILE
+                                                            | --tx-out-datum-embed-value JSON_VALUE
+                                                            | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                            | --tx-out-inline-datum-file JSON_FILE
+                                                            | --tx-out-inline-datum-value JSON_VALUE
                                                             ]
                                                             [--tx-out-reference-script-file FILE]
 
@@ -38,44 +38,43 @@ Available options:
                            Lovelace).
   --tx-out-datum-hash HASH The script datum hash for this tx output, as the raw
                            datum hash (in hex).
-  --tx-out-datum-hash-cbor-file CBOR FILE
+  --tx-out-datum-hash-cbor-file CBOR_FILE
                            The script datum hash for this tx output, by hashing
-                           the script datum in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-out-datum-hash-file JSON FILE
+                           the script datum in the file. The file has to be in
+                           CBOR format.
+  --tx-out-datum-hash-file JSON_FILE
                            The script datum hash for this tx output, by hashing
-                           the script datum in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-out-datum-hash-value JSON VALUE
+                           the script datum in the file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-datum-hash-value JSON_VALUE
                            The script datum hash for this tx output, by hashing
-                           the script datum given here in JSON syntax. There is
-                           no schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
-  --tx-out-datum-embed-cbor-file CBOR FILE
-                           The script datum to embed in the tx for this output,
-                           in the given JSON file. The file must follow the
-                           special JSON schema for script data.
-  --tx-out-datum-embed-file JSON FILE
-                           The script datum to embed in the tx for this output,
-                           in the given JSON file. The file must follow the
-                           special JSON schema for script data.
-  --tx-out-datum-embed-value JSON VALUE
-                           The script datum to embed in the tx for this output,
-                           given here in JSON syntax. There is no schema:
+                           the script datum given here. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
-  --tx-out-inline-datum-cbor-file CBOR FILE
+  --tx-out-datum-embed-cbor-file CBOR_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file has to be in CBOR format.
+  --tx-out-datum-embed-file JSON_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file must follow the detailed
+                           JSON schema for script data.
+  --tx-out-datum-embed-value JSON_VALUE
+                           The script datum to embed in the tx for this output,
+                           given here. There is no schema: (almost) any JSON
+                           value is supported, including top-level strings and
+                           numbers.
+  --tx-out-inline-datum-cbor-file CBOR_FILE
                            The script datum to embed in the tx output as an
-                           inline datum, in the given JSON file. The file must
-                           follow the special JSON schema for script data.
-  --tx-out-inline-datum-file JSON FILE
+                           inline datum, in the given file. The file has to be
+                           in CBOR format.
+  --tx-out-inline-datum-file JSON_FILE
                            The script datum to embed in the tx output as an
-                           inline datum, in the given JSON file. The file must
-                           follow the special JSON schema for script data.
-  --tx-out-inline-datum-value JSON VALUE
+                           inline datum, in the given file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-inline-datum-value JSON_VALUE
                            The script datum to embed in the tx output as an
-                           inline datum, given here in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+                           inline datum, given here. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --tx-out-reference-script-file FILE
                            Reference script input file.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_transaction_hash-script-data.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_transaction_hash-script-data.cli
@@ -1,20 +1,20 @@
 Usage: cardano-cli legacy transaction hash-script-data 
-                                                         ( --script-data-cbor-file CBOR FILE
-                                                         | --script-data-file JSON FILE
-                                                         | --script-data-value JSON VALUE
+                                                         ( --script-data-cbor-file CBOR_FILE
+                                                         | --script-data-file JSON_FILE
+                                                         | --script-data-value JSON_VALUE
                                                          )
 
   Calculate the hash of script data.
 
 Available options:
-  --script-data-cbor-file CBOR FILE
-                           The script data, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --script-data-file JSON FILE
-                           The script data, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --script-data-value JSON VALUE
-                           The script data, in JSON syntax. There is no schema:
-                           (almost) any JSON value is supported, including
-                           top-level strings and numbers.
+  --script-data-cbor-file CBOR_FILE
+                           The script data file. The file has to be in CBOR
+                           format.
+  --script-data-file JSON_FILE
+                           The script data file. The file must follow the
+                           detailed JSON schema for script data.
+  --script-data-value JSON_VALUE
+                           The script data. There is no schema: (almost) any
+                           JSON value is supported, including top-level strings
+                           and numbers.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_transaction_build-estimate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_transaction_build-estimate.cli
@@ -11,27 +11,27 @@ Usage: cardano-cli mary transaction build-estimate
                                                          ( --spending-plutus-script-v2
                                                          | --spending-plutus-script-v3
                                                          )
-                                                         ( --spending-reference-tx-in-datum-cbor-file CBOR FILE
-                                                         | --spending-reference-tx-in-datum-file JSON FILE
-                                                         | --spending-reference-tx-in-datum-value JSON VALUE
+                                                         ( --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                                                         | --spending-reference-tx-in-datum-file JSON_FILE
+                                                         | --spending-reference-tx-in-datum-value JSON_VALUE
                                                          | --spending-reference-tx-in-inline-datum-present
                                                          )
-                                                         ( --spending-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                         | --spending-reference-tx-in-redeemer-file JSON FILE
-                                                         | --spending-reference-tx-in-redeemer-value JSON VALUE
+                                                         ( --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                         | --spending-reference-tx-in-redeemer-file JSON_FILE
+                                                         | --spending-reference-tx-in-redeemer-value JSON_VALUE
                                                          )
                                                          --spending-reference-tx-in-execution-units (INT, INT)
                                                        | --simple-script-tx-in-reference TX-IN
                                                        | --tx-in-script-file FILE
                                                          [
-                                                           ( --tx-in-datum-cbor-file CBOR FILE
-                                                           | --tx-in-datum-file JSON FILE
-                                                           | --tx-in-datum-value JSON VALUE
+                                                           ( --tx-in-datum-cbor-file CBOR_FILE
+                                                           | --tx-in-datum-file JSON_FILE
+                                                           | --tx-in-datum-value JSON_VALUE
                                                            | --tx-in-inline-datum-present
                                                            )
-                                                           ( --tx-in-redeemer-cbor-file CBOR FILE
-                                                           | --tx-in-redeemer-file JSON FILE
-                                                           | --tx-in-redeemer-value JSON VALUE
+                                                           ( --tx-in-redeemer-cbor-file CBOR_FILE
+                                                           | --tx-in-redeemer-file JSON_FILE
+                                                           | --tx-in-redeemer-value JSON_VALUE
                                                            )
                                                            --tx-in-execution-units (INT, INT)]
                                                        ])
@@ -43,24 +43,24 @@ Usage: cardano-cli mary transaction build-estimate
                                                      [--tx-out-return-collateral ADDRESS VALUE]
                                                      [--tx-out ADDRESS VALUE
                                                        [ --tx-out-datum-hash HASH
-                                                       | --tx-out-datum-hash-cbor-file CBOR FILE
-                                                       | --tx-out-datum-hash-file JSON FILE
-                                                       | --tx-out-datum-hash-value JSON VALUE
-                                                       | --tx-out-datum-embed-cbor-file CBOR FILE
-                                                       | --tx-out-datum-embed-file JSON FILE
-                                                       | --tx-out-datum-embed-value JSON VALUE
-                                                       | --tx-out-inline-datum-cbor-file CBOR FILE
-                                                       | --tx-out-inline-datum-file JSON FILE
-                                                       | --tx-out-inline-datum-value JSON VALUE
+                                                       | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                       | --tx-out-datum-hash-file JSON_FILE
+                                                       | --tx-out-datum-hash-value JSON_VALUE
+                                                       | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                       | --tx-out-datum-embed-file JSON_FILE
+                                                       | --tx-out-datum-embed-value JSON_VALUE
+                                                       | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                       | --tx-out-inline-datum-file JSON_FILE
+                                                       | --tx-out-inline-datum-value JSON_VALUE
                                                        ]
                                                        [--tx-out-reference-script-file FILE]]
                                                      --change-address ADDRESS
                                                      [--mint VALUE
                                                        ( --mint-script-file FILE
                                                          [
-                                                           ( --mint-redeemer-cbor-file CBOR FILE
-                                                           | --mint-redeemer-file JSON FILE
-                                                           | --mint-redeemer-value JSON VALUE
+                                                           ( --mint-redeemer-cbor-file CBOR_FILE
+                                                           | --mint-redeemer-file JSON_FILE
+                                                           | --mint-redeemer-value JSON_VALUE
                                                            )
                                                            --mint-execution-units (INT, INT)]
                                                        | --simple-minting-script-tx-in-reference TX-IN
@@ -69,9 +69,9 @@ Usage: cardano-cli mary transaction build-estimate
                                                          ( --mint-plutus-script-v2
                                                          | --mint-plutus-script-v3
                                                          )
-                                                         ( --mint-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                         | --mint-reference-tx-in-redeemer-file JSON FILE
-                                                         | --mint-reference-tx-in-redeemer-value JSON VALUE
+                                                         ( --mint-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                         | --mint-reference-tx-in-redeemer-file JSON_FILE
+                                                         | --mint-reference-tx-in-redeemer-value JSON_VALUE
                                                          )
                                                          --mint-reference-tx-in-execution-units (INT, INT)
                                                          --policy-id HASH
@@ -81,36 +81,36 @@ Usage: cardano-cli mary transaction build-estimate
                                                      [--certificate-file FILE
                                                        [ --certificate-script-file FILE
                                                          [
-                                                           ( --certificate-redeemer-cbor-file CBOR FILE
-                                                           | --certificate-redeemer-file JSON FILE
-                                                           | --certificate-redeemer-value JSON VALUE
+                                                           ( --certificate-redeemer-cbor-file CBOR_FILE
+                                                           | --certificate-redeemer-file JSON_FILE
+                                                           | --certificate-redeemer-value JSON_VALUE
                                                            )
                                                            --certificate-execution-units (INT, INT)]
                                                        | --certificate-tx-in-reference TX-IN
                                                          ( --certificate-plutus-script-v2
                                                          | --certificate-plutus-script-v3
                                                          )
-                                                         ( --certificate-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                         | --certificate-reference-tx-in-redeemer-file JSON FILE
-                                                         | --certificate-reference-tx-in-redeemer-value JSON VALUE
+                                                         ( --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                         | --certificate-reference-tx-in-redeemer-file JSON_FILE
+                                                         | --certificate-reference-tx-in-redeemer-value JSON_VALUE
                                                          )
                                                          --certificate-reference-tx-in-execution-units (INT, INT)
                                                        ]]
                                                      [--withdrawal WITHDRAWAL
                                                        [ --withdrawal-script-file FILE
                                                          [
-                                                           ( --withdrawal-redeemer-cbor-file CBOR FILE
-                                                           | --withdrawal-redeemer-file JSON FILE
-                                                           | --withdrawal-redeemer-value JSON VALUE
+                                                           ( --withdrawal-redeemer-cbor-file CBOR_FILE
+                                                           | --withdrawal-redeemer-file JSON_FILE
+                                                           | --withdrawal-redeemer-value JSON_VALUE
                                                            )
                                                            --withdrawal-execution-units (INT, INT)]
                                                        | --withdrawal-tx-in-reference TX-IN
                                                          ( --withdrawal-plutus-script-v2
                                                          | --withdrawal-plutus-script-v3
                                                          )
-                                                         ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                         | --withdrawal-reference-tx-in-redeemer-file JSON FILE
-                                                         | --withdrawal-reference-tx-in-redeemer-value JSON VALUE
+                                                         ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                         | --withdrawal-reference-tx-in-redeemer-file JSON_FILE
+                                                         | --withdrawal-reference-tx-in-redeemer-value JSON_VALUE
                                                          )
                                                          --withdrawal-reference-tx-in-execution-units (INT, INT)
                                                        ]]
@@ -153,28 +153,28 @@ Available options:
                            Specify a plutus script v2 reference script.
   --spending-plutus-script-v3
                            Specify a plutus script v3 reference script.
-  --spending-reference-tx-in-datum-cbor-file CBOR FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-datum-file JSON FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-datum-value JSON VALUE
-                           The script datum, in JSON syntax. There is no schema:
-                           (almost) any JSON value is supported, including
-                           top-level strings and numbers.
+  --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                           The script datum file. The file has to be in CBOR
+                           format.
+  --spending-reference-tx-in-datum-file JSON_FILE
+                           The script datum file. The file must follow the
+                           detailed JSON schema for script data.
+  --spending-reference-tx-in-datum-value JSON_VALUE
+                           The script datum. There is no schema: (almost) any
+                           JSON value is supported, including top-level strings
+                           and numbers.
   --spending-reference-tx-in-inline-datum-present
                            Inline datum present at transaction input.
-  --spending-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --spending-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --spending-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --spending-reference-tx-in-execution-units (INT, INT)
                            The time and space units needed by the script.
   --simple-script-tx-in-reference TX-IN
@@ -182,28 +182,28 @@ Available options:
                            input must have a simple reference script attached.
   --tx-in-script-file FILE The file containing the script to witness the
                            spending of the transaction input.
-  --tx-in-datum-cbor-file CBOR FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-datum-file JSON FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-datum-value JSON VALUE
-                           The script datum, in JSON syntax. There is no schema:
-                           (almost) any JSON value is supported, including
-                           top-level strings and numbers.
+  --tx-in-datum-cbor-file CBOR_FILE
+                           The script datum file. The file has to be in CBOR
+                           format.
+  --tx-in-datum-file JSON_FILE
+                           The script datum file. The file must follow the
+                           detailed JSON schema for script data.
+  --tx-in-datum-value JSON_VALUE
+                           The script datum. There is no schema: (almost) any
+                           JSON value is supported, including top-level strings
+                           and numbers.
   --tx-in-inline-datum-present
                            Inline datum present at transaction input.
-  --tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --tx-in-execution-units (INT, INT)
                            The time and space units needed by the script.
   --read-only-tx-in-reference TX-IN
@@ -229,45 +229,44 @@ Available options:
                            Lovelace).
   --tx-out-datum-hash HASH The script datum hash for this tx output, as the raw
                            datum hash (in hex).
-  --tx-out-datum-hash-cbor-file CBOR FILE
+  --tx-out-datum-hash-cbor-file CBOR_FILE
                            The script datum hash for this tx output, by hashing
-                           the script datum in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-out-datum-hash-file JSON FILE
+                           the script datum in the file. The file has to be in
+                           CBOR format.
+  --tx-out-datum-hash-file JSON_FILE
                            The script datum hash for this tx output, by hashing
-                           the script datum in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-out-datum-hash-value JSON VALUE
+                           the script datum in the file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-datum-hash-value JSON_VALUE
                            The script datum hash for this tx output, by hashing
-                           the script datum given here in JSON syntax. There is
-                           no schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
-  --tx-out-datum-embed-cbor-file CBOR FILE
-                           The script datum to embed in the tx for this output,
-                           in the given JSON file. The file must follow the
-                           special JSON schema for script data.
-  --tx-out-datum-embed-file JSON FILE
-                           The script datum to embed in the tx for this output,
-                           in the given JSON file. The file must follow the
-                           special JSON schema for script data.
-  --tx-out-datum-embed-value JSON VALUE
-                           The script datum to embed in the tx for this output,
-                           given here in JSON syntax. There is no schema:
+                           the script datum given here. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
-  --tx-out-inline-datum-cbor-file CBOR FILE
+  --tx-out-datum-embed-cbor-file CBOR_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file has to be in CBOR format.
+  --tx-out-datum-embed-file JSON_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file must follow the detailed
+                           JSON schema for script data.
+  --tx-out-datum-embed-value JSON_VALUE
+                           The script datum to embed in the tx for this output,
+                           given here. There is no schema: (almost) any JSON
+                           value is supported, including top-level strings and
+                           numbers.
+  --tx-out-inline-datum-cbor-file CBOR_FILE
                            The script datum to embed in the tx output as an
-                           inline datum, in the given JSON file. The file must
-                           follow the special JSON schema for script data.
-  --tx-out-inline-datum-file JSON FILE
+                           inline datum, in the given file. The file has to be
+                           in CBOR format.
+  --tx-out-inline-datum-file JSON_FILE
                            The script datum to embed in the tx output as an
-                           inline datum, in the given JSON file. The file must
-                           follow the special JSON schema for script data.
-  --tx-out-inline-datum-value JSON VALUE
+                           inline datum, in the given file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-inline-datum-value JSON_VALUE
                            The script datum to embed in the tx output as an
-                           inline datum, given here in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+                           inline datum, given here. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --tx-out-reference-script-file FILE
                            Reference script input file.
   --change-address ADDRESS Address where ADA in excess of the tx fee will go to.
@@ -275,16 +274,16 @@ Available options:
                            syntax. You must specify a script witness.
   --mint-script-file FILE  The file containing the script to witness the minting
                            of assets for a particular policy Id.
-  --mint-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --mint-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --mint-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --mint-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --mint-execution-units (INT, INT)
                            The time and space units needed by the script.
   --simple-minting-script-tx-in-reference TX-IN
@@ -296,16 +295,16 @@ Available options:
                            input must have a plutus reference script attached.
   --mint-plutus-script-v2  Specify a plutus script v2 reference script.
   --mint-plutus-script-v3  Specify a plutus script v3 reference script.
-  --mint-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --mint-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --mint-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --mint-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --mint-reference-tx-in-execution-units (INT, INT)
                            The time and space units needed by the script.
   --policy-id HASH         Policy id of minting script.
@@ -318,16 +317,16 @@ Available options:
   --certificate-script-file FILE
                            The file containing the script to witness the use of
                            the certificate.
-  --certificate-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --certificate-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --certificate-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --certificate-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --certificate-execution-units (INT, INT)
                            The time and space units needed by the script.
   --certificate-tx-in-reference TX-IN
@@ -337,16 +336,16 @@ Available options:
                            Specify a plutus script v2 reference script.
   --certificate-plutus-script-v3
                            Specify a plutus script v3 reference script.
-  --certificate-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --certificate-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --certificate-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --certificate-reference-tx-in-execution-units (INT, INT)
                            The time and space units needed by the script.
   --withdrawal WITHDRAWAL  The reward withdrawal as StakeAddress+Lovelace where
@@ -356,16 +355,16 @@ Available options:
   --withdrawal-script-file FILE
                            The file containing the script to witness the
                            withdrawal of rewards.
-  --withdrawal-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --withdrawal-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --withdrawal-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --withdrawal-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --withdrawal-execution-units (INT, INT)
                            The time and space units needed by the script.
   --withdrawal-tx-in-reference TX-IN
@@ -375,16 +374,16 @@ Available options:
                            Specify a plutus script v2 reference script.
   --withdrawal-plutus-script-v3
                            Specify a plutus script v3 reference script.
-  --withdrawal-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --withdrawal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --withdrawal-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --withdrawal-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --withdrawal-reference-tx-in-execution-units (INT, INT)
                            The time and space units needed by the script.
   --tx-total-collateral INTEGER

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_transaction_build-raw.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_transaction_build-raw.cli
@@ -7,27 +7,27 @@ Usage: cardano-cli mary transaction build-raw
                                                     ( --spending-plutus-script-v2
                                                     | --spending-plutus-script-v3
                                                     )
-                                                    ( --spending-reference-tx-in-datum-cbor-file CBOR FILE
-                                                    | --spending-reference-tx-in-datum-file JSON FILE
-                                                    | --spending-reference-tx-in-datum-value JSON VALUE
+                                                    ( --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                                                    | --spending-reference-tx-in-datum-file JSON_FILE
+                                                    | --spending-reference-tx-in-datum-value JSON_VALUE
                                                     | --spending-reference-tx-in-inline-datum-present
                                                     )
-                                                    ( --spending-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                    | --spending-reference-tx-in-redeemer-file JSON FILE
-                                                    | --spending-reference-tx-in-redeemer-value JSON VALUE
+                                                    ( --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                    | --spending-reference-tx-in-redeemer-file JSON_FILE
+                                                    | --spending-reference-tx-in-redeemer-value JSON_VALUE
                                                     )
                                                     --spending-reference-tx-in-execution-units (INT, INT)
                                                   | --simple-script-tx-in-reference TX-IN
                                                   | --tx-in-script-file FILE
                                                     [
-                                                      ( --tx-in-datum-cbor-file CBOR FILE
-                                                      | --tx-in-datum-file JSON FILE
-                                                      | --tx-in-datum-value JSON VALUE
+                                                      ( --tx-in-datum-cbor-file CBOR_FILE
+                                                      | --tx-in-datum-file JSON_FILE
+                                                      | --tx-in-datum-value JSON_VALUE
                                                       | --tx-in-inline-datum-present
                                                       )
-                                                      ( --tx-in-redeemer-cbor-file CBOR FILE
-                                                      | --tx-in-redeemer-file JSON FILE
-                                                      | --tx-in-redeemer-value JSON VALUE
+                                                      ( --tx-in-redeemer-cbor-file CBOR_FILE
+                                                      | --tx-in-redeemer-file JSON_FILE
+                                                      | --tx-in-redeemer-value JSON_VALUE
                                                       )
                                                       --tx-in-execution-units (INT, INT)]
                                                   ])
@@ -40,23 +40,23 @@ Usage: cardano-cli mary transaction build-raw
                                                 ]
                                                 [--tx-out ADDRESS VALUE
                                                   [ --tx-out-datum-hash HASH
-                                                  | --tx-out-datum-hash-cbor-file CBOR FILE
-                                                  | --tx-out-datum-hash-file JSON FILE
-                                                  | --tx-out-datum-hash-value JSON VALUE
-                                                  | --tx-out-datum-embed-cbor-file CBOR FILE
-                                                  | --tx-out-datum-embed-file JSON FILE
-                                                  | --tx-out-datum-embed-value JSON VALUE
-                                                  | --tx-out-inline-datum-cbor-file CBOR FILE
-                                                  | --tx-out-inline-datum-file JSON FILE
-                                                  | --tx-out-inline-datum-value JSON VALUE
+                                                  | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                  | --tx-out-datum-hash-file JSON_FILE
+                                                  | --tx-out-datum-hash-value JSON_VALUE
+                                                  | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                  | --tx-out-datum-embed-file JSON_FILE
+                                                  | --tx-out-datum-embed-value JSON_VALUE
+                                                  | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                  | --tx-out-inline-datum-file JSON_FILE
+                                                  | --tx-out-inline-datum-value JSON_VALUE
                                                   ]
                                                   [--tx-out-reference-script-file FILE]]
                                                 [--mint VALUE
                                                   ( --mint-script-file FILE
                                                     [
-                                                      ( --mint-redeemer-cbor-file CBOR FILE
-                                                      | --mint-redeemer-file JSON FILE
-                                                      | --mint-redeemer-value JSON VALUE
+                                                      ( --mint-redeemer-cbor-file CBOR_FILE
+                                                      | --mint-redeemer-file JSON_FILE
+                                                      | --mint-redeemer-value JSON_VALUE
                                                       )
                                                       --mint-execution-units (INT, INT)]
                                                   | --simple-minting-script-tx-in-reference TX-IN
@@ -65,9 +65,9 @@ Usage: cardano-cli mary transaction build-raw
                                                     ( --mint-plutus-script-v2
                                                     | --mint-plutus-script-v3
                                                     )
-                                                    ( --mint-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                    | --mint-reference-tx-in-redeemer-file JSON FILE
-                                                    | --mint-reference-tx-in-redeemer-value JSON VALUE
+                                                    ( --mint-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                    | --mint-reference-tx-in-redeemer-file JSON_FILE
+                                                    | --mint-reference-tx-in-redeemer-value JSON_VALUE
                                                     )
                                                     --mint-reference-tx-in-execution-units (INT, INT)
                                                     --policy-id HASH
@@ -78,36 +78,36 @@ Usage: cardano-cli mary transaction build-raw
                                                 [--certificate-file FILE
                                                   [ --certificate-script-file FILE
                                                     [
-                                                      ( --certificate-redeemer-cbor-file CBOR FILE
-                                                      | --certificate-redeemer-file JSON FILE
-                                                      | --certificate-redeemer-value JSON VALUE
+                                                      ( --certificate-redeemer-cbor-file CBOR_FILE
+                                                      | --certificate-redeemer-file JSON_FILE
+                                                      | --certificate-redeemer-value JSON_VALUE
                                                       )
                                                       --certificate-execution-units (INT, INT)]
                                                   | --certificate-tx-in-reference TX-IN
                                                     ( --certificate-plutus-script-v2
                                                     | --certificate-plutus-script-v3
                                                     )
-                                                    ( --certificate-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                    | --certificate-reference-tx-in-redeemer-file JSON FILE
-                                                    | --certificate-reference-tx-in-redeemer-value JSON VALUE
+                                                    ( --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                    | --certificate-reference-tx-in-redeemer-file JSON_FILE
+                                                    | --certificate-reference-tx-in-redeemer-value JSON_VALUE
                                                     )
                                                     --certificate-reference-tx-in-execution-units (INT, INT)
                                                   ]]
                                                 [--withdrawal WITHDRAWAL
                                                   [ --withdrawal-script-file FILE
                                                     [
-                                                      ( --withdrawal-redeemer-cbor-file CBOR FILE
-                                                      | --withdrawal-redeemer-file JSON FILE
-                                                      | --withdrawal-redeemer-value JSON VALUE
+                                                      ( --withdrawal-redeemer-cbor-file CBOR_FILE
+                                                      | --withdrawal-redeemer-file JSON_FILE
+                                                      | --withdrawal-redeemer-value JSON_VALUE
                                                       )
                                                       --withdrawal-execution-units (INT, INT)]
                                                   | --withdrawal-tx-in-reference TX-IN
                                                     ( --withdrawal-plutus-script-v2
                                                     | --withdrawal-plutus-script-v3
                                                     )
-                                                    ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                    | --withdrawal-reference-tx-in-redeemer-file JSON FILE
-                                                    | --withdrawal-reference-tx-in-redeemer-value JSON VALUE
+                                                    ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                    | --withdrawal-reference-tx-in-redeemer-file JSON_FILE
+                                                    | --withdrawal-reference-tx-in-redeemer-value JSON_VALUE
                                                     )
                                                     --withdrawal-reference-tx-in-execution-units (INT, INT)
                                                   ]]
@@ -139,28 +139,28 @@ Available options:
                            Specify a plutus script v2 reference script.
   --spending-plutus-script-v3
                            Specify a plutus script v3 reference script.
-  --spending-reference-tx-in-datum-cbor-file CBOR FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-datum-file JSON FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-datum-value JSON VALUE
-                           The script datum, in JSON syntax. There is no schema:
-                           (almost) any JSON value is supported, including
-                           top-level strings and numbers.
+  --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                           The script datum file. The file has to be in CBOR
+                           format.
+  --spending-reference-tx-in-datum-file JSON_FILE
+                           The script datum file. The file must follow the
+                           detailed JSON schema for script data.
+  --spending-reference-tx-in-datum-value JSON_VALUE
+                           The script datum. There is no schema: (almost) any
+                           JSON value is supported, including top-level strings
+                           and numbers.
   --spending-reference-tx-in-inline-datum-present
                            Inline datum present at transaction input.
-  --spending-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --spending-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --spending-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --spending-reference-tx-in-execution-units (INT, INT)
                            The time and space units needed by the script.
   --simple-script-tx-in-reference TX-IN
@@ -168,28 +168,28 @@ Available options:
                            input must have a simple reference script attached.
   --tx-in-script-file FILE The file containing the script to witness the
                            spending of the transaction input.
-  --tx-in-datum-cbor-file CBOR FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-datum-file JSON FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-datum-value JSON VALUE
-                           The script datum, in JSON syntax. There is no schema:
-                           (almost) any JSON value is supported, including
-                           top-level strings and numbers.
+  --tx-in-datum-cbor-file CBOR_FILE
+                           The script datum file. The file has to be in CBOR
+                           format.
+  --tx-in-datum-file JSON_FILE
+                           The script datum file. The file must follow the
+                           detailed JSON schema for script data.
+  --tx-in-datum-value JSON_VALUE
+                           The script datum. There is no schema: (almost) any
+                           JSON value is supported, including top-level strings
+                           and numbers.
   --tx-in-inline-datum-present
                            Inline datum present at transaction input.
-  --tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --tx-in-execution-units (INT, INT)
                            The time and space units needed by the script.
   --read-only-tx-in-reference TX-IN
@@ -220,61 +220,60 @@ Available options:
                            Lovelace).
   --tx-out-datum-hash HASH The script datum hash for this tx output, as the raw
                            datum hash (in hex).
-  --tx-out-datum-hash-cbor-file CBOR FILE
+  --tx-out-datum-hash-cbor-file CBOR_FILE
                            The script datum hash for this tx output, by hashing
-                           the script datum in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-out-datum-hash-file JSON FILE
+                           the script datum in the file. The file has to be in
+                           CBOR format.
+  --tx-out-datum-hash-file JSON_FILE
                            The script datum hash for this tx output, by hashing
-                           the script datum in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-out-datum-hash-value JSON VALUE
+                           the script datum in the file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-datum-hash-value JSON_VALUE
                            The script datum hash for this tx output, by hashing
-                           the script datum given here in JSON syntax. There is
-                           no schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
-  --tx-out-datum-embed-cbor-file CBOR FILE
-                           The script datum to embed in the tx for this output,
-                           in the given JSON file. The file must follow the
-                           special JSON schema for script data.
-  --tx-out-datum-embed-file JSON FILE
-                           The script datum to embed in the tx for this output,
-                           in the given JSON file. The file must follow the
-                           special JSON schema for script data.
-  --tx-out-datum-embed-value JSON VALUE
-                           The script datum to embed in the tx for this output,
-                           given here in JSON syntax. There is no schema:
+                           the script datum given here. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
-  --tx-out-inline-datum-cbor-file CBOR FILE
+  --tx-out-datum-embed-cbor-file CBOR_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file has to be in CBOR format.
+  --tx-out-datum-embed-file JSON_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file must follow the detailed
+                           JSON schema for script data.
+  --tx-out-datum-embed-value JSON_VALUE
+                           The script datum to embed in the tx for this output,
+                           given here. There is no schema: (almost) any JSON
+                           value is supported, including top-level strings and
+                           numbers.
+  --tx-out-inline-datum-cbor-file CBOR_FILE
                            The script datum to embed in the tx output as an
-                           inline datum, in the given JSON file. The file must
-                           follow the special JSON schema for script data.
-  --tx-out-inline-datum-file JSON FILE
+                           inline datum, in the given file. The file has to be
+                           in CBOR format.
+  --tx-out-inline-datum-file JSON_FILE
                            The script datum to embed in the tx output as an
-                           inline datum, in the given JSON file. The file must
-                           follow the special JSON schema for script data.
-  --tx-out-inline-datum-value JSON VALUE
+                           inline datum, in the given file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-inline-datum-value JSON_VALUE
                            The script datum to embed in the tx output as an
-                           inline datum, given here in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+                           inline datum, given here. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --tx-out-reference-script-file FILE
                            Reference script input file.
   --mint VALUE             Mint multi-asset value(s) with the multi-asset cli
                            syntax. You must specify a script witness.
   --mint-script-file FILE  The file containing the script to witness the minting
                            of assets for a particular policy Id.
-  --mint-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --mint-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --mint-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --mint-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --mint-execution-units (INT, INT)
                            The time and space units needed by the script.
   --simple-minting-script-tx-in-reference TX-IN
@@ -286,16 +285,16 @@ Available options:
                            input must have a plutus reference script attached.
   --mint-plutus-script-v2  Specify a plutus script v2 reference script.
   --mint-plutus-script-v3  Specify a plutus script v3 reference script.
-  --mint-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --mint-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --mint-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --mint-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --mint-reference-tx-in-execution-units (INT, INT)
                            The time and space units needed by the script.
   --policy-id HASH         Policy id of minting script.
@@ -309,16 +308,16 @@ Available options:
   --certificate-script-file FILE
                            The file containing the script to witness the use of
                            the certificate.
-  --certificate-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --certificate-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --certificate-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --certificate-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --certificate-execution-units (INT, INT)
                            The time and space units needed by the script.
   --certificate-tx-in-reference TX-IN
@@ -328,16 +327,16 @@ Available options:
                            Specify a plutus script v2 reference script.
   --certificate-plutus-script-v3
                            Specify a plutus script v3 reference script.
-  --certificate-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --certificate-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --certificate-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --certificate-reference-tx-in-execution-units (INT, INT)
                            The time and space units needed by the script.
   --withdrawal WITHDRAWAL  The reward withdrawal as StakeAddress+Lovelace where
@@ -347,16 +346,16 @@ Available options:
   --withdrawal-script-file FILE
                            The file containing the script to witness the
                            withdrawal of rewards.
-  --withdrawal-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --withdrawal-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --withdrawal-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --withdrawal-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --withdrawal-execution-units (INT, INT)
                            The time and space units needed by the script.
   --withdrawal-tx-in-reference TX-IN
@@ -366,16 +365,16 @@ Available options:
                            Specify a plutus script v2 reference script.
   --withdrawal-plutus-script-v3
                            Specify a plutus script v3 reference script.
-  --withdrawal-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --withdrawal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --withdrawal-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --withdrawal-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --withdrawal-reference-tx-in-execution-units (INT, INT)
                            The time and space units needed by the script.
   --json-metadata-no-schema

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_transaction_build.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_transaction_build.cli
@@ -11,26 +11,26 @@ Usage: cardano-cli mary transaction build --socket-path SOCKET_PATH
                                                 ( --spending-plutus-script-v2
                                                 | --spending-plutus-script-v3
                                                 )
-                                                ( --spending-reference-tx-in-datum-cbor-file CBOR FILE
-                                                | --spending-reference-tx-in-datum-file JSON FILE
-                                                | --spending-reference-tx-in-datum-value JSON VALUE
+                                                ( --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                                                | --spending-reference-tx-in-datum-file JSON_FILE
+                                                | --spending-reference-tx-in-datum-value JSON_VALUE
                                                 | --spending-reference-tx-in-inline-datum-present
                                                 )
-                                                ( --spending-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                | --spending-reference-tx-in-redeemer-file JSON FILE
-                                                | --spending-reference-tx-in-redeemer-value JSON VALUE
+                                                ( --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                | --spending-reference-tx-in-redeemer-file JSON_FILE
+                                                | --spending-reference-tx-in-redeemer-value JSON_VALUE
                                                 )
                                               | --simple-script-tx-in-reference TX-IN
                                               | --tx-in-script-file FILE
                                                 [
-                                                  ( --tx-in-datum-cbor-file CBOR FILE
-                                                  | --tx-in-datum-file JSON FILE
-                                                  | --tx-in-datum-value JSON VALUE
+                                                  ( --tx-in-datum-cbor-file CBOR_FILE
+                                                  | --tx-in-datum-file JSON_FILE
+                                                  | --tx-in-datum-value JSON_VALUE
                                                   | --tx-in-inline-datum-present
                                                   )
-                                                  ( --tx-in-redeemer-cbor-file CBOR FILE
-                                                  | --tx-in-redeemer-file JSON FILE
-                                                  | --tx-in-redeemer-value JSON VALUE
+                                                  ( --tx-in-redeemer-cbor-file CBOR_FILE
+                                                  | --tx-in-redeemer-file JSON_FILE
+                                                  | --tx-in-redeemer-value JSON_VALUE
                                                   )]
                                               ])
                                             [--read-only-tx-in-reference TX-IN]
@@ -42,23 +42,23 @@ Usage: cardano-cli mary transaction build --socket-path SOCKET_PATH
                                             [--tx-total-collateral INTEGER]
                                             [--tx-out ADDRESS VALUE
                                               [ --tx-out-datum-hash HASH
-                                              | --tx-out-datum-hash-cbor-file CBOR FILE
-                                              | --tx-out-datum-hash-file JSON FILE
-                                              | --tx-out-datum-hash-value JSON VALUE
-                                              | --tx-out-datum-embed-cbor-file CBOR FILE
-                                              | --tx-out-datum-embed-file JSON FILE
-                                              | --tx-out-datum-embed-value JSON VALUE
-                                              | --tx-out-inline-datum-cbor-file CBOR FILE
-                                              | --tx-out-inline-datum-file JSON FILE
-                                              | --tx-out-inline-datum-value JSON VALUE
+                                              | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                              | --tx-out-datum-hash-file JSON_FILE
+                                              | --tx-out-datum-hash-value JSON_VALUE
+                                              | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                              | --tx-out-datum-embed-file JSON_FILE
+                                              | --tx-out-datum-embed-value JSON_VALUE
+                                              | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                              | --tx-out-inline-datum-file JSON_FILE
+                                              | --tx-out-inline-datum-value JSON_VALUE
                                               ]
                                               [--tx-out-reference-script-file FILE]]
                                             --change-address ADDRESS
                                             [--mint VALUE
                                               ( --mint-script-file FILE
-                                                [ --mint-redeemer-cbor-file CBOR FILE
-                                                | --mint-redeemer-file JSON FILE
-                                                | --mint-redeemer-value JSON VALUE
+                                                [ --mint-redeemer-cbor-file CBOR_FILE
+                                                | --mint-redeemer-file JSON_FILE
+                                                | --mint-redeemer-value JSON_VALUE
                                                 ]
                                               | --simple-minting-script-tx-in-reference TX-IN
                                                 --policy-id HASH
@@ -66,9 +66,9 @@ Usage: cardano-cli mary transaction build --socket-path SOCKET_PATH
                                                 ( --mint-plutus-script-v2
                                                 | --mint-plutus-script-v3
                                                 )
-                                                ( --mint-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                | --mint-reference-tx-in-redeemer-file JSON FILE
-                                                | --mint-reference-tx-in-redeemer-value JSON VALUE
+                                                ( --mint-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                | --mint-reference-tx-in-redeemer-file JSON_FILE
+                                                | --mint-reference-tx-in-redeemer-value JSON_VALUE
                                                 )
                                                 --policy-id HASH
                                               )]
@@ -76,32 +76,32 @@ Usage: cardano-cli mary transaction build --socket-path SOCKET_PATH
                                             [--invalid-hereafter SLOT]
                                             [--certificate-file FILE
                                               [ --certificate-script-file FILE
-                                                [ --certificate-redeemer-cbor-file CBOR FILE
-                                                | --certificate-redeemer-file JSON FILE
-                                                | --certificate-redeemer-value JSON VALUE
+                                                [ --certificate-redeemer-cbor-file CBOR_FILE
+                                                | --certificate-redeemer-file JSON_FILE
+                                                | --certificate-redeemer-value JSON_VALUE
                                                 ]
                                               | --certificate-tx-in-reference TX-IN
                                                 ( --certificate-plutus-script-v2
                                                 | --certificate-plutus-script-v3
                                                 )
-                                                ( --certificate-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                | --certificate-reference-tx-in-redeemer-file JSON FILE
-                                                | --certificate-reference-tx-in-redeemer-value JSON VALUE
+                                                ( --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                | --certificate-reference-tx-in-redeemer-file JSON_FILE
+                                                | --certificate-reference-tx-in-redeemer-value JSON_VALUE
                                                 )
                                               ]]
                                             [--withdrawal WITHDRAWAL
                                               [ --withdrawal-script-file FILE
-                                                [ --withdrawal-redeemer-cbor-file CBOR FILE
-                                                | --withdrawal-redeemer-file JSON FILE
-                                                | --withdrawal-redeemer-value JSON VALUE
+                                                [ --withdrawal-redeemer-cbor-file CBOR_FILE
+                                                | --withdrawal-redeemer-file JSON_FILE
+                                                | --withdrawal-redeemer-value JSON_VALUE
                                                 ]
                                               | --withdrawal-tx-in-reference TX-IN
                                                 ( --withdrawal-plutus-script-v2
                                                 | --withdrawal-plutus-script-v3
                                                 )
-                                                ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                | --withdrawal-reference-tx-in-redeemer-file JSON FILE
-                                                | --withdrawal-reference-tx-in-redeemer-value JSON VALUE
+                                                ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                | --withdrawal-reference-tx-in-redeemer-file JSON_FILE
+                                                | --withdrawal-reference-tx-in-redeemer-value JSON_VALUE
                                                 )
                                               ]]
                                             [ --json-metadata-no-schema
@@ -148,55 +148,55 @@ Available options:
                            Specify a plutus script v2 reference script.
   --spending-plutus-script-v3
                            Specify a plutus script v3 reference script.
-  --spending-reference-tx-in-datum-cbor-file CBOR FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-datum-file JSON FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-datum-value JSON VALUE
-                           The script datum, in JSON syntax. There is no schema:
-                           (almost) any JSON value is supported, including
-                           top-level strings and numbers.
+  --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                           The script datum file. The file has to be in CBOR
+                           format.
+  --spending-reference-tx-in-datum-file JSON_FILE
+                           The script datum file. The file must follow the
+                           detailed JSON schema for script data.
+  --spending-reference-tx-in-datum-value JSON_VALUE
+                           The script datum. There is no schema: (almost) any
+                           JSON value is supported, including top-level strings
+                           and numbers.
   --spending-reference-tx-in-inline-datum-present
                            Inline datum present at transaction input.
-  --spending-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --spending-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --spending-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --simple-script-tx-in-reference TX-IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a simple reference script attached.
   --tx-in-script-file FILE The file containing the script to witness the
                            spending of the transaction input.
-  --tx-in-datum-cbor-file CBOR FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-datum-file JSON FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-datum-value JSON VALUE
-                           The script datum, in JSON syntax. There is no schema:
-                           (almost) any JSON value is supported, including
-                           top-level strings and numbers.
+  --tx-in-datum-cbor-file CBOR_FILE
+                           The script datum file. The file has to be in CBOR
+                           format.
+  --tx-in-datum-file JSON_FILE
+                           The script datum file. The file must follow the
+                           detailed JSON schema for script data.
+  --tx-in-datum-value JSON_VALUE
+                           The script datum. There is no schema: (almost) any
+                           JSON value is supported, including top-level strings
+                           and numbers.
   --tx-in-inline-datum-present
                            Inline datum present at transaction input.
-  --tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --read-only-tx-in-reference TX-IN
                            Specify a read only reference input. This reference
                            input is not witnessing anything it is simply
@@ -225,45 +225,44 @@ Available options:
                            Lovelace).
   --tx-out-datum-hash HASH The script datum hash for this tx output, as the raw
                            datum hash (in hex).
-  --tx-out-datum-hash-cbor-file CBOR FILE
+  --tx-out-datum-hash-cbor-file CBOR_FILE
                            The script datum hash for this tx output, by hashing
-                           the script datum in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-out-datum-hash-file JSON FILE
+                           the script datum in the file. The file has to be in
+                           CBOR format.
+  --tx-out-datum-hash-file JSON_FILE
                            The script datum hash for this tx output, by hashing
-                           the script datum in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-out-datum-hash-value JSON VALUE
+                           the script datum in the file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-datum-hash-value JSON_VALUE
                            The script datum hash for this tx output, by hashing
-                           the script datum given here in JSON syntax. There is
-                           no schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
-  --tx-out-datum-embed-cbor-file CBOR FILE
-                           The script datum to embed in the tx for this output,
-                           in the given JSON file. The file must follow the
-                           special JSON schema for script data.
-  --tx-out-datum-embed-file JSON FILE
-                           The script datum to embed in the tx for this output,
-                           in the given JSON file. The file must follow the
-                           special JSON schema for script data.
-  --tx-out-datum-embed-value JSON VALUE
-                           The script datum to embed in the tx for this output,
-                           given here in JSON syntax. There is no schema:
+                           the script datum given here. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
-  --tx-out-inline-datum-cbor-file CBOR FILE
+  --tx-out-datum-embed-cbor-file CBOR_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file has to be in CBOR format.
+  --tx-out-datum-embed-file JSON_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file must follow the detailed
+                           JSON schema for script data.
+  --tx-out-datum-embed-value JSON_VALUE
+                           The script datum to embed in the tx for this output,
+                           given here. There is no schema: (almost) any JSON
+                           value is supported, including top-level strings and
+                           numbers.
+  --tx-out-inline-datum-cbor-file CBOR_FILE
                            The script datum to embed in the tx output as an
-                           inline datum, in the given JSON file. The file must
-                           follow the special JSON schema for script data.
-  --tx-out-inline-datum-file JSON FILE
+                           inline datum, in the given file. The file has to be
+                           in CBOR format.
+  --tx-out-inline-datum-file JSON_FILE
                            The script datum to embed in the tx output as an
-                           inline datum, in the given JSON file. The file must
-                           follow the special JSON schema for script data.
-  --tx-out-inline-datum-value JSON VALUE
+                           inline datum, in the given file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-inline-datum-value JSON_VALUE
                            The script datum to embed in the tx output as an
-                           inline datum, given here in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+                           inline datum, given here. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --tx-out-reference-script-file FILE
                            Reference script input file.
   --change-address ADDRESS Address where ADA in excess of the tx fee will go to.
@@ -271,16 +270,16 @@ Available options:
                            syntax. You must specify a script witness.
   --mint-script-file FILE  The file containing the script to witness the minting
                            of assets for a particular policy Id.
-  --mint-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --mint-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --mint-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --mint-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --simple-minting-script-tx-in-reference TX-IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a simple reference script attached.
@@ -290,16 +289,16 @@ Available options:
                            input must have a plutus reference script attached.
   --mint-plutus-script-v2  Specify a plutus script v2 reference script.
   --mint-plutus-script-v3  Specify a plutus script v3 reference script.
-  --mint-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --mint-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --mint-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --mint-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --policy-id HASH         Policy id of minting script.
   --invalid-before SLOT    Time that transaction is valid from (in slots).
   --invalid-hereafter SLOT Time that transaction is valid until (in slots).
@@ -310,16 +309,16 @@ Available options:
   --certificate-script-file FILE
                            The file containing the script to witness the use of
                            the certificate.
-  --certificate-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --certificate-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --certificate-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --certificate-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --certificate-tx-in-reference TX-IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a plutus reference script attached.
@@ -327,16 +326,16 @@ Available options:
                            Specify a plutus script v2 reference script.
   --certificate-plutus-script-v3
                            Specify a plutus script v3 reference script.
-  --certificate-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --certificate-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --certificate-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --withdrawal WITHDRAWAL  The reward withdrawal as StakeAddress+Lovelace where
                            StakeAddress is the Bech32-encoded stake address
                            followed by the amount in Lovelace. Optionally
@@ -344,16 +343,16 @@ Available options:
   --withdrawal-script-file FILE
                            The file containing the script to witness the
                            withdrawal of rewards.
-  --withdrawal-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --withdrawal-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --withdrawal-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --withdrawal-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --withdrawal-tx-in-reference TX-IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a plutus reference script attached.
@@ -361,16 +360,16 @@ Available options:
                            Specify a plutus script v2 reference script.
   --withdrawal-plutus-script-v3
                            Specify a plutus script v3 reference script.
-  --withdrawal-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --withdrawal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --withdrawal-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --withdrawal-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --json-metadata-no-schema
                            Use the "no schema" conversion from JSON to tx
                            metadata (default).

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_transaction_calculate-min-required-utxo.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_transaction_calculate-min-required-utxo.cli
@@ -1,15 +1,15 @@
 Usage: cardano-cli mary transaction calculate-min-required-utxo --protocol-params-file FILE
                                                                   --tx-out ADDRESS VALUE
                                                                   [ --tx-out-datum-hash HASH
-                                                                  | --tx-out-datum-hash-cbor-file CBOR FILE
-                                                                  | --tx-out-datum-hash-file JSON FILE
-                                                                  | --tx-out-datum-hash-value JSON VALUE
-                                                                  | --tx-out-datum-embed-cbor-file CBOR FILE
-                                                                  | --tx-out-datum-embed-file JSON FILE
-                                                                  | --tx-out-datum-embed-value JSON VALUE
-                                                                  | --tx-out-inline-datum-cbor-file CBOR FILE
-                                                                  | --tx-out-inline-datum-file JSON FILE
-                                                                  | --tx-out-inline-datum-value JSON VALUE
+                                                                  | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                                  | --tx-out-datum-hash-file JSON_FILE
+                                                                  | --tx-out-datum-hash-value JSON_VALUE
+                                                                  | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                                  | --tx-out-datum-embed-file JSON_FILE
+                                                                  | --tx-out-datum-embed-value JSON_VALUE
+                                                                  | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                                  | --tx-out-inline-datum-file JSON_FILE
+                                                                  | --tx-out-inline-datum-value JSON_VALUE
                                                                   ]
                                                                   [--tx-out-reference-script-file FILE]
 
@@ -24,45 +24,44 @@ Available options:
                            Lovelace).
   --tx-out-datum-hash HASH The script datum hash for this tx output, as the raw
                            datum hash (in hex).
-  --tx-out-datum-hash-cbor-file CBOR FILE
+  --tx-out-datum-hash-cbor-file CBOR_FILE
                            The script datum hash for this tx output, by hashing
-                           the script datum in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-out-datum-hash-file JSON FILE
+                           the script datum in the file. The file has to be in
+                           CBOR format.
+  --tx-out-datum-hash-file JSON_FILE
                            The script datum hash for this tx output, by hashing
-                           the script datum in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-out-datum-hash-value JSON VALUE
+                           the script datum in the file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-datum-hash-value JSON_VALUE
                            The script datum hash for this tx output, by hashing
-                           the script datum given here in JSON syntax. There is
-                           no schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
-  --tx-out-datum-embed-cbor-file CBOR FILE
-                           The script datum to embed in the tx for this output,
-                           in the given JSON file. The file must follow the
-                           special JSON schema for script data.
-  --tx-out-datum-embed-file JSON FILE
-                           The script datum to embed in the tx for this output,
-                           in the given JSON file. The file must follow the
-                           special JSON schema for script data.
-  --tx-out-datum-embed-value JSON VALUE
-                           The script datum to embed in the tx for this output,
-                           given here in JSON syntax. There is no schema:
+                           the script datum given here. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
-  --tx-out-inline-datum-cbor-file CBOR FILE
+  --tx-out-datum-embed-cbor-file CBOR_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file has to be in CBOR format.
+  --tx-out-datum-embed-file JSON_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file must follow the detailed
+                           JSON schema for script data.
+  --tx-out-datum-embed-value JSON_VALUE
+                           The script datum to embed in the tx for this output,
+                           given here. There is no schema: (almost) any JSON
+                           value is supported, including top-level strings and
+                           numbers.
+  --tx-out-inline-datum-cbor-file CBOR_FILE
                            The script datum to embed in the tx output as an
-                           inline datum, in the given JSON file. The file must
-                           follow the special JSON schema for script data.
-  --tx-out-inline-datum-file JSON FILE
+                           inline datum, in the given file. The file has to be
+                           in CBOR format.
+  --tx-out-inline-datum-file JSON_FILE
                            The script datum to embed in the tx output as an
-                           inline datum, in the given JSON file. The file must
-                           follow the special JSON schema for script data.
-  --tx-out-inline-datum-value JSON VALUE
+                           inline datum, in the given file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-inline-datum-value JSON_VALUE
                            The script datum to embed in the tx output as an
-                           inline datum, given here in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+                           inline datum, given here. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --tx-out-reference-script-file FILE
                            Reference script input file.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_transaction_calculate-min-value.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_transaction_calculate-min-value.cli
@@ -1,15 +1,15 @@
 Usage: cardano-cli mary transaction calculate-min-value --protocol-params-file FILE
                                                           --tx-out ADDRESS VALUE
                                                           [ --tx-out-datum-hash HASH
-                                                          | --tx-out-datum-hash-cbor-file CBOR FILE
-                                                          | --tx-out-datum-hash-file JSON FILE
-                                                          | --tx-out-datum-hash-value JSON VALUE
-                                                          | --tx-out-datum-embed-cbor-file CBOR FILE
-                                                          | --tx-out-datum-embed-file JSON FILE
-                                                          | --tx-out-datum-embed-value JSON VALUE
-                                                          | --tx-out-inline-datum-cbor-file CBOR FILE
-                                                          | --tx-out-inline-datum-file JSON FILE
-                                                          | --tx-out-inline-datum-value JSON VALUE
+                                                          | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                          | --tx-out-datum-hash-file JSON_FILE
+                                                          | --tx-out-datum-hash-value JSON_VALUE
+                                                          | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                          | --tx-out-datum-embed-file JSON_FILE
+                                                          | --tx-out-datum-embed-value JSON_VALUE
+                                                          | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                          | --tx-out-inline-datum-file JSON_FILE
+                                                          | --tx-out-inline-datum-value JSON_VALUE
                                                           ]
                                                           [--tx-out-reference-script-file FILE]
 
@@ -24,44 +24,43 @@ Available options:
                            Lovelace).
   --tx-out-datum-hash HASH The script datum hash for this tx output, as the raw
                            datum hash (in hex).
-  --tx-out-datum-hash-cbor-file CBOR FILE
+  --tx-out-datum-hash-cbor-file CBOR_FILE
                            The script datum hash for this tx output, by hashing
-                           the script datum in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-out-datum-hash-file JSON FILE
+                           the script datum in the file. The file has to be in
+                           CBOR format.
+  --tx-out-datum-hash-file JSON_FILE
                            The script datum hash for this tx output, by hashing
-                           the script datum in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-out-datum-hash-value JSON VALUE
+                           the script datum in the file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-datum-hash-value JSON_VALUE
                            The script datum hash for this tx output, by hashing
-                           the script datum given here in JSON syntax. There is
-                           no schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
-  --tx-out-datum-embed-cbor-file CBOR FILE
-                           The script datum to embed in the tx for this output,
-                           in the given JSON file. The file must follow the
-                           special JSON schema for script data.
-  --tx-out-datum-embed-file JSON FILE
-                           The script datum to embed in the tx for this output,
-                           in the given JSON file. The file must follow the
-                           special JSON schema for script data.
-  --tx-out-datum-embed-value JSON VALUE
-                           The script datum to embed in the tx for this output,
-                           given here in JSON syntax. There is no schema:
+                           the script datum given here. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
-  --tx-out-inline-datum-cbor-file CBOR FILE
+  --tx-out-datum-embed-cbor-file CBOR_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file has to be in CBOR format.
+  --tx-out-datum-embed-file JSON_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file must follow the detailed
+                           JSON schema for script data.
+  --tx-out-datum-embed-value JSON_VALUE
+                           The script datum to embed in the tx for this output,
+                           given here. There is no schema: (almost) any JSON
+                           value is supported, including top-level strings and
+                           numbers.
+  --tx-out-inline-datum-cbor-file CBOR_FILE
                            The script datum to embed in the tx output as an
-                           inline datum, in the given JSON file. The file must
-                           follow the special JSON schema for script data.
-  --tx-out-inline-datum-file JSON FILE
+                           inline datum, in the given file. The file has to be
+                           in CBOR format.
+  --tx-out-inline-datum-file JSON_FILE
                            The script datum to embed in the tx output as an
-                           inline datum, in the given JSON file. The file must
-                           follow the special JSON schema for script data.
-  --tx-out-inline-datum-value JSON VALUE
+                           inline datum, in the given file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-inline-datum-value JSON_VALUE
                            The script datum to embed in the tx output as an
-                           inline datum, given here in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+                           inline datum, given here. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --tx-out-reference-script-file FILE
                            Reference script input file.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_transaction_hash-script-data.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_transaction_hash-script-data.cli
@@ -1,20 +1,20 @@
 Usage: cardano-cli mary transaction hash-script-data 
-                                                       ( --script-data-cbor-file CBOR FILE
-                                                       | --script-data-file JSON FILE
-                                                       | --script-data-value JSON VALUE
+                                                       ( --script-data-cbor-file CBOR_FILE
+                                                       | --script-data-file JSON_FILE
+                                                       | --script-data-value JSON_VALUE
                                                        )
 
   Calculate the hash of script data.
 
 Available options:
-  --script-data-cbor-file CBOR FILE
-                           The script data, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --script-data-file JSON FILE
-                           The script data, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --script-data-value JSON VALUE
-                           The script data, in JSON syntax. There is no schema:
-                           (almost) any JSON value is supported, including
-                           top-level strings and numbers.
+  --script-data-cbor-file CBOR_FILE
+                           The script data file. The file has to be in CBOR
+                           format.
+  --script-data-file JSON_FILE
+                           The script data file. The file must follow the
+                           detailed JSON schema for script data.
+  --script-data-value JSON_VALUE
+                           The script data. There is no schema: (almost) any
+                           JSON value is supported, including top-level strings
+                           and numbers.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_transaction_build-raw.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_transaction_build-raw.cli
@@ -7,27 +7,27 @@ Usage: cardano-cli shelley transaction build-raw
                                                        ( --spending-plutus-script-v2
                                                        | --spending-plutus-script-v3
                                                        )
-                                                       ( --spending-reference-tx-in-datum-cbor-file CBOR FILE
-                                                       | --spending-reference-tx-in-datum-file JSON FILE
-                                                       | --spending-reference-tx-in-datum-value JSON VALUE
+                                                       ( --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                                                       | --spending-reference-tx-in-datum-file JSON_FILE
+                                                       | --spending-reference-tx-in-datum-value JSON_VALUE
                                                        | --spending-reference-tx-in-inline-datum-present
                                                        )
-                                                       ( --spending-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                       | --spending-reference-tx-in-redeemer-file JSON FILE
-                                                       | --spending-reference-tx-in-redeemer-value JSON VALUE
+                                                       ( --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                       | --spending-reference-tx-in-redeemer-file JSON_FILE
+                                                       | --spending-reference-tx-in-redeemer-value JSON_VALUE
                                                        )
                                                        --spending-reference-tx-in-execution-units (INT, INT)
                                                      | --simple-script-tx-in-reference TX-IN
                                                      | --tx-in-script-file FILE
                                                        [
-                                                         ( --tx-in-datum-cbor-file CBOR FILE
-                                                         | --tx-in-datum-file JSON FILE
-                                                         | --tx-in-datum-value JSON VALUE
+                                                         ( --tx-in-datum-cbor-file CBOR_FILE
+                                                         | --tx-in-datum-file JSON_FILE
+                                                         | --tx-in-datum-value JSON_VALUE
                                                          | --tx-in-inline-datum-present
                                                          )
-                                                         ( --tx-in-redeemer-cbor-file CBOR FILE
-                                                         | --tx-in-redeemer-file JSON FILE
-                                                         | --tx-in-redeemer-value JSON VALUE
+                                                         ( --tx-in-redeemer-cbor-file CBOR_FILE
+                                                         | --tx-in-redeemer-file JSON_FILE
+                                                         | --tx-in-redeemer-value JSON_VALUE
                                                          )
                                                          --tx-in-execution-units (INT, INT)]
                                                      ])
@@ -40,23 +40,23 @@ Usage: cardano-cli shelley transaction build-raw
                                                    ]
                                                    [--tx-out ADDRESS VALUE
                                                      [ --tx-out-datum-hash HASH
-                                                     | --tx-out-datum-hash-cbor-file CBOR FILE
-                                                     | --tx-out-datum-hash-file JSON FILE
-                                                     | --tx-out-datum-hash-value JSON VALUE
-                                                     | --tx-out-datum-embed-cbor-file CBOR FILE
-                                                     | --tx-out-datum-embed-file JSON FILE
-                                                     | --tx-out-datum-embed-value JSON VALUE
-                                                     | --tx-out-inline-datum-cbor-file CBOR FILE
-                                                     | --tx-out-inline-datum-file JSON FILE
-                                                     | --tx-out-inline-datum-value JSON VALUE
+                                                     | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                     | --tx-out-datum-hash-file JSON_FILE
+                                                     | --tx-out-datum-hash-value JSON_VALUE
+                                                     | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                     | --tx-out-datum-embed-file JSON_FILE
+                                                     | --tx-out-datum-embed-value JSON_VALUE
+                                                     | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                     | --tx-out-inline-datum-file JSON_FILE
+                                                     | --tx-out-inline-datum-value JSON_VALUE
                                                      ]
                                                      [--tx-out-reference-script-file FILE]]
                                                    [--mint VALUE
                                                      ( --mint-script-file FILE
                                                        [
-                                                         ( --mint-redeemer-cbor-file CBOR FILE
-                                                         | --mint-redeemer-file JSON FILE
-                                                         | --mint-redeemer-value JSON VALUE
+                                                         ( --mint-redeemer-cbor-file CBOR_FILE
+                                                         | --mint-redeemer-file JSON_FILE
+                                                         | --mint-redeemer-value JSON_VALUE
                                                          )
                                                          --mint-execution-units (INT, INT)]
                                                      | --simple-minting-script-tx-in-reference TX-IN
@@ -65,9 +65,9 @@ Usage: cardano-cli shelley transaction build-raw
                                                        ( --mint-plutus-script-v2
                                                        | --mint-plutus-script-v3
                                                        )
-                                                       ( --mint-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                       | --mint-reference-tx-in-redeemer-file JSON FILE
-                                                       | --mint-reference-tx-in-redeemer-value JSON VALUE
+                                                       ( --mint-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                       | --mint-reference-tx-in-redeemer-file JSON_FILE
+                                                       | --mint-reference-tx-in-redeemer-value JSON_VALUE
                                                        )
                                                        --mint-reference-tx-in-execution-units (INT, INT)
                                                        --policy-id HASH
@@ -78,36 +78,36 @@ Usage: cardano-cli shelley transaction build-raw
                                                    [--certificate-file FILE
                                                      [ --certificate-script-file FILE
                                                        [
-                                                         ( --certificate-redeemer-cbor-file CBOR FILE
-                                                         | --certificate-redeemer-file JSON FILE
-                                                         | --certificate-redeemer-value JSON VALUE
+                                                         ( --certificate-redeemer-cbor-file CBOR_FILE
+                                                         | --certificate-redeemer-file JSON_FILE
+                                                         | --certificate-redeemer-value JSON_VALUE
                                                          )
                                                          --certificate-execution-units (INT, INT)]
                                                      | --certificate-tx-in-reference TX-IN
                                                        ( --certificate-plutus-script-v2
                                                        | --certificate-plutus-script-v3
                                                        )
-                                                       ( --certificate-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                       | --certificate-reference-tx-in-redeemer-file JSON FILE
-                                                       | --certificate-reference-tx-in-redeemer-value JSON VALUE
+                                                       ( --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                       | --certificate-reference-tx-in-redeemer-file JSON_FILE
+                                                       | --certificate-reference-tx-in-redeemer-value JSON_VALUE
                                                        )
                                                        --certificate-reference-tx-in-execution-units (INT, INT)
                                                      ]]
                                                    [--withdrawal WITHDRAWAL
                                                      [ --withdrawal-script-file FILE
                                                        [
-                                                         ( --withdrawal-redeemer-cbor-file CBOR FILE
-                                                         | --withdrawal-redeemer-file JSON FILE
-                                                         | --withdrawal-redeemer-value JSON VALUE
+                                                         ( --withdrawal-redeemer-cbor-file CBOR_FILE
+                                                         | --withdrawal-redeemer-file JSON_FILE
+                                                         | --withdrawal-redeemer-value JSON_VALUE
                                                          )
                                                          --withdrawal-execution-units (INT, INT)]
                                                      | --withdrawal-tx-in-reference TX-IN
                                                        ( --withdrawal-plutus-script-v2
                                                        | --withdrawal-plutus-script-v3
                                                        )
-                                                       ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                       | --withdrawal-reference-tx-in-redeemer-file JSON FILE
-                                                       | --withdrawal-reference-tx-in-redeemer-value JSON VALUE
+                                                       ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                       | --withdrawal-reference-tx-in-redeemer-file JSON_FILE
+                                                       | --withdrawal-reference-tx-in-redeemer-value JSON_VALUE
                                                        )
                                                        --withdrawal-reference-tx-in-execution-units (INT, INT)
                                                      ]]
@@ -139,28 +139,28 @@ Available options:
                            Specify a plutus script v2 reference script.
   --spending-plutus-script-v3
                            Specify a plutus script v3 reference script.
-  --spending-reference-tx-in-datum-cbor-file CBOR FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-datum-file JSON FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-datum-value JSON VALUE
-                           The script datum, in JSON syntax. There is no schema:
-                           (almost) any JSON value is supported, including
-                           top-level strings and numbers.
+  --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                           The script datum file. The file has to be in CBOR
+                           format.
+  --spending-reference-tx-in-datum-file JSON_FILE
+                           The script datum file. The file must follow the
+                           detailed JSON schema for script data.
+  --spending-reference-tx-in-datum-value JSON_VALUE
+                           The script datum. There is no schema: (almost) any
+                           JSON value is supported, including top-level strings
+                           and numbers.
   --spending-reference-tx-in-inline-datum-present
                            Inline datum present at transaction input.
-  --spending-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --spending-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --spending-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --spending-reference-tx-in-execution-units (INT, INT)
                            The time and space units needed by the script.
   --simple-script-tx-in-reference TX-IN
@@ -168,28 +168,28 @@ Available options:
                            input must have a simple reference script attached.
   --tx-in-script-file FILE The file containing the script to witness the
                            spending of the transaction input.
-  --tx-in-datum-cbor-file CBOR FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-datum-file JSON FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-datum-value JSON VALUE
-                           The script datum, in JSON syntax. There is no schema:
-                           (almost) any JSON value is supported, including
-                           top-level strings and numbers.
+  --tx-in-datum-cbor-file CBOR_FILE
+                           The script datum file. The file has to be in CBOR
+                           format.
+  --tx-in-datum-file JSON_FILE
+                           The script datum file. The file must follow the
+                           detailed JSON schema for script data.
+  --tx-in-datum-value JSON_VALUE
+                           The script datum. There is no schema: (almost) any
+                           JSON value is supported, including top-level strings
+                           and numbers.
   --tx-in-inline-datum-present
                            Inline datum present at transaction input.
-  --tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --tx-in-execution-units (INT, INT)
                            The time and space units needed by the script.
   --read-only-tx-in-reference TX-IN
@@ -220,61 +220,60 @@ Available options:
                            Lovelace).
   --tx-out-datum-hash HASH The script datum hash for this tx output, as the raw
                            datum hash (in hex).
-  --tx-out-datum-hash-cbor-file CBOR FILE
+  --tx-out-datum-hash-cbor-file CBOR_FILE
                            The script datum hash for this tx output, by hashing
-                           the script datum in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-out-datum-hash-file JSON FILE
+                           the script datum in the file. The file has to be in
+                           CBOR format.
+  --tx-out-datum-hash-file JSON_FILE
                            The script datum hash for this tx output, by hashing
-                           the script datum in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-out-datum-hash-value JSON VALUE
+                           the script datum in the file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-datum-hash-value JSON_VALUE
                            The script datum hash for this tx output, by hashing
-                           the script datum given here in JSON syntax. There is
-                           no schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
-  --tx-out-datum-embed-cbor-file CBOR FILE
-                           The script datum to embed in the tx for this output,
-                           in the given JSON file. The file must follow the
-                           special JSON schema for script data.
-  --tx-out-datum-embed-file JSON FILE
-                           The script datum to embed in the tx for this output,
-                           in the given JSON file. The file must follow the
-                           special JSON schema for script data.
-  --tx-out-datum-embed-value JSON VALUE
-                           The script datum to embed in the tx for this output,
-                           given here in JSON syntax. There is no schema:
+                           the script datum given here. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
-  --tx-out-inline-datum-cbor-file CBOR FILE
+  --tx-out-datum-embed-cbor-file CBOR_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file has to be in CBOR format.
+  --tx-out-datum-embed-file JSON_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file must follow the detailed
+                           JSON schema for script data.
+  --tx-out-datum-embed-value JSON_VALUE
+                           The script datum to embed in the tx for this output,
+                           given here. There is no schema: (almost) any JSON
+                           value is supported, including top-level strings and
+                           numbers.
+  --tx-out-inline-datum-cbor-file CBOR_FILE
                            The script datum to embed in the tx output as an
-                           inline datum, in the given JSON file. The file must
-                           follow the special JSON schema for script data.
-  --tx-out-inline-datum-file JSON FILE
+                           inline datum, in the given file. The file has to be
+                           in CBOR format.
+  --tx-out-inline-datum-file JSON_FILE
                            The script datum to embed in the tx output as an
-                           inline datum, in the given JSON file. The file must
-                           follow the special JSON schema for script data.
-  --tx-out-inline-datum-value JSON VALUE
+                           inline datum, in the given file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-inline-datum-value JSON_VALUE
                            The script datum to embed in the tx output as an
-                           inline datum, given here in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+                           inline datum, given here. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --tx-out-reference-script-file FILE
                            Reference script input file.
   --mint VALUE             Mint multi-asset value(s) with the multi-asset cli
                            syntax. You must specify a script witness.
   --mint-script-file FILE  The file containing the script to witness the minting
                            of assets for a particular policy Id.
-  --mint-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --mint-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --mint-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --mint-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --mint-execution-units (INT, INT)
                            The time and space units needed by the script.
   --simple-minting-script-tx-in-reference TX-IN
@@ -286,16 +285,16 @@ Available options:
                            input must have a plutus reference script attached.
   --mint-plutus-script-v2  Specify a plutus script v2 reference script.
   --mint-plutus-script-v3  Specify a plutus script v3 reference script.
-  --mint-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --mint-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --mint-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --mint-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --mint-reference-tx-in-execution-units (INT, INT)
                            The time and space units needed by the script.
   --policy-id HASH         Policy id of minting script.
@@ -309,16 +308,16 @@ Available options:
   --certificate-script-file FILE
                            The file containing the script to witness the use of
                            the certificate.
-  --certificate-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --certificate-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --certificate-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --certificate-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --certificate-execution-units (INT, INT)
                            The time and space units needed by the script.
   --certificate-tx-in-reference TX-IN
@@ -328,16 +327,16 @@ Available options:
                            Specify a plutus script v2 reference script.
   --certificate-plutus-script-v3
                            Specify a plutus script v3 reference script.
-  --certificate-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --certificate-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --certificate-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --certificate-reference-tx-in-execution-units (INT, INT)
                            The time and space units needed by the script.
   --withdrawal WITHDRAWAL  The reward withdrawal as StakeAddress+Lovelace where
@@ -347,16 +346,16 @@ Available options:
   --withdrawal-script-file FILE
                            The file containing the script to witness the
                            withdrawal of rewards.
-  --withdrawal-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --withdrawal-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --withdrawal-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --withdrawal-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --withdrawal-execution-units (INT, INT)
                            The time and space units needed by the script.
   --withdrawal-tx-in-reference TX-IN
@@ -366,16 +365,16 @@ Available options:
                            Specify a plutus script v2 reference script.
   --withdrawal-plutus-script-v3
                            Specify a plutus script v3 reference script.
-  --withdrawal-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --withdrawal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --withdrawal-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --withdrawal-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --withdrawal-reference-tx-in-execution-units (INT, INT)
                            The time and space units needed by the script.
   --json-metadata-no-schema

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_transaction_build.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_transaction_build.cli
@@ -13,26 +13,26 @@ Usage: cardano-cli shelley transaction build --socket-path SOCKET_PATH
                                                    ( --spending-plutus-script-v2
                                                    | --spending-plutus-script-v3
                                                    )
-                                                   ( --spending-reference-tx-in-datum-cbor-file CBOR FILE
-                                                   | --spending-reference-tx-in-datum-file JSON FILE
-                                                   | --spending-reference-tx-in-datum-value JSON VALUE
+                                                   ( --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                                                   | --spending-reference-tx-in-datum-file JSON_FILE
+                                                   | --spending-reference-tx-in-datum-value JSON_VALUE
                                                    | --spending-reference-tx-in-inline-datum-present
                                                    )
-                                                   ( --spending-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                   | --spending-reference-tx-in-redeemer-file JSON FILE
-                                                   | --spending-reference-tx-in-redeemer-value JSON VALUE
+                                                   ( --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                   | --spending-reference-tx-in-redeemer-file JSON_FILE
+                                                   | --spending-reference-tx-in-redeemer-value JSON_VALUE
                                                    )
                                                  | --simple-script-tx-in-reference TX-IN
                                                  | --tx-in-script-file FILE
                                                    [
-                                                     ( --tx-in-datum-cbor-file CBOR FILE
-                                                     | --tx-in-datum-file JSON FILE
-                                                     | --tx-in-datum-value JSON VALUE
+                                                     ( --tx-in-datum-cbor-file CBOR_FILE
+                                                     | --tx-in-datum-file JSON_FILE
+                                                     | --tx-in-datum-value JSON_VALUE
                                                      | --tx-in-inline-datum-present
                                                      )
-                                                     ( --tx-in-redeemer-cbor-file CBOR FILE
-                                                     | --tx-in-redeemer-file JSON FILE
-                                                     | --tx-in-redeemer-value JSON VALUE
+                                                     ( --tx-in-redeemer-cbor-file CBOR_FILE
+                                                     | --tx-in-redeemer-file JSON_FILE
+                                                     | --tx-in-redeemer-value JSON_VALUE
                                                      )]
                                                  ])
                                                [--read-only-tx-in-reference TX-IN]
@@ -44,23 +44,23 @@ Usage: cardano-cli shelley transaction build --socket-path SOCKET_PATH
                                                [--tx-total-collateral INTEGER]
                                                [--tx-out ADDRESS VALUE
                                                  [ --tx-out-datum-hash HASH
-                                                 | --tx-out-datum-hash-cbor-file CBOR FILE
-                                                 | --tx-out-datum-hash-file JSON FILE
-                                                 | --tx-out-datum-hash-value JSON VALUE
-                                                 | --tx-out-datum-embed-cbor-file CBOR FILE
-                                                 | --tx-out-datum-embed-file JSON FILE
-                                                 | --tx-out-datum-embed-value JSON VALUE
-                                                 | --tx-out-inline-datum-cbor-file CBOR FILE
-                                                 | --tx-out-inline-datum-file JSON FILE
-                                                 | --tx-out-inline-datum-value JSON VALUE
+                                                 | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                 | --tx-out-datum-hash-file JSON_FILE
+                                                 | --tx-out-datum-hash-value JSON_VALUE
+                                                 | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                 | --tx-out-datum-embed-file JSON_FILE
+                                                 | --tx-out-datum-embed-value JSON_VALUE
+                                                 | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                 | --tx-out-inline-datum-file JSON_FILE
+                                                 | --tx-out-inline-datum-value JSON_VALUE
                                                  ]
                                                  [--tx-out-reference-script-file FILE]]
                                                --change-address ADDRESS
                                                [--mint VALUE
                                                  ( --mint-script-file FILE
-                                                   [ --mint-redeemer-cbor-file CBOR FILE
-                                                   | --mint-redeemer-file JSON FILE
-                                                   | --mint-redeemer-value JSON VALUE
+                                                   [ --mint-redeemer-cbor-file CBOR_FILE
+                                                   | --mint-redeemer-file JSON_FILE
+                                                   | --mint-redeemer-value JSON_VALUE
                                                    ]
                                                  | --simple-minting-script-tx-in-reference TX-IN
                                                    --policy-id HASH
@@ -68,9 +68,9 @@ Usage: cardano-cli shelley transaction build --socket-path SOCKET_PATH
                                                    ( --mint-plutus-script-v2
                                                    | --mint-plutus-script-v3
                                                    )
-                                                   ( --mint-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                   | --mint-reference-tx-in-redeemer-file JSON FILE
-                                                   | --mint-reference-tx-in-redeemer-value JSON VALUE
+                                                   ( --mint-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                   | --mint-reference-tx-in-redeemer-file JSON_FILE
+                                                   | --mint-reference-tx-in-redeemer-value JSON_VALUE
                                                    )
                                                    --policy-id HASH
                                                  )]
@@ -78,32 +78,32 @@ Usage: cardano-cli shelley transaction build --socket-path SOCKET_PATH
                                                [--invalid-hereafter SLOT]
                                                [--certificate-file FILE
                                                  [ --certificate-script-file FILE
-                                                   [ --certificate-redeemer-cbor-file CBOR FILE
-                                                   | --certificate-redeemer-file JSON FILE
-                                                   | --certificate-redeemer-value JSON VALUE
+                                                   [ --certificate-redeemer-cbor-file CBOR_FILE
+                                                   | --certificate-redeemer-file JSON_FILE
+                                                   | --certificate-redeemer-value JSON_VALUE
                                                    ]
                                                  | --certificate-tx-in-reference TX-IN
                                                    ( --certificate-plutus-script-v2
                                                    | --certificate-plutus-script-v3
                                                    )
-                                                   ( --certificate-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                   | --certificate-reference-tx-in-redeemer-file JSON FILE
-                                                   | --certificate-reference-tx-in-redeemer-value JSON VALUE
+                                                   ( --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                   | --certificate-reference-tx-in-redeemer-file JSON_FILE
+                                                   | --certificate-reference-tx-in-redeemer-value JSON_VALUE
                                                    )
                                                  ]]
                                                [--withdrawal WITHDRAWAL
                                                  [ --withdrawal-script-file FILE
-                                                   [ --withdrawal-redeemer-cbor-file CBOR FILE
-                                                   | --withdrawal-redeemer-file JSON FILE
-                                                   | --withdrawal-redeemer-value JSON VALUE
+                                                   [ --withdrawal-redeemer-cbor-file CBOR_FILE
+                                                   | --withdrawal-redeemer-file JSON_FILE
+                                                   | --withdrawal-redeemer-value JSON_VALUE
                                                    ]
                                                  | --withdrawal-tx-in-reference TX-IN
                                                    ( --withdrawal-plutus-script-v2
                                                    | --withdrawal-plutus-script-v3
                                                    )
-                                                   ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                                   | --withdrawal-reference-tx-in-redeemer-file JSON FILE
-                                                   | --withdrawal-reference-tx-in-redeemer-value JSON VALUE
+                                                   ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                   | --withdrawal-reference-tx-in-redeemer-file JSON_FILE
+                                                   | --withdrawal-reference-tx-in-redeemer-value JSON_VALUE
                                                    )
                                                  ]]
                                                [ --json-metadata-no-schema
@@ -150,55 +150,55 @@ Available options:
                            Specify a plutus script v2 reference script.
   --spending-plutus-script-v3
                            Specify a plutus script v3 reference script.
-  --spending-reference-tx-in-datum-cbor-file CBOR FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-datum-file JSON FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-datum-value JSON VALUE
-                           The script datum, in JSON syntax. There is no schema:
-                           (almost) any JSON value is supported, including
-                           top-level strings and numbers.
+  --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                           The script datum file. The file has to be in CBOR
+                           format.
+  --spending-reference-tx-in-datum-file JSON_FILE
+                           The script datum file. The file must follow the
+                           detailed JSON schema for script data.
+  --spending-reference-tx-in-datum-value JSON_VALUE
+                           The script datum. There is no schema: (almost) any
+                           JSON value is supported, including top-level strings
+                           and numbers.
   --spending-reference-tx-in-inline-datum-present
                            Inline datum present at transaction input.
-  --spending-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --spending-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --spending-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --simple-script-tx-in-reference TX-IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a simple reference script attached.
   --tx-in-script-file FILE The file containing the script to witness the
                            spending of the transaction input.
-  --tx-in-datum-cbor-file CBOR FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-datum-file JSON FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-datum-value JSON VALUE
-                           The script datum, in JSON syntax. There is no schema:
-                           (almost) any JSON value is supported, including
-                           top-level strings and numbers.
+  --tx-in-datum-cbor-file CBOR_FILE
+                           The script datum file. The file has to be in CBOR
+                           format.
+  --tx-in-datum-file JSON_FILE
+                           The script datum file. The file must follow the
+                           detailed JSON schema for script data.
+  --tx-in-datum-value JSON_VALUE
+                           The script datum. There is no schema: (almost) any
+                           JSON value is supported, including top-level strings
+                           and numbers.
   --tx-in-inline-datum-present
                            Inline datum present at transaction input.
-  --tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --read-only-tx-in-reference TX-IN
                            Specify a read only reference input. This reference
                            input is not witnessing anything it is simply
@@ -227,45 +227,44 @@ Available options:
                            Lovelace).
   --tx-out-datum-hash HASH The script datum hash for this tx output, as the raw
                            datum hash (in hex).
-  --tx-out-datum-hash-cbor-file CBOR FILE
+  --tx-out-datum-hash-cbor-file CBOR_FILE
                            The script datum hash for this tx output, by hashing
-                           the script datum in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-out-datum-hash-file JSON FILE
+                           the script datum in the file. The file has to be in
+                           CBOR format.
+  --tx-out-datum-hash-file JSON_FILE
                            The script datum hash for this tx output, by hashing
-                           the script datum in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-out-datum-hash-value JSON VALUE
+                           the script datum in the file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-datum-hash-value JSON_VALUE
                            The script datum hash for this tx output, by hashing
-                           the script datum given here in JSON syntax. There is
-                           no schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
-  --tx-out-datum-embed-cbor-file CBOR FILE
-                           The script datum to embed in the tx for this output,
-                           in the given JSON file. The file must follow the
-                           special JSON schema for script data.
-  --tx-out-datum-embed-file JSON FILE
-                           The script datum to embed in the tx for this output,
-                           in the given JSON file. The file must follow the
-                           special JSON schema for script data.
-  --tx-out-datum-embed-value JSON VALUE
-                           The script datum to embed in the tx for this output,
-                           given here in JSON syntax. There is no schema:
+                           the script datum given here. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
-  --tx-out-inline-datum-cbor-file CBOR FILE
+  --tx-out-datum-embed-cbor-file CBOR_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file has to be in CBOR format.
+  --tx-out-datum-embed-file JSON_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file must follow the detailed
+                           JSON schema for script data.
+  --tx-out-datum-embed-value JSON_VALUE
+                           The script datum to embed in the tx for this output,
+                           given here. There is no schema: (almost) any JSON
+                           value is supported, including top-level strings and
+                           numbers.
+  --tx-out-inline-datum-cbor-file CBOR_FILE
                            The script datum to embed in the tx output as an
-                           inline datum, in the given JSON file. The file must
-                           follow the special JSON schema for script data.
-  --tx-out-inline-datum-file JSON FILE
+                           inline datum, in the given file. The file has to be
+                           in CBOR format.
+  --tx-out-inline-datum-file JSON_FILE
                            The script datum to embed in the tx output as an
-                           inline datum, in the given JSON file. The file must
-                           follow the special JSON schema for script data.
-  --tx-out-inline-datum-value JSON VALUE
+                           inline datum, in the given file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-inline-datum-value JSON_VALUE
                            The script datum to embed in the tx output as an
-                           inline datum, given here in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+                           inline datum, given here. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --tx-out-reference-script-file FILE
                            Reference script input file.
   --change-address ADDRESS Address where ADA in excess of the tx fee will go to.
@@ -273,16 +272,16 @@ Available options:
                            syntax. You must specify a script witness.
   --mint-script-file FILE  The file containing the script to witness the minting
                            of assets for a particular policy Id.
-  --mint-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --mint-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --mint-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --mint-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --simple-minting-script-tx-in-reference TX-IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a simple reference script attached.
@@ -292,16 +291,16 @@ Available options:
                            input must have a plutus reference script attached.
   --mint-plutus-script-v2  Specify a plutus script v2 reference script.
   --mint-plutus-script-v3  Specify a plutus script v3 reference script.
-  --mint-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --mint-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --mint-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --mint-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --policy-id HASH         Policy id of minting script.
   --invalid-before SLOT    Time that transaction is valid from (in slots).
   --invalid-hereafter SLOT Time that transaction is valid until (in slots).
@@ -312,16 +311,16 @@ Available options:
   --certificate-script-file FILE
                            The file containing the script to witness the use of
                            the certificate.
-  --certificate-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --certificate-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --certificate-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --certificate-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --certificate-tx-in-reference TX-IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a plutus reference script attached.
@@ -329,16 +328,16 @@ Available options:
                            Specify a plutus script v2 reference script.
   --certificate-plutus-script-v3
                            Specify a plutus script v3 reference script.
-  --certificate-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --certificate-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --certificate-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --withdrawal WITHDRAWAL  The reward withdrawal as StakeAddress+Lovelace where
                            StakeAddress is the Bech32-encoded stake address
                            followed by the amount in Lovelace. Optionally
@@ -346,16 +345,16 @@ Available options:
   --withdrawal-script-file FILE
                            The file containing the script to witness the
                            withdrawal of rewards.
-  --withdrawal-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --withdrawal-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --withdrawal-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --withdrawal-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --withdrawal-tx-in-reference TX-IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a plutus reference script attached.
@@ -363,16 +362,16 @@ Available options:
                            Specify a plutus script v2 reference script.
   --withdrawal-plutus-script-v3
                            Specify a plutus script v3 reference script.
-  --withdrawal-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --withdrawal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --withdrawal-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --withdrawal-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --json-metadata-no-schema
                            Use the "no schema" conversion from JSON to tx
                            metadata (default).

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_transaction_calculate-min-required-utxo.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_transaction_calculate-min-required-utxo.cli
@@ -1,15 +1,15 @@
 Usage: cardano-cli shelley transaction calculate-min-required-utxo --protocol-params-file FILE
                                                                      --tx-out ADDRESS VALUE
                                                                      [ --tx-out-datum-hash HASH
-                                                                     | --tx-out-datum-hash-cbor-file CBOR FILE
-                                                                     | --tx-out-datum-hash-file JSON FILE
-                                                                     | --tx-out-datum-hash-value JSON VALUE
-                                                                     | --tx-out-datum-embed-cbor-file CBOR FILE
-                                                                     | --tx-out-datum-embed-file JSON FILE
-                                                                     | --tx-out-datum-embed-value JSON VALUE
-                                                                     | --tx-out-inline-datum-cbor-file CBOR FILE
-                                                                     | --tx-out-inline-datum-file JSON FILE
-                                                                     | --tx-out-inline-datum-value JSON VALUE
+                                                                     | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                                     | --tx-out-datum-hash-file JSON_FILE
+                                                                     | --tx-out-datum-hash-value JSON_VALUE
+                                                                     | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                                     | --tx-out-datum-embed-file JSON_FILE
+                                                                     | --tx-out-datum-embed-value JSON_VALUE
+                                                                     | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                                     | --tx-out-inline-datum-file JSON_FILE
+                                                                     | --tx-out-inline-datum-value JSON_VALUE
                                                                      ]
                                                                      [--tx-out-reference-script-file FILE]
 
@@ -24,45 +24,44 @@ Available options:
                            Lovelace).
   --tx-out-datum-hash HASH The script datum hash for this tx output, as the raw
                            datum hash (in hex).
-  --tx-out-datum-hash-cbor-file CBOR FILE
+  --tx-out-datum-hash-cbor-file CBOR_FILE
                            The script datum hash for this tx output, by hashing
-                           the script datum in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-out-datum-hash-file JSON FILE
+                           the script datum in the file. The file has to be in
+                           CBOR format.
+  --tx-out-datum-hash-file JSON_FILE
                            The script datum hash for this tx output, by hashing
-                           the script datum in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-out-datum-hash-value JSON VALUE
+                           the script datum in the file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-datum-hash-value JSON_VALUE
                            The script datum hash for this tx output, by hashing
-                           the script datum given here in JSON syntax. There is
-                           no schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
-  --tx-out-datum-embed-cbor-file CBOR FILE
-                           The script datum to embed in the tx for this output,
-                           in the given JSON file. The file must follow the
-                           special JSON schema for script data.
-  --tx-out-datum-embed-file JSON FILE
-                           The script datum to embed in the tx for this output,
-                           in the given JSON file. The file must follow the
-                           special JSON schema for script data.
-  --tx-out-datum-embed-value JSON VALUE
-                           The script datum to embed in the tx for this output,
-                           given here in JSON syntax. There is no schema:
+                           the script datum given here. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
-  --tx-out-inline-datum-cbor-file CBOR FILE
+  --tx-out-datum-embed-cbor-file CBOR_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file has to be in CBOR format.
+  --tx-out-datum-embed-file JSON_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file must follow the detailed
+                           JSON schema for script data.
+  --tx-out-datum-embed-value JSON_VALUE
+                           The script datum to embed in the tx for this output,
+                           given here. There is no schema: (almost) any JSON
+                           value is supported, including top-level strings and
+                           numbers.
+  --tx-out-inline-datum-cbor-file CBOR_FILE
                            The script datum to embed in the tx output as an
-                           inline datum, in the given JSON file. The file must
-                           follow the special JSON schema for script data.
-  --tx-out-inline-datum-file JSON FILE
+                           inline datum, in the given file. The file has to be
+                           in CBOR format.
+  --tx-out-inline-datum-file JSON_FILE
                            The script datum to embed in the tx output as an
-                           inline datum, in the given JSON file. The file must
-                           follow the special JSON schema for script data.
-  --tx-out-inline-datum-value JSON VALUE
+                           inline datum, in the given file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-inline-datum-value JSON_VALUE
                            The script datum to embed in the tx output as an
-                           inline datum, given here in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+                           inline datum, given here. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --tx-out-reference-script-file FILE
                            Reference script input file.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_transaction_calculate-min-value.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_transaction_calculate-min-value.cli
@@ -1,15 +1,15 @@
 Usage: cardano-cli shelley transaction calculate-min-value --protocol-params-file FILE
                                                              --tx-out ADDRESS VALUE
                                                              [ --tx-out-datum-hash HASH
-                                                             | --tx-out-datum-hash-cbor-file CBOR FILE
-                                                             | --tx-out-datum-hash-file JSON FILE
-                                                             | --tx-out-datum-hash-value JSON VALUE
-                                                             | --tx-out-datum-embed-cbor-file CBOR FILE
-                                                             | --tx-out-datum-embed-file JSON FILE
-                                                             | --tx-out-datum-embed-value JSON VALUE
-                                                             | --tx-out-inline-datum-cbor-file CBOR FILE
-                                                             | --tx-out-inline-datum-file JSON FILE
-                                                             | --tx-out-inline-datum-value JSON VALUE
+                                                             | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                             | --tx-out-datum-hash-file JSON_FILE
+                                                             | --tx-out-datum-hash-value JSON_VALUE
+                                                             | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                             | --tx-out-datum-embed-file JSON_FILE
+                                                             | --tx-out-datum-embed-value JSON_VALUE
+                                                             | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                             | --tx-out-inline-datum-file JSON_FILE
+                                                             | --tx-out-inline-datum-value JSON_VALUE
                                                              ]
                                                              [--tx-out-reference-script-file FILE]
 
@@ -24,44 +24,43 @@ Available options:
                            Lovelace).
   --tx-out-datum-hash HASH The script datum hash for this tx output, as the raw
                            datum hash (in hex).
-  --tx-out-datum-hash-cbor-file CBOR FILE
+  --tx-out-datum-hash-cbor-file CBOR_FILE
                            The script datum hash for this tx output, by hashing
-                           the script datum in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-out-datum-hash-file JSON FILE
+                           the script datum in the file. The file has to be in
+                           CBOR format.
+  --tx-out-datum-hash-file JSON_FILE
                            The script datum hash for this tx output, by hashing
-                           the script datum in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-out-datum-hash-value JSON VALUE
+                           the script datum in the file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-datum-hash-value JSON_VALUE
                            The script datum hash for this tx output, by hashing
-                           the script datum given here in JSON syntax. There is
-                           no schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
-  --tx-out-datum-embed-cbor-file CBOR FILE
-                           The script datum to embed in the tx for this output,
-                           in the given JSON file. The file must follow the
-                           special JSON schema for script data.
-  --tx-out-datum-embed-file JSON FILE
-                           The script datum to embed in the tx for this output,
-                           in the given JSON file. The file must follow the
-                           special JSON schema for script data.
-  --tx-out-datum-embed-value JSON VALUE
-                           The script datum to embed in the tx for this output,
-                           given here in JSON syntax. There is no schema:
+                           the script datum given here. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
-  --tx-out-inline-datum-cbor-file CBOR FILE
+  --tx-out-datum-embed-cbor-file CBOR_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file has to be in CBOR format.
+  --tx-out-datum-embed-file JSON_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file must follow the detailed
+                           JSON schema for script data.
+  --tx-out-datum-embed-value JSON_VALUE
+                           The script datum to embed in the tx for this output,
+                           given here. There is no schema: (almost) any JSON
+                           value is supported, including top-level strings and
+                           numbers.
+  --tx-out-inline-datum-cbor-file CBOR_FILE
                            The script datum to embed in the tx output as an
-                           inline datum, in the given JSON file. The file must
-                           follow the special JSON schema for script data.
-  --tx-out-inline-datum-file JSON FILE
+                           inline datum, in the given file. The file has to be
+                           in CBOR format.
+  --tx-out-inline-datum-file JSON_FILE
                            The script datum to embed in the tx output as an
-                           inline datum, in the given JSON file. The file must
-                           follow the special JSON schema for script data.
-  --tx-out-inline-datum-value JSON VALUE
+                           inline datum, in the given file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-inline-datum-value JSON_VALUE
                            The script datum to embed in the tx output as an
-                           inline datum, given here in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+                           inline datum, given here. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --tx-out-reference-script-file FILE
                            Reference script input file.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_transaction_hash-script-data.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_transaction_hash-script-data.cli
@@ -1,20 +1,20 @@
 Usage: cardano-cli shelley transaction hash-script-data 
-                                                          ( --script-data-cbor-file CBOR FILE
-                                                          | --script-data-file JSON FILE
-                                                          | --script-data-value JSON VALUE
+                                                          ( --script-data-cbor-file CBOR_FILE
+                                                          | --script-data-file JSON_FILE
+                                                          | --script-data-value JSON_VALUE
                                                           )
 
   Calculate the hash of script data.
 
 Available options:
-  --script-data-cbor-file CBOR FILE
-                           The script data, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --script-data-file JSON FILE
-                           The script data, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --script-data-value JSON VALUE
-                           The script data, in JSON syntax. There is no schema:
-                           (almost) any JSON value is supported, including
-                           top-level strings and numbers.
+  --script-data-cbor-file CBOR_FILE
+                           The script data file. The file has to be in CBOR
+                           format.
+  --script-data-file JSON_FILE
+                           The script data file. The file must follow the
+                           detailed JSON schema for script data.
+  --script-data-value JSON_VALUE
+                           The script data. There is no schema: (almost) any
+                           JSON value is supported, including top-level strings
+                           and numbers.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/transaction_build-raw.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/transaction_build-raw.cli
@@ -12,27 +12,27 @@ Usage: cardano-cli transaction build-raw
                                                ( --spending-plutus-script-v2
                                                | --spending-plutus-script-v3
                                                )
-                                               ( --spending-reference-tx-in-datum-cbor-file CBOR FILE
-                                               | --spending-reference-tx-in-datum-file JSON FILE
-                                               | --spending-reference-tx-in-datum-value JSON VALUE
+                                               ( --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                                               | --spending-reference-tx-in-datum-file JSON_FILE
+                                               | --spending-reference-tx-in-datum-value JSON_VALUE
                                                | --spending-reference-tx-in-inline-datum-present
                                                )
-                                               ( --spending-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                               | --spending-reference-tx-in-redeemer-file JSON FILE
-                                               | --spending-reference-tx-in-redeemer-value JSON VALUE
+                                               ( --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                               | --spending-reference-tx-in-redeemer-file JSON_FILE
+                                               | --spending-reference-tx-in-redeemer-value JSON_VALUE
                                                )
                                                --spending-reference-tx-in-execution-units (INT, INT)
                                              | --simple-script-tx-in-reference TX-IN
                                              | --tx-in-script-file FILE
                                                [
-                                                 ( --tx-in-datum-cbor-file CBOR FILE
-                                                 | --tx-in-datum-file JSON FILE
-                                                 | --tx-in-datum-value JSON VALUE
+                                                 ( --tx-in-datum-cbor-file CBOR_FILE
+                                                 | --tx-in-datum-file JSON_FILE
+                                                 | --tx-in-datum-value JSON_VALUE
                                                  | --tx-in-inline-datum-present
                                                  )
-                                                 ( --tx-in-redeemer-cbor-file CBOR FILE
-                                                 | --tx-in-redeemer-file JSON FILE
-                                                 | --tx-in-redeemer-value JSON VALUE
+                                                 ( --tx-in-redeemer-cbor-file CBOR_FILE
+                                                 | --tx-in-redeemer-file JSON_FILE
+                                                 | --tx-in-redeemer-value JSON_VALUE
                                                  )
                                                  --tx-in-execution-units (INT, INT)]
                                              ])
@@ -45,23 +45,23 @@ Usage: cardano-cli transaction build-raw
                                            ]
                                            [--tx-out ADDRESS VALUE
                                              [ --tx-out-datum-hash HASH
-                                             | --tx-out-datum-hash-cbor-file CBOR FILE
-                                             | --tx-out-datum-hash-file JSON FILE
-                                             | --tx-out-datum-hash-value JSON VALUE
-                                             | --tx-out-datum-embed-cbor-file CBOR FILE
-                                             | --tx-out-datum-embed-file JSON FILE
-                                             | --tx-out-datum-embed-value JSON VALUE
-                                             | --tx-out-inline-datum-cbor-file CBOR FILE
-                                             | --tx-out-inline-datum-file JSON FILE
-                                             | --tx-out-inline-datum-value JSON VALUE
+                                             | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                             | --tx-out-datum-hash-file JSON_FILE
+                                             | --tx-out-datum-hash-value JSON_VALUE
+                                             | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                             | --tx-out-datum-embed-file JSON_FILE
+                                             | --tx-out-datum-embed-value JSON_VALUE
+                                             | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                             | --tx-out-inline-datum-file JSON_FILE
+                                             | --tx-out-inline-datum-value JSON_VALUE
                                              ]
                                              [--tx-out-reference-script-file FILE]]
                                            [--mint VALUE
                                              ( --mint-script-file FILE
                                                [
-                                                 ( --mint-redeemer-cbor-file CBOR FILE
-                                                 | --mint-redeemer-file JSON FILE
-                                                 | --mint-redeemer-value JSON VALUE
+                                                 ( --mint-redeemer-cbor-file CBOR_FILE
+                                                 | --mint-redeemer-file JSON_FILE
+                                                 | --mint-redeemer-value JSON_VALUE
                                                  )
                                                  --mint-execution-units (INT, INT)]
                                              | --simple-minting-script-tx-in-reference TX-IN
@@ -70,9 +70,9 @@ Usage: cardano-cli transaction build-raw
                                                ( --mint-plutus-script-v2
                                                | --mint-plutus-script-v3
                                                )
-                                               ( --mint-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                               | --mint-reference-tx-in-redeemer-file JSON FILE
-                                               | --mint-reference-tx-in-redeemer-value JSON VALUE
+                                               ( --mint-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                               | --mint-reference-tx-in-redeemer-file JSON_FILE
+                                               | --mint-reference-tx-in-redeemer-value JSON_VALUE
                                                )
                                                --mint-reference-tx-in-execution-units (INT, INT)
                                                --policy-id HASH
@@ -83,36 +83,36 @@ Usage: cardano-cli transaction build-raw
                                            [--certificate-file FILE
                                              [ --certificate-script-file FILE
                                                [
-                                                 ( --certificate-redeemer-cbor-file CBOR FILE
-                                                 | --certificate-redeemer-file JSON FILE
-                                                 | --certificate-redeemer-value JSON VALUE
+                                                 ( --certificate-redeemer-cbor-file CBOR_FILE
+                                                 | --certificate-redeemer-file JSON_FILE
+                                                 | --certificate-redeemer-value JSON_VALUE
                                                  )
                                                  --certificate-execution-units (INT, INT)]
                                              | --certificate-tx-in-reference TX-IN
                                                ( --certificate-plutus-script-v2
                                                | --certificate-plutus-script-v3
                                                )
-                                               ( --certificate-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                               | --certificate-reference-tx-in-redeemer-file JSON FILE
-                                               | --certificate-reference-tx-in-redeemer-value JSON VALUE
+                                               ( --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                               | --certificate-reference-tx-in-redeemer-file JSON_FILE
+                                               | --certificate-reference-tx-in-redeemer-value JSON_VALUE
                                                )
                                                --certificate-reference-tx-in-execution-units (INT, INT)
                                              ]]
                                            [--withdrawal WITHDRAWAL
                                              [ --withdrawal-script-file FILE
                                                [
-                                                 ( --withdrawal-redeemer-cbor-file CBOR FILE
-                                                 | --withdrawal-redeemer-file JSON FILE
-                                                 | --withdrawal-redeemer-value JSON VALUE
+                                                 ( --withdrawal-redeemer-cbor-file CBOR_FILE
+                                                 | --withdrawal-redeemer-file JSON_FILE
+                                                 | --withdrawal-redeemer-value JSON_VALUE
                                                  )
                                                  --withdrawal-execution-units (INT, INT)]
                                              | --withdrawal-tx-in-reference TX-IN
                                                ( --withdrawal-plutus-script-v2
                                                | --withdrawal-plutus-script-v3
                                                )
-                                               ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                               | --withdrawal-reference-tx-in-redeemer-file JSON FILE
-                                               | --withdrawal-reference-tx-in-redeemer-value JSON VALUE
+                                               ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                               | --withdrawal-reference-tx-in-redeemer-file JSON_FILE
+                                               | --withdrawal-reference-tx-in-redeemer-value JSON_VALUE
                                                )
                                                --withdrawal-reference-tx-in-execution-units (INT, INT)
                                              ]]
@@ -150,28 +150,28 @@ Available options:
                            Specify a plutus script v2 reference script.
   --spending-plutus-script-v3
                            Specify a plutus script v3 reference script.
-  --spending-reference-tx-in-datum-cbor-file CBOR FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-datum-file JSON FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-datum-value JSON VALUE
-                           The script datum, in JSON syntax. There is no schema:
-                           (almost) any JSON value is supported, including
-                           top-level strings and numbers.
+  --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                           The script datum file. The file has to be in CBOR
+                           format.
+  --spending-reference-tx-in-datum-file JSON_FILE
+                           The script datum file. The file must follow the
+                           detailed JSON schema for script data.
+  --spending-reference-tx-in-datum-value JSON_VALUE
+                           The script datum. There is no schema: (almost) any
+                           JSON value is supported, including top-level strings
+                           and numbers.
   --spending-reference-tx-in-inline-datum-present
                            Inline datum present at transaction input.
-  --spending-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --spending-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --spending-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --spending-reference-tx-in-execution-units (INT, INT)
                            The time and space units needed by the script.
   --simple-script-tx-in-reference TX-IN
@@ -179,28 +179,28 @@ Available options:
                            input must have a simple reference script attached.
   --tx-in-script-file FILE The file containing the script to witness the
                            spending of the transaction input.
-  --tx-in-datum-cbor-file CBOR FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-datum-file JSON FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-datum-value JSON VALUE
-                           The script datum, in JSON syntax. There is no schema:
-                           (almost) any JSON value is supported, including
-                           top-level strings and numbers.
+  --tx-in-datum-cbor-file CBOR_FILE
+                           The script datum file. The file has to be in CBOR
+                           format.
+  --tx-in-datum-file JSON_FILE
+                           The script datum file. The file must follow the
+                           detailed JSON schema for script data.
+  --tx-in-datum-value JSON_VALUE
+                           The script datum. There is no schema: (almost) any
+                           JSON value is supported, including top-level strings
+                           and numbers.
   --tx-in-inline-datum-present
                            Inline datum present at transaction input.
-  --tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --tx-in-execution-units (INT, INT)
                            The time and space units needed by the script.
   --read-only-tx-in-reference TX-IN
@@ -231,61 +231,60 @@ Available options:
                            Lovelace).
   --tx-out-datum-hash HASH The script datum hash for this tx output, as the raw
                            datum hash (in hex).
-  --tx-out-datum-hash-cbor-file CBOR FILE
+  --tx-out-datum-hash-cbor-file CBOR_FILE
                            The script datum hash for this tx output, by hashing
-                           the script datum in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-out-datum-hash-file JSON FILE
+                           the script datum in the file. The file has to be in
+                           CBOR format.
+  --tx-out-datum-hash-file JSON_FILE
                            The script datum hash for this tx output, by hashing
-                           the script datum in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-out-datum-hash-value JSON VALUE
+                           the script datum in the file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-datum-hash-value JSON_VALUE
                            The script datum hash for this tx output, by hashing
-                           the script datum given here in JSON syntax. There is
-                           no schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
-  --tx-out-datum-embed-cbor-file CBOR FILE
-                           The script datum to embed in the tx for this output,
-                           in the given JSON file. The file must follow the
-                           special JSON schema for script data.
-  --tx-out-datum-embed-file JSON FILE
-                           The script datum to embed in the tx for this output,
-                           in the given JSON file. The file must follow the
-                           special JSON schema for script data.
-  --tx-out-datum-embed-value JSON VALUE
-                           The script datum to embed in the tx for this output,
-                           given here in JSON syntax. There is no schema:
+                           the script datum given here. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
-  --tx-out-inline-datum-cbor-file CBOR FILE
+  --tx-out-datum-embed-cbor-file CBOR_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file has to be in CBOR format.
+  --tx-out-datum-embed-file JSON_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file must follow the detailed
+                           JSON schema for script data.
+  --tx-out-datum-embed-value JSON_VALUE
+                           The script datum to embed in the tx for this output,
+                           given here. There is no schema: (almost) any JSON
+                           value is supported, including top-level strings and
+                           numbers.
+  --tx-out-inline-datum-cbor-file CBOR_FILE
                            The script datum to embed in the tx output as an
-                           inline datum, in the given JSON file. The file must
-                           follow the special JSON schema for script data.
-  --tx-out-inline-datum-file JSON FILE
+                           inline datum, in the given file. The file has to be
+                           in CBOR format.
+  --tx-out-inline-datum-file JSON_FILE
                            The script datum to embed in the tx output as an
-                           inline datum, in the given JSON file. The file must
-                           follow the special JSON schema for script data.
-  --tx-out-inline-datum-value JSON VALUE
+                           inline datum, in the given file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-inline-datum-value JSON_VALUE
                            The script datum to embed in the tx output as an
-                           inline datum, given here in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+                           inline datum, given here. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --tx-out-reference-script-file FILE
                            Reference script input file.
   --mint VALUE             Mint multi-asset value(s) with the multi-asset cli
                            syntax. You must specify a script witness.
   --mint-script-file FILE  The file containing the script to witness the minting
                            of assets for a particular policy Id.
-  --mint-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --mint-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --mint-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --mint-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --mint-execution-units (INT, INT)
                            The time and space units needed by the script.
   --simple-minting-script-tx-in-reference TX-IN
@@ -297,16 +296,16 @@ Available options:
                            input must have a plutus reference script attached.
   --mint-plutus-script-v2  Specify a plutus script v2 reference script.
   --mint-plutus-script-v3  Specify a plutus script v3 reference script.
-  --mint-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --mint-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --mint-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --mint-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --mint-reference-tx-in-execution-units (INT, INT)
                            The time and space units needed by the script.
   --policy-id HASH         Policy id of minting script.
@@ -320,16 +319,16 @@ Available options:
   --certificate-script-file FILE
                            The file containing the script to witness the use of
                            the certificate.
-  --certificate-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --certificate-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --certificate-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --certificate-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --certificate-execution-units (INT, INT)
                            The time and space units needed by the script.
   --certificate-tx-in-reference TX-IN
@@ -339,16 +338,16 @@ Available options:
                            Specify a plutus script v2 reference script.
   --certificate-plutus-script-v3
                            Specify a plutus script v3 reference script.
-  --certificate-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --certificate-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --certificate-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --certificate-reference-tx-in-execution-units (INT, INT)
                            The time and space units needed by the script.
   --withdrawal WITHDRAWAL  The reward withdrawal as StakeAddress+Lovelace where
@@ -358,16 +357,16 @@ Available options:
   --withdrawal-script-file FILE
                            The file containing the script to witness the
                            withdrawal of rewards.
-  --withdrawal-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --withdrawal-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --withdrawal-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --withdrawal-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --withdrawal-execution-units (INT, INT)
                            The time and space units needed by the script.
   --withdrawal-tx-in-reference TX-IN
@@ -377,16 +376,16 @@ Available options:
                            Specify a plutus script v2 reference script.
   --withdrawal-plutus-script-v3
                            Specify a plutus script v3 reference script.
-  --withdrawal-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --withdrawal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --withdrawal-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --withdrawal-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --withdrawal-reference-tx-in-execution-units (INT, INT)
                            The time and space units needed by the script.
   --json-metadata-no-schema

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/transaction_build.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/transaction_build.cli
@@ -14,26 +14,26 @@ Usage: cardano-cli transaction build --socket-path SOCKET_PATH
                                            ( --spending-plutus-script-v2
                                            | --spending-plutus-script-v3
                                            )
-                                           ( --spending-reference-tx-in-datum-cbor-file CBOR FILE
-                                           | --spending-reference-tx-in-datum-file JSON FILE
-                                           | --spending-reference-tx-in-datum-value JSON VALUE
+                                           ( --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                                           | --spending-reference-tx-in-datum-file JSON_FILE
+                                           | --spending-reference-tx-in-datum-value JSON_VALUE
                                            | --spending-reference-tx-in-inline-datum-present
                                            )
-                                           ( --spending-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                           | --spending-reference-tx-in-redeemer-file JSON FILE
-                                           | --spending-reference-tx-in-redeemer-value JSON VALUE
+                                           ( --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                           | --spending-reference-tx-in-redeemer-file JSON_FILE
+                                           | --spending-reference-tx-in-redeemer-value JSON_VALUE
                                            )
                                          | --simple-script-tx-in-reference TX-IN
                                          | --tx-in-script-file FILE
                                            [
-                                             ( --tx-in-datum-cbor-file CBOR FILE
-                                             | --tx-in-datum-file JSON FILE
-                                             | --tx-in-datum-value JSON VALUE
+                                             ( --tx-in-datum-cbor-file CBOR_FILE
+                                             | --tx-in-datum-file JSON_FILE
+                                             | --tx-in-datum-value JSON_VALUE
                                              | --tx-in-inline-datum-present
                                              )
-                                             ( --tx-in-redeemer-cbor-file CBOR FILE
-                                             | --tx-in-redeemer-file JSON FILE
-                                             | --tx-in-redeemer-value JSON VALUE
+                                             ( --tx-in-redeemer-cbor-file CBOR_FILE
+                                             | --tx-in-redeemer-file JSON_FILE
+                                             | --tx-in-redeemer-value JSON_VALUE
                                              )]
                                          ])
                                        [--read-only-tx-in-reference TX-IN]
@@ -45,23 +45,23 @@ Usage: cardano-cli transaction build --socket-path SOCKET_PATH
                                        [--tx-total-collateral INTEGER]
                                        [--tx-out ADDRESS VALUE
                                          [ --tx-out-datum-hash HASH
-                                         | --tx-out-datum-hash-cbor-file CBOR FILE
-                                         | --tx-out-datum-hash-file JSON FILE
-                                         | --tx-out-datum-hash-value JSON VALUE
-                                         | --tx-out-datum-embed-cbor-file CBOR FILE
-                                         | --tx-out-datum-embed-file JSON FILE
-                                         | --tx-out-datum-embed-value JSON VALUE
-                                         | --tx-out-inline-datum-cbor-file CBOR FILE
-                                         | --tx-out-inline-datum-file JSON FILE
-                                         | --tx-out-inline-datum-value JSON VALUE
+                                         | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                         | --tx-out-datum-hash-file JSON_FILE
+                                         | --tx-out-datum-hash-value JSON_VALUE
+                                         | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                         | --tx-out-datum-embed-file JSON_FILE
+                                         | --tx-out-datum-embed-value JSON_VALUE
+                                         | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                         | --tx-out-inline-datum-file JSON_FILE
+                                         | --tx-out-inline-datum-value JSON_VALUE
                                          ]
                                          [--tx-out-reference-script-file FILE]]
                                        --change-address ADDRESS
                                        [--mint VALUE
                                          ( --mint-script-file FILE
-                                           [ --mint-redeemer-cbor-file CBOR FILE
-                                           | --mint-redeemer-file JSON FILE
-                                           | --mint-redeemer-value JSON VALUE
+                                           [ --mint-redeemer-cbor-file CBOR_FILE
+                                           | --mint-redeemer-file JSON_FILE
+                                           | --mint-redeemer-value JSON_VALUE
                                            ]
                                          | --simple-minting-script-tx-in-reference TX-IN
                                            --policy-id HASH
@@ -69,9 +69,9 @@ Usage: cardano-cli transaction build --socket-path SOCKET_PATH
                                            ( --mint-plutus-script-v2
                                            | --mint-plutus-script-v3
                                            )
-                                           ( --mint-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                           | --mint-reference-tx-in-redeemer-file JSON FILE
-                                           | --mint-reference-tx-in-redeemer-value JSON VALUE
+                                           ( --mint-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                           | --mint-reference-tx-in-redeemer-file JSON_FILE
+                                           | --mint-reference-tx-in-redeemer-value JSON_VALUE
                                            )
                                            --policy-id HASH
                                          )]
@@ -79,32 +79,32 @@ Usage: cardano-cli transaction build --socket-path SOCKET_PATH
                                        [--invalid-hereafter SLOT]
                                        [--certificate-file FILE
                                          [ --certificate-script-file FILE
-                                           [ --certificate-redeemer-cbor-file CBOR FILE
-                                           | --certificate-redeemer-file JSON FILE
-                                           | --certificate-redeemer-value JSON VALUE
+                                           [ --certificate-redeemer-cbor-file CBOR_FILE
+                                           | --certificate-redeemer-file JSON_FILE
+                                           | --certificate-redeemer-value JSON_VALUE
                                            ]
                                          | --certificate-tx-in-reference TX-IN
                                            ( --certificate-plutus-script-v2
                                            | --certificate-plutus-script-v3
                                            )
-                                           ( --certificate-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                           | --certificate-reference-tx-in-redeemer-file JSON FILE
-                                           | --certificate-reference-tx-in-redeemer-value JSON VALUE
+                                           ( --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                           | --certificate-reference-tx-in-redeemer-file JSON_FILE
+                                           | --certificate-reference-tx-in-redeemer-value JSON_VALUE
                                            )
                                          ]]
                                        [--withdrawal WITHDRAWAL
                                          [ --withdrawal-script-file FILE
-                                           [ --withdrawal-redeemer-cbor-file CBOR FILE
-                                           | --withdrawal-redeemer-file JSON FILE
-                                           | --withdrawal-redeemer-value JSON VALUE
+                                           [ --withdrawal-redeemer-cbor-file CBOR_FILE
+                                           | --withdrawal-redeemer-file JSON_FILE
+                                           | --withdrawal-redeemer-value JSON_VALUE
                                            ]
                                          | --withdrawal-tx-in-reference TX-IN
                                            ( --withdrawal-plutus-script-v2
                                            | --withdrawal-plutus-script-v3
                                            )
-                                           ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR FILE
-                                           | --withdrawal-reference-tx-in-redeemer-file JSON FILE
-                                           | --withdrawal-reference-tx-in-redeemer-value JSON VALUE
+                                           ( --withdrawal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                           | --withdrawal-reference-tx-in-redeemer-file JSON_FILE
+                                           | --withdrawal-reference-tx-in-redeemer-value JSON_VALUE
                                            )
                                          ]]
                                        [ --json-metadata-no-schema
@@ -117,15 +117,15 @@ Usage: cardano-cli transaction build --socket-path SOCKET_PATH
                                        [--update-proposal-file FILE]
                                        [--vote-file FILE
                                          [--vote-script-file FILE
-                                           [ --vote-redeemer-cbor-file CBOR FILE
-                                           | --vote-redeemer-file JSON FILE
-                                           | --vote-redeemer-value JSON VALUE
+                                           [ --vote-redeemer-cbor-file CBOR_FILE
+                                           | --vote-redeemer-file JSON_FILE
+                                           | --vote-redeemer-value JSON_VALUE
                                            ]]]
                                        [--proposal-file FILE
                                          [--proposal-script-file FILE
-                                           [ --proposal-redeemer-cbor-file CBOR FILE
-                                           | --proposal-redeemer-file JSON FILE
-                                           | --proposal-redeemer-value JSON VALUE
+                                           [ --proposal-redeemer-cbor-file CBOR_FILE
+                                           | --proposal-redeemer-file JSON_FILE
+                                           | --proposal-redeemer-value JSON_VALUE
                                            ]]]
                                        ( --out-file FILE
                                        | --calculate-plutus-script-cost FILE
@@ -168,55 +168,55 @@ Available options:
                            Specify a plutus script v2 reference script.
   --spending-plutus-script-v3
                            Specify a plutus script v3 reference script.
-  --spending-reference-tx-in-datum-cbor-file CBOR FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-datum-file JSON FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-datum-value JSON VALUE
-                           The script datum, in JSON syntax. There is no schema:
-                           (almost) any JSON value is supported, including
-                           top-level strings and numbers.
+  --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                           The script datum file. The file has to be in CBOR
+                           format.
+  --spending-reference-tx-in-datum-file JSON_FILE
+                           The script datum file. The file must follow the
+                           detailed JSON schema for script data.
+  --spending-reference-tx-in-datum-value JSON_VALUE
+                           The script datum. There is no schema: (almost) any
+                           JSON value is supported, including top-level strings
+                           and numbers.
   --spending-reference-tx-in-inline-datum-present
                            Inline datum present at transaction input.
-  --spending-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --spending-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --spending-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --spending-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --simple-script-tx-in-reference TX-IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a simple reference script attached.
   --tx-in-script-file FILE The file containing the script to witness the
                            spending of the transaction input.
-  --tx-in-datum-cbor-file CBOR FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-datum-file JSON FILE
-                           The script datum, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-datum-value JSON VALUE
-                           The script datum, in JSON syntax. There is no schema:
-                           (almost) any JSON value is supported, including
-                           top-level strings and numbers.
+  --tx-in-datum-cbor-file CBOR_FILE
+                           The script datum file. The file has to be in CBOR
+                           format.
+  --tx-in-datum-file JSON_FILE
+                           The script datum file. The file must follow the
+                           detailed JSON schema for script data.
+  --tx-in-datum-value JSON_VALUE
+                           The script datum. There is no schema: (almost) any
+                           JSON value is supported, including top-level strings
+                           and numbers.
   --tx-in-inline-datum-present
                            Inline datum present at transaction input.
-  --tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --read-only-tx-in-reference TX-IN
                            Specify a read only reference input. This reference
                            input is not witnessing anything it is simply
@@ -245,45 +245,44 @@ Available options:
                            Lovelace).
   --tx-out-datum-hash HASH The script datum hash for this tx output, as the raw
                            datum hash (in hex).
-  --tx-out-datum-hash-cbor-file CBOR FILE
+  --tx-out-datum-hash-cbor-file CBOR_FILE
                            The script datum hash for this tx output, by hashing
-                           the script datum in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-out-datum-hash-file JSON FILE
+                           the script datum in the file. The file has to be in
+                           CBOR format.
+  --tx-out-datum-hash-file JSON_FILE
                            The script datum hash for this tx output, by hashing
-                           the script datum in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-out-datum-hash-value JSON VALUE
+                           the script datum in the file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-datum-hash-value JSON_VALUE
                            The script datum hash for this tx output, by hashing
-                           the script datum given here in JSON syntax. There is
-                           no schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
-  --tx-out-datum-embed-cbor-file CBOR FILE
-                           The script datum to embed in the tx for this output,
-                           in the given JSON file. The file must follow the
-                           special JSON schema for script data.
-  --tx-out-datum-embed-file JSON FILE
-                           The script datum to embed in the tx for this output,
-                           in the given JSON file. The file must follow the
-                           special JSON schema for script data.
-  --tx-out-datum-embed-value JSON VALUE
-                           The script datum to embed in the tx for this output,
-                           given here in JSON syntax. There is no schema:
+                           the script datum given here. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
-  --tx-out-inline-datum-cbor-file CBOR FILE
+  --tx-out-datum-embed-cbor-file CBOR_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file has to be in CBOR format.
+  --tx-out-datum-embed-file JSON_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file must follow the detailed
+                           JSON schema for script data.
+  --tx-out-datum-embed-value JSON_VALUE
+                           The script datum to embed in the tx for this output,
+                           given here. There is no schema: (almost) any JSON
+                           value is supported, including top-level strings and
+                           numbers.
+  --tx-out-inline-datum-cbor-file CBOR_FILE
                            The script datum to embed in the tx output as an
-                           inline datum, in the given JSON file. The file must
-                           follow the special JSON schema for script data.
-  --tx-out-inline-datum-file JSON FILE
+                           inline datum, in the given file. The file has to be
+                           in CBOR format.
+  --tx-out-inline-datum-file JSON_FILE
                            The script datum to embed in the tx output as an
-                           inline datum, in the given JSON file. The file must
-                           follow the special JSON schema for script data.
-  --tx-out-inline-datum-value JSON VALUE
+                           inline datum, in the given file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-inline-datum-value JSON_VALUE
                            The script datum to embed in the tx output as an
-                           inline datum, given here in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+                           inline datum, given here. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --tx-out-reference-script-file FILE
                            Reference script input file.
   --change-address ADDRESS Address where ADA in excess of the tx fee will go to.
@@ -291,16 +290,16 @@ Available options:
                            syntax. You must specify a script witness.
   --mint-script-file FILE  The file containing the script to witness the minting
                            of assets for a particular policy Id.
-  --mint-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --mint-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --mint-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --mint-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --simple-minting-script-tx-in-reference TX-IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a simple reference script attached.
@@ -310,16 +309,16 @@ Available options:
                            input must have a plutus reference script attached.
   --mint-plutus-script-v2  Specify a plutus script v2 reference script.
   --mint-plutus-script-v3  Specify a plutus script v3 reference script.
-  --mint-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --mint-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --mint-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --mint-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --mint-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --policy-id HASH         Policy id of minting script.
   --invalid-before SLOT    Time that transaction is valid from (in slots).
   --invalid-hereafter SLOT Time that transaction is valid until (in slots).
@@ -330,16 +329,16 @@ Available options:
   --certificate-script-file FILE
                            The file containing the script to witness the use of
                            the certificate.
-  --certificate-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --certificate-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --certificate-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --certificate-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --certificate-tx-in-reference TX-IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a plutus reference script attached.
@@ -347,16 +346,16 @@ Available options:
                            Specify a plutus script v2 reference script.
   --certificate-plutus-script-v3
                            Specify a plutus script v3 reference script.
-  --certificate-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --certificate-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --certificate-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --certificate-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --withdrawal WITHDRAWAL  The reward withdrawal as StakeAddress+Lovelace where
                            StakeAddress is the Bech32-encoded stake address
                            followed by the amount in Lovelace. Optionally
@@ -364,16 +363,16 @@ Available options:
   --withdrawal-script-file FILE
                            The file containing the script to witness the
                            withdrawal of rewards.
-  --withdrawal-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --withdrawal-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --withdrawal-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --withdrawal-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --withdrawal-tx-in-reference TX-IN
                            TxId#TxIx - Specify a reference input. The reference
                            input must have a plutus reference script attached.
@@ -381,16 +380,16 @@ Available options:
                            Specify a plutus script v2 reference script.
   --withdrawal-plutus-script-v3
                            Specify a plutus script v3 reference script.
-  --withdrawal-reference-tx-in-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-reference-tx-in-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --withdrawal-reference-tx-in-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --withdrawal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --withdrawal-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --withdrawal-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --json-metadata-no-schema
                            Use the "no schema" conversion from JSON to tx
                            metadata (default).
@@ -407,29 +406,29 @@ Available options:
                            Filepath of the update proposal.
   --vote-file FILE         Filepath of the vote.
   --vote-script-file FILE  The file containing the script to witness a vote
-  --vote-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --vote-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --vote-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --vote-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --vote-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --vote-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --proposal-file FILE     Filepath of the proposal.
   --proposal-script-file FILE
                            The file containing the script to witness a proposal
-  --proposal-redeemer-cbor-file CBOR FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --proposal-redeemer-file JSON FILE
-                           The script redeemer, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --proposal-redeemer-value JSON VALUE
-                           The script redeemer, in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+  --proposal-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --proposal-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --proposal-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --out-file FILE          Output filepath of the JSON TxBody.
   --calculate-plutus-script-cost FILE
                            (File () Out) filepath of the script cost

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/transaction_calculate-min-required-utxo.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/transaction_calculate-min-required-utxo.cli
@@ -9,15 +9,15 @@ Usage: cardano-cli transaction calculate-min-required-utxo
                                                              --protocol-params-file FILE
                                                              --tx-out ADDRESS VALUE
                                                              [ --tx-out-datum-hash HASH
-                                                             | --tx-out-datum-hash-cbor-file CBOR FILE
-                                                             | --tx-out-datum-hash-file JSON FILE
-                                                             | --tx-out-datum-hash-value JSON VALUE
-                                                             | --tx-out-datum-embed-cbor-file CBOR FILE
-                                                             | --tx-out-datum-embed-file JSON FILE
-                                                             | --tx-out-datum-embed-value JSON VALUE
-                                                             | --tx-out-inline-datum-cbor-file CBOR FILE
-                                                             | --tx-out-inline-datum-file JSON FILE
-                                                             | --tx-out-inline-datum-value JSON VALUE
+                                                             | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                             | --tx-out-datum-hash-file JSON_FILE
+                                                             | --tx-out-datum-hash-value JSON_VALUE
+                                                             | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                             | --tx-out-datum-embed-file JSON_FILE
+                                                             | --tx-out-datum-embed-value JSON_VALUE
+                                                             | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                             | --tx-out-inline-datum-file JSON_FILE
+                                                             | --tx-out-inline-datum-value JSON_VALUE
                                                              ]
                                                              [--tx-out-reference-script-file FILE]
 
@@ -38,45 +38,44 @@ Available options:
                            Lovelace).
   --tx-out-datum-hash HASH The script datum hash for this tx output, as the raw
                            datum hash (in hex).
-  --tx-out-datum-hash-cbor-file CBOR FILE
+  --tx-out-datum-hash-cbor-file CBOR_FILE
                            The script datum hash for this tx output, by hashing
-                           the script datum in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-out-datum-hash-file JSON FILE
+                           the script datum in the file. The file has to be in
+                           CBOR format.
+  --tx-out-datum-hash-file JSON_FILE
                            The script datum hash for this tx output, by hashing
-                           the script datum in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-out-datum-hash-value JSON VALUE
+                           the script datum in the file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-datum-hash-value JSON_VALUE
                            The script datum hash for this tx output, by hashing
-                           the script datum given here in JSON syntax. There is
-                           no schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
-  --tx-out-datum-embed-cbor-file CBOR FILE
-                           The script datum to embed in the tx for this output,
-                           in the given JSON file. The file must follow the
-                           special JSON schema for script data.
-  --tx-out-datum-embed-file JSON FILE
-                           The script datum to embed in the tx for this output,
-                           in the given JSON file. The file must follow the
-                           special JSON schema for script data.
-  --tx-out-datum-embed-value JSON VALUE
-                           The script datum to embed in the tx for this output,
-                           given here in JSON syntax. There is no schema:
+                           the script datum given here. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
-  --tx-out-inline-datum-cbor-file CBOR FILE
+  --tx-out-datum-embed-cbor-file CBOR_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file has to be in CBOR format.
+  --tx-out-datum-embed-file JSON_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file must follow the detailed
+                           JSON schema for script data.
+  --tx-out-datum-embed-value JSON_VALUE
+                           The script datum to embed in the tx for this output,
+                           given here. There is no schema: (almost) any JSON
+                           value is supported, including top-level strings and
+                           numbers.
+  --tx-out-inline-datum-cbor-file CBOR_FILE
                            The script datum to embed in the tx output as an
-                           inline datum, in the given JSON file. The file must
-                           follow the special JSON schema for script data.
-  --tx-out-inline-datum-file JSON FILE
+                           inline datum, in the given file. The file has to be
+                           in CBOR format.
+  --tx-out-inline-datum-file JSON_FILE
                            The script datum to embed in the tx output as an
-                           inline datum, in the given JSON file. The file must
-                           follow the special JSON schema for script data.
-  --tx-out-inline-datum-value JSON VALUE
+                           inline datum, in the given file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-inline-datum-value JSON_VALUE
                            The script datum to embed in the tx output as an
-                           inline datum, given here in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+                           inline datum, given here. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --tx-out-reference-script-file FILE
                            Reference script input file.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/transaction_calculate-min-value.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/transaction_calculate-min-value.cli
@@ -9,15 +9,15 @@ Usage: cardano-cli transaction calculate-min-value
                                                      --protocol-params-file FILE
                                                      --tx-out ADDRESS VALUE
                                                      [ --tx-out-datum-hash HASH
-                                                     | --tx-out-datum-hash-cbor-file CBOR FILE
-                                                     | --tx-out-datum-hash-file JSON FILE
-                                                     | --tx-out-datum-hash-value JSON VALUE
-                                                     | --tx-out-datum-embed-cbor-file CBOR FILE
-                                                     | --tx-out-datum-embed-file JSON FILE
-                                                     | --tx-out-datum-embed-value JSON VALUE
-                                                     | --tx-out-inline-datum-cbor-file CBOR FILE
-                                                     | --tx-out-inline-datum-file JSON FILE
-                                                     | --tx-out-inline-datum-value JSON VALUE
+                                                     | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                     | --tx-out-datum-hash-file JSON_FILE
+                                                     | --tx-out-datum-hash-value JSON_VALUE
+                                                     | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                     | --tx-out-datum-embed-file JSON_FILE
+                                                     | --tx-out-datum-embed-value JSON_VALUE
+                                                     | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                     | --tx-out-inline-datum-file JSON_FILE
+                                                     | --tx-out-inline-datum-value JSON_VALUE
                                                      ]
                                                      [--tx-out-reference-script-file FILE]
 
@@ -38,44 +38,43 @@ Available options:
                            Lovelace).
   --tx-out-datum-hash HASH The script datum hash for this tx output, as the raw
                            datum hash (in hex).
-  --tx-out-datum-hash-cbor-file CBOR FILE
+  --tx-out-datum-hash-cbor-file CBOR_FILE
                            The script datum hash for this tx output, by hashing
-                           the script datum in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-out-datum-hash-file JSON FILE
+                           the script datum in the file. The file has to be in
+                           CBOR format.
+  --tx-out-datum-hash-file JSON_FILE
                            The script datum hash for this tx output, by hashing
-                           the script datum in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --tx-out-datum-hash-value JSON VALUE
+                           the script datum in the file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-datum-hash-value JSON_VALUE
                            The script datum hash for this tx output, by hashing
-                           the script datum given here in JSON syntax. There is
-                           no schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
-  --tx-out-datum-embed-cbor-file CBOR FILE
-                           The script datum to embed in the tx for this output,
-                           in the given JSON file. The file must follow the
-                           special JSON schema for script data.
-  --tx-out-datum-embed-file JSON FILE
-                           The script datum to embed in the tx for this output,
-                           in the given JSON file. The file must follow the
-                           special JSON schema for script data.
-  --tx-out-datum-embed-value JSON VALUE
-                           The script datum to embed in the tx for this output,
-                           given here in JSON syntax. There is no schema:
+                           the script datum given here. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
-  --tx-out-inline-datum-cbor-file CBOR FILE
+  --tx-out-datum-embed-cbor-file CBOR_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file has to be in CBOR format.
+  --tx-out-datum-embed-file JSON_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file must follow the detailed
+                           JSON schema for script data.
+  --tx-out-datum-embed-value JSON_VALUE
+                           The script datum to embed in the tx for this output,
+                           given here. There is no schema: (almost) any JSON
+                           value is supported, including top-level strings and
+                           numbers.
+  --tx-out-inline-datum-cbor-file CBOR_FILE
                            The script datum to embed in the tx output as an
-                           inline datum, in the given JSON file. The file must
-                           follow the special JSON schema for script data.
-  --tx-out-inline-datum-file JSON FILE
+                           inline datum, in the given file. The file has to be
+                           in CBOR format.
+  --tx-out-inline-datum-file JSON_FILE
                            The script datum to embed in the tx output as an
-                           inline datum, in the given JSON file. The file must
-                           follow the special JSON schema for script data.
-  --tx-out-inline-datum-value JSON VALUE
+                           inline datum, in the given file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-inline-datum-value JSON_VALUE
                            The script datum to embed in the tx output as an
-                           inline datum, given here in JSON syntax. There is no
-                           schema: (almost) any JSON value is supported,
-                           including top-level strings and numbers.
+                           inline datum, given here. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --tx-out-reference-script-file FILE
                            Reference script input file.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/transaction_hash-script-data.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/transaction_hash-script-data.cli
@@ -1,20 +1,20 @@
 Usage: cardano-cli transaction hash-script-data 
-                                                  ( --script-data-cbor-file CBOR FILE
-                                                  | --script-data-file JSON FILE
-                                                  | --script-data-value JSON VALUE
+                                                  ( --script-data-cbor-file CBOR_FILE
+                                                  | --script-data-file JSON_FILE
+                                                  | --script-data-value JSON_VALUE
                                                   )
 
   Calculate the hash of script data.
 
 Available options:
-  --script-data-cbor-file CBOR FILE
-                           The script data, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --script-data-file JSON FILE
-                           The script data, in the given JSON file. The file
-                           must follow the special JSON schema for script data.
-  --script-data-value JSON VALUE
-                           The script data, in JSON syntax. There is no schema:
-                           (almost) any JSON value is supported, including
-                           top-level strings and numbers.
+  --script-data-cbor-file CBOR_FILE
+                           The script data file. The file has to be in CBOR
+                           format.
+  --script-data-file JSON_FILE
+                           The script data file. The file must follow the
+                           detailed JSON schema for script data.
+  --script-data-value JSON_VALUE
+                           The script data. There is no schema: (almost) any
+                           JSON value is supported, including top-level strings
+                           and numbers.
   -h,--help                Show this help text


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Clarify help texts related to JSON and CBOR
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
   - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Some help texts were misleading, they were mentioning CBOR in JSON arguments and were referencing "special JSON schema" where "detailed JSON schema" should be used.
This is a partial fix for: https://github.com/IntersectMBO/cardano-cli/issues/593

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
