### PR TITLE
Plutus V3 script updates

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
@@ -1399,12 +1399,14 @@ pProposalFiles
 pProposalFiles sbe balExUnits =
   caseShelleyToBabbageOrConwayEraOnwards
     (const $ pure [])
-    (const $ many (pProposalFile balExUnits))
+    (const $ many (pProposalFile sbe balExUnits))
     sbe
 
 pProposalFile
-  :: BalanceTxExecUnits -> Parser (ProposalFile In, Maybe (ScriptWitnessFiles WitCtxStake))
-pProposalFile balExUnits =
+  :: ShelleyBasedEra era
+  -> BalanceTxExecUnits
+  -> Parser (ProposalFile In, Maybe (ScriptWitnessFiles WitCtxStake))
+pProposalFile sbe balExUnits =
   (,)
     <$> pFileInDirection "proposal-file" "Filepath of the proposal."
     <*> optional (pProposingScriptOrReferenceScriptWitness balExUnits)
@@ -1413,11 +1415,13 @@ pProposalFile balExUnits =
     :: BalanceTxExecUnits -> Parser (ScriptWitnessFiles WitCtxStake)
   pProposingScriptOrReferenceScriptWitness bExUnits =
     pScriptWitnessFiles
+      sbe
       WitCtxStake
       bExUnits
       "proposal"
       Nothing
       "a proposal"
+      <|> pPlutusStakeReferenceScriptWitnessFilesVotingProposing "proposal-" balExUnits
 
 pCurrentTreasuryValueAndDonation
   :: ShelleyBasedEra era -> Parser (Maybe (TxCurrentTreasuryValue, TxTreasuryDonation))

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
@@ -1368,11 +1368,14 @@ pVoteFiles
 pVoteFiles sbe bExUnits =
   caseShelleyToBabbageOrConwayEraOnwards
     (const $ pure [])
-    (const . many $ pVoteFile bExUnits)
+    (const . many $ pVoteFile sbe bExUnits)
     sbe
 
-pVoteFile :: BalanceTxExecUnits -> Parser (VoteFile In, Maybe (ScriptWitnessFiles WitCtxStake))
-pVoteFile balExUnits =
+pVoteFile
+  :: ShelleyBasedEra era
+  -> BalanceTxExecUnits
+  -> Parser (VoteFile In, Maybe (ScriptWitnessFiles WitCtxStake))
+pVoteFile sbe balExUnits =
   (,)
     <$> pFileInDirection "vote-file" "Filepath of the vote."
     <*> optional (pVoteScriptOrReferenceScriptWitness balExUnits)
@@ -1381,11 +1384,13 @@ pVoteFile balExUnits =
     :: BalanceTxExecUnits -> Parser (ScriptWitnessFiles WitCtxStake)
   pVoteScriptOrReferenceScriptWitness bExUnits =
     pScriptWitnessFiles
+      sbe
       WitCtxStake
       bExUnits
       "vote"
       Nothing
       "a vote"
+      <|> pPlutusStakeReferenceScriptWitnessFilesVotingProposing "vote-" balExUnits
 
 pProposalFiles
   :: ShelleyBasedEra era

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
@@ -1243,6 +1243,31 @@ pScriptRedeemerOrFile scriptFlagPrefix =
     "The script redeemer value."
     "The script redeemer file."
 
+pScriptDatumOrFileCip69 :: String -> WitCtx witctx -> Parser (ScriptDatumOrFile witctx)
+pScriptDatumOrFileCip69 scriptFlagPrefix witctx =
+  case witctx of
+    WitCtxTxIn ->
+      asum
+        [ ScriptDatumOrFileForTxIn
+            <$> optional
+              ( pScriptDataOrFile
+                  (scriptFlagPrefix ++ "-datum")
+                  "The script datum."
+                  "The script datum file."
+              )
+        , pInlineDatumPresent
+        ]
+    WitCtxMint -> pure NoScriptDatumOrFileForMint
+    WitCtxStake -> pure NoScriptDatumOrFileForStake
+ where
+  pInlineDatumPresent :: Parser (ScriptDatumOrFile WitCtxTxIn)
+  pInlineDatumPresent =
+    flag' InlineDatumPresentAtTxIn $
+      mconcat
+        [ long (scriptFlagPrefix ++ "-inline-datum-present")
+        , Opt.help "Inline datum present at transaction input."
+        ]
+
 pScriptDatumOrFile :: String -> WitCtx witctx -> Parser (ScriptDatumOrFile witctx)
 pScriptDatumOrFile scriptFlagPrefix witctx =
   case witctx of

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
@@ -2227,17 +2227,33 @@ pTxIn balance =
       let simpleLang = AnyScriptLanguage SimpleScriptLanguage
        in SimpleReferenceScriptWitnessFiles refTxIn simpleLang Nothing
 
-  pPlutusReferenceScriptWitness :: BalanceTxExecUnits -> Parser (ScriptWitnessFiles WitCtxTxIn)
-  pPlutusReferenceScriptWitness autoBalanceExecUnits =
-    createPlutusReferenceScriptWitnessFiles
-      <$> pReferenceTxIn "spending-" "plutus"
-      <*> pPlutusScriptLanguage "spending-"
-      <*> pScriptDatumOrFile "spending-reference-tx-in" WitCtxTxIn
-      <*> pScriptRedeemerOrFile "spending-reference-tx-in"
-      <*> ( case autoBalanceExecUnits of
-              AutoBalance -> pure (ExecutionUnits 0 0)
-              ManualBalance -> pExecutionUnits "spending-reference-tx-in"
-          )
+  pPlutusReferenceScriptWitness
+    :: ShelleyBasedEra era -> BalanceTxExecUnits -> Parser (ScriptWitnessFiles WitCtxTxIn)
+  pPlutusReferenceScriptWitness sbe' autoBalanceExecUnits =
+    caseShelleyToBabbageOrConwayEraOnwards
+      ( const $
+          createPlutusReferenceScriptWitnessFiles
+            <$> pReferenceTxIn "spending-" "plutus"
+            <*> pPlutusScriptLanguage "spending-"
+            <*> pScriptDatumOrFile "spending-reference-tx-in" WitCtxTxIn
+            <*> pScriptRedeemerOrFile "spending-reference-tx-in"
+            <*> ( case autoBalanceExecUnits of
+                    AutoBalance -> pure (ExecutionUnits 0 0)
+                    ManualBalance -> pExecutionUnits "spending-reference-tx-in"
+                )
+      )
+      ( const $
+          createPlutusReferenceScriptWitnessFiles
+            <$> pReferenceTxIn "spending-" "plutus"
+            <*> pPlutusScriptLanguage "spending-"
+            <*> pScriptDatumOrFileCip69 "spending-reference-tx-in" WitCtxTxIn
+            <*> pScriptRedeemerOrFile "spending-reference-tx-in"
+            <*> ( case autoBalanceExecUnits of
+                    AutoBalance -> pure (ExecutionUnits 0 0)
+                    ManualBalance -> pExecutionUnits "spending-reference-tx-in"
+                )
+      )
+      sbe'
    where
     createPlutusReferenceScriptWitnessFiles
       :: TxIn

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Transaction.hs
@@ -173,7 +173,7 @@ pTransactionBuildCmd era envCli = do
         <*> pNetworkId envCli
         <*> optional pScriptValidity
         <*> optional pWitnessOverride
-        <*> some (pTxIn AutoBalance)
+        <*> some (pTxIn sbe AutoBalance)
         <*> many pReadOnlyReferenceTxIn
         <*> many pRequiredSigner
         <*> many pTxInCollateral
