### PR TITLE
Use `IsList(toList,fromList)` instead of specialised functions

### DIFF
--- a/cardano-cli/src/Cardano/CLI/Byron/Tx.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Tx.hs
@@ -52,6 +52,7 @@ import           Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
 import           Formatting (sformat, (%))
+import           GHC.Exts (IsList (..))
 
 data ByronTxError
   = TxDeserialisationFailed !FilePath !Binary.DecoderError
@@ -109,7 +110,7 @@ genesisUTxOTxIn gc vk genAddr =
     Map.fromList
       . mapMaybe (\(inp, out) -> mkEntry inp genAddr <$> keyMatchesUTxO vk out)
       . fromCompactTxInTxOutList
-      . Map.toList
+      . toList
       . UTxO.unUTxO
       . UTxO.genesisUtxo
       $ gc

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Genesis.hs
@@ -93,6 +93,7 @@ import qualified Data.Text as Text
 import qualified Data.Text.IO as Text
 import           Data.Word (Word64)
 import qualified Data.Yaml as Yaml
+import           GHC.Exts (IsList (..))
 import           GHC.Generics (Generic)
 import           Lens.Micro ((^.))
 import           System.Directory (createDirectoryIfMissing, listDirectory)
@@ -810,7 +811,7 @@ updateOutputTemplate
         | ( GenesisKeyHash gh
             , (GenesisDelegateKeyHash gdh, VrfKeyHash h)
             ) <-
-            Map.toList genDelegMap
+            toList genDelegMap
         ]
 
     unLovelace :: Integral a => L.Coin -> a
@@ -1137,7 +1138,7 @@ updateTemplate
         | ( GenesisKeyHash gh
             , (GenesisDelegateKeyHash gdh, VrfKeyHash h)
             ) <-
-            Map.toList genDelegMap
+            toList genDelegMap
         ]
 
     unLovelace :: Integral a => L.Coin -> a

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Genesis/CreateTestnetData.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Genesis/CreateTestnetData.hs
@@ -759,7 +759,7 @@ updateOutputTemplate
         | ( GenesisKeyHash gh
             , (GenesisDelegateKeyHash gdh, VrfKeyHash h)
             ) <-
-            Map.toList genDelegMap
+            toList genDelegMap
         ]
 
     unLovelace :: Integral a => L.Coin -> a

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Query.hs
@@ -90,6 +90,7 @@ import qualified Data.Text.Encoding as Text
 import qualified Data.Text.IO as T
 import qualified Data.Text.Lazy.IO as LT
 import           Data.Time.Clock
+import           GHC.Exts (IsList (..))
 import           GHC.Generics
 import           Lens.Micro ((^.))
 import           Numeric (showEFloat)
