### PR TITLE
Bump upload-artifact version

### DIFF
--- a/.github/workflows/github-page.yml
+++ b/.github/workflows/github-page.yml
@@ -125,7 +125,7 @@ jobs:
       run: ./.github/bin/haddocks.sh ./haddocks true
 
     - name: Upload documentation
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       if: ${{ always() }}
       continue-on-error: true
       with:


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Bump upload-artifact version
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

As stated on https://github.com/actions/upload-artifact#actionsupload-artifact, version 2 will be deleted soon, and version 3 at the end of the year. So this PR bumps `upload-artifact`'s version from 2 to 4 in one pipeline.

This also unblocks merges as the occurrence of `upload-artifact@v2` is now an error in `actionlint`: https://github.com/IntersectMBO/cardano-cli/actions/runs/9060363581/job/24889904799?pr=758 (this is how I found out about this change being required soon).

# How to trust this PR

Check that the haddock still publishes fine after merging this PR.

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] Self-reviewed the diff