### PR TITLE
Add Haskell Language Server check to CI

### DIFF
--- a/.github/workflows/hls.yml
+++ b/.github/workflows/hls.yml
@@ -10,20 +10,42 @@ permissions:
   contents: read
   
 jobs:
+
   test-hls-works:
+    env:
+      # Modify this value to "invalidate" the cache.
+      HLS_CACHE_VERSION: "2024-06-25"
+  
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - name: Check out repo
+        uses: actions/checkout@v4
       - name: Install Nix with good defaults
         uses: input-output-hk/install-nix-action@v20
         with:
           extra_nix_config: |
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
             substituters = https://cache.iog.io/ https://cache.nixos.org/
-          nix_path: nixpkgs=channel:nixos-unstable
-      - uses: cachix/install-nix-action@v18
+          nix_path: nixpkgs=channel:nixos-unstable 
+      - name: Open nix environment
+        uses: rrbutani/use-nix-shell-action@v1
+      - name: Update dependencies
+        run: cabal update; cabal freeze
+      - name: Obtain GHC version
+        run: |
+          echo "VERSION=$(ghc --numeric-version)" >> "$GITHUB_OUTPUT"
+        id: ghc
+      - name: HLS caching
+        uses: actions/cache@v4
         with:
-          nix_path: nixpkgs=channel:nixos-unstable
-      # Make the Nix environment available to next steps
-      - uses: rrbutani/use-nix-shell-action@v1
-      - run: cabal update; haskell-language-server
+          path: |
+            /home/runner/.cache/hie-bios
+            /home/runner/.cache/ghcide
+            /home/runner/.local/state/cabal
+            .ghc.environment.x86_64-linux-9.8.2
+            dist-newstyle
+          key: hls-cache-${{ env.HLS_CACHE_VERSION }}-${{ runner.os }}-${{ steps.ghc.outputs.VERSION }}-${{ hashFiles('**/cabal.project.freeze') }}-${{ hashFiles('**/*.cabal', '**/cabal.project') }}
+          restore-keys: |
+            hls-cache-${{ env.HLS_CACHE_VERSION }}-${{ runner.os }}-${{ steps.ghc.outputs.VERSION }}-${{ hashFiles('**/cabal.project.freeze') }}-
+      - name: Test HLS works
+        run: haskell-language-server

--- a/.github/workflows/hls.yml
+++ b/.github/workflows/hls.yml
@@ -1,0 +1,20 @@
+name: "Haskell Language Server works"
+on:
+  merge_group:
+  pull_request:
+  push:
+    branches:
+      - main
+ 
+permissions:
+  contents: read
+  
+jobs:
+  test-hls-works:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+    - uses: cachix/install-nix-action@daddc62a2e67d1decb56e028c9fa68344b9b7c2a
+      with:
+        nix_path: nixpkgs=channel:nixos-23.11
+    - run: nix develop --accept-flake-config --command bash -c "cabal update; haskell-language-server"

--- a/.github/workflows/hls.yml
+++ b/.github/workflows/hls.yml
@@ -13,8 +13,17 @@ jobs:
   test-hls-works:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
-    - uses: cachix/install-nix-action@daddc62a2e67d1decb56e028c9fa68344b9b7c2a
-      with:
-        nix_path: nixpkgs=channel:nixos-23.11
-    - run: nix develop --accept-flake-config --command bash -c "cabal update; haskell-language-server"
+      - uses: actions/checkout@v4
+      - name: Install Nix with good defaults
+        uses: input-output-hk/install-nix-action@v20
+        with:
+          extra_nix_config: |
+            trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
+            substituters = https://cache.iog.io/ https://cache.nixos.org/
+          nix_path: nixpkgs=channel:nixos-unstable
+      - uses: cachix/install-nix-action@v18
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      # Make the Nix environment available to next steps
+      - uses: rrbutani/use-nix-shell-action@v1
+      - run: cabal update; haskell-language-server

--- a/.github/workflows/hls.yml
+++ b/.github/workflows/hls.yml
@@ -17,6 +17,7 @@ jobs:
       HLS_CACHE_VERSION: "2024-06-25"
   
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: Check out repo
         uses: actions/checkout@v4

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -113,6 +113,7 @@ library
                         Cardano.CLI.EraBased.Run.TextView
                         Cardano.CLI.EraBased.Run.Transaction
                         Cardano.CLI.Helpers
+                        Cardano.CLI.IO.Compat
                         Cardano.CLI.IO.Lazy
                         Cardano.CLI.Json.Friendly
                         Cardano.CLI.Legacy.Commands


### PR DESCRIPTION
This PR adds a check to the CI that ensures that it works with the developer shell as it is.

# Changelog

```yaml
- description: |
    Add CI check that ensures HLS works with developer shell
  type:
  - test
```

# Context

Recently we had an issue with HLS not working because of a bug. We could have catched that if we had a test in the CI that ensured HLS worked. This PR aims to address this.

# How to trust this PR

Check the workflow makes sense. But basically, I would just look at [the CI's output](https://github.com/IntersectMBO/cardano-cli/actions/runs/9618399739/job/26532205253?pr=798).

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff

