### PR TITLE
Release cardano-cli-9.0.0.0

### DIFF
--- a/cardano-cli/CHANGELOG.md
+++ b/cardano-cli/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog for cardano-cli
 
+## 9.0.0.0
+
+- Add --hot-script-hash option to committee create-hot-key-authorization-certificate subcommand
+  (breaking)
+  [PR 806](https://github.com/IntersectMBO/cardano-cli/pull/806)
+
+- Move "conway governance hash" commands to "hash". Users should adapt their calls as follows:
+  
+  `cardano-cli conway governance hash anchor-data ...` becomes `cardano-cli hash anchor-data ...`
+  `cardano-cli conway governance hash script ...` becomes `cardano-cli hash script ...`
+  (breaking)
+  [PR 787](https://github.com/IntersectMBO/cardano-cli/pull/787)
+  
 ## 8.25.0.0
 
 - Add --current-treasury-value and --treasury-donation to transaction build and friends

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -1,7 +1,7 @@
 cabal-version: 3.4
 
 name:                   cardano-cli
-version:                8.25.0.0
+version:                9.0.0.0
 synopsis:               The Cardano command-line interface
 description:            The Cardano command-line interface.
 copyright:              2020-2023 Input Output Global Inc (IOG).


### PR DESCRIPTION
- Add --hot-script-hash option to committee create-hot-key-authorization-certificate subcommand
  (breaking)
  [PR 806](https://github.com/IntersectMBO/cardano-cli/pull/806)

- Move "conway governance hash" commands to "hash". Users should adapt their calls as follows:
  
  `cardano-cli conway governance hash anchor-data ...` becomes `cardano-cli hash anchor-data ...`
  `cardano-cli conway governance hash script ...` becomes `cardano-cli hash script ...`
  (breaking)
  [PR 787](https://github.com/IntersectMBO/cardano-cli/pull/787)
# Changelog

```yaml
- description: |
    Release cardano-cli-9.0.0.0
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
   - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
   - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

For cardano-node 9.0


# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
