### PR TITLE
Add output options flags to calculate-min-fee

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Query.hs
@@ -73,7 +73,7 @@ data QueryLeadershipScheduleCmdArgs = QueryLeadershipScheduleCmdArgs
   , vrkSkeyFp           :: !(SigningKeyFile In)
   , whichSchedule       :: !EpochLeadershipSchedule
   , target              :: !(Consensus.Target ChainPoint)
-  , format              :: Maybe QueryOutputFormat
+  , format              :: Maybe OutputFormatJsonOrText
   , mOutFile            :: !(Maybe (File () Out))
   } deriving (Generic, Show)
 
@@ -105,7 +105,7 @@ data QueryStakePoolsCmdArgs = QueryStakePoolsCmdArgs
   , consensusModeParams :: !ConsensusModeParams
   , networkId           :: !NetworkId
   , target              :: !(Consensus.Target ChainPoint)
-  , format              :: Maybe QueryOutputFormat
+  , format              :: Maybe OutputFormatJsonOrText
   , mOutFile            :: !(Maybe (File () Out))
   } deriving (Generic, Show)
 
@@ -114,7 +114,7 @@ data QueryStakeDistributionCmdArgs = QueryStakeDistributionCmdArgs
   , consensusModeParams :: !ConsensusModeParams
   , networkId           :: !NetworkId
   , target              :: !(Consensus.Target ChainPoint)
-  , format              :: Maybe QueryOutputFormat
+  , format              :: Maybe OutputFormatJsonOrText
   , mOutFile            :: !(Maybe (File () Out))
   } deriving (Generic, Show)
 
@@ -133,7 +133,7 @@ data QueryUTxOCmdArgs = QueryUTxOCmdArgs
   , queryFilter         :: !QueryUTxOFilter
   , networkId           :: !NetworkId
   , target              :: !(Consensus.Target ChainPoint)
-  , format              :: Maybe QueryOutputFormat
+  , format              :: Maybe OutputFormatJsonOrText
   , mOutFile            :: !(Maybe (File () Out))
   } deriving (Generic, Show)
 
@@ -203,7 +203,7 @@ data QueryRefScriptSizeCmdArgs = QueryRefScriptSizeCmdArgs
   , transactionInputs   :: !(Set TxIn)
   , networkId           :: !NetworkId
   , target              :: !(Consensus.Target ChainPoint)
-  , format              :: Maybe QueryOutputFormat
+  , format              :: Maybe OutputFormatJsonOrText
   , mOutFile            :: !(Maybe (File () Out))
   } deriving (Generic, Show)
 

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Transaction.hs
@@ -218,6 +218,8 @@ data TransactionCalculateMinFeeCmdArgs = TransactionCalculateMinFeeCmdArgs
   , txByronWitnessCount   :: !TxByronWitnessCount
     -- | The total size in bytes of the transaction reference scripts.
   , referenceScriptSize   :: !ReferenceScriptSize
+  , outputFormat          :: !(Maybe OutputFormatJsonOrText)
+  , outFile               :: !(Maybe (File () Out))
   } deriving Show
 
 data TransactionCalculateMinValueCmdArgs era = TransactionCalculateMinValueCmdArgs

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
@@ -1642,13 +1642,13 @@ pPoolIdOutputFormat =
     , Opt.value IdOutputFormatBech32
     ]
 
--- | @pQueryOutputFormat kind@ is a parser to specify in which format
+-- | @pOutputFormatJsonOrText kind@ is a parser to specify in which format
 -- to view some data (json or text). @kind@ is the kind of data considered.
-pQueryOutputFormat :: String -> Parser QueryOutputFormat
-pQueryOutputFormat kind =
+pOutputFormatJsonOrText :: String -> Parser OutputFormatJsonOrText
+pOutputFormatJsonOrText kind =
   asum
