### PR TITLE
Fix estmated fee rendering

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Transaction.hs
@@ -49,7 +49,9 @@ pTransactionCmds era envCli =
                   , line
                   , H.yellow $
                       mconcat
-                        [ "Please note the order of some cmd options is crucial. If used incorrectly may produce "
+                        [ "Please note "
+                        , H.underline "the order"
+                        , " of some cmd options is crucial. If used incorrectly may produce "
                         , "undesired tx body. See nested [] notation above for details."
                         ]
                   ]

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Transaction.hs
@@ -1065,7 +1065,7 @@ runTxBuild
             cAddr
             mOverrideWits
 
-      liftIO $ putStrLn $ "Estimated transaction fee: " <> (show fee :: String)
+      liftIO . putStrLn . docToString $ "Estimated transaction fee:" <+> pretty fee
 
       return balancedTxBody
 

--- a/cardano-cli/src/Cardano/CLI/Legacy/Options.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Options.hs
@@ -238,7 +238,9 @@ pTransaction envCli =
                 , line
                 , H.yellow $
                     mconcat
-                      [ "Please note the order of some cmd options is crucial. If used incorrectly may produce "
+                      [ "Please note "
+                      , H.underline "the order"
+                      , " of some cmd options is crucial. If used incorrectly may produce "
                       , "undesired tx body. See nested [] notation above for details."
                       ]
                 ]

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -964,7 +964,7 @@ Usage: cardano-cli shelley transaction build-raw
 
   Build a transaction (low-level, inconvenient)
 
