### PR TITLE
[Don't Merge] Pre-integration for the Cardano Node 8.12 release

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -14,7 +14,7 @@ repository cardano-haskell-packages
 -- you need to run if you change them
 index-state:
   , hackage.haskell.org 2024-06-13T08:49:27Z
-  , cardano-haskell-packages 2024-06-12T11:52:25Z
+  , cardano-haskell-packages 2024-06-17T12:18:52Z
 
 packages:
   cardano-cli
@@ -57,8 +57,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/IntersectMBO/cardano-ledger
-  tag: b1eedacfc60c5c2d215d4d8b27f6ac6a45e57f78
-  --sha256: sha256-eNZno0XuQVlgdxJmM9NXlADp2IrbAajmLDaDje5jMC0=
+  tag: 434cf8cac8332246c2a41b47a36a8d13de61da26
+  --sha256: sha256-r18PIrbmfDaDFnE9brK0jCFyXDU60yfcaSab3il8sC8=
   subdir:
     eras/alonzo/impl
     eras/alonzo/test-suite
@@ -89,18 +89,8 @@ source-repository-package
 
 source-repository-package
   type: git
-  location: https://github.com/IntersectMBO/plutus
-  tag: 5dffbd7fe2bf6b030d5c3c945886a38be5a09b35
-  --sha256: sha256-8L926zcs3BpzniLQ2pi1YNDry266I/54lbm1ebkWp4M=
-  subdir:
-    plutus-core
-    plutus-ledger-api
-    plutus-tx
-
-source-repository-package
-  type: git
   location: https://github.com/IntersectMBO/cardano-api
-  tag: 5a2cac07c0cfafda016a045f843816f834aeb257
-  --sha256: sha256-cfHNDUm8cBaXRnj98Vrp79HSel69mOlQgGxjmFGUwRQ=
+  tag: da4ad7729abc3447f22a9af280c95b85c427e5ab
+  --sha256: sha256-LgUsBiLj21eGFVei70CZ6TsS/Ub51o2VyVDiZS7ELtQ=
   subdir:
     cardano-api

--- a/cabal.project
+++ b/cabal.project
@@ -13,8 +13,8 @@ repository cardano-haskell-packages
 -- See CONTRIBUTING for information about these, including some Nix commands
 -- you need to run if you change them
 index-state:
-  , hackage.haskell.org 2024-06-12T10:10:17Z
-  , cardano-haskell-packages 2024-06-12T10:10:17Z
+  , hackage.haskell.org 2024-06-13T08:49:27Z
+  , cardano-haskell-packages 2024-06-12T11:52:25Z
 
 packages:
   cardano-cli
@@ -31,10 +31,6 @@ package bitvec
   -- Workaround for windows cross-compilation
   flags: -simd
 
-constraints:
-  -- io-classes-mtl-0.1.2.0 is not buildable
-  io-classes-mtl < 0.1.2.0
-
 tests: True
 
 test-show-details: direct
@@ -45,3 +41,66 @@ write-ghc-environment-files: always
 -- IMPORTANT
 -- Do NOT add more source-repository-package stanzas here unless they are strictly
 -- temporary! Please read the section in CONTRIBUTING about updating dependencies.
+
+
+source-repository-package
+  type: git
+  location: https://github.com/IntersectMBO/ouroboros-consensus
+  tag: ead2494e080664b39360225fac8f4e6d921ebd93
+  --sha256: sha256-+M3kmlkaB0ssQoNQG2iLxcuYSTv8AzTxtvZdOpaViss=
+  subdir:
+    ouroboros-consensus
+    ouroboros-consensus-cardano
+    ouroboros-consensus-diffusion
+    ouroboros-consensus-protocol
+
+source-repository-package
+  type: git
+  location: https://github.com/IntersectMBO/cardano-ledger
+  tag: b1eedacfc60c5c2d215d4d8b27f6ac6a45e57f78
+  --sha256: sha256-eNZno0XuQVlgdxJmM9NXlADp2IrbAajmLDaDje5jMC0=
+  subdir:
+    eras/alonzo/impl
+    eras/alonzo/test-suite
+    eras/allegra/impl
+    eras/babbage/impl
+    eras/babbage/test-suite
+    eras/byron/chain/executable-spec
+    eras/byron/crypto
+    eras/byron/crypto/test
+    eras/byron/ledger/executable-spec
+    eras/byron/ledger/impl
+    eras/byron/ledger/impl/test
+    eras/conway/impl
+    eras/conway/test-suite
+    eras/mary/impl
+    eras/shelley-ma/test-suite
+    eras/shelley/impl
+    eras/shelley/test-suite
+    libs/cardano-data
+    libs/cardano-ledger-api
+    libs/cardano-ledger-binary
+    libs/cardano-ledger-core
+    libs/cardano-protocol-tpraos
+    libs/non-integral
+    libs/set-algebra
+    libs/small-steps
+    libs/vector-map
+
+source-repository-package
+  type: git
+  location: https://github.com/IntersectMBO/plutus
+  tag: 5dffbd7fe2bf6b030d5c3c945886a38be5a09b35
+  --sha256: sha256-8L926zcs3BpzniLQ2pi1YNDry266I/54lbm1ebkWp4M=
+  subdir:
+    plutus-core
+    plutus-ledger-api
+    plutus-tx
+
+source-repository-package
+  type: git
+  location: https://github.com/IntersectMBO/cardano-api
+  tag: 5a2cac07c0cfafda016a045f843816f834aeb257
+  --sha256: sha256-cfHNDUm8cBaXRnj98Vrp79HSel69mOlQgGxjmFGUwRQ=
+  subdir:
+    cardano-api

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -234,12 +234,12 @@ library
                       , microlens
                       , network
                       , optparse-applicative-fork
-                      , ouroboros-consensus >= 0.17
+                      , ouroboros-consensus >= 0.18
                       -- TODO: bump consensus back
-                      , ouroboros-consensus-cardano >= 0.15
+                      , ouroboros-consensus-cardano >= 0.16
                       , ouroboros-consensus-protocol >= 0.9
                       , ouroboros-network-api
-                      , ouroboros-network-protocols ^>=0.8
+                      , ouroboros-network-protocols ^>=0.9
                       , parsec
                       , prettyprinter
                       , prettyprinter-ansi-terminal

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/Actions.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/Actions.hs
@@ -54,7 +54,7 @@ data GovernanceActionUpdateCommitteeCmdArgs era
       , oldCommitteeVkeySource  :: ![VerificationKeyOrHashOrFileOrScriptHash CommitteeColdKey]
       , newCommitteeVkeySource  :: ![(VerificationKeyOrHashOrFileOrScriptHash CommitteeColdKey, EpochNo)]
       , requiredThreshold       :: !Rational
-      , mPrevGovernanceActionId :: !(Maybe (TxId, Word32))
+      , mPrevGovernanceActionId :: !(Maybe (TxId, Word16))
       , outFile                 :: !(File () Out)
       } deriving Show
 
