### PR TITLE
create-testnet-data: better behavior for create-testnet-data --total-supply and --delegated-supply

### DIFF
--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -292,6 +292,7 @@ library cardano-cli-test-lib
     bytestring,
     cardano-api,
     cardano-cli,
+    containers,
     directory,
     exceptions,
     filepath,
@@ -302,6 +303,7 @@ library cardano-cli-test-lib
     process,
     text,
     transformers-base,
+    vector,
 
 test-suite cardano-cli-test
   import: project-config

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Genesis.hs
@@ -328,10 +328,9 @@ pGenesisCreateTestNetData sbe envCli =
             , Opt.metavar "LOVELACE"
             , Opt.help $
                 mconcat
-                  [ "The maximum possible amount of Lovelace, which is evenly distributed across stake holders. Defaults to 1 million Ada (i.e. 10^12 Lovelace)."
+                  [ "The maximum possible amount of Lovelace, which is evenly distributed across stake holders. Overrides the value from the shelley genesis."
                   , " If --delegated-supply is specified, a part of this amount will be delegated."
                   ]
-            , Opt.value 1_000_000_000_000
             ]
   pSupplyDelegated :: Parser (Maybe Coin)
   pSupplyDelegated =
@@ -343,10 +342,9 @@ pGenesisCreateTestNetData sbe envCli =
             , Opt.metavar "LOVELACE"
             , Opt.help $
                 mconcat
-                  [ "The amount of the total supply which is evenly delegated. Defaults to 500 000 Ada (i.e. (10^12) / 2 Lovelace)."
+                  [ "The amount of the total supply which is evenly delegated. Defaulted to half of the total supply."
                   , " Cannot be more than the amount specified with --total-supply."
                   ]
-            , Opt.value 500_000_000_000
             ]
   pRelays :: Parser FilePath
   pRelays =

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Genesis/CreateTestnetData.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Genesis/CreateTestnetData.hs
@@ -738,7 +738,7 @@ updateOutputTemplate
     totalSupply = fromIntegral $ maybe maximumLovelaceSupply unLovelace mTotalSupply
 
     delegCoinRaw, nonDelegCoinRaw :: Integer
-    delegCoinRaw = maybe 0 unLovelace mDelegatedSupply
+    delegCoinRaw = maybe (totalSupply `div` 2) unLovelace mDelegatedSupply
     -- Since the user can specify total supply and delegated amount, the non-delegated amount is:
     nonDelegCoinRaw = totalSupply - delegCoinRaw
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/conway/custom-lovelace-supply-shelley-genesis.json
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/conway/custom-lovelace-supply-shelley-genesis.json
@@ -1,0 +1,43 @@
+{
+    "activeSlotsCoeff": 0.99,
+    "epochLength": 21600,
+    "genDelegs": "<redacted>",
+    "initialFunds": {},
+    "maxKESEvolutions": 1080000,
+    "maxLovelaceSupply": 3123456000000,
+    "networkId": "Testnet",
+    "networkMagic": 403,
+    "protocolParams": {
+        "a0": 0,
+        "decentralisationParam": 0.99,
+        "eMax": 0,
+        "extraEntropy": {
+            "tag": "NeutralNonce"
+        },
+        "keyDeposit": 0,
+        "maxBlockBodySize": 2097152,
+        "maxBlockHeaderSize": 8192,
+        "maxTxSize": 2048,
+        "minFeeA": 0,
+        "minFeeB": 0,
+        "minPoolCost": 100,
+        "minUTxOValue": 1,
+        "nOpt": 100,
+        "poolDeposit": 0,
+        "protocolVersion": {
+            "major": 0,
+            "minor": 0
+        },
+        "rho": 0,
+        "tau": 0
+    },
+    "securityParam": 2160,
+    "slotLength": 20,
+    "slotsPerKESPeriod": 216000,
+    "staking": {
+        "pools": {},
+        "stake": {}
+    },
+    "systemStart": "<redacted>",
+    "updateQuorum": 12
+}

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_genesis_create-testnet-data.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_genesis_create-testnet-data.cli
@@ -45,15 +45,15 @@ Available options:
                            is 0).
   --utxo-keys INT          The number of UTxO keys to make (default is 0).
   --total-supply LOVELACE  The maximum possible amount of Lovelace, which is
