### PR TITLE
Share code in parsers of committee commands

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
@@ -719,7 +719,7 @@ pScriptHash longOptionName helpText =
 
 pRemoveCommitteeColdVerificationKeyHash :: Parser (Hash CommitteeColdKey)
 pRemoveCommitteeColdVerificationKeyHash =
-  Opt.option (Opt.eitherReader deserialiseColdCCKeyHashFromHex) $ mconcat
+  Opt.option deserialiseColdCCKeyHashFromHex $ mconcat
     [ Opt.long "remove-cc-cold-verification-key-hash"
     , Opt.metavar "STRING"
     , Opt.help "Constitutional Committee key hash (hex-encoded)."
@@ -746,11 +746,9 @@ deserialiseColdCCKeyFromHex =
     . deserialiseFromRawBytesHex (AsVerificationKey AsCommitteeColdKey)
     . BSC.pack
 
-deserialiseColdCCKeyHashFromHex :: String -> Either String (Hash CommitteeColdKey)
+deserialiseColdCCKeyHashFromHex :: ReadM (Hash CommitteeColdKey)
 deserialiseColdCCKeyHashFromHex =
-  first (\e -> docToString $ "Invalid Constitutional Committee cold key hash: " <> prettyError e)
-    . deserialiseFromRawBytesHex (AsHash AsCommitteeColdKey)
-    . BSC.pack
+  pHexHash AsCommitteeColdKey (Just "Invalid Constitutional Committee cold key hash")
 
 pRemoveCommitteeColdVerificationKeyFile :: Parser (File (VerificationKey keyrole) In)
 pRemoveCommitteeColdVerificationKeyFile =
@@ -787,7 +785,7 @@ pCommitteeColdVerificationKey =
 
 pCommitteeColdVerificationKeyHash :: Parser (Hash CommitteeColdKey)
 pCommitteeColdVerificationKeyHash =
-  Opt.option (Opt.eitherReader deserialiseColdCCKeyHashFromHex) $ mconcat
+  Opt.option deserialiseColdCCKeyHashFromHex $ mconcat
     [ Opt.long "cold-verification-key-hash"
     , Opt.metavar "STRING"
     , Opt.help "Constitutional Committee key hash (hex-encoded)."
@@ -847,7 +845,7 @@ pCommitteeHotVerificationKeyOrFile =
 
 pCommitteeHotVerificationKeyHash :: Parser (Hash CommitteeHotKey)
 pCommitteeHotVerificationKeyHash =
-  Opt.option (Opt.eitherReader deserialiseHotCCKeyHashFromHex) $ mconcat
+  Opt.option deserialiseHotCCKeyHashFromHex $ mconcat
     [ Opt.long "hot-verification-key-hash"
     , Opt.metavar "STRING"
     , Opt.help "Constitutional Committee key hash (hex-encoded)."
@@ -867,11 +865,9 @@ deserialiseHotCCKeyFromHex =
     . deserialiseFromRawBytesHex (AsVerificationKey AsCommitteeHotKey)
     . BSC.pack
 
-deserialiseHotCCKeyHashFromHex :: String -> Either String (Hash CommitteeHotKey)
+deserialiseHotCCKeyHashFromHex :: ReadM (Hash CommitteeHotKey)
 deserialiseHotCCKeyHashFromHex =
-  first (\e -> docToString $ "Invalid Consitutional Committee hot key hash: " <> prettyError e)
-    . deserialiseFromRawBytesHex (AsHash AsCommitteeHotKey)
-    . BSC.pack
+  pHexHash AsCommitteeHotKey (Just "Invalid Consitutional Committee hot key hash")
 
 pCommitteeHotVerificationKeyFile :: String -> Parser (VerificationKeyFile In)
 pCommitteeHotVerificationKeyFile longFlag =
@@ -885,7 +881,7 @@ pCommitteeHotVerificationKeyFile longFlag =
 -- | The first argument is the optional prefix.
 pCommitteeHotKeyHash :: Maybe String -> Parser (Hash CommitteeHotKey)
 pCommitteeHotKeyHash prefix =
-  Opt.option (Opt.eitherReader deserialiseHotCCKeyHashFromHex) $ mconcat
+  Opt.option deserialiseHotCCKeyHashFromHex $ mconcat
     [ Opt.long $ prefixFlag prefix "hot-key-hash"
     , Opt.metavar "STRING"
     , Opt.help "Constitutional Committee key hash (hex-encoded)."

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
@@ -714,17 +714,11 @@ pScriptHash longOptionName helpText =
 
 pRemoveCommitteeColdVerificationKeyHash :: Parser (Hash CommitteeColdKey)
 pRemoveCommitteeColdVerificationKeyHash =
-  Opt.option (Opt.eitherReader deserialiseFromHex) $ mconcat
+  Opt.option (Opt.eitherReader deserialiseColdCCKeyHashFromHex) $ mconcat
     [ Opt.long "remove-cc-cold-verification-key-hash"
     , Opt.metavar "STRING"
     , Opt.help "Constitutional Committee key hash (hex-encoded)."
     ]
-  where
-    deserialiseFromHex :: String -> Either String (Hash CommitteeColdKey)
-    deserialiseFromHex =
-      first (\e -> docToString $ "Invalid Constitutional Committee cold key hash: " <> prettyError e)
-        . deserialiseFromRawBytesHex (AsHash AsCommitteeColdKey)
-        . BSC.pack
 
 pRemoveCommitteeColdVerificationKeyOrFile :: Parser (VerificationKeyOrFile CommitteeColdKey)
 pRemoveCommitteeColdVerificationKeyOrFile =
@@ -735,17 +729,23 @@ pRemoveCommitteeColdVerificationKeyOrFile =
 
 pRemoveCommitteeColdVerificationKey :: Parser (VerificationKey CommitteeColdKey)
 pRemoveCommitteeColdVerificationKey =
-  Opt.option (Opt.eitherReader deserialiseFromHex) $ mconcat
+  Opt.option (Opt.eitherReader deserialiseColdCCKeyFromHex) $ mconcat
     [ Opt.long "remove-cc-cold-verification-key"
     , Opt.metavar "STRING"
     , Opt.help "Constitutional Committee cold key (hex-encoded)."
     ]
-  where
-    deserialiseFromHex :: String -> Either String (VerificationKey CommitteeColdKey)
-    deserialiseFromHex =
-      first (\e -> docToString $ "Invalid Constitutional Committee cold key: " <> prettyError e)
-        . deserialiseFromRawBytesHex (AsVerificationKey AsCommitteeColdKey)
-        . BSC.pack
+
+deserialiseColdCCKeyFromHex :: String -> Either String (VerificationKey CommitteeColdKey)
+deserialiseColdCCKeyFromHex =
+  first (\e -> docToString $ "Invalid Constitutional Committee cold key: " <> prettyError e)
+    . deserialiseFromRawBytesHex (AsVerificationKey AsCommitteeColdKey)
+    . BSC.pack
+
+deserialiseColdCCKeyHashFromHex :: String -> Either String (Hash CommitteeColdKey)
+deserialiseColdCCKeyHashFromHex =
+  first (\e -> docToString $ "Invalid Constitutional Committee cold key hash: " <> prettyError e)
+    . deserialiseFromRawBytesHex (AsHash AsCommitteeColdKey)
+    . BSC.pack
 
 pRemoveCommitteeColdVerificationKeyFile :: Parser (File (VerificationKey keyrole) In)
 pRemoveCommitteeColdVerificationKeyFile =
@@ -774,31 +774,19 @@ pCommitteeColdVerificationKeyOrFile =
 
 pCommitteeColdVerificationKey :: Parser (VerificationKey CommitteeColdKey)
 pCommitteeColdVerificationKey =
-  Opt.option (Opt.eitherReader deserialiseFromHex) $ mconcat
+  Opt.option (Opt.eitherReader deserialiseColdCCKeyFromHex) $ mconcat
     [ Opt.long "cold-verification-key"
     , Opt.metavar "STRING"
     , Opt.help "Constitutional Committee cold key (hex-encoded)."
     ]
-  where
-    deserialiseFromHex :: String -> Either String (VerificationKey CommitteeColdKey)
-    deserialiseFromHex =
-      first (\e -> docToString $ "Invalid Constitutional Committee cold key: " <> prettyError e)
-        . deserialiseFromRawBytesHex (AsVerificationKey AsCommitteeColdKey)
-        . BSC.pack
 
 pCommitteeColdVerificationKeyHash :: Parser (Hash CommitteeColdKey)
 pCommitteeColdVerificationKeyHash =
-  Opt.option (Opt.eitherReader deserialiseFromHex) $ mconcat
+  Opt.option (Opt.eitherReader deserialiseColdCCKeyHashFromHex) $ mconcat
     [ Opt.long "cold-verification-key-hash"
     , Opt.metavar "STRING"
     , Opt.help "Constitutional Committee key hash (hex-encoded)."
     ]
-  where
-    deserialiseFromHex :: String -> Either String (Hash CommitteeColdKey)
-    deserialiseFromHex =
-      first (\e -> docToString $ "Invalid Consitutional Committee cold key hash: " <> prettyError e)
-        . deserialiseFromRawBytesHex (AsHash AsCommitteeColdKey)
-        . BSC.pack
 
 pCommitteeColdVerificationKeyFile :: Parser (File (VerificationKey keyrole) In)
 pCommitteeColdVerificationKeyFile =

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
@@ -843,12 +843,7 @@ pAnyVerificationKeySource helpText =
     ]
 
 pCommitteeHotKey :: Parser (VerificationKey CommitteeHotKey)
-pCommitteeHotKey =
-  Opt.option (Opt.eitherReader deserialiseHotCCKeyFromHex) $ mconcat
-    [ Opt.long "hot-key"
-    , Opt.metavar "STRING"
-    , Opt.help "Constitutional Committee hot key (hex-encoded)."
-    ]
+pCommitteeHotKey = pCommitteeHotVerificationKey "hot-key"
 
 pCommitteeHotVerificationKeyOrFile :: Parser (VerificationKeyOrFile CommitteeHotKey)
 pCommitteeHotVerificationKeyOrFile =

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
@@ -854,17 +854,11 @@ pCommitteeHotVerificationKeyOrFile =
 
 pCommitteeHotVerificationKeyHash :: Parser (Hash CommitteeHotKey)
 pCommitteeHotVerificationKeyHash =
-  Opt.option (Opt.eitherReader deserialiseFromHex) $ mconcat
+  Opt.option (Opt.eitherReader deserialiseHotCCKeyHashFromHex) $ mconcat
     [ Opt.long "hot-verification-key-hash"
     , Opt.metavar "STRING"
     , Opt.help "Constitutional Committee key hash (hex-encoded)."
     ]
-  where
-    deserialiseFromHex :: String -> Either String (Hash CommitteeHotKey)
-    deserialiseFromHex =
-      first (\e -> docToString $ "Invalid Consitutional Committee hot key hash: " <> prettyError e)
-        . deserialiseFromRawBytesHex (AsHash AsCommitteeHotKey)
-        . BSC.pack
 
 pCommitteeHotVerificationKey :: String -> Parser (VerificationKey CommitteeHotKey)
 pCommitteeHotVerificationKey longFlag =
@@ -878,6 +872,12 @@ deserialiseHotCCKeyFromHex :: String -> Either String (VerificationKey Committee
 deserialiseHotCCKeyFromHex =
   first (\e -> docToString $ "Invalid Constitutional Committee hot key: " <> prettyError e)
     . deserialiseFromRawBytesHex (AsVerificationKey AsCommitteeHotKey)
+    . BSC.pack
+
+deserialiseHotCCKeyHashFromHex :: String -> Either String (Hash CommitteeHotKey)
+deserialiseHotCCKeyHashFromHex =
+  first (\e -> docToString $ "Invalid Consitutional Committee hot key hash: " <> prettyError e)
+    . deserialiseFromRawBytesHex (AsHash AsCommitteeHotKey)
     . BSC.pack
 
 pCommitteeHotKeyFile :: Parser (VerificationKeyFile In)
@@ -901,17 +901,11 @@ pCommitteeHotVerificationKeyFile longFlag =
 -- | The first argument is the optional prefix.
 pCommitteeHotKeyHash :: Maybe String -> Parser (Hash CommitteeHotKey)
 pCommitteeHotKeyHash prefix =
-  Opt.option (Opt.eitherReader deserialiseFromHex) $ mconcat
+  Opt.option (Opt.eitherReader deserialiseHotCCKeyHashFromHex) $ mconcat
     [ Opt.long $ prefixFlag prefix "hot-key-hash"
     , Opt.metavar "STRING"
     , Opt.help "Constitutional Committee key hash (hex-encoded)."
     ]
-  where
-    deserialiseFromHex :: String -> Either String (Hash CommitteeHotKey)
-    deserialiseFromHex =
-      first (\e -> docToString $ "Invalid Consitutional Committee hot key hash: " <> prettyError e)
-        . deserialiseFromRawBytesHex (AsHash AsCommitteeHotKey)
-        . BSC.pack
 
 pCommitteeHotKeyOrHashOrFile :: Parser (VerificationKeyOrHashOrFile CommitteeHotKey)
 pCommitteeHotKeyOrHashOrFile =

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
@@ -880,15 +880,6 @@ deserialiseHotCCKeyHashFromHex =
     . deserialiseFromRawBytesHex (AsHash AsCommitteeHotKey)
     . BSC.pack
 
-pCommitteeHotKeyFile :: Parser (VerificationKeyFile In)
-pCommitteeHotKeyFile =
-  fmap File $ Opt.strOption $ mconcat
-    [ Opt.long "hot-key-file"
-    , Opt.metavar "FILE"
-    , Opt.help "Filepath of the Consitutional Committee hot key."
-    , Opt.completer (Opt.bashCompleter "file")
-    ]
-
 pCommitteeHotVerificationKeyFile :: String -> Parser (VerificationKeyFile In)
 pCommitteeHotVerificationKeyFile longFlag =
   fmap File $ Opt.strOption $ mconcat
@@ -911,7 +902,7 @@ pCommitteeHotKeyOrHashOrFile :: Parser (VerificationKeyOrHashOrFile CommitteeHot
 pCommitteeHotKeyOrHashOrFile =
   asum
     [ VerificationKeyOrFile . VerificationKeyValue <$> pCommitteeHotKey
-    , VerificationKeyOrFile . VerificationKeyFilePath <$> pCommitteeHotKeyFile
+    , VerificationKeyOrFile . VerificationKeyFilePath <$> pCommitteeHotVerificationKeyFile "hot-key-file"
     , VerificationKeyHash <$> pCommitteeHotKeyHash Nothing
     ]
 


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Share code in parsers of committee commands. This doesn't share the CLI's behavior.
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

* While doing PRs recently in this part of the codebase, I realized that some places had code duplicated, without a good reason. Sharing will also fixes to affect multiple commands at once in the future, and also helps keeping different commands consistent.
* Fixes https://github.com/IntersectMBO/cardano-cli/issues/811

More sharing is possible (e.g. hot VS cold), but I don't want to stack too much in one PR.

# How to trust this PR

* Golden files are not changed
* The tight types means that if the code still compiles, and the types didn't change; then probably the runtime behavior didn't change either.
* Each commit is standalone and makes sense on his own, to ease review. So it's advised to review commit per commit.
* It's twice more deletions than additions

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] Self-reviewed the diff