@@ -64,7 +64,7 @@ data GovernanceActionCreateConstitutionCmdArgs era
       , networkId               :: !L.Network
       , deposit                 :: !L.Coin
       , stakeCredential         :: !StakeIdentifier
-      , mPrevGovernanceActionId :: !(Maybe (TxId, Word32))
+      , mPrevGovernanceActionId :: !(Maybe (TxId, Word16))
       , proposalUrl             :: !ProposalUrl
       , proposalHash            :: !(L.SafeHash L.StandardCrypto L.AnchorData)
       , constitutionUrl         :: !ConstitutionUrl
@@ -93,7 +93,7 @@ data GovernanceActionCreateNoConfidenceCmdArgs era
       , returnStakeAddress      :: !StakeIdentifier
       , proposalUrl             :: !ProposalUrl
       , proposalHash            :: !(L.SafeHash L.StandardCrypto L.AnchorData)
-      , mPrevGovernanceActionId :: !(Maybe (TxId, Word32))
+      , mPrevGovernanceActionId :: !(Maybe (TxId, Word16))
       , outFile                 :: !(File () Out)
       } deriving Show
 
@@ -133,7 +133,7 @@ data GovernanceActionHardforkInitCmdArgs era
       , networkId             :: !L.Network
       , deposit               :: !L.Coin
       , returnStakeAddress    :: !StakeIdentifier
