### PR TITLE
Add proposal hash check when creating `info` governance action

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
+cardano-cli/test/cardano-cli-golden/files/input/example_anchor_data.txt -text
 cardano-cli/test/cardano-cli-test/files/input/example_anchor_data.txt -text

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -289,6 +289,7 @@ library cardano-cli-test-lib
   hs-source-dirs: test/cardano-cli-test-lib
   exposed-modules:
     Test.Cardano.CLI.Aeson
+    Test.Cardano.CLI.Hash
     Test.Cardano.CLI.Util
 
   build-depends:
@@ -303,12 +304,17 @@ library cardano-cli-test-lib
     filepath,
     hedgehog,
     hedgehog-extras ^>=0.6.1.0,
+    http-types,
     lifted-base,
     monad-control,
+    network,
     process,
     text,
     transformers-base,
+    utf8-string,
     vector,
+    wai,
+    warp,
 
 test-suite cardano-cli-test
   import: project-config
@@ -331,10 +337,6 @@ test-suite cardano-cli-test
     filepath,
     hedgehog,
     hedgehog-extras ^>=0.6.1.0,
-    http-types,
-    lifted-base,
-    monad-control,
-    network,
     parsec,
     regex-tdfa,
     tasty,
@@ -342,9 +344,6 @@ test-suite cardano-cli-test
     text,
     time,
     transformers,
-    utf8-string,
-    wai,
-    warp,
 
   build-tool-depends: tasty-discover:tasty-discover
   other-modules:
@@ -399,10 +398,12 @@ test-suite cardano-cli-golden
     cborg,
     containers,
     directory,
+    exceptions,
     extra,
     filepath,
     hedgehog ^>=1.4,
     hedgehog-extras ^>=0.6.1.0,
+    monad-control,
     regex-compat,
     regex-tdfa,
     tasty,

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/Actions.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/Actions.hs
@@ -84,6 +84,7 @@ data GovernanceActionInfoCmdArgs era
   , returnStakeAddress :: !StakeIdentifier
   , proposalUrl :: !ProposalUrl
   , proposalHash :: !(L.SafeHash L.StandardCrypto L.AnchorData)
+  , checkProposalHash :: !(MustCheckHash ProposalUrl)
   , outFile :: !(File () Out)
   }
   deriving Show

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Actions.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Actions.hs
@@ -74,9 +74,26 @@ pGovernanceActionNewInfoCmd era = do
             <*> pStakeIdentifier (Just "deposit-return")
             <*> pAnchorUrl
             <*> pAnchorDataHash
+            <*> pMustCheckProposalHash
             <*> pFileOutDirection "out-file" "Path to action file to be used later on with build or build-raw "
       )
     $ Opt.progDesc "Create an info action."
+ where
+  pMustCheckProposalHash :: Parser (MustCheckHash ProposalUrl)
+  pMustCheckProposalHash =
+    asum
+      [ Opt.flag' CheckHash $
+          mconcat
+            [ Opt.long "check-anchor-data"
+            , Opt.help
+                "Check the proposal hash (from --anchor-data-hash) by downloading anchor data (from --anchor-url)."
+            ]
+      , Opt.flag' TrustHash $
+          mconcat
+            [ Opt.long "trust-anchor-data"
+            , Opt.help "Do not check the proposal hash (from --anchor-data-hash) and trust it is correct."
+            ]
+      ]
 
 pGovernanceActionNewConstitutionCmd
   :: CardanoEra era

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Actions.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Actions.hs
@@ -21,7 +21,7 @@ import           Cardano.CLI.EraBased.Commands.Governance.Actions
 import qualified Cardano.CLI.EraBased.Commands.Governance.Actions as Cmd
 import           Cardano.CLI.Json.Friendly
 import           Cardano.CLI.Read
-import           Cardano.CLI.Run.Hash (getByteStringFromURL)
+import           Cardano.CLI.Run.Hash (getByteStringFromURL, httpsAndIpfsSchemas)
 import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Errors.GovernanceActionsError
 import           Cardano.CLI.Types.Errors.HashCmdError (FetchURLError)
@@ -107,7 +107,7 @@ runGovernanceActionInfoCmd
           L.AnchorData
             <$> fetchURLErrorToGovernanceActionError
               ProposalCheck
-              (getByteStringFromURL $ L.anchorUrl proposalAnchor)
+              (getByteStringFromURL httpsAndIpfsSchemas $ L.anchorUrl proposalAnchor)
         let hash = L.hashAnchorData anchorData
         when (hash /= L.anchorDataHash proposalAnchor) $
           left $

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Actions.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Actions.hs
@@ -21,8 +21,10 @@ import           Cardano.CLI.EraBased.Commands.Governance.Actions
 import qualified Cardano.CLI.EraBased.Commands.Governance.Actions as Cmd
 import           Cardano.CLI.Json.Friendly
 import           Cardano.CLI.Read
+import           Cardano.CLI.Run.Hash (getByteStringFromURL)
 import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Errors.GovernanceActionsError