@@ -181,11 +181,11 @@ pTransactionBuildCmd era envCli = do
         <*> optional pTotalCollateral
         <*> many pTxOut
         <*> pChangeAddress
-        <*> optional (pMintMultiAsset AutoBalance)
+        <*> optional (pMintMultiAsset sbe AutoBalance)
         <*> optional pInvalidBefore
         <*> pInvalidHereafter sbe
-        <*> many (pCertificateFile AutoBalance)
-        <*> many (pWithdrawal AutoBalance)
+        <*> many (pCertificateFile sbe AutoBalance)
+        <*> many (pWithdrawal sbe AutoBalance)
         <*> pTxMetadataJsonSchema
         <*> many
           ( pScriptFor
@@ -232,18 +232,18 @@ pTransactionBuildEstimateCmd era _envCli = do
         <*> optional pNumberOfByronKeyWitnesses
         <*> pProtocolParamsFile
         <*> pTotalUTxOValue
-        <*> some (pTxIn ManualBalance)
+        <*> some (pTxIn sbe ManualBalance)
         <*> many pReadOnlyReferenceTxIn
         <*> many pRequiredSigner
         <*> many pTxInCollateral
         <*> optional pReturnCollateral
         <*> many pTxOut
         <*> pChangeAddress
-        <*> optional (pMintMultiAsset ManualBalance)
+        <*> optional (pMintMultiAsset sbe ManualBalance)
         <*> optional pInvalidBefore
         <*> pInvalidHereafter sbe
-        <*> many (pCertificateFile ManualBalance)
-        <*> many (pWithdrawal ManualBalance)
+        <*> many (pCertificateFile sbe ManualBalance)
+        <*> many (pWithdrawal sbe ManualBalance)
         <*> optional pTotalCollateral
         <*> optional pReferenceScriptSize
         <*> pTxMetadataJsonSchema
@@ -275,19 +275,19 @@ pTransactionBuildRaw era =
   fmap TransactionBuildRawCmd $
     TransactionBuildRawCmdArgs era
       <$> optional pScriptValidity
-      <*> some (pTxIn ManualBalance)
+      <*> some (pTxIn era ManualBalance)
       <*> many pReadOnlyReferenceTxIn
       <*> many pTxInCollateral
       <*> optional pReturnCollateral
       <*> optional pTotalCollateral
       <*> many pRequiredSigner
       <*> many pTxOut
-      <*> optional (pMintMultiAsset ManualBalance)
+      <*> optional (pMintMultiAsset era ManualBalance)
       <*> optional pInvalidBefore
       <*> pInvalidHereafter era
       <*> pTxFee
-      <*> many (pCertificateFile ManualBalance)
-      <*> many (pWithdrawal ManualBalance)
+      <*> many (pCertificateFile era ManualBalance)
+      <*> many (pWithdrawal era ManualBalance)
       <*> pTxMetadataJsonSchema
       <*> many (pScriptFor "auxiliary-script-file" Nothing "Filepath of auxiliary script(s)")
       <*> many pMetadataFile

--- a/cardano-cli/src/Cardano/CLI/Legacy/Options.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Options.hs
@@ -353,7 +353,7 @@ pTransaction envCli =
       <*> pNetworkId envCli
       <*> optional pScriptValidity
       <*> optional pWitnessOverride
-      <*> some (pTxIn AutoBalance)
+      <*> some (pTxIn ShelleyBasedEraConway AutoBalance)
       <*> many pReadOnlyReferenceTxIn
       <*> many pRequiredSigner
       <*> many pTxInCollateral
@@ -361,11 +361,11 @@ pTransaction envCli =
       <*> optional pTotalCollateral
       <*> many pTxOut
       <*> pChangeAddress
-      <*> optional (pMintMultiAsset AutoBalance)
+      <*> optional (pMintMultiAsset ShelleyBasedEraConway AutoBalance)
       <*> optional pInvalidBefore
       <*> optional pLegacyInvalidHereafter
-      <*> many (pCertificateFile AutoBalance)
-      <*> many (pWithdrawal AutoBalance)
+      <*> many (pCertificateFile ShelleyBasedEraConway AutoBalance)
+      <*> many (pWithdrawal ShelleyBasedEraConway AutoBalance)
       <*> pTxMetadataJsonSchema
       <*> many
         ( pScriptFor
@@ -395,19 +395,19 @@ pTransaction envCli =
     TransactionBuildRawCmd
       <$> pLegacyCardanoEra envCli
       <*> optional pScriptValidity
-      <*> some (pTxIn ManualBalance)
+      <*> some (pTxIn ShelleyBasedEraConway ManualBalance)
       <*> many pReadOnlyReferenceTxIn
       <*> many pTxInCollateral
       <*> optional pReturnCollateral
       <*> optional pTotalCollateral
       <*> many pRequiredSigner
       <*> many pTxOut
-      <*> optional (pMintMultiAsset ManualBalance)
+      <*> optional (pMintMultiAsset ShelleyBasedEraConway ManualBalance)
       <*> optional pInvalidBefore
       <*> optional pLegacyInvalidHereafter
       <*> pTxFee
-      <*> many (pCertificateFile ManualBalance)
-      <*> many (pWithdrawal ManualBalance)
+      <*> many (pCertificateFile ShelleyBasedEraConway ManualBalance)
+      <*> many (pWithdrawal ShelleyBasedEraConway ManualBalance)
       <*> pTxMetadataJsonSchema
       <*> many (pScriptFor "auxiliary-script-file" Nothing "Filepath of auxiliary script(s)")
       <*> many pMetadataFile

--- a/cardano-cli/src/Cardano/CLI/Read.hs
+++ b/cardano-cli/src/Cardano/CLI/Read.hs
@@ -450,7 +450,8 @@ renderScriptDataError = \case
 readScriptDatumOrFile
   :: ScriptDatumOrFile witctx
   -> ExceptT ScriptDataError IO (ScriptDatum witctx)
-readScriptDatumOrFile (ScriptDatumOrFileForTxIn df) =
+readScriptDatumOrFile (ScriptDatumOrFileForTxIn Nothing) = pure $ ScriptDatumForTxIn Nothing
+readScriptDatumOrFile (ScriptDatumOrFileForTxIn (Just df)) =
   ScriptDatumForTxIn . Just
     <$> readScriptDataOrFile df
 readScriptDatumOrFile InlineDatumPresentAtTxIn = pure InlineScriptDatum

--- a/cardano-cli/src/Cardano/CLI/Types/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Common.hs
@@ -415,7 +415,7 @@ deriving instance Show (ScriptWitnessFiles witctx)
 
 data ScriptDatumOrFile witctx where
   ScriptDatumOrFileForTxIn
-    :: ScriptDataOrFile
+    :: Maybe ScriptDataOrFile -- CIP-0069 - Spending datums optional in Conway era onwards
     -> ScriptDatumOrFile WitCtxTxIn
   InlineDatumPresentAtTxIn :: ScriptDatumOrFile WitCtxTxIn
   NoScriptDatumOrFileForMint :: ScriptDatumOrFile WitCtxMint

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -7708,11 +7708,11 @@ Usage: cardano-cli conway transaction build-raw
                                                       ( --spending-plutus-script-v2
                                                       | --spending-plutus-script-v3
                                                       )
-                                                      ( --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                                                      [ --spending-reference-tx-in-datum-cbor-file CBOR_FILE
                                                       | --spending-reference-tx-in-datum-file JSON_FILE
                                                       | --spending-reference-tx-in-datum-value JSON_VALUE
                                                       | --spending-reference-tx-in-inline-datum-present
-                                                      )
+                                                      ]
                                                       ( --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
                                                       | --spending-reference-tx-in-redeemer-file JSON_FILE
                                                       | --spending-reference-tx-in-redeemer-value JSON_VALUE
@@ -7721,11 +7721,11 @@ Usage: cardano-cli conway transaction build-raw
                                                     | --simple-script-tx-in-reference TX-IN
                                                     | --tx-in-script-file FILE
                                                       [
-                                                        ( --tx-in-datum-cbor-file CBOR_FILE
+                                                        [ --tx-in-datum-cbor-file CBOR_FILE
                                                         | --tx-in-datum-file JSON_FILE
                                                         | --tx-in-datum-value JSON_VALUE
                                                         | --tx-in-inline-datum-present
-                                                        )
+                                                        ]
                                                         ( --tx-in-redeemer-cbor-file CBOR_FILE
                                                         | --tx-in-redeemer-file JSON_FILE
                                                         | --tx-in-redeemer-value JSON_VALUE
@@ -7821,21 +7821,37 @@ Usage: cardano-cli conway transaction build-raw
                                                   ]
                                                   [--protocol-params-file FILE]
                                                   [--vote-file FILE
-                                                    [--vote-script-file FILE
+                                                    [ --vote-script-file FILE
                                                       [
                                                         ( --vote-redeemer-cbor-file CBOR_FILE
                                                         | --vote-redeemer-file JSON_FILE
                                                         | --vote-redeemer-value JSON_VALUE
                                                         )
-                                                        --vote-execution-units (INT, INT)]]]
+                                                        --vote-execution-units (INT, INT)]
+                                                    | --vote-tx-in-reference TX-IN
+                                                      --vote-plutus-script-v3
+                                                      ( --vote-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                      | --vote-reference-tx-in-redeemer-file JSON_FILE
+                                                      | --vote-reference-tx-in-redeemer-value JSON_VALUE
+                                                      )
+                                                      --vote-reference-tx-in-execution-units (INT, INT)
+                                                    ]]
                                                   [--proposal-file FILE
-                                                    [--proposal-script-file FILE
+                                                    [ --proposal-script-file FILE
                                                       [
                                                         ( --proposal-redeemer-cbor-file CBOR_FILE
                                                         | --proposal-redeemer-file JSON_FILE
                                                         | --proposal-redeemer-value JSON_VALUE
                                                         )
-                                                        --proposal-execution-units (INT, INT)]]]
+                                                        --proposal-execution-units (INT, INT)]
+                                                    | --proposal-tx-in-reference TX-IN
+                                                      --proposal-plutus-script-v3
+                                                      ( --proposal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                      | --proposal-reference-tx-in-redeemer-file JSON_FILE
+                                                      | --proposal-reference-tx-in-redeemer-value JSON_VALUE
+                                                      )
+                                                      --proposal-reference-tx-in-execution-units (INT, INT)
+                                                    ]]
                                                   [--current-treasury-value LOVELACE
                                                     --treasury-donation LOVELACE]
                                                   --out-file FILE
