### PR TITLE
cardano-ping: report user friendly error on misconfiguration

### DIFF
--- a/cardano-cli/src/Cardano/CLI/Commands/Ping.hs
+++ b/cardano-cli/src/Cardano/CLI/Commands/Ping.hs
@@ -1,6 +1,7 @@
 module Cardano.CLI.Commands.Ping
   ( EndPoint (..)
   , PingCmd (..)
+  , getConfigurationError
   )
 where
 
@@ -22,3 +23,16 @@ data PingCmd = PingCmd
   , pingOptsGetTip :: !Bool
   }
   deriving (Eq, Show)
+
+getConfigurationError :: PingCmd -> Maybe String
+getConfigurationError
+  PingCmd
+    { pingCmdEndPoint = endPoint
+    , pingOptsGetTip = getTip
+    , pingOptsHandshakeQuery = query
+    } =
+    case endPoint of
+      UnixSockEndPoint{}
+        | query || getTip -> Nothing
+        | otherwise -> Just "Unix sockets only support queries for available versions or a tip."
+      HostEndPoint{} -> Nothing


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Show user friendly warning when `cardano ping` command is misconfigured.
# uncomment types applicable to the change:
  type:
    - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Fixes #49. 

# How to trust this PR

When using unix sockets, `cardano-ping` can only query tip or supported
versions, since the `node-to-client` protocol doesn't include `keep-alive`
mini-protocol.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
