### PR TITLE
Remove era|legacy transaction view

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Transaction.hs
@@ -43,7 +43,6 @@ data TransactionCmds era
   | TransactionCalculateMinValueCmd !(TransactionCalculateMinValueCmdArgs era)
   | TransactionHashScriptDataCmd !TransactionHashScriptDataCmdArgs
   | TransactionTxIdCmd !TransactionTxIdCmdArgs
-  | TransactionViewCmd !TransactionViewCmdArgs
 
 data TransactionBuildRawCmdArgs era = TransactionBuildRawCmdArgs
   { eon :: !(ShelleyBasedEra era)
@@ -265,4 +264,3 @@ renderTransactionCmds = \case
   TransactionCalculateMinValueCmd{} -> "transaction calculate-min-value"
   TransactionHashScriptDataCmd{} -> "transaction hash-script-data"
   TransactionTxIdCmd{} -> "transaction txid"
-  TransactionViewCmd{} -> "transaction view"

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Transaction.hs
@@ -100,11 +100,6 @@ pTransactionCmds era' envCli =
         subParser "txid" $
           Opt.info pTransactionId $
             Opt.progDesc "Print a transaction identifier."
-    , Just $
-        subParser "view" $
-          Opt.info
-            (pure $ TransactionViewCmd TransactionViewCmdArgs)
-            (Opt.progDesc "This command has been removed. Please use \"debug transaction view\" instead.")
     ]
 
 -- Backwards compatible parsers

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Transaction.hs
@@ -26,7 +26,6 @@ module Cardano.CLI.EraBased.Run.Transaction
   , runTransactionPolicyIdCmd
   , runTransactionHashScriptDataCmd
   , runTransactionTxIdCmd
-  , runTransactionViewCmd
   , runTransactionWitnessCmd
   , runTransactionSignWitnessCmd
   , toTxOutByronEra
@@ -80,7 +79,6 @@ import qualified Data.Text.IO as Text
 import           Data.Type.Equality (TestEquality (..))
 import           GHC.Exts (IsList (..))
 import           Lens.Micro ((^.))
-import qualified System.Exit as IO
 import qualified System.IO as IO
 
 runTransactionCmds :: Cmd.TransactionCmds era -> ExceptT TxCmdError IO ()
@@ -94,7 +92,6 @@ runTransactionCmds = \case
   Cmd.TransactionCalculateMinValueCmd args -> runTransactionCalculateMinValueCmd args
   Cmd.TransactionHashScriptDataCmd args -> runTransactionHashScriptDataCmd args
   Cmd.TransactionTxIdCmd args -> runTransactionTxIdCmd args
-  Cmd.TransactionViewCmd args -> runTransactionViewCmd args
   Cmd.TransactionPolicyIdCmd args -> runTransactionPolicyIdCmd args
   Cmd.TransactionWitnessCmd args -> runTransactionWitnessCmd args
   Cmd.TransactionSignWitnessCmd args -> runTransactionSignWitnessCmd args
@@ -1701,18 +1698,6 @@ runTransactionTxIdCmd
           return . InAnyShelleyBasedEra era $ getTxBody tx
 
     liftIO $ BS.putStrLn $ serialiseToRawBytesHex (getTxId txbody)
-
-runTransactionViewCmd
-  :: ()
-  => Cmd.TransactionViewCmdArgs
-  -> ExceptT TxCmdError IO ()
-runTransactionViewCmd
-  Cmd.TransactionViewCmdArgs =
-    liftIO $ do
-      IO.hPutStrLn
-        IO.stderr
-        "Command \"era transaction view\" has been removed. Please use \"debug transaction view\" instead."
-      IO.exitWith (IO.ExitFailure 1)
 
 -- ----------------------------------------------------------------------------
 -- Witness commands

--- a/cardano-cli/src/Cardano/CLI/Legacy/Commands/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Commands/Transaction.hs
@@ -135,7 +135,6 @@ data LegacyTransactionCmds
       ScriptDataOrFile
   | TransactionTxIdCmd
       InputTxBodyOrTxFile
-  | TransactionViewCmd
 
 renderLegacyTransactionCmds :: LegacyTransactionCmds -> Text
 renderLegacyTransactionCmds = \case
@@ -150,4 +149,3 @@ renderLegacyTransactionCmds = \case
   TransactionCalculateMinValueCmd{} -> "transaction calculate-min-value"
   TransactionHashScriptDataCmd{} -> "transaction hash-script-data"
   TransactionTxIdCmd{} -> "transaction txid"