+import           Cardano.CLI.Types.Errors.HashCmdError (FetchURLError)
 import           Cardano.CLI.Types.Key
 
 import           Control.Monad
@@ -86,6 +88,7 @@ runGovernanceActionInfoCmd
     , Cmd.returnStakeAddress
     , Cmd.proposalUrl
     , Cmd.proposalHash
+    , Cmd.checkProposalHash
     , Cmd.outFile
     } = do
     depositStakeCredential <-
@@ -98,6 +101,19 @@ runGovernanceActionInfoCmd
             , L.anchorDataHash = proposalHash
             }
 
+    case checkProposalHash of
+      CheckHash -> do
+        anchorData <-
+          L.AnchorData
+            <$> fetchURLErrorToGovernanceActionError
+              ProposalCheck
+              (getByteStringFromURL $ L.anchorUrl proposalAnchor)
+        let hash = L.hashAnchorData anchorData
+        when (hash /= L.anchorDataHash proposalAnchor) $
+          left $
+            GovernanceActionsProposalMismatchedHashError ProposalCheck proposalHash hash
+      TrustHash -> pure ()
+
     let sbe = conwayEraOnwardsToShelleyBasedEra eon
         govAction = InfoAct
         proposalProcedure = createProposalProcedure sbe networkId deposit depositStakeCredential govAction proposalAnchor
@@ -105,6 +121,10 @@ runGovernanceActionInfoCmd
     firstExceptT GovernanceActionsCmdWriteFileError . newExceptT $
       conwayEraOnwardsConstraints eon $
         writeFileTextEnvelope outFile (Just "Info proposal") proposalProcedure
+   where
+    fetchURLErrorToGovernanceActionError
+      :: AnchorDataTypeCheck -> ExceptT FetchURLError IO a -> ExceptT GovernanceActionsError IO a
+    fetchURLErrorToGovernanceActionError adt = withExceptT (GovernanceActionsProposalFetchURLError adt)
 
 -- TODO: Conway era - update with new ledger types from cardano-ledger-conway-1.7.0.0
 runGovernanceActionCreateNoConfidenceCmd

--- a/cardano-cli/src/Cardano/CLI/Run/Hash.hs
+++ b/cardano-cli/src/Cardano/CLI/Run/Hash.hs
@@ -29,6 +29,7 @@ import           Control.Monad.Catch (Exception, Handler (Handler))
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Char8 as BS8
 import qualified Data.ByteString.Lazy as BSL
+import qualified Data.ByteString.Lazy.Char8 as BSL8
 import           Data.Char (toLower)
 import           Data.Function
 import           Data.List (intercalate)
@@ -129,7 +130,11 @@ getByteStringFromURL supportedSchemas urlText = do
     response <- httpLbs request manager
     let status = responseStatus response
     if statusCode status /= 200
-      then throw $ BadStatusCodeHRE (statusCode status) (BS8.unpack $ statusMessage status)
+      then
+        throw $
+          BadStatusCodeHRE
+            (statusCode status)
+            (BS8.unpack (statusMessage status) ++ ": " ++ BSL8.unpack (responseBody response))
       else return $ BS.concat . BSL.toChunks $ responseBody response
 
   handlers :: [Handler IO FetchURLError]

--- a/cardano-cli/src/Cardano/CLI/Types/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Common.hs
@@ -31,6 +31,7 @@ module Cardano.CLI.Types.Common
   , InputTxBodyOrTxFile (..)
   , KeyOutputFormat (..)
   , MetadataFile (..)
+  , MustCheckHash (..)
   , OpCertCounter
   , OpCertCounterFile
   , OpCertEndingKesPeriod (..)