-    [ make QueryOutputFormatJson "JSON" "json" (Just " Default format when writing to a file")
-    , make QueryOutputFormatText "TEXT" "text" (Just " Default format when writing to stdout")
+    [ make OutputFormatJson "JSON" "json" (Just " Default format when writing to a file")
+    , make OutputFormatText "TEXT" "text" (Just " Default format when writing to stdout")
     ]
   where
     make format desc flag_ extraHelp =

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Query.hs
@@ -149,7 +149,7 @@ pQueryUTxOCmd era envCli =
       <*> pQueryUTxOFilter
       <*> pNetworkId envCli
       <*> pTarget era
-      <*> (optional $ pQueryOutputFormat "utxo")
+      <*> (optional $ pOutputFormatJsonOrText "utxo")
       <*> pMaybeOutputFile
 
 pQueryStakePoolsCmd :: CardanoEra era -> EnvCli -> Parser (QueryCmds era)
@@ -160,7 +160,7 @@ pQueryStakePoolsCmd era envCli =
       <*> pConsensusModeParams
       <*> pNetworkId envCli
       <*> pTarget era
-      <*> (optional $ pQueryOutputFormat "stake-pools")
+      <*> (optional $ pOutputFormatJsonOrText "stake-pools")
       <*> pMaybeOutputFile
 
 pQueryStakeDistributionCmd :: CardanoEra era -> EnvCli -> Parser (QueryCmds era)
@@ -171,7 +171,7 @@ pQueryStakeDistributionCmd era envCli =
       <*> pConsensusModeParams
       <*> pNetworkId envCli
       <*> pTarget era
-      <*> (optional $ pQueryOutputFormat "stake-distribution")
+      <*> (optional $ pOutputFormatJsonOrText "stake-distribution")
       <*> pMaybeOutputFile
 
 pQueryStakeAddressInfoCmd :: CardanoEra era -> EnvCli -> Parser (QueryCmds era)
@@ -271,7 +271,7 @@ pLeadershipScheduleCmd era envCli =
       <*> pVrfSigningKeyFile
       <*> pWhichLeadershipSchedule
       <*> pTarget era
-      <*> (optional $ pQueryOutputFormat "leadership-schedule")
+      <*> (optional $ pOutputFormatJsonOrText "leadership-schedule")
       <*> pMaybeOutputFile
 
 pKesPeriodInfoCmd :: CardanoEra era -> EnvCli -> Parser (QueryCmds era)
@@ -310,7 +310,7 @@ pQueryRefScriptSizeCmd era envCli =
       <*> (fromList <$> some pByTxIn)
       <*> pNetworkId envCli
       <*> pTarget era
-      <*> (optional $ pQueryOutputFormat "reference inputs")
+      <*> (optional $ pOutputFormatJsonOrText "reference inputs")
       <*> pMaybeOutputFile
   where
     pByTxIn :: Parser TxIn

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Transaction.hs
@@ -327,6 +327,8 @@ pTransactionCalculateMinFee =
       <*> pTxShelleyWitnessCount
       <*> pTxByronWitnessCount
       <*> pReferenceScriptSize
+      <*> (optional $ pOutputFormatJsonOrText "calculate-min-fee")
+      <*> optional pOutputFile
       -- Deprecated options:
       <*  optional pNetworkIdDeprecated
       <*  optional pTxInCountDeprecated

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Query.hs
@@ -33,6 +33,7 @@ module Cardano.CLI.EraBased.Run.Query
   , runQueryUTxOCmd
 
   , DelegationsAndRewards(..)
+  , newOutputFormat
   , renderQueryCmdError
   , renderOpCertIntervalInformation
   , percentage

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Query.hs
@@ -1044,7 +1044,7 @@ writeProtocolState sbe mOutFile ps@(ProtocolState pstate) =
         Right chainDepstate -> liftIO . LBS.putStrLn $ encodePretty chainDepstate
 
 writeFilteredUTxOs :: Api.ShelleyBasedEra era
-                   -> Maybe QueryOutputFormat
+                   -> Maybe OutputFormatJsonOrText
                    -> Maybe (File () Out)
                    -> UTxO era
                    -> ExceptT QueryCmdError IO ()
@@ -1053,8 +1053,8 @@ writeFilteredUTxOs sbe format mOutFile utxo =
     firstExceptT QueryCmdWriteFileError . newExceptT .
       writeLazyByteStringOutput mOutFile $
         case newOutputFormat format mOutFile of
-          QueryOutputFormatJson -> encodePretty utxo
-          QueryOutputFormatText -> strictTextToLazyBytestring $ filteredUTxOsToText sbe utxo
+          OutputFormatJson -> encodePretty utxo
+          OutputFormatText -> strictTextToLazyBytestring $ filteredUTxOsToText sbe utxo
 
 filteredUTxOsToText :: Api.ShelleyBasedEra era -> UTxO era -> Text
 filteredUTxOsToText sbe (UTxO utxo) = do
@@ -1172,7 +1172,7 @@ runQueryStakePoolsCmd
 
 -- TODO: replace with writeFormattedOutput
 writeStakePools
-  :: QueryOutputFormat
+  :: OutputFormatJsonOrText
   -> Maybe (File () Out)
   -> Set PoolId
   -> ExceptT QueryCmdError IO ()
@@ -1182,18 +1182,18 @@ writeStakePools format mOutFile stakePools =
   where
     toWrite :: LBS.ByteString =
       case format of
-        QueryOutputFormatText ->
+        OutputFormatText ->
           LBS.unlines
             $ map (strictTextToLazyBytestring . serialiseToBech32)
             $ Set.toList stakePools
-        QueryOutputFormatJson ->
+        OutputFormatJson ->
           encodePretty stakePools
 
 writeFormattedOutput
   :: MonadIOTransError QueryCmdError t m
   => ToJSON a
   => Pretty a
-  => Maybe QueryOutputFormat
+  => Maybe OutputFormatJsonOrText
   -> Maybe (File b Out)
   -> a
   -> t m ()
@@ -1203,8 +1203,8 @@ writeFormattedOutput mFormat mOutFile value =
   where
     toWrite :: LBS.ByteString =
       case newOutputFormat mFormat mOutFile of
-        QueryOutputFormatText -> fromString . docToString $ pretty value
-        QueryOutputFormatJson -> encodePretty value
+        OutputFormatText -> fromString . docToString $ pretty value
+        OutputFormatJson -> encodePretty value
 
 runQueryStakeDistributionCmd :: ()
   => Cmd.QueryStakeDistributionCmdArgs
@@ -1239,7 +1239,7 @@ runQueryStakeDistributionCmd
     & onLeft left
 
 writeStakeDistribution
-  :: QueryOutputFormat
+  :: OutputFormatJsonOrText
   -> Maybe (File () Out)
   -> Map PoolId Rational
   -> ExceptT QueryCmdError IO ()
@@ -1249,8 +1249,8 @@ writeStakeDistribution format mOutFile stakeDistrib =
   where
     toWrite :: LBS.ByteString =
       case format of
-        QueryOutputFormatJson -> encodePretty stakeDistrib
-        QueryOutputFormatText -> strictTextToLazyBytestring stakeDistributionText
+        OutputFormatJson -> encodePretty stakeDistrib
+        OutputFormatText -> strictTextToLazyBytestring stakeDistributionText
     stakeDistributionText =
       Text.unlines $
         [ title
@@ -1371,9 +1371,9 @@ runQueryLeadershipScheduleCmd
         start = SystemStart $ sgSystemStart shelleyGenesis
         toWrite =
           case newOutputFormat format mOutFile' of
-            QueryOutputFormatJson ->
+            OutputFormatJson ->
               encodePretty $ leadershipScheduleToJson schedule eInfo start
-            QueryOutputFormatText ->
+            OutputFormatText ->
               strictTextToLazyBytestring $ leadershipScheduleToText schedule eInfo start
 
     leadershipScheduleToText
@@ -1660,12 +1660,12 @@ requireEon minEra era =
 -- | The output format to use, for commands with a recently introduced --output-[json,text] flag
 -- and that used to have the following default: --out-file implies JSON,
 -- output to stdout implied text.
-newOutputFormat :: Maybe QueryOutputFormat -> Maybe a -> QueryOutputFormat
+newOutputFormat :: Maybe OutputFormatJsonOrText -> Maybe a -> OutputFormatJsonOrText
 newOutputFormat format mOutFile =
   case (format, mOutFile) of
     (Just f, _) -> f -- Take flag from CLI if specified
-    (Nothing, Nothing) -> QueryOutputFormatText -- No CLI flag, writing to stdout: write text
-    (Nothing, Just _) -> QueryOutputFormatJson -- No CLI flag, writing to a file: write JSON
+    (Nothing, Nothing) -> OutputFormatText -- No CLI flag, writing to stdout: write text
+    (Nothing, Just _) ->  OutputFormatJson -- No CLI flag, writing to a file: write JSON
 
 strictTextToLazyBytestring :: Text -> LBS.ByteString
 strictTextToLazyBytestring t = BS.fromChunks [Text.encodeUtf8 t]

--- a/cardano-cli/src/Cardano/CLI/Legacy/Commands/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Commands/Query.hs
@@ -57,7 +57,7 @@ data LegacyQueryLeadershipScheduleCmdArgs = LegacyQueryLeadershipScheduleCmdArgs
   , poolColdVerKeyFile  :: !(VerificationKeyOrHashOrFile StakePoolKey)
   , vrkSkeyFp           :: !(SigningKeyFile In)
   , whichSchedule       :: !EpochLeadershipSchedule
-  , format              :: Maybe QueryOutputFormat
+  , format              :: Maybe OutputFormatJsonOrText
   , mOutFile            :: !(Maybe (File () Out))
   } deriving (Generic, Show)
 
@@ -86,7 +86,7 @@ data LegacyQueryStakePoolsCmdArgs = LegacyQueryStakePoolsCmdArgs
   { nodeSocketPath      :: !SocketPath
   , consensusModeParams :: !ConsensusModeParams
   , networkId           :: !NetworkId
-  , format              :: Maybe QueryOutputFormat
+  , format              :: Maybe OutputFormatJsonOrText
   , mOutFile            :: !(Maybe (File () Out))
   } deriving (Generic, Show)
 
@@ -94,7 +94,7 @@ data LegacyQueryStakeDistributionCmdArgs = LegacyQueryStakeDistributionCmdArgs
   { nodeSocketPath      :: !SocketPath
   , consensusModeParams :: !ConsensusModeParams
   , networkId           :: !NetworkId
-  , format              :: Maybe QueryOutputFormat
+  , format              :: Maybe OutputFormatJsonOrText
   , mOutFile            :: !(Maybe (File () Out))
   } deriving (Generic, Show)
 
@@ -111,7 +111,7 @@ data LegacyQueryUTxOCmdArgs = LegacyQueryUTxOCmdArgs
   , consensusModeParams :: !ConsensusModeParams
   , queryFilter         :: !QueryUTxOFilter
   , networkId           :: !NetworkId
-  , format              :: Maybe QueryOutputFormat
+  , format              :: Maybe OutputFormatJsonOrText
   , mOutFile            :: !(Maybe (File () Out))
   } deriving (Generic, Show)
 