-  TransactionViewCmd{} -> "transaction view"

--- a/cardano-cli/src/Cardano/CLI/Legacy/Options.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Options.hs
@@ -300,9 +300,6 @@ pTransaction envCli =
     , subParser
         "txid"
         (Opt.info pTransactionId $ Opt.progDesc "Print a transaction identifier.")
-    , subParser "view" $
-        Opt.info pTransactionView $
-          Opt.progDesc "This command has been removed. Please use \"debug transaction view\" instead."
     ]
  where
   -- Backwards compatible parsers
@@ -487,10 +484,6 @@ pTransaction envCli =
   pTransactionId =
     TransactionTxIdCmd
       <$> pInputTxOrTxBodyFile
-
-  pTransactionView :: Parser LegacyTransactionCmds
-  pTransactionView =
-    pure TransactionViewCmd
 
 pNodeCmds :: Parser LegacyNodeCmds
 pNodeCmds =

--- a/cardano-cli/src/Cardano/CLI/Legacy/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Run/Transaction.hs
@@ -157,8 +157,6 @@ runLegacyTransactionCmds = \case
     runLegacyTransactionHashScriptDataCmd scriptDataOrFile
   TransactionTxIdCmd txinfile ->
     runLegacyTransactionTxIdCmd txinfile
-  TransactionViewCmd ->
-    runLegacyTransactionViewCmd
   TransactionPolicyIdCmd sFile ->
     runLegacyTransactionPolicyIdCmd sFile
   TransactionWitnessCmd txBodyfile witSignData mbNw outFile ->
@@ -513,11 +511,6 @@ runLegacyTransactionTxIdCmd txfile =
     ( Cmd.TransactionTxIdCmdArgs
         txfile
     )
-
-runLegacyTransactionViewCmd :: ExceptT TxCmdError IO ()
-runLegacyTransactionViewCmd =
-  runTransactionViewCmd
-    Cmd.TransactionViewCmdArgs
 
 runLegacyTransactionWitnessCmd
   :: ()

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -832,7 +832,6 @@ Usage: cardano-cli shelley transaction
                                          | calculate-min-required-utxo
                                          | hash-script-data
                                          | txid
-                                         | view
                                          )
 
   Transaction commands.
@@ -1080,10 +1079,6 @@ Usage: cardano-cli shelley transaction txid
                                               )
 
   Print a transaction identifier.
-
-Usage: cardano-cli shelley transaction view 
-
-  This command has been removed. Please use "debug transaction view" instead.
 
 Usage: cardano-cli allegra 
                              ( address
@@ -1902,7 +1897,6 @@ Usage: cardano-cli allegra transaction
                                          | calculate-min-required-utxo
                                          | hash-script-data
                                          | txid
-                                         | view
                                          )
 
   Transaction commands.
@@ -2150,10 +2144,6 @@ Usage: cardano-cli allegra transaction txid
                                               )
 
   Print a transaction identifier.
-
-Usage: cardano-cli allegra transaction view 
-
-  This command has been removed. Please use "debug transaction view" instead.
 
 Usage: cardano-cli mary 
                           ( address
@@ -2964,7 +2954,6 @@ Usage: cardano-cli mary transaction
                                       | calculate-min-required-utxo
                                       | hash-script-data
                                       | txid
-                                      | view
                                       )
 
   Transaction commands.
@@ -3210,10 +3199,6 @@ Usage: cardano-cli mary transaction txid
                                            )
 
   Print a transaction identifier.
-
-Usage: cardano-cli mary transaction view 
-
-  This command has been removed. Please use "debug transaction view" instead.
 
 Usage: cardano-cli alonzo 
                             ( address
@@ -4037,7 +4022,6 @@ Usage: cardano-cli alonzo transaction
                                         | calculate-min-required-utxo
                                         | hash-script-data
                                         | txid
-                                        | view
                                         )
 
   Transaction commands.
@@ -4285,10 +4269,6 @@ Usage: cardano-cli alonzo transaction txid
                                              )
 
   Print a transaction identifier.
-
-Usage: cardano-cli alonzo transaction view 
-
-  This command has been removed. Please use "debug transaction view" instead.
 
 Usage: cardano-cli babbage 
                              ( address
@@ -5135,7 +5115,6 @@ Usage: cardano-cli babbage transaction
                                          | calculate-min-required-utxo
                                          | hash-script-data
                                          | txid
-                                         | view
                                          )
 
   Transaction commands.
