### PR TITLE
Avoid using Opt.auto to avoid overflows going silent

### DIFF
--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -323,6 +323,7 @@ test-suite cardano-cli-test
     filepath,
     hedgehog,
     hedgehog-extras ^>=0.6.1.0,
+    parsec,
     regex-tdfa,
     tasty,
     tasty-hedgehog,
@@ -340,6 +341,7 @@ test-suite cardano-cli-test
     Test.Cli.ITN
     Test.Cli.Json
     Test.Cli.MonadWarning
+    Test.Cli.Parser
     Test.Cli.Pioneers.Exercise1
     Test.Cli.Pioneers.Exercise2
     Test.Cli.Pioneers.Exercise3

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
@@ -26,7 +26,7 @@ import           Cardano.CLI.Types.Key
 import           Cardano.CLI.Types.Key.VerificationKey
 import qualified Ouroboros.Network.Protocol.LocalStateQuery.Type as Consensus
 
-import           Control.Monad (mfilter)
+import           Control.Monad (mfilter, void)
 import qualified Data.Aeson as Aeson
 import           Data.Bifunctor
 import           Data.Bits (Bits, toIntegralSized)
@@ -1152,7 +1152,7 @@ pPollAnswer =
 
 pPollAnswerIndex :: Parser Word
 pPollAnswerIndex =