--- a/cardano-cli/src/Cardano/CLI/Legacy/Commands/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Commands/Transaction.hs
@@ -122,6 +122,8 @@ data LegacyTransactionCmds
       TxShelleyWitnessCount
       TxByronWitnessCount
       ReferenceScriptSize
+      (Maybe OutputFormatJsonOrText)
+      (Maybe (File () Out))
       -- ^ The total size in bytes of the transaction reference scripts.
   | TransactionCalculateMinValueCmd
       (EraInEon ShelleyBasedEra)

--- a/cardano-cli/src/Cardano/CLI/Legacy/Options.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Options.hs
@@ -652,7 +652,7 @@ pQueryCmds envCli =
           <*> pConsensusModeParams
           <*> pQueryUTxOFilter
           <*> pNetworkId envCli
-          <*> (optional $ pQueryOutputFormat "utxo")
+          <*> (optional $ pOutputFormatJsonOrText "utxo")
           <*> pMaybeOutputFile
 
     pQueryStakePools :: Parser LegacyQueryCmds
@@ -662,7 +662,7 @@ pQueryCmds envCli =
           <$> pSocketPath envCli
           <*> pConsensusModeParams
           <*> pNetworkId envCli
-          <*> (optional $ pQueryOutputFormat "stake-pools")
+          <*> (optional $ pOutputFormatJsonOrText "stake-pools")
           <*> pMaybeOutputFile
 
     pQueryStakeDistribution :: Parser LegacyQueryCmds
