### PR TITLE
Add --current-treasury-value and --treasury-donation to transaction build and friends

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Transaction.hs
@@ -80,6 +80,8 @@ data TransactionBuildRawCmdArgs era = TransactionBuildRawCmdArgs
   , mUpdateProprosalFile  :: !(Maybe (Featured ShelleyToBabbageEra era (Maybe UpdateProposalFile)))
   , voteFiles             :: ![(VoteFile In, Maybe (ScriptWitnessFiles WitCtxStake))]
   , proposalFiles         :: ![(ProposalFile In, Maybe (ScriptWitnessFiles WitCtxStake))]
+  , currentTreasuryValue  :: !(Maybe TxCurrentTreasuryValue)
+  , treasuryDonation      :: !(Maybe TxTreasuryDonation)
   , txBodyOutFile         :: !(TxBodyFile Out)
   } deriving Show
 
@@ -126,6 +128,7 @@ data TransactionBuildCmdArgs era = TransactionBuildCmdArgs
   , mUpdateProposalFile     :: !(Maybe (Featured ShelleyToBabbageEra era (Maybe UpdateProposalFile)))
   , voteFiles               :: ![(VoteFile In, Maybe (ScriptWitnessFiles WitCtxStake))]
   , proposalFiles           :: ![(ProposalFile In, Maybe (ScriptWitnessFiles WitCtxStake))]
+  , treasuryDonation        :: !(Maybe TxTreasuryDonation)
   , buildOutputOptions      :: !TxBuildOutputOptions
   } deriving Show
 
@@ -174,6 +177,8 @@ data TransactionBuildEstimateCmdArgs era = TransactionBuildEstimateCmdArgs
   , mUpdateProposalFile      :: !(Maybe (Featured ShelleyToBabbageEra era (Maybe UpdateProposalFile)))
   , voteFiles                :: ![(VoteFile In, Maybe (ScriptWitnessFiles WitCtxStake))]
   , proposalFiles            :: ![(ProposalFile In, Maybe (ScriptWitnessFiles WitCtxStake))]
+  , currentTreasuryValue     :: !(Maybe TxCurrentTreasuryValue)
+  , treasuryDonation         :: !(Maybe TxTreasuryDonation)
   , txBodyOutFile            :: !(TxBodyFile Out)
   }
 

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
@@ -1344,14 +1344,18 @@ pProtocolParamsFile =
     , Opt.completer (Opt.bashCompleter "file")
     ]
 
-pCalculatePlutusScriptCost :: Parser TxBuildOutputOptions
-pCalculatePlutusScriptCost =
-  OutputScriptCostOnly <$> Opt.strOption
-   ( Opt.long "calculate-plutus-script-cost" <>
-     Opt.metavar "FILE" <>
-     Opt.help "(File () Out) filepath of the script cost information." <>
-     Opt.completer (Opt.bashCompleter "file")
-   )
+pTxBuildOutputOptions :: Parser TxBuildOutputOptions
+pTxBuildOutputOptions =
+  (OutputTxBodyOnly <$> pTxBodyFileOut) <|> pCalculatePlutusScriptCost
+  where
+    pCalculatePlutusScriptCost :: Parser TxBuildOutputOptions
+    pCalculatePlutusScriptCost =
+      OutputScriptCostOnly <$> Opt.strOption
+       ( Opt.long "calculate-plutus-script-cost" <>
+         Opt.metavar "FILE" <>
+         Opt.help "(File () Out) filepath of the script cost information." <>
+         Opt.completer (Opt.bashCompleter "file")
+       )
 
 pCertificateFile
   :: BalanceTxExecUnits

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
@@ -1223,6 +1223,32 @@ pProposalFile balExUnits =
        Nothing
        "a proposal"
 
+pCurrentTreasuryValue :: ShelleyBasedEra era -> Parser (Maybe TxCurrentTreasuryValue)
+pCurrentTreasuryValue =
+  caseShelleyToBabbageOrConwayEraOnwards
+    (const $ pure Nothing)
+    (const $ optional $ TxCurrentTreasuryValue <$> coinParser)
+  where
+    coinParser :: Parser L.Coin =
+      Opt.option (readerFromParsecParser parseLovelace) $ mconcat
+        [ Opt.long "current-treasury-value"
+        , Opt.metavar "LOVELACE"
+        , Opt.help "The current treasury value."
+        ]
+
+pTreasuryDonation :: ShelleyBasedEra era -> Parser (Maybe TxTreasuryDonation)
+pTreasuryDonation =
+  caseShelleyToBabbageOrConwayEraOnwards
+    (const $ pure Nothing)
+    (const $ optional $ TxTreasuryDonation <$> coinParser)
+  where
+    coinParser :: Parser L.Coin =
+      Opt.option (readerFromParsecParser parseLovelace) $ mconcat
+        [ Opt.long "treasury-donation"
+        , Opt.metavar "LOVELACE"
+        , Opt.help "The donation to the treasury to perform."
+        ]
+
 --------------------------------------------------------------------------------
 
 pPaymentVerifier :: Parser PaymentVerifier

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Transaction.hs
@@ -183,6 +183,7 @@ pTransactionBuildCmd era envCli = do
           <*> pFeatured (shelleyBasedToCardanoEra sbe) (optional pUpdateProposalFile)
           <*> pVoteFiles sbe AutoBalance
           <*> pProposalFiles sbe AutoBalance
+          <*> pTreasuryDonation sbe
           <*> (OutputTxBodyOnly <$> pTxBodyFileOut <|> pCalculatePlutusScriptCost)
 
 -- | Estimate the transaction fees without access to a live node.
