### PR TITLE
Add support for supplementary datums

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -57,3 +57,9 @@ write-ghc-environment-files: always
 -- IMPORTANT
 -- Do NOT add more source-repository-package stanzas here unless they are strictly
 -- temporary! Please read the section in CONTRIBUTING about updating dependencies.
+
+source-repository-package
+    type: git
+    location: https://github.com/IntersectMBO/cardano-api.git
+    tag: 22417a0f7fce857324dd01389afbeb9fee948cac
+    subdir: cardano-api

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Transaction.hs
@@ -1313,7 +1313,7 @@ toTxAlonzoDatum supp cliDatum =
       pure (TxOutDatumHash supp $ hashScriptDataBytes sData)
     TxOutDatumByValue sDataOrFile -> do
       sData <- firstExceptT TxCmdScriptDataError $ readScriptDataOrFile sDataOrFile
-      pure (TxOutDatumInTx supp sData)
+      pure (TxOutSupplementalDatum supp sData)
     TxOutInlineDatumByValue sDataOrFile -> do
       let cEra = toCardanoEra supp
       forEraInEon cEra (txFeatureMismatch cEra TxFeatureInlineDatums) $ \babbageOnwards -> do

--- a/cardano-cli/src/Cardano/CLI/Json/Friendly.hs
+++ b/cardano-cli/src/Cardano/CLI/Json/Friendly.hs
@@ -212,7 +212,6 @@ friendlyTxBodyImpl
             txValidityUpperBound
             txMetadata
             txAuxScripts
-            txSupplementalData
             txExtraKeyWits
             _txProtocolParams
             txWithdrawals
@@ -252,10 +251,6 @@ friendlyTxBodyImpl
                     era
                     (`getRedeemerDetails` tb)
                  )
