### PR TITLE
Remove check for drep metadata size

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/DRep.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/DRep.hs
@@ -164,10 +164,7 @@ runGovernanceDRepMetadataHashCmd
       , mOutFile
       } = do
   metadataBytes <- firstExceptT ReadFileError $ newExceptT (readByteStringFile metadataFile)
-  (_metadata, metadataHash) <-
-    firstExceptT GovernanceCmdDRepMetadataValidationError
-     . hoistEither
-     $ validateAndHashDRepMetadata metadataBytes
+  let (_metadata, metadataHash) = hashDRepMetadata metadataBytes
   firstExceptT WriteFileError
     . newExceptT
     . writeByteStringOutput mOutFile

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/GovernanceCmdError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/GovernanceCmdError.hs
@@ -50,7 +50,6 @@ data GovernanceCmdError
   | GovernanceCmdDecoderError !DecoderError
   | GovernanceCmdVerifyPollError !GovernancePollError
   | GovernanceCmdWriteFileError !(FileError ())
-  | GovernanceCmdDRepMetadataValidationError !DRepMetadataValidationError
   -- Legacy - remove me after cardano-cli transitions to new era based structure
   | GovernanceCmdMIRCertNotSupportedInConway
   | GovernanceCmdGenesisDelegationNotSupportedInConway
@@ -108,8 +107,6 @@ instance Error GovernanceCmdError where
       pretty $ renderGovernancePollError pollError
     GovernanceCmdWriteFileError fileError ->
       "Cannot write file: " <> prettyError fileError
-    GovernanceCmdDRepMetadataValidationError e ->
-      "DRep metadata validation error: " <> prettyError e
     GovernanceCmdMIRCertNotSupportedInConway ->
       "MIR certificates are not supported in Conway era onwards."
     GovernanceCmdGenesisDelegationNotSupportedInConway ->


### PR DESCRIPTION
# Changelog

```yaml
- description: |
   Remove check for drep metadata size
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context
Resolves: https://github.com/IntersectMBO/cardano-cli/issues/792
Depends on: https://github.com/IntersectMBO/cardano-api/pull/569 which is not on the tagged cardano-api-9.0.0.0 . Therefore this requires a new release of cardano-api.

# How to trust this PR

The resulting hash matches the one on the [test vector of CIP-119 ](https://github.com/cardano-foundation/CIPs/blob/master/CIP-0119/test-vector.md) AND  matches the hash obtained with `governance hash anchor-data` AND matches the result of using blake2b directly:

```
$ ./dist-newstyle/build/x86_64-linux/ghc-8.10.7/cardano-cli-8.25.0.0/x/cardano-cli/build/cardano-cli/cardano-cli conway governance drep metadata-hash
 --drep-metadata-file tmp/drep.jsonld 
a14a5ad4f36bddc00f92ddb39fd9ac633c0fd43f8bfa57758f9163d10ef916de

$ ./dist-newstyle/build/x86_64-linux/ghc-8.10.7/cardano-cli-8.25.0.0/x/cardano-cli/build/cardano-cli/cardano-cli conway governance hash anchor-data --file-text tmp/drep.jsonld 
a14a5ad4f36bddc00f92ddb39fd9ac633c0fd43f8bfa57758f9163d10ef916de

$ b2sum -l 256 tmp/drep.jsonld 
a14a5ad4f36bddc00f92ddb39fd9ac633c0fd43f8bfa57758f9163d10ef916de  tmp/drep.jsonld
```

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
