### PR TITLE
release-upload.yaml: simplify logic by aggregating steps

### DIFF
--- a/.github/workflows/release-upload.yaml
+++ b/.github/workflows/release-upload.yaml
@@ -1,6 +1,6 @@
 name: Release Upload
 # Pipeline to download binaries from Hydra builds and create GitHub
-# releases out of them (or attaching the binaries to an already existing release)
+# releases out of them (or attaching the binaries to an already existing release).
 #
 # This pipeline is divided in three jobs:
 #
@@ -112,15 +112,15 @@ jobs:
             # (see https://stackoverflow.com/questions/22101778/how-to-preserve-line-breaks-when-storing-command-output-to-a-variable)
   
             # shellcheck disable=SC2126
-            nb_failure=$(echo "$conclusion" | grep "^failure" | wc -l)
-            nb_statuses=$(echo "$conclusion" | wc -l)
+            num_failure=$(echo "$conclusion" | grep "^failure" | wc -l)
+            num_status=$(echo "$conclusion" | wc -l)
             # shellcheck disable=SC2126
-            nb_success=$(echo  "$conclusion" | grep "^success" | wc -l)
-            echo "nb_failure=$nb_failure nb_statuses=$nb_statuses nb_success=$nb_success"
-            if [[ "$nb_failure" != "0" ]]; then
+            num_success=$(echo  "$conclusion" | grep "^success" | wc -l)
+            echo "num_failure=$num_failure num_status=$num_status num_success=$num_success"
+            if [[ "$num_failure" != "0" ]]; then
               echo "ci/hydra-build:required failed"
               exit 1
-            elif [[ "$nb_statuses" == "$nb_success" ]]; then
+            elif [[ "$num_status" == "$num_success" ]]; then
               echo "ci/hydra-build:required succeeded"
               exit 0
             else

--- a/.github/workflows/release-upload.yaml
+++ b/.github/workflows/release-upload.yaml
@@ -54,50 +54,47 @@ jobs:
     name: "Wait for Hydra check-runs"
     runs-on: ubuntu-latest
     outputs:
-      TARGET_TAG: ${{ steps.store_target_tag.outputs.TARGET_TAG }}
-      DRY_RUN:    ${{ steps.store_target_tag.outputs.DRY_RUN }}
-      FLAKE_REF:  ${{ steps.define_flake_ref.outputs.FLAKE_REF }}
+      TARGET_TAG: ${{ steps.store_vars.outputs.TARGET_TAG }}
+      DRY_RUN:    ${{ steps.store_vars.outputs.DRY_RUN }}
+      FLAKE_REF:  ${{ steps.store_vars.outputs.FLAKE_REF }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Because the target tag may not be HEAD
           fetch-tags: true # So that tags are known to git commands
-      - name: Define target tag (1/2)
-        if: ${{ inputs.target_tag != '' }} # If a tag was specified manually as input, use it
+      - name: Define target tag, flake ref, and compute drynesss
+        id: store_vars
         run: |
-          echo "TARGET_TAG=${{ inputs.target_tag }}" >> "$GITHUB_ENV"
-      - name: Define target tag (2/2)
-        if: ${{ inputs.target_tag == '' }} # If no tag was specified manually as input, take the tag from the current commit
-        run: |
-          current_tag=$(git tag --points-at HEAD | head -n 1)
-          if [[ "$current_tag" != "" ]]
+          dry_run="false"
+          if [[ -z "${{ inputs.target_tag }}" ]]
           then
-            # The workflow runs on a commit that has a tag, use this tag
-            echo "TARGET_TAG=$current_tag" >> "$GITHUB_ENV"
-          fi
-      - name: Default tag if needed and compute dryness
-        id: store_target_tag
-        run: |
-          if [[ "${{ env.TARGET_TAG }}" == "" ]]
-          then
-            # Tag was not specified manually as input, and current commit has no tag.
-            echo "Tag not yet defined, using current commit as reference."
-            echo "TARGET_TAG=${{ github.ref_name }}" >> "$GITHUB_ENV"
-          fi
-          if [[ $(git tag --points-at ${{ env.TARGET_TAG }} | wc -l) == "0" ]]
-          then
-            echo "Run targets a commit that has no attached tag: no release will be published."
-            echo "DRY_RUN=true" >> "$GITHUB_OUTPUT"
+            # No tag was specified manually as input, take the tag from the current commit (if any)
+            current_tag=$(git tag --points-at HEAD | head -n 1)
+            if [[ -z "$current_tag" ]]
+            then
+              # No tag was specified manually as input, and current commit has no tag.
+              echo "Tag not yet defined, using current commit as reference."
+              target_tag="${{ github.ref_name }}"
+
+              echo "Run targets a commit that has no attached tag: no release will be published."
+              # This is the only case we won't run the create_release job at the end
+              dry_run="true"
+            else
+              # Workflow runs on a commit that has a tag, use this tag
+              target_tag="$current_tag"
+            fi
           else
-            echo "DRY_RUN=false" >> "$GITHUB_OUTPUT"
+            # A tag was specified manually as input, use it
+            target_tag="${{ inputs.target_tag }}"
           fi
-          echo "TARGET_TAG=${{ env.TARGET_TAG }}" >> "$GITHUB_OUTPUT"
-      - name: Define FLAKE_REF
-        id: define_flake_ref
-        run: |
+          # Set variables in GITHUB_ENV for next steps and in GITHUB_OUTPUT for next jobs
+          echo "TARGET_TAG=$target_tag" >> "$GITHUB_ENV"
+          echo "TARGET_TAG=$target_tag" >> "$GITHUB_OUTPUT"
+
           flake_ref="github:${{ github.repository }}/${{ env.TARGET_TAG }}"
-          echo "FLAKE_REF=$flake_ref" >> "$GITHUB_ENV"
           echo "FLAKE_REF=$flake_ref" >> "$GITHUB_OUTPUT"
+
+          echo "DRY_RUN=$dry_run" >> "$GITHUB_OUTPUT"
       - name: Get specific check run status
         timeout-minutes: 120
         run: |


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Simplify logic of releasing pipeline
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Follow-up of earlier discussions that were left opened on https://github.com/IntersectMBO/cardano-cli/pull/749

# How to trust this PR

I executed this pipeline manually and it goes through the modified steps nicely: https://github.com/IntersectMBO/cardano-cli/actions/runs/9068498972/job/24915930335

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] Self-reviewed the diff