### PR TITLE
query protocol-parameters: use ledger JSON encoding, not API one

### DIFF
--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -203,6 +203,7 @@ library
                       , cardano-crypto-wrapper ^>= 1.5.1
                       , cardano-data >= 1.1
                       , cardano-git-rev ^>= 0.2.2
+                      , cardano-ledger-api
                       , cardano-ledger-byron >= 1.0.1.0
                       , cardano-ping ^>= 0.2.0.13
                       , cardano-prelude

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Genesis.hs
@@ -1176,9 +1176,11 @@ readConwayGenesis fpath = do
 
 --TODO: eliminate this and get only the necessary params, and get them in a more
 -- helpful way rather than requiring them as a local file.
-readProtocolParameters :: ProtocolParamsFile
-                       -> ExceptT ProtocolParamsError IO ProtocolParameters
-readProtocolParameters (ProtocolParamsFile fpath) = do
+readProtocolParameters :: ()
+  => ShelleyBasedEra era
+  -> ProtocolParamsFile
+  -> ExceptT ProtocolParamsError IO (L.PParams (ShelleyLedgerEra era))
+readProtocolParameters sbe (ProtocolParamsFile fpath) = do
   pparams <- handleIOExceptT (ProtocolParamsErrorFile . FileIOError fpath) $ LBS.readFile fpath
   firstExceptT (ProtocolParamsErrorJSON fpath . Text.pack) . hoistEither $
-    Aeson.eitherDecode' pparams
+    shelleyBasedEraConstraints sbe $ Aeson.eitherDecode' pparams

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Query.hs
@@ -177,7 +177,6 @@ runQueryProtocolParametersCmd
           . newExceptT $ executeQueryAnyMode localNodeConnInfo qInMode
   writeProtocolParameters sbe mOutFile pp
   where
-    -- TODO: Conway era - use ledger PParams JSON
     writeProtocolParameters
       :: ShelleyBasedEra era
       -> Maybe (File () Out)
@@ -185,7 +184,9 @@ runQueryProtocolParametersCmd
       -> ExceptT QueryCmdError IO ()
     writeProtocolParameters sbe mOutFile' pparams =
       firstExceptT QueryCmdWriteFileError . newExceptT
-        $ writeLazyByteStringOutput mOutFile' $ encodePretty $ fromLedgerPParams sbe pparams
+        $ writeLazyByteStringOutput mOutFile'
+          $ shelleyBasedEraConstraints sbe
+            $ encodePretty pparams
 
 -- | Calculate the percentage sync rendered as text.
 percentage


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    query protocol-parameters: use ledger JSON encoding, not API one
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

* Fixes https://github.com/IntersectMBO/cardano-cli/issues/729
* Result looked at by @gitmachtl already

# How to trust this PR

* `cardano-node`'s tests ran on this PR: https://github.com/IntersectMBO/cardano-node/pull/5839
* Review the diff of golden files on `cardano-node`'s PR: https://github.com/IntersectMBO/cardano-node/pull/5839/files

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] Self-reviewed the diff