@@ -638,4 +639,9 @@ data InputTxBodyOrTxFile = InputTxBodyFile (TxBodyFile In) | InputTxFile (TxFile
 data ParserFileDirection
   = Input
   | Output
+  deriving (Eq, Show)
+
+data MustCheckHash a
+  = CheckHash
+  | TrustHash
   deriving (Eq, Show)

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/GovernanceActionsError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/GovernanceActionsError.hs
@@ -2,13 +2,18 @@
 
 module Cardano.CLI.Types.Errors.GovernanceActionsError
   ( GovernanceActionsError (..)
+  , AnchorDataTypeCheck (..)
   )
 where
 
 import           Cardano.Api
+import qualified Cardano.Api.Ledger as L
 
 import           Cardano.CLI.Read
+import           Cardano.CLI.Types.Errors.HashCmdError (FetchURLError)
 import           Cardano.CLI.Types.Errors.StakeCredentialError
+
+import           Control.Exception (displayException)
 
 data GovernanceActionsError
   = GovernanceActionsCmdConstitutionError ConstitutionError
@@ -19,6 +24,18 @@ data GovernanceActionsError
   | GovernanceActionsCmdReadTextEnvelopeFileError (FileError TextEnvelopeError)
   | GovernanceActionsCmdWriteFileError (FileError ())
   | GovernanceActionsValueUpdateProtocolParametersNotFound AnyShelleyBasedEra
+  | GovernanceActionsProposalMismatchedHashError
+      AnchorDataTypeCheck
+      -- ^ Type of anchor data that we were checking
+      !(L.SafeHash L.StandardCrypto L.AnchorData)
+      -- ^ Expected hash
+      !(L.SafeHash L.StandardCrypto L.AnchorData)
+      -- ^ Actual hash
+  | GovernanceActionsProposalFetchURLError
+      AnchorDataTypeCheck
+      -- ^ Type of anchor data that we were checking
+      FetchURLError
+      -- ^ Error that occurred while fetching the anchor data
   deriving Show
 
 instance Error GovernanceActionsError where
@@ -39,3 +56,22 @@ instance Error GovernanceActionsError where
       "Protocol parameters update value for" <+> pretty expectedShelleyEra <+> "was not found."
     GovernanceActionsReadStakeCredErrror e ->
       prettyError e
+    GovernanceActionsProposalMismatchedHashError adt expectedHash actualHash ->
+      "Hashes do not match while checking "
+        <> pretty (anchorDataTypeCheckName adt)
+        <> " hashes! \n"
+        <> "Expected: "
+        <> pretty (show (L.extractHash expectedHash))
+        <> "\n  Actual: "
+        <> pretty (show (L.extractHash actualHash))
+    GovernanceActionsProposalFetchURLError adt fetchErr ->
+      "Error while checking "
+        <> pretty (anchorDataTypeCheckName adt)
+        <> " hash:"
+        <> pretty (displayException fetchErr)
+
+data AnchorDataTypeCheck = ProposalCheck
+  deriving Show
+
+anchorDataTypeCheckName :: AnchorDataTypeCheck -> String
+anchorDataTypeCheckName ProposalCheck = "proposal"

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/GovernanceActionsError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/GovernanceActionsError.hs
@@ -57,18 +57,18 @@ instance Error GovernanceActionsError where
     GovernanceActionsReadStakeCredErrror e ->
       prettyError e
     GovernanceActionsProposalMismatchedHashError adt expectedHash actualHash ->
-      "Hashes do not match while checking "
-        <> pretty (anchorDataTypeCheckName adt)
-        <> " hashes! \n"
-        <> "Expected: "
-        <> pretty (show (L.extractHash expectedHash))
-        <> "\n  Actual: "
-        <> pretty (show (L.extractHash actualHash))
+      "Hashes do not match while checking"
+        <+> pretty (anchorDataTypeCheckName adt)
+        <+> "hashes!"
+        <> "\nExpected:"
+          <+> pretty (show (L.extractHash expectedHash))
+        <> "\n  Actual:"
+          <+> pretty (show (L.extractHash actualHash))
     GovernanceActionsProposalFetchURLError adt fetchErr ->
-      "Error while checking "
-        <> pretty (anchorDataTypeCheckName adt)
-        <> " hash: "
-        <> pretty (displayException fetchErr)
+      "Error while checking"
+        <+> pretty (anchorDataTypeCheckName adt)
+        <+> "hash:"
+        <+> pretty (displayException fetchErr)
 
 data AnchorDataTypeCheck = ProposalCheck
   deriving Show

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/GovernanceActionsError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/GovernanceActionsError.hs
@@ -67,7 +67,7 @@ instance Error GovernanceActionsError where
     GovernanceActionsProposalFetchURLError adt fetchErr ->
       "Error while checking "
         <> pretty (anchorDataTypeCheckName adt)
-        <> " hash:"
+        <> " hash: "
         <> pretty (displayException fetchErr)
 
 data AnchorDataTypeCheck = ProposalCheck

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/HashCmdError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/HashCmdError.hs
@@ -32,17 +32,17 @@ data HashCmdError
 instance Error HashCmdError where
   prettyError = \case
     HashMismatchedHashError expectedHash actualHash ->
-      "Hashes do not match! \n"
-        <> "Expected: "
-        <> pretty (show (extractHash expectedHash))
-        <> "\n  Actual: "
-        <> pretty (show (extractHash actualHash))
+      "Hashes do not match!"
+        <> "\nExpected:"
+          <+> pretty (show (extractHash expectedHash))
+        <> "\n  Actual:"
+          <+> pretty (show (extractHash actualHash))
     HashReadFileError filepath exc ->
-      "Cannot read " <> pretty filepath <> ": " <> pretty (displayException exc)
+      "Cannot read" <+> pretty filepath <> ":" <+> pretty (displayException exc)
     HashWriteFileError fileErr ->
       prettyError fileErr
     HashReadScriptError filepath err ->
-      "Cannot read script at " <> pretty filepath <> ": " <> prettyError err
+      "Cannot read script at" <+> pretty filepath <> ":" <+> prettyError err
     HashFetchURLError fetchErr ->
       pretty (displayException fetchErr)
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Governance/Action.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Governance/Action.hs
@@ -11,7 +11,7 @@ import           Control.Monad.Catch (MonadCatch)
 import           Control.Monad.Trans.Control (MonadBaseControl)
 
 import           Test.Cardano.CLI.Hash (exampleAnchorDataHash, exampleAnchorDataIpfsHash,
-                   exampleAnchorDataPath, serveFileWhile)
+                   exampleAnchorDataPathGolden, serveFileWhile)
 import qualified Test.Cardano.CLI.Util as H
 import           Test.Cardano.CLI.Util (execCardanoCLI, execCardanoCLIWithEnvVars, expectFailure,
                    noteInputFile, noteTempFile, propertyOnce)