@@ -672,7 +672,7 @@ pQueryCmds envCli =
         <$> pSocketPath envCli
         <*> pConsensusModeParams
         <*> pNetworkId envCli
-        <*> (optional $ pQueryOutputFormat "stake-distribution")
+        <*> (optional $ pOutputFormatJsonOrText "stake-distribution")
         <*> pMaybeOutputFile
 
     pQueryStakeAddressInfo :: Parser LegacyQueryCmds
@@ -766,7 +766,7 @@ pQueryCmds envCli =
           <*> pStakePoolVerificationKeyOrHashOrFile Nothing
           <*> pVrfSigningKeyFile
           <*> pWhichLeadershipSchedule
-          <*> (optional $ pQueryOutputFormat "leadership-schedule")
+          <*> (optional $ pOutputFormatJsonOrText "leadership-schedule")
           <*> pMaybeOutputFile
 
     pKesPeriodInfo :: Parser LegacyQueryCmds

--- a/cardano-cli/src/Cardano/CLI/Legacy/Options.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Options.hs
@@ -419,6 +419,8 @@ pTransaction envCli =
       <*> pTxShelleyWitnessCount
       <*> pTxByronWitnessCount
       <*> pReferenceScriptSize
+      <*> (optional $ pOutputFormatJsonOrText "calculate-min-fee")
+      <*> optional pOutputFile
       -- Deprecated options:
       <*  optional pNetworkIdDeprecated
       <*  optional pTxInCountDeprecated

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Transaction.hs
@@ -43,8 +43,8 @@ runLegacyTransactionCmds = \case
       runLegacyTransactionSignCmd txinfile skfiles network txoutfile
   TransactionSubmitCmd mNodeSocketPath consensusModeParams network txFp ->
       runLegacyTransactionSubmitCmd mNodeSocketPath consensusModeParams network txFp
-  TransactionCalculateMinFeeCmd txbody pParamsFile nShelleyKeyWitnesses nByronKeyWitnesses referenceScriptSize ->
-      runLegacyTransactionCalculateMinFeeCmd txbody pParamsFile nShelleyKeyWitnesses nByronKeyWitnesses referenceScriptSize
+  TransactionCalculateMinFeeCmd txbody pParamsFile nShelleyKeyWitnesses nByronKeyWitnesses referenceScriptSize format mOutFile ->
+      runLegacyTransactionCalculateMinFeeCmd txbody pParamsFile nShelleyKeyWitnesses nByronKeyWitnesses referenceScriptSize format mOutFile
   TransactionCalculateMinValueCmd (EraInEon sbe) pParamsFile txOuts' ->
       runLegacyTransactionCalculateMinValueCmd (AnyShelleyBasedEra sbe) pParamsFile txOuts'
   TransactionHashScriptDataCmd scriptDataOrFile ->
@@ -230,13 +230,17 @@ runLegacyTransactionCalculateMinFeeCmd :: ()
   -> TxShelleyWitnessCount
   -> TxByronWitnessCount
   -> ReferenceScriptSize
+  -> Maybe OutputFormatJsonOrText
+  -> Maybe (File () Out)
   -> ExceptT TxCmdError IO ()
 runLegacyTransactionCalculateMinFeeCmd
     txbodyFile
     pParamsFile
     txShelleyWitnessCount
     txByronWitnessCount