-                           evenly distributed across stake holders. Defaults to
-                           1 million Ada (i.e. 10^12 Lovelace). If
+                           evenly distributed across stake holders. Overrides
+                           the value from the shelley genesis. If
                            --delegated-supply is specified, a part of this
                            amount will be delegated.
   --delegated-supply LOVELACE
                            The amount of the total supply which is evenly
-                           delegated. Defaults to 500 000 Ada (i.e. (10^12) / 2
-                           Lovelace). Cannot be more than the amount specified
-                           with --total-supply.
+                           delegated. Defaulted to half of the total supply.
+                           Cannot be more than the amount specified with
+                           --total-supply.
   --testnet-magic NATURAL  Specify a testnet magic id for the cluster. This
                            overrides both the network magic from the spec file
                            and CARDANO_NODE_NETWORK_ID environment variable.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_genesis_create-testnet-data.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_genesis_create-testnet-data.cli
@@ -45,15 +45,15 @@ Available options:
                            is 0).
   --utxo-keys INT          The number of UTxO keys to make (default is 0).
   --total-supply LOVELACE  The maximum possible amount of Lovelace, which is
-                           evenly distributed across stake holders. Defaults to
-                           1 million Ada (i.e. 10^12 Lovelace). If
+                           evenly distributed across stake holders. Overrides
+                           the value from the shelley genesis. If
                            --delegated-supply is specified, a part of this
                            amount will be delegated.
   --delegated-supply LOVELACE
                            The amount of the total supply which is evenly
-                           delegated. Defaults to 500 000 Ada (i.e. (10^12) / 2
-                           Lovelace). Cannot be more than the amount specified
-                           with --total-supply.
+                           delegated. Defaulted to half of the total supply.
+                           Cannot be more than the amount specified with
+                           --total-supply.
   --testnet-magic NATURAL  Specify a testnet magic id for the cluster. This
                            overrides both the network magic from the spec file
                            and CARDANO_NODE_NETWORK_ID environment variable.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_genesis_create-testnet-data.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_genesis_create-testnet-data.cli
@@ -45,15 +45,15 @@ Available options:
                            is 0).
   --utxo-keys INT          The number of UTxO keys to make (default is 0).
   --total-supply LOVELACE  The maximum possible amount of Lovelace, which is
-                           evenly distributed across stake holders. Defaults to
-                           1 million Ada (i.e. 10^12 Lovelace). If
+                           evenly distributed across stake holders. Overrides
+                           the value from the shelley genesis. If
                            --delegated-supply is specified, a part of this
                            amount will be delegated.
   --delegated-supply LOVELACE
                            The amount of the total supply which is evenly
-                           delegated. Defaults to 500 000 Ada (i.e. (10^12) / 2
-                           Lovelace). Cannot be more than the amount specified
-                           with --total-supply.
+                           delegated. Defaulted to half of the total supply.
+                           Cannot be more than the amount specified with
+                           --total-supply.
   --testnet-magic NATURAL  Specify a testnet magic id for the cluster. This
                            overrides both the network magic from the spec file
                            and CARDANO_NODE_NETWORK_ID environment variable.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_genesis_create-testnet-data.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_genesis_create-testnet-data.cli
@@ -45,15 +45,15 @@ Available options:
                            is 0).
   --utxo-keys INT          The number of UTxO keys to make (default is 0).
   --total-supply LOVELACE  The maximum possible amount of Lovelace, which is
-                           evenly distributed across stake holders. Defaults to
-                           1 million Ada (i.e. 10^12 Lovelace). If
+                           evenly distributed across stake holders. Overrides
+                           the value from the shelley genesis. If
                            --delegated-supply is specified, a part of this
                            amount will be delegated.
   --delegated-supply LOVELACE
                            The amount of the total supply which is evenly
-                           delegated. Defaults to 500 000 Ada (i.e. (10^12) / 2
-                           Lovelace). Cannot be more than the amount specified
-                           with --total-supply.
+                           delegated. Defaulted to half of the total supply.
+                           Cannot be more than the amount specified with
+                           --total-supply.
   --testnet-magic NATURAL  Specify a testnet magic id for the cluster. This
                            overrides both the network magic from the spec file
                            and CARDANO_NODE_NETWORK_ID environment variable.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_genesis_create-testnet-data.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_genesis_create-testnet-data.cli
