### PR TITLE
governance committee: fix hot/cold confusion in help text

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Committee.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Committee.hs
@@ -66,7 +66,7 @@ pGovernanceCommitteeKeyGenHotCmd era = do
     $ Opt.info (pCmd w)
     $ Opt.progDesc
     $ mconcat
-        [ "Create a cold key pair for a Constitutional Committee Member"
+        [ "Create a hot key pair for a Constitutional Committee Member"
         ]
   where
     pCmd :: ()

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -6913,7 +6913,7 @@ Usage: cardano-cli conway governance committee key-gen-cold
 Usage: cardano-cli conway governance committee key-gen-hot --verification-key-file FILE
                                                              --signing-key-file FILE
 
-  Create a cold key pair for a Constitutional Committee Member
+  Create a hot key pair for a Constitutional Committee Member
 
 Usage: cardano-cli conway governance committee key-hash 
                                                           ( --verification-key STRING

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_committee.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_committee.cli
@@ -14,7 +14,7 @@ Available options:
 Available commands:
   key-gen-cold             Create a cold key pair for a Constitutional Committee
                            Member
-  key-gen-hot              Create a cold key pair for a Constitutional Committee
+  key-gen-hot              Create a hot key pair for a Constitutional Committee
                            Member
   key-hash                 Print the identifier (hash) of a public key
   create-hot-key-authorization-certificate

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_committee_key-gen-hot.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_committee_key-gen-hot.cli
@@ -1,7 +1,7 @@
 Usage: cardano-cli conway governance committee key-gen-hot --verification-key-file FILE
                                                              --signing-key-file FILE
 
-  Create a cold key pair for a Constitutional Committee Member
+  Create a hot key pair for a Constitutional Committee Member
 
 Available options:
   --verification-key-file FILE


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    governance committee: fix hot/cold confusion in help text
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  - documentation  # change in code docs, haddocks...
```

# Context

Fixes https://github.com/IntersectMBO/cardano-cli/issues/794

# How to trust this PR

It's only changing help text

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] Self-reviewed the diff