@@ -7859,11 +7875,11 @@ Usage: cardano-cli conway transaction build --socket-path SOCKET_PATH
                                                   ( --spending-plutus-script-v2
                                                   | --spending-plutus-script-v3
                                                   )
-                                                  ( --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                                                  [ --spending-reference-tx-in-datum-cbor-file CBOR_FILE
                                                   | --spending-reference-tx-in-datum-file JSON_FILE
                                                   | --spending-reference-tx-in-datum-value JSON_VALUE
                                                   | --spending-reference-tx-in-inline-datum-present
-                                                  )
+                                                  ]
                                                   ( --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
                                                   | --spending-reference-tx-in-redeemer-file JSON_FILE
                                                   | --spending-reference-tx-in-redeemer-value JSON_VALUE
@@ -7871,11 +7887,11 @@ Usage: cardano-cli conway transaction build --socket-path SOCKET_PATH
                                                 | --simple-script-tx-in-reference TX-IN
                                                 | --tx-in-script-file FILE
                                                   [
-                                                    ( --tx-in-datum-cbor-file CBOR_FILE
+                                                    [ --tx-in-datum-cbor-file CBOR_FILE
                                                     | --tx-in-datum-file JSON_FILE
                                                     | --tx-in-datum-value JSON_VALUE
                                                     | --tx-in-inline-datum-present
-                                                    )
+                                                    ]
                                                     ( --tx-in-redeemer-cbor-file CBOR_FILE
                                                     | --tx-in-redeemer-file JSON_FILE
                                                     | --tx-in-redeemer-value JSON_VALUE
@@ -7960,17 +7976,31 @@ Usage: cardano-cli conway transaction build --socket-path SOCKET_PATH
                                               | --metadata-cbor-file FILE
                                               ]
                                               [--vote-file FILE
-                                                [--vote-script-file FILE
+                                                [ --vote-script-file FILE
                                                   [ --vote-redeemer-cbor-file CBOR_FILE
                                                   | --vote-redeemer-file JSON_FILE
                                                   | --vote-redeemer-value JSON_VALUE
-                                                  ]]]
+                                                  ]
+                                                | --vote-tx-in-reference TX-IN
+                                                  --vote-plutus-script-v3
+                                                  ( --vote-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                  | --vote-reference-tx-in-redeemer-file JSON_FILE
+                                                  | --vote-reference-tx-in-redeemer-value JSON_VALUE
+                                                  )
+                                                ]]
                                               [--proposal-file FILE
-                                                [--proposal-script-file FILE
+                                                [ --proposal-script-file FILE
                                                   [ --proposal-redeemer-cbor-file CBOR_FILE
                                                   | --proposal-redeemer-file JSON_FILE
                                                   | --proposal-redeemer-value JSON_VALUE
-                                                  ]]]
+                                                  ]
+                                                | --proposal-tx-in-reference TX-IN
+                                                  --proposal-plutus-script-v3
+                                                  ( --proposal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                  | --proposal-reference-tx-in-redeemer-file JSON_FILE
+                                                  | --proposal-reference-tx-in-redeemer-value JSON_VALUE
+                                                  )
+                                                ]]
                                               [--treasury-donation LOVELACE]
                                               ( --out-file FILE
                                               | --calculate-plutus-script-cost FILE
@@ -7993,11 +8023,11 @@ Usage: cardano-cli conway transaction build-estimate
                                                            ( --spending-plutus-script-v2
                                                            | --spending-plutus-script-v3
                                                            )
-                                                           ( --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                                                           [ --spending-reference-tx-in-datum-cbor-file CBOR_FILE
                                                            | --spending-reference-tx-in-datum-file JSON_FILE
                                                            | --spending-reference-tx-in-datum-value JSON_VALUE
                                                            | --spending-reference-tx-in-inline-datum-present
-                                                           )
+                                                           ]
                                                            ( --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
                                                            | --spending-reference-tx-in-redeemer-file JSON_FILE
                                                            | --spending-reference-tx-in-redeemer-value JSON_VALUE
@@ -8006,11 +8036,11 @@ Usage: cardano-cli conway transaction build-estimate
                                                          | --simple-script-tx-in-reference TX-IN
                                                          | --tx-in-script-file FILE
                                                            [
-                                                             ( --tx-in-datum-cbor-file CBOR_FILE
+                                                             [ --tx-in-datum-cbor-file CBOR_FILE
                                                              | --tx-in-datum-file JSON_FILE
                                                              | --tx-in-datum-value JSON_VALUE
                                                              | --tx-in-inline-datum-present
-                                                             )
+                                                             ]
                                                              ( --tx-in-redeemer-cbor-file CBOR_FILE
                                                              | --tx-in-redeemer-file JSON_FILE
                                                              | --tx-in-redeemer-value JSON_VALUE
@@ -8106,21 +8136,37 @@ Usage: cardano-cli conway transaction build-estimate
                                                        | --metadata-cbor-file FILE
                                                        ]
                                                        [--vote-file FILE
-                                                         [--vote-script-file FILE
+                                                         [ --vote-script-file FILE
                                                            [
                                                              ( --vote-redeemer-cbor-file CBOR_FILE
                                                              | --vote-redeemer-file JSON_FILE
                                                              | --vote-redeemer-value JSON_VALUE
                                                              )
-                                                             --vote-execution-units (INT, INT)]]]
+                                                             --vote-execution-units (INT, INT)]
+                                                         | --vote-tx-in-reference TX-IN
+                                                           --vote-plutus-script-v3
+                                                           ( --vote-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                           | --vote-reference-tx-in-redeemer-file JSON_FILE
+                                                           | --vote-reference-tx-in-redeemer-value JSON_VALUE
+                                                           )
+                                                           --vote-reference-tx-in-execution-units (INT, INT)
+                                                         ]]
                                                        [--proposal-file FILE
-                                                         [--proposal-script-file FILE
+                                                         [ --proposal-script-file FILE
                                                            [
                                                              ( --proposal-redeemer-cbor-file CBOR_FILE
                                                              | --proposal-redeemer-file JSON_FILE
                                                              | --proposal-redeemer-value JSON_VALUE
                                                              )
-                                                             --proposal-execution-units (INT, INT)]]]
+                                                             --proposal-execution-units (INT, INT)]
+                                                         | --proposal-tx-in-reference TX-IN
+                                                           --proposal-plutus-script-v3
+                                                           ( --proposal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                           | --proposal-reference-tx-in-redeemer-file JSON_FILE
+                                                           | --proposal-reference-tx-in-redeemer-value JSON_VALUE
+                                                           )
+                                                           --proposal-reference-tx-in-execution-units (INT, INT)
+                                                         ]]
                                                        [--current-treasury-value LOVELACE
                                                          --treasury-donation LOVELACE]
                                                        --out-file FILE
