### PR TITLE
Make genesis creation commands era-sensitive

### DIFF
--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -99,8 +99,9 @@ library
     Cardano.CLI.EraBased.Run
     Cardano.CLI.EraBased.Run.Address
     Cardano.CLI.EraBased.Run.Address.Info
-    Cardano.CLI.EraBased.Run.CreateTestnetData
     Cardano.CLI.EraBased.Run.Genesis
+    Cardano.CLI.EraBased.Run.Genesis.Common
+    Cardano.CLI.EraBased.Run.Genesis.CreateTestnetData
     Cardano.CLI.EraBased.Run.Governance
     Cardano.CLI.EraBased.Run.Governance.Actions
     Cardano.CLI.EraBased.Run.Governance.Committee

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands.hs
@@ -117,7 +117,7 @@ pCmds era envCli =
     catMaybes
       [ fmap AddressCmds <$> pAddressCmds (toCardanoEra era) envCli
       , fmap KeyCmds <$> pKeyCmds
-      , fmap GenesisCmds <$> pGenesisCmds envCli
+      , fmap GenesisCmds <$> pGenesisCmds (toCardanoEra era) envCli
       , fmap GovernanceCmds <$> pGovernanceCmds (toCardanoEra era)
       , fmap NodeCmds <$> pNodeCmds
       , fmap QueryCmds <$> pQueryCmds (toCardanoEra era) envCli

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Genesis.hs
@@ -27,10 +27,10 @@ import           Cardano.CLI.Types.Common
 import           Data.Text (Text)
 
 data GenesisCmds era
-  = GenesisCreate !GenesisCreateCmdArgs
-  | GenesisCreateCardano !GenesisCreateCardanoCmdArgs
-  | GenesisCreateStaked !GenesisCreateStakedCmdArgs
-  | GenesisCreateTestNetData !GenesisCreateTestNetDataCmdArgs
+  = GenesisCreate !(GenesisCreateCmdArgs era)
+  | GenesisCreateCardano !(GenesisCreateCardanoCmdArgs era)
+  | GenesisCreateStaked !(GenesisCreateStakedCmdArgs era)
+  | GenesisCreateTestNetData !(GenesisCreateTestNetDataCmdArgs era)
   | GenesisKeyGenGenesis !GenesisKeyGenGenesisCmdArgs
   | GenesisKeyGenDelegate !GenesisKeyGenDelegateCmdArgs
   | GenesisKeyGenUTxO !GenesisKeyGenUTxOCmdArgs
@@ -41,8 +41,9 @@ data GenesisCmds era
   | GenesisHashFile !GenesisFile
   deriving Show
 
-data GenesisCreateCmdArgs = GenesisCreateCmdArgs
-  { keyOutputFormat :: !KeyOutputFormat
+data GenesisCreateCmdArgs era = GenesisCreateCmdArgs
+  { eon :: !(ShelleyBasedEra era)
+  , keyOutputFormat :: !KeyOutputFormat
   , genesisDir :: !GenesisDir
   , numGenesisKeys :: !Word
   , numUTxOKeys :: !Word
@@ -52,8 +53,9 @@ data GenesisCreateCmdArgs = GenesisCreateCmdArgs
   }
   deriving Show
 
-data GenesisCreateCardanoCmdArgs = GenesisCreateCardanoCmdArgs
-  { genesisDir :: !GenesisDir
+data GenesisCreateCardanoCmdArgs era = GenesisCreateCardanoCmdArgs
+  { eon :: !(ShelleyBasedEra era)
+  , genesisDir :: !GenesisDir
   , numGenesisKeys :: !Word
   , numUTxOKeys :: !Word
   , mSystemStart :: !(Maybe SystemStart)
@@ -70,8 +72,9 @@ data GenesisCreateCardanoCmdArgs = GenesisCreateCardanoCmdArgs
   }
   deriving Show
 
-data GenesisCreateStakedCmdArgs = GenesisCreateStakedCmdArgs
-  { keyOutputFormat :: !KeyOutputFormat
+data GenesisCreateStakedCmdArgs era = GenesisCreateStakedCmdArgs
+  { eon :: !(ShelleyBasedEra era)
+  , keyOutputFormat :: !KeyOutputFormat
   , genesisDir :: !GenesisDir
   , numGenesisKeys :: !Word
   , numUTxOKeys :: !Word
@@ -89,8 +92,9 @@ data GenesisCreateStakedCmdArgs = GenesisCreateStakedCmdArgs
   }
   deriving Show
 
-data GenesisCreateTestNetDataCmdArgs = GenesisCreateTestNetDataCmdArgs
-  { specShelley :: !(Maybe FilePath)
+data GenesisCreateTestNetDataCmdArgs era = GenesisCreateTestNetDataCmdArgs
+  { eon :: !(ShelleyBasedEra era)
+  , specShelley :: !(Maybe FilePath)
   -- ^ Path to the @genesis-shelley@ file to use. If unspecified, a default one will be used.
   , specAlonzo :: !(Maybe FilePath)
   -- ^ Path to the @genesis-alonzo@ file to use. If unspecified, a default one will be used.

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Genesis/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Genesis/Common.hs
@@ -1,0 +1,136 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Cardano.CLI.EraBased.Run.Genesis.Common
+  ( decodeShelleyGenesisFile
+  , decodeAlonzoGenesisFile
+  , decodeConwayGenesisFile
+  , genStuffedAddress
+  , getCurrentTimePlus30
+  , readRelays
+
+    -- * Protocol Parameters
+  , readProtocolParameters
+  )
+where
+
+import           Cardano.Api hiding (ConwayEra)
+import           Cardano.Api.Ledger (AlonzoGenesis, ConwayGenesis, StandardCrypto)
+import qualified Cardano.Api.Ledger as L
+import           Cardano.Api.Shelley (Address (ShelleyAddress), ShelleyGenesis, ShelleyLedgerEra,
+                   decodeAlonzoGenesis)
+
+import           Cardano.CLI.Types.Common
+import           Cardano.CLI.Types.Errors.GenesisCmdError
+import           Cardano.CLI.Types.Errors.ProtocolParamsError
+import           Cardano.Crypto.Hash (HashAlgorithm)
+import qualified Cardano.Crypto.Hash as Hash
+import qualified Cardano.Crypto.Random as Crypto
+
+import qualified Data.Aeson as A
+import qualified Data.Binary.Get as Bin
+import           Data.ByteString (ByteString)
+import qualified Data.ByteString.Lazy.Char8 as LBS
+import           Data.Coerce (coerce)
+import           Data.Data (Proxy (..))
+import           Data.Map.Strict (Map)
+import qualified Data.Text as Text
+import           Data.Time (NominalDiffTime, UTCTime, addUTCTime, getCurrentTime)
+import           Data.Word (Word64)
+
+import           Crypto.Random (getRandomBytes)
+
+decodeShelleyGenesisFile
+  :: MonadIOTransError GenesisCmdError t m
+  => FilePath
+  -> t m (ShelleyGenesis StandardCrypto)
+decodeShelleyGenesisFile = readAndDecodeGenesisFileWith A.eitherDecode
+
+-- | Decode Alonzo Genesis file. See 'Cardano.Api.Genesis.decodeAlonzoGenesis' haddocks for details.
+decodeAlonzoGenesisFile
+  :: MonadIOTransError GenesisCmdError t m
+  => Maybe (CardanoEra era)
+  -- ^ Optional era in which we're decoding alonzo genesis.
+  -> FilePath
+  -> t m AlonzoGenesis
+decodeAlonzoGenesisFile mEra = readAndDecodeGenesisFileWith (runExcept . decodeAlonzoGenesis mEra)
+
+decodeConwayGenesisFile
+  :: MonadIOTransError GenesisCmdError t m
+  => FilePath
+  -> t m (ConwayGenesis StandardCrypto)
+decodeConwayGenesisFile = readAndDecodeGenesisFileWith A.eitherDecode
+
+readAndDecodeGenesisFileWith
+  :: MonadIOTransError GenesisCmdError t m
+  => (LBS.ByteString -> Either String a)
+  -> FilePath
+  -> t m a
+readAndDecodeGenesisFileWith decode' fpath = do
+  lbs <-
+    handleIOExceptionsLiftWith (GenesisCmdGenesisFileError . FileIOError fpath) . liftIO $
+      LBS.readFile fpath
+  modifyError (GenesisCmdGenesisFileDecodeError fpath . Text.pack)
+    . hoistEither
+    $ decode' lbs
+
+genStuffedAddress :: L.Network -> IO (AddressInEra ShelleyEra)
+genStuffedAddress network = do
+  paymentCredential <-
+    L.KeyHashObj . mkKeyHash . read64BitInt <$> Crypto.runSecureRandom (getRandomBytes 8)
+  pure . shelleyAddressInEra ShelleyBasedEraShelley $
+    ShelleyAddress network paymentCredential L.StakeRefNull
+ where
+  read64BitInt :: ByteString -> Int
+  read64BitInt =
+    (fromIntegral :: Word64 -> Int)
+      . Bin.runGet Bin.getWord64le
+      . LBS.fromStrict
+
+  mkDummyHash :: forall h a. HashAlgorithm h => Proxy h -> Int -> Hash.Hash h a
+  mkDummyHash _ = coerce . L.hashWithSerialiser @h L.toCBOR
+
+  mkKeyHash :: forall c discriminator. L.Crypto c => Int -> L.KeyHash discriminator c
+  mkKeyHash = L.KeyHash . mkDummyHash (Proxy @(L.ADDRHASH c))
+
+-- | Current UTCTime plus 30 seconds
+getCurrentTimePlus30 :: MonadIO m => m UTCTime
+getCurrentTimePlus30 =
+  plus30sec <$> liftIO getCurrentTime
+ where
+  plus30sec :: UTCTime -> UTCTime
+  plus30sec = addUTCTime (30 :: NominalDiffTime)
+
+-- @readRelays fp@ reads the relays specification from a file
+readRelays
+  :: ()
+  => MonadIO m
+  => FilePath
+  -- ^ The file to read from
+  -> ExceptT GenesisCmdError m (Map Word [L.StakePoolRelay])
+readRelays fp = do
+  relaySpecJsonBs <-
+    handleIOExceptT (GenesisCmdStakePoolRelayFileError fp) (LBS.readFile fp)
+  firstExceptT (GenesisCmdStakePoolRelayJsonDecodeError fp)
+    . hoistEither
+    $ A.eitherDecode relaySpecJsonBs
+
+-- TODO: eliminate this and get only the necessary params, and get them in a more
+-- helpful way rather than requiring them as a local file.
+readProtocolParameters
+  :: ()
+  => ShelleyBasedEra era
+  -> ProtocolParamsFile
+  -> ExceptT ProtocolParamsError IO (L.PParams (ShelleyLedgerEra era))
+readProtocolParameters sbe (ProtocolParamsFile fpath) = do
+  pparams <- handleIOExceptT (ProtocolParamsErrorFile . FileIOError fpath) $ LBS.readFile fpath
+  firstExceptT (ProtocolParamsErrorJSON fpath . Text.pack) . hoistEither $
+    shelleyBasedEraConstraints sbe $
+      A.eitherDecode' pparams

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/DRep.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/DRep.hs
@@ -168,7 +168,7 @@ runGovernanceDRepMetadataHashCmd
     { metadataFile
     , mOutFile
     } = do
-    metadataBytes <- firstExceptT ReadFileError $ newExceptT (readByteStringFile metadataFile)
+    metadataBytes <- firstExceptT ReadFileError . newExceptT $ readByteStringFile metadataFile
     let (_metadata, metadataHash) = hashDRepMetadata metadataBytes
     firstExceptT WriteFileError
       . newExceptT

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Transaction.hs
@@ -42,7 +42,7 @@ import           Cardano.Api.Shelley
 import qualified Cardano.Binary as CBOR
 import qualified Cardano.Chain.Common as Byron
 import qualified Cardano.CLI.EraBased.Commands.Transaction as Cmd
-import           Cardano.CLI.EraBased.Run.Genesis
+import           Cardano.CLI.EraBased.Run.Genesis.Common (readProtocolParameters)
 import           Cardano.CLI.EraBased.Run.Query
 import           Cardano.CLI.Json.Friendly (friendlyTx, friendlyTxBody,
                    viewOutputFormatToFriendlyFormat)

--- a/cardano-cli/src/Cardano/CLI/Legacy/Commands/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Commands/Genesis.hs
@@ -17,6 +17,7 @@ import           Data.Text (Text)
 
 data LegacyGenesisCmds
   = GenesisCreate
+      (EraInEon ShelleyBasedEra)
       KeyOutputFormat
       GenesisDir
       Word
@@ -25,6 +26,7 @@ data LegacyGenesisCmds
       (Maybe Coin)
       NetworkId
   | GenesisCreateCardano
+      (EraInEon ShelleyBasedEra)
       GenesisDir
       Word
       Word
@@ -41,6 +43,7 @@ data LegacyGenesisCmds
       (Maybe FilePath)
   | -- | Relay specification filepath
     GenesisCreateStaked
+      (EraInEon ShelleyBasedEra)
       KeyOutputFormat
       GenesisDir
       Word

--- a/cardano-cli/src/Cardano/CLI/Legacy/Options.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Options.hs
@@ -1052,7 +1052,8 @@ pGenesisCmds envCli =
   pGenesisCreateCardano :: Parser LegacyGenesisCmds
   pGenesisCreateCardano =
     GenesisCreateCardano
-      <$> pGenesisDir
+      <$> pAnyShelleyBasedEra envCli
+      <*> pGenesisDir
       <*> pGenesisNumGenesisKeys
       <*> pGenesisNumUTxOKeys
       <*> pMaybeSystemStart
@@ -1078,7 +1079,8 @@ pGenesisCmds envCli =
   pGenesisCreate :: Parser LegacyGenesisCmds
   pGenesisCreate =
     GenesisCreate
-      <$> pKeyOutputFormat
+      <$> pAnyShelleyBasedEra envCli
+      <*> pKeyOutputFormat
       <*> pGenesisDir
       <*> pGenesisNumGenesisKeys
       <*> pGenesisNumUTxOKeys
@@ -1089,7 +1091,8 @@ pGenesisCmds envCli =
   pGenesisCreateStaked :: Parser LegacyGenesisCmds
   pGenesisCreateStaked =
     GenesisCreateStaked
-      <$> pKeyOutputFormat
+      <$> pAnyShelleyBasedEra envCli
+      <*> pKeyOutputFormat
       <*> pGenesisDir
       <*> pGenesisNumGenesisKeys
       <*> pGenesisNumUTxOKeys

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Genesis.hs
@@ -16,8 +16,8 @@ import           Cardano.Chain.Common (BlockCount)
 import           Cardano.CLI.EraBased.Commands.Genesis
                    (GenesisKeyGenGenesisCmdArgs (GenesisKeyGenGenesisCmdArgs))
 import qualified Cardano.CLI.EraBased.Commands.Genesis as Cmd
-import qualified Cardano.CLI.EraBased.Run.CreateTestnetData as CreateTestnetData
 import           Cardano.CLI.EraBased.Run.Genesis
+import qualified Cardano.CLI.EraBased.Run.Genesis.CreateTestnetData as CreateTestnetData
 import           Cardano.CLI.Legacy.Commands.Genesis
 import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Errors.GenesisCmdError
@@ -38,12 +38,12 @@ runLegacyGenesisCmds = \case
     runLegacyGenesisTxInCmd vk nw mOutFile
   GenesisAddr vk nw mOutFile ->
     runLegacyGenesisAddrCmd vk nw mOutFile
-  GenesisCreate fmt gd gn un ms am nw ->
-    runLegacyGenesisCreateCmd fmt gd gn un ms am nw
-  GenesisCreateCardano gd gn un ms am k slotLength sc nw bg sg ag cg mNodeCfg ->
-    runLegacyGenesisCreateCardanoCmd gd gn un ms am k slotLength sc nw bg sg ag cg mNodeCfg
-  GenesisCreateStaked fmt gd gn gp gl un ms am ds nw bf bp su relayJsonFp ->
-    runLegacyGenesisCreateStakedCmd fmt gd gn gp gl un ms am ds nw bf bp su relayJsonFp
+  GenesisCreate eSbe fmt gd gn un ms am nw ->
+    runLegacyGenesisCreateCmd eSbe fmt gd gn un ms am nw
+  GenesisCreateCardano eSbe gd gn un ms am k slotLength sc nw bg sg ag cg mNodeCfg ->
+    runLegacyGenesisCreateCardanoCmd eSbe gd gn un ms am k slotLength sc nw bg sg ag cg mNodeCfg
+  GenesisCreateStaked eSbe fmt gd gn gp gl un ms am ds nw bf bp su relayJsonFp ->
+    runLegacyGenesisCreateStakedCmd eSbe fmt gd gn gp gl un ms am ds nw bf bp su relayJsonFp
   GenesisHashFile gf ->
     runLegacyGenesisHashFileCmd gf
 
@@ -124,7 +124,8 @@ runLegacyGenesisAddrCmd vkf nid mOf =
 
 runLegacyGenesisCreateCmd
   :: ()
-  => KeyOutputFormat
+  => EraInEon ShelleyBasedEra
+  -> KeyOutputFormat
   -> GenesisDir
   -> Word
   -- ^ num genesis & delegate keys to make
@@ -134,10 +135,11 @@ runLegacyGenesisCreateCmd
   -> Maybe Coin
   -> NetworkId
   -> ExceptT GenesisCmdError IO ()
-runLegacyGenesisCreateCmd fmt genDir nGenKeys nUTxOKeys mStart mSupply network =
+runLegacyGenesisCreateCmd (EraInEon asbe) fmt genDir nGenKeys nUTxOKeys mStart mSupply network =
   runGenesisCreateCmd
     Cmd.GenesisCreateCmdArgs
-      { Cmd.keyOutputFormat = fmt
+      { Cmd.eon = asbe
+      , Cmd.keyOutputFormat = fmt
       , Cmd.genesisDir = genDir
       , Cmd.numGenesisKeys = nGenKeys
       , Cmd.numUTxOKeys = nUTxOKeys
@@ -148,7 +150,8 @@ runLegacyGenesisCreateCmd fmt genDir nGenKeys nUTxOKeys mStart mSupply network =
 
 runLegacyGenesisCreateCardanoCmd
   :: ()
-  => GenesisDir
+  => EraInEon ShelleyBasedEra
+  -> GenesisDir
   -> Word
   -- ^ num genesis & delegate keys to make
   -> Word
@@ -171,6 +174,7 @@ runLegacyGenesisCreateCardanoCmd
   -> Maybe FilePath
   -> ExceptT GenesisCmdError IO ()
 runLegacyGenesisCreateCardanoCmd
+  (EraInEon sbe)
   genDir
   nGenKeys
   nUTxOKeys
@@ -187,7 +191,8 @@ runLegacyGenesisCreateCardanoCmd
   mNodeCfg =
     runGenesisCreateCardanoCmd
       Cmd.GenesisCreateCardanoCmdArgs
-        { Cmd.genesisDir = genDir
+        { Cmd.eon = sbe
+        , Cmd.genesisDir = genDir
         , Cmd.numGenesisKeys = nGenKeys
         , Cmd.numUTxOKeys = nUTxOKeys
         , Cmd.mSystemStart = mStart
@@ -205,7 +210,8 @@ runLegacyGenesisCreateCardanoCmd
 
 runLegacyGenesisCreateStakedCmd
   :: ()
-  => KeyOutputFormat
+  => EraInEon ShelleyBasedEra
+  -> KeyOutputFormat
   -- ^ key output format
   -> GenesisDir
   -> Word
@@ -232,6 +238,7 @@ runLegacyGenesisCreateStakedCmd
   -- ^ Specified stake pool relays
   -> ExceptT GenesisCmdError IO ()
 runLegacyGenesisCreateStakedCmd
+  (EraInEon sbe)
   keyOutputFormat
   genesisDir
   numGenesisKeys
@@ -248,7 +255,8 @@ runLegacyGenesisCreateStakedCmd
   mStakePoolRelaySpecFile =
     runGenesisCreateStakedCmd
       Cmd.GenesisCreateStakedCmdArgs
-        { Cmd.keyOutputFormat = keyOutputFormat
+        { Cmd.eon = sbe
+        , Cmd.keyOutputFormat = keyOutputFormat
         , Cmd.genesisDir = genesisDir
         , Cmd.numGenesisKeys = numGenesisKeys
         , Cmd.numUTxOKeys = numUTxOKeys

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -9828,7 +9828,15 @@ Usage: cardano-cli legacy genesis initial-txin --verification-key-file FILE
 
   Get the TxIn for an initial UTxO based on the verification key
 
-Usage: cardano-cli legacy genesis create-cardano --genesis-dir DIR
+Usage: cardano-cli legacy genesis create-cardano 
+                                                   [ --shelley-era
+                                                   | --allegra-era
+                                                   | --mary-era
+                                                   | --alonzo-era
+                                                   | --babbage-era
+                                                   | --conway-era
+                                                   ]
+                                                   --genesis-dir DIR
                                                    [--gen-genesis-keys INT]
                                                    [--gen-utxo-keys INT]
                                                    [--start-time UTC-TIME]
@@ -9848,7 +9856,15 @@ Usage: cardano-cli legacy genesis create-cardano --genesis-dir DIR
   Create a Byron and Shelley genesis file from a genesis template and
   genesis/delegation/spending keys.
 
-Usage: cardano-cli legacy genesis create [--key-output-format STRING]
+Usage: cardano-cli legacy genesis create 
+                                           [ --shelley-era
+                                           | --allegra-era
+                                           | --mary-era
+                                           | --alonzo-era
+                                           | --babbage-era
+                                           | --conway-era
+                                           ]
+                                           [--key-output-format STRING]
                                            --genesis-dir DIR
                                            [--gen-genesis-keys INT]
                                            [--gen-utxo-keys INT]
@@ -9859,7 +9875,15 @@ Usage: cardano-cli legacy genesis create [--key-output-format STRING]
   Create a Shelley genesis file from a genesis template and
   genesis/delegation/spending keys.
 
-Usage: cardano-cli legacy genesis create-staked [--key-output-format STRING]
+Usage: cardano-cli legacy genesis create-staked 
+                                                  [ --shelley-era
+                                                  | --allegra-era
+                                                  | --mary-era
+                                                  | --alonzo-era
+                                                  | --babbage-era
+                                                  | --conway-era
+                                                  ]
+                                                  [--key-output-format STRING]
                                                   --genesis-dir DIR
                                                   [--gen-genesis-keys INT]
                                                   [--gen-utxo-keys INT]
@@ -11103,7 +11127,15 @@ Usage: cardano-cli genesis initial-txin --verification-key-file FILE
 
   Get the TxIn for an initial UTxO based on the verification key
 
-Usage: cardano-cli genesis create-cardano --genesis-dir DIR
+Usage: cardano-cli genesis create-cardano 
+                                            [ --shelley-era
+                                            | --allegra-era
+                                            | --mary-era
+                                            | --alonzo-era
+                                            | --babbage-era
+                                            | --conway-era
+                                            ]
+                                            --genesis-dir DIR
                                             [--gen-genesis-keys INT]
                                             [--gen-utxo-keys INT]
                                             [--start-time UTC-TIME]
@@ -11123,7 +11155,15 @@ Usage: cardano-cli genesis create-cardano --genesis-dir DIR
   Create a Byron and Shelley genesis file from a genesis template and
   genesis/delegation/spending keys.
 
-Usage: cardano-cli genesis create [--key-output-format STRING]
+Usage: cardano-cli genesis create 
+                                    [ --shelley-era
+                                    | --allegra-era
+                                    | --mary-era
+                                    | --alonzo-era
+                                    | --babbage-era
+                                    | --conway-era
+                                    ]
+                                    [--key-output-format STRING]
                                     --genesis-dir DIR
                                     [--gen-genesis-keys INT]
                                     [--gen-utxo-keys INT]
@@ -11134,7 +11174,15 @@ Usage: cardano-cli genesis create [--key-output-format STRING]
   Create a Shelley genesis file from a genesis template and
   genesis/delegation/spending keys.
 
-Usage: cardano-cli genesis create-staked [--key-output-format STRING]
+Usage: cardano-cli genesis create-staked 
+                                           [ --shelley-era
+                                           | --allegra-era
+                                           | --mary-era
+                                           | --alonzo-era
+                                           | --babbage-era
+                                           | --conway-era
+                                           ]
+                                           [--key-output-format STRING]
                                            --genesis-dir DIR
                                            [--gen-genesis-keys INT]
                                            [--gen-utxo-keys INT]

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/genesis_create-cardano.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/genesis_create-cardano.cli
@@ -1,4 +1,12 @@
-Usage: cardano-cli genesis create-cardano --genesis-dir DIR
+Usage: cardano-cli genesis create-cardano 
+                                            [ --shelley-era
+                                            | --allegra-era
+                                            | --mary-era
+                                            | --alonzo-era
+                                            | --babbage-era
+                                            | --conway-era
+                                            ]
+                                            --genesis-dir DIR
                                             [--gen-genesis-keys INT]
                                             [--gen-utxo-keys INT]
                                             [--start-time UTC-TIME]
@@ -19,6 +27,12 @@ Usage: cardano-cli genesis create-cardano --genesis-dir DIR
   genesis/delegation/spending keys.
 
 Available options:
+  --shelley-era            Specify the Shelley era
+  --allegra-era            Specify the Allegra era
+  --mary-era               Specify the Mary era
+  --alonzo-era             Specify the Alonzo era
+  --babbage-era            Specify the Babbage era (default)
+  --conway-era             Specify the Conway era
   --genesis-dir DIR        The genesis directory containing the genesis template
                            and required genesis/delegation/spending keys.
   --gen-genesis-keys INT   The number of genesis keys to make [default is 3].

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/genesis_create-staked.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/genesis_create-staked.cli
@@ -1,4 +1,12 @@
-Usage: cardano-cli genesis create-staked [--key-output-format STRING]
+Usage: cardano-cli genesis create-staked 
+                                           [ --shelley-era
+                                           | --allegra-era
+                                           | --mary-era
+                                           | --alonzo-era
+                                           | --babbage-era
+                                           | --conway-era
+                                           ]
+                                           [--key-output-format STRING]
                                            --genesis-dir DIR
                                            [--gen-genesis-keys INT]
                                            [--gen-utxo-keys INT]
@@ -17,6 +25,12 @@ Usage: cardano-cli genesis create-staked [--key-output-format STRING]
   genesis/delegation/spending keys.
 
 Available options:
+  --shelley-era            Specify the Shelley era
+  --allegra-era            Specify the Allegra era
+  --mary-era               Specify the Mary era
+  --alonzo-era             Specify the Alonzo era
+  --babbage-era            Specify the Babbage era (default)
+  --conway-era             Specify the Conway era
   --key-output-format STRING
                            Optional key output format. Accepted output formats
                            are "text-envelope" and "bech32" (default is

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/genesis_create.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/genesis_create.cli
@@ -1,4 +1,12 @@
-Usage: cardano-cli genesis create [--key-output-format STRING]
+Usage: cardano-cli genesis create 
+                                    [ --shelley-era
+                                    | --allegra-era
+                                    | --mary-era
+                                    | --alonzo-era
+                                    | --babbage-era
+                                    | --conway-era
+                                    ]
+                                    [--key-output-format STRING]
                                     --genesis-dir DIR
                                     [--gen-genesis-keys INT]
                                     [--gen-utxo-keys INT]
@@ -10,6 +18,12 @@ Usage: cardano-cli genesis create [--key-output-format STRING]
   genesis/delegation/spending keys.
 
 Available options:
+  --shelley-era            Specify the Shelley era
+  --allegra-era            Specify the Allegra era
+  --mary-era               Specify the Mary era
+  --alonzo-era             Specify the Alonzo era
+  --babbage-era            Specify the Babbage era (default)
+  --conway-era             Specify the Conway era
   --key-output-format STRING
                            Optional key output format. Accepted output formats
                            are "text-envelope" and "bech32" (default is

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_genesis_create-cardano.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_genesis_create-cardano.cli
@@ -1,4 +1,12 @@
-Usage: cardano-cli legacy genesis create-cardano --genesis-dir DIR
+Usage: cardano-cli legacy genesis create-cardano 
+                                                   [ --shelley-era
+                                                   | --allegra-era
+                                                   | --mary-era
+                                                   | --alonzo-era
+                                                   | --babbage-era
+                                                   | --conway-era
+                                                   ]
+                                                   --genesis-dir DIR
                                                    [--gen-genesis-keys INT]
                                                    [--gen-utxo-keys INT]
                                                    [--start-time UTC-TIME]
@@ -19,6 +27,12 @@ Usage: cardano-cli legacy genesis create-cardano --genesis-dir DIR
   genesis/delegation/spending keys.
 
 Available options:
+  --shelley-era            Specify the Shelley era
+  --allegra-era            Specify the Allegra era
+  --mary-era               Specify the Mary era
+  --alonzo-era             Specify the Alonzo era
+  --babbage-era            Specify the Babbage era (default)
+  --conway-era             Specify the Conway era
   --genesis-dir DIR        The genesis directory containing the genesis template
                            and required genesis/delegation/spending keys.
   --gen-genesis-keys INT   The number of genesis keys to make [default is 3].

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_genesis_create-staked.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_genesis_create-staked.cli
@@ -1,4 +1,12 @@
-Usage: cardano-cli legacy genesis create-staked [--key-output-format STRING]
+Usage: cardano-cli legacy genesis create-staked 
+                                                  [ --shelley-era
+                                                  | --allegra-era
+                                                  | --mary-era
+                                                  | --alonzo-era
+                                                  | --babbage-era
+                                                  | --conway-era
+                                                  ]
+                                                  [--key-output-format STRING]
                                                   --genesis-dir DIR
                                                   [--gen-genesis-keys INT]
                                                   [--gen-utxo-keys INT]
@@ -19,6 +27,12 @@ Usage: cardano-cli legacy genesis create-staked [--key-output-format STRING]
   genesis/delegation/spending keys.
 
 Available options:
+  --shelley-era            Specify the Shelley era
+  --allegra-era            Specify the Allegra era
+  --mary-era               Specify the Mary era
+  --alonzo-era             Specify the Alonzo era
+  --babbage-era            Specify the Babbage era (default)
+  --conway-era             Specify the Conway era
   --key-output-format STRING
                            Optional key output format. Accepted output formats
                            are "text-envelope" and "bech32" (default is

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_genesis_create.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_genesis_create.cli
@@ -1,4 +1,12 @@
-Usage: cardano-cli legacy genesis create [--key-output-format STRING]
+Usage: cardano-cli legacy genesis create 
+                                           [ --shelley-era
+                                           | --allegra-era
+                                           | --mary-era
+                                           | --alonzo-era
+                                           | --babbage-era
+                                           | --conway-era
+                                           ]
+                                           [--key-output-format STRING]
                                            --genesis-dir DIR
                                            [--gen-genesis-keys INT]
                                            [--gen-utxo-keys INT]
@@ -10,6 +18,12 @@ Usage: cardano-cli legacy genesis create [--key-output-format STRING]
   genesis/delegation/spending keys.
 
 Available options:
+  --shelley-era            Specify the Shelley era
+  --allegra-era            Specify the Allegra era
+  --mary-era               Specify the Mary era
+  --alonzo-era             Specify the Alonzo era
+  --babbage-era            Specify the Babbage era (default)
+  --conway-era             Specify the Conway era
   --key-output-format STRING
                            Optional key output format. Accepted output formats
                            are "text-envelope" and "bech32" (default is


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Make `genesis`: `create`, `create-staked` and `create-cardano` commands accept optional era parameters.
# uncomment types applicable to the change:
  type:
   - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
   - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Make `genesis`: `create`, `create-staked` and `create-cardano` commands accept optional era parameters. This is needed for decoding of Alonzo genesis. This PR requires changes from: https://github.com/IntersectMBO/cardano-api/pull/564

Fixes: https://github.com/IntersectMBO/cardano-cli/issues/801

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
