### PR TITLE
Enable aarch64-linux but disable it in hydra

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -16,10 +16,7 @@
     supportedSystems = [
       "x86_64-linux"
       "x86_64-darwin"
-      # this is slow as we don't have aarch64-linux native builders as of 2024-04-03
-      # disabling to reduce CI time initially. Uncomment later
-      # When you uncomment, lookup the "TODO generalize" comments in release-upload.yaml
-      # "aarch64-linux"
+      "aarch64-linux"
       "aarch64-darwin"
     ];
 
@@ -183,9 +180,8 @@
           }
         );
       in
-        lib.recursiveUpdate flake rec {
+        (lib.recursiveUpdate flake rec {
           project = cabalProject;
-          # add a required job, that's basically all hydraJobs.
           hydraJobs =
             nixpkgs.callPackages inputs.iohkNix.utils.ciJobsAggregates
             {
@@ -221,7 +217,11 @@
 
           # formatter used by nix fmt
           formatter = nixpkgs.alejandra;
-        }
+      })
+      # Disable aarch64-linux hydraJobs as we don't have any native builders for this architecture
+      # as of 2024-07-15 so this would choke the CI. aarch64-linux binary building is enabled through
+      # cross-compilation.
+      // lib.optionalAttrs (system == "aarch64-linux") { hydraJobs = { }; }
     );
 
   nixConfig = {


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Enable aarch64-linux but disable it in hydra
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
   - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

[We don't have aarch64-linux native builders for now](https://github.com/IntersectMBO/cardano-cli/pull/686#issuecomment-2033090278). This PR simply enables this architecture in flake, but it does not build it in hydra. 

Fixes #805.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