@@ -237,6 +238,8 @@ pTransactionBuildEstimateCmd era _envCli = do
           <*> pFeatured (shelleyBasedToCardanoEra sbe) (optional pUpdateProposalFile)
           <*> pVoteFiles sbe ManualBalance
           <*> pProposalFiles sbe ManualBalance
+          <*> pCurrentTreasuryValue sbe
+          <*> pTreasuryDonation sbe
           <*> pTxBodyFileOut
 
 pChangeAddress :: Parser TxOutChangeAddress
@@ -272,6 +275,8 @@ pTransactionBuildRaw era =
       <*> pFeatured era (optional pUpdateProposalFile)
       <*> pVoteFiles era ManualBalance
       <*> pProposalFiles era ManualBalance
+      <*> pCurrentTreasuryValue era
+      <*> pTreasuryDonation era
       <*> pTxBodyFileOut
 
 pTransactionSign  :: EnvCli -> Parser (TransactionCmds era)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Transaction.hs
@@ -184,7 +184,7 @@ pTransactionBuildCmd era envCli = do
           <*> pVoteFiles sbe AutoBalance
           <*> pProposalFiles sbe AutoBalance
           <*> pTreasuryDonation sbe
-          <*> (OutputTxBodyOnly <$> pTxBodyFileOut <|> pCalculatePlutusScriptCost)
+          <*> pTxBuildOutputOptions
 
 -- | Estimate the transaction fees without access to a live node.
 pTransactionBuildEstimateCmd :: MaryEraOnwards era -> EnvCli -> Maybe (Parser (TransactionCmds era))

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Transaction.hs
@@ -655,13 +655,13 @@ constructTxBodyContent sbe mScriptValidity mPparams inputsAndMaybeScriptWits rea
 
   validatedCollateralTxIns <- validateTxInsCollateral sbe txinsc
   validatedRefInputs <- validateTxInsReference sbe allReferenceInputs
-  validatedTotCollateral <- first TxCmdNotSupportedInAnyCardanoEraValidationError $ validateTxTotalCollateral sbe mTotCollateral
-  validatedRetCol        <- first TxCmdNotSupportedInAnyCardanoEraValidationError $ validateTxReturnCollateral sbe mReturnCollateral
+  validatedTotCollateral <- first TxCmdNotSupportedInEraValidationError $ validateTxTotalCollateral sbe mTotCollateral
+  validatedRetCol        <- first TxCmdNotSupportedInEraValidationError $ validateTxReturnCollateral sbe mReturnCollateral
   let txFee = TxFeeExplicit sbe fee
-  validatedLowerBound <- first TxCmdNotSupportedInAnyCardanoEraValidationError $ validateTxValidityLowerBound sbe mLowerBound
-  validatedReqSigners <- first TxCmdNotSupportedInAnyCardanoEraValidationError $ validateRequiredSigners sbe reqSigners
+  validatedLowerBound <- first TxCmdNotSupportedInEraValidationError $ validateTxValidityLowerBound sbe mLowerBound
+  validatedReqSigners <- first TxCmdNotSupportedInEraValidationError $ validateRequiredSigners sbe reqSigners
   validatedMintValue <- createTxMintValue sbe valuesWithScriptWits
-  validatedTxScriptValidity <- first TxCmdNotSupportedInAnyCardanoEraValidationError $ validateTxScriptValidity sbe mScriptValidity
+  validatedTxScriptValidity <- first TxCmdNotSupportedInEraValidationError $ validateTxScriptValidity sbe mScriptValidity
   validatedVotingProcedures <- first TxCmdTxGovDuplicateVotes $ convertToTxVotingProcedures votingProcedures
   return $ shelleyBasedEraConstraints sbe $ (defaultTxBodyContent sbe
              & setTxIns (validateTxIns inputsAndMaybeScriptWits)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Transaction.hs
@@ -128,6 +128,7 @@ runTransactionBuildCmd
       , mUpdateProposalFile
       , voteFiles
       , proposalFiles
+      , treasuryDonation
       , buildOutputOptions
       } = shelleyBasedEraConstraints eon $ do
   let era = shelleyBasedToCardanoEra eon
@@ -184,18 +185,7 @@ runTransactionBuildCmd
   -- the same collateral input can be used for several plutus scripts
   let filteredTxinsc = Set.toList $ Set.fromList txinsc
 
-  -- We need to construct the txBodycontent outside of runTxBuild
-  BalancedTxBody txBodyContent balancedTxBody _ _ <-
-    runTxBuild
-      eon nodeSocketPath networkId mScriptValidity inputsAndMaybeScriptWits readOnlyReferenceInputs
-      filteredTxinsc mReturnCollateral mTotalCollateral txOuts changeAddresses valuesWithScriptWits
-      mValidityLowerBound mValidityUpperBound certsAndMaybeScriptWits withdrawalsAndMaybeScriptWits
-      requiredSigners txAuxScripts txMetadata mProp mOverrideWitnesses votingProceduresAndMaybeScriptWits
-      proposals buildOutputOptions
-
-  let mScriptWits =
-        forEraInEon era [] $ \sbe -> collectTxBodyScriptWitnesses sbe txBodyContent
-      allReferenceInputs = getAllReferenceInputs
+  let allReferenceInputs = getAllReferenceInputs
                              inputsAndMaybeScriptWits
                              (snd valuesWithScriptWits)
                              certsAndMaybeScriptWits
@@ -207,6 +197,26 @@ runTransactionBuildCmd
   let inputsThatRequireWitnessing = [input | (input,_) <- inputsAndMaybeScriptWits]
       allTxInputs = inputsThatRequireWitnessing ++ allReferenceInputs ++ filteredTxinsc
 