@@ -45,15 +45,15 @@ Available options:
                            is 0).
   --utxo-keys INT          The number of UTxO keys to make (default is 0).
   --total-supply LOVELACE  The maximum possible amount of Lovelace, which is
-                           evenly distributed across stake holders. Defaults to
-                           1 million Ada (i.e. 10^12 Lovelace). If
+                           evenly distributed across stake holders. Overrides
+                           the value from the shelley genesis. If
                            --delegated-supply is specified, a part of this
                            amount will be delegated.
   --delegated-supply LOVELACE
                            The amount of the total supply which is evenly
-                           delegated. Defaults to 500 000 Ada (i.e. (10^12) / 2
-                           Lovelace). Cannot be more than the amount specified
-                           with --total-supply.
+                           delegated. Defaulted to half of the total supply.
+                           Cannot be more than the amount specified with
+                           --total-supply.
   --testnet-magic NATURAL  Specify a testnet magic id for the cluster. This
                            overrides both the network magic from the spec file
                            and CARDANO_NODE_NETWORK_ID environment variable.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_genesis_create-testnet-data.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_genesis_create-testnet-data.cli
@@ -45,15 +45,15 @@ Available options:
                            is 0).
   --utxo-keys INT          The number of UTxO keys to make (default is 0).
   --total-supply LOVELACE  The maximum possible amount of Lovelace, which is
-                           evenly distributed across stake holders. Defaults to
-                           1 million Ada (i.e. 10^12 Lovelace). If
+                           evenly distributed across stake holders. Overrides
+                           the value from the shelley genesis. If
                            --delegated-supply is specified, a part of this
                            amount will be delegated.
   --delegated-supply LOVELACE
                            The amount of the total supply which is evenly
-                           delegated. Defaults to 500 000 Ada (i.e. (10^12) / 2
-                           Lovelace). Cannot be more than the amount specified
-                           with --total-supply.
+                           delegated. Defaulted to half of the total supply.
+                           Cannot be more than the amount specified with
+                           --total-supply.
   --testnet-magic NATURAL  Specify a testnet magic id for the cluster. This
                            overrides both the network magic from the spec file
                            and CARDANO_NODE_NETWORK_ID environment variable.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_genesis_create-testnet-data.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_genesis_create-testnet-data.cli
@@ -45,15 +45,15 @@ Available options:
                            is 0).
   --utxo-keys INT          The number of UTxO keys to make (default is 0).
   --total-supply LOVELACE  The maximum possible amount of Lovelace, which is
-                           evenly distributed across stake holders. Defaults to
-                           1 million Ada (i.e. 10^12 Lovelace). If
+                           evenly distributed across stake holders. Overrides
+                           the value from the shelley genesis. If
                            --delegated-supply is specified, a part of this
                            amount will be delegated.
   --delegated-supply LOVELACE
                            The amount of the total supply which is evenly
-                           delegated. Defaults to 500 000 Ada (i.e. (10^12) / 2
-                           Lovelace). Cannot be more than the amount specified
-                           with --total-supply.
+                           delegated. Defaulted to half of the total supply.
+                           Cannot be more than the amount specified with
+                           --total-supply.
   --testnet-magic NATURAL  Specify a testnet magic id for the cluster. This
                            overrides both the network magic from the spec file
                            and CARDANO_NODE_NETWORK_ID environment variable.


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    create-testnet-data's --total-supply option doesn't have a default anymore. The default value is to take the value from the shelley genesis file (if provided, otherwise this file is defaulted, so total supply comes from the default shelley genesis). create-testnet-data's --delegated-supply option doesn't have a default anymore. The default is to use half of the total supply.
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Contributes to fixing https://github.com/IntersectMBO/cardano-node/issues/5953

The API for `create-testnet-data`'s total supply and delegated supply was bad:

1. `--total-supply` had a default value. So we would never pick up the value coming from the shelley genesis file. Now the behavior is that, if `--total-supply` is specified, it overrides the value from the shelley genesis file. Because the shelley genesis file is defaulted, there is always a value available.
2. `--delegated-supply` had a default value. This does not play well with the value of total supply coming from either the genesis file or `--total-supply`. Now the default is to take half of the total supply (no matter from where it comes from).

# How to trust this PR

* Tested with `cardano-testnet` at fecf2bf0c728060c0ff408d2a7fecc152c25dd4f

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [X] Self-reviewed the diff