@@ -10291,11 +10337,11 @@ Usage: cardano-cli legacy transaction build-raw
                                                       ( --spending-plutus-script-v2
                                                       | --spending-plutus-script-v3
                                                       )
-                                                      ( --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                                                      [ --spending-reference-tx-in-datum-cbor-file CBOR_FILE
                                                       | --spending-reference-tx-in-datum-file JSON_FILE
                                                       | --spending-reference-tx-in-datum-value JSON_VALUE
                                                       | --spending-reference-tx-in-inline-datum-present
-                                                      )
+                                                      ]
                                                       ( --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
                                                       | --spending-reference-tx-in-redeemer-file JSON_FILE
                                                       | --spending-reference-tx-in-redeemer-value JSON_VALUE
@@ -10304,11 +10350,11 @@ Usage: cardano-cli legacy transaction build-raw
                                                     | --simple-script-tx-in-reference TX-IN
                                                     | --tx-in-script-file FILE
                                                       [
-                                                        ( --tx-in-datum-cbor-file CBOR_FILE
+                                                        [ --tx-in-datum-cbor-file CBOR_FILE
                                                         | --tx-in-datum-file JSON_FILE
                                                         | --tx-in-datum-value JSON_VALUE
                                                         | --tx-in-inline-datum-present
-                                                        )
+                                                        ]
                                                         ( --tx-in-redeemer-cbor-file CBOR_FILE
                                                         | --tx-in-redeemer-file JSON_FILE
                                                         | --tx-in-redeemer-value JSON_VALUE
@@ -10431,11 +10477,11 @@ Usage: cardano-cli legacy transaction build --socket-path SOCKET_PATH
                                                   ( --spending-plutus-script-v2
                                                   | --spending-plutus-script-v3
                                                   )
-                                                  ( --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                                                  [ --spending-reference-tx-in-datum-cbor-file CBOR_FILE
                                                   | --spending-reference-tx-in-datum-file JSON_FILE
                                                   | --spending-reference-tx-in-datum-value JSON_VALUE
                                                   | --spending-reference-tx-in-inline-datum-present
-                                                  )
+                                                  ]
                                                   ( --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
                                                   | --spending-reference-tx-in-redeemer-file JSON_FILE
                                                   | --spending-reference-tx-in-redeemer-value JSON_VALUE
@@ -10443,11 +10489,11 @@ Usage: cardano-cli legacy transaction build --socket-path SOCKET_PATH
                                                 | --simple-script-tx-in-reference TX-IN
                                                 | --tx-in-script-file FILE
                                                   [
-                                                    ( --tx-in-datum-cbor-file CBOR_FILE
+                                                    [ --tx-in-datum-cbor-file CBOR_FILE
                                                     | --tx-in-datum-file JSON_FILE
                                                     | --tx-in-datum-value JSON_VALUE
                                                     | --tx-in-inline-datum-present
-                                                    )
+                                                    ]
                                                     ( --tx-in-redeemer-cbor-file CBOR_FILE
                                                     | --tx-in-redeemer-file JSON_FILE
                                                     | --tx-in-redeemer-value JSON_VALUE
@@ -10533,17 +10579,31 @@ Usage: cardano-cli legacy transaction build --socket-path SOCKET_PATH
                                               ]
                                               [--update-proposal-file FILE]
                                               [--vote-file FILE
-                                                [--vote-script-file FILE
+                                                [ --vote-script-file FILE
                                                   [ --vote-redeemer-cbor-file CBOR_FILE
                                                   | --vote-redeemer-file JSON_FILE
                                                   | --vote-redeemer-value JSON_VALUE
-                                                  ]]]
+                                                  ]
+                                                | --vote-tx-in-reference TX-IN
+                                                  --vote-plutus-script-v3
+                                                  ( --vote-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                  | --vote-reference-tx-in-redeemer-file JSON_FILE
+                                                  | --vote-reference-tx-in-redeemer-value JSON_VALUE
+                                                  )
+                                                ]]
                                               [--proposal-file FILE
-                                                [--proposal-script-file FILE
+                                                [ --proposal-script-file FILE
                                                   [ --proposal-redeemer-cbor-file CBOR_FILE
                                                   | --proposal-redeemer-file JSON_FILE
                                                   | --proposal-redeemer-value JSON_VALUE
-                                                  ]]]
+                                                  ]
+                                                | --proposal-tx-in-reference TX-IN
+                                                  --proposal-plutus-script-v3
+                                                  ( --proposal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                  | --proposal-reference-tx-in-redeemer-file JSON_FILE
+                                                  | --proposal-reference-tx-in-redeemer-value JSON_VALUE
+                                                  )
+                                                ]]
                                               [--treasury-donation LOVELACE]
                                               ( --out-file FILE
                                               | --calculate-plutus-script-cost FILE
@@ -11556,11 +11616,11 @@ Usage: cardano-cli transaction build-raw
                                                ( --spending-plutus-script-v2
                                                | --spending-plutus-script-v3
                                                )
-                                               ( --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                                               [ --spending-reference-tx-in-datum-cbor-file CBOR_FILE
                                                | --spending-reference-tx-in-datum-file JSON_FILE
                                                | --spending-reference-tx-in-datum-value JSON_VALUE
                                                | --spending-reference-tx-in-inline-datum-present
-                                               )
+                                               ]
                                                ( --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
                                                | --spending-reference-tx-in-redeemer-file JSON_FILE
                                                | --spending-reference-tx-in-redeemer-value JSON_VALUE
@@ -11569,11 +11629,11 @@ Usage: cardano-cli transaction build-raw
                                              | --simple-script-tx-in-reference TX-IN
                                              | --tx-in-script-file FILE
                                                [
-                                                 ( --tx-in-datum-cbor-file CBOR_FILE
+                                                 [ --tx-in-datum-cbor-file CBOR_FILE
                                                  | --tx-in-datum-file JSON_FILE
                                                  | --tx-in-datum-value JSON_VALUE
                                                  | --tx-in-inline-datum-present
-                                                 )
+                                                 ]
                                                  ( --tx-in-redeemer-cbor-file CBOR_FILE
                                                  | --tx-in-redeemer-file JSON_FILE
                                                  | --tx-in-redeemer-value JSON_VALUE
@@ -11691,11 +11751,11 @@ Usage: cardano-cli transaction build --socket-path SOCKET_PATH
                                            ( --spending-plutus-script-v2
                                            | --spending-plutus-script-v3
                                            )
-                                           ( --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                                           [ --spending-reference-tx-in-datum-cbor-file CBOR_FILE
                                            | --spending-reference-tx-in-datum-file JSON_FILE
                                            | --spending-reference-tx-in-datum-value JSON_VALUE
                                            | --spending-reference-tx-in-inline-datum-present
-                                           )
+                                           ]
                                            ( --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
                                            | --spending-reference-tx-in-redeemer-file JSON_FILE
                                            | --spending-reference-tx-in-redeemer-value JSON_VALUE
@@ -11703,11 +11763,11 @@ Usage: cardano-cli transaction build --socket-path SOCKET_PATH
                                          | --simple-script-tx-in-reference TX-IN
                                          | --tx-in-script-file FILE
                                            [
-                                             ( --tx-in-datum-cbor-file CBOR_FILE
+                                             [ --tx-in-datum-cbor-file CBOR_FILE
                                              | --tx-in-datum-file JSON_FILE
                                              | --tx-in-datum-value JSON_VALUE
                                              | --tx-in-inline-datum-present
-                                             )
+                                             ]
                                              ( --tx-in-redeemer-cbor-file CBOR_FILE
                                              | --tx-in-redeemer-file JSON_FILE
                                              | --tx-in-redeemer-value JSON_VALUE
@@ -11793,17 +11853,31 @@ Usage: cardano-cli transaction build --socket-path SOCKET_PATH
                                        ]
                                        [--update-proposal-file FILE]
                                        [--vote-file FILE
-                                         [--vote-script-file FILE
+                                         [ --vote-script-file FILE
                                            [ --vote-redeemer-cbor-file CBOR_FILE
                                            | --vote-redeemer-file JSON_FILE
                                            | --vote-redeemer-value JSON_VALUE
-                                           ]]]
+                                           ]
+                                         | --vote-tx-in-reference TX-IN
+                                           --vote-plutus-script-v3
+                                           ( --vote-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                           | --vote-reference-tx-in-redeemer-file JSON_FILE
+                                           | --vote-reference-tx-in-redeemer-value JSON_VALUE
+                                           )
+                                         ]]
                                        [--proposal-file FILE
-                                         [--proposal-script-file FILE
+                                         [ --proposal-script-file FILE
                                            [ --proposal-redeemer-cbor-file CBOR_FILE
                                            | --proposal-redeemer-file JSON_FILE
                                            | --proposal-redeemer-value JSON_VALUE
-                                           ]]]
+                                           ]
+                                         | --proposal-tx-in-reference TX-IN
+                                           --proposal-plutus-script-v3
+                                           ( --proposal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                           | --proposal-reference-tx-in-redeemer-file JSON_FILE
+                                           | --proposal-reference-tx-in-redeemer-value JSON_VALUE
+                                           )
+                                         ]]
                                        [--treasury-donation LOVELACE]
                                        ( --out-file FILE
                                        | --calculate-plutus-script-cost FILE

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_build-estimate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_build-estimate.cli
@@ -11,11 +11,11 @@ Usage: cardano-cli conway transaction build-estimate
                                                            ( --spending-plutus-script-v2
                                                            | --spending-plutus-script-v3
                                                            )
-                                                           ( --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                                                           [ --spending-reference-tx-in-datum-cbor-file CBOR_FILE
                                                            | --spending-reference-tx-in-datum-file JSON_FILE
                                                            | --spending-reference-tx-in-datum-value JSON_VALUE
                                                            | --spending-reference-tx-in-inline-datum-present
-                                                           )
+                                                           ]
                                                            ( --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
                                                            | --spending-reference-tx-in-redeemer-file JSON_FILE
                                                            | --spending-reference-tx-in-redeemer-value JSON_VALUE
@@ -24,11 +24,11 @@ Usage: cardano-cli conway transaction build-estimate
                                                          | --simple-script-tx-in-reference TX-IN
                                                          | --tx-in-script-file FILE
                                                            [
-                                                             ( --tx-in-datum-cbor-file CBOR_FILE
+                                                             [ --tx-in-datum-cbor-file CBOR_FILE
                                                              | --tx-in-datum-file JSON_FILE
                                                              | --tx-in-datum-value JSON_VALUE
                                                              | --tx-in-inline-datum-present
-                                                             )
+                                                             ]
                                                              ( --tx-in-redeemer-cbor-file CBOR_FILE
                                                              | --tx-in-redeemer-file JSON_FILE
                                                              | --tx-in-redeemer-value JSON_VALUE
@@ -124,21 +124,37 @@ Usage: cardano-cli conway transaction build-estimate
                                                        | --metadata-cbor-file FILE
                                                        ]
                                                        [--vote-file FILE
-                                                         [--vote-script-file FILE
+                                                         [ --vote-script-file FILE
                                                            [
                                                              ( --vote-redeemer-cbor-file CBOR_FILE
                                                              | --vote-redeemer-file JSON_FILE
                                                              | --vote-redeemer-value JSON_VALUE
                                                              )
-                                                             --vote-execution-units (INT, INT)]]]
+                                                             --vote-execution-units (INT, INT)]
+                                                         | --vote-tx-in-reference TX-IN
+                                                           --vote-plutus-script-v3
+                                                           ( --vote-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                           | --vote-reference-tx-in-redeemer-file JSON_FILE
+                                                           | --vote-reference-tx-in-redeemer-value JSON_VALUE
+                                                           )
+                                                           --vote-reference-tx-in-execution-units (INT, INT)
+                                                         ]]
                                                        [--proposal-file FILE
-                                                         [--proposal-script-file FILE
+                                                         [ --proposal-script-file FILE
                                                            [
                                                              ( --proposal-redeemer-cbor-file CBOR_FILE
                                                              | --proposal-redeemer-file JSON_FILE
                                                              | --proposal-redeemer-value JSON_VALUE
                                                              )
-                                                             --proposal-execution-units (INT, INT)]]]
+                                                             --proposal-execution-units (INT, INT)]
+                                                         | --proposal-tx-in-reference TX-IN
+                                                           --proposal-plutus-script-v3
+                                                           ( --proposal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                           | --proposal-reference-tx-in-redeemer-file JSON_FILE
+                                                           | --proposal-reference-tx-in-redeemer-value JSON_VALUE
+                                                           )
+                                                           --proposal-reference-tx-in-execution-units (INT, INT)
+                                                         ]]
                                                        [--current-treasury-value LOVELACE
                                                          --treasury-donation LOVELACE]
                                                        --out-file FILE
@@ -437,6 +453,22 @@ Available options:
                            top-level strings and numbers.
   --vote-execution-units (INT, INT)
                            The time and space units needed by the script.
+  --vote-tx-in-reference TX-IN
+                           TxId#TxIx - Specify a reference input. The reference
+                           input must have a plutus reference script attached.
+  --vote-plutus-script-v3  Specify a plutus script v3 reference script.
+  --vote-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --vote-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --vote-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --vote-reference-tx-in-execution-units (INT, INT)
+                           The time and space units needed by the script.
   --proposal-file FILE     Filepath of the proposal.
   --proposal-script-file FILE
                            The file containing the script to witness a proposal
@@ -451,6 +483,23 @@ Available options:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
   --proposal-execution-units (INT, INT)
+                           The time and space units needed by the script.
+  --proposal-tx-in-reference TX-IN
+                           TxId#TxIx - Specify a reference input. The reference
+                           input must have a plutus reference script attached.
+  --proposal-plutus-script-v3
+                           Specify a plutus script v3 reference script.
+  --proposal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --proposal-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --proposal-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --proposal-reference-tx-in-execution-units (INT, INT)
                            The time and space units needed by the script.
   --current-treasury-value LOVELACE
                            The current treasury value.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_build-raw.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_build-raw.cli
@@ -7,11 +7,11 @@ Usage: cardano-cli conway transaction build-raw
                                                       ( --spending-plutus-script-v2
                                                       | --spending-plutus-script-v3
                                                       )
-                                                      ( --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                                                      [ --spending-reference-tx-in-datum-cbor-file CBOR_FILE
                                                       | --spending-reference-tx-in-datum-file JSON_FILE
                                                       | --spending-reference-tx-in-datum-value JSON_VALUE
                                                       | --spending-reference-tx-in-inline-datum-present
-                                                      )
+                                                      ]
                                                       ( --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
                                                       | --spending-reference-tx-in-redeemer-file JSON_FILE
                                                       | --spending-reference-tx-in-redeemer-value JSON_VALUE
@@ -20,11 +20,11 @@ Usage: cardano-cli conway transaction build-raw
                                                     | --simple-script-tx-in-reference TX-IN
                                                     | --tx-in-script-file FILE
                                                       [
-                                                        ( --tx-in-datum-cbor-file CBOR_FILE
+                                                        [ --tx-in-datum-cbor-file CBOR_FILE
                                                         | --tx-in-datum-file JSON_FILE
                                                         | --tx-in-datum-value JSON_VALUE
                                                         | --tx-in-inline-datum-present
-                                                        )
+                                                        ]
                                                         ( --tx-in-redeemer-cbor-file CBOR_FILE
                                                         | --tx-in-redeemer-file JSON_FILE
                                                         | --tx-in-redeemer-value JSON_VALUE
@@ -120,21 +120,37 @@ Usage: cardano-cli conway transaction build-raw
                                                   ]
                                                   [--protocol-params-file FILE]
                                                   [--vote-file FILE
-                                                    [--vote-script-file FILE
+                                                    [ --vote-script-file FILE
                                                       [
                                                         ( --vote-redeemer-cbor-file CBOR_FILE
                                                         | --vote-redeemer-file JSON_FILE
                                                         | --vote-redeemer-value JSON_VALUE
                                                         )
-                                                        --vote-execution-units (INT, INT)]]]
+                                                        --vote-execution-units (INT, INT)]
+                                                    | --vote-tx-in-reference TX-IN
+                                                      --vote-plutus-script-v3
+                                                      ( --vote-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                      | --vote-reference-tx-in-redeemer-file JSON_FILE
+                                                      | --vote-reference-tx-in-redeemer-value JSON_VALUE
+                                                      )
+                                                      --vote-reference-tx-in-execution-units (INT, INT)
+                                                    ]]
                                                   [--proposal-file FILE
-                                                    [--proposal-script-file FILE
+                                                    [ --proposal-script-file FILE
                                                       [
                                                         ( --proposal-redeemer-cbor-file CBOR_FILE
                                                         | --proposal-redeemer-file JSON_FILE
                                                         | --proposal-redeemer-value JSON_VALUE
                                                         )
-                                                        --proposal-execution-units (INT, INT)]]]
+                                                        --proposal-execution-units (INT, INT)]
+                                                    | --proposal-tx-in-reference TX-IN
+                                                      --proposal-plutus-script-v3
+                                                      ( --proposal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                      | --proposal-reference-tx-in-redeemer-file JSON_FILE
+                                                      | --proposal-reference-tx-in-redeemer-value JSON_VALUE
+                                                      )
+                                                      --proposal-reference-tx-in-execution-units (INT, INT)
+                                                    ]]
                                                   [--current-treasury-value LOVELACE
                                                     --treasury-donation LOVELACE]
                                                   --out-file FILE
