### PR TITLE
Clean-up remainings of `query constitution-hash`

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Query.hs
@@ -8,7 +8,6 @@ module Cardano.CLI.EraBased.Commands.Query
   , QueryCommitteeMembersStateCmdArgs (..)
   , QueryLeadershipScheduleCmdArgs (..)
   , QueryProtocolParametersCmdArgs (..)
-  , QueryConstitutionHashCmdArgs (..)
   , QueryTipCmdArgs (..)
   , QueryStakePoolsCmdArgs (..)
   , QueryStakeDistributionCmdArgs (..)
@@ -46,7 +45,6 @@ import           GHC.Generics
 data QueryCmds era
   = QueryLeadershipScheduleCmd !QueryLeadershipScheduleCmdArgs
   | QueryProtocolParametersCmd !QueryProtocolParametersCmdArgs
-  | QueryConstitutionHashCmd !QueryConstitutionHashCmdArgs
   | QueryTipCmd !QueryTipCmdArgs
   | QueryStakePoolsCmd !QueryStakePoolsCmdArgs
   | QueryStakeDistributionCmd !QueryStakeDistributionCmdArgs
@@ -87,15 +85,6 @@ data QueryProtocolParametersCmdArgs = QueryProtocolParametersCmdArgs
   { nodeSocketPath :: !SocketPath
   , consensusModeParams :: !ConsensusModeParams
   , networkId :: !NetworkId
-  , mOutFile :: !(Maybe (File () Out))
-  }
-  deriving (Generic, Show)
-
-data QueryConstitutionHashCmdArgs = QueryConstitutionHashCmdArgs
-  { nodeSocketPath :: !SocketPath
-  , consensusModeParams :: !ConsensusModeParams
-  , networkId :: !NetworkId
-  , target :: !(Consensus.Target ChainPoint)
   , mOutFile :: !(Maybe (File () Out))
   }
   deriving (Generic, Show)
@@ -301,8 +290,6 @@ renderQueryCmds = \case
     "query leadership-schedule"
   QueryProtocolParametersCmd{} ->
     "query protocol-parameters "
-  QueryConstitutionHashCmd{} ->
-    "query constitution-hash "
   QueryTipCmd{} ->
     "query tip"
   QueryStakePoolsCmd{} ->

--- a/cardano-cli/src/Cardano/CLI/Legacy/Commands/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Commands/Query.hs
@@ -7,7 +7,6 @@ module Cardano.CLI.Legacy.Commands.Query
   ( LegacyQueryCmds (..)
   , LegacyQueryLeadershipScheduleCmdArgs (..)
   , LegacyQueryProtocolParametersCmdArgs (..)
-  , LegacyQueryConstitutionHashCmdArgs (..)
   , LegacyQueryTipCmdArgs (..)
   , LegacyQueryStakePoolsCmdArgs (..)
   , LegacyQueryStakeDistributionCmdArgs (..)
@@ -64,14 +63,6 @@ data LegacyQueryLeadershipScheduleCmdArgs = LegacyQueryLeadershipScheduleCmdArgs
   deriving (Generic, Show)
 
 data LegacyQueryProtocolParametersCmdArgs = LegacyQueryProtocolParametersCmdArgs
-  { nodeSocketPath :: !SocketPath
-  , consensusModeParams :: !ConsensusModeParams
-  , networkId :: !NetworkId
-  , mOutFile :: !(Maybe (File () Out))
-  }
-  deriving (Generic, Show)
-
-data LegacyQueryConstitutionHashCmdArgs = LegacyQueryConstitutionHashCmdArgs
   { nodeSocketPath :: !SocketPath
   , consensusModeParams :: !ConsensusModeParams
   , networkId :: !NetworkId


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Cleaned up remainings of constitution-hash query
# uncomment types applicable to the change:
  type:
  - refactoring    # QoL changes
```

# Context

This is a follow-up of https://github.com/IntersectMBO/cardano-node/pull/5920#discussion_r1707323667

Investigation showed that removal of `query constitution-hash` was a conscious decision motivated to it no longer being relevant since its functionality is already covered by `query constitution`:
- Decision to remove it from the era's query:
  * Issue: [[cardano-cli] Issue #345](https://github.com/IntersectMBO/cardano-cli/issues/354)
  * PR: [[cardano-cli] PR #370](https://github.com/IntersectMBO/cardano-cli/pull/370/files)
- Decision to remove it from legacy:
  * Issue: [[cardano-cli] Issue #503](https://github.com/IntersectMBO/cardano-cli/issues/503)
  * PR: [[cardano-cli] PR #515](https://github.com/IntersectMBO/cardano-cli/pull/515)

# How to trust this PR

I think the fact that tests pass and that it compiles are pretty telling. Maybe check the context and let me know if you foresee that this removal will have effects somewhere else, but I doubt.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
