### PR TITLE
Make `--fee` mandatory in `transaction build-raw`

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Transaction.hs
@@ -67,7 +67,7 @@ data TransactionBuildRawCmdArgs era = TransactionBuildRawCmdArgs
     -- ^ Transaction validity lower bound
   , mValidityUpperBound   :: !(TxValidityUpperBound era)
     -- ^ Transaction validity upper bound
-  , fee                   :: !(Maybe Coin)
+  , fee                   :: !Coin
     -- ^ Transaction fee
   , certificates          :: ![(CertificateFile, Maybe (ScriptWitnessFiles WitCtxStake))]
     -- ^ Certificates with potential script witness

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Transaction.hs
@@ -262,7 +262,7 @@ pTransactionBuildRaw era =
       <*> optional (pMintMultiAsset ManualBalance)
       <*> optional pInvalidBefore
       <*> pInvalidHereafter era
-      <*> optional pTxFee
+      <*> pTxFee
       <*> many (pCertificateFile ManualBalance )
       <*> many (pWithdrawal ManualBalance)
       <*> pTxMetadataJsonSchema

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Transaction.hs
@@ -22,6 +22,7 @@ import           Cardano.CLI.Types.Errors.TxValidationError
 import           Cardano.CLI.Types.Governance
 
 import           Data.Function
+import           Data.Maybe
 
 runLegacyTransactionCmds :: LegacyTransactionCmds -> ExceptT TxCmdError IO ()
 runLegacyTransactionCmds = \case
@@ -175,7 +176,7 @@ runLegacyTransactionBuildRawCmd
        runTransactionBuildRawCmd
          ( Cmd.TransactionBuildRawCmdArgs
              sbe mScriptValidity txins readOnlyRefIns txinsc mReturnColl
-             mTotColl reqSigners txouts mValue mLowBound upperBound fee certs wdrls
+             mTotColl reqSigners txouts mValue mLowBound upperBound (fromMaybe 0 fee) certs wdrls
              metadataSchema scriptFiles metadataFiles mProtocolParamsFile mUpdateProposalFile [] []
              outFile
          )

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/TxCmdError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/TxCmdError.hs
@@ -84,7 +84,6 @@ data TxCmdError
   | TxCmdAuxScriptsValidationError TxAuxScriptsValidationError
   | TxCmdTotalCollateralValidationError TxTotalCollateralValidationError
   | TxCmdReturnCollateralValidationError TxReturnCollateralValidationError
-  | TxCmdTxFeeValidationError TxFeeValidationError
   | TxCmdTxValidityLowerBoundValidationError TxValidityLowerBoundValidationError
   | TxCmdTxValidityUpperBoundValidationError TxValidityUpperBoundValidationError
   | TxCmdRequiredSignersValidationError TxRequiredSignersValidationError
@@ -219,8 +218,6 @@ renderTxCmdError = \case
   TxCmdTotalCollateralValidationError e ->
     prettyError e
   TxCmdReturnCollateralValidationError e ->
-    prettyError e
-  TxCmdTxFeeValidationError e ->
     prettyError e
   TxCmdTxValidityLowerBoundValidationError e ->
     prettyError e

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/TxValidationError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/TxValidationError.hs
@@ -9,7 +9,6 @@
 module Cardano.CLI.Types.Errors.TxValidationError
   ( TxAuxScriptsValidationError(..)
   , TxCertificatesValidationError(..)
-  , TxFeeValidationError(..)
   , TxGovDuplicateVotes(..)
   , TxProtocolParametersValidationError
   , TxScriptValidityValidationError(..)
@@ -26,7 +25,6 @@ module Cardano.CLI.Types.Errors.TxValidationError
   , validateScriptSupportedInEra
   , validateTxAuxScripts
   , validateTxCertificates
-  , validateTxFee
   , validateRequiredSigners
   , validateTxReturnCollateral
   , validateTxScriptValidity
@@ -71,27 +69,6 @@ validateScriptSupportedInEra era script@(ScriptInAnyLang lang _) =
     Nothing -> Left $ ScriptLanguageValidationError
                         (AnyScriptLanguage lang) (anyCardanoEra $ toCardanoEra era)
     Just script' -> pure script'
-
-
-data TxFeeValidationError
-  = TxFeatureImplicitFeesE AnyCardanoEra -- ^ Expected an explicit fee
-  | TxFeatureExplicitFeesE AnyCardanoEra -- ^ Expected an implicit fee
-  deriving Show
-
-instance Error TxFeeValidationError where
-  prettyError (TxFeatureImplicitFeesE era) =
-    "Implicit transaction fee not supported in " <> pretty era
-  prettyError (TxFeatureExplicitFeesE era) =
-    "Explicit transaction fee not supported in " <> pretty era
-
-validateTxFee :: ShelleyBasedEra era
-              -> Maybe L.Coin -- TODO: Make this mandatory in the cli (Remove Maybe)
-              -> Either TxFeeValidationError (TxFee era)
-validateTxFee era = \case
-  Nothing ->
-    let cEra = toCardanoEra era
-    in Left . TxFeatureImplicitFeesE $ cardanoEraConstraints cEra $ AnyCardanoEra cEra
-  Just fee -> pure (TxFeeExplicit era fee)
 
 newtype TxTotalCollateralValidationError
   = TxTotalCollateralNotSupported AnyCardanoEra

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -912,7 +912,7 @@ Usage: cardano-cli shelley transaction build-raw
                                                      )]
                                                    [--invalid-before SLOT]
                                                    [--invalid-hereafter SLOT]
-                                                   [--fee LOVELACE]
+                                                   --fee LOVELACE
                                                    [--certificate-file FILE
                                                      [ --certificate-script-file FILE
                                                        [
@@ -2107,7 +2107,7 @@ Usage: cardano-cli allegra transaction build-raw
                                                      )]
                                                    [--invalid-before SLOT]
                                                    [--invalid-hereafter SLOT]
-                                                   [--fee LOVELACE]
+                                                   --fee LOVELACE
                                                    [--certificate-file FILE
                                                      [ --certificate-script-file FILE
                                                        [
@@ -3294,7 +3294,7 @@ Usage: cardano-cli mary transaction build-raw
                                                   )]
                                                 [--invalid-before SLOT]
                                                 [--invalid-hereafter SLOT]
-                                                [--fee LOVELACE]
+                                                --fee LOVELACE
                                                 [--certificate-file FILE
                                                   [ --certificate-script-file FILE
                                                     [
@@ -4616,7 +4616,7 @@ Usage: cardano-cli alonzo transaction build-raw
                                                     )]
                                                   [--invalid-before SLOT]
                                                   [--invalid-hereafter SLOT]
-                                                  [--fee LOVELACE]
+                                                  --fee LOVELACE
                                                   [--certificate-file FILE
                                                     [ --certificate-script-file FILE
                                                       [
@@ -5970,7 +5970,7 @@ Usage: cardano-cli babbage transaction build-raw
                                                      )]
                                                    [--invalid-before SLOT]
                                                    [--invalid-hereafter SLOT]
-                                                   [--fee LOVELACE]
+                                                   --fee LOVELACE
                                                    [--certificate-file FILE
                                                      [ --certificate-script-file FILE
                                                        [
@@ -7772,7 +7772,7 @@ Usage: cardano-cli conway transaction build-raw
                                                     )]
                                                   [--invalid-before SLOT]
                                                   [--invalid-hereafter SLOT]
-                                                  [--fee LOVELACE]
+                                                  --fee LOVELACE
                                                   [--certificate-file FILE
                                                     [ --certificate-script-file FILE
                                                       [
@@ -9164,7 +9164,7 @@ Usage: cardano-cli latest transaction build-raw
                                                     )]
                                                   [--invalid-before SLOT]
                                                   [--invalid-hereafter SLOT]
-                                                  [--fee LOVELACE]
+                                                  --fee LOVELACE
                                                   [--certificate-file FILE
                                                     [ --certificate-script-file FILE
                                                       [

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_transaction_build-raw.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_transaction_build-raw.cli
@@ -74,7 +74,7 @@ Usage: cardano-cli allegra transaction build-raw
                                                      )]
                                                    [--invalid-before SLOT]
                                                    [--invalid-hereafter SLOT]
-                                                   [--fee LOVELACE]
+                                                   --fee LOVELACE
                                                    [--certificate-file FILE
                                                      [ --certificate-script-file FILE
                                                        [

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_transaction_build-raw.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_transaction_build-raw.cli
@@ -74,7 +74,7 @@ Usage: cardano-cli alonzo transaction build-raw
                                                     )]
                                                   [--invalid-before SLOT]
                                                   [--invalid-hereafter SLOT]
-                                                  [--fee LOVELACE]
+                                                  --fee LOVELACE
                                                   [--certificate-file FILE
                                                     [ --certificate-script-file FILE
                                                       [

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_transaction_build-raw.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_transaction_build-raw.cli
@@ -74,7 +74,7 @@ Usage: cardano-cli babbage transaction build-raw
                                                      )]
                                                    [--invalid-before SLOT]
                                                    [--invalid-hereafter SLOT]
-                                                   [--fee LOVELACE]
+                                                   --fee LOVELACE
                                                    [--certificate-file FILE
                                                      [ --certificate-script-file FILE
                                                        [

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_build-raw.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_build-raw.cli
@@ -74,7 +74,7 @@ Usage: cardano-cli conway transaction build-raw
                                                     )]
                                                   [--invalid-before SLOT]
                                                   [--invalid-hereafter SLOT]
-                                                  [--fee LOVELACE]
+                                                  --fee LOVELACE
                                                   [--certificate-file FILE
                                                     [ --certificate-script-file FILE
                                                       [

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_transaction_build-raw.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_transaction_build-raw.cli
@@ -74,7 +74,7 @@ Usage: cardano-cli latest transaction build-raw
                                                     )]
                                                   [--invalid-before SLOT]
                                                   [--invalid-hereafter SLOT]
-                                                  [--fee LOVELACE]
+                                                  --fee LOVELACE
                                                   [--certificate-file FILE
                                                     [ --certificate-script-file FILE
                                                       [

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_transaction_build-raw.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_transaction_build-raw.cli
@@ -74,7 +74,7 @@ Usage: cardano-cli mary transaction build-raw
                                                   )]
                                                 [--invalid-before SLOT]
                                                 [--invalid-hereafter SLOT]
-                                                [--fee LOVELACE]
+                                                --fee LOVELACE
                                                 [--certificate-file FILE
                                                   [ --certificate-script-file FILE
                                                     [

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_transaction_build-raw.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_transaction_build-raw.cli
@@ -74,7 +74,7 @@ Usage: cardano-cli shelley transaction build-raw
                                                      )]
                                                    [--invalid-before SLOT]
                                                    [--invalid-hereafter SLOT]
-                                                   [--fee LOVELACE]
+                                                   --fee LOVELACE
                                                    [--certificate-file FILE
                                                      [ --certificate-script-file FILE
                                                        [


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Make `--fee` mandatory in `transaction build-raw`. Remove `TxCmdTxFeeValidationError` type.
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
   - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
   - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Seems that fees should be mandatory for eras >= Shelley, but the CLI interface wasn't saying so and was defaulting to 0.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