@@ -5640,10 +5619,6 @@ Usage: cardano-cli babbage transaction txid
                                               )
 
   Print a transaction identifier.
-
-Usage: cardano-cli babbage transaction view 
-
-  This command has been removed. Please use "debug transaction view" instead.
 
 Usage: cardano-cli conway 
                             ( address
@@ -6952,7 +6927,6 @@ Usage: cardano-cli conway transaction
                                         | calculate-min-required-utxo
                                         | hash-script-data
                                         | txid
-                                        | view
                                         )
 
   Transaction commands.
@@ -7549,10 +7523,6 @@ Usage: cardano-cli conway transaction txid
                                              )
 
   Print a transaction identifier.
-
-Usage: cardano-cli conway transaction view 
-
-  This command has been removed. Please use "debug transaction view" instead.
 
 Usage: cardano-cli latest 
                             ( address
@@ -8397,7 +8367,6 @@ Usage: cardano-cli latest transaction
                                         | calculate-min-required-utxo
                                         | hash-script-data
                                         | txid
-                                        | view
                                         )
 
   Transaction commands.
@@ -8902,10 +8871,6 @@ Usage: cardano-cli latest transaction txid
                                              )
 
   Print a transaction identifier.
-
-Usage: cardano-cli latest transaction view 
-
-  This command has been removed. Please use "debug transaction view" instead.
 
 Usage: cardano-cli legacy Legacy commands
 
@@ -9570,7 +9535,6 @@ Usage: cardano-cli legacy transaction
                                         | calculate-min-required-utxo
                                         | hash-script-data
                                         | txid
-                                        | view
                                         )
 
   Transaction commands
@@ -9993,10 +9957,6 @@ Usage: cardano-cli legacy transaction txid
                                              )
 
   Print a transaction identifier.
-
-Usage: cardano-cli legacy transaction view 
-
-  This command has been removed. Please use "debug transaction view" instead.
 
 Usage: cardano-cli legacy key 
                                 ( verification-key
@@ -10843,7 +10803,6 @@ Usage: cardano-cli transaction
                                  | calculate-min-required-utxo
                                  | hash-script-data
                                  | txid
-                                 | view
                                  )
 
   Transaction commands
@@ -11252,10 +11211,6 @@ Usage: cardano-cli transaction txid
                                       )
 
   Print a transaction identifier.
-
-Usage: cardano-cli transaction view 
-
-  This command has been removed. Please use "debug transaction view" instead.
 
 Usage: cardano-cli key 
                          ( verification-key

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_transaction.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_transaction.cli
@@ -9,7 +9,6 @@ Usage: cardano-cli allegra transaction
                                          | calculate-min-required-utxo
                                          | hash-script-data
                                          | txid
-                                         | view
                                          )
 
   Transaction commands.
@@ -36,5 +35,3 @@ Available commands:
                            output.
   hash-script-data         Calculate the hash of script data.
   txid                     Print a transaction identifier.
-  view                     This command has been removed. Please use "debug
-                           transaction view" instead.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_transaction_view.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_transaction_view.cli
@@ -1,2 +1,0 @@
-WARNING: Selected era is deprecated and will be removed in the future.
-Command "era transaction view" has been removed. Please use "debug transaction view" instead.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_transaction.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_transaction.cli
@@ -9,7 +9,6 @@ Usage: cardano-cli alonzo transaction
                                         | calculate-min-required-utxo
                                         | hash-script-data
                                         | txid
-                                        | view
                                         )
 
   Transaction commands.
@@ -36,5 +35,3 @@ Available commands:
                            output.
   hash-script-data         Calculate the hash of script data.
   txid                     Print a transaction identifier.
-  view                     This command has been removed. Please use "debug
-                           transaction view" instead.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_transaction_view.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_transaction_view.cli
@@ -1,2 +1,0 @@
-WARNING: Selected era is deprecated and will be removed in the future.
-Command "era transaction view" has been removed. Please use "debug transaction view" instead.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_transaction.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_transaction.cli
@@ -11,7 +11,6 @@ Usage: cardano-cli babbage transaction
                                          | calculate-min-required-utxo
                                          | hash-script-data
                                          | txid
-                                         | view
                                          )
 
   Transaction commands.
@@ -44,5 +43,3 @@ Available commands:
                            output.
   hash-script-data         Calculate the hash of script data.
   txid                     Print a transaction identifier.
