### PR TITLE
Add --hot-script-hash option to committee create-hot-key-authorization-certificate subcommand

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/Committee.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/Committee.hs
@@ -53,7 +53,7 @@ data GovernanceCommitteeCreateHotKeyAuthorizationCertificateCmdArgs era =
   GovernanceCommitteeCreateHotKeyAuthorizationCertificateCmdArgs
     { eon               :: !(ConwayEraOnwards era)
     , vkeyColdKeySource :: !(VerificationKeySource CommitteeColdKey)
-    , vkeyHotKeySource  :: !(VerificationKeyOrHashOrFileOrScript CommitteeHotKey)
+    , vkeyHotKeySource  :: !(VerificationKeySource CommitteeHotKey)
     , outFile           :: !(File () Out)
     } deriving Show
 

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Committee.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Committee.hs
@@ -106,18 +106,13 @@ pGovernanceCommitteeCreateHotKeyAuthorizationCertificateCmd era = do
         ( fmap GovernanceCommitteeCreateHotKeyAuthorizationCertificateCmd $
             GovernanceCommitteeCreateHotKeyAuthorizationCertificateCmdArgs w
               <$> pColdCredential
-              <*> pHotVerificationKeyOrHashOrFileOrScript
+              <*> pHotCredential
               <*> pOutputFile
         )
     $ Opt.progDesc
     $ mconcat
         [ "Create hot key authorization certificate for a Constitutional Committee Member"
         ]
-  where
-    pHotVerificationKeyOrHashOrFileOrScript = asum
-      [ VkhfsKeyHashFile <$> pCommitteeHotKeyOrHashOrFile
-      , VkhfsScript <$> pScriptFor "hot-script-file" Nothing "Hot Native or Plutus script file"
-      ]
 
 pGovernanceCommitteeCreateColdKeyResignationCertificateCmd :: ()
   => CardanoEra era
@@ -147,6 +142,18 @@ pColdCredential =
           "cold-script-hash"
           "Committee cold Native or Plutus script file hash (hex-encoded). Obtain it with \"cardano-cli hash script ...\"."
     , VksScript <$> pScriptFor "cold-script-file" Nothing "Cold Native or Plutus script file"
+    ]
+
+pHotCredential :: Parser (VerificationKeySource CommitteeHotKey)
+pHotCredential =
+  asum
+    [ VksKeyHashFile . VerificationKeyOrFile <$> pCommitteeHotVerificationKeyOrFile
+    , VksKeyHashFile . VerificationKeyHash <$> pCommitteeHotVerificationKeyHash
+    , VksScriptHash <$>
+        pScriptHash
+          "hot-script-hash"
+          "Committee hot Native or Plutus script file hash (hex-encoded). Obtain it with \"cardano-cli hash script ...\"."
+    , VksScript <$> pScriptFor "hot-script-file" Nothing "Hot Native or Plutus script file"
     ]
 
 pAnchor :: Parser (Maybe (L.Anchor L.StandardCrypto))

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Committee.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Committee.hs
@@ -14,8 +14,7 @@ import           Cardano.Api.Shelley
 import           Cardano.CLI.EraBased.Commands.Governance.Committee
 import qualified Cardano.CLI.EraBased.Commands.Governance.Committee as Cmd
 import qualified Cardano.CLI.EraBased.Run.Key as Key
-import           Cardano.CLI.Read (readVerificationKeyOrHashOrFileOrScript,
-                   readVerificationKeySource)
+import           Cardano.CLI.Read (readVerificationKeySource)
 import           Cardano.CLI.Types.Errors.GovernanceCommitteeError
 import           Cardano.CLI.Types.Key.VerificationKey
 
@@ -141,7 +140,7 @@ runGovernanceCommitteeCreateHotKeyAuthorizationCertificate
     let mapError' = modifyError $ either GovernanceCommitteeCmdScriptReadError  GovernanceCommitteeCmdKeyReadError
     hotCred <-
       mapError' $
