### PR TITLE
Future proof against extensions of TxBodyContent

### DIFF
--- a/cardano-cli/src/Cardano/CLI/Json/Friendly.hs
+++ b/cardano-cli/src/Cardano/CLI/Json/Friendly.hs
@@ -166,27 +166,31 @@ friendlyTxBodyImpl :: MonadWarning m
   -> m [Aeson.Pair]
 friendlyTxBodyImpl
   era
-  tb@(TxBody
-    TxBodyContent
-      { txAuxScripts
-      , txCertificates
-      , txExtraKeyWits
-      , txFee
-      , txIns
-      , txInsCollateral
-      , txMetadata
-      , txMintValue
-      , txOuts
-      , txTotalCollateral
-      , txReturnCollateral
-      , txInsReference
-      , txProposalProcedures
-      , txVotingProcedures
-      , txUpdateProposal
-      , txValidityLowerBound
-      , txValidityUpperBound
-      , txWithdrawals
-      }) =
+  tb@(TxBody 
+       -- Enumerating the fields, so that we are warned by GHC when we add a new one
+       (TxBodyContent
+         txIns
+         txInsCollateral
+         txInsReference
+         txOuts
+         txTotalCollateral
+         txReturnCollateral
+         txFee
+         txValidityLowerBound
+         txValidityUpperBound
+         txMetadata
+         txAuxScripts
+         txExtraKeyWits
+         _txProtocolParams
+         txWithdrawals
+         txCertificates
+         txUpdateProposal
+         txMintValue
+         _txScriptValidity
+         txProposalProcedures
+         txVotingProcedures
+         _txCurrentTreasuryValue
+         _txTreasuryDonation)) =
   do redeemerDetails <- redeemerIfShelleyBased era tb
      return $ cardanoEraConstraints era
                 ( redeemerDetails ++


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Future proof against extensions of TxBodyContent
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Fixes https://github.com/IntersectMBO/cardano-cli/issues/784

# How to trust this PR

* To enumerate the fields, I copied them from the [declaration of the TxBodyContent datatype](https://github.com/IntersectMBO/cardano-api/blob/5eca9140f9594f493d68e0fd3a9f2502aa712ee6/cardano-api/internal/Cardano/Api/Tx/Body.hs#L1199) in API
* And then I `_` prefixed the unused ones.

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] Self-reviewed the diff