### PR TITLE
actionlint: provision it in Nix shell, and use the same in CI

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -9,8 +9,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # We want to install Nix to provision shellcheck, so that actionlint doesn't install
-      # its own shellcheck. This will also make sure that this pipeline runs using
+      # Note that, because our Nix configuration provisions *both* shellcheck and actionlint,
+      # actionlint is not going to install its own shellcheck.
+      # This also makes sure that this pipeline runs using
       # the same shellcheck as the ones in Nix shells of developers.
       - name: Install Nix with good defaults
         uses: input-output-hk/install-nix-action@v20
@@ -25,11 +26,6 @@ jobs:
       # Make the Nix environment available to next steps
       - uses: rrbutani/use-nix-shell-action@v1
 
-      - name: Install actionlint
-        run: |
-          # Puts the "actionlint" binary in the working folder
-          bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
-
       - name: Run Actionlint
         run: |
           for file in $(git ls-files ".github/workflows/*.y*ml")
@@ -38,7 +34,7 @@ jobs:
             then
               echo "⚠️ $file is ignored from actionlint's verifications. Please consider fixing it."
             else
-              echo "./actionlint $file"
-              ./actionlint "$file"
+              echo "actionlint $file"
+              actionlint "$file"
             fi
           done

--- a/flake.nix
+++ b/flake.nix
@@ -81,7 +81,7 @@
               stylish-haskell = "0.14.5.0";
             };
           # and from nixpkgs or other inputs
-          shell.nativeBuildInputs = with nixpkgs; [ gh jq yq-go shellcheck ];
+          shell.nativeBuildInputs = with nixpkgs; [ gh jq yq-go actionlint shellcheck ];
           # disable Hoogle until someone request it
           shell.withHoogle = false;
           # Skip cross compilers for the shell


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    actionlint: provision it in Nix shell, and use the same in CI
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

* Implementation of https://github.com/IntersectMBO/cardano-node/pull/5804#discussion_r1601292560 in CLI
* This is a nice change because it makes `actionlint` available to Nix users automatically and also ensures that the version used by the CI is the same one as in Nix shells.

# How to trust this PR

* Load the Nix shell locally and observe you have `actionlint` in your `PATH`.
* Look at the execution of the `actionlint` pipeline on this PR and witness it works like before: https://github.com/IntersectMBO/cardano-cli/actions/runs/9095975027/job/25000363605?pr=767

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] Self-reviewed the diff