-    referenceScriptSize =
+    referenceScriptSize
+    outputFormat
+    outFile =
   runTransactionCalculateMinFeeCmd
     ( Cmd.TransactionCalculateMinFeeCmdArgs
         txbodyFile
@@ -244,6 +248,8 @@ runLegacyTransactionCalculateMinFeeCmd
         txShelleyWitnessCount
         txByronWitnessCount
         referenceScriptSize
+        outputFormat
+        outFile
     )
 
 runLegacyTransactionCalculateMinValueCmd :: ()

--- a/cardano-cli/src/Cardano/CLI/Types/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Common.hs
@@ -47,7 +47,7 @@ module Cardano.CLI.Types.Common
   , ProposalText
   , ProposalUrl(..)
   , ProtocolParamsFile(..)
-  , QueryOutputFormat(..)
+  , OutputFormatJsonOrText(..)
   , ReferenceScriptAnyEra (..)
   , ReferenceScriptSize (..)
   , RequiredSigner (..)
@@ -478,9 +478,9 @@ data TxMempoolQuery =
     | TxMempoolQueryInfo
   deriving Show
 
-data QueryOutputFormat
-  = QueryOutputFormatJson
-  | QueryOutputFormatText
+data OutputFormatJsonOrText
+  = OutputFormatJson
+  | OutputFormatText
   deriving Show
 
 data ViewOutputFormat

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Transaction/CalculateMinFee.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Transaction/CalculateMinFee.hs
@@ -1,27 +1,68 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 module Test.Golden.Shelley.Transaction.CalculateMinFee
    where
+
+import           Control.Monad (forM_)
+import           Data.Aeson ((.=))
+import qualified Data.Aeson as Aeson
+import qualified Data.Text.Lazy as TL
+import qualified Data.Text.Lazy.Encoding as TL
+import           System.FilePath ((</>))
 
 import           Test.Cardano.CLI.Util
 
 import           Hedgehog (Property)
 import qualified Hedgehog as H
+import qualified Hedgehog.Extras as H
 
 {- HLINT ignore "Use camelCase" -}
 
+-- | Execute me with:
+-- @cabal test cardano-cli-golden --test-options '-p "/golden shelley transaction calculate min fee/"'@
 hprop_golden_shelley_transaction_calculate_min_fee :: Property
-hprop_golden_shelley_transaction_calculate_min_fee = propertyOnce $ do
-  protocolParamsJsonFile <- noteInputFile "test/cardano-cli-golden/files/input/shelley/transaction-calculate-min-fee/protocol-params.json"
-  txBodyFile <- noteInputFile "test/cardano-cli-golden/files/input/shelley/tx/txbody"
+hprop_golden_shelley_transaction_calculate_min_fee = do
+  let supplyValues = [ []
+                     , ["--output-json"]
+                     , ["--output-text"]
+                     , ["--output-json", "--out-file"]
+                     , ["--output-text", "--out-file"]
+                     ]
+  propertyOnce $ forM_ supplyValues $ \flags ->
+    H.moduleWorkspace "tmp" $ \tempDir -> do
+      protocolParamsJsonFile <- noteInputFile "test/cardano-cli-golden/files/input/shelley/transaction-calculate-min-fee/protocol-params.json"
+      txBodyFile <- noteInputFile "test/cardano-cli-golden/files/input/shelley/tx/txbody"
+      let outFileFp = tempDir </> "out.txt"
+          outFile =
+            case flags of
+              _ : ["--out-file"] -> [outFileFp]
+              _ -> []
 
-  minFeeTxt <- execCardanoCLI
-    [ "transaction","calculate-min-fee"
-    , "--byron-witness-count", "10"
-    , "--witness-count", "5"
-    , "--protocol-params-file", protocolParamsJsonFile
-    , "--reference-script-size", "0"
-    , "--tx-body-file", txBodyFile
-    ]
+      minFeeTxt <- execCardanoCLI $
+        [ "transaction","calculate-min-fee"
+        , "--byron-witness-count", "10"
+        , "--witness-count", "5"
+        , "--protocol-params-file", protocolParamsJsonFile
+        , "--reference-script-size", "0"
+        , "--tx-body-file", txBodyFile
+        ] ++ flags
+          ++ outFile
 
-  H.diff minFeeTxt (==) "2050100 Lovelace\n"
+      case flags of
+        [] ->
+          H.diff minFeeTxt (==) "2050100 Lovelace\n"
+        ["--output-text"] ->
+          H.diff minFeeTxt (==) "2050100 Lovelace\n"
+        ["--output-text", "--out-file"] -> do
+          textOnDisk <- H.readFile outFileFp
+          H.diff textOnDisk (==) "2050100 Lovelace"
+        ["--output-json"] -> do
+          let jsonFromStdout = Aeson.decode $ TL.encodeUtf8 $ TL.pack minFeeTxt
+          H.diff jsonFromStdout (==) (Just $ Aeson.object ["fee" .= (2050100 :: Int)])
+        ["--output-json", "--out-file"] -> do
+          jsonOnDisk :: Aeson.Value <- H.readJsonFileOk outFileFp
+          H.diff jsonOnDisk (==) (Aeson.object ["fee" .= (2050100 :: Int)])
+        _ -> do
+          H.note_ ("Unexpected flags:" <> show flags)
+          H.assert False

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -1145,6 +1145,10 @@ Usage: cardano-cli shelley transaction calculate-min-fee --tx-body-file FILE
                                                            --witness-count NATURAL
                                                            [--byron-witness-count NATURAL]
                                                            [--reference-script-size NATURAL]
