### PR TITLE
Fix typo in help/error messages

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
@@ -537,7 +537,7 @@ pHexHash a mErrPrefix =
       . deserialiseFromRawBytesHex (AsHash a)
       . BSC.pack
   where
-    errPrefix = maybe "" ((<>) ": ") mErrPrefix
+    errPrefix = maybe "" (": " <>) mErrPrefix
 
 pBech32KeyHash :: SerialiseAsBech32 (Hash a) => AsType a -> ReadM (Hash a)
 pBech32KeyHash a =

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
@@ -660,7 +660,7 @@ pAddCommitteeColdVerificationKeyHash =
   where
     deserialiseFromHex :: String -> Either String (Hash CommitteeColdKey)
     deserialiseFromHex =
-      first (\e -> docToString $ "Invalid Consitutional Committee cold key hash: " <> prettyError e)
+      first (\e -> docToString $ "Invalid Constitutional Committee cold key hash: " <> prettyError e)
         . deserialiseFromRawBytesHex (AsHash AsCommitteeColdKey)
         . BSC.pack
 
@@ -690,7 +690,7 @@ pAddCommitteeColdVerificationKeyFile =
   fmap File $ Opt.strOption $ mconcat
     [ Opt.long "add-cc-cold-verification-key-file"
     , Opt.metavar "FILE"
-    , Opt.help "Filepath of the Consitutional Committee cold key."
+    , Opt.help "Filepath of the Constitutional Committee cold key."
     , Opt.completer (Opt.bashCompleter "file")
     ]
 
@@ -755,7 +755,7 @@ pRemoveCommitteeColdVerificationKeyFile =
   fmap File $ Opt.strOption $ mconcat
     [ Opt.long "remove-cc-cold-verification-key-file"
     , Opt.metavar "FILE"
-    , Opt.help "Filepath of the Consitutional Committee cold key."
+    , Opt.help "Filepath of the Constitutional Committee cold key."
     , Opt.completer (Opt.bashCompleter "file")
     ]
 
@@ -796,7 +796,7 @@ pCommitteeColdVerificationKeyFile =
   fmap File $ Opt.strOption $ mconcat
     [ Opt.long "cold-verification-key-file"
     , Opt.metavar "FILE"
-    , Opt.help "Filepath of the Consitutional Committee cold key."
+    , Opt.help "Filepath of the Constitutional Committee cold key."
     , Opt.completer (Opt.bashCompleter "file")
     ]
 
@@ -867,14 +867,14 @@ deserialiseHotCCKeyFromHex =
 
 deserialiseHotCCKeyHashFromHex :: ReadM (Hash CommitteeHotKey)
 deserialiseHotCCKeyHashFromHex =
-  pHexHash AsCommitteeHotKey (Just "Invalid Consitutional Committee hot key hash")
+  pHexHash AsCommitteeHotKey (Just "Invalid Constitutional Committee hot key hash")
 
 pCommitteeHotVerificationKeyFile :: String -> Parser (VerificationKeyFile In)
 pCommitteeHotVerificationKeyFile longFlag =
   fmap File $ Opt.strOption $ mconcat
     [ Opt.long longFlag
     , Opt.metavar "FILE"
-    , Opt.help "Filepath of the Consitutional Committee hot key."
+    , Opt.help "Filepath of the Constitutional Committee hot key."
     , Opt.completer (Opt.bashCompleter "file")
     ]
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_update-committee.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_update-committee.cli
@@ -51,7 +51,7 @@ Available options:
   --remove-cc-cold-verification-key STRING
                            Constitutional Committee cold key (hex-encoded).
   --remove-cc-cold-verification-key-file FILE
-                           Filepath of the Consitutional Committee cold key.
+                           Filepath of the Constitutional Committee cold key.
   --remove-cc-cold-verification-key-hash STRING
                            Constitutional Committee key hash (hex-encoded).
   --remove-cc-cold-script-hash HASH
