### PR TITLE
Update create-treasury-withdrawal

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/Actions.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/Actions.hs
@@ -128,7 +128,7 @@ data GovernanceActionTreasuryWithdrawalCmdArgs era
   , returnAddr :: !StakeIdentifier
   , proposalUrl :: !ProposalUrl
   , proposalHash :: !(L.SafeHash L.StandardCrypto L.AnchorData)
-  , treasuryWithdrawal :: ![(VerificationKeyOrHashOrFile StakeKey, Lovelace)]
+  , treasuryWithdrawal :: ![(StakeIdentifier, Lovelace)]
   , constitutionScriptHash :: !(Maybe ScriptHash)
   , outFile :: !(File () Out)
   }

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
@@ -491,6 +491,20 @@ pTransferAmt =
       , Opt.help "The amount to transfer."
       ]
 
+pTreasuryWithdrawalAmt :: Parser Lovelace
+pTreasuryWithdrawalAmt =
+  Opt.option (readerFromParsecParser parseLovelace) $
+    mconcat
+      [ Opt.long "transfer"
+      , Opt.metavar "LOVELACE"
+      , Opt.help $
+          mconcat
+            [ "The amount of lovelace the proposal intends to withdraw from the Treasury. "
+            , "Multiple withdrawals can be proposed in a single governance action "
+            , "by repeating the --funds-receiving-stake and --transfer options as many times as needed."
+            ]
+      ]
+
 rHexHash
   :: ()
   => SerialiseAsRawBytes (Hash a)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Actions.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Actions.hs
@@ -395,7 +395,7 @@ pGovernanceActionTreasuryWithdrawalCmd era = do
             <*> pStakeIdentifier (Just "deposit-return")
             <*> pAnchorUrl
             <*> pAnchorDataHash
-            <*> some ((,) <$> pStakeVerificationKeyOrHashOrFile (Just "funds-receiving") <*> pTransferAmt)
+            <*> some ((,) <$> pStakeIdentifier (Just "funds-receiving") <*> pTreasuryWithdrawalAmt)
             <*> optional pConstitutionScriptHash
             <*> pFileOutDirection "out-file" "Output filepath of the treasury withdrawal."
       )

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -6082,6 +6082,8 @@ Usage: cardano-cli conway governance action create-treasury-withdrawal
                                                                            ( --funds-receiving-stake-verification-key STRING
                                                                            | --funds-receiving-stake-verification-key-file FILEPATH
                                                                            | --funds-receiving-stake-key-hash HASH
+                                                                           | --funds-receiving-stake-script-file FILEPATH
+                                                                           | --funds-receiving-stake-address ADDRESS
                                                                            )
                                                                            --transfer LOVELACE)
                                                                          [--constitution-script-hash HASH]

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_create-treasury-withdrawal.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_action_create-treasury-withdrawal.cli
@@ -15,6 +15,8 @@ Usage: cardano-cli conway governance action create-treasury-withdrawal
                                                                            ( --funds-receiving-stake-verification-key STRING
                                                                            | --funds-receiving-stake-verification-key-file FILEPATH
                                                                            | --funds-receiving-stake-key-hash HASH
+                                                                           | --funds-receiving-stake-script-file FILEPATH
+                                                                           | --funds-receiving-stake-address ADDRESS
                                                                            )
                                                                            --transfer LOVELACE)
                                                                          [--constitution-script-hash HASH]
@@ -46,7 +48,15 @@ Available options:
                            Filepath of the staking verification key.
   --funds-receiving-stake-key-hash HASH
                            Stake verification key hash (hex-encoded).
-  --transfer LOVELACE      The amount to transfer.
+  --funds-receiving-stake-script-file FILEPATH
+                           Filepath of the staking script.
+  --funds-receiving-stake-address ADDRESS
+                           Target stake address (bech32 format).
+  --transfer LOVELACE      The amount of lovelace the proposal intends to
+                           withdraw from the Treasury. Multiple withdrawals can
+                           be proposed in a single governance action by
+                           repeating the --funds-receiving-stake and --transfer
+                           options as many times as needed.
   --constitution-script-hash HASH
                            Constitution script hash (hex-encoded). Obtain it
                            with "cardano-cli hash script ...".


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Adding support for script stake credentials and stake address in `create-treasury-withdrawal` and improving help text. New options are: `--funds-receiving-stake-script-file` and `--funds-receiving-stake-address` 
     
# uncomment types applicable to the change:
  type:
   - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
   - documentation  # change in code docs, haddocks...
```

# Context

Resolves https://github.com/IntersectMBO/cardano-cli/issues/898 originally raised by @Crypto2099.  

# How to trust this PR
```shell
cardano-cli conway governance action create-treasury-withdrawal \
--testnet --governance-action-deposit 50000000000 \
--deposit-return-stake-verification-key-file example/utxo-keys/stake1.vkey \
--anchor-url https://tinyurl.com/3wrwb2as \
-anchor-data-hash 52e69500a92d80f2126c836a4903dc582006709f004cf7a28ed648f732dff8d2 \
--funds-receiving-stake-script-file scriptrewardsaccount/stake.script \
--transfer 97893290 \ 
--constitution-script-hash fa24fb305126805cf2164c161d852a0e7330cf988f1fe558cf7d4a64 \
--out-file example/transactions/treasury.action
```
after submitting that in a transaction we see
```json
[
  {
    "actionId": {
      "govActionIx": 0,
      "txId": "940469d7a02f3022c0062ab93f10fd39b8f07959a3d930a818b5b86eceeb400c"
    },
    "committeeVotes": {},
    "dRepVotes": {},
    "expiresAfter": 6,
    "proposalProcedure": {
      "anchor": {
        "dataHash": "52e69500a92d80f2126c836a4903dc582006709f004cf7a28ed648f732dff8d2",
        "url": "https://tinyurl.com/3wrwb2as"
      },
      "deposit": 50000000000,
      "govAction": {
        "contents": [
          [
            [
              {
                "credential": {
                  "scriptHash": "96ec5e35abc0970316947ca6d8ea28d0dba9f4023db9a4fb0057e20c"
                },
                "network": "Testnet"
              },
              97893290
            ]
          ],
          "fa24fb305126805cf2164c161d852a0e7330cf988f1fe558cf7d4a64"
        ],
        "tag": "TreasuryWithdrawals"
      },
      "returnAddr": {
        "credential": {
          "keyHash": "c209926b297f9bb72142cdf02aba43bac174ef8141183be7da1ac3b8"
        },
        "network": "Testnet"
      }
    },
    "proposedIn": 3,
    "stakePoolVotes": {}
  }
]
```
After  enactment of the action by `yes` votes from CC and DReps: 

```shell
cardano-cli conway query stake-address-info --address stake_test17ztwch3440qfwqckj372dk829rgdh205qg7mnf8mqpt7yrqfvnvwr
[
    {
        "address": "stake_test17ztwch3440qfwqckj372dk829rgdh205qg7mnf8mqpt7yrqfvnvwr",
        "delegationDeposit": 2000000,
        "rewardAccountBalance": 97893290,
        "stakeDelegation": null,
        "voteDelegation": null
    }
]
```

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