+  AnyCardanoEra nodeEra <- lift (executeLocalStateQueryExpr localNodeConnInfo Consensus.VolatileTip queryCurrentEra)
+    & onLeft (left . TxCmdQueryConvenienceError . AcqFailure)
+    & onLeft (left . TxCmdQueryConvenienceError . QceUnsupportedNtcVersion)
+
+  (txEraUtxo, _, eraHistory, systemStart, _, _, _, featuredCurrentTreasuryValueM) <-
+    lift (executeLocalStateQueryExpr localNodeConnInfo Consensus.VolatileTip (queryStateForBalancedTx nodeEra allTxInputs []))
+      & onLeft (left . TxCmdQueryConvenienceError . AcqFailure)
+      & onLeft (left . TxCmdQueryConvenienceError)
+
+  -- We need to construct the txBodycontent outside of runTxBuild
+  BalancedTxBody txBodyContent balancedTxBody _ _ <-
+    runTxBuild
+      eon nodeSocketPath networkId mScriptValidity inputsAndMaybeScriptWits readOnlyReferenceInputs
+      filteredTxinsc mReturnCollateral mTotalCollateral txOuts changeAddresses valuesWithScriptWits
+      mValidityLowerBound mValidityUpperBound certsAndMaybeScriptWits withdrawalsAndMaybeScriptWits
+      requiredSigners txAuxScripts txMetadata mProp mOverrideWitnesses votingProceduresAndMaybeScriptWits
+      proposals
+      (unFeatured <$> featuredCurrentTreasuryValueM) treasuryDonation
+      buildOutputOptions
+
   -- TODO: Calculating the script cost should live as a different command.
   -- Why? Because then we can simply read a txbody and figure out
   -- the script cost vs having to build the tx body each time
@@ -217,15 +227,6 @@ runTransactionBuildCmd
       pparams <- pure mTxProtocolParams & onNothing (left TxCmdProtocolParametersNotPresentInTxBody)
       executionUnitPrices <- pure (getExecutionUnitPrices era pparams) & onNothing (left TxCmdPParamExecutionUnitsNotAvailable)
 
-      AnyCardanoEra nodeEra <- lift (executeLocalStateQueryExpr localNodeConnInfo Consensus.VolatileTip queryCurrentEra)
-        & onLeft (left . TxCmdQueryConvenienceError . AcqFailure)
-        & onLeft (left . TxCmdQueryConvenienceError . QceUnsupportedNtcVersion)
-
-      (txEraUtxo, _, eraHistory, systemStart, _, _, _, _) <-
-        lift (executeLocalStateQueryExpr localNodeConnInfo Consensus.VolatileTip (queryStateForBalancedTx nodeEra allTxInputs []))
-          & onLeft (left . TxCmdQueryConvenienceError . AcqFailure)
-          & onLeft (left . TxCmdQueryConvenienceError)
-
       Refl <- testEquality era nodeEra
         & hoistMaybe (TxCmdTxNodeEraMismatchError $ NodeEraMismatchError era nodeEra)
 
@@ -234,6 +235,8 @@ runTransactionBuildCmd
           $ evaluateTransactionExecutionUnits era
               systemStart (toLedgerEpochInfo eraHistory)
               pparams txEraUtxo balancedTxBody
+
+      let mScriptWits = forEraInEon era [] $ \sbe -> collectTxBodyScriptWitnesses sbe txBodyContent
 
       scriptCostOutput <-
         firstExceptT TxCmdPlutusScriptCostErr $ hoistEither
@@ -281,6 +284,8 @@ runTransactionBuildEstimateCmd
     , proposalFiles
     , plutusCollateral
     , totalReferenceScriptSize
+    , currentTreasuryValue
+    , treasuryDonation
     , txBodyOutFile
     } = do
   let sbe = maryEraOnwardsToShelleyBasedEra eon
@@ -354,6 +359,8 @@ runTransactionBuildEstimateCmd
                      txUpdateProposal
                      votingProceduresAndMaybeScriptWits
                      proposals
+                     currentTreasuryValue
+                     treasuryDonation
   let stakeCredentialsToDeregisterMap = Map.fromList $ catMaybes [getStakeDeregistrationInfo cert | (cert,_) <- certsAndMaybeScriptWits]
       drepsToDeregisterMap = Map.fromList $ catMaybes [getDRepDeregistrationInfo cert | (cert,_) <- certsAndMaybeScriptWits]
       poolsToDeregister = Set.fromList $ catMaybes [getPoolDeregistrationInfo cert | (cert,_) <- certsAndMaybeScriptWits]
@@ -487,6 +494,8 @@ runTransactionBuildRawCmd
       , voteFiles
       , proposalFiles
       , txBodyOutFile
+      , currentTreasuryValue
+      , treasuryDonation
       } = do
   inputsAndMaybeScriptWits <- firstExceptT TxCmdScriptWitnessError
                                 $ readScriptWitnessFiles eon txIns
@@ -545,6 +554,7 @@ runTransactionBuildRawCmd
       mReturnCollateral mTotalCollateral txOuts mValidityLowerBound mValidityUpperBound fee valuesWithScriptWits
       certsAndMaybeScriptWits withdrawalsAndMaybeScriptWits requiredSigners txAuxScripts
       txMetadata mLedgerPParams txUpdateProposal votingProceduresAndMaybeScriptWits proposals
+      currentTreasuryValue treasuryDonation
 
   let noWitTx = makeSignedTransaction [] txBody
   lift (writeTxFileTextEnvelopeCddl eon txBodyOutFile noWitTx)
@@ -585,6 +595,8 @@ runTxBuildRaw :: ()
   -> TxUpdateProposal era
   -> [(VotingProcedures era, Maybe (ScriptWitness WitCtxStake era))]
   -> [(Proposal era, Maybe (ScriptWitness WitCtxStake era))]