@@ -422,6 +438,22 @@ Available options:
                            top-level strings and numbers.
   --vote-execution-units (INT, INT)
                            The time and space units needed by the script.
+  --vote-tx-in-reference TX-IN
+                           TxId#TxIx - Specify a reference input. The reference
+                           input must have a plutus reference script attached.
+  --vote-plutus-script-v3  Specify a plutus script v3 reference script.
+  --vote-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --vote-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --vote-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --vote-reference-tx-in-execution-units (INT, INT)
+                           The time and space units needed by the script.
   --proposal-file FILE     Filepath of the proposal.
   --proposal-script-file FILE
                            The file containing the script to witness a proposal
@@ -436,6 +468,23 @@ Available options:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
   --proposal-execution-units (INT, INT)
+                           The time and space units needed by the script.
+  --proposal-tx-in-reference TX-IN
+                           TxId#TxIx - Specify a reference input. The reference
+                           input must have a plutus reference script attached.
+  --proposal-plutus-script-v3
+                           Specify a plutus script v3 reference script.
+  --proposal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --proposal-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --proposal-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --proposal-reference-tx-in-execution-units (INT, INT)
                            The time and space units needed by the script.
   --current-treasury-value LOVELACE
                            The current treasury value.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_build.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_build.cli
@@ -13,11 +13,11 @@ Usage: cardano-cli conway transaction build --socket-path SOCKET_PATH
                                                   ( --spending-plutus-script-v2
                                                   | --spending-plutus-script-v3
                                                   )