@@ -60,7 +60,7 @@ Available options:
   --add-cc-cold-verification-key STRING
                            Constitutional Committee cold key (hex-encoded).
   --add-cc-cold-verification-key-file FILE
-                           Filepath of the Consitutional Committee cold key.
+                           Filepath of the Constitutional Committee cold key.
   --add-cc-cold-verification-key-hash STRING
                            Constitutional Committee key hash (hex-encoded).
   --add-cc-cold-script-hash HASH

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_committee_create-cold-key-resignation-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_committee_create-cold-key-resignation-certificate.cli
@@ -15,7 +15,7 @@ Available options:
   --cold-verification-key STRING
                            Constitutional Committee cold key (hex-encoded).
   --cold-verification-key-file FILE
-                           Filepath of the Consitutional Committee cold key.
+                           Filepath of the Constitutional Committee cold key.
   --cold-verification-key-hash STRING
                            Constitutional Committee key hash (hex-encoded).
   --cold-script-hash HASH  Committee cold Native or Plutus script file hash

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_committee_create-hot-key-authorization-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_committee_create-hot-key-authorization-certificate.cli
@@ -19,7 +19,7 @@ Available options:
   --cold-verification-key STRING
                            Constitutional Committee cold key (hex-encoded).
   --cold-verification-key-file FILE
-                           Filepath of the Consitutional Committee cold key.
+                           Filepath of the Constitutional Committee cold key.
   --cold-verification-key-hash STRING
                            Constitutional Committee key hash (hex-encoded).
   --cold-script-hash HASH  Committee cold Native or Plutus script file hash
@@ -29,7 +29,7 @@ Available options:
   --hot-verification-key STRING
                            Constitutional Committee hot key (hex-encoded).
   --hot-verification-key-file FILE
-                           Filepath of the Consitutional Committee hot key.
+                           Filepath of the Constitutional Committee hot key.
   --hot-verification-key-hash STRING
                            Constitutional Committee key hash (hex-encoded).
   --hot-script-hash HASH   Committee hot Native or Plutus script file hash

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_vote_create.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_vote_create.cli
@@ -42,7 +42,7 @@ Available options:
   --cc-hot-verification-key STRING
                            Constitutional Committee hot key (hex-encoded).
   --cc-hot-verification-key-file FILE
-                           Filepath of the Consitutional Committee hot key.
+                           Filepath of the Constitutional Committee hot key.
   --cc-hot-key-hash STRING Constitutional Committee key hash (hex-encoded).
   --cc-hot-script-hash HASH
                            Cold Native or Plutus script file hash (hex-encoded).

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_committee-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_committee-state.cli
@@ -42,13 +42,13 @@ Available options:
   --cold-verification-key STRING
                            Constitutional Committee cold key (hex-encoded).
   --cold-verification-key-file FILE
-                           Filepath of the Consitutional Committee cold key.
+                           Filepath of the Constitutional Committee cold key.
   --cold-verification-key-hash STRING
                            Constitutional Committee key hash (hex-encoded).
   --cold-script-hash HASH  Cold Native or Plutus script file hash (hex-encoded).
                            Obtain it with "cardano-cli hash script ...".
   --hot-key STRING         Constitutional Committee hot key (hex-encoded).
-  --hot-key-file FILE      Filepath of the Consitutional Committee hot key.
+  --hot-key-file FILE      Filepath of the Constitutional Committee hot key.
   --hot-key-hash STRING    Constitutional Committee key hash (hex-encoded).
   --hot-script-hash HASH   Hot Native or Plutus script file hash (hex-encoded).
                            Obtain it with "cardano-cli hash script ...".


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Fix typo in committee help and error messages
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Follow-up of @palas' remark: https://github.com/IntersectMBO/cardano-cli/pull/816#discussion_r1664953604

# How to trust this PR

* Only changes help and error messages
* `git grep Consitutional` now returns 1

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] Self-reviewed the diff