+                                                           [ --output-json
+                                                           | --output-text
+                                                           ]
+                                                           [--out-file FILE]
                                                            [ --mainnet
                                                            | --testnet-magic NATURAL
                                                            ]
@@ -2340,6 +2344,10 @@ Usage: cardano-cli allegra transaction calculate-min-fee --tx-body-file FILE
                                                            --witness-count NATURAL
                                                            [--byron-witness-count NATURAL]
                                                            [--reference-script-size NATURAL]
+                                                           [ --output-json
+                                                           | --output-text
+                                                           ]
+                                                           [--out-file FILE]
                                                            [ --mainnet
                                                            | --testnet-magic NATURAL
                                                            ]
@@ -3652,6 +3660,10 @@ Usage: cardano-cli mary transaction calculate-min-fee --tx-body-file FILE
                                                         --witness-count NATURAL
                                                         [--byron-witness-count NATURAL]
                                                         [--reference-script-size NATURAL]
+                                                        [ --output-json
+                                                        | --output-text
+                                                        ]
+                                                        [--out-file FILE]
                                                         [ --mainnet
                                                         | --testnet-magic NATURAL
                                                         ]
@@ -4981,6 +4993,10 @@ Usage: cardano-cli alonzo transaction calculate-min-fee --tx-body-file FILE
                                                           --witness-count NATURAL
                                                           [--byron-witness-count NATURAL]
                                                           [--reference-script-size NATURAL]
+                                                          [ --output-json
+                                                          | --output-text
+                                                          ]
+                                                          [--out-file FILE]
                                                           [ --mainnet
                                                           | --testnet-magic NATURAL
                                                           ]
@@ -6335,6 +6351,10 @@ Usage: cardano-cli babbage transaction calculate-min-fee --tx-body-file FILE
                                                            --witness-count NATURAL
                                                            [--byron-witness-count NATURAL]
                                                            [--reference-script-size NATURAL]
+                                                           [ --output-json
+                                                           | --output-text
+                                                           ]
+                                                           [--out-file FILE]
                                                            [ --mainnet
                                                            | --testnet-magic NATURAL
                                                            ]
@@ -8164,6 +8184,10 @@ Usage: cardano-cli conway transaction calculate-min-fee --tx-body-file FILE
                                                           --witness-count NATURAL
                                                           [--byron-witness-count NATURAL]
                                                           [--reference-script-size NATURAL]
+                                                          [ --output-json
+                                                          | --output-text
+                                                          ]
+                                                          [--out-file FILE]
                                                           [ --mainnet
                                                           | --testnet-magic NATURAL
                                                           ]
@@ -9515,6 +9539,10 @@ Usage: cardano-cli latest transaction calculate-min-fee --tx-body-file FILE
                                                           --witness-count NATURAL
                                                           [--byron-witness-count NATURAL]
                                                           [--reference-script-size NATURAL]
+                                                          [ --output-json
+                                                          | --output-text
+                                                          ]
+                                                          [--out-file FILE]
                                                           [ --mainnet
                                                           | --testnet-magic NATURAL
                                                           ]
@@ -10556,6 +10584,10 @@ Usage: cardano-cli legacy transaction calculate-min-fee --tx-body-file FILE
                                                           --witness-count NATURAL
                                                           [--byron-witness-count NATURAL]
                                                           [--reference-script-size NATURAL]
+                                                          [ --output-json
+                                                          | --output-text
+                                                          ]
+                                                          [--out-file FILE]
                                                           [ --mainnet
                                                           | --testnet-magic NATURAL
                                                           ]
@@ -11778,6 +11810,10 @@ Usage: cardano-cli transaction calculate-min-fee --tx-body-file FILE
                                                    --witness-count NATURAL
                                                    [--byron-witness-count NATURAL]
                                                    [--reference-script-size NATURAL]
+                                                   [ --output-json
+                                                   | --output-text
+                                                   ]
+                                                   [--out-file FILE]
                                                    [ --mainnet
                                                    | --testnet-magic NATURAL
                                                    ]

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_transaction_calculate-min-fee.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_transaction_calculate-min-fee.cli
@@ -3,6 +3,10 @@ Usage: cardano-cli allegra transaction calculate-min-fee --tx-body-file FILE
                                                            --witness-count NATURAL
                                                            [--byron-witness-count NATURAL]
                                                            [--reference-script-size NATURAL]
+                                                           [ --output-json
+                                                           | --output-text
+                                                           ]
+                                                           [--out-file FILE]
                                                            [ --mainnet
                                                            | --testnet-magic NATURAL
                                                            ]
@@ -21,6 +25,11 @@ Available options:
   --reference-script-size NATURAL
                            Total size in bytes of transaction reference scripts
                            (default is 0).