+  -> Maybe TxCurrentTreasuryValue
+  -> Maybe TxTreasuryDonation
   -> Either TxCmdError (TxBody era)
 runTxBuildRaw sbe
               mScriptValidity inputsAndMaybeScriptWits
@@ -593,12 +605,13 @@ runTxBuildRaw sbe
               mLowerBound mUpperBound
               fee valuesWithScriptWits
               certsAndMaybeSriptWits withdrawals reqSigners
-              txAuxScripts txMetadata mpparams txUpdateProposal votingProcedures proposals = do
+              txAuxScripts txMetadata mpparams txUpdateProposal votingProcedures proposals
+              mCurrentTreasuryValue mTreasuryDonation = do
 
     txBodyContent <- constructTxBodyContent sbe mScriptValidity (unLedgerProtocolParameters <$> mpparams) inputsAndMaybeScriptWits readOnlyRefIns txinsc
                       mReturnCollateral mTotCollateral txouts mLowerBound mUpperBound valuesWithScriptWits
                       certsAndMaybeSriptWits withdrawals reqSigners fee txAuxScripts txMetadata txUpdateProposal
-                      votingProcedures proposals
+                      votingProcedures proposals mCurrentTreasuryValue mTreasuryDonation
 
     first TxCmdTxBodyError $ createAndValidateTransactionBody sbe txBodyContent
 
@@ -637,12 +650,14 @@ constructTxBodyContent
   -> TxUpdateProposal era
   -> [(VotingProcedures era, Maybe (ScriptWitness WitCtxStake era))]
   -> [(Proposal era, Maybe (ScriptWitness WitCtxStake era))]
+  -> Maybe TxCurrentTreasuryValue
+  -> Maybe TxTreasuryDonation
   -> Either TxCmdError (TxBodyContent BuildTx era)
 constructTxBodyContent sbe mScriptValidity mPparams inputsAndMaybeScriptWits readOnlyRefIns txinsc
                        mReturnCollateral mTotCollateral txouts mLowerBound mUpperBound
                        valuesWithScriptWits certsAndMaybeScriptWits withdrawals
                        reqSigners fee txAuxScripts txMetadata txUpdateProposal
-                       votingProcedures proposals
+                       votingProcedures proposals mCurrentTreasuryValue mTreasuryDonation
                        = do
   let allReferenceInputs = getAllReferenceInputs
                              inputsAndMaybeScriptWits
@@ -663,6 +678,8 @@ constructTxBodyContent sbe mScriptValidity mPparams inputsAndMaybeScriptWits rea
   validatedMintValue <- createTxMintValue sbe valuesWithScriptWits
   validatedTxScriptValidity <- first TxCmdNotSupportedInEraValidationError $ validateTxScriptValidity sbe mScriptValidity
   validatedVotingProcedures <- first TxCmdTxGovDuplicateVotes $ convertToTxVotingProcedures votingProcedures
+  validatedCurrentTreasuryValue <- first TxCmdNotSupportedInEraValidationError (validateTxCurrentTreasuryValue sbe mCurrentTreasuryValue)
+  validatedTreasuryDonation <- first TxCmdNotSupportedInEraValidationError (validateTxTreasuryDonation sbe mTreasuryDonation)
   return $ shelleyBasedEraConstraints sbe $ (defaultTxBodyContent sbe
              & setTxIns (validateTxIns inputsAndMaybeScriptWits)
              & setTxInsCollateral validatedCollateralTxIns
@@ -686,6 +703,8 @@ constructTxBodyContent sbe mScriptValidity mPparams inputsAndMaybeScriptWits rea
              { txProposalProcedures = forShelleyBasedEraInEonMaybe sbe (`Featured` convToTxProposalProcedures proposals)
              , txVotingProcedures = forShelleyBasedEraInEonMaybe sbe (`Featured` validatedVotingProcedures)
              }
+             & setTxCurrentTreasuryValue validatedCurrentTreasuryValue
+             & setTxTreasuryDonation validatedTreasuryDonation
  where
   convertWithdrawals
     :: (StakeAddress, L.Coin, Maybe (ScriptWitness WitCtxStake era))
@@ -732,6 +751,8 @@ runTxBuild :: ()
   -> Maybe Word
   -> [(VotingProcedures era, Maybe (ScriptWitness WitCtxStake era))]
   -> [(Proposal era, Maybe (ScriptWitness WitCtxStake era))]
+  -> Maybe TxCurrentTreasuryValue
+  -> Maybe TxTreasuryDonation
   -> TxBuildOutputOptions
   -> ExceptT TxCmdError IO (BalancedTxBody era)
 runTxBuild
@@ -739,7 +760,9 @@ runTxBuild
     inputsAndMaybeScriptWits readOnlyRefIns txinsc mReturnCollateral mTotCollateral txouts
     (TxOutChangeAddress changeAddr) valuesWithScriptWits mLowerBound mUpperBound
     certsAndMaybeScriptWits withdrawals reqSigners txAuxScripts txMetadata
-    txUpdateProposal mOverrideWits votingProcedures proposals _outputOptions = shelleyBasedEraConstraints sbe $ do
+    txUpdateProposal mOverrideWits votingProcedures proposals
+    mCurrentTreasuryValue mTreasuryDonation
+    _outputOptions = shelleyBasedEraConstraints sbe $ do
 
   -- TODO: All functions should be parameterized by ShelleyBasedEra
   -- as it's not possible to call this function with ByronEra
@@ -800,6 +823,7 @@ runTxBuild
                      txMetadata
                      txUpdateProposal
                      votingProcedures proposals
+                     mCurrentTreasuryValue mTreasuryDonation
 
   firstExceptT TxCmdTxInsDoNotExist
     . hoistEither $ txInsExistInUTxO allTxInputs txEraUtxo

--- a/cardano-cli/src/Cardano/CLI/Json/Friendly.hs
+++ b/cardano-cli/src/Cardano/CLI/Json/Friendly.hs
@@ -189,8 +189,8 @@ friendlyTxBodyImpl
          _txScriptValidity
          txProposalProcedures
          txVotingProcedures
-         _txCurrentTreasuryValue
-         _txTreasuryDonation)) =
+         txCurrentTreasuryValue
+         txTreasuryDonation)) =
   do redeemerDetails <- redeemerIfShelleyBased era tb
      return $ cardanoEraConstraints era
                 ( redeemerDetails ++
@@ -231,6 +231,8 @@ friendlyTxBodyImpl
                              Just (Featured _ (TxVotingProcedures votes _witnesses)) ->
                                friendlyVotingProcedures cOnwards votes)
                         era)
