### PR TITLE
Fix HLS in nix development shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -24,7 +24,7 @@
     ];
 
     # see flake `variants` below for alternative compilers
-    defaultCompiler = "ghc965";
+    defaultCompiler = "ghc982";
     haddockShellCompiler = defaultCompiler;
 
     cabalHeadOverlay = final: prev: {
@@ -105,9 +105,9 @@
             }
             // lib.optionalAttrs (config.compiler-nix-name == defaultCompiler) {
               # tools that work only with default compiler
-              haskell-language-server.src = nixpkgs.haskell-nix.sources."hls-2.6";
-              hlint = "3.6.1";
-              stylish-haskell = "0.14.5.0";
+              haskell-language-server.src = nixpkgs.haskell-nix.sources."hls-2.8";
+              hlint = "3.8";
+              stylish-haskell = "0.14.6.0";
             };
           # and from nixpkgs or other inputs
           shell.nativeBuildInputs = with nixpkgs; [gh jq yq-go actionlint shellcheck cabal-head];

--- a/flake.nix
+++ b/flake.nix
@@ -26,7 +26,7 @@
     # see flake `variants` below for alternative compilers
     defaultCompiler = "ghc982";
     haddockShellCompiler = defaultCompiler;
-
+    mingwVersion = "ghc965";
     cabalHeadOverlay = final: prev: {
       cabal-head =
         (final.haskell-nix.cabalProject {
@@ -85,7 +85,7 @@
 
           # we also want cross compilation to windows on linux (and only with default compiler).
           crossPlatforms = p:
-            lib.optional (system == "x86_64-linux" && config.compiler-nix-name == defaultCompiler)
+            lib.optional (system == "x86_64-linux" && config.compiler-nix-name == mingwVersion)
             p.mingwW64;
 
           # CHaP input map, so we can find CHaP packages (needs to be more
@@ -167,7 +167,7 @@
         flake = cabalProject.flake (
           lib.optionalAttrs (system == "x86_64-linux") {
             # on linux, build/test other supported compilers
-            variants = lib.genAttrs ["ghc8107"] (compiler-nix-name: {
+            variants = lib.genAttrs ["ghc8107" mingwVersion] (compiler-nix-name: {
               inherit compiler-nix-name;
             });
           }


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Update GHC in Nix shell and update HLS
  type:
  - maintenance    # not directly related to the code
```

# Context

We've had a good experience with HLS 2.8 so we update GHC and HLS to be able to use 2.8.

# How to trust this PR

Probably best to just test that it works for you.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
