### PR TITLE
release-upload: create file with checksums of binaries

### DIFF
--- a/.github/workflows/release-upload.yaml
+++ b/.github/workflows/release-upload.yaml
@@ -183,6 +183,12 @@ jobs:
           done
           # TODO generalize
           # zip ${{ needs.wait_for_hydra.outputs.TARGET_TAG }}-win64.zip cardano-cli-win64
+      - name: Checksums
+        run: |
+          # (3)
+          for arch in x86_64-linux x86_64-darwin aarch64-darwin; do
+            sha256sum ${{ needs.wait_for_hydra.outputs.TARGET_TAG }}-$arch.tar.gz >> ${{ needs.wait_for_hydra.outputs.TARGET_TAG }}-sha256sums.txt
+          done
       - name: Create short tag
         run: |
           # Transform the long tag (e.g. "cardano-cli-8.22.0.0")
@@ -202,9 +208,10 @@ jobs:
           name: ${{ env.SHORT_TAG }} # Release name in GitHub UI
           # TODO generalize
           # cardano-cli-${{ needs.wait_for_hydra.outputs.TARGET_TAG }}-win64.zip
-          # All entries in 'files' below should match (2)
+          # All entries in 'files' below should match (2) and (3)
           files: |
             ${{ needs.wait_for_hydra.outputs.TARGET_TAG }}-x86_64-linux.tar.gz
             ${{ needs.wait_for_hydra.outputs.TARGET_TAG }}-x86_64-darwin.tar.gz
             ${{ needs.wait_for_hydra.outputs.TARGET_TAG }}-aarch64-darwin.tar.gz
+            ${{ needs.wait_for_hydra.outputs.TARGET_TAG }}-sha256sums.txt
           body_path: RELEASE_CHANGELOG.md


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    release-upload: create file with checksums of binaries
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Fixes https://github.com/IntersectMBO/cardano-cli/issues/755

# How to trust this PR

Release https://github.com/IntersectMBO/cardano-cli/releases/tag/cardano-cli-8.23.1.0 was created by the pipeline of this PR (thanks to a manual execution with `gh workflow run "Release Upload" -r smelc/add-checksums-to-releases -f target_tag=cardano-cli-8.23.1.0`).

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] Self-reviewed the diff