-      , mPrevGovernanceActionId :: !(Maybe (TxId, Word32))
+      , mPrevGovernanceActionId :: !(Maybe (TxId, Word16))
       , proposalUrl           :: !ProposalUrl
       , proposalHash          :: !(L.SafeHash L.StandardCrypto L.AnchorData)
       , protVer               :: !L.ProtVer
@@ -156,7 +156,7 @@ data UpdateProtocolParametersConwayOnwards era
       , returnAddr          :: !StakeIdentifier
       , proposalUrl         :: !ProposalUrl
       , proposalHash        :: !(L.SafeHash L.StandardCrypto L.AnchorData)
-      , governanceActionId  :: !(Maybe (TxId, Word32))
+      , governanceActionId  :: !(Maybe (TxId, Word16))
       , constitutionScriptHash :: !(Maybe ScriptHash)
       }
 

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/Vote.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/Vote.hs
@@ -28,7 +28,7 @@ data GovernanceVoteCreateCmdArgs era
   = GovernanceVoteCreateCmdArgs
       { eon                         :: ConwayEraOnwards era
       , voteChoice                  :: Vote
-      , governanceAction            :: (TxId, Word32)
+      , governanceAction            :: (TxId, Word16)
       , votingStakeCredentialSource :: AnyVotingStakeVerificationKeyOrHashOrFile
       , mAnchor                     :: Maybe (VoteUrl, L.SafeHash L.StandardCrypto L.AnchorData)
       , outFile                     :: VoteFile Out

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
@@ -3284,21 +3284,29 @@ pAnchorDataHash =
     , Opt.help "Proposal anchor data hash (obtain it with \"cardano-cli conway governance hash anchor-data ...\")"
     ]
 
-pPreviousGovernanceAction :: Parser (Maybe (TxId, Word32))
+pPreviousGovernanceAction :: Parser (Maybe (TxId, Word16))
 pPreviousGovernanceAction = optional $
   (,) <$> pTxId "prev-governance-action-tx-id" "Txid of the previous governance action."
-      <*> pWord32 "prev-governance-action-index" "Action index of the previous governance action."
+      <*> pWord16 "prev-governance-action-index" "Action index of the previous governance action."
 
-pGovernanceActionId :: Parser (TxId, Word32)
+pGovernanceActionId :: Parser (TxId, Word16)
 pGovernanceActionId =
   (,) <$> pTxId "governance-action-tx-id" "Txid of the governance action."
-      <*> pWord32 "governance-action-index" "Tx's governance action index."
+      <*> pWord16 "governance-action-index" "Tx's governance action index."
 
 pWord32 :: String -> String -> Parser Word32
 pWord32 l h =
   Opt.option auto $ mconcat
     [ Opt.long l
     , Opt.metavar "WORD32"
+    , Opt.help h
+    ]
+
+pWord16 :: String -> String -> Parser Word16
+pWord16 l h =
+  Opt.option auto $ mconcat
+    [ Opt.long l
+    , Opt.metavar "WORD16"
     , Opt.help h
     ]
 

