### PR TITLE
Fix commands' descriptions referencing old 'governance hash' command

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
@@ -959,7 +959,7 @@ pConstitutionHash =
   Opt.option readSafeHash $ mconcat
     [ Opt.long "constitution-hash"
     , Opt.metavar "HASH"
-    , Opt.help "Hash of the constitution data (obtain it with \"cardano-cli conway governance hash anchor-data ...\")."
+    , Opt.help "Hash of the constitution data (obtain it with \"cardano-cli hash anchor-data ...\")."
     ]
 
 pUrl :: String -> String -> Parser L.Url
@@ -3219,7 +3219,7 @@ pVoteAnchorDataHash =
   Opt.option readSafeHash $ mconcat
     [ Opt.long "anchor-data-hash"
     , Opt.metavar "HASH"
-    , Opt.help "Hash of the vote anchor data (obtain it with \"cardano-cli conway governance hash anchor-data ...\")."
+    , Opt.help "Hash of the vote anchor data (obtain it with \"cardano-cli hash anchor-data ...\")."
     ]
 
 pAlwaysNoConfidence :: Parser ()
@@ -3332,7 +3332,7 @@ pAnchorDataHash =
   Opt.option readSafeHash $ mconcat
     [ Opt.long "anchor-data-hash"
     , Opt.metavar "HASH"
-    , Opt.help "Proposal anchor data hash (obtain it with \"cardano-cli conway governance hash anchor-data ...\")"
+    , Opt.help "Proposal anchor data hash (obtain it with \"cardano-cli hash anchor-data ...\")"
     ]
 
 pPreviousGovernanceAction :: Parser (Maybe (TxId, Word16))

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_create-constitution.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_create-constitution.cli
@@ -41,11 +41,10 @@ Available options:
                            Action index of the previous governance action.
   --anchor-url TEXT        Anchor URL
   --anchor-data-hash HASH  Proposal anchor data hash (obtain it with
-                           "cardano-cli conway governance hash anchor-data ...")
+                           "cardano-cli hash anchor-data ...")
   --constitution-url TEXT  Constitution URL.
   --constitution-hash HASH Hash of the constitution data (obtain it with
-                           "cardano-cli conway governance hash anchor-data
-                           ...").
+                           "cardano-cli hash anchor-data ...").
   --constitution-script-hash HASH
                            Constitution script hash (hex-encoded). Obtain it
                            with "cardano-cli hash script ...".

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_create-hardfork.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_create-hardfork.cli
@@ -40,7 +40,7 @@ Available options:
                            Action index of the previous governance action.
   --anchor-url TEXT        Anchor URL
   --anchor-data-hash HASH  Proposal anchor data hash (obtain it with
-                           "cardano-cli conway governance hash anchor-data ...")
+                           "cardano-cli hash anchor-data ...")
   --protocol-major-version MAJOR
                            Specify the major protocol version to fork into. It
                            must be the next natural number after the current

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_create-info.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_create-info.cli
@@ -29,7 +29,7 @@ Available options:
                            Target stake address (bech32 format).
   --anchor-url TEXT        Anchor URL
   --anchor-data-hash HASH  Proposal anchor data hash (obtain it with
-                           "cardano-cli conway governance hash anchor-data ...")
+                           "cardano-cli hash anchor-data ...")
   --out-file FILE          Path to action file to be used later on with build or
                            build-raw
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_create-no-confidence.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_create-no-confidence.cli
@@ -34,7 +34,7 @@ Available options:
                            Target stake address (bech32 format).
   --anchor-url TEXT        Anchor URL
   --anchor-data-hash HASH  Proposal anchor data hash (obtain it with
-                           "cardano-cli conway governance hash anchor-data ...")
+                           "cardano-cli hash anchor-data ...")
   --prev-governance-action-tx-id TXID
                            Txid of the previous governance action.
   --prev-governance-action-index WORD16

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_create-protocol-parameters-update.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_create-protocol-parameters-update.cli
@@ -79,7 +79,7 @@ Available options:
                            Target stake address (bech32 format).
   --anchor-url TEXT        Anchor URL
   --anchor-data-hash HASH  Proposal anchor data hash (obtain it with
-                           "cardano-cli conway governance hash anchor-data ...")
+                           "cardano-cli hash anchor-data ...")
   --prev-governance-action-tx-id TXID
                            Txid of the previous governance action.
   --prev-governance-action-index WORD16

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_create-treasury-withdrawal.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_create-treasury-withdrawal.cli
@@ -39,7 +39,7 @@ Available options:
                            Target stake address (bech32 format).
   --anchor-url TEXT        Anchor URL
   --anchor-data-hash HASH  Proposal anchor data hash (obtain it with
-                           "cardano-cli conway governance hash anchor-data ...")
+                           "cardano-cli hash anchor-data ...")
   --funds-receiving-stake-verification-key STRING
                            Stake verification key (Bech32 or hex-encoded).
   --funds-receiving-stake-verification-key-file FILE

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_update-committee.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_update-committee.cli
@@ -47,7 +47,7 @@ Available options:
                            Target stake address (bech32 format).
   --anchor-url TEXT        Anchor URL
   --anchor-data-hash HASH  Proposal anchor data hash (obtain it with
-                           "cardano-cli conway governance hash anchor-data ...")
+                           "cardano-cli hash anchor-data ...")
   --remove-cc-cold-verification-key STRING
                            Constitutional Committee cold key (hex-encoded).
   --remove-cc-cold-verification-key-file FILE

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_vote_create.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_vote_create.cli
@@ -49,7 +49,6 @@ Available options:
                            Obtain it with "cardano-cli hash script ...".
   --anchor-url TEXT        Vote anchor URL
   --anchor-data-hash HASH  Hash of the vote anchor data (obtain it with
-                           "cardano-cli conway governance hash anchor-data
-                           ...").
+                           "cardano-cli hash anchor-data ...").
   --out-file FILE          Output filepath of the vote.
   -h,--help                Show this help text


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Fix commands' descriptions referencing old 'governance hash' command
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
   - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

There were references to old syntax of `conway governance hash` command in the help texts.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