+  --output-json            Format calculate-min-fee query output to JSON.
+                           Default format when writing to a file
+  --output-text            Format calculate-min-fee query output to TEXT.
+                           Default format when writing to stdout
+  --out-file FILE          The output file.
   --mainnet                DEPRECATED. This argument has no effect.
   --testnet-magic NATURAL  DEPRECATED. This argument has no effect.
   --tx-in-count NATURAL    DEPRECATED. This argument has no effect.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_transaction_calculate-min-fee.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_transaction_calculate-min-fee.cli
@@ -3,6 +3,10 @@ Usage: cardano-cli alonzo transaction calculate-min-fee --tx-body-file FILE
                                                           --witness-count NATURAL
                                                           [--byron-witness-count NATURAL]
                                                           [--reference-script-size NATURAL]
+                                                          [ --output-json
+                                                          | --output-text
+                                                          ]
+                                                          [--out-file FILE]
                                                           [ --mainnet
                                                           | --testnet-magic NATURAL
                                                           ]
@@ -21,6 +25,11 @@ Available options:
   --reference-script-size NATURAL
                            Total size in bytes of transaction reference scripts
                            (default is 0).
+  --output-json            Format calculate-min-fee query output to JSON.
+                           Default format when writing to a file
+  --output-text            Format calculate-min-fee query output to TEXT.
+                           Default format when writing to stdout
+  --out-file FILE          The output file.
   --mainnet                DEPRECATED. This argument has no effect.
   --testnet-magic NATURAL  DEPRECATED. This argument has no effect.
   --tx-in-count NATURAL    DEPRECATED. This argument has no effect.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_transaction_calculate-min-fee.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_transaction_calculate-min-fee.cli
@@ -3,6 +3,10 @@ Usage: cardano-cli babbage transaction calculate-min-fee --tx-body-file FILE
                                                            --witness-count NATURAL
                                                            [--byron-witness-count NATURAL]
                                                            [--reference-script-size NATURAL]
+                                                           [ --output-json
+                                                           | --output-text
+                                                           ]
+                                                           [--out-file FILE]
                                                            [ --mainnet
                                                            | --testnet-magic NATURAL
                                                            ]
@@ -21,6 +25,11 @@ Available options:
   --reference-script-size NATURAL
                            Total size in bytes of transaction reference scripts
                            (default is 0).
+  --output-json            Format calculate-min-fee query output to JSON.
+                           Default format when writing to a file
+  --output-text            Format calculate-min-fee query output to TEXT.
+                           Default format when writing to stdout
+  --out-file FILE          The output file.
   --mainnet                DEPRECATED. This argument has no effect.
   --testnet-magic NATURAL  DEPRECATED. This argument has no effect.
   --tx-in-count NATURAL    DEPRECATED. This argument has no effect.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_calculate-min-fee.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_calculate-min-fee.cli
@@ -3,6 +3,10 @@ Usage: cardano-cli conway transaction calculate-min-fee --tx-body-file FILE
                                                           --witness-count NATURAL
                                                           [--byron-witness-count NATURAL]
                                                           [--reference-script-size NATURAL]
+                                                          [ --output-json
+                                                          | --output-text
+                                                          ]
+                                                          [--out-file FILE]
                                                           [ --mainnet
                                                           | --testnet-magic NATURAL
                                                           ]
@@ -21,6 +25,11 @@ Available options:
   --reference-script-size NATURAL
                            Total size in bytes of transaction reference scripts
                            (default is 0).
+  --output-json            Format calculate-min-fee query output to JSON.
+                           Default format when writing to a file
+  --output-text            Format calculate-min-fee query output to TEXT.
+                           Default format when writing to stdout
+  --out-file FILE          The output file.
   --mainnet                DEPRECATED. This argument has no effect.
   --testnet-magic NATURAL  DEPRECATED. This argument has no effect.
   --tx-in-count NATURAL    DEPRECATED. This argument has no effect.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_transaction_calculate-min-fee.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_transaction_calculate-min-fee.cli
@@ -3,6 +3,10 @@ Usage: cardano-cli latest transaction calculate-min-fee --tx-body-file FILE
                                                           --witness-count NATURAL
                                                           [--byron-witness-count NATURAL]
                                                           [--reference-script-size NATURAL]
+                                                          [ --output-json
+                                                          | --output-text
+                                                          ]
+                                                          [--out-file FILE]
                                                           [ --mainnet
                                                           | --testnet-magic NATURAL
                                                           ]
@@ -21,6 +25,11 @@ Available options:
   --reference-script-size NATURAL
                            Total size in bytes of transaction reference scripts
                            (default is 0).
+  --output-json            Format calculate-min-fee query output to JSON.
+                           Default format when writing to a file
+  --output-text            Format calculate-min-fee query output to TEXT.
+                           Default format when writing to stdout
+  --out-file FILE          The output file.
   --mainnet                DEPRECATED. This argument has no effect.
   --testnet-magic NATURAL  DEPRECATED. This argument has no effect.
   --tx-in-count NATURAL    DEPRECATED. This argument has no effect.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_transaction_calculate-min-fee.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_transaction_calculate-min-fee.cli