--- a/cardano-cli/src/Cardano/CLI/Types/Governance.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Governance.hs
@@ -17,7 +17,7 @@ data ConwayVote
   = ConwayVote
     { cvVoteChoice :: Vote
     , cvVoterType :: VType
-    , cvGovActionId :: (TxId, Word32)
+    , cvGovActionId :: (TxId, Word16)
     , cvVotingStakeCredential :: VerificationKeyOrFile StakePoolKey
     , cvEra :: AnyShelleyBasedEra
     , cvFilepath :: VoteFile Out

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1718200515,
-        "narHash": "sha256-LhZDhH/Ii4X7r+bo7LGC+Q//OiUJ8uRwCJ5ULNpbj00=",
+        "lastModified": 1718628684,
+        "narHash": "sha256-UAyiQYotlXmZdANSqO+J/TTtITPTA7VvDfST6I5FE7Y=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "b731179078dc9960d68c3d0297d1c26f69e33614",
+        "rev": "86bcc75d40ea283e0934cd3f3cced70db1493920",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -210,11 +210,11 @@
     "hackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1716770092,
-        "narHash": "sha256-N4YGGedV+OfpVPQNqjBfZYfCjBjbWfZ5pdHcapVOScg=",
+        "lastModified": 1718239062,
+        "narHash": "sha256-EE2UmHeFA0hOGuJmDNaq3mD1qdxvEfMB8dzlVldaJCU=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "179e52b7d49e43ffc2f1826a01e0c1b750db6073",
+        "rev": "bcddede5a9e756a6077bf4ff2d711d7edf7f9dc2",
         "type": "github"
       },
       "original": {
@@ -263,11 +263,11 @@
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1716771027,
-        "narHash": "sha256-rWtqMkpEDcF1901KEm/Y+hL+y1SidBJA/KdnAePae5c=",
+        "lastModified": 1718239828,
+        "narHash": "sha256-1chHzdklYFbIyWsLn+5jA4TDRxmtI4qeAF1YVHA54LY=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "200be01f6c0390da8044fbd2998dc7b1e49121a3",
+        "rev": "08f455cefb5305b53cc5c7f4484ca9fb0d26bda7",
         "type": "github"
       },
       "original": {
@@ -473,11 +473,11 @@
         "nixlib": "nixlib"
       },
       "locked": {
-        "lastModified": 1669263024,
-        "narHash": "sha256-E/+23NKtxAqYG/0ydYgxlgarKnxmDbg6rCMWnOBqn9Q=",
+        "lastModified": 1693483555,
+        "narHash": "sha256-Beq4WhSeH3jRTZgC1XopTSU10yLpK1nmMcnGoXO0XYo=",
         "owner": "divnix",
         "repo": "incl",
-        "rev": "ce7bebaee048e4cd7ebdb4cee7885e00c4e2abca",
+        "rev": "526751ad3d1e23b07944b14e3f6b7a5948d3007b",
         "type": "github"
       },
       "original": {
@@ -494,11 +494,11 @@
         "sodium": "sodium"
       },
       "locked": {
-        "lastModified": 1708437078,
-        "narHash": "sha256-EUsAEG0LmnMmX7Z6JW2LX8/VhpAJ2dXVwVGXWn5LmxQ=",
+        "lastModified": 1715898223,
+        "narHash": "sha256-G1LFsvP53twrqaC1FVard/6rjJJ3oitnpJ1E+mTZDGM=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "5ab7134bb21d7bd858dbe1c702761aa7e15eaf88",
+        "rev": "29f19cd41dc593cf17bbc24194e34e7c20889fc9",
         "type": "github"
       },
       "original": {
@@ -510,11 +510,11 @@
     "iserv-proxy": {
       "flake": false,
       "locked": {
-        "lastModified": 1710581758,
-        "narHash": "sha256-UNUXGiKLGUv1TuQumV70rfjCJERP4w8KZEDxsMG0RHc=",
+        "lastModified": 1717479972,
+        "narHash": "sha256-7vE3RQycHI1YT9LHJ1/fUaeln2vIpYm6Mmn8FTpYeVo=",
         "owner": "stable-haskell",
         "repo": "iserv-proxy",
-        "rev": "50ea210590ab0519149bfd163d5ba199be925fb6",
+        "rev": "2ed34002247213fc435d0062350b91bab920626e",
         "type": "github"
       },
       "original": {
@@ -819,11 +819,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1716769250,
-        "narHash": "sha256-oTWTrrliw5GMe1qh27WWY7ToN3nfmPieZUYgSyR2uaM=",
+        "lastModified": 1718238200,
+        "narHash": "sha256-+jqYlXVxXe8xPKcJBZpdYPYKn22wiqLRezhz4TvvEYg=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "d250d0a37d4c8ce39052eeb0174bcea64bc7be33",
+        "rev": "b3c17e923da5729f375df86aa0999752d641e192",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
As a part of the [Cardano Node 8.12 release](https://github.com/IntersectMBO/cardano-node/issues/5868) this PR does the preliminary integration (using the `source-repository-package` cabal project stanzas) of the latest downstream component versions.

This PR is not supposed to be merged: it exists to trigger CI checks and make changes visible. Once this change is E2E tested, then it needs to be re-worked such that dependency declarations use CHaP instead of  the `source-repository-package` .