### PR TITLE
Remove the unused output options from runTxBuild

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Transaction.hs
@@ -215,7 +215,6 @@ runTransactionBuildCmd
       requiredSigners txAuxScripts txMetadata mProp mOverrideWitnesses votingProceduresAndMaybeScriptWits
       proposals
       (unFeatured <$> featuredCurrentTreasuryValueM) treasuryDonation
-      buildOutputOptions
 
   -- TODO: Calculating the script cost should live as a different command.
   -- Why? Because then we can simply read a txbody and figure out
@@ -753,7 +752,6 @@ runTxBuild :: ()
   -> [(Proposal era, Maybe (ScriptWitness WitCtxStake era))]
   -> Maybe TxCurrentTreasuryValue
   -> Maybe TxTreasuryDonation
-  -> TxBuildOutputOptions
   -> ExceptT TxCmdError IO (BalancedTxBody era)
 runTxBuild
     sbe socketPath networkId mScriptValidity
@@ -761,8 +759,8 @@ runTxBuild
     (TxOutChangeAddress changeAddr) valuesWithScriptWits mLowerBound mUpperBound
     certsAndMaybeScriptWits withdrawals reqSigners txAuxScripts txMetadata
     txUpdateProposal mOverrideWits votingProcedures proposals
-    mCurrentTreasuryValue mTreasuryDonation
-    _outputOptions = shelleyBasedEraConstraints sbe $ do
+    mCurrentTreasuryValue mTreasuryDonation =
+    shelleyBasedEraConstraints sbe $ do
 
   -- TODO: All functions should be parameterized by ShelleyBasedEra
   -- as it's not possible to call this function with ByronEra


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Remove the unused output options from runTxBuild
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

* Follow-up of https://github.com/IntersectMBO/cardano-cli/pull/778#discussion_r1660714925
* Note that the CLI flag corresponding to the parameter being removed cannot be removed: this option's value is used elsewhere in the same command.

# How to trust this PR

It doesn't change the runtime behavior

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] Self-reviewed the diff