+                  , "currentTreasuryValue" .= toJSON (unFeatured <$> txCurrentTreasuryValue)
+                  , "treasuryDonation" .= toJSON (unFeatured <$> txTreasuryDonation)
                   ])
   where
     friendlyLedgerProposals :: ConwayEraOnwards era -> [L.ProposalProcedure (ShelleyLedgerEra era)] -> Aeson.Value

--- a/cardano-cli/src/Cardano/CLI/Legacy/Commands/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Commands/Transaction.hs
@@ -93,6 +93,7 @@ data LegacyTransactionCmds
       (Maybe UpdateProposalFile)
       [(VoteFile In, Maybe (ScriptWitnessFiles WitCtxStake))]
       [(ProposalFile In, Maybe (ScriptWitnessFiles WitCtxStake))]
+      (Maybe TxTreasuryDonation)
       TxBuildOutputOptions
   | TransactionSignCmd
       InputTxBodyOrTxFile

--- a/cardano-cli/src/Cardano/CLI/Legacy/Options.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Options.hs
@@ -340,7 +340,7 @@ pTransaction envCli =
       <*> pVoteFiles ShelleyBasedEraConway AutoBalance
       <*> pProposalFiles ShelleyBasedEraConway AutoBalance
       <*> pTreasuryDonation ShelleyBasedEraConway
-      <*> (OutputTxBodyOnly <$> pTxBodyFileOut <|> pCalculatePlutusScriptCost)
+      <*> pTxBuildOutputOptions
 
   pChangeAddress :: Parser TxOutChangeAddress
   pChangeAddress =

--- a/cardano-cli/src/Cardano/CLI/Legacy/Options.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Options.hs
@@ -339,6 +339,7 @@ pTransaction envCli =
       <*> optional pUpdateProposalFile
       <*> pVoteFiles ShelleyBasedEraConway AutoBalance
       <*> pProposalFiles ShelleyBasedEraConway AutoBalance
+      <*> pTreasuryDonation ShelleyBasedEraConway
       <*> (OutputTxBodyOnly <$> pTxBodyFileOut <|> pCalculatePlutusScriptCost)
 
   pChangeAddress :: Parser TxOutChangeAddress

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Transaction.hs
@@ -28,11 +28,11 @@ runLegacyTransactionCmds = \case
   TransactionBuildCmd mNodeSocketPath era consensusModeParams nid mScriptValidity mOverrideWits txins readOnlyRefIns
             reqSigners txinsc mReturnColl mTotCollateral txouts changeAddr mValue mLowBound
             mUpperBound certs wdrls metadataSchema scriptFiles metadataFiles mUpProp mconwayVote
-            mNewConstitution outputOptions -> do
+            mNewConstitution mTreasuryDonation outputOptions -> do
       runLegacyTransactionBuildCmd mNodeSocketPath era consensusModeParams nid mScriptValidity mOverrideWits txins readOnlyRefIns
             reqSigners txinsc mReturnColl mTotCollateral txouts changeAddr mValue mLowBound
             mUpperBound certs wdrls metadataSchema scriptFiles metadataFiles mUpProp mconwayVote
-            mNewConstitution outputOptions
+            mNewConstitution mTreasuryDonation outputOptions
   TransactionBuildRawCmd era mScriptValidity txins readOnlyRefIns txinsc mReturnColl
                mTotColl reqSigners txouts mValue mLowBound mUpperBound fee certs wdrls
                metadataSchema scriptFiles metadataFiles mProtocolParamsFile mUpProp out -> do
@@ -90,6 +90,7 @@ runLegacyTransactionBuildCmd :: ()
   -> Maybe UpdateProposalFile
   -> [(VoteFile In, Maybe (ScriptWitnessFiles WitCtxStake))]
   -> [(ProposalFile In, Maybe (ScriptWitnessFiles WitCtxStake))]
+  -> Maybe TxTreasuryDonation
   -> TxBuildOutputOptions
   -> ExceptT TxCmdError IO ()
 runLegacyTransactionBuildCmd
@@ -97,7 +98,9 @@ runLegacyTransactionBuildCmd
     consensusModeParams nid mScriptValidity mOverrideWits txins readOnlyRefIns
     reqSigners txinsc mReturnColl mTotCollateral txouts changeAddr mValue mLowBound
     mUpperBound certs wdrls metadataSchema scriptFiles metadataFiles mUpdateProposal voteFiles
-    proposalFiles outputOptions = do
+    proposalFiles
+    mTreasuryDonation
+    outputOptions = do
 
   mUpdateProposalFile <-
     validateUpdateProposalFile (shelleyBasedToCardanoEra sbe) mUpdateProposal
@@ -111,7 +114,7 @@ runLegacyTransactionBuildCmd
         consensusModeParams nid mScriptValidity mOverrideWits txins readOnlyRefIns
         reqSigners txinsc mReturnColl mTotCollateral txouts changeAddr mValue mLowBound
         upperBound certs wdrls metadataSchema scriptFiles metadataFiles mUpdateProposalFile voteFiles