@@ -3,6 +3,10 @@ Usage: cardano-cli legacy transaction calculate-min-fee --tx-body-file FILE
                                                           --witness-count NATURAL
                                                           [--byron-witness-count NATURAL]
                                                           [--reference-script-size NATURAL]
+                                                          [ --output-json
+                                                          | --output-text
+                                                          ]
+                                                          [--out-file FILE]
                                                           [ --mainnet
                                                           | --testnet-magic NATURAL
                                                           ]
@@ -21,6 +25,11 @@ Available options:
   --reference-script-size NATURAL
                            Total size in bytes of transaction reference scripts
                            (default is 0).
+  --output-json            Format calculate-min-fee query output to JSON.
+                           Default format when writing to a file
+  --output-text            Format calculate-min-fee query output to TEXT.
+                           Default format when writing to stdout
+  --out-file FILE          The output file.
   --mainnet                DEPRECATED. This argument has no effect.
   --testnet-magic NATURAL  DEPRECATED. This argument has no effect.
   --tx-in-count NATURAL    DEPRECATED. This argument has no effect.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_transaction_calculate-min-fee.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_transaction_calculate-min-fee.cli
@@ -3,6 +3,10 @@ Usage: cardano-cli mary transaction calculate-min-fee --tx-body-file FILE
                                                         --witness-count NATURAL
                                                         [--byron-witness-count NATURAL]
                                                         [--reference-script-size NATURAL]
+                                                        [ --output-json
+                                                        | --output-text
+                                                        ]
+                                                        [--out-file FILE]
                                                         [ --mainnet
                                                         | --testnet-magic NATURAL
                                                         ]
@@ -21,6 +25,11 @@ Available options:
   --reference-script-size NATURAL
                            Total size in bytes of transaction reference scripts
                            (default is 0).
+  --output-json            Format calculate-min-fee query output to JSON.
+                           Default format when writing to a file
+  --output-text            Format calculate-min-fee query output to TEXT.
+                           Default format when writing to stdout
+  --out-file FILE          The output file.
   --mainnet                DEPRECATED. This argument has no effect.
   --testnet-magic NATURAL  DEPRECATED. This argument has no effect.
   --tx-in-count NATURAL    DEPRECATED. This argument has no effect.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_transaction_calculate-min-fee.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_transaction_calculate-min-fee.cli
@@ -3,6 +3,10 @@ Usage: cardano-cli shelley transaction calculate-min-fee --tx-body-file FILE
                                                            --witness-count NATURAL
                                                            [--byron-witness-count NATURAL]
                                                            [--reference-script-size NATURAL]
+                                                           [ --output-json
+                                                           | --output-text
+                                                           ]
+                                                           [--out-file FILE]
                                                            [ --mainnet
                                                            | --testnet-magic NATURAL
                                                            ]
@@ -21,6 +25,11 @@ Available options:
   --reference-script-size NATURAL
                            Total size in bytes of transaction reference scripts
                            (default is 0).
+  --output-json            Format calculate-min-fee query output to JSON.
+                           Default format when writing to a file
+  --output-text            Format calculate-min-fee query output to TEXT.
+                           Default format when writing to stdout
+  --out-file FILE          The output file.
   --mainnet                DEPRECATED. This argument has no effect.
   --testnet-magic NATURAL  DEPRECATED. This argument has no effect.
   --tx-in-count NATURAL    DEPRECATED. This argument has no effect.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/transaction_calculate-min-fee.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/transaction_calculate-min-fee.cli
@@ -3,6 +3,10 @@ Usage: cardano-cli transaction calculate-min-fee --tx-body-file FILE
                                                    --witness-count NATURAL
                                                    [--byron-witness-count NATURAL]
                                                    [--reference-script-size NATURAL]
+                                                   [ --output-json
+                                                   | --output-text
+                                                   ]
+                                                   [--out-file FILE]
                                                    [ --mainnet
                                                    | --testnet-magic NATURAL
                                                    ]
@@ -21,6 +25,11 @@ Available options:
   --reference-script-size NATURAL
                            Total size in bytes of transaction reference scripts
                            (default is 0).
+  --output-json            Format calculate-min-fee query output to JSON.
+                           Default format when writing to a file
+  --output-text            Format calculate-min-fee query output to TEXT.
+                           Default format when writing to stdout
+  --out-file FILE          The output file.
   --mainnet                DEPRECATED. This argument has no effect.
   --testnet-magic NATURAL  DEPRECATED. This argument has no effect.
   --tx-in-count NATURAL    DEPRECATED. This argument has no effect.


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Add output options flags to calculate-min-fee
# uncomment types applicable to the change:
  type:
  - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

* Fixes https://github.com/IntersectMBO/cardano-cli/issues/802
* Doesn't change the existing behavior: when no output flag is passed, text is written on stdout

# How to trust this PR

Look at the added tests. Check they implement the expected behavior.

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [X] Self-reviewed the diff