### PR TITLE
Fix production of Linux static binaries in release workflow

### DIFF
--- a/.github/workflows/release-upload.yml
+++ b/.github/workflows/release-upload.yml
@@ -159,10 +159,10 @@ jobs:
               derivation+="${{ matrix.arch }}"
               ;;
             "x86_64-linux")
-              derivation+="x86_64-linux.x86_64-unknown-linux-musl"
+              derivation+="x86_64-linux.ghc965-x86_64-unknown-linux-musl"
               ;;
             "aarch64-linux")
-              derivation+="x86_64-linux.aarch64-unknown-linux-musl"
+              derivation+="x86_64-linux.ghc965-aarch64-unknown-linux-musl"
               ;;
             *)
               echo "Unexpected matrix.arch value: ${{ matrix.arch }}"

--- a/flake.nix
+++ b/flake.nix
@@ -23,7 +23,7 @@
     # see flake `variants` below for alternative compilers
     defaultCompiler = "ghc982";
     haddockShellCompiler = defaultCompiler;
-    mingwVersion = "ghc965";
+    mingwVersion = "ghc965"; # Used for cross compilation, and so referenced in .github/workflows/release-upload.yml. Adapt the latter if you change this value.
     cabalHeadOverlay = final: prev: {
       cabal-head =
         (final.haskell-nix.cabalProject {


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Fix production of static binaries in releases (by adapting to changes in Hydra's job names)
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

* Make https://github.com/IntersectMBO/cardano-cli/pull/819 work again
* Fixes https://github.com/IntersectMBO/cardano-cli/issues/838

# How to trust this PR

This PR's new workflow was triggered manually as follows:

```shell
gh workflow run .github/workflows/release-upload.yml -r $(git branch --show-current) -f target_tag=e5bb0adc4d43f1470619f7fcf5a4831f20910100
```

This makes this PR's workflow download the binaries from commit e5bb0adc4d43f1470619f7fcf5a4831f20910100 (which is on `main`). The workflow succeeded as visible here: https://github.com/IntersectMBO/cardano-cli/actions/runs/9959206931

Then you can download the artifact: 

![image](https://github.com/user-attachments/assets/0799e665-5808-4330-a010-b16d04c41b07)

And run `file` on it:

```shell
05:13:57 HOME/Downloads → file ./cardano-cli-x86_64-linux
./cardano-cli-x86_64-linux: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, not stripped
```