-        readVerificationKeyOrHashOrFileOrScript AsCommitteeHotKey unCommitteeHotKeyHash vkeyHotKeySource
+        readVerificationKeySource AsCommitteeHotKey unCommitteeHotKeyHash vkeyHotKeySource
     coldCred <-
       mapError' $
         readVerificationKeySource AsCommitteeColdKey unCommitteeColdKeyHash vkeyColdKeySource

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Governance/Committee.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Governance/Committee.hs
@@ -73,7 +73,7 @@ hprop_golden_governance_CommitteeCreateHotKeyAuthorizationCertificate =
     H.noteShowM_ $ execCardanoCLI
       [ "conway", "governance", "committee", "create-hot-key-authorization-certificate"
       , "--cold-verification-key-file", ccColdVKey
-      , "--hot-key-file", ccHotVKey
+      , "--hot-verification-key-file", ccHotVKey
       , "--out-file", certFile
       ]
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -6930,9 +6930,10 @@ Usage: cardano-cli conway governance committee create-hot-key-authorization-cert
                                                                                           | --cold-script-hash HASH
                                                                                           | --cold-script-file FILE
                                                                                           )
-                                                                                          ( --hot-key STRING
-                                                                                          | --hot-key-file FILE
-                                                                                          | --hot-key-hash STRING
+                                                                                          ( --hot-verification-key STRING
+                                                                                          | --hot-verification-key-file FILE
+                                                                                          | --hot-verification-key-hash STRING
+                                                                                          | --hot-script-hash HASH
                                                                                           | --hot-script-file FILE
                                                                                           )
                                                                                           --out-file FILE

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_committee_create-hot-key-authorization-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_committee_create-hot-key-authorization-certificate.cli
@@ -5,9 +5,10 @@ Usage: cardano-cli conway governance committee create-hot-key-authorization-cert
                                                                                           | --cold-script-hash HASH
                                                                                           | --cold-script-file FILE
                                                                                           )
-                                                                                          ( --hot-key STRING
-                                                                                          | --hot-key-file FILE
-                                                                                          | --hot-key-hash STRING
+                                                                                          ( --hot-verification-key STRING
+                                                                                          | --hot-verification-key-file FILE
+                                                                                          | --hot-verification-key-hash STRING
+                                                                                          | --hot-script-hash HASH
                                                                                           | --hot-script-file FILE
                                                                                           )
                                                                                           --out-file FILE
@@ -25,9 +26,15 @@ Available options:
                            (hex-encoded). Obtain it with "cardano-cli hash
                            script ...".
   --cold-script-file FILE  Cold Native or Plutus script file
-  --hot-key STRING         Constitutional Committee hot key (hex-encoded).
-  --hot-key-file FILE      Filepath of the Consitutional Committee hot key.
-  --hot-key-hash STRING    Constitutional Committee key hash (hex-encoded).
+  --hot-verification-key STRING
+                           Constitutional Committee hot key (hex-encoded).
+  --hot-verification-key-file FILE
+                           Filepath of the Consitutional Committee hot key.
+  --hot-verification-key-hash STRING
+                           Constitutional Committee key hash (hex-encoded).
+  --hot-script-hash HASH   Committee hot Native or Plutus script file hash
+                           (hex-encoded). Obtain it with "cardano-cli hash
+                           script ...".
   --hot-script-file FILE   Hot Native or Plutus script file
   --out-file FILE          The output file.
   -h,--help                Show this help text


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Add --hot-script-hash option to committee create-hot-key-authorization-certificate subcommand
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Fixes https://github.com/IntersectMBO/cardano-cli/issues/803

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] Self-reviewed the diff
- [x] Look if `VerificationKeyOrHashOrFileOrScript` is still used (yes)
- [x] Look if `pHotVerificatioNKeyOrHashOrFileOrScript` is still used (nope, got deleted)