-        proposalFiles outputOptions
+        proposalFiles mTreasuryDonation outputOptions
     )
 
 -- TODO: Neither QA nor Sam is using `cardano-cli byron transaction build-raw`
@@ -177,6 +180,7 @@ runLegacyTransactionBuildRawCmd
              sbe mScriptValidity txins readOnlyRefIns txinsc mReturnColl
              mTotColl reqSigners txouts mValue mLowBound upperBound fee certs wdrls
              metadataSchema scriptFiles metadataFiles mProtocolParamsFile mUpdateProposalFile [] []
+             Nothing Nothing
              outFile
          )
          )

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Transaction.hs
@@ -102,7 +102,7 @@ runLegacyTransactionBuildCmd
   mUpdateProposalFile <-
     validateUpdateProposalFile (shelleyBasedToCardanoEra sbe) mUpdateProposal
       & hoistEither
-      & firstExceptT TxCmdNotSupportedInAnyCardanoEraValidationError
+      & firstExceptT TxCmdNotSupportedInEraValidationError
 
   let upperBound = TxValidityUpperBound sbe mUpperBound
 
@@ -168,7 +168,7 @@ runLegacyTransactionBuildRawCmd
     (\sbe -> do
        mUpdateProposalFile <- validateUpdateProposalFile era mUpdateProposal
                                  & hoistEither
-                                 & firstExceptT TxCmdNotSupportedInAnyCardanoEraValidationError
+                                 & firstExceptT TxCmdNotSupportedInEraValidationError
 
        let upperBound = TxValidityUpperBound sbe mUpperBound
 

--- a/cardano-cli/src/Cardano/CLI/Types/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Common.hs
@@ -66,6 +66,7 @@ module Cardano.CLI.Types.Common
   , TxBuildOutputOptions(..)
   , TxByronWitnessCount(..)
   , TxFile
+  , TxTreasuryDonation(..)
   , TxInCount(..)
   , TxMempoolQuery (..)
   , TxOutAnyEra (..)
@@ -467,6 +468,9 @@ data EpochLeadershipSchedule
 type TxBodyFile = File (TxBody ())
 
 type TxFile = File (Tx ())
+
+newtype TxTreasuryDonation = TxTreasuryDonation { unTxTreasuryDonation :: L.Coin }
+  deriving Show
 
 data TxMempoolQuery =
       TxMempoolQueryTxExists TxId

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/TxCmdError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/TxCmdError.hs
@@ -79,7 +79,7 @@ data TxCmdError
   | TxCmdCddlWitnessError CddlWitnessError
   | TxCmdRequiredSignerError RequiredSignerError
   -- Validation errors
-  | forall era. TxCmdNotSupportedInAnyCardanoEraValidationError (TxNotSupportedInAnyCardanoEraValidationError era)
+  | forall era. TxCmdNotSupportedInEraValidationError (TxNotSupportedInEraValidationError era)
   | TxCmdAuxScriptsValidationError TxAuxScriptsValidationError
   | TxCmdProtocolParamsConverstionError ProtocolParametersConversionError
   | forall era. TxCmdTxGovDuplicateVotes (TxGovDuplicateVotes era)
@@ -204,7 +204,7 @@ renderTxCmdError = \case
   TxCmdRequiredSignerError e ->
     prettyError e
   -- Validation errors
-  TxCmdNotSupportedInAnyCardanoEraValidationError e ->
+  TxCmdNotSupportedInEraValidationError e ->
     prettyError e
   TxCmdAuxScriptsValidationError e ->
     prettyError e

--- a/cardano-cli/test/cardano-cli-golden/files/golden/allegra/transaction-view.out
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/allegra/transaction-view.out
@@ -1,6 +1,7 @@
 auxiliary scripts: null
 certificates: null
 collateral inputs: null
+currentTreasuryValue: null
 era: Allegra
 fee: 100 Lovelace
 governance actions: null
@@ -23,6 +24,7 @@ reference inputs: null
 required signers (payment key hashes needed for scripts): null
 return collateral: null
 total collateral: null
+treasuryDonation: null
 update proposal: null
 validity range:
   lower bound: null

--- a/cardano-cli/test/cardano-cli-golden/files/golden/alonzo/signed-transaction-view.out
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/alonzo/signed-transaction-view.out
@@ -2,6 +2,7 @@ auxiliary scripts: null
 certificates: null
 collateral inputs:
 - c9765d7d0e3955be8920e6d7a38e1f3f2032eac48c7c59b0b9193caa87727e7e#256
+currentTreasuryValue: null
 era: Alonzo
 fee: 213 Lovelace
 governance actions: null
@@ -17,6 +18,7 @@ required signers (payment key hashes needed for scripts):
 - fafaaac8681b5050a8987f95bce4a7f99362f189879258fdbf733fa4
 return collateral: null
 total collateral: null
+treasuryDonation: null
 update proposal: null
 validity range:
   lower bound: null

--- a/cardano-cli/test/cardano-cli-golden/files/golden/alonzo/transaction-view.out
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/alonzo/transaction-view.out
@@ -2,6 +2,7 @@ auxiliary scripts: null
 certificates: null
 collateral inputs:
 - c9765d7d0e3955be8920e6d7a38e1f3f2032eac48c7c59b0b9193caa87727e7e#256
+currentTreasuryValue: null
 era: Alonzo
 fee: 213 Lovelace
 governance actions: null
@@ -17,6 +18,7 @@ required signers (payment key hashes needed for scripts):
 - fafaaac8681b5050a8987f95bce4a7f99362f189879258fdbf733fa4
 return collateral: null
 total collateral: null
+treasuryDonation: null
 update proposal:
   epoch: 190
   updates:

--- a/cardano-cli/test/cardano-cli-golden/files/golden/babbage/transaction-view-metadata-detailedschema.out
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/babbage/transaction-view-metadata-detailedschema.out
@@ -1,6 +1,7 @@
 auxiliary scripts: null
 certificates: null
 collateral inputs: []
+currentTreasuryValue: null
 era: Babbage
 fee: 21300 Lovelace
 governance actions: null
@@ -35,6 +36,7 @@ reference inputs: []
 required signers (payment key hashes needed for scripts): null
 return collateral: null
 total collateral: null
+treasuryDonation: null
 update proposal: null
 validity range:
   lower bound: null

--- a/cardano-cli/test/cardano-cli-golden/files/golden/babbage/transaction-view-metadata-noschema.out
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/babbage/transaction-view-metadata-noschema.out
@@ -1,6 +1,7 @@
 auxiliary scripts: null
 certificates: null
 collateral inputs: []
+currentTreasuryValue: null
 era: Babbage
 fee: 21300 Lovelace
 governance actions: null
@@ -68,6 +69,7 @@ reference inputs: []
 required signers (payment key hashes needed for scripts): null
 return collateral: null
 total collateral: null
+treasuryDonation: null
 update proposal: null
 validity range:
   lower bound: null

--- a/cardano-cli/test/cardano-cli-golden/files/golden/babbage/transaction-view-redeemer.out
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/babbage/transaction-view-redeemer.out
@@ -2,6 +2,7 @@ auxiliary scripts: null
 certificates: null
 collateral inputs:
 - c9765d7d0e3955be8920e6d7a38e1f3f2032eac48c7c59b0b9193caa87727e7e#256
+currentTreasuryValue: null
 era: Babbage
 fee: 213 Lovelace
 governance actions: null
@@ -20,6 +21,7 @@ reference inputs: []
 required signers (payment key hashes needed for scripts): null
 return collateral: null
 total collateral: null
+treasuryDonation: null
 update proposal: null
 validity range:
   lower bound: null

--- a/cardano-cli/test/cardano-cli-golden/files/golden/conway/tx-proposal.out.json
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/conway/tx-proposal.out.json
@@ -2,6 +2,7 @@
     "auxiliary scripts": null,
     "certificates": null,
     "collateral inputs": [],
+    "currentTreasuryValue": null,
     "era": "Conway",
     "fee": "181517 Lovelace",
     "governance actions": [
@@ -54,6 +55,7 @@
     "required signers (payment key hashes needed for scripts)": null,
     "return collateral": null,
     "total collateral": null,
+    "treasuryDonation": 0,
     "update proposal": null,
     "validity range": {
         "lower bound": null,

--- a/cardano-cli/test/cardano-cli-golden/files/golden/conway/tx-three-votes-view.out.json
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/conway/tx-three-votes-view.out.json
@@ -2,6 +2,7 @@
     "auxiliary scripts": null,
     "certificates": null,
     "collateral inputs": [],
+    "currentTreasuryValue": null,
     "era": "Conway",
     "fee": "185433 Lovelace",
     "governance actions": [],
@@ -30,6 +31,7 @@
     "required signers (payment key hashes needed for scripts)": null,
     "return collateral": null,
     "total collateral": null,
+    "treasuryDonation": 0,
     "update proposal": null,
     "validity range": {
         "lower bound": null,

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -7834,6 +7834,8 @@ Usage: cardano-cli conway transaction build-raw
                                                         | --proposal-redeemer-value JSON_VALUE
                                                         )
                                                         --proposal-execution-units (INT, INT)]]]