-  view                     This command has been removed. Please use "debug
-                           transaction view" instead.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_transaction_view.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_transaction_view.cli
@@ -1,2 +1,0 @@
-WARNING: Selected era is deprecated and will be removed in the future.
-Command "era transaction view" has been removed. Please use "debug transaction view" instead.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction.cli
@@ -11,7 +11,6 @@ Usage: cardano-cli conway transaction
                                         | calculate-min-required-utxo
                                         | hash-script-data
                                         | txid
-                                        | view
                                         )
 
   Transaction commands.
@@ -44,5 +43,3 @@ Available commands:
                            output.
   hash-script-data         Calculate the hash of script data.
   txid                     Print a transaction identifier.
-  view                     This command has been removed. Please use "debug
-                           transaction view" instead.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_view.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_view.cli
@@ -1,1 +1,0 @@
-Command "era transaction view" has been removed. Please use "debug transaction view" instead.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_transaction.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_transaction.cli
@@ -11,7 +11,6 @@ Usage: cardano-cli latest transaction
                                         | calculate-min-required-utxo
                                         | hash-script-data
                                         | txid
-                                        | view
                                         )
 
   Transaction commands.
@@ -44,5 +43,3 @@ Available commands:
                            output.
   hash-script-data         Calculate the hash of script data.
   txid                     Print a transaction identifier.
-  view                     This command has been removed. Please use "debug
-                           transaction view" instead.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_transaction_view.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_transaction_view.cli
@@ -1,2 +1,0 @@
-WARNING: Selected era is deprecated and will be removed in the future.
-Command "era transaction view" has been removed. Please use "debug transaction view" instead.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_transaction.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_transaction.cli
@@ -10,7 +10,6 @@ Usage: cardano-cli legacy transaction
                                         | calculate-min-required-utxo
                                         | hash-script-data
                                         | txid
-                                        | view
                                         )
 
   Transaction commands
@@ -40,5 +39,3 @@ Available commands:
                            output.
   hash-script-data         Calculate the hash of script data.
   txid                     Print a transaction identifier.
-  view                     This command has been removed. Please use "debug
-                           transaction view" instead.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_transaction_view.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_transaction_view.cli
@@ -1,1 +1,0 @@
-Command "era transaction view" has been removed. Please use "debug transaction view" instead.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_transaction.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_transaction.cli
@@ -9,7 +9,6 @@ Usage: cardano-cli mary transaction
                                       | calculate-min-required-utxo
                                       | hash-script-data
                                       | txid
-                                      | view
                                       )
 
   Transaction commands.
@@ -36,5 +35,3 @@ Available commands:
                            output.
   hash-script-data         Calculate the hash of script data.
   txid                     Print a transaction identifier.
-  view                     This command has been removed. Please use "debug
-                           transaction view" instead.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_transaction_view.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_transaction_view.cli
@@ -1,2 +1,0 @@
-WARNING: Selected era is deprecated and will be removed in the future.
-Command "era transaction view" has been removed. Please use "debug transaction view" instead.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_transaction.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_transaction.cli
@@ -9,7 +9,6 @@ Usage: cardano-cli shelley transaction
                                          | calculate-min-required-utxo
                                          | hash-script-data
                                          | txid
-                                         | view
                                          )
 
   Transaction commands.
@@ -36,5 +35,3 @@ Available commands:
                            output.
   hash-script-data         Calculate the hash of script data.
   txid                     Print a transaction identifier.
-  view                     This command has been removed. Please use "debug
-                           transaction view" instead.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_transaction_view.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_transaction_view.cli
@@ -1,2 +1,0 @@
-WARNING: Selected era is deprecated and will be removed in the future.
-Command "era transaction view" has been removed. Please use "debug transaction view" instead.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/transaction.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/transaction.cli
@@ -10,7 +10,6 @@ Usage: cardano-cli transaction
                                  | calculate-min-required-utxo
                                  | hash-script-data
                                  | txid
-                                 | view
                                  )
 
   Transaction commands
@@ -40,5 +39,3 @@ Available commands:
                            output.
   hash-script-data         Calculate the hash of script data.
   txid                     Print a transaction identifier.
-  view                     This command has been removed. Please use "debug
-                           transaction view" instead.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/transaction_view.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/transaction_view.cli
@@ -1,1 +1,0 @@
-Command "era transaction view" has been removed. Please use "debug transaction view" instead.


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Remove `era transaction view` and `transaction view` commands. Use `debug transaction view` instead.
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

* Follow-up of https://github.com/IntersectMBO/cardano-cli/pull/858
* Fixes https://github.com/IntersectMBO/cardano-cli/issues/843

# How to trust this PR

* It only removes code

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] Self-reviewed the diff