-                                                  ( --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                                                  [ --spending-reference-tx-in-datum-cbor-file CBOR_FILE
                                                   | --spending-reference-tx-in-datum-file JSON_FILE
                                                   | --spending-reference-tx-in-datum-value JSON_VALUE
                                                   | --spending-reference-tx-in-inline-datum-present
-                                                  )
+                                                  ]
                                                   ( --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
                                                   | --spending-reference-tx-in-redeemer-file JSON_FILE
                                                   | --spending-reference-tx-in-redeemer-value JSON_VALUE
@@ -25,11 +25,11 @@ Usage: cardano-cli conway transaction build --socket-path SOCKET_PATH
                                                 | --simple-script-tx-in-reference TX-IN
                                                 | --tx-in-script-file FILE
                                                   [
-                                                    ( --tx-in-datum-cbor-file CBOR_FILE
+                                                    [ --tx-in-datum-cbor-file CBOR_FILE
                                                     | --tx-in-datum-file JSON_FILE
                                                     | --tx-in-datum-value JSON_VALUE
                                                     | --tx-in-inline-datum-present
-                                                    )
+                                                    ]
                                                     ( --tx-in-redeemer-cbor-file CBOR_FILE
                                                     | --tx-in-redeemer-file JSON_FILE
                                                     | --tx-in-redeemer-value JSON_VALUE
@@ -114,17 +114,31 @@ Usage: cardano-cli conway transaction build --socket-path SOCKET_PATH
                                               | --metadata-cbor-file FILE
                                               ]
                                               [--vote-file FILE
-                                                [--vote-script-file FILE
+                                                [ --vote-script-file FILE
                                                   [ --vote-redeemer-cbor-file CBOR_FILE
                                                   | --vote-redeemer-file JSON_FILE
                                                   | --vote-redeemer-value JSON_VALUE
-                                                  ]]]
+                                                  ]
+                                                | --vote-tx-in-reference TX-IN
+                                                  --vote-plutus-script-v3
+                                                  ( --vote-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                  | --vote-reference-tx-in-redeemer-file JSON_FILE
+                                                  | --vote-reference-tx-in-redeemer-value JSON_VALUE
+                                                  )
+                                                ]]
                                               [--proposal-file FILE
-                                                [--proposal-script-file FILE
+                                                [ --proposal-script-file FILE
                                                   [ --proposal-redeemer-cbor-file CBOR_FILE
                                                   | --proposal-redeemer-file JSON_FILE
                                                   | --proposal-redeemer-value JSON_VALUE
-                                                  ]]]
+                                                  ]
+                                                | --proposal-tx-in-reference TX-IN
+                                                  --proposal-plutus-script-v3
+                                                  ( --proposal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                  | --proposal-reference-tx-in-redeemer-file JSON_FILE
+                                                  | --proposal-reference-tx-in-redeemer-value JSON_VALUE
+                                                  )
+                                                ]]
                                               [--treasury-donation LOVELACE]
                                               ( --out-file FILE
                                               | --calculate-plutus-script-cost FILE
@@ -408,6 +422,20 @@ Available options:
                            The script redeemer value. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
+  --vote-tx-in-reference TX-IN
+                           TxId#TxIx - Specify a reference input. The reference
+                           input must have a plutus reference script attached.
+  --vote-plutus-script-v3  Specify a plutus script v3 reference script.
+  --vote-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --vote-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --vote-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --proposal-file FILE     Filepath of the proposal.
   --proposal-script-file FILE
                            The file containing the script to witness a proposal
@@ -418,6 +446,21 @@ Available options:
                            The script redeemer file. The file must follow the
                            detailed JSON schema for script data.
   --proposal-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --proposal-tx-in-reference TX-IN
+                           TxId#TxIx - Specify a reference input. The reference
+                           input must have a plutus reference script attached.
+  --proposal-plutus-script-v3
+                           Specify a plutus script v3 reference script.
+  --proposal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --proposal-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --proposal-reference-tx-in-redeemer-value JSON_VALUE
                            The script redeemer value. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_transaction_build-raw.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_transaction_build-raw.cli
@@ -14,11 +14,11 @@ Usage: cardano-cli legacy transaction build-raw
                                                       ( --spending-plutus-script-v2
                                                       | --spending-plutus-script-v3
                                                       )
-                                                      ( --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                                                      [ --spending-reference-tx-in-datum-cbor-file CBOR_FILE
                                                       | --spending-reference-tx-in-datum-file JSON_FILE
                                                       | --spending-reference-tx-in-datum-value JSON_VALUE
                                                       | --spending-reference-tx-in-inline-datum-present
-                                                      )
+                                                      ]
                                                       ( --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
                                                       | --spending-reference-tx-in-redeemer-file JSON_FILE
                                                       | --spending-reference-tx-in-redeemer-value JSON_VALUE
@@ -27,11 +27,11 @@ Usage: cardano-cli legacy transaction build-raw
                                                     | --simple-script-tx-in-reference TX-IN
                                                     | --tx-in-script-file FILE
                                                       [
-                                                        ( --tx-in-datum-cbor-file CBOR_FILE
+                                                        [ --tx-in-datum-cbor-file CBOR_FILE
                                                         | --tx-in-datum-file JSON_FILE
                                                         | --tx-in-datum-value JSON_VALUE
                                                         | --tx-in-inline-datum-present
-                                                        )
+                                                        ]
                                                         ( --tx-in-redeemer-cbor-file CBOR_FILE
                                                         | --tx-in-redeemer-file JSON_FILE
                                                         | --tx-in-redeemer-value JSON_VALUE

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_transaction_build.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_transaction_build.cli
@@ -19,11 +19,11 @@ Usage: cardano-cli legacy transaction build --socket-path SOCKET_PATH
                                                   ( --spending-plutus-script-v2
                                                   | --spending-plutus-script-v3
                                                   )
-                                                  ( --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                                                  [ --spending-reference-tx-in-datum-cbor-file CBOR_FILE
                                                   | --spending-reference-tx-in-datum-file JSON_FILE
                                                   | --spending-reference-tx-in-datum-value JSON_VALUE
                                                   | --spending-reference-tx-in-inline-datum-present
-                                                  )
+                                                  ]
                                                   ( --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
                                                   | --spending-reference-tx-in-redeemer-file JSON_FILE
                                                   | --spending-reference-tx-in-redeemer-value JSON_VALUE
@@ -31,11 +31,11 @@ Usage: cardano-cli legacy transaction build --socket-path SOCKET_PATH
                                                 | --simple-script-tx-in-reference TX-IN
                                                 | --tx-in-script-file FILE
                                                   [
-                                                    ( --tx-in-datum-cbor-file CBOR_FILE
+                                                    [ --tx-in-datum-cbor-file CBOR_FILE
                                                     | --tx-in-datum-file JSON_FILE
                                                     | --tx-in-datum-value JSON_VALUE
                                                     | --tx-in-inline-datum-present
-                                                    )
+                                                    ]
                                                     ( --tx-in-redeemer-cbor-file CBOR_FILE
                                                     | --tx-in-redeemer-file JSON_FILE
                                                     | --tx-in-redeemer-value JSON_VALUE
@@ -121,17 +121,31 @@ Usage: cardano-cli legacy transaction build --socket-path SOCKET_PATH
                                               ]
                                               [--update-proposal-file FILE]
                                               [--vote-file FILE
-                                                [--vote-script-file FILE
+                                                [ --vote-script-file FILE
                                                   [ --vote-redeemer-cbor-file CBOR_FILE
                                                   | --vote-redeemer-file JSON_FILE
                                                   | --vote-redeemer-value JSON_VALUE
-                                                  ]]]
+                                                  ]
+                                                | --vote-tx-in-reference TX-IN
+                                                  --vote-plutus-script-v3
+                                                  ( --vote-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                  | --vote-reference-tx-in-redeemer-file JSON_FILE
+                                                  | --vote-reference-tx-in-redeemer-value JSON_VALUE
+                                                  )
+                                                ]]
                                               [--proposal-file FILE
-                                                [--proposal-script-file FILE
+                                                [ --proposal-script-file FILE
                                                   [ --proposal-redeemer-cbor-file CBOR_FILE
                                                   | --proposal-redeemer-file JSON_FILE
                                                   | --proposal-redeemer-value JSON_VALUE
-                                                  ]]]
+                                                  ]
+                                                | --proposal-tx-in-reference TX-IN
+                                                  --proposal-plutus-script-v3
+                                                  ( --proposal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                  | --proposal-reference-tx-in-redeemer-file JSON_FILE
+                                                  | --proposal-reference-tx-in-redeemer-value JSON_VALUE
+                                                  )
+                                                ]]
                                               [--treasury-donation LOVELACE]
                                               ( --out-file FILE
                                               | --calculate-plutus-script-cost FILE
@@ -422,6 +436,20 @@ Available options:
                            The script redeemer value. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
+  --vote-tx-in-reference TX-IN
+                           TxId#TxIx - Specify a reference input. The reference
+                           input must have a plutus reference script attached.
+  --vote-plutus-script-v3  Specify a plutus script v3 reference script.
+  --vote-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --vote-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --vote-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --proposal-file FILE     Filepath of the proposal.
   --proposal-script-file FILE
                            The file containing the script to witness a proposal
@@ -432,6 +460,21 @@ Available options:
                            The script redeemer file. The file must follow the
                            detailed JSON schema for script data.
   --proposal-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --proposal-tx-in-reference TX-IN
+                           TxId#TxIx - Specify a reference input. The reference
+                           input must have a plutus reference script attached.
+  --proposal-plutus-script-v3
+                           Specify a plutus script v3 reference script.
+  --proposal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --proposal-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --proposal-reference-tx-in-redeemer-value JSON_VALUE
                            The script redeemer value. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/transaction_build-raw.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/transaction_build-raw.cli
@@ -12,11 +12,11 @@ Usage: cardano-cli transaction build-raw
                                                ( --spending-plutus-script-v2
                                                | --spending-plutus-script-v3
                                                )
-                                               ( --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                                               [ --spending-reference-tx-in-datum-cbor-file CBOR_FILE
                                                | --spending-reference-tx-in-datum-file JSON_FILE
                                                | --spending-reference-tx-in-datum-value JSON_VALUE
                                                | --spending-reference-tx-in-inline-datum-present
-                                               )
+                                               ]
                                                ( --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
                                                | --spending-reference-tx-in-redeemer-file JSON_FILE
                                                | --spending-reference-tx-in-redeemer-value JSON_VALUE
@@ -25,11 +25,11 @@ Usage: cardano-cli transaction build-raw
                                              | --simple-script-tx-in-reference TX-IN
                                              | --tx-in-script-file FILE
                                                [
-                                                 ( --tx-in-datum-cbor-file CBOR_FILE
+                                                 [ --tx-in-datum-cbor-file CBOR_FILE
                                                  | --tx-in-datum-file JSON_FILE
                                                  | --tx-in-datum-value JSON_VALUE
                                                  | --tx-in-inline-datum-present
-                                                 )
+                                                 ]
                                                  ( --tx-in-redeemer-cbor-file CBOR_FILE
                                                  | --tx-in-redeemer-file JSON_FILE
                                                  | --tx-in-redeemer-value JSON_VALUE

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/transaction_build.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/transaction_build.cli
@@ -14,11 +14,11 @@ Usage: cardano-cli transaction build --socket-path SOCKET_PATH
                                            ( --spending-plutus-script-v2
                                            | --spending-plutus-script-v3
                                            )
-                                           ( --spending-reference-tx-in-datum-cbor-file CBOR_FILE
+                                           [ --spending-reference-tx-in-datum-cbor-file CBOR_FILE
                                            | --spending-reference-tx-in-datum-file JSON_FILE
                                            | --spending-reference-tx-in-datum-value JSON_VALUE
                                            | --spending-reference-tx-in-inline-datum-present
-                                           )
+                                           ]
                                            ( --spending-reference-tx-in-redeemer-cbor-file CBOR_FILE
                                            | --spending-reference-tx-in-redeemer-file JSON_FILE
                                            | --spending-reference-tx-in-redeemer-value JSON_VALUE
@@ -26,11 +26,11 @@ Usage: cardano-cli transaction build --socket-path SOCKET_PATH
                                          | --simple-script-tx-in-reference TX-IN
                                          | --tx-in-script-file FILE
                                            [
-                                             ( --tx-in-datum-cbor-file CBOR_FILE
+                                             [ --tx-in-datum-cbor-file CBOR_FILE
                                              | --tx-in-datum-file JSON_FILE
                                              | --tx-in-datum-value JSON_VALUE
                                              | --tx-in-inline-datum-present
-                                             )
+                                             ]
                                              ( --tx-in-redeemer-cbor-file CBOR_FILE
                                              | --tx-in-redeemer-file JSON_FILE
                                              | --tx-in-redeemer-value JSON_VALUE
@@ -116,17 +116,31 @@ Usage: cardano-cli transaction build --socket-path SOCKET_PATH
                                        ]
                                        [--update-proposal-file FILE]
                                        [--vote-file FILE
-                                         [--vote-script-file FILE
+                                         [ --vote-script-file FILE
                                            [ --vote-redeemer-cbor-file CBOR_FILE
                                            | --vote-redeemer-file JSON_FILE
                                            | --vote-redeemer-value JSON_VALUE
-                                           ]]]
+                                           ]
+                                         | --vote-tx-in-reference TX-IN
+                                           --vote-plutus-script-v3
+                                           ( --vote-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                           | --vote-reference-tx-in-redeemer-file JSON_FILE
+                                           | --vote-reference-tx-in-redeemer-value JSON_VALUE
+                                           )
+                                         ]]
                                        [--proposal-file FILE
-                                         [--proposal-script-file FILE
+                                         [ --proposal-script-file FILE
                                            [ --proposal-redeemer-cbor-file CBOR_FILE
                                            | --proposal-redeemer-file JSON_FILE
                                            | --proposal-redeemer-value JSON_VALUE
-                                           ]]]
+                                           ]
+                                         | --proposal-tx-in-reference TX-IN
+                                           --proposal-plutus-script-v3
+                                           ( --proposal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                           | --proposal-reference-tx-in-redeemer-file JSON_FILE
+                                           | --proposal-reference-tx-in-redeemer-value JSON_VALUE
+                                           )
+                                         ]]
                                        [--treasury-donation LOVELACE]
                                        ( --out-file FILE
                                        | --calculate-plutus-script-cost FILE
@@ -417,6 +431,20 @@ Available options:
                            The script redeemer value. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
+  --vote-tx-in-reference TX-IN
+                           TxId#TxIx - Specify a reference input. The reference
+                           input must have a plutus reference script attached.
+  --vote-plutus-script-v3  Specify a plutus script v3 reference script.
+  --vote-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --vote-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --vote-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
   --proposal-file FILE     Filepath of the proposal.
   --proposal-script-file FILE
                            The file containing the script to witness a proposal
@@ -427,6 +455,21 @@ Available options:
                            The script redeemer file. The file must follow the
                            detailed JSON schema for script data.
   --proposal-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --proposal-tx-in-reference TX-IN
+                           TxId#TxIx - Specify a reference input. The reference
+                           input must have a plutus reference script attached.
+  --proposal-plutus-script-v3
+                           Specify a plutus script v3 reference script.
+  --proposal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --proposal-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --proposal-reference-tx-in-redeemer-value JSON_VALUE
                            The script redeemer value. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Relax requirement of supplying datums to plutus spending scripts
    Add flags to enable use of reference scripts with voting and proposing scripts
      - `--vote-tx-in-reference`
      - `--proposal-tx-in-reference`
# uncomment types applicable to the change:
  type:
  - feature        # introduces a new feature
  - compatible     # the API has changed but is non-breaking
```

# Context

Additional context for the PR goes here. If the PR fixes a particular issue please provide a [link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=) to the issue.

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