+                                                  [--current-treasury-value LOVELACE]
+                                                  [--treasury-donation LOVELACE]
                                                   --out-file FILE
 
   Build a transaction (low-level, inconvenient)
@@ -7967,6 +7969,7 @@ Usage: cardano-cli conway transaction build --socket-path SOCKET_PATH
                                                   | --proposal-redeemer-file JSON_FILE
                                                   | --proposal-redeemer-value JSON_VALUE
                                                   ]]]
+                                              [--treasury-donation LOVELACE]
                                               ( --out-file FILE
                                               | --calculate-plutus-script-cost FILE
                                               )
@@ -8116,6 +8119,8 @@ Usage: cardano-cli conway transaction build-estimate
                                                              | --proposal-redeemer-value JSON_VALUE
                                                              )
                                                              --proposal-execution-units (INT, INT)]]]
+                                                       [--current-treasury-value LOVELACE]
+                                                       [--treasury-donation LOVELACE]
                                                        --out-file FILE
 
   Build a balanced transaction without access to a live node (automatically estimates fees)
@@ -10505,6 +10510,7 @@ Usage: cardano-cli legacy transaction build --socket-path SOCKET_PATH
                                                   | --proposal-redeemer-file JSON_FILE
                                                   | --proposal-redeemer-value JSON_VALUE
                                                   ]]]
+                                              [--treasury-donation LOVELACE]
                                               ( --out-file FILE
                                               | --calculate-plutus-script-cost FILE
                                               )
@@ -11736,6 +11742,7 @@ Usage: cardano-cli transaction build --socket-path SOCKET_PATH
                                            | --proposal-redeemer-file JSON_FILE
                                            | --proposal-redeemer-value JSON_VALUE
                                            ]]]
+                                       [--treasury-donation LOVELACE]
                                        ( --out-file FILE
                                        | --calculate-plutus-script-cost FILE
                                        )

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_build-estimate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_build-estimate.cli
@@ -139,6 +139,8 @@ Usage: cardano-cli conway transaction build-estimate
                                                              | --proposal-redeemer-value JSON_VALUE
                                                              )
                                                              --proposal-execution-units (INT, INT)]]]
