### PR TITLE
Add support for relative files and rebasing

### DIFF
--- a/scripts/devshell/prettify
+++ b/scripts/devshell/prettify
@@ -6,24 +6,26 @@ show_help() {
     echo "Format Haskell source files using fourmolu and stylish-haskell."
     echo ""
     echo "Options:"
-    echo "  -t, --tracked     Format all tracked Haskell (*.hs) files in the repository"
-    echo "  -s, --staged      Format all staged Haskell (*.hs) files"
-    echo "  -m, --modified    Format all modified Haskell (*.hs) files, including staged and unstaged"
-    echo "  -n, --not-staged  Format all non-staged modified Haskell (*.hs) files"
-    echo "  -h, --help        Show this help message"
+    echo "  -t, --tracked           Format all tracked Haskell (*.hs) files in the repository"
+    echo "  -s, --staged            Format all staged Haskell (*.hs) files"
+    echo "  -m, --modified          Format all modified Haskell (*.hs) files, including staged and unstaged"
+    echo "  -n, --not-staged        Format all non-staged modified Haskell (*.hs) files"
+    echo "  -p, --previous-commit   Format all Haskell (*.hs) files modified before the last commit (HEAD~1)"
+    echo "  -h, --help              Show this help message"
 }
 
 # Function to run the formatting commands
 run_format() {
+    top_level=$(git rev-parse --show-toplevel) 
     for file in "$@"; do
         if [[ $file == *.hs ]]; then
-            if grep -qE '^#' "$file"; then
+            if grep -qE '^#' "$top_level/$file"; then
               echo "$file contains CPP.  Skipping."
             else
               echo "Formatting: $file"
-              fourmolu -q -i "$file"
-              fourmolu -q -i "$file"
-              stylish-haskell -i "$file"
+              fourmolu -q -i "$top_level/$file"
+              fourmolu -q -i "$top_level/$file"
+              stylish-haskell -i "$top_level/$file"
             fi
         fi
     done
@@ -44,6 +46,9 @@ case $1 in
         ;;
     -n|--not-staged)
         files=$(git diff --name-only --diff-filter=ACM '*.hs')
+        ;;
+    -p|--previous-commit)
+        files=$(git diff --name-only --diff-filter=ACM HEAD~1 '*.hs')
         ;;
     -h|--help)
         show_help


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Added support for relative files and rebasing to the prettify tool
# uncomment types applicable to the change:
  type:
  - maintenance    # not directly related to the code
```

# Context

When rebasing there was no option of `prettify` that would work (because changes while rebasing are neither staged nor unstaged, they are in the previous commit). So this PR adds an option `-p` that diffs against `HEAD~1`.

Also the tool would not work unless run from the top level in the repo, which is kind of inconvenient. So this change make `prettify` work from any subfolder.

[Twin PR #589 in cardano-api](https://github.com/IntersectMBO/cardano-api/pull/589)

# How to trust this PR

Probably testing is the best way to ensure it works. But they are few changes, so a quick look at the diff would also be nice.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