@@ -216,7 +216,7 @@ base_golden_conway_governance_action_view_create_info_json_outfile hash tempDir 
   let relativeUrl = ["ipfs", exampleAnchorDataIpfsHash]
   serveFileWhile
     relativeUrl
-    exampleAnchorDataPath
+    exampleAnchorDataPathGolden
     ( \port -> do
         void $
           execCardanoCLIWithEnvVars

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Governance/Action.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Governance/Action.hs
@@ -1,13 +1,22 @@
+{-# LANGUAGE FlexibleContexts #-}
 {- HLINT ignore "Use camelCase" -}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 module Test.Golden.Governance.Action where
 
+import           Cardano.Api (MonadIO)
+
 import           Control.Monad (void)
+import           Control.Monad.Catch (MonadCatch)
+import           Control.Monad.Trans.Control (MonadBaseControl)
 
+import           Test.Cardano.CLI.Hash (exampleAnchorDataHash, exampleAnchorDataIpfsHash,
+                   exampleAnchorDataPath, serveFileWhile)
 import qualified Test.Cardano.CLI.Util as H
-import           Test.Cardano.CLI.Util
+import           Test.Cardano.CLI.Util (execCardanoCLI, execCardanoCLIWithEnvVars, expectFailure,
+                   noteInputFile, noteTempFile, propertyOnce)
 
-import           Hedgehog (Property)
+import           Hedgehog (MonadTest, Property)
 import qualified Hedgehog.Extras as H
 import qualified Hedgehog.Extras.Test.Golden as H
 
@@ -186,47 +195,66 @@ hprop_golden_conway_governance_action_view_update_committee_yaml =
         ]
     H.diffVsGoldenFile actionView goldenActionViewFile
 
+hprop_golden_conway_governance_action_view_create_info_json_outfile_wrong_hash_fails :: Property
+hprop_golden_conway_governance_action_view_create_info_json_outfile_wrong_hash_fails =
+  propertyOnce . expectFailure . H.moduleWorkspace "tmp" $ \tempDir ->
+    base_golden_conway_governance_action_view_create_info_json_outfile
+      ('a' : drop 1 exampleAnchorDataHash)
+      tempDir
+
 hprop_golden_conway_governance_action_view_create_info_json_outfile :: Property
 hprop_golden_conway_governance_action_view_create_info_json_outfile =
-  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
-    stakeAddressVKeyFile <- H.note "test/cardano-cli-golden/files/input/governance/stake-address.vkey"
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir ->
+    base_golden_conway_governance_action_view_create_info_json_outfile exampleAnchorDataHash tempDir
 
-    actionFile <- noteTempFile tempDir "action"
+base_golden_conway_governance_action_view_create_info_json_outfile
+  :: (MonadBaseControl IO m, MonadTest m, MonadIO m, MonadCatch m) => String -> FilePath -> m ()
+base_golden_conway_governance_action_view_create_info_json_outfile hash tempDir = do
+  stakeAddressVKeyFile <- H.note "test/cardano-cli-golden/files/input/governance/stake-address.vkey"
 
-    void $
-      execCardanoCLI
-        [ "conway"
-        , "governance"
-        , "action"
-        , "create-info"
-        , "--testnet"
-        , "--governance-action-deposit"
-        , "10"
-        , "--deposit-return-stake-verification-key-file"
-        , stakeAddressVKeyFile
-        , "--anchor-url"
-        , "proposal-dummy-url"
-        , "--anchor-data-hash"
-        , "c7ddb5b493faa4d3d2d679847740bdce0c5d358d56f9b1470ca67f5652a02745"
-        , "--out-file"
-        , actionFile
-        ]
+  actionFile <- noteTempFile tempDir "action"
+  let relativeUrl = ["ipfs", exampleAnchorDataIpfsHash]
+  serveFileWhile
+    relativeUrl
+    exampleAnchorDataPath
+    ( \port -> do
+        void $
+          execCardanoCLIWithEnvVars
+            [("IPFS_GATEWAY_URI", "http://localhost:" ++ show port ++ "/")]
+            [ "conway"
+            , "governance"
+            , "action"
+            , "create-info"
+            , "--testnet"
+            , "--governance-action-deposit"
+            , "10"
+            , "--deposit-return-stake-verification-key-file"
+            , stakeAddressVKeyFile
+            , "--anchor-url"
+            , "ipfs://" ++ exampleAnchorDataIpfsHash
+            , "--anchor-data-hash"
+            , hash
+            , "--check-anchor-data"
+            , "--out-file"
+            , actionFile
+            ]
+    )
 
-    actionViewFile <- noteTempFile tempDir "action-view"
-    goldenActionViewFile <-
-      H.note "test/cardano-cli-golden/files/golden/governance/action/view/create-info.action.view"
-    void $
-      execCardanoCLI
-        [ "conway"
-        , "governance"
-        , "action"
-        , "view"
-        , "--action-file"
-        , actionFile
-        , "--out-file"
-        , actionViewFile
-        ]
-    H.diffFileVsGoldenFile actionViewFile goldenActionViewFile
+  actionViewFile <- noteTempFile tempDir "action-view"
+  goldenActionViewFile <-
+    H.note "test/cardano-cli-golden/files/golden/governance/action/view/create-info.action.view"
+  void $
+    execCardanoCLI
+      [ "conway"
+      , "governance"
+      , "action"
+      , "view"
+      , "--action-file"
+      , actionFile
+      , "--out-file"
+      , actionViewFile
+      ]
+  H.diffFileVsGoldenFile actionViewFile goldenActionViewFile
 
 hprop_golden_governanceActionCreateNoConfidence :: Property
 hprop_golden_governanceActionCreateNoConfidence =

--- a/cardano-cli/test/cardano-cli-golden/files/golden/governance/action/view/create-info.action.view
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/governance/action/view/create-info.action.view
@@ -1,7 +1,7 @@
 {
     "anchor": {
-        "dataHash": "c7ddb5b493faa4d3d2d679847740bdce0c5d358d56f9b1470ca67f5652a02745",
-        "url": "proposal-dummy-url"
+        "dataHash": "de38a4f5b8b9d8372386cc923bad19d1a0662298cf355bbe947e5eedf127fa9c",
+        "url": "ipfs://QmbL5EBFJLf8DdPkWAskG3Euin9tHY8naqQ2JDoHnWHHXJ"
     },
     "deposit": 10,
     "governance action": {

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -5975,6 +5975,9 @@ Usage: cardano-cli conway governance action create-info (--mainnet | --testnet)
                                                           )
                                                           --anchor-url TEXT
                                                           --anchor-data-hash HASH
+                                                          ( --check-anchor-data
+                                                          | --trust-anchor-data
+                                                          )
                                                           --out-file FILEPATH
 
   Create an info action.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_create-info.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_create-info.cli
@@ -8,6 +8,9 @@ Usage: cardano-cli conway governance action create-info (--mainnet | --testnet)
                                                           )
                                                           --anchor-url TEXT
                                                           --anchor-data-hash HASH
+                                                          ( --check-anchor-data
+                                                          | --trust-anchor-data
+                                                          )
                                                           --out-file FILEPATH
 
   Create an info action.
@@ -30,6 +33,10 @@ Available options:
   --anchor-url TEXT        Anchor URL
   --anchor-data-hash HASH  Proposal anchor data hash (obtain it with
                            "cardano-cli hash anchor-data ...")
+  --check-anchor-data      Check the proposal hash (from --anchor-data-hash) by
+                           downloading anchor data (from --anchor-url).
+  --trust-anchor-data      Do not check the proposal hash (from
+                           --anchor-data-hash) and trust it is correct.
   --out-file FILEPATH      Path to action file to be used later on with build or
                            build-raw
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/input/example_anchor_data.txt
+++ b/cardano-cli/test/cardano-cli-golden/files/input/example_anchor_data.txt
@@ -1,0 +1,2 @@
+This is just a random file with content that is used for
+testing the hashing of anchor data files.

--- a/cardano-cli/test/cardano-cli-test-lib/Test/Cardano/CLI/Hash.hs
+++ b/cardano-cli/test/cardano-cli-test-lib/Test/Cardano/CLI/Hash.hs
@@ -1,6 +1,13 @@
 {-# LANGUAGE FlexibleContexts #-}
 
-module Test.Cardano.CLI.Hash (exampleAnchorDataHash, serveFileWhile, exampleAnchorDataPath, exampleAnchorDataIpfsHash) where
+module Test.Cardano.CLI.Hash
+  ( exampleAnchorDataHash
+  , serveFileWhile
+  , exampleAnchorDataPathTest
+  , exampleAnchorDataPathGolden
+  , exampleAnchorDataIpfsHash
+  )
+where
 
 import           Cardano.Api (MonadIO)
 
@@ -26,8 +33,11 @@ import           Hedgehog.Internal.Source (HasCallStack)
 exampleAnchorDataHash :: String
 exampleAnchorDataHash = "de38a4f5b8b9d8372386cc923bad19d1a0662298cf355bbe947e5eedf127fa9c"
 
-exampleAnchorDataPath :: String
-exampleAnchorDataPath = "test/cardano-cli-test/files/input/example_anchor_data.txt"
+exampleAnchorDataPathGolden :: String
+exampleAnchorDataPathGolden = "test/cardano-cli-golden/files/input/example_anchor_data.txt"
+
+exampleAnchorDataPathTest :: String
+exampleAnchorDataPathTest = "test/cardano-cli-test/files/input/example_anchor_data.txt"
 
 exampleAnchorDataIpfsHash :: String
 exampleAnchorDataIpfsHash = "QmbL5EBFJLf8DdPkWAskG3Euin9tHY8naqQ2JDoHnWHHXJ"

--- a/cardano-cli/test/cardano-cli-test-lib/Test/Cardano/CLI/Hash.hs
+++ b/cardano-cli/test/cardano-cli-test-lib/Test/Cardano/CLI/Hash.hs
@@ -1,0 +1,82 @@
+{-# LANGUAGE FlexibleContexts #-}
+
+module Test.Cardano.CLI.Hash (exampleAnchorDataHash, serveFileWhile, exampleAnchorDataPath, exampleAnchorDataIpfsHash) where
+
+import           Cardano.Api (MonadIO)
+
+import           Control.Concurrent (forkOS)
+import           Control.Exception.Lifted (bracket)
+import           Control.Monad (void)
+import           Control.Monad.Trans.Control (MonadBaseControl)
+import qualified Data.ByteString.UTF8 as BSU8
+import           Data.List (intercalate)
+import           Data.String (IsString (fromString))
+import           Data.Text (unpack)
+import qualified Data.Text as T
+import           Network.HTTP.Types.Status (status200, status404)
+import           Network.HTTP.Types.URI (renderQuery)
+import           Network.Socket (close)
+import           Network.Wai (Request (..), Response, ResponseReceived, pathInfo, responseFile,
+                   responseLBS)
+import           Network.Wai.Handler.Warp (defaultSettings, openFreePort, runSettingsSocket)
+
+import           Hedgehog as H
+import           Hedgehog.Internal.Source (HasCallStack)
+
+exampleAnchorDataHash :: String
+exampleAnchorDataHash = "de38a4f5b8b9d8372386cc923bad19d1a0662298cf355bbe947e5eedf127fa9c"
+
+exampleAnchorDataPath :: String
+exampleAnchorDataPath = "test/cardano-cli-test/files/input/example_anchor_data.txt"
+
+exampleAnchorDataIpfsHash :: String
+exampleAnchorDataIpfsHash = "QmbL5EBFJLf8DdPkWAskG3Euin9tHY8naqQ2JDoHnWHHXJ"
+
+-- | Takes a relative url (as a list of segments), a file path, and an action, and it serves
+-- the file in the url provided in a random free port that is passed as a parameter to the
+-- action. After the action returns, it shuts down the server. It returns the result of the
+-- action. It also ensures the server is shut down even if the action throws an exception.
+serveFileWhile
+  :: (MonadBaseControl IO m, MonadTest m, MonadIO m, HasCallStack)
+  => [String]
+  -- ^ Relative URL where the file will be served.
+  -- Each element is a segment of the URL.
+  -> FilePath
+  -- ^ File path for the file to serve
+  -> (Int -> m a)
+  -- ^ Action to run while the file is being served.
+  -- It receives the port the server is listening on
+  -> m a
+serveFileWhile relativeUrl filePath action =
+  bracket
+    -- Server setup (resource acquisition)
+    ( do
+        -- Get the port the server is listening on
+        (port, socket) <- H.evalIO openFreePort
+        -- Serve the file
+        let app :: Request -> (Response -> IO ResponseReceived) -> IO ResponseReceived
+            app req respond = do
+              let path = T.unpack <$> pathInfo req
+              if path == relativeUrl
+                then respond $ responseFile status200 [("Content-Type", "text/plain")] filePath Nothing
+                else
+                  respond $
+                    responseLBS status404 [("Content-Type", "text/plain")] $
+                      fromString ("404 - Url \"" ++ urlFromRequest req ++ "\" - Not Found")
+
+        -- Run server asynchronously in a separate thread
+        void $ H.evalIO $ forkOS $ runSettingsSocket defaultSettings socket app
+        return (port, socket)
+    )
+    -- Server teardown (resource release)
+    (\(_, socket) -> H.evalIO $ close socket)
+    -- Test action
+    (\(port, _) -> action port)
+ where
+  urlFromRequest :: Request -> String
+  urlFromRequest req =
+    "http://"
+      ++ maybe "localhost" BSU8.toString (requestHeaderHost req)
+      ++ "/"
+      ++ intercalate "/" (unpack <$> pathInfo req)
+      ++ BSU8.toString (renderQuery True (queryString req))

--- a/cardano-cli/test/cardano-cli-test-lib/Test/Cardano/CLI/Util.hs
+++ b/cardano-cli/test/cardano-cli-test-lib/Test/Cardano/CLI/Util.hs
@@ -10,6 +10,7 @@ module Test.Cardano.CLI.Util
   , checkTextEnvelopeFormat
   , equivalence
   , execCardanoCLI
+  , execCardanoCLIWithEnvVars
   , execDetailCardanoCLI
   , execDetailConfigCardanoCLI
   , tryExecCardanoCLI
@@ -43,6 +44,7 @@ import           Data.Function ((&))
 import qualified Data.List as List
 import           Data.Monoid (Last (..))
 import           Data.Text (Text)
+import           GHC.IO.Exception (ExitCode (..))
 import           GHC.Stack (CallStack, HasCallStack)
 import qualified GHC.Stack as GHC
 import qualified System.Directory as IO
@@ -73,6 +75,31 @@ execCardanoCLI
   -> m String
   -- ^ Captured stdout
 execCardanoCLI = GHC.withFrozenCallStack $ H.execFlex "cardano-cli" "CARDANO_CLI"
+
+-- | Execute cardano-cli via the command line but set
+-- environment variables. Fails if the process returns a non-zero exit code.
+--
+-- Waits for the process to finish and returns the stdout.
+execCardanoCLIWithEnvVars
+  :: (MonadTest m, MonadCatch m, MonadIO m, HasCallStack)
+  => [(String, String)]
+  -- ^ Environment variables to set
+  -> [String]
+  -- ^ Arguments to the CLI command
+  -> m String
+execCardanoCLIWithEnvVars envVars args = GHC.withFrozenCallStack $ do
+  env <- H.evalIO IO.getEnvironment
+  result <-
+    execDetailConfigCardanoCLI
+      H.defaultExecConfig
+        { H.execConfigEnv = Last $ Just (envVars ++ env)
+        }
+      args
+  case result of
+    (ExitFailure _, _, stderr) -> do
+      H.note_ stderr
+      H.failure
+    (ExitSuccess, stdout, _) -> return stdout
 
 -- | Execute cardano-cli via the command line, expecting it to fail.
 --

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/Hash.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/Hash.hs
@@ -2,42 +2,19 @@
 
 module Test.Cli.Hash where
 
-import           Cardano.Api (MonadIO)
-
-import           Control.Concurrent (forkOS)
-import           Control.Exception.Lifted (bracket)
 import           Control.Monad (void)
-import           Control.Monad.Trans.Control (MonadBaseControl)
-import qualified Data.ByteString.UTF8 as BSU8
 import           Data.List (intercalate)
-import           Data.String (IsString (fromString))
-import           Data.Text (unpack)
-import qualified Data.Text as T
 import           GHC.IO.Exception (ExitCode (..))
-import           Network.HTTP.Types.Status (status200, status404)
-import           Network.HTTP.Types.URI (renderQuery)
-import           Network.Socket (close)
-import           Network.Wai (Request (..), Response, ResponseReceived, pathInfo, responseFile,
-                   responseLBS)
-import           Network.Wai.Handler.Warp (defaultSettings, openFreePort, runSettingsSocket)
 import           System.Directory (getCurrentDirectory)
 import           System.FilePath (dropTrailingPathSeparator)
 import           System.FilePath.Posix (splitDirectories)
 
+import           Test.Cardano.CLI.Hash (exampleAnchorDataHash, exampleAnchorDataIpfsHash,
+                   exampleAnchorDataPath, serveFileWhile)
 import           Test.Cardano.CLI.Util
 
 import           Hedgehog as H
 import qualified Hedgehog.Extras as H
-import           Hedgehog.Internal.Source (HasCallStack)
-
-exampleAnchorDataHash :: String
-exampleAnchorDataHash = "de38a4f5b8b9d8372386cc923bad19d1a0662298cf355bbe947e5eedf127fa9c"
-
-exampleAnchorDataPath :: String
-exampleAnchorDataPath = "test/cardano-cli-test/files/input/example_anchor_data.txt"
-
-exampleAnchorDataIpfsHash :: String
-exampleAnchorDataIpfsHash = "QmbL5EBFJLf8DdPkWAskG3Euin9tHY8naqQ2JDoHnWHHXJ"
 
 -- | Execute me with:
 -- @cabal test cardano-cli-test --test-options '-p "/generate anchor data hash from file/"'@
@@ -157,52 +134,3 @@ hprop_check_anchor_data_hash_from_ipfs_uri =
               , exampleAnchorDataHash
               ]
       )
-
--- | Takes a relative url (as a list of segments), a file path, and an action, and it serves
--- the file in the url provided in a random free port that is passed as a parameter to the
--- action. After the action returns, it shuts down the server. It returns the result of the
--- action. It also ensures the server is shut down even if the action throws an exception.
-serveFileWhile
-  :: (MonadBaseControl IO m, MonadTest m, MonadIO m, HasCallStack)
-  => [String]
-  -- ^ Relative URL where the file will be served.
-  -- Each element is a segment of the URL.
-  -> FilePath
-  -- ^ File path for the file to serve
-  -> (Int -> m a)
-  -- ^ Action to run while the file is being served.
-  -- It receives the port the server is listening on
-  -> m a
-serveFileWhile relativeUrl filePath action =
-  bracket
-    -- Server setup (resource acquisition)
-    ( do
-        -- Get the port the server is listening on
-        (port, socket) <- H.evalIO openFreePort
-        -- Serve the file
-        let app :: Request -> (Response -> IO ResponseReceived) -> IO ResponseReceived
-            app req respond = do
-              let path = T.unpack <$> pathInfo req
-              if path == relativeUrl
-                then respond $ responseFile status200 [("Content-Type", "text/plain")] filePath Nothing
-                else
-                  respond $
-                    responseLBS status404 [("Content-Type", "text/plain")] $
-                      fromString ("404 - Url \"" ++ urlFromRequest req ++ "\" - Not Found")
-
-        -- Run server asynchronously in a separate thread
-        void $ H.evalIO $ forkOS $ runSettingsSocket defaultSettings socket app
-        return (port, socket)
-    )
-    -- Server teardown (resource release)
-    (\(_, socket) -> H.evalIO $ close socket)
-    -- Test action
-    (\(port, _) -> action port)
- where
-  urlFromRequest :: Request -> String
-  urlFromRequest req =
-    "http://"
-      ++ maybe "localhost" BSU8.toString (requestHeaderHost req)
-      ++ "/"
-      ++ intercalate "/" (unpack <$> pathInfo req)
-      ++ BSU8.toString (renderQuery True (queryString req))

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/Hash.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/Hash.hs
@@ -10,7 +10,7 @@ import           System.FilePath (dropTrailingPathSeparator)
 import           System.FilePath.Posix (splitDirectories)
 
 import           Test.Cardano.CLI.Hash (exampleAnchorDataHash, exampleAnchorDataIpfsHash,
-                   exampleAnchorDataPath, serveFileWhile)
+                   exampleAnchorDataPathTest, serveFileWhile)
 import           Test.Cardano.CLI.Util
 
 import           Hedgehog as H