-              ++ ( monoidForEraInEon @AlonzoEraOnwards
-                    era
-                    (`friendlySupplementalDatums` txSupplementalData)
-                 )
               ++ ( monoidForEraInEon @ConwayEraOnwards
                     era
                     ( \cOnwards ->
@@ -292,16 +287,6 @@ friendlyTxBodyImpl
       :: ConwayEraOnwards era -> [L.ProposalProcedure (ShelleyLedgerEra era)] -> Aeson.Value
     friendlyLedgerProposals cOnwards proposalProcedures =
       Array $ fromList $ map (friendlyLedgerProposal cOnwards) proposalProcedures
-
--- | API doesn't yet show that supplemental datums are alonzo onwards. So we do it in this function prototype,
--- even if we don't use the witness.
-friendlySupplementalDatums
-  :: AlonzoEraOnwards era -> BuildTxWith build (TxSupplementalDatums era) -> [Aeson.Pair]
-friendlySupplementalDatums _era = \case
-  ViewTx -> []
-  BuildTxWith TxSupplementalDataNone -> []
-  BuildTxWith (TxSupplementalDatums hashableScriptDatas) ->
-    ["supplemental datums" .= toJSON hashableScriptDatas]
 
 friendlyLedgerProposal
   :: ConwayEraOnwards era -> L.ProposalProcedure (ShelleyLedgerEra era) -> Aeson.Value
@@ -483,7 +468,7 @@ friendlyTxOut era (TxOut addr amount mdatum script) =
   renderDatum = \case
     TxOutDatumNone -> Nothing
     TxOutDatumHash _ h -> Just $ toJSON h
-    TxOutDatumInTx _ sData -> Just $ scriptDataToJson ScriptDataJsonDetailedSchema sData
+    TxOutSupplementalDatum _ sData -> Just $ scriptDataToJson ScriptDataJsonDetailedSchema sData
     TxOutDatumInline _ sData -> Just $ scriptDataToJson ScriptDataJsonDetailedSchema sData
 
 friendlyStakeReference :: StakeAddressReference -> Aeson.Value

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -1618,9 +1618,9 @@ Usage: cardano-cli shelley transaction build-raw
                                                      | --tx-out-datum-hash-cbor-file CBOR_FILE
                                                      | --tx-out-datum-hash-file JSON_FILE
                                                      | --tx-out-datum-hash-value JSON_VALUE
-                                                     | --tx-out-datum-embed-cbor-file CBOR_FILE
-                                                     | --tx-out-datum-embed-file JSON_FILE
-                                                     | --tx-out-datum-embed-value JSON_VALUE
+                                                     | --tx-out-supplemental-datum-cbor-file CBOR_FILE
+                                                     | --tx-out-supplemental-datum-file JSON_FILE
+                                                     | --tx-out-supplemental-datum-value JSON_VALUE
                                                      | --tx-out-inline-datum-cbor-file CBOR_FILE
                                                      | --tx-out-inline-datum-file JSON_FILE
                                                      | --tx-out-inline-datum-value JSON_VALUE
@@ -1774,9 +1774,9 @@ Usage: cardano-cli shelley transaction calculate-min-required-utxo --protocol-pa
                                                                      | --tx-out-datum-hash-cbor-file CBOR_FILE
                                                                      | --tx-out-datum-hash-file JSON_FILE
                                                                      | --tx-out-datum-hash-value JSON_VALUE
-                                                                     | --tx-out-datum-embed-cbor-file CBOR_FILE
-                                                                     | --tx-out-datum-embed-file JSON_FILE
-                                                                     | --tx-out-datum-embed-value JSON_VALUE
+                                                                     | --tx-out-supplemental-datum-cbor-file CBOR_FILE
+                                                                     | --tx-out-supplemental-datum-file JSON_FILE
+                                                                     | --tx-out-supplemental-datum-value JSON_VALUE
                                                                      | --tx-out-inline-datum-cbor-file CBOR_FILE
                                                                      | --tx-out-inline-datum-file JSON_FILE
                                                                      | --tx-out-inline-datum-value JSON_VALUE
@@ -1791,9 +1791,9 @@ Usage: cardano-cli shelley transaction calculate-min-value --protocol-params-fil
                                                              | --tx-out-datum-hash-cbor-file CBOR_FILE
                                                              | --tx-out-datum-hash-file JSON_FILE
                                                              | --tx-out-datum-hash-value JSON_VALUE
-                                                             | --tx-out-datum-embed-cbor-file CBOR_FILE
-                                                             | --tx-out-datum-embed-file JSON_FILE
-                                                             | --tx-out-datum-embed-value JSON_VALUE
+                                                             | --tx-out-supplemental-datum-cbor-file CBOR_FILE
+                                                             | --tx-out-supplemental-datum-file JSON_FILE
+                                                             | --tx-out-supplemental-datum-value JSON_VALUE
                                                              | --tx-out-inline-datum-cbor-file CBOR_FILE
                                                              | --tx-out-inline-datum-file JSON_FILE
                                                              | --tx-out-inline-datum-value JSON_VALUE
@@ -2690,9 +2690,9 @@ Usage: cardano-cli allegra transaction build-raw
                                                      | --tx-out-datum-hash-cbor-file CBOR_FILE
                                                      | --tx-out-datum-hash-file JSON_FILE
                                                      | --tx-out-datum-hash-value JSON_VALUE
-                                                     | --tx-out-datum-embed-cbor-file CBOR_FILE
-                                                     | --tx-out-datum-embed-file JSON_FILE
-                                                     | --tx-out-datum-embed-value JSON_VALUE
+                                                     | --tx-out-supplemental-datum-cbor-file CBOR_FILE
+                                                     | --tx-out-supplemental-datum-file JSON_FILE
+                                                     | --tx-out-supplemental-datum-value JSON_VALUE
                                                      | --tx-out-inline-datum-cbor-file CBOR_FILE
                                                      | --tx-out-inline-datum-file JSON_FILE
                                                      | --tx-out-inline-datum-value JSON_VALUE
@@ -2846,9 +2846,9 @@ Usage: cardano-cli allegra transaction calculate-min-required-utxo --protocol-pa
                                                                      | --tx-out-datum-hash-cbor-file CBOR_FILE
                                                                      | --tx-out-datum-hash-file JSON_FILE
                                                                      | --tx-out-datum-hash-value JSON_VALUE
-                                                                     | --tx-out-datum-embed-cbor-file CBOR_FILE
-                                                                     | --tx-out-datum-embed-file JSON_FILE
-                                                                     | --tx-out-datum-embed-value JSON_VALUE
+                                                                     | --tx-out-supplemental-datum-cbor-file CBOR_FILE
+                                                                     | --tx-out-supplemental-datum-file JSON_FILE
+                                                                     | --tx-out-supplemental-datum-value JSON_VALUE
                                                                      | --tx-out-inline-datum-cbor-file CBOR_FILE
                                                                      | --tx-out-inline-datum-file JSON_FILE
                                                                      | --tx-out-inline-datum-value JSON_VALUE
@@ -2863,9 +2863,9 @@ Usage: cardano-cli allegra transaction calculate-min-value --protocol-params-fil
                                                              | --tx-out-datum-hash-cbor-file CBOR_FILE
                                                              | --tx-out-datum-hash-file JSON_FILE
                                                              | --tx-out-datum-hash-value JSON_VALUE
-                                                             | --tx-out-datum-embed-cbor-file CBOR_FILE
-                                                             | --tx-out-datum-embed-file JSON_FILE
-                                                             | --tx-out-datum-embed-value JSON_VALUE
+                                                             | --tx-out-supplemental-datum-cbor-file CBOR_FILE
+                                                             | --tx-out-supplemental-datum-file JSON_FILE
+                                                             | --tx-out-supplemental-datum-value JSON_VALUE
                                                              | --tx-out-inline-datum-cbor-file CBOR_FILE
                                                              | --tx-out-inline-datum-file JSON_FILE
                                                              | --tx-out-inline-datum-value JSON_VALUE
@@ -3754,9 +3754,9 @@ Usage: cardano-cli mary transaction build-raw
                                                   | --tx-out-datum-hash-cbor-file CBOR_FILE
                                                   | --tx-out-datum-hash-file JSON_FILE
                                                   | --tx-out-datum-hash-value JSON_VALUE
-                                                  | --tx-out-datum-embed-cbor-file CBOR_FILE
-                                                  | --tx-out-datum-embed-file JSON_FILE
-                                                  | --tx-out-datum-embed-value JSON_VALUE
+                                                  | --tx-out-supplemental-datum-cbor-file CBOR_FILE
+                                                  | --tx-out-supplemental-datum-file JSON_FILE
+                                                  | --tx-out-supplemental-datum-value JSON_VALUE
                                                   | --tx-out-inline-datum-cbor-file CBOR_FILE
                                                   | --tx-out-inline-datum-file JSON_FILE
                                                   | --tx-out-inline-datum-value JSON_VALUE
@@ -3908,9 +3908,9 @@ Usage: cardano-cli mary transaction calculate-min-required-utxo --protocol-param
                                                                   | --tx-out-datum-hash-cbor-file CBOR_FILE
                                                                   | --tx-out-datum-hash-file JSON_FILE
                                                                   | --tx-out-datum-hash-value JSON_VALUE
-                                                                  | --tx-out-datum-embed-cbor-file CBOR_FILE
-                                                                  | --tx-out-datum-embed-file JSON_FILE
-                                                                  | --tx-out-datum-embed-value JSON_VALUE
+                                                                  | --tx-out-supplemental-datum-cbor-file CBOR_FILE
+                                                                  | --tx-out-supplemental-datum-file JSON_FILE
+                                                                  | --tx-out-supplemental-datum-value JSON_VALUE
                                                                   | --tx-out-inline-datum-cbor-file CBOR_FILE
                                                                   | --tx-out-inline-datum-file JSON_FILE
                                                                   | --tx-out-inline-datum-value JSON_VALUE
@@ -3925,9 +3925,9 @@ Usage: cardano-cli mary transaction calculate-min-value --protocol-params-file F
                                                           | --tx-out-datum-hash-cbor-file CBOR_FILE
                                                           | --tx-out-datum-hash-file JSON_FILE
                                                           | --tx-out-datum-hash-value JSON_VALUE
-                                                          | --tx-out-datum-embed-cbor-file CBOR_FILE
-                                                          | --tx-out-datum-embed-file JSON_FILE
-                                                          | --tx-out-datum-embed-value JSON_VALUE
+                                                          | --tx-out-supplemental-datum-cbor-file CBOR_FILE
+                                                          | --tx-out-supplemental-datum-file JSON_FILE
+                                                          | --tx-out-supplemental-datum-value JSON_VALUE
                                                           | --tx-out-inline-datum-cbor-file CBOR_FILE
                                                           | --tx-out-inline-datum-file JSON_FILE
                                                           | --tx-out-inline-datum-value JSON_VALUE
@@ -4829,9 +4829,9 @@ Usage: cardano-cli alonzo transaction build-raw
                                                     | --tx-out-datum-hash-cbor-file CBOR_FILE
                                                     | --tx-out-datum-hash-file JSON_FILE
                                                     | --tx-out-datum-hash-value JSON_VALUE
-                                                    | --tx-out-datum-embed-cbor-file CBOR_FILE
-                                                    | --tx-out-datum-embed-file JSON_FILE
-                                                    | --tx-out-datum-embed-value JSON_VALUE
+                                                    | --tx-out-supplemental-datum-cbor-file CBOR_FILE
+                                                    | --tx-out-supplemental-datum-file JSON_FILE
+                                                    | --tx-out-supplemental-datum-value JSON_VALUE
                                                     | --tx-out-inline-datum-cbor-file CBOR_FILE
                                                     | --tx-out-inline-datum-file JSON_FILE
                                                     | --tx-out-inline-datum-value JSON_VALUE
@@ -4985,9 +4985,9 @@ Usage: cardano-cli alonzo transaction calculate-min-required-utxo --protocol-par
                                                                     | --tx-out-datum-hash-cbor-file CBOR_FILE
                                                                     | --tx-out-datum-hash-file JSON_FILE
                                                                     | --tx-out-datum-hash-value JSON_VALUE
-                                                                    | --tx-out-datum-embed-cbor-file CBOR_FILE
-                                                                    | --tx-out-datum-embed-file JSON_FILE
-                                                                    | --tx-out-datum-embed-value JSON_VALUE
+                                                                    | --tx-out-supplemental-datum-cbor-file CBOR_FILE
+                                                                    | --tx-out-supplemental-datum-file JSON_FILE
+                                                                    | --tx-out-supplemental-datum-value JSON_VALUE
                                                                     | --tx-out-inline-datum-cbor-file CBOR_FILE
                                                                     | --tx-out-inline-datum-file JSON_FILE
                                                                     | --tx-out-inline-datum-value JSON_VALUE
@@ -5002,9 +5002,9 @@ Usage: cardano-cli alonzo transaction calculate-min-value --protocol-params-file
                                                             | --tx-out-datum-hash-cbor-file CBOR_FILE
                                                             | --tx-out-datum-hash-file JSON_FILE
                                                             | --tx-out-datum-hash-value JSON_VALUE
-                                                            | --tx-out-datum-embed-cbor-file CBOR_FILE
-                                                            | --tx-out-datum-embed-file JSON_FILE
-                                                            | --tx-out-datum-embed-value JSON_VALUE
+                                                            | --tx-out-supplemental-datum-cbor-file CBOR_FILE
+                                                            | --tx-out-supplemental-datum-file JSON_FILE
+                                                            | --tx-out-supplemental-datum-value JSON_VALUE
                                                             | --tx-out-inline-datum-cbor-file CBOR_FILE
                                                             | --tx-out-inline-datum-file JSON_FILE
                                                             | --tx-out-inline-datum-value JSON_VALUE
@@ -5929,9 +5929,9 @@ Usage: cardano-cli babbage transaction build-raw
                                                      | --tx-out-datum-hash-cbor-file CBOR_FILE
                                                      | --tx-out-datum-hash-file JSON_FILE
                                                      | --tx-out-datum-hash-value JSON_VALUE
-                                                     | --tx-out-datum-embed-cbor-file CBOR_FILE
-                                                     | --tx-out-datum-embed-file JSON_FILE
-                                                     | --tx-out-datum-embed-value JSON_VALUE
+                                                     | --tx-out-supplemental-datum-cbor-file CBOR_FILE
+                                                     | --tx-out-supplemental-datum-file JSON_FILE
+                                                     | --tx-out-supplemental-datum-value JSON_VALUE
                                                      | --tx-out-inline-datum-cbor-file CBOR_FILE
                                                      | --tx-out-inline-datum-file JSON_FILE
                                                      | --tx-out-inline-datum-value JSON_VALUE
@@ -6061,9 +6061,9 @@ Usage: cardano-cli babbage transaction build --socket-path SOCKET_PATH
                                                  | --tx-out-datum-hash-cbor-file CBOR_FILE
                                                  | --tx-out-datum-hash-file JSON_FILE
                                                  | --tx-out-datum-hash-value JSON_VALUE
-                                                 | --tx-out-datum-embed-cbor-file CBOR_FILE
-                                                 | --tx-out-datum-embed-file JSON_FILE
-                                                 | --tx-out-datum-embed-value JSON_VALUE
+                                                 | --tx-out-supplemental-datum-cbor-file CBOR_FILE
+                                                 | --tx-out-supplemental-datum-file JSON_FILE
+                                                 | --tx-out-supplemental-datum-value JSON_VALUE
                                                  | --tx-out-inline-datum-cbor-file CBOR_FILE
                                                  | --tx-out-inline-datum-file JSON_FILE
                                                  | --tx-out-inline-datum-value JSON_VALUE
@@ -6184,9 +6184,9 @@ Usage: cardano-cli babbage transaction build-estimate
                                                           | --tx-out-datum-hash-cbor-file CBOR_FILE
                                                           | --tx-out-datum-hash-file JSON_FILE
                                                           | --tx-out-datum-hash-value JSON_VALUE
-                                                          | --tx-out-datum-embed-cbor-file CBOR_FILE
-                                                          | --tx-out-datum-embed-file JSON_FILE
-                                                          | --tx-out-datum-embed-value JSON_VALUE
+                                                          | --tx-out-supplemental-datum-cbor-file CBOR_FILE
+                                                          | --tx-out-supplemental-datum-file JSON_FILE
+                                                          | --tx-out-supplemental-datum-value JSON_VALUE
                                                           | --tx-out-inline-datum-cbor-file CBOR_FILE
                                                           | --tx-out-inline-datum-file JSON_FILE
                                                           | --tx-out-inline-datum-value JSON_VALUE
@@ -6342,9 +6342,9 @@ Usage: cardano-cli babbage transaction calculate-min-required-utxo --protocol-pa
                                                                      | --tx-out-datum-hash-cbor-file CBOR_FILE
                                                                      | --tx-out-datum-hash-file JSON_FILE
                                                                      | --tx-out-datum-hash-value JSON_VALUE
-                                                                     | --tx-out-datum-embed-cbor-file CBOR_FILE
-                                                                     | --tx-out-datum-embed-file JSON_FILE
-                                                                     | --tx-out-datum-embed-value JSON_VALUE
+                                                                     | --tx-out-supplemental-datum-cbor-file CBOR_FILE
+                                                                     | --tx-out-supplemental-datum-file JSON_FILE
+                                                                     | --tx-out-supplemental-datum-value JSON_VALUE
                                                                      | --tx-out-inline-datum-cbor-file CBOR_FILE
                                                                      | --tx-out-inline-datum-file JSON_FILE
                                                                      | --tx-out-inline-datum-value JSON_VALUE
@@ -6359,9 +6359,9 @@ Usage: cardano-cli babbage transaction calculate-min-value --protocol-params-fil
                                                              | --tx-out-datum-hash-cbor-file CBOR_FILE
                                                              | --tx-out-datum-hash-file JSON_FILE
                                                              | --tx-out-datum-hash-value JSON_VALUE
-                                                             | --tx-out-datum-embed-cbor-file CBOR_FILE
-                                                             | --tx-out-datum-embed-file JSON_FILE
-                                                             | --tx-out-datum-embed-value JSON_VALUE
+                                                             | --tx-out-supplemental-datum-cbor-file CBOR_FILE
+                                                             | --tx-out-supplemental-datum-file JSON_FILE
+                                                             | --tx-out-supplemental-datum-value JSON_VALUE
                                                              | --tx-out-inline-datum-cbor-file CBOR_FILE
                                                              | --tx-out-inline-datum-file JSON_FILE
                                                              | --tx-out-inline-datum-value JSON_VALUE
@@ -7836,9 +7836,9 @@ Usage: cardano-cli conway transaction build-raw
                                                     | --tx-out-datum-hash-cbor-file CBOR_FILE
                                                     | --tx-out-datum-hash-file JSON_FILE
                                                     | --tx-out-datum-hash-value JSON_VALUE
-                                                    | --tx-out-datum-embed-cbor-file CBOR_FILE
-                                                    | --tx-out-datum-embed-file JSON_FILE
-                                                    | --tx-out-datum-embed-value JSON_VALUE
+                                                    | --tx-out-supplemental-datum-cbor-file CBOR_FILE
+                                                    | --tx-out-supplemental-datum-file JSON_FILE
+                                                    | --tx-out-supplemental-datum-value JSON_VALUE
                                                     | --tx-out-inline-datum-cbor-file CBOR_FILE
                                                     | --tx-out-inline-datum-file JSON_FILE
                                                     | --tx-out-inline-datum-value JSON_VALUE
@@ -8001,9 +8001,9 @@ Usage: cardano-cli conway transaction build --socket-path SOCKET_PATH
                                                 | --tx-out-datum-hash-cbor-file CBOR_FILE
                                                 | --tx-out-datum-hash-file JSON_FILE
                                                 | --tx-out-datum-hash-value JSON_VALUE
-                                                | --tx-out-datum-embed-cbor-file CBOR_FILE
-                                                | --tx-out-datum-embed-file JSON_FILE
-                                                | --tx-out-datum-embed-value JSON_VALUE
+                                                | --tx-out-supplemental-datum-cbor-file CBOR_FILE
+                                                | --tx-out-supplemental-datum-file JSON_FILE
+                                                | --tx-out-supplemental-datum-value JSON_VALUE
                                                 | --tx-out-inline-datum-cbor-file CBOR_FILE
                                                 | --tx-out-inline-datum-file JSON_FILE
                                                 | --tx-out-inline-datum-value JSON_VALUE
@@ -8150,9 +8150,9 @@ Usage: cardano-cli conway transaction build-estimate
                                                          | --tx-out-datum-hash-cbor-file CBOR_FILE
                                                          | --tx-out-datum-hash-file JSON_FILE
                                                          | --tx-out-datum-hash-value JSON_VALUE
-                                                         | --tx-out-datum-embed-cbor-file CBOR_FILE
-                                                         | --tx-out-datum-embed-file JSON_FILE
-                                                         | --tx-out-datum-embed-value JSON_VALUE
+                                                         | --tx-out-supplemental-datum-cbor-file CBOR_FILE
+                                                         | --tx-out-supplemental-datum-file JSON_FILE
+                                                         | --tx-out-supplemental-datum-value JSON_VALUE
                                                          | --tx-out-inline-datum-cbor-file CBOR_FILE
                                                          | --tx-out-inline-datum-file JSON_FILE
                                                          | --tx-out-inline-datum-value JSON_VALUE
@@ -8341,9 +8341,9 @@ Usage: cardano-cli conway transaction calculate-min-required-utxo --protocol-par
                                                                     | --tx-out-datum-hash-cbor-file CBOR_FILE
                                                                     | --tx-out-datum-hash-file JSON_FILE
                                                                     | --tx-out-datum-hash-value JSON_VALUE
-                                                                    | --tx-out-datum-embed-cbor-file CBOR_FILE
-                                                                    | --tx-out-datum-embed-file JSON_FILE
-                                                                    | --tx-out-datum-embed-value JSON_VALUE
+                                                                    | --tx-out-supplemental-datum-cbor-file CBOR_FILE
+                                                                    | --tx-out-supplemental-datum-file JSON_FILE
+                                                                    | --tx-out-supplemental-datum-value JSON_VALUE
                                                                     | --tx-out-inline-datum-cbor-file CBOR_FILE
                                                                     | --tx-out-inline-datum-file JSON_FILE
                                                                     | --tx-out-inline-datum-value JSON_VALUE
@@ -8358,9 +8358,9 @@ Usage: cardano-cli conway transaction calculate-min-value --protocol-params-file
                                                             | --tx-out-datum-hash-cbor-file CBOR_FILE
                                                             | --tx-out-datum-hash-file JSON_FILE
                                                             | --tx-out-datum-hash-value JSON_VALUE
-                                                            | --tx-out-datum-embed-cbor-file CBOR_FILE
-                                                            | --tx-out-datum-embed-file JSON_FILE
-                                                            | --tx-out-datum-embed-value JSON_VALUE
+                                                            | --tx-out-supplemental-datum-cbor-file CBOR_FILE
+                                                            | --tx-out-supplemental-datum-file JSON_FILE
+                                                            | --tx-out-supplemental-datum-value JSON_VALUE
                                                             | --tx-out-inline-datum-cbor-file CBOR_FILE
                                                             | --tx-out-inline-datum-file JSON_FILE
                                                             | --tx-out-inline-datum-value JSON_VALUE
@@ -9835,9 +9835,9 @@ Usage: cardano-cli latest transaction build-raw
                                                     | --tx-out-datum-hash-cbor-file CBOR_FILE
                                                     | --tx-out-datum-hash-file JSON_FILE
                                                     | --tx-out-datum-hash-value JSON_VALUE
-                                                    | --tx-out-datum-embed-cbor-file CBOR_FILE
-                                                    | --tx-out-datum-embed-file JSON_FILE
-                                                    | --tx-out-datum-embed-value JSON_VALUE
+                                                    | --tx-out-supplemental-datum-cbor-file CBOR_FILE
+                                                    | --tx-out-supplemental-datum-file JSON_FILE
+                                                    | --tx-out-supplemental-datum-value JSON_VALUE
                                                     | --tx-out-inline-datum-cbor-file CBOR_FILE
                                                     | --tx-out-inline-datum-file JSON_FILE
                                                     | --tx-out-inline-datum-value JSON_VALUE
@@ -10000,9 +10000,9 @@ Usage: cardano-cli latest transaction build --socket-path SOCKET_PATH
                                                 | --tx-out-datum-hash-cbor-file CBOR_FILE
                                                 | --tx-out-datum-hash-file JSON_FILE
                                                 | --tx-out-datum-hash-value JSON_VALUE
-                                                | --tx-out-datum-embed-cbor-file CBOR_FILE
-                                                | --tx-out-datum-embed-file JSON_FILE
-                                                | --tx-out-datum-embed-value JSON_VALUE
+                                                | --tx-out-supplemental-datum-cbor-file CBOR_FILE
+                                                | --tx-out-supplemental-datum-file JSON_FILE
+                                                | --tx-out-supplemental-datum-value JSON_VALUE
                                                 | --tx-out-inline-datum-cbor-file CBOR_FILE
                                                 | --tx-out-inline-datum-file JSON_FILE
                                                 | --tx-out-inline-datum-value JSON_VALUE
@@ -10149,9 +10149,9 @@ Usage: cardano-cli latest transaction build-estimate
                                                          | --tx-out-datum-hash-cbor-file CBOR_FILE
                                                          | --tx-out-datum-hash-file JSON_FILE
                                                          | --tx-out-datum-hash-value JSON_VALUE
-                                                         | --tx-out-datum-embed-cbor-file CBOR_FILE
-                                                         | --tx-out-datum-embed-file JSON_FILE
-                                                         | --tx-out-datum-embed-value JSON_VALUE
+                                                         | --tx-out-supplemental-datum-cbor-file CBOR_FILE
+                                                         | --tx-out-supplemental-datum-file JSON_FILE
+                                                         | --tx-out-supplemental-datum-value JSON_VALUE
                                                          | --tx-out-inline-datum-cbor-file CBOR_FILE
                                                          | --tx-out-inline-datum-file JSON_FILE
                                                          | --tx-out-inline-datum-value JSON_VALUE
@@ -10340,9 +10340,9 @@ Usage: cardano-cli latest transaction calculate-min-required-utxo --protocol-par
                                                                     | --tx-out-datum-hash-cbor-file CBOR_FILE
                                                                     | --tx-out-datum-hash-file JSON_FILE
                                                                     | --tx-out-datum-hash-value JSON_VALUE
-                                                                    | --tx-out-datum-embed-cbor-file CBOR_FILE
-                                                                    | --tx-out-datum-embed-file JSON_FILE
-                                                                    | --tx-out-datum-embed-value JSON_VALUE
+                                                                    | --tx-out-supplemental-datum-cbor-file CBOR_FILE
+                                                                    | --tx-out-supplemental-datum-file JSON_FILE
+                                                                    | --tx-out-supplemental-datum-value JSON_VALUE
                                                                     | --tx-out-inline-datum-cbor-file CBOR_FILE
                                                                     | --tx-out-inline-datum-file JSON_FILE
                                                                     | --tx-out-inline-datum-value JSON_VALUE
@@ -10357,9 +10357,9 @@ Usage: cardano-cli latest transaction calculate-min-value --protocol-params-file
                                                             | --tx-out-datum-hash-cbor-file CBOR_FILE
                                                             | --tx-out-datum-hash-file JSON_FILE
                                                             | --tx-out-datum-hash-value JSON_VALUE
-                                                            | --tx-out-datum-embed-cbor-file CBOR_FILE
-                                                            | --tx-out-datum-embed-file JSON_FILE
-                                                            | --tx-out-datum-embed-value JSON_VALUE
+                                                            | --tx-out-supplemental-datum-cbor-file CBOR_FILE
+                                                            | --tx-out-supplemental-datum-file JSON_FILE
+                                                            | --tx-out-supplemental-datum-value JSON_VALUE
                                                             | --tx-out-inline-datum-cbor-file CBOR_FILE
                                                             | --tx-out-inline-datum-file JSON_FILE
                                                             | --tx-out-inline-datum-value JSON_VALUE

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_transaction_build-raw.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_transaction_build-raw.cli
@@ -43,9 +43,9 @@ Usage: cardano-cli allegra transaction build-raw
                                                      | --tx-out-datum-hash-cbor-file CBOR_FILE
                                                      | --tx-out-datum-hash-file JSON_FILE
                                                      | --tx-out-datum-hash-value JSON_VALUE
-                                                     | --tx-out-datum-embed-cbor-file CBOR_FILE
-                                                     | --tx-out-datum-embed-file JSON_FILE
-                                                     | --tx-out-datum-embed-value JSON_VALUE
+                                                     | --tx-out-supplemental-datum-cbor-file CBOR_FILE
+                                                     | --tx-out-supplemental-datum-file JSON_FILE
+                                                     | --tx-out-supplemental-datum-value JSON_VALUE
                                                      | --tx-out-inline-datum-cbor-file CBOR_FILE
                                                      | --tx-out-inline-datum-file JSON_FILE
                                                      | --tx-out-inline-datum-value JSON_VALUE
@@ -235,18 +235,19 @@ Available options:
                            the script datum given here. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
-  --tx-out-datum-embed-cbor-file CBOR_FILE
-                           The script datum to embed in the tx for this output,
-                           in the given file. The file has to be in CBOR format.
-  --tx-out-datum-embed-file JSON_FILE
-                           The script datum to embed in the tx for this output,
-                           in the given file. The file must follow the detailed
-                           JSON schema for script data.
-  --tx-out-datum-embed-value JSON_VALUE
-                           The script datum to embed in the tx for this output,
-                           given here. There is no schema: (almost) any JSON
-                           value is supported, including top-level strings and
-                           numbers.
+  --tx-out-supplemental-datum-cbor-file CBOR_FILE
+                           The supplemental script datum to embed in the tx for
+                           this output, in the given file. The file has to be in
+                           CBOR format.
+  --tx-out-supplemental-datum-file JSON_FILE
+                           The supplemental script datum to embed in the tx for
+                           this output, in the given file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-supplemental-datum-value JSON_VALUE
+                           The supplemental script datum to embed in the tx for
+                           this output, given here. There is no schema: (almost)
+                           any JSON value is supported, including top-level
+                           strings and numbers.
   --tx-out-inline-datum-cbor-file CBOR_FILE
                            The script datum to embed in the tx output as an
                            inline datum, in the given file. The file has to be

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_transaction_calculate-min-required-utxo.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_transaction_calculate-min-required-utxo.cli
@@ -4,9 +4,9 @@ Usage: cardano-cli allegra transaction calculate-min-required-utxo --protocol-pa
                                                                      | --tx-out-datum-hash-cbor-file CBOR_FILE
                                                                      | --tx-out-datum-hash-file JSON_FILE
                                                                      | --tx-out-datum-hash-value JSON_VALUE
-                                                                     | --tx-out-datum-embed-cbor-file CBOR_FILE
-                                                                     | --tx-out-datum-embed-file JSON_FILE
-                                                                     | --tx-out-datum-embed-value JSON_VALUE
+                                                                     | --tx-out-supplemental-datum-cbor-file CBOR_FILE
+                                                                     | --tx-out-supplemental-datum-file JSON_FILE
+                                                                     | --tx-out-supplemental-datum-value JSON_VALUE
                                                                      | --tx-out-inline-datum-cbor-file CBOR_FILE
                                                                      | --tx-out-inline-datum-file JSON_FILE
                                                                      | --tx-out-inline-datum-value JSON_VALUE
@@ -37,18 +37,19 @@ Available options:
                            the script datum given here. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
-  --tx-out-datum-embed-cbor-file CBOR_FILE
-                           The script datum to embed in the tx for this output,
-                           in the given file. The file has to be in CBOR format.
-  --tx-out-datum-embed-file JSON_FILE
-                           The script datum to embed in the tx for this output,
-                           in the given file. The file must follow the detailed
-                           JSON schema for script data.
-  --tx-out-datum-embed-value JSON_VALUE
-                           The script datum to embed in the tx for this output,
-                           given here. There is no schema: (almost) any JSON
-                           value is supported, including top-level strings and
-                           numbers.
+  --tx-out-supplemental-datum-cbor-file CBOR_FILE
+                           The supplemental script datum to embed in the tx for
+                           this output, in the given file. The file has to be in
+                           CBOR format.
+  --tx-out-supplemental-datum-file JSON_FILE
+                           The supplemental script datum to embed in the tx for
+                           this output, in the given file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-supplemental-datum-value JSON_VALUE
+                           The supplemental script datum to embed in the tx for
+                           this output, given here. There is no schema: (almost)
+                           any JSON value is supported, including top-level
+                           strings and numbers.
   --tx-out-inline-datum-cbor-file CBOR_FILE
                            The script datum to embed in the tx output as an
                            inline datum, in the given file. The file has to be

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_transaction_calculate-min-value.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_transaction_calculate-min-value.cli
@@ -4,9 +4,9 @@ Usage: cardano-cli allegra transaction calculate-min-value --protocol-params-fil
                                                              | --tx-out-datum-hash-cbor-file CBOR_FILE
                                                              | --tx-out-datum-hash-file JSON_FILE
                                                              | --tx-out-datum-hash-value JSON_VALUE
-                                                             | --tx-out-datum-embed-cbor-file CBOR_FILE
-                                                             | --tx-out-datum-embed-file JSON_FILE
-                                                             | --tx-out-datum-embed-value JSON_VALUE
+                                                             | --tx-out-supplemental-datum-cbor-file CBOR_FILE
+                                                             | --tx-out-supplemental-datum-file JSON_FILE
+                                                             | --tx-out-supplemental-datum-value JSON_VALUE
                                                              | --tx-out-inline-datum-cbor-file CBOR_FILE
                                                              | --tx-out-inline-datum-file JSON_FILE
                                                              | --tx-out-inline-datum-value JSON_VALUE
@@ -37,18 +37,19 @@ Available options:
                            the script datum given here. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
-  --tx-out-datum-embed-cbor-file CBOR_FILE
-                           The script datum to embed in the tx for this output,
-                           in the given file. The file has to be in CBOR format.
-  --tx-out-datum-embed-file JSON_FILE
-                           The script datum to embed in the tx for this output,
-                           in the given file. The file must follow the detailed
-                           JSON schema for script data.
-  --tx-out-datum-embed-value JSON_VALUE
-                           The script datum to embed in the tx for this output,
-                           given here. There is no schema: (almost) any JSON
-                           value is supported, including top-level strings and
-                           numbers.
+  --tx-out-supplemental-datum-cbor-file CBOR_FILE
+                           The supplemental script datum to embed in the tx for
+                           this output, in the given file. The file has to be in
+                           CBOR format.
+  --tx-out-supplemental-datum-file JSON_FILE
+                           The supplemental script datum to embed in the tx for
+                           this output, in the given file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-supplemental-datum-value JSON_VALUE
+                           The supplemental script datum to embed in the tx for
+                           this output, given here. There is no schema: (almost)
+                           any JSON value is supported, including top-level
+                           strings and numbers.
   --tx-out-inline-datum-cbor-file CBOR_FILE
                            The script datum to embed in the tx output as an
                            inline datum, in the given file. The file has to be

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_transaction_build-raw.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_transaction_build-raw.cli
@@ -43,9 +43,9 @@ Usage: cardano-cli alonzo transaction build-raw
                                                     | --tx-out-datum-hash-cbor-file CBOR_FILE
                                                     | --tx-out-datum-hash-file JSON_FILE
                                                     | --tx-out-datum-hash-value JSON_VALUE
-                                                    | --tx-out-datum-embed-cbor-file CBOR_FILE
-                                                    | --tx-out-datum-embed-file JSON_FILE
-                                                    | --tx-out-datum-embed-value JSON_VALUE
+                                                    | --tx-out-supplemental-datum-cbor-file CBOR_FILE
+                                                    | --tx-out-supplemental-datum-file JSON_FILE
+                                                    | --tx-out-supplemental-datum-value JSON_VALUE
                                                     | --tx-out-inline-datum-cbor-file CBOR_FILE
                                                     | --tx-out-inline-datum-file JSON_FILE
                                                     | --tx-out-inline-datum-value JSON_VALUE
@@ -235,18 +235,19 @@ Available options:
                            the script datum given here. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
-  --tx-out-datum-embed-cbor-file CBOR_FILE
-                           The script datum to embed in the tx for this output,
-                           in the given file. The file has to be in CBOR format.
-  --tx-out-datum-embed-file JSON_FILE
-                           The script datum to embed in the tx for this output,
-                           in the given file. The file must follow the detailed
-                           JSON schema for script data.
-  --tx-out-datum-embed-value JSON_VALUE
-                           The script datum to embed in the tx for this output,
-                           given here. There is no schema: (almost) any JSON
-                           value is supported, including top-level strings and
-                           numbers.
+  --tx-out-supplemental-datum-cbor-file CBOR_FILE
+                           The supplemental script datum to embed in the tx for
+                           this output, in the given file. The file has to be in
+                           CBOR format.
+  --tx-out-supplemental-datum-file JSON_FILE
+                           The supplemental script datum to embed in the tx for
+                           this output, in the given file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-supplemental-datum-value JSON_VALUE
+                           The supplemental script datum to embed in the tx for
+                           this output, given here. There is no schema: (almost)
+                           any JSON value is supported, including top-level
+                           strings and numbers.
   --tx-out-inline-datum-cbor-file CBOR_FILE
                            The script datum to embed in the tx output as an
                            inline datum, in the given file. The file has to be

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_transaction_calculate-min-required-utxo.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_transaction_calculate-min-required-utxo.cli
@@ -4,9 +4,9 @@ Usage: cardano-cli alonzo transaction calculate-min-required-utxo --protocol-par
                                                                     | --tx-out-datum-hash-cbor-file CBOR_FILE
                                                                     | --tx-out-datum-hash-file JSON_FILE
                                                                     | --tx-out-datum-hash-value JSON_VALUE
-                                                                    | --tx-out-datum-embed-cbor-file CBOR_FILE
-                                                                    | --tx-out-datum-embed-file JSON_FILE
-                                                                    | --tx-out-datum-embed-value JSON_VALUE
+                                                                    | --tx-out-supplemental-datum-cbor-file CBOR_FILE
+                                                                    | --tx-out-supplemental-datum-file JSON_FILE
+                                                                    | --tx-out-supplemental-datum-value JSON_VALUE
                                                                     | --tx-out-inline-datum-cbor-file CBOR_FILE
                                                                     | --tx-out-inline-datum-file JSON_FILE
                                                                     | --tx-out-inline-datum-value JSON_VALUE
@@ -37,18 +37,19 @@ Available options:
                            the script datum given here. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
-  --tx-out-datum-embed-cbor-file CBOR_FILE
-                           The script datum to embed in the tx for this output,
-                           in the given file. The file has to be in CBOR format.
-  --tx-out-datum-embed-file JSON_FILE
-                           The script datum to embed in the tx for this output,
-                           in the given file. The file must follow the detailed
-                           JSON schema for script data.
-  --tx-out-datum-embed-value JSON_VALUE
-                           The script datum to embed in the tx for this output,
-                           given here. There is no schema: (almost) any JSON
-                           value is supported, including top-level strings and
-                           numbers.
+  --tx-out-supplemental-datum-cbor-file CBOR_FILE
+                           The supplemental script datum to embed in the tx for
+                           this output, in the given file. The file has to be in
+                           CBOR format.
+  --tx-out-supplemental-datum-file JSON_FILE
+                           The supplemental script datum to embed in the tx for
+                           this output, in the given file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-supplemental-datum-value JSON_VALUE
+                           The supplemental script datum to embed in the tx for
+                           this output, given here. There is no schema: (almost)
+                           any JSON value is supported, including top-level
+                           strings and numbers.
   --tx-out-inline-datum-cbor-file CBOR_FILE
                            The script datum to embed in the tx output as an
                            inline datum, in the given file. The file has to be

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_transaction_calculate-min-value.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_transaction_calculate-min-value.cli
@@ -4,9 +4,9 @@ Usage: cardano-cli alonzo transaction calculate-min-value --protocol-params-file
                                                             | --tx-out-datum-hash-cbor-file CBOR_FILE
                                                             | --tx-out-datum-hash-file JSON_FILE
                                                             | --tx-out-datum-hash-value JSON_VALUE
-                                                            | --tx-out-datum-embed-cbor-file CBOR_FILE
-                                                            | --tx-out-datum-embed-file JSON_FILE
-                                                            | --tx-out-datum-embed-value JSON_VALUE
+                                                            | --tx-out-supplemental-datum-cbor-file CBOR_FILE
+                                                            | --tx-out-supplemental-datum-file JSON_FILE
+                                                            | --tx-out-supplemental-datum-value JSON_VALUE
                                                             | --tx-out-inline-datum-cbor-file CBOR_FILE
                                                             | --tx-out-inline-datum-file JSON_FILE
                                                             | --tx-out-inline-datum-value JSON_VALUE
@@ -37,18 +37,19 @@ Available options:
                            the script datum given here. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
-  --tx-out-datum-embed-cbor-file CBOR_FILE
-                           The script datum to embed in the tx for this output,
-                           in the given file. The file has to be in CBOR format.
-  --tx-out-datum-embed-file JSON_FILE
-                           The script datum to embed in the tx for this output,
-                           in the given file. The file must follow the detailed
-                           JSON schema for script data.
-  --tx-out-datum-embed-value JSON_VALUE
-                           The script datum to embed in the tx for this output,
-                           given here. There is no schema: (almost) any JSON
-                           value is supported, including top-level strings and
-                           numbers.
+  --tx-out-supplemental-datum-cbor-file CBOR_FILE
+                           The supplemental script datum to embed in the tx for
+                           this output, in the given file. The file has to be in
+                           CBOR format.
+  --tx-out-supplemental-datum-file JSON_FILE
+                           The supplemental script datum to embed in the tx for
+                           this output, in the given file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-supplemental-datum-value JSON_VALUE
+                           The supplemental script datum to embed in the tx for
+                           this output, given here. There is no schema: (almost)
+                           any JSON value is supported, including top-level
+                           strings and numbers.
   --tx-out-inline-datum-cbor-file CBOR_FILE
                            The script datum to embed in the tx output as an
                            inline datum, in the given file. The file has to be

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_transaction_build-estimate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_transaction_build-estimate.cli
@@ -46,9 +46,9 @@ Usage: cardano-cli babbage transaction build-estimate
                                                           | --tx-out-datum-hash-cbor-file CBOR_FILE
                                                           | --tx-out-datum-hash-file JSON_FILE
                                                           | --tx-out-datum-hash-value JSON_VALUE
-                                                          | --tx-out-datum-embed-cbor-file CBOR_FILE
-                                                          | --tx-out-datum-embed-file JSON_FILE
-                                                          | --tx-out-datum-embed-value JSON_VALUE
+                                                          | --tx-out-supplemental-datum-cbor-file CBOR_FILE
+                                                          | --tx-out-supplemental-datum-file JSON_FILE
+                                                          | --tx-out-supplemental-datum-value JSON_VALUE
                                                           | --tx-out-inline-datum-cbor-file CBOR_FILE
                                                           | --tx-out-inline-datum-file JSON_FILE
                                                           | --tx-out-inline-datum-value JSON_VALUE
@@ -245,18 +245,19 @@ Available options:
                            the script datum given here. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
-  --tx-out-datum-embed-cbor-file CBOR_FILE
-                           The script datum to embed in the tx for this output,
-                           in the given file. The file has to be in CBOR format.
-  --tx-out-datum-embed-file JSON_FILE
-                           The script datum to embed in the tx for this output,
-                           in the given file. The file must follow the detailed
-                           JSON schema for script data.
-  --tx-out-datum-embed-value JSON_VALUE
-                           The script datum to embed in the tx for this output,
-                           given here. There is no schema: (almost) any JSON
-                           value is supported, including top-level strings and
-                           numbers.
+  --tx-out-supplemental-datum-cbor-file CBOR_FILE
+                           The supplemental script datum to embed in the tx for
+                           this output, in the given file. The file has to be in
+                           CBOR format.
+  --tx-out-supplemental-datum-file JSON_FILE
+                           The supplemental script datum to embed in the tx for
+                           this output, in the given file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-supplemental-datum-value JSON_VALUE
+                           The supplemental script datum to embed in the tx for
+                           this output, given here. There is no schema: (almost)
+                           any JSON value is supported, including top-level
+                           strings and numbers.
   --tx-out-inline-datum-cbor-file CBOR_FILE
                            The script datum to embed in the tx output as an
                            inline datum, in the given file. The file has to be

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_transaction_build-raw.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_transaction_build-raw.cli
@@ -43,9 +43,9 @@ Usage: cardano-cli babbage transaction build-raw
                                                      | --tx-out-datum-hash-cbor-file CBOR_FILE
                                                      | --tx-out-datum-hash-file JSON_FILE
                                                      | --tx-out-datum-hash-value JSON_VALUE
-                                                     | --tx-out-datum-embed-cbor-file CBOR_FILE
-                                                     | --tx-out-datum-embed-file JSON_FILE
-                                                     | --tx-out-datum-embed-value JSON_VALUE
+                                                     | --tx-out-supplemental-datum-cbor-file CBOR_FILE
+                                                     | --tx-out-supplemental-datum-file JSON_FILE
+                                                     | --tx-out-supplemental-datum-value JSON_VALUE
                                                      | --tx-out-inline-datum-cbor-file CBOR_FILE
                                                      | --tx-out-inline-datum-file JSON_FILE
                                                      | --tx-out-inline-datum-value JSON_VALUE
@@ -235,18 +235,19 @@ Available options:
                            the script datum given here. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
-  --tx-out-datum-embed-cbor-file CBOR_FILE
-                           The script datum to embed in the tx for this output,
-                           in the given file. The file has to be in CBOR format.
-  --tx-out-datum-embed-file JSON_FILE
-                           The script datum to embed in the tx for this output,
-                           in the given file. The file must follow the detailed
-                           JSON schema for script data.
-  --tx-out-datum-embed-value JSON_VALUE
-                           The script datum to embed in the tx for this output,
-                           given here. There is no schema: (almost) any JSON
-                           value is supported, including top-level strings and
-                           numbers.
+  --tx-out-supplemental-datum-cbor-file CBOR_FILE
+                           The supplemental script datum to embed in the tx for
+                           this output, in the given file. The file has to be in
+                           CBOR format.
+  --tx-out-supplemental-datum-file JSON_FILE
+                           The supplemental script datum to embed in the tx for
+                           this output, in the given file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-supplemental-datum-value JSON_VALUE
+                           The supplemental script datum to embed in the tx for
+                           this output, given here. There is no schema: (almost)
+                           any JSON value is supported, including top-level
+                           strings and numbers.
   --tx-out-inline-datum-cbor-file CBOR_FILE
                            The script datum to embed in the tx output as an
                            inline datum, in the given file. The file has to be

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_transaction_build.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_transaction_build.cli
@@ -47,9 +47,9 @@ Usage: cardano-cli babbage transaction build --socket-path SOCKET_PATH
                                                  | --tx-out-datum-hash-cbor-file CBOR_FILE
                                                  | --tx-out-datum-hash-file JSON_FILE
                                                  | --tx-out-datum-hash-value JSON_VALUE
-                                                 | --tx-out-datum-embed-cbor-file CBOR_FILE
-                                                 | --tx-out-datum-embed-file JSON_FILE
-                                                 | --tx-out-datum-embed-value JSON_VALUE
+                                                 | --tx-out-supplemental-datum-cbor-file CBOR_FILE
+                                                 | --tx-out-supplemental-datum-file JSON_FILE
+                                                 | --tx-out-supplemental-datum-value JSON_VALUE
                                                  | --tx-out-inline-datum-cbor-file CBOR_FILE
                                                  | --tx-out-inline-datum-file JSON_FILE
                                                  | --tx-out-inline-datum-value JSON_VALUE
@@ -242,18 +242,19 @@ Available options:
                            the script datum given here. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
-  --tx-out-datum-embed-cbor-file CBOR_FILE
-                           The script datum to embed in the tx for this output,
-                           in the given file. The file has to be in CBOR format.
-  --tx-out-datum-embed-file JSON_FILE
-                           The script datum to embed in the tx for this output,
-                           in the given file. The file must follow the detailed
-                           JSON schema for script data.
-  --tx-out-datum-embed-value JSON_VALUE
-                           The script datum to embed in the tx for this output,
-                           given here. There is no schema: (almost) any JSON
-                           value is supported, including top-level strings and
-                           numbers.
+  --tx-out-supplemental-datum-cbor-file CBOR_FILE
+                           The supplemental script datum to embed in the tx for
+                           this output, in the given file. The file has to be in
+                           CBOR format.
+  --tx-out-supplemental-datum-file JSON_FILE
+                           The supplemental script datum to embed in the tx for
+                           this output, in the given file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-supplemental-datum-value JSON_VALUE
+                           The supplemental script datum to embed in the tx for
+                           this output, given here. There is no schema: (almost)
+                           any JSON value is supported, including top-level
+                           strings and numbers.
   --tx-out-inline-datum-cbor-file CBOR_FILE
                            The script datum to embed in the tx output as an
                            inline datum, in the given file. The file has to be

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_transaction_calculate-min-required-utxo.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_transaction_calculate-min-required-utxo.cli
@@ -4,9 +4,9 @@ Usage: cardano-cli babbage transaction calculate-min-required-utxo --protocol-pa
                                                                      | --tx-out-datum-hash-cbor-file CBOR_FILE
                                                                      | --tx-out-datum-hash-file JSON_FILE
                                                                      | --tx-out-datum-hash-value JSON_VALUE
-                                                                     | --tx-out-datum-embed-cbor-file CBOR_FILE
-                                                                     | --tx-out-datum-embed-file JSON_FILE
-                                                                     | --tx-out-datum-embed-value JSON_VALUE
+                                                                     | --tx-out-supplemental-datum-cbor-file CBOR_FILE
+                                                                     | --tx-out-supplemental-datum-file JSON_FILE
+                                                                     | --tx-out-supplemental-datum-value JSON_VALUE
                                                                      | --tx-out-inline-datum-cbor-file CBOR_FILE
                                                                      | --tx-out-inline-datum-file JSON_FILE
                                                                      | --tx-out-inline-datum-value JSON_VALUE
@@ -37,18 +37,19 @@ Available options:
                            the script datum given here. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
-  --tx-out-datum-embed-cbor-file CBOR_FILE
-                           The script datum to embed in the tx for this output,
-                           in the given file. The file has to be in CBOR format.
-  --tx-out-datum-embed-file JSON_FILE
-                           The script datum to embed in the tx for this output,
-                           in the given file. The file must follow the detailed
-                           JSON schema for script data.
-  --tx-out-datum-embed-value JSON_VALUE
-                           The script datum to embed in the tx for this output,
-                           given here. There is no schema: (almost) any JSON
-                           value is supported, including top-level strings and
-                           numbers.
+  --tx-out-supplemental-datum-cbor-file CBOR_FILE
+                           The supplemental script datum to embed in the tx for
+                           this output, in the given file. The file has to be in
+                           CBOR format.
+  --tx-out-supplemental-datum-file JSON_FILE
+                           The supplemental script datum to embed in the tx for
+                           this output, in the given file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-supplemental-datum-value JSON_VALUE
+                           The supplemental script datum to embed in the tx for
+                           this output, given here. There is no schema: (almost)
+                           any JSON value is supported, including top-level
+                           strings and numbers.
   --tx-out-inline-datum-cbor-file CBOR_FILE
                            The script datum to embed in the tx output as an
                            inline datum, in the given file. The file has to be

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_transaction_calculate-min-value.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_transaction_calculate-min-value.cli
@@ -4,9 +4,9 @@ Usage: cardano-cli babbage transaction calculate-min-value --protocol-params-fil
                                                              | --tx-out-datum-hash-cbor-file CBOR_FILE
                                                              | --tx-out-datum-hash-file JSON_FILE
                                                              | --tx-out-datum-hash-value JSON_VALUE
-                                                             | --tx-out-datum-embed-cbor-file CBOR_FILE
-                                                             | --tx-out-datum-embed-file JSON_FILE
-                                                             | --tx-out-datum-embed-value JSON_VALUE
+                                                             | --tx-out-supplemental-datum-cbor-file CBOR_FILE
+                                                             | --tx-out-supplemental-datum-file JSON_FILE
+                                                             | --tx-out-supplemental-datum-value JSON_VALUE
                                                              | --tx-out-inline-datum-cbor-file CBOR_FILE
                                                              | --tx-out-inline-datum-file JSON_FILE
                                                              | --tx-out-inline-datum-value JSON_VALUE
@@ -37,18 +37,19 @@ Available options:
                            the script datum given here. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
-  --tx-out-datum-embed-cbor-file CBOR_FILE
-                           The script datum to embed in the tx for this output,
-                           in the given file. The file has to be in CBOR format.
-  --tx-out-datum-embed-file JSON_FILE
-                           The script datum to embed in the tx for this output,
-                           in the given file. The file must follow the detailed
-                           JSON schema for script data.
-  --tx-out-datum-embed-value JSON_VALUE
-                           The script datum to embed in the tx for this output,
-                           given here. There is no schema: (almost) any JSON
-                           value is supported, including top-level strings and
-                           numbers.
+  --tx-out-supplemental-datum-cbor-file CBOR_FILE
+                           The supplemental script datum to embed in the tx for
+                           this output, in the given file. The file has to be in
+                           CBOR format.
+  --tx-out-supplemental-datum-file JSON_FILE
+                           The supplemental script datum to embed in the tx for
+                           this output, in the given file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-supplemental-datum-value JSON_VALUE
+                           The supplemental script datum to embed in the tx for
+                           this output, given here. There is no schema: (almost)
+                           any JSON value is supported, including top-level
+                           strings and numbers.
   --tx-out-inline-datum-cbor-file CBOR_FILE
                            The script datum to embed in the tx output as an
                            inline datum, in the given file. The file has to be

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_build-estimate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_build-estimate.cli
@@ -46,9 +46,9 @@ Usage: cardano-cli conway transaction build-estimate
                                                          | --tx-out-datum-hash-cbor-file CBOR_FILE
                                                          | --tx-out-datum-hash-file JSON_FILE
                                                          | --tx-out-datum-hash-value JSON_VALUE
-                                                         | --tx-out-datum-embed-cbor-file CBOR_FILE
-                                                         | --tx-out-datum-embed-file JSON_FILE
-                                                         | --tx-out-datum-embed-value JSON_VALUE
+                                                         | --tx-out-supplemental-datum-cbor-file CBOR_FILE
+                                                         | --tx-out-supplemental-datum-file JSON_FILE
+                                                         | --tx-out-supplemental-datum-value JSON_VALUE
                                                          | --tx-out-inline-datum-cbor-file CBOR_FILE
                                                          | --tx-out-inline-datum-file JSON_FILE
                                                          | --tx-out-inline-datum-value JSON_VALUE
@@ -278,18 +278,19 @@ Available options:
                            the script datum given here. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
-  --tx-out-datum-embed-cbor-file CBOR_FILE
-                           The script datum to embed in the tx for this output,
-                           in the given file. The file has to be in CBOR format.
-  --tx-out-datum-embed-file JSON_FILE
-                           The script datum to embed in the tx for this output,
-                           in the given file. The file must follow the detailed
-                           JSON schema for script data.
-  --tx-out-datum-embed-value JSON_VALUE
-                           The script datum to embed in the tx for this output,
-                           given here. There is no schema: (almost) any JSON
-                           value is supported, including top-level strings and
-                           numbers.
+  --tx-out-supplemental-datum-cbor-file CBOR_FILE
+                           The supplemental script datum to embed in the tx for
+                           this output, in the given file. The file has to be in
+                           CBOR format.
+  --tx-out-supplemental-datum-file JSON_FILE
+                           The supplemental script datum to embed in the tx for
+                           this output, in the given file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-supplemental-datum-value JSON_VALUE
+                           The supplemental script datum to embed in the tx for
+                           this output, given here. There is no schema: (almost)
+                           any JSON value is supported, including top-level
+                           strings and numbers.
   --tx-out-inline-datum-cbor-file CBOR_FILE
                            The script datum to embed in the tx output as an
                            inline datum, in the given file. The file has to be

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_build-raw.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_build-raw.cli
@@ -43,9 +43,9 @@ Usage: cardano-cli conway transaction build-raw
                                                     | --tx-out-datum-hash-cbor-file CBOR_FILE
                                                     | --tx-out-datum-hash-file JSON_FILE
                                                     | --tx-out-datum-hash-value JSON_VALUE
-                                                    | --tx-out-datum-embed-cbor-file CBOR_FILE
-                                                    | --tx-out-datum-embed-file JSON_FILE
-                                                    | --tx-out-datum-embed-value JSON_VALUE
+                                                    | --tx-out-supplemental-datum-cbor-file CBOR_FILE
+                                                    | --tx-out-supplemental-datum-file JSON_FILE
+                                                    | --tx-out-supplemental-datum-value JSON_VALUE
                                                     | --tx-out-inline-datum-cbor-file CBOR_FILE
                                                     | --tx-out-inline-datum-file JSON_FILE
                                                     | --tx-out-inline-datum-value JSON_VALUE
@@ -268,18 +268,19 @@ Available options:
                            the script datum given here. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
-  --tx-out-datum-embed-cbor-file CBOR_FILE
-                           The script datum to embed in the tx for this output,
-                           in the given file. The file has to be in CBOR format.
-  --tx-out-datum-embed-file JSON_FILE
-                           The script datum to embed in the tx for this output,
-                           in the given file. The file must follow the detailed
-                           JSON schema for script data.
-  --tx-out-datum-embed-value JSON_VALUE
-                           The script datum to embed in the tx for this output,
-                           given here. There is no schema: (almost) any JSON
-                           value is supported, including top-level strings and
-                           numbers.
+  --tx-out-supplemental-datum-cbor-file CBOR_FILE
+                           The supplemental script datum to embed in the tx for
+                           this output, in the given file. The file has to be in
+                           CBOR format.
+  --tx-out-supplemental-datum-file JSON_FILE
+                           The supplemental script datum to embed in the tx for
+                           this output, in the given file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-supplemental-datum-value JSON_VALUE
+                           The supplemental script datum to embed in the tx for
+                           this output, given here. There is no schema: (almost)
+                           any JSON value is supported, including top-level
+                           strings and numbers.
   --tx-out-inline-datum-cbor-file CBOR_FILE
                            The script datum to embed in the tx output as an
                            inline datum, in the given file. The file has to be

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_build.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_build.cli
@@ -47,9 +47,9 @@ Usage: cardano-cli conway transaction build --socket-path SOCKET_PATH
                                                 | --tx-out-datum-hash-cbor-file CBOR_FILE
                                                 | --tx-out-datum-hash-file JSON_FILE
                                                 | --tx-out-datum-hash-value JSON_VALUE
-                                                | --tx-out-datum-embed-cbor-file CBOR_FILE
-                                                | --tx-out-datum-embed-file JSON_FILE
-                                                | --tx-out-datum-embed-value JSON_VALUE
+                                                | --tx-out-supplemental-datum-cbor-file CBOR_FILE
+                                                | --tx-out-supplemental-datum-file JSON_FILE
+                                                | --tx-out-supplemental-datum-value JSON_VALUE
                                                 | --tx-out-inline-datum-cbor-file CBOR_FILE
                                                 | --tx-out-inline-datum-file JSON_FILE
                                                 | --tx-out-inline-datum-value JSON_VALUE
@@ -268,18 +268,19 @@ Available options:
                            the script datum given here. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
-  --tx-out-datum-embed-cbor-file CBOR_FILE
-                           The script datum to embed in the tx for this output,
-                           in the given file. The file has to be in CBOR format.
-  --tx-out-datum-embed-file JSON_FILE
-                           The script datum to embed in the tx for this output,
-                           in the given file. The file must follow the detailed
-                           JSON schema for script data.
-  --tx-out-datum-embed-value JSON_VALUE
-                           The script datum to embed in the tx for this output,
-                           given here. There is no schema: (almost) any JSON
-                           value is supported, including top-level strings and
-                           numbers.
+  --tx-out-supplemental-datum-cbor-file CBOR_FILE
+                           The supplemental script datum to embed in the tx for
+                           this output, in the given file. The file has to be in
+                           CBOR format.
+  --tx-out-supplemental-datum-file JSON_FILE
+                           The supplemental script datum to embed in the tx for
+                           this output, in the given file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-supplemental-datum-value JSON_VALUE
+                           The supplemental script datum to embed in the tx for
+                           this output, given here. There is no schema: (almost)
+                           any JSON value is supported, including top-level
+                           strings and numbers.
   --tx-out-inline-datum-cbor-file CBOR_FILE
                            The script datum to embed in the tx output as an
                            inline datum, in the given file. The file has to be

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_calculate-min-required-utxo.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_calculate-min-required-utxo.cli
@@ -4,9 +4,9 @@ Usage: cardano-cli conway transaction calculate-min-required-utxo --protocol-par
                                                                     | --tx-out-datum-hash-cbor-file CBOR_FILE
                                                                     | --tx-out-datum-hash-file JSON_FILE
                                                                     | --tx-out-datum-hash-value JSON_VALUE
-                                                                    | --tx-out-datum-embed-cbor-file CBOR_FILE
-                                                                    | --tx-out-datum-embed-file JSON_FILE
-                                                                    | --tx-out-datum-embed-value JSON_VALUE
+                                                                    | --tx-out-supplemental-datum-cbor-file CBOR_FILE
+                                                                    | --tx-out-supplemental-datum-file JSON_FILE
+                                                                    | --tx-out-supplemental-datum-value JSON_VALUE
                                                                     | --tx-out-inline-datum-cbor-file CBOR_FILE
                                                                     | --tx-out-inline-datum-file JSON_FILE
                                                                     | --tx-out-inline-datum-value JSON_VALUE
@@ -37,18 +37,19 @@ Available options:
                            the script datum given here. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
-  --tx-out-datum-embed-cbor-file CBOR_FILE
-                           The script datum to embed in the tx for this output,
-                           in the given file. The file has to be in CBOR format.
-  --tx-out-datum-embed-file JSON_FILE
-                           The script datum to embed in the tx for this output,
-                           in the given file. The file must follow the detailed
-                           JSON schema for script data.
-  --tx-out-datum-embed-value JSON_VALUE
-                           The script datum to embed in the tx for this output,
-                           given here. There is no schema: (almost) any JSON
-                           value is supported, including top-level strings and
-                           numbers.
+  --tx-out-supplemental-datum-cbor-file CBOR_FILE
+                           The supplemental script datum to embed in the tx for
+                           this output, in the given file. The file has to be in
+                           CBOR format.
+  --tx-out-supplemental-datum-file JSON_FILE
+                           The supplemental script datum to embed in the tx for
+                           this output, in the given file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-supplemental-datum-value JSON_VALUE
+                           The supplemental script datum to embed in the tx for
+                           this output, given here. There is no schema: (almost)
+                           any JSON value is supported, including top-level
+                           strings and numbers.
   --tx-out-inline-datum-cbor-file CBOR_FILE
                            The script datum to embed in the tx output as an
                            inline datum, in the given file. The file has to be

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_calculate-min-value.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_calculate-min-value.cli
@@ -4,9 +4,9 @@ Usage: cardano-cli conway transaction calculate-min-value --protocol-params-file
                                                             | --tx-out-datum-hash-cbor-file CBOR_FILE
                                                             | --tx-out-datum-hash-file JSON_FILE
                                                             | --tx-out-datum-hash-value JSON_VALUE
-                                                            | --tx-out-datum-embed-cbor-file CBOR_FILE
-                                                            | --tx-out-datum-embed-file JSON_FILE
-                                                            | --tx-out-datum-embed-value JSON_VALUE
+                                                            | --tx-out-supplemental-datum-cbor-file CBOR_FILE
+                                                            | --tx-out-supplemental-datum-file JSON_FILE
+                                                            | --tx-out-supplemental-datum-value JSON_VALUE
                                                             | --tx-out-inline-datum-cbor-file CBOR_FILE
                                                             | --tx-out-inline-datum-file JSON_FILE
                                                             | --tx-out-inline-datum-value JSON_VALUE
@@ -37,18 +37,19 @@ Available options:
                            the script datum given here. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
-  --tx-out-datum-embed-cbor-file CBOR_FILE
-                           The script datum to embed in the tx for this output,
-                           in the given file. The file has to be in CBOR format.
-  --tx-out-datum-embed-file JSON_FILE
-                           The script datum to embed in the tx for this output,
-                           in the given file. The file must follow the detailed
-                           JSON schema for script data.
-  --tx-out-datum-embed-value JSON_VALUE
-                           The script datum to embed in the tx for this output,
-                           given here. There is no schema: (almost) any JSON
-                           value is supported, including top-level strings and
-                           numbers.
+  --tx-out-supplemental-datum-cbor-file CBOR_FILE
+                           The supplemental script datum to embed in the tx for
+                           this output, in the given file. The file has to be in
+                           CBOR format.
+  --tx-out-supplemental-datum-file JSON_FILE
+                           The supplemental script datum to embed in the tx for
+                           this output, in the given file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-supplemental-datum-value JSON_VALUE
+                           The supplemental script datum to embed in the tx for
+                           this output, given here. There is no schema: (almost)
+                           any JSON value is supported, including top-level
+                           strings and numbers.
   --tx-out-inline-datum-cbor-file CBOR_FILE
                            The script datum to embed in the tx output as an
                            inline datum, in the given file. The file has to be

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_transaction_build-estimate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_transaction_build-estimate.cli
@@ -46,9 +46,9 @@ Usage: cardano-cli latest transaction build-estimate
                                                          | --tx-out-datum-hash-cbor-file CBOR_FILE
                                                          | --tx-out-datum-hash-file JSON_FILE
                                                          | --tx-out-datum-hash-value JSON_VALUE
-                                                         | --tx-out-datum-embed-cbor-file CBOR_FILE
-                                                         | --tx-out-datum-embed-file JSON_FILE
-                                                         | --tx-out-datum-embed-value JSON_VALUE
+                                                         | --tx-out-supplemental-datum-cbor-file CBOR_FILE
+                                                         | --tx-out-supplemental-datum-file JSON_FILE
+                                                         | --tx-out-supplemental-datum-value JSON_VALUE
                                                          | --tx-out-inline-datum-cbor-file CBOR_FILE
                                                          | --tx-out-inline-datum-file JSON_FILE
                                                          | --tx-out-inline-datum-value JSON_VALUE
@@ -278,18 +278,19 @@ Available options:
                            the script datum given here. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
-  --tx-out-datum-embed-cbor-file CBOR_FILE
-                           The script datum to embed in the tx for this output,
-                           in the given file. The file has to be in CBOR format.
-  --tx-out-datum-embed-file JSON_FILE
-                           The script datum to embed in the tx for this output,
-                           in the given file. The file must follow the detailed
-                           JSON schema for script data.
-  --tx-out-datum-embed-value JSON_VALUE
-                           The script datum to embed in the tx for this output,
-                           given here. There is no schema: (almost) any JSON
-                           value is supported, including top-level strings and
-                           numbers.
+  --tx-out-supplemental-datum-cbor-file CBOR_FILE
+                           The supplemental script datum to embed in the tx for
+                           this output, in the given file. The file has to be in
+                           CBOR format.
+  --tx-out-supplemental-datum-file JSON_FILE
+                           The supplemental script datum to embed in the tx for
+                           this output, in the given file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-supplemental-datum-value JSON_VALUE
+                           The supplemental script datum to embed in the tx for
+                           this output, given here. There is no schema: (almost)
+                           any JSON value is supported, including top-level
+                           strings and numbers.
   --tx-out-inline-datum-cbor-file CBOR_FILE
                            The script datum to embed in the tx output as an
                            inline datum, in the given file. The file has to be

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_transaction_build-raw.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_transaction_build-raw.cli
@@ -43,9 +43,9 @@ Usage: cardano-cli latest transaction build-raw
                                                     | --tx-out-datum-hash-cbor-file CBOR_FILE
                                                     | --tx-out-datum-hash-file JSON_FILE
                                                     | --tx-out-datum-hash-value JSON_VALUE
-                                                    | --tx-out-datum-embed-cbor-file CBOR_FILE
-                                                    | --tx-out-datum-embed-file JSON_FILE
-                                                    | --tx-out-datum-embed-value JSON_VALUE
+                                                    | --tx-out-supplemental-datum-cbor-file CBOR_FILE
+                                                    | --tx-out-supplemental-datum-file JSON_FILE
+                                                    | --tx-out-supplemental-datum-value JSON_VALUE
                                                     | --tx-out-inline-datum-cbor-file CBOR_FILE
                                                     | --tx-out-inline-datum-file JSON_FILE
                                                     | --tx-out-inline-datum-value JSON_VALUE
@@ -268,18 +268,19 @@ Available options:
                            the script datum given here. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
-  --tx-out-datum-embed-cbor-file CBOR_FILE
-                           The script datum to embed in the tx for this output,
-                           in the given file. The file has to be in CBOR format.
-  --tx-out-datum-embed-file JSON_FILE
-                           The script datum to embed in the tx for this output,
-                           in the given file. The file must follow the detailed
-                           JSON schema for script data.
-  --tx-out-datum-embed-value JSON_VALUE
-                           The script datum to embed in the tx for this output,
-                           given here. There is no schema: (almost) any JSON
-                           value is supported, including top-level strings and
-                           numbers.
+  --tx-out-supplemental-datum-cbor-file CBOR_FILE
+                           The supplemental script datum to embed in the tx for
+                           this output, in the given file. The file has to be in
+                           CBOR format.
+  --tx-out-supplemental-datum-file JSON_FILE
+                           The supplemental script datum to embed in the tx for
+                           this output, in the given file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-supplemental-datum-value JSON_VALUE
+                           The supplemental script datum to embed in the tx for
+                           this output, given here. There is no schema: (almost)
+                           any JSON value is supported, including top-level
+                           strings and numbers.
   --tx-out-inline-datum-cbor-file CBOR_FILE
                            The script datum to embed in the tx output as an
                            inline datum, in the given file. The file has to be

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_transaction_build.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_transaction_build.cli
@@ -47,9 +47,9 @@ Usage: cardano-cli latest transaction build --socket-path SOCKET_PATH
                                                 | --tx-out-datum-hash-cbor-file CBOR_FILE
                                                 | --tx-out-datum-hash-file JSON_FILE
                                                 | --tx-out-datum-hash-value JSON_VALUE
-                                                | --tx-out-datum-embed-cbor-file CBOR_FILE
-                                                | --tx-out-datum-embed-file JSON_FILE
-                                                | --tx-out-datum-embed-value JSON_VALUE
+                                                | --tx-out-supplemental-datum-cbor-file CBOR_FILE
+                                                | --tx-out-supplemental-datum-file JSON_FILE
+                                                | --tx-out-supplemental-datum-value JSON_VALUE
                                                 | --tx-out-inline-datum-cbor-file CBOR_FILE
                                                 | --tx-out-inline-datum-file JSON_FILE
                                                 | --tx-out-inline-datum-value JSON_VALUE
@@ -268,18 +268,19 @@ Available options:
                            the script datum given here. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
-  --tx-out-datum-embed-cbor-file CBOR_FILE
-                           The script datum to embed in the tx for this output,
-                           in the given file. The file has to be in CBOR format.
-  --tx-out-datum-embed-file JSON_FILE
-                           The script datum to embed in the tx for this output,
-                           in the given file. The file must follow the detailed
-                           JSON schema for script data.
-  --tx-out-datum-embed-value JSON_VALUE
-                           The script datum to embed in the tx for this output,
-                           given here. There is no schema: (almost) any JSON
-                           value is supported, including top-level strings and
-                           numbers.
+  --tx-out-supplemental-datum-cbor-file CBOR_FILE
+                           The supplemental script datum to embed in the tx for
+                           this output, in the given file. The file has to be in
+                           CBOR format.
+  --tx-out-supplemental-datum-file JSON_FILE
+                           The supplemental script datum to embed in the tx for
+                           this output, in the given file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-supplemental-datum-value JSON_VALUE
+                           The supplemental script datum to embed in the tx for
+                           this output, given here. There is no schema: (almost)
+                           any JSON value is supported, including top-level
+                           strings and numbers.
   --tx-out-inline-datum-cbor-file CBOR_FILE
                            The script datum to embed in the tx output as an
                            inline datum, in the given file. The file has to be

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_transaction_calculate-min-required-utxo.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_transaction_calculate-min-required-utxo.cli
@@ -4,9 +4,9 @@ Usage: cardano-cli latest transaction calculate-min-required-utxo --protocol-par
                                                                     | --tx-out-datum-hash-cbor-file CBOR_FILE
                                                                     | --tx-out-datum-hash-file JSON_FILE
                                                                     | --tx-out-datum-hash-value JSON_VALUE
-                                                                    | --tx-out-datum-embed-cbor-file CBOR_FILE
-                                                                    | --tx-out-datum-embed-file JSON_FILE
-                                                                    | --tx-out-datum-embed-value JSON_VALUE
+                                                                    | --tx-out-supplemental-datum-cbor-file CBOR_FILE
+                                                                    | --tx-out-supplemental-datum-file JSON_FILE
+                                                                    | --tx-out-supplemental-datum-value JSON_VALUE
                                                                     | --tx-out-inline-datum-cbor-file CBOR_FILE
                                                                     | --tx-out-inline-datum-file JSON_FILE
                                                                     | --tx-out-inline-datum-value JSON_VALUE
@@ -37,18 +37,19 @@ Available options:
                            the script datum given here. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
-  --tx-out-datum-embed-cbor-file CBOR_FILE
-                           The script datum to embed in the tx for this output,
-                           in the given file. The file has to be in CBOR format.
-  --tx-out-datum-embed-file JSON_FILE
-                           The script datum to embed in the tx for this output,
-                           in the given file. The file must follow the detailed
-                           JSON schema for script data.
-  --tx-out-datum-embed-value JSON_VALUE
-                           The script datum to embed in the tx for this output,
-                           given here. There is no schema: (almost) any JSON
-                           value is supported, including top-level strings and
-                           numbers.
+  --tx-out-supplemental-datum-cbor-file CBOR_FILE
+                           The supplemental script datum to embed in the tx for
+                           this output, in the given file. The file has to be in
+                           CBOR format.
+  --tx-out-supplemental-datum-file JSON_FILE
+                           The supplemental script datum to embed in the tx for
+                           this output, in the given file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-supplemental-datum-value JSON_VALUE
+                           The supplemental script datum to embed in the tx for
+                           this output, given here. There is no schema: (almost)
+                           any JSON value is supported, including top-level
+                           strings and numbers.
   --tx-out-inline-datum-cbor-file CBOR_FILE
                            The script datum to embed in the tx output as an
                            inline datum, in the given file. The file has to be

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_transaction_calculate-min-value.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_transaction_calculate-min-value.cli
@@ -4,9 +4,9 @@ Usage: cardano-cli latest transaction calculate-min-value --protocol-params-file
                                                             | --tx-out-datum-hash-cbor-file CBOR_FILE
                                                             | --tx-out-datum-hash-file JSON_FILE
                                                             | --tx-out-datum-hash-value JSON_VALUE
-                                                            | --tx-out-datum-embed-cbor-file CBOR_FILE
-                                                            | --tx-out-datum-embed-file JSON_FILE
-                                                            | --tx-out-datum-embed-value JSON_VALUE
+                                                            | --tx-out-supplemental-datum-cbor-file CBOR_FILE
+                                                            | --tx-out-supplemental-datum-file JSON_FILE
+                                                            | --tx-out-supplemental-datum-value JSON_VALUE
                                                             | --tx-out-inline-datum-cbor-file CBOR_FILE
                                                             | --tx-out-inline-datum-file JSON_FILE
                                                             | --tx-out-inline-datum-value JSON_VALUE
@@ -37,18 +37,19 @@ Available options:
                            the script datum given here. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
-  --tx-out-datum-embed-cbor-file CBOR_FILE
-                           The script datum to embed in the tx for this output,
-                           in the given file. The file has to be in CBOR format.
-  --tx-out-datum-embed-file JSON_FILE
-                           The script datum to embed in the tx for this output,
-                           in the given file. The file must follow the detailed
-                           JSON schema for script data.
-  --tx-out-datum-embed-value JSON_VALUE
-                           The script datum to embed in the tx for this output,
-                           given here. There is no schema: (almost) any JSON
-                           value is supported, including top-level strings and
-                           numbers.
+  --tx-out-supplemental-datum-cbor-file CBOR_FILE
+                           The supplemental script datum to embed in the tx for
+                           this output, in the given file. The file has to be in
+                           CBOR format.
+  --tx-out-supplemental-datum-file JSON_FILE
+                           The supplemental script datum to embed in the tx for
+                           this output, in the given file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-supplemental-datum-value JSON_VALUE
+                           The supplemental script datum to embed in the tx for
+                           this output, given here. There is no schema: (almost)
+                           any JSON value is supported, including top-level
+                           strings and numbers.
   --tx-out-inline-datum-cbor-file CBOR_FILE
                            The script datum to embed in the tx output as an
                            inline datum, in the given file. The file has to be

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_transaction_build-raw.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_transaction_build-raw.cli
@@ -43,9 +43,9 @@ Usage: cardano-cli mary transaction build-raw
                                                   | --tx-out-datum-hash-cbor-file CBOR_FILE
                                                   | --tx-out-datum-hash-file JSON_FILE
                                                   | --tx-out-datum-hash-value JSON_VALUE
-                                                  | --tx-out-datum-embed-cbor-file CBOR_FILE
-                                                  | --tx-out-datum-embed-file JSON_FILE
-                                                  | --tx-out-datum-embed-value JSON_VALUE
+                                                  | --tx-out-supplemental-datum-cbor-file CBOR_FILE
+                                                  | --tx-out-supplemental-datum-file JSON_FILE
+                                                  | --tx-out-supplemental-datum-value JSON_VALUE
                                                   | --tx-out-inline-datum-cbor-file CBOR_FILE
                                                   | --tx-out-inline-datum-file JSON_FILE
                                                   | --tx-out-inline-datum-value JSON_VALUE
@@ -235,18 +235,19 @@ Available options:
                            the script datum given here. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
-  --tx-out-datum-embed-cbor-file CBOR_FILE
-                           The script datum to embed in the tx for this output,
-                           in the given file. The file has to be in CBOR format.
-  --tx-out-datum-embed-file JSON_FILE
-                           The script datum to embed in the tx for this output,
-                           in the given file. The file must follow the detailed
-                           JSON schema for script data.
-  --tx-out-datum-embed-value JSON_VALUE
-                           The script datum to embed in the tx for this output,
-                           given here. There is no schema: (almost) any JSON
-                           value is supported, including top-level strings and
-                           numbers.
+  --tx-out-supplemental-datum-cbor-file CBOR_FILE
+                           The supplemental script datum to embed in the tx for
+                           this output, in the given file. The file has to be in
+                           CBOR format.
+  --tx-out-supplemental-datum-file JSON_FILE
+                           The supplemental script datum to embed in the tx for
+                           this output, in the given file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-supplemental-datum-value JSON_VALUE
+                           The supplemental script datum to embed in the tx for
+                           this output, given here. There is no schema: (almost)
+                           any JSON value is supported, including top-level
+                           strings and numbers.
   --tx-out-inline-datum-cbor-file CBOR_FILE
                            The script datum to embed in the tx output as an
                            inline datum, in the given file. The file has to be

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_transaction_calculate-min-required-utxo.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_transaction_calculate-min-required-utxo.cli
@@ -4,9 +4,9 @@ Usage: cardano-cli mary transaction calculate-min-required-utxo --protocol-param
                                                                   | --tx-out-datum-hash-cbor-file CBOR_FILE
                                                                   | --tx-out-datum-hash-file JSON_FILE
                                                                   | --tx-out-datum-hash-value JSON_VALUE
-                                                                  | --tx-out-datum-embed-cbor-file CBOR_FILE
-                                                                  | --tx-out-datum-embed-file JSON_FILE
-                                                                  | --tx-out-datum-embed-value JSON_VALUE
+                                                                  | --tx-out-supplemental-datum-cbor-file CBOR_FILE
+                                                                  | --tx-out-supplemental-datum-file JSON_FILE
+                                                                  | --tx-out-supplemental-datum-value JSON_VALUE
                                                                   | --tx-out-inline-datum-cbor-file CBOR_FILE
                                                                   | --tx-out-inline-datum-file JSON_FILE
                                                                   | --tx-out-inline-datum-value JSON_VALUE
@@ -37,18 +37,19 @@ Available options:
                            the script datum given here. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
-  --tx-out-datum-embed-cbor-file CBOR_FILE
-                           The script datum to embed in the tx for this output,
-                           in the given file. The file has to be in CBOR format.
-  --tx-out-datum-embed-file JSON_FILE
-                           The script datum to embed in the tx for this output,
-                           in the given file. The file must follow the detailed
-                           JSON schema for script data.
-  --tx-out-datum-embed-value JSON_VALUE
-                           The script datum to embed in the tx for this output,
-                           given here. There is no schema: (almost) any JSON
-                           value is supported, including top-level strings and
-                           numbers.
+  --tx-out-supplemental-datum-cbor-file CBOR_FILE
+                           The supplemental script datum to embed in the tx for
+                           this output, in the given file. The file has to be in
+                           CBOR format.
+  --tx-out-supplemental-datum-file JSON_FILE
+                           The supplemental script datum to embed in the tx for
+                           this output, in the given file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-supplemental-datum-value JSON_VALUE
+                           The supplemental script datum to embed in the tx for
+                           this output, given here. There is no schema: (almost)
+                           any JSON value is supported, including top-level
+                           strings and numbers.
   --tx-out-inline-datum-cbor-file CBOR_FILE
                            The script datum to embed in the tx output as an
                            inline datum, in the given file. The file has to be

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_transaction_calculate-min-value.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_transaction_calculate-min-value.cli
@@ -4,9 +4,9 @@ Usage: cardano-cli mary transaction calculate-min-value --protocol-params-file F
                                                           | --tx-out-datum-hash-cbor-file CBOR_FILE
                                                           | --tx-out-datum-hash-file JSON_FILE
                                                           | --tx-out-datum-hash-value JSON_VALUE
-                                                          | --tx-out-datum-embed-cbor-file CBOR_FILE
-                                                          | --tx-out-datum-embed-file JSON_FILE
-                                                          | --tx-out-datum-embed-value JSON_VALUE
+                                                          | --tx-out-supplemental-datum-cbor-file CBOR_FILE
+                                                          | --tx-out-supplemental-datum-file JSON_FILE
+                                                          | --tx-out-supplemental-datum-value JSON_VALUE
                                                           | --tx-out-inline-datum-cbor-file CBOR_FILE
                                                           | --tx-out-inline-datum-file JSON_FILE
                                                           | --tx-out-inline-datum-value JSON_VALUE
@@ -37,18 +37,19 @@ Available options:
                            the script datum given here. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
-  --tx-out-datum-embed-cbor-file CBOR_FILE
-                           The script datum to embed in the tx for this output,
-                           in the given file. The file has to be in CBOR format.
-  --tx-out-datum-embed-file JSON_FILE
-                           The script datum to embed in the tx for this output,
-                           in the given file. The file must follow the detailed
-                           JSON schema for script data.
-  --tx-out-datum-embed-value JSON_VALUE
-                           The script datum to embed in the tx for this output,
-                           given here. There is no schema: (almost) any JSON
-                           value is supported, including top-level strings and
-                           numbers.
+  --tx-out-supplemental-datum-cbor-file CBOR_FILE
+                           The supplemental script datum to embed in the tx for
+                           this output, in the given file. The file has to be in
+                           CBOR format.
+  --tx-out-supplemental-datum-file JSON_FILE
+                           The supplemental script datum to embed in the tx for
+                           this output, in the given file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-supplemental-datum-value JSON_VALUE
+                           The supplemental script datum to embed in the tx for
+                           this output, given here. There is no schema: (almost)
+                           any JSON value is supported, including top-level
+                           strings and numbers.
   --tx-out-inline-datum-cbor-file CBOR_FILE
                            The script datum to embed in the tx output as an
                            inline datum, in the given file. The file has to be

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_transaction_build-raw.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_transaction_build-raw.cli
@@ -43,9 +43,9 @@ Usage: cardano-cli shelley transaction build-raw
                                                      | --tx-out-datum-hash-cbor-file CBOR_FILE
                                                      | --tx-out-datum-hash-file JSON_FILE
                                                      | --tx-out-datum-hash-value JSON_VALUE
-                                                     | --tx-out-datum-embed-cbor-file CBOR_FILE
-                                                     | --tx-out-datum-embed-file JSON_FILE
-                                                     | --tx-out-datum-embed-value JSON_VALUE
+                                                     | --tx-out-supplemental-datum-cbor-file CBOR_FILE
+                                                     | --tx-out-supplemental-datum-file JSON_FILE
+                                                     | --tx-out-supplemental-datum-value JSON_VALUE
                                                      | --tx-out-inline-datum-cbor-file CBOR_FILE
                                                      | --tx-out-inline-datum-file JSON_FILE
                                                      | --tx-out-inline-datum-value JSON_VALUE
@@ -235,18 +235,19 @@ Available options:
                            the script datum given here. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
-  --tx-out-datum-embed-cbor-file CBOR_FILE
-                           The script datum to embed in the tx for this output,
-                           in the given file. The file has to be in CBOR format.
-  --tx-out-datum-embed-file JSON_FILE
-                           The script datum to embed in the tx for this output,
-                           in the given file. The file must follow the detailed
-                           JSON schema for script data.
-  --tx-out-datum-embed-value JSON_VALUE
-                           The script datum to embed in the tx for this output,
-                           given here. There is no schema: (almost) any JSON
-                           value is supported, including top-level strings and
-                           numbers.
+  --tx-out-supplemental-datum-cbor-file CBOR_FILE
+                           The supplemental script datum to embed in the tx for
+                           this output, in the given file. The file has to be in
+                           CBOR format.
+  --tx-out-supplemental-datum-file JSON_FILE
+                           The supplemental script datum to embed in the tx for
+                           this output, in the given file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-supplemental-datum-value JSON_VALUE
+                           The supplemental script datum to embed in the tx for
+                           this output, given here. There is no schema: (almost)
+                           any JSON value is supported, including top-level
+                           strings and numbers.
   --tx-out-inline-datum-cbor-file CBOR_FILE
                            The script datum to embed in the tx output as an
                            inline datum, in the given file. The file has to be

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_transaction_calculate-min-required-utxo.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_transaction_calculate-min-required-utxo.cli
@@ -4,9 +4,9 @@ Usage: cardano-cli shelley transaction calculate-min-required-utxo --protocol-pa
                                                                      | --tx-out-datum-hash-cbor-file CBOR_FILE
                                                                      | --tx-out-datum-hash-file JSON_FILE
                                                                      | --tx-out-datum-hash-value JSON_VALUE
-                                                                     | --tx-out-datum-embed-cbor-file CBOR_FILE
-                                                                     | --tx-out-datum-embed-file JSON_FILE
-                                                                     | --tx-out-datum-embed-value JSON_VALUE
+                                                                     | --tx-out-supplemental-datum-cbor-file CBOR_FILE
+                                                                     | --tx-out-supplemental-datum-file JSON_FILE
+                                                                     | --tx-out-supplemental-datum-value JSON_VALUE
                                                                      | --tx-out-inline-datum-cbor-file CBOR_FILE
                                                                      | --tx-out-inline-datum-file JSON_FILE
                                                                      | --tx-out-inline-datum-value JSON_VALUE
@@ -37,18 +37,19 @@ Available options:
                            the script datum given here. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
-  --tx-out-datum-embed-cbor-file CBOR_FILE
-                           The script datum to embed in the tx for this output,
-                           in the given file. The file has to be in CBOR format.
-  --tx-out-datum-embed-file JSON_FILE
-                           The script datum to embed in the tx for this output,
-                           in the given file. The file must follow the detailed
-                           JSON schema for script data.
-  --tx-out-datum-embed-value JSON_VALUE
-                           The script datum to embed in the tx for this output,
-                           given here. There is no schema: (almost) any JSON
-                           value is supported, including top-level strings and
-                           numbers.
+  --tx-out-supplemental-datum-cbor-file CBOR_FILE
+                           The supplemental script datum to embed in the tx for
+                           this output, in the given file. The file has to be in
+                           CBOR format.
+  --tx-out-supplemental-datum-file JSON_FILE
+                           The supplemental script datum to embed in the tx for
+                           this output, in the given file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-supplemental-datum-value JSON_VALUE
+                           The supplemental script datum to embed in the tx for
+                           this output, given here. There is no schema: (almost)
+                           any JSON value is supported, including top-level
+                           strings and numbers.
   --tx-out-inline-datum-cbor-file CBOR_FILE
                            The script datum to embed in the tx output as an
                            inline datum, in the given file. The file has to be

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_transaction_calculate-min-value.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_transaction_calculate-min-value.cli
@@ -4,9 +4,9 @@ Usage: cardano-cli shelley transaction calculate-min-value --protocol-params-fil
                                                              | --tx-out-datum-hash-cbor-file CBOR_FILE
                                                              | --tx-out-datum-hash-file JSON_FILE
                                                              | --tx-out-datum-hash-value JSON_VALUE
-                                                             | --tx-out-datum-embed-cbor-file CBOR_FILE
-                                                             | --tx-out-datum-embed-file JSON_FILE
-                                                             | --tx-out-datum-embed-value JSON_VALUE
+                                                             | --tx-out-supplemental-datum-cbor-file CBOR_FILE
+                                                             | --tx-out-supplemental-datum-file JSON_FILE
+                                                             | --tx-out-supplemental-datum-value JSON_VALUE
                                                              | --tx-out-inline-datum-cbor-file CBOR_FILE
                                                              | --tx-out-inline-datum-file JSON_FILE
                                                              | --tx-out-inline-datum-value JSON_VALUE
@@ -37,18 +37,19 @@ Available options:
                            the script datum given here. There is no schema:
                            (almost) any JSON value is supported, including
                            top-level strings and numbers.
-  --tx-out-datum-embed-cbor-file CBOR_FILE
-                           The script datum to embed in the tx for this output,
-                           in the given file. The file has to be in CBOR format.
-  --tx-out-datum-embed-file JSON_FILE
-                           The script datum to embed in the tx for this output,
-                           in the given file. The file must follow the detailed
-                           JSON schema for script data.
-  --tx-out-datum-embed-value JSON_VALUE
-                           The script datum to embed in the tx for this output,
-                           given here. There is no schema: (almost) any JSON
-                           value is supported, including top-level strings and
-                           numbers.
+  --tx-out-supplemental-datum-cbor-file CBOR_FILE
+                           The supplemental script datum to embed in the tx for
+                           this output, in the given file. The file has to be in
+                           CBOR format.
+  --tx-out-supplemental-datum-file JSON_FILE
+                           The supplemental script datum to embed in the tx for
+                           this output, in the given file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-supplemental-datum-value JSON_VALUE
+                           The supplemental script datum to embed in the tx for
+                           this output, given here. There is no schema: (almost)
+                           any JSON value is supported, including top-level
+                           strings and numbers.
   --tx-out-inline-datum-cbor-file CBOR_FILE
                            The script datum to embed in the tx output as an
                            inline datum, in the given file. The file has to be


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Add support for supplementary datums

  type:
  - feature        # introduces a new feature
```

# Context

Integrates:
 - https://github.com/IntersectMBO/cardano-api/pull/640

Implements:
 - https://github.com/IntersectMBO/cardano-api/issues/600

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