+                                                       [--current-treasury-value LOVELACE]
+                                                       [--treasury-donation LOVELACE]
                                                        --out-file FILE
 
   Build a balanced transaction without access to a live node (automatically estimates fees)
@@ -450,5 +452,9 @@ Available options:
                            top-level strings and numbers.
   --proposal-execution-units (INT, INT)
                            The time and space units needed by the script.
+  --current-treasury-value LOVELACE
+                           The current treasury value.
+  --treasury-donation LOVELACE
+                           The donation to the treasury to perform.
   --out-file FILE          Output filepath of the JSON TxBody.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_build-raw.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_build-raw.cli
@@ -135,6 +135,8 @@ Usage: cardano-cli conway transaction build-raw
                                                         | --proposal-redeemer-value JSON_VALUE
                                                         )
                                                         --proposal-execution-units (INT, INT)]]]
+                                                  [--current-treasury-value LOVELACE]
+                                                  [--treasury-donation LOVELACE]
                                                   --out-file FILE
 
   Build a transaction (low-level, inconvenient)
@@ -435,5 +437,9 @@ Available options:
                            top-level strings and numbers.
   --proposal-execution-units (INT, INT)
                            The time and space units needed by the script.
+  --current-treasury-value LOVELACE
+                           The current treasury value.
+  --treasury-donation LOVELACE
+                           The donation to the treasury to perform.
   --out-file FILE          Output filepath of the JSON TxBody.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_build.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_build.cli
@@ -125,6 +125,7 @@ Usage: cardano-cli conway transaction build --socket-path SOCKET_PATH
                                                   | --proposal-redeemer-file JSON_FILE
                                                   | --proposal-redeemer-value JSON_VALUE
                                                   ]]]
+                                              [--treasury-donation LOVELACE]
                                               ( --out-file FILE
                                               | --calculate-plutus-script-cost FILE
                                               )
@@ -420,6 +421,8 @@ Available options:
                            The script redeemer value. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
+  --treasury-donation LOVELACE
+                           The donation to the treasury to perform.
   --out-file FILE          Output filepath of the JSON TxBody.
   --calculate-plutus-script-cost FILE
                            (File () Out) filepath of the script cost

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_transaction_build.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_transaction_build.cli
@@ -132,6 +132,7 @@ Usage: cardano-cli legacy transaction build --socket-path SOCKET_PATH
                                                   | --proposal-redeemer-file JSON_FILE
                                                   | --proposal-redeemer-value JSON_VALUE
                                                   ]]]
+                                              [--treasury-donation LOVELACE]
                                               ( --out-file FILE
                                               | --calculate-plutus-script-cost FILE
                                               )
@@ -434,6 +435,8 @@ Available options:
                            The script redeemer value. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
+  --treasury-donation LOVELACE
+                           The donation to the treasury to perform.
   --out-file FILE          Output filepath of the JSON TxBody.
   --calculate-plutus-script-cost FILE
                            (File () Out) filepath of the script cost

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/transaction_build.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/transaction_build.cli
@@ -127,6 +127,7 @@ Usage: cardano-cli transaction build --socket-path SOCKET_PATH
                                            | --proposal-redeemer-file JSON_FILE
                                            | --proposal-redeemer-value JSON_VALUE
                                            ]]]
+                                       [--treasury-donation LOVELACE]
                                        ( --out-file FILE
                                        | --calculate-plutus-script-cost FILE
                                        )
@@ -429,6 +430,8 @@ Available options:
                            The script redeemer value. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
+  --treasury-donation LOVELACE
+                           The donation to the treasury to perform.
   --out-file FILE          Output filepath of the JSON TxBody.
   --calculate-plutus-script-cost FILE
                            (File () Out) filepath of the script cost

--- a/cardano-cli/test/cardano-cli-golden/files/golden/mary/transaction-view.out
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/mary/transaction-view.out
@@ -1,6 +1,7 @@
 auxiliary scripts: null
 certificates: null
 collateral inputs: null
+currentTreasuryValue: null
 era: Mary
 fee: 139 Lovelace
 governance actions: null
@@ -39,6 +40,7 @@ reference inputs: null
 required signers (payment key hashes needed for scripts): null
 return collateral: null
 total collateral: null
+treasuryDonation: null
 update proposal: null
 validity range:
   lower bound: 140

--- a/cardano-cli/test/cardano-cli-golden/files/golden/shelley/transaction-view.out
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/shelley/transaction-view.out
@@ -31,6 +31,7 @@ certificates:
       network: Mainnet
     vrf: 8d445260282cef45e4c6a862b8a924aeed1b316ccba779dd39f9517220e96407
 collateral inputs: null
+currentTreasuryValue: null
 era: Shelley
 fee: 32 Lovelace
 governance actions: null
@@ -52,6 +53,7 @@ reference inputs: null
 required signers (payment key hashes needed for scripts): null
 return collateral: null
 total collateral: null
+treasuryDonation: null
 update proposal:
   epoch: 64
   updates:


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Add --current-treasury-value and --treasury-donation to transaction build and friends
# uncomment types applicable to the change:
  type:
  - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Fixes https://github.com/IntersectMBO/cardano-cli/issues/590

# How to trust this PR

We tested this new feature in `cardano-testnet` in this `cardano-node` PR: https://github.com/IntersectMBO/cardano-node/pull/5866

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
- [x] Consider https://github.com/IntersectMBO/cardano-cli/pull/783#discussion_r1638321013
- [x] Consider https://github.com/IntersectMBO/cardano-cli/pull/783#discussion_r1638321175
- [x] Use `CurrentTreasuryValue` type from API instead of introducing a new one (see how API PR is received)