@@ -26,7 +26,7 @@ hprop_generate_anchor_data_hash_from_file =
         [ "hash"
         , "anchor-data"
         , "--file-binary"
-        , exampleAnchorDataPath
+        , exampleAnchorDataPathTest
         ]
     result === exampleAnchorDataHash
 
@@ -40,7 +40,7 @@ hprop_check_anchor_data_hash_from_file =
         [ "hash"
         , "anchor-data"
         , "--file-binary"
-        , exampleAnchorDataPath
+        , exampleAnchorDataPathTest
         , "--expected-hash"
         , exampleAnchorDataHash
         ]
@@ -55,7 +55,7 @@ hprop_check_anchor_data_hash_from_file_fails =
         [ "hash"
         , "anchor-data"
         , "--file-binary"
-        , exampleAnchorDataPath
+        , exampleAnchorDataPathTest
         , "--expected-hash"
         , 'c' : drop 1 exampleAnchorDataHash
         ]
@@ -73,7 +73,7 @@ hprop_generate_anchor_data_hash_from_file_uri =
         [ "hash"
         , "anchor-data"
         , "--url"
-        , "file://" ++ posixCwd ++ "/" ++ exampleAnchorDataPath
+        , "file://" ++ posixCwd ++ "/" ++ exampleAnchorDataPathTest
         ]
     result === exampleAnchorDataHash
  where