@@ -1036,7 +1037,7 @@ writeStakeAddressInfo
     merged =
       [ (addr, mBalance, mPoolId, mDRep, mDeposit)
       | addr <-
-          Set.toList
+          toList
             ( Set.unions
                 [ Map.keysSet stakeAccountBalances
                 , Map.keysSet stakePools
@@ -1102,7 +1103,7 @@ writePoolState mOutFile serialisedCurrentEpochState = do
       & onLeft (left . QueryCmdPoolStateDecodeError)
 
   let hks =
-        Set.toList $
+        toList $
           Set.fromList $
             Map.keys (L.psStakePoolParams poolState)
               <> Map.keys (L.psFutureStakePoolParams poolState)
@@ -1188,17 +1189,17 @@ filteredUTxOsToText sbe (UTxO utxo) = do
     [ Text.unlines [title, Text.replicate (Text.length title + 2) "-"]
     , Text.unlines $ case sbe of
         ShelleyBasedEraShelley ->
-          map (utxoToText sbe) $ Map.toList utxo
+          map (utxoToText sbe) $ toList utxo
         ShelleyBasedEraAllegra ->
-          map (utxoToText sbe) $ Map.toList utxo
+          map (utxoToText sbe) $ toList utxo
         ShelleyBasedEraMary ->
-          map (utxoToText sbe) $ Map.toList utxo
+          map (utxoToText sbe) $ toList utxo
         ShelleyBasedEraAlonzo ->
-          map (utxoToText sbe) $ Map.toList utxo
+          map (utxoToText sbe) $ toList utxo
         ShelleyBasedEraBabbage ->
-          map (utxoToText sbe) $ Map.toList utxo
+          map (utxoToText sbe) $ toList utxo
         ShelleyBasedEraConway ->
-          map (utxoToText sbe) $ Map.toList utxo
+          map (utxoToText sbe) $ toList utxo
     ]
  where
   title :: Text
@@ -1314,7 +1315,7 @@ writeStakePools format mOutFile stakePools =
       OutputFormatText ->
         LBS.unlines $
           map (strictTextToLazyBytestring . serialiseToBech32) $
-            Set.toList stakePools
+            toList stakePools
       OutputFormatJson ->
         encodePretty stakePools
 
@@ -1390,7 +1391,7 @@ writeStakeDistribution format mOutFile stakeDistrib =
       [ title
       , Text.replicate (Text.length title + 2) "-"
       ]
-        ++ [showStakeDistr poolId stakeFraction | (poolId, stakeFraction) <- Map.toList stakeDistrib]
+        ++ [showStakeDistr poolId stakeFraction | (poolId, stakeFraction) <- toList stakeDistrib]
    where
     title :: Text
     title =
@@ -1541,7 +1542,7 @@ runQueryLeadershipScheduleCmd
       Text.unlines $
         title
           : Text.replicate (Text.length title + 2) "-"
-          : [showLeadershipSlot slot eInfo sStart | slot <- Set.toList leadershipSlots]
+          : [showLeadershipSlot slot eInfo sStart | slot <- toList leadershipSlots]
      where
       title :: Text
       title =
@@ -1574,7 +1575,7 @@ runQueryLeadershipScheduleCmd
       -> SystemStart
       -> [Aeson.Value]
     leadershipScheduleToJson leadershipSlots eInfo sStart =
-      showLeadershipSlot <$> List.sort (Set.toList leadershipSlots)
+      showLeadershipSlot <$> List.sort (toList leadershipSlots)
      where
       showLeadershipSlot :: SlotNo -> Aeson.Value
       showLeadershipSlot lSlot@(SlotNo sn) =

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Transaction.hs
@@ -199,7 +199,7 @@ runTransactionBuildCmd
           <$> readTxGovernanceActions eon proposalFiles
 
     -- the same collateral input can be used for several plutus scripts
-    let filteredTxinsc = Set.toList $ Set.fromList txinsc
+    let filteredTxinsc = toList $ Set.fromList txinsc
 
     let allReferenceInputs =
           getAllReferenceInputs
@@ -377,7 +377,7 @@ runTransactionBuildEstimateCmd -- TODO change type
     txOuts <- mapM (toTxOutInAnyEra sbe) txouts
 
     -- the same collateral input can be used for several plutus scripts
-    let filteredTxinsc = Set.toList $ Set.fromList txInsCollateral
+    let filteredTxinsc = toList $ Set.fromList txInsCollateral
 
     -- Conway related
     votingProceduresAndMaybeScriptWits <-
@@ -616,7 +616,7 @@ runTransactionBuildRawCmd
     txOuts <- mapM (toTxOutInAnyEra eon) txouts
 
     -- the same collateral input can be used for several plutus scripts
-    let filteredTxinsc = Set.toList $ Set.fromList txInsCollateral
+    let filteredTxinsc = toList $ Set.fromList txInsCollateral
 
     -- Conway related
     votingProceduresAndMaybeScriptWits <-

--- a/cardano-cli/src/Cardano/CLI/Json/Friendly.hs
+++ b/cardano-cli/src/Cardano/CLI/Json/Friendly.hs
@@ -45,7 +45,6 @@ import           Cardano.Api.Shelley (Address (ShelleyAddress), Hash (..),
 
 import           Cardano.CLI.Types.Common (ViewOutputFormat (..))
 import           Cardano.CLI.Types.MonadWarning (MonadWarning, eitherToWarning, runWarningIO)
-import           Cardano.Prelude (Foldable (..), first)
 
 import           Codec.CBOR.Encoding (Encoding)
 import           Codec.CBOR.FlatTerm (fromFlatTerm, toFlatTerm)
@@ -55,6 +54,7 @@ import qualified Data.Aeson as Aeson
 import qualified Data.Aeson.Encode.Pretty as Aeson
 import qualified Data.Aeson.Key as Aeson
 import qualified Data.Aeson.Types as Aeson
+import           Data.Bifunctor (first)
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as BSC
 import qualified Data.ByteString.Lazy as LBS
@@ -69,6 +69,7 @@ import qualified Data.Vector as Vector
 import           Data.Yaml (array)
 import           Data.Yaml.Pretty (setConfCompare)
 import qualified Data.Yaml.Pretty as Yaml
+import           GHC.Exts (IsList (..))
 import           GHC.Real (denominator)
 import           GHC.Unicode (isAlphaNum)
 
@@ -663,7 +664,7 @@ friendlyMirTarget sbe = \case
             [ friendlyStakeCredential credential
             , "amount" .= friendlyLovelace (L.Coin 0 `L.addDeltaCoin` lovelace)
             ]
-         | (credential, lovelace) <- Map.toList (shelleyBasedEraConstraints sbe addresses)
+         | (credential, lovelace) <- shelleyBasedEraConstraints sbe $ toList addresses
          ]
   L.SendToOppositePotMIR amount -> "MIR amount" .= friendlyLovelace amount
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Genesis/Create.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/Genesis/Create.hs
@@ -10,7 +10,6 @@ where
 import           Control.Monad (void)
 import qualified Data.Aeson as J
 import qualified Data.Aeson.Key as J
-import qualified Data.Aeson.KeyMap as KeyMap
 import qualified Data.Aeson.Types as J
 import           Data.Bifunctor (Bifunctor (..))
 import qualified Data.ByteString.Lazy as LBS
@@ -18,6 +17,7 @@ import           Data.Foldable (for_)
 import qualified Data.HashMap.Lazy as HM
 import qualified Data.Set as S
 import qualified Data.Time.Clock as DT
+import           GHC.Exts (IsList (..))
 
 import           Test.Cardano.CLI.Aeson (assertHasMappings)
 import           Test.Cardano.CLI.Util as OP
@@ -42,7 +42,7 @@ parseSystemStart :: J.Value -> J.Parser String
 parseSystemStart = J.withObject "Object" $ \o -> o J..: "systemStart"
 
 parseHashMap :: J.Value -> J.Parser (HM.HashMap String J.Value)
-parseHashMap (J.Object hm) = pure $ HM.fromList $ fmap (first J.toString) (KeyMap.toList hm)
+parseHashMap (J.Object hm) = pure $ HM.fromList $ fmap (first J.toString) (toList hm)
 parseHashMap v = J.typeMismatch "Object" v
 
 parseDelegateCount :: J.Value -> J.Parser Int
@@ -56,17 +56,17 @@ parseDelegateKey = J.withObject "Object" $ \o -> o J..: "delegate"
 parseDelegateKeys :: J.Value -> J.Parser [String]
 parseDelegateKeys = J.withObject "Object" $ \o -> do
   delegates <- (o J..: "genDelegs") >>= parseHashMap
-  sequence $ fmap (parseDelegateKey . snd) (HM.toList delegates)
+  sequence $ fmap (parseDelegateKey . snd) (toList delegates)
 
 parseHashKeys :: J.Value -> J.Parser [String]
 parseHashKeys = J.withObject "Object" $ \o -> do
   delegates <- (o J..: "genDelegs") >>= parseHashMap
-  pure $ fmap fst (HM.toList delegates)
+  pure $ fmap fst (toList delegates)
 
 parseTotalSupply :: J.Value -> J.Parser Int
 parseTotalSupply = J.withObject "Object" $ \o -> do
   initialFunds <- (o J..: "initialFunds") >>= parseHashMap
-  fmap sum (sequence (fmap (J.parseJSON @Int . snd) (HM.toList initialFunds)))
+  fmap sum (sequence (fmap (J.parseJSON @Int . snd) (toList initialFunds)))
 
 hprop_golden_shelleyGenesisCreate :: Property
 hprop_golden_shelleyGenesisCreate = propertyOnce $ do


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Use `IsList(toList,fromList)` instead of specialised functions
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
   - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Replaced specialized `toList` and `fromList` with `IsList(toList, fromList)` functions. This reduces mental overhead when writing code - you don't have to wonder which collection are you converting to/from anymore.


# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