-  Please note the order of some cmd options is crucial. If used incorrectly may produce undesired tx body. See nested [] notation above for details.[0;22;23;24m
+  Please note the order[93;22;23;24m of some cmd options is crucial. If used incorrectly may produce undesired tx body. See nested [] notation above for details.[0;22;23;24m
 
 Usage: cardano-cli shelley transaction build --socket-path SOCKET_PATH
                                                [--cardano-mode
@@ -2159,7 +2159,7 @@ Usage: cardano-cli allegra transaction build-raw
 
   Build a transaction (low-level, inconvenient)
 
-  Please note the order of some cmd options is crucial. If used incorrectly may produce undesired tx body. See nested [] notation above for details.[0;22;23;24m
+  Please note the order[93;22;23;24m of some cmd options is crucial. If used incorrectly may produce undesired tx body. See nested [] notation above for details.[0;22;23;24m
 
 Usage: cardano-cli allegra transaction build --socket-path SOCKET_PATH
                                                [--cardano-mode
@@ -3346,7 +3346,7 @@ Usage: cardano-cli mary transaction build-raw
 
   Build a transaction (low-level, inconvenient)
 
-  Please note the order of some cmd options is crucial. If used incorrectly may produce undesired tx body. See nested [] notation above for details.[0;22;23;24m
+  Please note the order[93;22;23;24m of some cmd options is crucial. If used incorrectly may produce undesired tx body. See nested [] notation above for details.[0;22;23;24m
 
 Usage: cardano-cli mary transaction build --socket-path SOCKET_PATH
                                             [--cardano-mode
@@ -4668,7 +4668,7 @@ Usage: cardano-cli alonzo transaction build-raw
 
   Build a transaction (low-level, inconvenient)
 
-  Please note the order of some cmd options is crucial. If used incorrectly may produce undesired tx body. See nested [] notation above for details.[0;22;23;24m
+  Please note the order[93;22;23;24m of some cmd options is crucial. If used incorrectly may produce undesired tx body. See nested [] notation above for details.[0;22;23;24m
 
 Usage: cardano-cli alonzo transaction build --socket-path SOCKET_PATH
                                               [--cardano-mode
@@ -6022,7 +6022,7 @@ Usage: cardano-cli babbage transaction build-raw
 
   Build a transaction (low-level, inconvenient)
 
-  Please note the order of some cmd options is crucial. If used incorrectly may produce undesired tx body. See nested [] notation above for details.[0;22;23;24m
+  Please note the order[93;22;23;24m of some cmd options is crucial. If used incorrectly may produce undesired tx body. See nested [] notation above for details.[0;22;23;24m
 
 Usage: cardano-cli babbage transaction build --socket-path SOCKET_PATH
                                                [--cardano-mode
@@ -7869,7 +7869,7 @@ Usage: cardano-cli conway transaction build-raw
 
   Build a transaction (low-level, inconvenient)
 
-  Please note the order of some cmd options is crucial. If used incorrectly may produce undesired tx body. See nested [] notation above for details.[0;22;23;24m
+  Please note the order[93;22;23;24m of some cmd options is crucial. If used incorrectly may produce undesired tx body. See nested [] notation above for details.[0;22;23;24m
 
 Usage: cardano-cli conway transaction build --socket-path SOCKET_PATH
                                               [--cardano-mode
@@ -9279,7 +9279,7 @@ Usage: cardano-cli latest transaction build-raw
 
   Build a transaction (low-level, inconvenient)
 
-  Please note the order of some cmd options is crucial. If used incorrectly may produce undesired tx body. See nested [] notation above for details.[0;22;23;24m
+  Please note the order[93;22;23;24m of some cmd options is crucial. If used incorrectly may produce undesired tx body. See nested [] notation above for details.[0;22;23;24m
 
 Usage: cardano-cli latest transaction build --socket-path SOCKET_PATH
                                               [--cardano-mode
@@ -10457,7 +10457,7 @@ Usage: cardano-cli legacy transaction build-raw
 
   Build a transaction (low-level, inconvenient)
 
-  Please note the order of some cmd options is crucial. If used incorrectly may produce undesired tx body. See nested [] notation above for details.[0;22;23;24m
+  Please note the order[93;22;23;24m of some cmd options is crucial. If used incorrectly may produce undesired tx body. See nested [] notation above for details.[0;22;23;24m
 
 Usage: cardano-cli legacy transaction build --socket-path SOCKET_PATH
                                               [ --shelley-era
@@ -11732,7 +11732,7 @@ Usage: cardano-cli transaction build-raw
 
   Build a transaction (low-level, inconvenient)
 
-  Please note the order of some cmd options is crucial. If used incorrectly may produce undesired tx body. See nested [] notation above for details.[0;22;23;24m
+  Please note the order[93;22;23;24m of some cmd options is crucial. If used incorrectly may produce undesired tx body. See nested [] notation above for details.[0;22;23;24m
 
 Usage: cardano-cli transaction build --socket-path SOCKET_PATH
                                        [ --shelley-era

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_transaction.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_transaction.cli
@@ -21,7 +21,7 @@ Available options:
 Available commands:
   build-raw                Build a transaction (low-level, inconvenient)
 
-                           Please note the order of some cmd options is crucial. If used incorrectly may produce undesired tx body. See nested [] notation above for details.[0;22;23;24m
+                           Please note the order[93;22;23;24m of some cmd options is crucial. If used incorrectly may produce undesired tx body. See nested [] notation above for details.[0;22;23;24m
   build                    Build a balanced transaction (automatically calculates fees)
 
                            Please note the order[93;22;23;24m of some cmd options is crucial. If used incorrectly may produce undesired tx body. See nested [] notation above for details.[0;22;23;24m

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_transaction_build-raw.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_transaction_build-raw.cli
@@ -124,7 +124,7 @@ Usage: cardano-cli allegra transaction build-raw
 
   Build a transaction (low-level, inconvenient)
 
-  Please note the order of some cmd options is crucial. If used incorrectly may produce undesired tx body. See nested [] notation above for details.[0;22;23;24m
+  Please note the order[93;22;23;24m of some cmd options is crucial. If used incorrectly may produce undesired tx body. See nested [] notation above for details.[0;22;23;24m
 
 Available options:
   --script-valid           Assertion that the script is valid. (default)

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_transaction.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_transaction.cli
@@ -22,7 +22,7 @@ Available options:
 Available commands:
   build-raw                Build a transaction (low-level, inconvenient)
 
-                           Please note the order of some cmd options is crucial. If used incorrectly may produce undesired tx body. See nested [] notation above for details.[0;22;23;24m
+                           Please note the order[93;22;23;24m of some cmd options is crucial. If used incorrectly may produce undesired tx body. See nested [] notation above for details.[0;22;23;24m
   build                    Build a balanced transaction (automatically calculates fees)
 
                            Please note the order[93;22;23;24m of some cmd options is crucial. If used incorrectly may produce undesired tx body. See nested [] notation above for details.[0;22;23;24m

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_transaction_build-raw.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_transaction_build-raw.cli
@@ -124,7 +124,7 @@ Usage: cardano-cli alonzo transaction build-raw
 
   Build a transaction (low-level, inconvenient)
 
-  Please note the order of some cmd options is crucial. If used incorrectly may produce undesired tx body. See nested [] notation above for details.[0;22;23;24m
+  Please note the order[93;22;23;24m of some cmd options is crucial. If used incorrectly may produce undesired tx body. See nested [] notation above for details.[0;22;23;24m
 
 Available options:
   --script-valid           Assertion that the script is valid. (default)

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_transaction.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_transaction.cli
@@ -22,7 +22,7 @@ Available options:
 Available commands:
   build-raw                Build a transaction (low-level, inconvenient)
 
-                           Please note the order of some cmd options is crucial. If used incorrectly may produce undesired tx body. See nested [] notation above for details.[0;22;23;24m
+                           Please note the order[93;22;23;24m of some cmd options is crucial. If used incorrectly may produce undesired tx body. See nested [] notation above for details.[0;22;23;24m
   build                    Build a balanced transaction (automatically calculates fees)
 
                            Please note the order[93;22;23;24m of some cmd options is crucial. If used incorrectly may produce undesired tx body. See nested [] notation above for details.[0;22;23;24m

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_transaction_build-raw.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_transaction_build-raw.cli
@@ -124,7 +124,7 @@ Usage: cardano-cli babbage transaction build-raw
 
   Build a transaction (low-level, inconvenient)
 
-  Please note the order of some cmd options is crucial. If used incorrectly may produce undesired tx body. See nested [] notation above for details.[0;22;23;24m
+  Please note the order[93;22;23;24m of some cmd options is crucial. If used incorrectly may produce undesired tx body. See nested [] notation above for details.[0;22;23;24m
 
 Available options:
   --script-valid           Assertion that the script is valid. (default)

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction.cli
@@ -22,7 +22,7 @@ Available options:
 Available commands:
   build-raw                Build a transaction (low-level, inconvenient)
 
-                           Please note the order of some cmd options is crucial. If used incorrectly may produce undesired tx body. See nested [] notation above for details.[0;22;23;24m
+                           Please note the order[93;22;23;24m of some cmd options is crucial. If used incorrectly may produce undesired tx body. See nested [] notation above for details.[0;22;23;24m
   build                    Build a balanced transaction (automatically calculates fees)
 
                            Please note the order[93;22;23;24m of some cmd options is crucial. If used incorrectly may produce undesired tx body. See nested [] notation above for details.[0;22;23;24m

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_build-raw.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_build-raw.cli
@@ -157,7 +157,7 @@ Usage: cardano-cli conway transaction build-raw
 
   Build a transaction (low-level, inconvenient)
 
-  Please note the order of some cmd options is crucial. If used incorrectly may produce undesired tx body. See nested [] notation above for details.[0;22;23;24m
+  Please note the order[93;22;23;24m of some cmd options is crucial. If used incorrectly may produce undesired tx body. See nested [] notation above for details.[0;22;23;24m
 
 Available options:
   --script-valid           Assertion that the script is valid. (default)

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_transaction.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_transaction.cli
@@ -22,7 +22,7 @@ Available options:
 Available commands:
   build-raw                Build a transaction (low-level, inconvenient)
 
-                           Please note the order of some cmd options is crucial. If used incorrectly may produce undesired tx body. See nested [] notation above for details.[0;22;23;24m
+                           Please note the order[93;22;23;24m of some cmd options is crucial. If used incorrectly may produce undesired tx body. See nested [] notation above for details.[0;22;23;24m
   build                    Build a balanced transaction (automatically calculates fees)
 
                            Please note the order[93;22;23;24m of some cmd options is crucial. If used incorrectly may produce undesired tx body. See nested [] notation above for details.[0;22;23;24m

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_transaction_build-raw.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_transaction_build-raw.cli
@@ -124,7 +124,7 @@ Usage: cardano-cli latest transaction build-raw
 
   Build a transaction (low-level, inconvenient)
 
-  Please note the order of some cmd options is crucial. If used incorrectly may produce undesired tx body. See nested [] notation above for details.[0;22;23;24m
+  Please note the order[93;22;23;24m of some cmd options is crucial. If used incorrectly may produce undesired tx body. See nested [] notation above for details.[0;22;23;24m
 
 Available options:
   --script-valid           Assertion that the script is valid. (default)

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_transaction.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_transaction.cli
@@ -21,7 +21,7 @@ Available options:
 Available commands:
   build-raw                Build a transaction (low-level, inconvenient)
 
-                           Please note the order of some cmd options is crucial. If used incorrectly may produce undesired tx body. See nested [] notation above for details.[0;22;23;24m
+                           Please note the order[93;22;23;24m of some cmd options is crucial. If used incorrectly may produce undesired tx body. See nested [] notation above for details.[0;22;23;24m
   build                    Build a balanced transaction (automatically calculates fees)
 
                            Please note the order[93;22;23;24m of some cmd options is crucial. If used incorrectly may produce undesired tx body. See nested [] notation above for details.[0;22;23;24m

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_transaction_build-raw.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/legacy_transaction_build-raw.cli
@@ -131,7 +131,7 @@ Usage: cardano-cli legacy transaction build-raw
 
   Build a transaction (low-level, inconvenient)
 
-  Please note the order of some cmd options is crucial. If used incorrectly may produce undesired tx body. See nested [] notation above for details.[0;22;23;24m
+  Please note the order[93;22;23;24m of some cmd options is crucial. If used incorrectly may produce undesired tx body. See nested [] notation above for details.[0;22;23;24m
 
 Available options:
   --byron-era              Specify the Byron era

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_transaction.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_transaction.cli
@@ -22,7 +22,7 @@ Available options:
 Available commands:
   build-raw                Build a transaction (low-level, inconvenient)
 
-                           Please note the order of some cmd options is crucial. If used incorrectly may produce undesired tx body. See nested [] notation above for details.[0;22;23;24m
+                           Please note the order[93;22;23;24m of some cmd options is crucial. If used incorrectly may produce undesired tx body. See nested [] notation above for details.[0;22;23;24m
   build                    Build a balanced transaction (automatically calculates fees)
 
                            Please note the order[93;22;23;24m of some cmd options is crucial. If used incorrectly may produce undesired tx body. See nested [] notation above for details.[0;22;23;24m

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_transaction_build-raw.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_transaction_build-raw.cli
@@ -124,7 +124,7 @@ Usage: cardano-cli mary transaction build-raw
 
   Build a transaction (low-level, inconvenient)
 
-  Please note the order of some cmd options is crucial. If used incorrectly may produce undesired tx body. See nested [] notation above for details.[0;22;23;24m
+  Please note the order[93;22;23;24m of some cmd options is crucial. If used incorrectly may produce undesired tx body. See nested [] notation above for details.[0;22;23;24m
 
 Available options:
   --script-valid           Assertion that the script is valid. (default)

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_transaction.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_transaction.cli
@@ -21,7 +21,7 @@ Available options:
 Available commands:
   build-raw                Build a transaction (low-level, inconvenient)
 
-                           Please note the order of some cmd options is crucial. If used incorrectly may produce undesired tx body. See nested [] notation above for details.[0;22;23;24m
+                           Please note the order[93;22;23;24m of some cmd options is crucial. If used incorrectly may produce undesired tx body. See nested [] notation above for details.[0;22;23;24m
   build                    Build a balanced transaction (automatically calculates fees)
 
                            Please note the order[93;22;23;24m of some cmd options is crucial. If used incorrectly may produce undesired tx body. See nested [] notation above for details.[0;22;23;24m

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_transaction_build-raw.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_transaction_build-raw.cli
@@ -124,7 +124,7 @@ Usage: cardano-cli shelley transaction build-raw
 
   Build a transaction (low-level, inconvenient)
 
-  Please note the order of some cmd options is crucial. If used incorrectly may produce undesired tx body. See nested [] notation above for details.[0;22;23;24m
+  Please note the order[93;22;23;24m of some cmd options is crucial. If used incorrectly may produce undesired tx body. See nested [] notation above for details.[0;22;23;24m
 
 Available options:
   --script-valid           Assertion that the script is valid. (default)

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/transaction.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/transaction.cli
@@ -21,7 +21,7 @@ Available options:
 Available commands:
   build-raw                Build a transaction (low-level, inconvenient)
 
-                           Please note the order of some cmd options is crucial. If used incorrectly may produce undesired tx body. See nested [] notation above for details.[0;22;23;24m
+                           Please note the order[93;22;23;24m of some cmd options is crucial. If used incorrectly may produce undesired tx body. See nested [] notation above for details.[0;22;23;24m
   build                    Build a balanced transaction (automatically calculates fees)
 
                            Please note the order[93;22;23;24m of some cmd options is crucial. If used incorrectly may produce undesired tx body. See nested [] notation above for details.[0;22;23;24m

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/transaction_build-raw.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/transaction_build-raw.cli
@@ -129,7 +129,7 @@ Usage: cardano-cli transaction build-raw
 
   Build a transaction (low-level, inconvenient)
 
-  Please note the order of some cmd options is crucial. If used incorrectly may produce undesired tx body. See nested [] notation above for details.[0;22;23;24m
+  Please note the order[93;22;23;24m of some cmd options is crucial. If used incorrectly may produce undesired tx body. See nested [] notation above for details.[0;22;23;24m
 
 Available options:
   --byron-era              Specify the Byron era


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Fix estimated fee rendering: previously the output was of the form `Estimated transaction fee: Coin 357154`.
    Now it is: `Estimated transaction fee: 357154 Lovelace`
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
   - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Previously estimated fee was rendered as:
```
Estimated transaction fee: Coin 357154
```
After the change:
```
Estimated transaction fee: 357154 Lovelace
```

This PR changes also some text highlighting in the help text to make it consistent.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