-  Opt.option auto $
+  Opt.option integralReader $
     mconcat
       [ Opt.long "answer"
       , Opt.metavar "INT"
@@ -1182,7 +1182,7 @@ pPollTxFile =
 
 pPollNonce :: Parser Word
 pPollNonce =
-  Opt.option auto $
+  Opt.option integralReader $
     mconcat
       [ Opt.long "nonce"
       , Opt.metavar "UINT"
@@ -1238,7 +1238,7 @@ pScriptWitnessFiles sbe witctx autoBalanceExecUnits scriptFlagPrefix scriptFlagP
 pExecutionUnits :: String -> Parser ExecutionUnits
 pExecutionUnits scriptFlagPrefix =
   fmap (uncurry ExecutionUnits) $
-    Opt.option Opt.auto $
+    Opt.option pairIntegralReader $
       mconcat
         [ Opt.long (scriptFlagPrefix ++ "-execution-units")
         , Opt.metavar "(INT, INT)"
@@ -2327,7 +2327,7 @@ pTotalCollateral =
 
 pWitnessOverride :: Parser Word
 pWitnessOverride =
-  Opt.option Opt.auto $
+  Opt.option integralReader $
     mconcat
       [ Opt.long "witness-override"
       , Opt.metavar "WORD"
@@ -2336,7 +2336,7 @@ pWitnessOverride =
 
 pNumberOfShelleyKeyWitnesses :: Parser Int
 pNumberOfShelleyKeyWitnesses =
-  Opt.option Opt.auto $
+  Opt.option integralReader $
     mconcat
       [ Opt.long "shelley-key-witnesses"
       , Opt.metavar "INT"
@@ -2345,7 +2345,7 @@ pNumberOfShelleyKeyWitnesses =
 
 pNumberOfByronKeyWitnesses :: Parser Int
 pNumberOfByronKeyWitnesses =
-  Opt.option Opt.auto $
+  Opt.option integralReader $
     mconcat
       [ Opt.long "byron-key-witnesses"
       , Opt.metavar "Int"
@@ -2609,7 +2609,7 @@ pInvalidHereafter eon =
 pTxFee :: Parser Lovelace
 pTxFee =
   fmap (L.Coin . (fromIntegral :: Natural -> Integer)) $
-    Opt.option Opt.auto $
+    Opt.option integralReader $
       mconcat
         [ Opt.long "fee"
         , Opt.metavar "LOVELACE"
@@ -2695,7 +2695,7 @@ pInputTxOrTxBodyFile =
 pTxInCountDeprecated :: Parser TxInCount
 pTxInCountDeprecated =
   fmap TxInCount $
-    Opt.option Opt.auto $
+    Opt.option integralReader $
       mconcat
         [ Opt.long "tx-in-count"
         , Opt.metavar "NATURAL"
@@ -2705,7 +2705,7 @@ pTxInCountDeprecated =
 pTxOutCountDeprecated :: Parser TxOutCount
 pTxOutCountDeprecated =
   fmap TxOutCount $
-    Opt.option Opt.auto $
+    Opt.option integralReader $
       mconcat
         [ Opt.long "tx-out-count"
         , Opt.metavar "NATURAL"
@@ -2715,7 +2715,7 @@ pTxOutCountDeprecated =
 pTxShelleyWitnessCount :: Parser TxShelleyWitnessCount
 pTxShelleyWitnessCount =
   fmap TxShelleyWitnessCount $
-    Opt.option Opt.auto $
+    Opt.option integralReader $
       mconcat
         [ Opt.long "witness-count"
         , Opt.metavar "NATURAL"
@@ -2725,7 +2725,7 @@ pTxShelleyWitnessCount =
 pTxByronWitnessCount :: Parser TxByronWitnessCount
 pTxByronWitnessCount =
   fmap TxByronWitnessCount $
-    Opt.option Opt.auto $
+    Opt.option integralReader $
       mconcat
         [ Opt.long "byron-witness-count"
         , Opt.metavar "NATURAL"
@@ -3167,7 +3167,7 @@ pMinPoolCost =
 
 pMaxBodySize :: Parser Word32
 pMaxBodySize =
-  Opt.option Opt.auto $
+  Opt.option integralReader $
     mconcat
       [ Opt.long "max-block-body-size"
       , Opt.metavar "WORD32"
@@ -3176,7 +3176,7 @@ pMaxBodySize =
 
 pMaxTransactionSize :: Parser Word32
 pMaxTransactionSize =
-  Opt.option Opt.auto $
+  Opt.option integralReader $
     mconcat
       [ Opt.long "max-tx-size"
       , Opt.metavar "WORD32"
@@ -3273,7 +3273,7 @@ pEpochBoundRetirement =
 
 pNumberOfPools :: Parser Natural
 pNumberOfPools =
-  Opt.option Opt.auto $
+  Opt.option integralReader $
     mconcat
       [ Opt.long "number-of-pools"
       , Opt.metavar "NATURAL"
@@ -3383,7 +3383,7 @@ pMaxTxExecutionUnits :: Parser ExecutionUnits
 pMaxTxExecutionUnits =
   uncurry ExecutionUnits
     <$> Opt.option
-      Opt.auto
+      pairIntegralReader
       ( mconcat
           [ Opt.long "max-tx-execution-units"
           , Opt.metavar "(INT, INT)"
@@ -3399,7 +3399,7 @@ pMaxBlockExecutionUnits :: Parser ExecutionUnits
 pMaxBlockExecutionUnits =
   uncurry ExecutionUnits
     <$> Opt.option
-      Opt.auto
+      pairIntegralReader
       ( mconcat
           [ Opt.long "max-block-execution-units"
           , Opt.metavar "(INT, INT)"
@@ -3413,7 +3413,7 @@ pMaxBlockExecutionUnits =
 
 pMaxValueSize :: Parser Natural
 pMaxValueSize =
-  Opt.option Opt.auto $
+  Opt.option integralReader $
     mconcat
       [ Opt.long "max-value-size"
       , Opt.metavar "INT"
@@ -3425,7 +3425,7 @@ pMaxValueSize =
 
 pCollateralPercent :: Parser Natural
 pCollateralPercent =
-  Opt.option Opt.auto $
+  Opt.option integralReader $
     mconcat
       [ Opt.long "collateral-percent"
       , Opt.metavar "INT"
@@ -3439,7 +3439,7 @@ pCollateralPercent =
 
 pMaxCollateralInputs :: Parser Natural
 pMaxCollateralInputs =
-  Opt.option Opt.auto $
+  Opt.option integralReader $
     mconcat
       [ Opt.long "max-collateral-inputs"
       , Opt.metavar "INT"
@@ -3455,7 +3455,7 @@ pProtocolVersion =
   (,) <$> pProtocolMajorVersion <*> pProtocolMinorVersion
  where
   pProtocolMajorVersion =
-    Opt.option Opt.auto $
+    Opt.option integralReader $
       mconcat
         [ Opt.long "protocol-major-version"
         , Opt.metavar "MAJOR"
@@ -3466,7 +3466,7 @@ pProtocolVersion =
               ]
         ]
   pProtocolMinorVersion =
-    Opt.option Opt.auto $
+    Opt.option integralReader $
       mconcat
         [ Opt.long "protocol-minor-version"
         , Opt.metavar "MINOR"
@@ -3617,7 +3617,7 @@ pDRepVotingThresholds =
 
 pMinCommitteeSize :: Parser Natural
 pMinCommitteeSize =
-  Opt.option Opt.auto $
+  Opt.option integralReader $
     mconcat
       [ Opt.long "min-committee-size"
       , Opt.metavar "INT"
@@ -3946,7 +3946,7 @@ pGovernanceActionId =
 
 pWord16 :: String -> String -> Parser Word16
 pWord16 l h =
-  Opt.option auto $
+  Opt.option integralReader $
     mconcat
       [ Opt.long l
       , Opt.metavar "WORD16"
@@ -3987,7 +3987,7 @@ pNetworkIdForTestnetData envCli =
 pReferenceScriptSize :: Parser ReferenceScriptSize
 pReferenceScriptSize =
   fmap ReferenceScriptSize $
-    Opt.option Opt.auto $
+    Opt.option integralReader $
       mconcat
         [ Opt.long "reference-script-size"
         , Opt.metavar "NATURAL"

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Genesis.hs
@@ -249,7 +249,7 @@ pGenesisCreateTestNetData sbe envCli =
             "The " <> eraStr <> " specification file to use as input. A default one is generated if omitted."
         ]
   pNumGenesisKeys =
-    Opt.option Opt.auto $
+    Opt.option integralReader $
       mconcat
         [ Opt.long "genesis-keys"
         , Opt.metavar "INT"
@@ -258,7 +258,7 @@ pGenesisCreateTestNetData sbe envCli =
         ]
   pNumPools :: Parser Word
   pNumPools =
-    Opt.option Opt.auto $
+    Opt.option integralReader $
       mconcat
         [ Opt.long "pools"
         , Opt.metavar "INT"
@@ -274,7 +274,7 @@ pGenesisCreateTestNetData sbe envCli =
     pDReps mode modeOptionName modeExplanation =
       DRepCredentials mode
         <$> Opt.option
-          Opt.auto
+          integralReader
           ( mconcat
               [ Opt.long modeOptionName
               , Opt.help $ "The number of DRep credentials to make (default is 0). " <> modeExplanation
@@ -291,7 +291,7 @@ pGenesisCreateTestNetData sbe envCli =
     pStakeDelegators mode modeOptionName modeExplanation =
       StakeDelegators mode
         <$> Opt.option
-          Opt.auto
+          integralReader
           ( mconcat
               [ Opt.long modeOptionName
               , Opt.help $
@@ -302,7 +302,7 @@ pGenesisCreateTestNetData sbe envCli =
           )
   pNumStuffedUtxoCount :: Parser Word
   pNumStuffedUtxoCount =
-    Opt.option Opt.auto $
+    Opt.option integralReader $
       mconcat
         [ Opt.long "stuffed-utxo"
         , Opt.metavar "INT"
@@ -311,7 +311,7 @@ pGenesisCreateTestNetData sbe envCli =
         ]
   pNumUtxoKeys :: Parser Word
   pNumUtxoKeys =
-    Opt.option Opt.auto $
+    Opt.option integralReader $
       mconcat
         [ Opt.long "utxo-keys"
         , Opt.metavar "INT"
@@ -322,7 +322,7 @@ pGenesisCreateTestNetData sbe envCli =
   pSupply =
     Opt.optional $
       fmap Coin $
-        Opt.option Opt.auto $
+        Opt.option integralReader $
           mconcat
             [ Opt.long "total-supply"
             , Opt.metavar "LOVELACE"
@@ -337,7 +337,7 @@ pGenesisCreateTestNetData sbe envCli =
   pSupplyDelegated =
     Opt.optional $
       fmap Coin $
-        Opt.option Opt.auto $
+        Opt.option integralReader $
           mconcat
             [ Opt.long "delegated-supply"
             , Opt.metavar "LOVELACE"
@@ -394,7 +394,7 @@ pMaybeSystemStart =
 
 pGenesisNumGenesisKeys :: Parser Word
 pGenesisNumGenesisKeys =
-  Opt.option Opt.auto $
+  Opt.option integralReader $
     mconcat
       [ Opt.long "gen-genesis-keys"
       , Opt.metavar "INT"
@@ -407,7 +407,7 @@ pNodeConfigTemplate = optional $ parseFilePath "node-config-template" "the node 
 
 pGenesisNumUTxOKeys :: Parser Word
 pGenesisNumUTxOKeys =
-  Opt.option Opt.auto $
+  Opt.option integralReader $
     mconcat
       [ Opt.long "gen-utxo-keys"
       , Opt.metavar "INT"
@@ -417,7 +417,7 @@ pGenesisNumUTxOKeys =
 
 pGenesisNumPools :: Parser Word
 pGenesisNumPools =
-  Opt.option Opt.auto $
+  Opt.option integralReader $
     mconcat
       [ Opt.long "gen-pools"
       , Opt.metavar "INT"
@@ -427,7 +427,7 @@ pGenesisNumPools =
 
 pGenesisNumStDelegs :: Parser Word
 pGenesisNumStDelegs =
-  Opt.option Opt.auto $
+  Opt.option integralReader $
     mconcat
       [ Opt.long "gen-stake-delegs"
       , Opt.metavar "INT"
@@ -437,7 +437,7 @@ pGenesisNumStDelegs =
 
 pStuffedUtxoCount :: Parser Word
 pStuffedUtxoCount =
-  Opt.option Opt.auto $
+  Opt.option integralReader $
     mconcat
       [ Opt.long "num-stuffed-utxo"
       , Opt.metavar "INT"
@@ -449,7 +449,7 @@ pInitialSupplyNonDelegated :: Parser (Maybe Coin)
 pInitialSupplyNonDelegated =
   Opt.optional $
     fmap Coin $
-      Opt.option Opt.auto $
+      Opt.option integralReader $
         mconcat
           [ Opt.long "supply"
           , Opt.metavar "LOVELACE"
@@ -461,7 +461,7 @@ pInitialSupplyDelegated :: Parser Coin
 pInitialSupplyDelegated =
   fmap (Coin . fromMaybe 0) $
     Opt.optional $
-      Opt.option Opt.auto $
+      Opt.option integralReader $
         mconcat
           [ Opt.long "supply-delegated"
           , Opt.metavar "LOVELACE"
@@ -472,7 +472,7 @@ pInitialSupplyDelegated =
 
 pSecurityParam :: Parser Word64
 pSecurityParam =
-  Opt.option Opt.auto $
+  Opt.option integralReader $
     mconcat
       [ Opt.long "security-param"
       , Opt.metavar "INT"
@@ -482,7 +482,7 @@ pSecurityParam =
 
 pSlotLength :: Parser Word
 pSlotLength =
-  Opt.option Opt.auto $
+  Opt.option integralReader $
     mconcat
       [ Opt.long "slot-length"
       , Opt.metavar "INT"
@@ -502,7 +502,7 @@ pSlotCoefficient =
 
 pBulkPoolCredFiles :: Parser Word
 pBulkPoolCredFiles =
-  Opt.option Opt.auto $
+  Opt.option integralReader $
     mconcat
       [ Opt.long "bulk-pool-cred-files"
       , Opt.metavar "INT"
@@ -512,7 +512,7 @@ pBulkPoolCredFiles =
 
 pBulkPoolsPerFile :: Parser Word
 pBulkPoolsPerFile =
-  Opt.option Opt.auto $
+  Opt.option integralReader $
     mconcat
       [ Opt.long "bulk-pools-per-file"
       , Opt.metavar "INT"

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Node.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Node.hs
@@ -115,7 +115,7 @@ pNewCounter =
 
 pCounterValue :: Parser Word
 pCounterValue =
-  Opt.option Opt.auto $
+  Opt.option integralReader $
     mconcat
       [ Opt.long "counter-value"
       , Opt.metavar "INT"

--- a/cardano-cli/src/Cardano/CLI/Legacy/Options.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Options.hs
@@ -564,7 +564,7 @@ pNodeCmds =
 
   pCounterValue :: Parser Word
   pCounterValue =
-    Opt.option Opt.auto $
+    Opt.option integralReader $
       mconcat
         [ Opt.long "counter-value"
         , Opt.metavar "INT"
@@ -1135,7 +1135,7 @@ pGenesisCmds envCli =
 
   pGenesisNumGenesisKeys :: Parser Word
   pGenesisNumGenesisKeys =
-    Opt.option Opt.auto $
+    Opt.option integralReader $
       mconcat
         [ Opt.long "gen-genesis-keys"
         , Opt.metavar "INT"
@@ -1148,7 +1148,7 @@ pGenesisCmds envCli =
 
   pGenesisNumUTxOKeys :: Parser Word
   pGenesisNumUTxOKeys =
-    Opt.option Opt.auto $
+    Opt.option integralReader $
       mconcat
         [ Opt.long "gen-utxo-keys"
         , Opt.metavar "INT"
@@ -1158,7 +1158,7 @@ pGenesisCmds envCli =
 
   pGenesisNumPools :: Parser Word
   pGenesisNumPools =
-    Opt.option Opt.auto $
+    Opt.option integralReader $
       mconcat
         [ Opt.long "gen-pools"
         , Opt.metavar "INT"
@@ -1168,7 +1168,7 @@ pGenesisCmds envCli =
 
   pGenesisNumStDelegs :: Parser Word
   pGenesisNumStDelegs =
-    Opt.option Opt.auto $
+    Opt.option integralReader $
       mconcat
         [ Opt.long "gen-stake-delegs"
         , Opt.metavar "INT"
@@ -1178,7 +1178,7 @@ pGenesisCmds envCli =
 
   pStuffedUtxoCount :: Parser Word
   pStuffedUtxoCount =
-    Opt.option Opt.auto $
+    Opt.option integralReader $
       mconcat
         [ Opt.long "num-stuffed-utxo"
         , Opt.metavar "INT"
@@ -1200,7 +1200,7 @@ pGenesisCmds envCli =
   pInitialSupplyNonDelegated =
     Opt.optional $
       fmap Coin $
-        Opt.option Opt.auto $
+        Opt.option integralReader $
           mconcat
             [ Opt.long "supply"
             , Opt.metavar "LOVELACE"
@@ -1212,7 +1212,7 @@ pGenesisCmds envCli =
   pInitialSupplyDelegated =
     fmap (Coin . fromMaybe 0) $
       Opt.optional $
-        Opt.option Opt.auto $
+        Opt.option integralReader $
           mconcat
             [ Opt.long "supply-delegated"
             , Opt.metavar "LOVELACE"
@@ -1223,7 +1223,7 @@ pGenesisCmds envCli =
 
   pSecurityParam :: Parser Word64
   pSecurityParam =
-    Opt.option Opt.auto $
+    Opt.option integralReader $
       mconcat
         [ Opt.long "security-param"
         , Opt.metavar "INT"
@@ -1233,7 +1233,7 @@ pGenesisCmds envCli =
 
   pSlotLength :: Parser Word
   pSlotLength =
-    Opt.option Opt.auto $
+    Opt.option integralReader $
       mconcat
         [ Opt.long "slot-length"
         , Opt.metavar "INT"
@@ -1253,7 +1253,7 @@ pGenesisCmds envCli =
 
   pBulkPoolCredFiles :: Parser Word
   pBulkPoolCredFiles =
-    Opt.option Opt.auto $
+    Opt.option integralReader $
       mconcat
         [ Opt.long "bulk-pool-cred-files"
         , Opt.metavar "INT"
@@ -1263,7 +1263,7 @@ pGenesisCmds envCli =
 
   pBulkPoolsPerFile :: Parser Word
   pBulkPoolsPerFile =
-    Opt.option Opt.auto $
+    Opt.option integralReader $
       mconcat
         [ Opt.long "bulk-pools-per-file"
         , Opt.metavar "INT"

--- a/cardano-cli/src/Cardano/CLI/Options/Ping.hs
+++ b/cardano-cli/src/Cardano/CLI/Options/Ping.hs
@@ -8,6 +8,7 @@ module Cardano.CLI.Options.Ping
 where
 
 import           Cardano.CLI.Commands.Ping
+import           Cardano.CLI.EraBased.Options.Common (integralReader)
 import qualified Cardano.Network.Ping as CNP
 
 import           Control.Applicative ((<|>))
@@ -55,7 +56,7 @@ pEndPoint = fmap HostEndPoint pHost <|> fmap UnixSockEndPoint pUnixSocket
 pPing :: Opt.Parser PingCmd
 pPing =
   PingCmd
-    <$> ( Opt.option Opt.auto $
+    <$> ( Opt.option integralReader $
             mconcat
               [ Opt.long "count"
               , Opt.short 'c'
@@ -78,7 +79,7 @@ pPing =
               , Opt.value "3001"
               ]
         )
-    <*> ( Opt.option Opt.auto $
+    <*> ( Opt.option integralReader $
             mconcat
               [ Opt.long "magic"
               , Opt.short 'm'

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/Parser.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/Parser.hs
@@ -1,0 +1,99 @@
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Test.Cli.Parser
+  ( hprop_integral_reader
+  , hprop_integral_pair_reader_positive
+  , hprop_integral_pair_reader_negative
+  )
+where
+
+import           Cardano.CLI.EraBased.Options.Common (integralParsecParser,
+                   pairIntegralParsecParser)
+
+import           Data.Bits (Bits)
+import           Data.Data (Proxy (..), Typeable)
+import           Data.Either (isLeft, isRight)
+import           Data.Word (Word16)
+import qualified Text.Parsec as Parsec
+
+import           Hedgehog (Gen, Property, assert, property, (===))
+import           Hedgehog.Extras (assertWith, propertyOnce)
+import qualified Hedgehog.Gen as Gen
+import           Hedgehog.Internal.Property (forAll)
+import qualified Hedgehog.Range as Gen
+import qualified Hedgehog.Range as Range
+
+-- | Execute me with:
+-- @cabal test cardano-cli-test --test-options '-p "/integral reader/"'@
+hprop_integral_reader :: Property
+hprop_integral_reader = property $ do
+  parse @Word "0" === Right 0
+  parse @Word "42" === Right 42
+  assertWith (parse @Word "-1") isLeft
+  assertWith (parse @Word "18446744073709551616") isLeft
+  assertWith (parse @Word "-1987090") isLeft
+
+  w <- forAll $ Gen.word $ Gen.linear minBound maxBound
+  parse @Word (show w) === Right w
+
+  parse @Word16 "0" === Right 0
+  parse @Word16 "42" === Right 42
+  assertWith (parse @Word16 "-1") isLeft
+  assertWith (parse @Word16 "65536") isLeft
+  assertWith (parse @Word16 "298709870987") isLeft
+  assertWith (parse @Word16 "-1987090") isLeft
+ where
+  parse :: (Typeable a, Integral a, Bits a) => String -> Either String a
+  parse s =
+    case Parsec.runParser integralParsecParser () "" s of
+      Left parsecError -> Left $ show parsecError
+      Right x -> Right x
+
+-- | Execute me with:
+-- @cabal test cardano-cli-test --test-options '-p "/integral pair reader positive/"'@
+hprop_integral_pair_reader_positive :: Property
+hprop_integral_pair_reader_positive = property $ do
+  validArbitraryTuple <- forAll $ genNumberTuple (Proxy :: Proxy Word)
+  assert $ isRight $ parse @Word validArbitraryTuple
+ where
+  parse :: (Typeable a, Integral a, Bits a) => String -> Either String (a, a)
+  parse s =
+    case Parsec.runParser pairIntegralParsecParser () "" s of
+      Left parsecError -> Left $ show parsecError
+      Right x -> Right x
+
+genNumberTuple :: forall a. Integral a => Show a => Proxy a -> Gen String
+genNumberTuple _ = do
+  x :: a <- Gen.integral (Range.linear 0 100)
+  y :: a <- Gen.integral (Range.linear 0 100)
+  space0 <- genArbitrarySpace
+  space1 <- genArbitrarySpace
+  space2 <- genArbitrarySpace
+  space3 <- genArbitrarySpace
+  return $
+    space0 ++ "(" ++ space2 ++ show x ++ space1 ++ "," ++ space2 ++ show y ++ space1 ++ ")" ++ space3
+
+genArbitrarySpace :: Gen String
+genArbitrarySpace = Gen.string (Range.linear 0 5) (return ' ')
+
+-- | Execute me with:
+-- @cabal test cardano-cli-test --test-options '-p "/integral pair reader negative/"'@
+hprop_integral_pair_reader_negative :: Property
+hprop_integral_pair_reader_negative = propertyOnce $ do
+  assertWith (parse @Word "(0, 0, 0)") isLeft
+  assertWith (parse @Word "(-1, 0)") isLeft
+  assertWith (parse @Word "(18446744073709551616, 0)") isLeft
+  assertWith (parse @Word "(0, 18446744073709551616)") isLeft
+  assertWith (parse @Word "(0, -1)") isLeft
+  assertWith (parse @Word "0, 0)") isLeft
+  assertWith (parse @Word "(0, 0") isLeft
+  assertWith (parse @Word "(0 0)") isLeft
+  assertWith (parse @Word "(   0, 0") isLeft
+ where
+  parse :: (Typeable a, Integral a, Bits a) => String -> Either String (a, a)
+  parse s =
+    case Parsec.runParser pairIntegralParsecParser () "" s of
+      Left parsecError -> Left $ show parsecError
+      Right x -> Right x


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Forbid incorrect values in parsers of many Int-like options. Previously those values would overflow and be turned into a random valid value. If this breaks your use case, this means your use case wasn't doing what you expected.
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

We use [auto](https://hackage.haskell.org/package/optparse-applicative-0.18.1.0/docs/Options-Applicative.html#v:auto) a lot in parsing. `auto` relies under the hood on **Read** instances which are [known to have problems](https://github.com/NorfairKing/haskell-WAT#read-instances-for-integral-types). Some instances accept wrong values and return out of thin air values. This PR fixes this.

Fixes https://github.com/IntersectMBO/cardano-cli/issues/860

# How to trust this PR

* [X] Try this PR with `cardano-testnet`: tested `cabal test cardano-testnet-test` with `cardano-node` at e9ab511272a7694196778007211991a9984557e8 and `cardano-cli` at 44ca6edd1b3064ddf8f3bc155a8203188758cf14
* Run `git grep auto "*.hs"` and observe that all the remaining calls are in a `byron` file (I didn't change those)

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff