### PR TITLE
Move parsing helpers from API

### DIFF
--- a/cardano-cli/src/Cardano/CLI/Byron/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Parsers.hs
@@ -24,7 +24,7 @@ module Cardano.CLI.Byron.Parsers
   )
 where
 
-import           Cardano.Api hiding (GenesisParameters, UpdateProposal)
+import           Cardano.Api hiding (GenesisParameters, UpdateProposal, parseFilePath)
 import           Cardano.Api.Byron (Address (..), ByronProtocolParametersUpdate (..),
                    toByronLovelace)
 import qualified Cardano.Api.Ledger as L

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Genesis.hs
@@ -9,7 +9,7 @@ module Cardano.CLI.EraBased.Options.Genesis
   )
 where
 
-import           Cardano.Api hiding (QueryInShelleyBasedEra (..))
+import           Cardano.Api hiding (QueryInShelleyBasedEra (..), parseFilePath)
 import           Cardano.Api.Ledger (Coin (..))
 
 import           Cardano.Chain.Common (BlockCount (BlockCount))

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Key.hs
@@ -8,7 +8,7 @@ module Cardano.CLI.EraBased.Options.Key
   )
 where
 
-import           Cardano.Api hiding (QueryInShelleyBasedEra (..))
+import           Cardano.Api hiding (QueryInShelleyBasedEra (..), parseFilePath)
 
 import           Cardano.CLI.EraBased.Commands.Key
 import           Cardano.CLI.EraBased.Options.Common

--- a/cardano-cli/src/Cardano/CLI/Legacy/Options.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Options.hs
@@ -21,9 +21,9 @@ module Cardano.CLI.Legacy.Options
   )
 where
 
-import           Cardano.Api hiding (QueryInShelleyBasedEra (..))
+import           Cardano.Api hiding (QueryInShelleyBasedEra (..), parseFilePath)
 import           Cardano.Api.Ledger (Coin (..))
-import           Cardano.Api.Shelley hiding (QueryInShelleyBasedEra (..))
+import           Cardano.Api.Shelley hiding (QueryInShelleyBasedEra (..), parseFilePath)
 
 import           Cardano.Chain.Common (BlockCount (BlockCount))
 import           Cardano.CLI.Environment

--- a/cardano-cli/src/Cardano/CLI/Legacy/Options/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Options/Key.hs
@@ -8,7 +8,7 @@ module Cardano.CLI.Legacy.Options.Key
   )
 where
 
-import           Cardano.Api hiding (QueryInShelleyBasedEra (..))
+import           Cardano.Api hiding (QueryInShelleyBasedEra (..), parseFilePath)
 
 import           Cardano.CLI.EraBased.Options.Common
 import           Cardano.CLI.Legacy.Commands.Key

--- a/cardano-cli/src/Cardano/CLI/Options/Debug.hs
+++ b/cardano-cli/src/Cardano/CLI/Options/Debug.hs
@@ -11,7 +11,7 @@ module Cardano.CLI.Options.Debug
   )
 where
 
-import           Cardano.Api.Shelley hiding (QueryInShelleyBasedEra (..))
+import           Cardano.Api.Shelley hiding (QueryInShelleyBasedEra (..), parseFilePath)
 
 import           Cardano.CLI.Commands.Debug
 import           Cardano.CLI.Commands.Debug.LogEpochState


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Adapts to https://github.com/IntersectMBO/cardano-api/pull/635
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Additional context for the PR goes here. If the PR fixes a particular issue please provide a [link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=) to the issue.

# How to trust this PR

Code compiling suffices, because this PR doesn't change the runtime behavior.

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] Self-reviewed the diff