### PR TITLE
Remove deprecation message when invoking a command in deprecated era

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run.hs
@@ -21,10 +21,8 @@ import           Cardano.CLI.EraBased.Run.StakeAddress
 import           Cardano.CLI.EraBased.Run.StakePool
 import           Cardano.CLI.EraBased.Run.TextView
 import           Cardano.CLI.EraBased.Run.Transaction
-import           Cardano.CLI.Helpers (printWarning)
 import           Cardano.CLI.Types.Errors.CmdError
 
-import           Control.Monad
 import           Data.Function ((&))
 
 runAnyEraCommand
@@ -33,10 +31,11 @@ runAnyEraCommand
   -> ExceptT CmdError IO ()
 runAnyEraCommand = \case
   AnyEraCommandOf sbe cmd -> do
-    let selectedEraNum = fromEnum $ AnyShelleyBasedEra sbe
-        currentEraNum = fromEnum $ AnyShelleyBasedEra ShelleyBasedEraConway
-    when (selectedEraNum < currentEraNum) $
-      printWarning "Selected era is deprecated and will be removed in the future."
+    -- FIXME: Uncomment this after CLI release
+    -- let selectedEraNum = fromEnum $ AnyShelleyBasedEra sbe
+    --     currentEraNum = fromEnum $ AnyShelleyBasedEra ShelleyBasedEraConway
+    -- when (selectedEraNum < currentEraNum) $
+    --   printWarning "Selected era is deprecated and will be removed in the future."
     shelleyBasedEraConstraints sbe $ runCmds cmd
 
 runCmds

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_transaction_view.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_transaction_view.cli
@@ -1,2 +1,1 @@
-WARNING: Selected era is deprecated and will be removed in the future.
 Command "era transaction view" has been removed. Please use "debug transaction view" instead.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_transaction_view.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_transaction_view.cli
@@ -1,2 +1,1 @@
-WARNING: Selected era is deprecated and will be removed in the future.
 Command "era transaction view" has been removed. Please use "debug transaction view" instead.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_transaction_view.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_transaction_view.cli
@@ -1,2 +1,1 @@
-WARNING: Selected era is deprecated and will be removed in the future.
 Command "era transaction view" has been removed. Please use "debug transaction view" instead.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_transaction_view.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_transaction_view.cli
@@ -1,2 +1,1 @@
-WARNING: Selected era is deprecated and will be removed in the future.
 Command "era transaction view" has been removed. Please use "debug transaction view" instead.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_transaction_view.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_transaction_view.cli
@@ -1,2 +1,1 @@
-WARNING: Selected era is deprecated and will be removed in the future.
 Command "era transaction view" has been removed. Please use "debug transaction view" instead.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_transaction_view.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_transaction_view.cli
@@ -1,2 +1,1 @@
-WARNING: Selected era is deprecated and will be removed in the future.
 Command "era transaction view" has been removed. Please use "debug transaction view" instead.


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Remove deprecation message when invoking a command in deprecated era
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
   - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

n/a

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
