### PR TITLE
Create toJSON instance for "query drep-state" output

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Query.hs
@@ -248,11 +248,6 @@ data QueryDRepStateCmdArgs era = QueryDRepStateCmdArgs
   }
   deriving Show
 
--- | Whether to include the stake, as queried by drep-stake-distribution, in
--- the output of drep-state. This is (computationally) expensive, but sometimes
--- convenient.
-data IncludeStake = WithStake | NoStake deriving Show
-
 data QueryDRepStakeDistributionCmdArgs era = QueryDRepStakeDistributionCmdArgs
   { eon :: !(ConwayEraOnwards era)
   , nodeSocketPath :: !SocketPath

--- a/cardano-cli/src/Cardano/CLI/Types/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Common.hs
@@ -27,6 +27,7 @@ module Cardano.CLI.Types.Common
   , GenesisDir (..)
   , GenesisFile (..)
   , GenesisKeyFile (..)
+  , IncludeStake (..)
   , InputTxBodyOrTxFile (..)
   , KeyOutputFormat (..)
   , MetadataFile (..)
@@ -158,6 +159,11 @@ data StakeDelegators = StakeDelegators
   -- ^ The number of stake credentials to generate
   }
   deriving Show
+
+-- | Whether to include the stake, as queried by drep-stake-distribution, in
+-- the output of drep-state. This is (computationally) expensive, but sometimes
+-- convenient.
+data IncludeStake = WithStake | NoStake deriving Show
 
 data DRepCredentials = DRepCredentials
   { dRepCredentialGenerationMode :: !CredentialGenerationMode


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Create toJSON instance for `query drep-state` output. Haskell users can know use this type to parse back `query drep-state`'s output to a Haskell value automatically.
# uncomment types applicable to the change:
  type:
  - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Fixes https://github.com/IntersectMBO/cardano-cli/issues/606

# How to trust this PR

* Use this version of `cardano-node`: https://github.com/IntersectMBO/cardano-node/pull/5943
* Execute the test running `query drep-state` with `RECREATE_GOLDEN_FILES=1 cabal test cardano-testnet-test --test-options '-p "/CliQueries/"'`. Observe that the test with the golden file still passes.

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] Self-reviewed the diff