@@ -100,7 +100,7 @@ hprop_check_anchor_data_hash_from_http_uri =
     let relativeUrl = ["example", "url", "file.txt"]
     serveFileWhile
       relativeUrl
-      exampleAnchorDataPath
+      exampleAnchorDataPathTest
       ( \port -> do
           void $
             execCardanoCLI
@@ -121,7 +121,7 @@ hprop_check_anchor_data_hash_from_ipfs_uri =
     let relativeUrl = ["ipfs", exampleAnchorDataIpfsHash]
     serveFileWhile
       relativeUrl
-      exampleAnchorDataPath
+      exampleAnchorDataPathTest
       ( \port -> do
           void $
             execCardanoCLIWithEnvVars

--- a/flake.nix
+++ b/flake.nix
@@ -160,7 +160,11 @@
               in ''
                 ${exportCliPath}
                 cp -r ${filteredProjectBase}/* ..
-              '';
+               '' + (if isDarwin
+                    then '' 
+                       export PATH=${macOS-security}/bin:$PATH
+                    ''
+                    else '''');
               packages.cardano-cli.components.tests.cardano-cli-test.preCheck = let
                 # This define files included in the directory that will be passed to `H.getProjectBase` for this test:
                 filteredProjectBase = inputs.incl ./. mainnetConfigFiles;


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Add proposal hash check when creating `info` governance action
  type:
  - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
```

# Context

This is another step forward on addressing https://github.com/IntersectMBO/cardano-cli/issues/882.

Previous related PR: https://github.com/IntersectMBO/cardano-cli/pull/895

So far I have only added the check to `governance action create-info`. There are several other places where to add the check, but I thought I would have a round of review first, before propagating.

# How to trust this PR

I adapted a test to validate the new functionality, and that gives me a lot of confidence. I would try to check that the code style is good, I didn't introduce any bugs, the parameter structure and names make sense, and the help is comprehensive and comprehensible.

This check disables `HTTP` schemas (and obviously `FILE`), because I have been told the spec says that only `HTTPS` and IPFS` are allowed. But I could not find where this is said. Could anybody confirm?

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
