### PR TITLE
Add compatible command group

### DIFF
--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -66,6 +66,10 @@ library
     Cardano.CLI.Commands.Key
     Cardano.CLI.Commands.Node
     Cardano.CLI.Commands.Ping
+    Cardano.CLI.Compatible.Commands
+    Cardano.CLI.Compatible.Governance
+    Cardano.CLI.Compatible.Run
+    Cardano.CLI.Compatible.Transaction
     Cardano.CLI.Environment
     Cardano.CLI.EraBased.Commands
     Cardano.CLI.EraBased.Commands.Genesis

--- a/cardano-cli/src/Cardano/CLI/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Commands.hs
@@ -12,6 +12,7 @@ import           Cardano.CLI.Commands.Hash (HashCmds)
 import           Cardano.CLI.Commands.Key
 import           Cardano.CLI.Commands.Node
 import           Cardano.CLI.Commands.Ping (PingCmd (..))
+import           Cardano.CLI.Compatible.Commands
 import           Cardano.CLI.EraBased.Commands
 import           Cardano.CLI.Legacy.Commands
 

--- a/cardano-cli/src/Cardano/CLI/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Commands.hs
@@ -23,7 +23,9 @@ data ClientCommand
   | AddressCommand AddressCmds
   | -- | Byron Related Commands
     ByronCommand ByronCommand
-  | -- | Era agnostic hashing commands
+  | -- | Backward compatible commands for testing only
+    CompatibleCommands AnyCompatibleCommand
+  | -- | Era-agnostic hashing commands
     HashCmds HashCmds
   | -- | Era agnostic key commands
     KeyCommands KeyCmds

--- a/cardano-cli/src/Cardano/CLI/Compatible/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Compatible/Commands.hs
@@ -1,0 +1,30 @@
+{-# LANGUAGE GADTs #-}
+{-
+This module is concerned with providing backwards compatible cli commands for our internal
+testing needs. The intention is to restrict as much as possible which functionality we maintain backwards
+compatibility for.
+-}
+
+module Cardano.CLI.Compatible.Commands
+  ( 
+  )
+where
+
+import Cardano.Api 
+import Options.Applicative
+import           Cardano.CLI.Environment
+
+data AnyCompatibleCommand where
+  AnyCompatibleCommand :: ShelleyBasedEra era -> CompatibleCommand era -> AnyCompatibleCommand
+
+data CompatibleCommand era 
+ = CompatibleSimpleSignedTransaction
+ | CompatibleCreateProtocolUpdate
+
+
+pAnyCompatibleCommand :: EnvCli -> Parser AnyCompatibleCommand
+pAnyCompatibleCommand = undefined 
+
+
+pCompatibleCommand :: ShelleyBasedEra era -> EnvCli -> Parser (CompatibleCommand era)
+pCompatibleCommand era env = undefined

--- a/cardano-cli/src/Cardano/CLI/Compatible/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Compatible/Commands.hs
@@ -1,4 +1,6 @@
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+
 {-
 This module is concerned with providing backwards compatible cli commands for our internal
 testing needs. The intention is to restrict as much as possible which functionality we maintain backwards
@@ -6,25 +8,67 @@ compatibility for.
 -}
 
 module Cardano.CLI.Compatible.Commands
-  ( 
+  ( AnyCompatibleCommand (..)
+  , CompatibleCommand (..)
+  , pAnyCompatibleCommand
+  , renderAnyCompatibleCommand
   )
 where
 
-import Cardano.Api 
-import Options.Applicative
+import           Cardano.Api
+
+import           Cardano.CLI.Compatible.Governance
+import           Cardano.CLI.Compatible.Transaction
 import           Cardano.CLI.Environment
+import           Cardano.CLI.Parser
+
+import           Data.Text
+import           Options.Applicative
+import qualified Options.Applicative as Opt
 
 data AnyCompatibleCommand where
-  AnyCompatibleCommand :: ShelleyBasedEra era -> CompatibleCommand era -> AnyCompatibleCommand
+  AnyCompatibleCommand :: CompatibleCommand era -> AnyCompatibleCommand
 
-data CompatibleCommand era 
- = CompatibleSimpleSignedTransaction
- | CompatibleCreateProtocolUpdate
+renderAnyCompatibleCommand :: AnyCompatibleCommand -> Text
+renderAnyCompatibleCommand = \case
+  AnyCompatibleCommand cmd -> renderCompatibleCommand cmd
 
+data CompatibleCommand era
+  = CompatibleTransactionCmd (CompatibleTransactionCmds era)
+  | CompatibleGovernanceCmds (CompatibleGovernanceCmds era)
+
+renderCompatibleCommand :: CompatibleCommand era -> Text
+renderCompatibleCommand = \case
+  CompatibleTransactionCmd cmd -> renderCompatibleTransactionCmd cmd
+  CompatibleGovernanceCmds cmd -> renderCompatibleGovernanceCmds cmd
 
 pAnyCompatibleCommand :: EnvCli -> Parser AnyCompatibleCommand
-pAnyCompatibleCommand = undefined 
-
+pAnyCompatibleCommand envCli =
+  asum
+    [ -- Note, byron is ommitted because there is already a legacy command group for it.
+      subParser "shelley" $
+        Opt.info (AnyCompatibleCommand <$> pCompatibleCommand ShelleyBasedEraShelley envCli) $
+          Opt.progDesc "Shelley era commands"
+    , subParser "allegra" $
+        Opt.info (AnyCompatibleCommand <$> pCompatibleCommand ShelleyBasedEraAllegra envCli) $
+          Opt.progDesc "Allegra era commands"
+    , subParser "mary" $
+        Opt.info (AnyCompatibleCommand <$> pCompatibleCommand ShelleyBasedEraMary envCli) $
+          Opt.progDesc "Mary era commands"
+    , subParser "alonzo" $
+        Opt.info (AnyCompatibleCommand <$> pCompatibleCommand ShelleyBasedEraAlonzo envCli) $
+          Opt.progDesc "Alonzo era commands"
+    , subParser "babbage" $
+        Opt.info (AnyCompatibleCommand <$> pCompatibleCommand ShelleyBasedEraBabbage envCli) $
+          Opt.progDesc "Babbage era commands"
+    , subParser "conway" $
+        Opt.info (AnyCompatibleCommand <$> pCompatibleCommand ShelleyBasedEraConway envCli) $
+          Opt.progDesc "Conway era commands"
+    ]
 
 pCompatibleCommand :: ShelleyBasedEra era -> EnvCli -> Parser (CompatibleCommand era)
-pCompatibleCommand era env = undefined
+pCompatibleCommand era env =
+  asum
+    [ CompatibleTransactionCmd <$> pAllCompatibleTransactionCommands env era
+    , CompatibleGovernanceCmds <$> pCompatibleGovernanceCmds era
+    ]

--- a/cardano-cli/src/Cardano/CLI/Compatible/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Compatible/Commands.hs
@@ -22,6 +22,7 @@ import           Cardano.CLI.Compatible.Transaction
 import           Cardano.CLI.Environment
 import           Cardano.CLI.Parser
 
+import           Data.Foldable
 import           Data.Text
 import           Options.Applicative
 import qualified Options.Applicative as Opt

--- a/cardano-cli/src/Cardano/CLI/Compatible/Governance.hs
+++ b/cardano-cli/src/Cardano/CLI/Compatible/Governance.hs
@@ -15,6 +15,7 @@ import           Cardano.CLI.EraBased.Options.Governance
 import           Cardano.CLI.EraBased.Run.Governance
 import           Cardano.CLI.Types.Errors.CmdError
 
+import           Data.Foldable
 import           Data.Maybe
 import           Data.Text
 import           Options.Applicative

--- a/cardano-cli/src/Cardano/CLI/Compatible/Governance.hs
+++ b/cardano-cli/src/Cardano/CLI/Compatible/Governance.hs
@@ -1,0 +1,38 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE LambdaCase #-}
+
+module Cardano.CLI.Compatible.Governance
+  ( CompatibleGovernanceCmds (..)
+  , pCompatibleGovernanceCmds
+  , renderCompatibleGovernanceCmds
+  , runCompatibleGovernanceCmds
+  )
+where
+
+import           Cardano.Api
+
+import           Cardano.CLI.EraBased.Options.Governance
+import           Cardano.CLI.EraBased.Run.Governance
+import           Cardano.CLI.Types.Errors.CmdError
+
+import           Data.Maybe
+import           Data.Text
+import           Options.Applicative
+
+pCompatibleGovernanceCmds :: ShelleyBasedEra era -> Parser (CompatibleGovernanceCmds era)
+pCompatibleGovernanceCmds sbe =
+  asum $ catMaybes [fmap CreateCompatibleProtocolUpdateCmd <$> pGovernanceCmds (toCardanoEra sbe)]
+
+-- TODO: After QA confirmms that the new compatibility commands meet their needs
+-- we can remove all remaining legacy commands. We can also remove/move the exising
+-- byron era commands under the new compatiblilty commands.
+newtype CompatibleGovernanceCmds era
+  = CreateCompatibleProtocolUpdateCmd (GovernanceCmds era)
+
+runCompatibleGovernanceCmds :: CompatibleGovernanceCmds era -> ExceptT CmdError IO ()
+runCompatibleGovernanceCmds = \case
+  CreateCompatibleProtocolUpdateCmd cmd -> runGovernanceCmds cmd
+
+renderCompatibleGovernanceCmds :: CompatibleGovernanceCmds era -> Text
+renderCompatibleGovernanceCmds = \case
+  CreateCompatibleProtocolUpdateCmd cmd -> renderGovernanceCmds cmd

--- a/cardano-cli/src/Cardano/CLI/Compatible/Governance.hs
+++ b/cardano-cli/src/Cardano/CLI/Compatible/Governance.hs
@@ -22,7 +22,7 @@ import           Options.Applicative
 
 pCompatibleGovernanceCmds :: ShelleyBasedEra era -> Parser (CompatibleGovernanceCmds era)
 pCompatibleGovernanceCmds sbe =
-  asum $ catMaybes [fmap CreateCompatibleProtocolUpdateCmd <$> pGovernanceCmds (toCardanoEra sbe)]
+  asum $ catMaybes [fmap CreateCompatibleProtocolUpdateCmd <$> pGovernanceCmds sbe]
 
 -- TODO: After QA confirmms that the new compatibility commands meet their needs
 -- we can remove all remaining legacy commands. We can also remove/move the exising

--- a/cardano-cli/src/Cardano/CLI/Compatible/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Compatible/Run.hs
@@ -1,0 +1,37 @@
+{-# LANGUAGE LambdaCase #-}
+
+module Cardano.CLI.Compatible.Run
+  ( CompatibleCmdError
+  , renderCompatibleCmdError
+  , runAnyCompatibleCommand
+  , runCompatibleCommand
+  )
+where
+
+import           Cardano.Api
+
+import           Cardano.CLI.Compatible.Commands
+import           Cardano.CLI.Compatible.Governance
+import           Cardano.CLI.Compatible.Transaction
+import           Cardano.CLI.Render
+import           Cardano.CLI.Types.Errors.CmdError
+
+import           Data.Text (Text)
+
+data CompatibleCmdError
+  = CompatibleTransactionError CompatibleTransactionError
+  | CompatibleGovernanceError CmdError
+
+renderCompatibleCmdError :: Text -> CompatibleCmdError -> Doc ann
+renderCompatibleCmdError cmdText = \case
+  CompatibleTransactionError e -> renderAnyCmdError cmdText prettyError e
+  CompatibleGovernanceError e -> renderCmdError cmdText e
+
+runAnyCompatibleCommand :: AnyCompatibleCommand -> ExceptT CompatibleCmdError IO ()
+runAnyCompatibleCommand (AnyCompatibleCommand cmd) = runCompatibleCommand cmd
+
+runCompatibleCommand :: CompatibleCommand era -> ExceptT CompatibleCmdError IO ()
+runCompatibleCommand (CompatibleTransactionCmd txCmd) =
+  firstExceptT CompatibleTransactionError $ runCompatibleTransactionCmd txCmd
+runCompatibleCommand (CompatibleGovernanceCmds govCmd) =
+  firstExceptT CompatibleGovernanceError $ runCompatibleGovernanceCmds govCmd

--- a/cardano-cli/src/Cardano/CLI/Compatible/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/Compatible/Transaction.hs
@@ -27,6 +27,7 @@ import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Errors.BootstrapWitnessError
 import           Cardano.CLI.Types.Errors.TxCmdError
 
+import           Data.Foldable
 import           Data.Function
 import           Data.Text (Text)
 import           Options.Applicative

--- a/cardano-cli/src/Cardano/CLI/Compatible/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/Compatible/Transaction.hs
@@ -15,7 +15,7 @@ where
 
 import           Cardano.Api
 import           Cardano.Api.Compatible
-import           Cardano.Api.Ledger hiding (VotingProcedures)
+import           Cardano.Api.Ledger hiding (TxIn, VotingProcedures)
 import           Cardano.Api.Shelley hiding (VotingProcedures)
 
 import           Cardano.CLI.Environment

--- a/cardano-cli/src/Cardano/CLI/Compatible/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/Compatible/Transaction.hs
@@ -1,0 +1,280 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE TupleSections #-}
+
+module Cardano.CLI.Compatible.Transaction
+  ( CompatibleTransactionCmds (..)
+  , CompatibleTransactionError (..)
+  , pAllCompatibleTransactionCommands
+  , renderCompatibleTransactionCmd
+  , runCompatibleTransactionCmd
+  )
+where
+
+import           Cardano.Api hiding (parseFilePath)
+import           Cardano.Api.Compatible
+import           Cardano.Api.Ledger
+import           Cardano.Api.Shelley hiding (parseFilePath)
+
+import           Cardano.CLI.Environment
+import           Cardano.CLI.EraBased.Options.Common hiding (pRefScriptFp, pTxOutDatum)
+import           Cardano.CLI.EraBased.Run.Transaction
+import           Cardano.CLI.Parser
+import           Cardano.CLI.Read
+import           Cardano.CLI.Types.Common
+import           Cardano.CLI.Types.Errors.BootstrapWitnessError
+import           Cardano.CLI.Types.Errors.TxCmdError
+
+import           Data.Function
+import           Data.Text (Text)
+import           Options.Applicative
+import qualified Options.Applicative as Opt
+
+pAllCompatibleTransactionCommands
+  :: EnvCli -> ShelleyBasedEra era -> Parser (CompatibleTransactionCmds era)
+pAllCompatibleTransactionCommands envCli sbe =
+  let allCommannds =
+        asum
+          [ pCompatibleSignedTransactionCommand envCli sbe
+          ]
+   in subParser "transaction" $
+        Opt.info allCommannds $
+          Opt.progDesc "Transaction commands."
+
+pCompatibleSignedTransactionCommand
+  :: EnvCli -> ShelleyBasedEra era -> Parser (CompatibleTransactionCmds era)
+pCompatibleSignedTransactionCommand envCli sbe =
+  subParser "signed-transaction" $
+    Opt.info (pCompatibleSignedTransaction envCli sbe) $
+      Opt.progDesc "Create a simple signed transaction."
+
+pCompatibleSignedTransaction
+  :: EnvCli -> ShelleyBasedEra era -> Parser (CompatibleTransactionCmds era)
+pCompatibleSignedTransaction env sbe =
+  CreateCompatibleSignedTransaction sbe
+    <$> many pTxInOnly
+    <*> many (pTxOutEraAware sbe)
+    <*> pFeatured (toCardanoEra sbe) (optional pUpdateProposalFile)
+    <*> pFeatured (toCardanoEra sbe) (many (pProposalFile sbe ManualBalance))
+    <*> many pWitnessSigningData
+    <*> optional (pNetworkId env)
+    <*> pTxFee
+    <*> pOutputFile
+
+pTxInOnly :: Parser TxIn
+pTxInOnly =
+  Opt.option
+    (readerFromParsecParser parseTxIn)
+    ( Opt.long "tx-in"
+        <> Opt.metavar "TX-IN"
+        <> Opt.help "TxId#TxIx"
+    )
+
+-- This parser renders the appropriate parsers depending on what
+-- functionality is available per era.
+pTxOutEraAware :: ShelleyBasedEra era -> Parser TxOutAnyEra
+pTxOutEraAware sbe =
+  Opt.option
+    (readerFromParsecParser parseTxOutAnyEra)
+    ( Opt.long "tx-out"
+        <> Opt.metavar "ADDRESS VALUE"
+        -- TODO alonzo: Update the help text to describe the new syntax as well.
+        <> Opt.help
+          "The transaction output as ADDRESS VALUE where ADDRESS is \
+          \the Bech32-encoded address followed by the value in \
+          \the multi-asset syntax (including simply Lovelace)."
+    )
+    <*> pTxOutDatum sbe
+    <*> pRefScriptFp sbe
+
+pTxOutDatum :: ShelleyBasedEra era -> Parser TxOutDatumAnyEra
+pTxOutDatum =
+  caseShelleyToMaryOrAlonzoEraOnwards
+    (const $ pure TxOutDatumByNone)
+    ( \case
+        AlonzoEraOnwardsAlonzo ->
+          pAlonzoDatumFunctionality <|> pure TxOutDatumByNone
+        AlonzoEraOnwardsBabbage ->
+          pBabbageDatumFunctionality <|> pure TxOutDatumByNone
+        AlonzoEraOnwardsConway -> pConwayDatumFunctionality <|> pure TxOutDatumByNone
+    )
+ where
+  pAlonzoDatumFunctionality =
+    asum
+      [ pTxOutDatumByHashOnly
+      , pTxOutDatumByHashOf
+      , pTxOutDatumByValue
+      ]
+  pBabbageDatumFunctionality =
+    asum
+      [ pAlonzoDatumFunctionality
+      , pTxOutInlineDatumByValue
+      ]
+
+  pConwayDatumFunctionality = pBabbageDatumFunctionality
+
+  pTxOutDatumByHashOnly =
+    fmap TxOutDatumByHashOnly $
+      Opt.option (readerFromParsecParser $ parseHash (AsHash AsScriptData)) $
+        mconcat
+          [ Opt.long "tx-out-datum-hash"
+          , Opt.metavar "HASH"
+          , Opt.help $
+              mconcat
+                [ "The script datum hash for this tx output, as "
+                , "the raw datum hash (in hex)."
+                ]
+          ]
+
+  pTxOutDatumByHashOf =
+    TxOutDatumByHashOf
+      <$> pScriptDataOrFile
+        "tx-out-datum-hash"
+        "The script datum hash for this tx output, by hashing the script datum given here."
+        "The script datum hash for this tx output, by hashing the script datum in the file."
+
+  pTxOutDatumByValue =
+    TxOutDatumByValue
+      <$> pScriptDataOrFile
+        "tx-out-datum-embed"
+        "The script datum to embed in the tx for this output, given here."
+        "The script datum to embed in the tx for this output, in the given file."
+
+  pTxOutInlineDatumByValue =
+    TxOutInlineDatumByValue
+      <$> pScriptDataOrFile
+        "tx-out-inline-datum"
+        "The script datum to embed in the tx output as an inline datum, given here."
+        "The script datum to embed in the tx output as an inline datum, in the given file."
+
+pRefScriptFp :: ShelleyBasedEra era -> Parser ReferenceScriptAnyEra
+pRefScriptFp =
+  caseShelleyToBabbageOrConwayEraOnwards
+    (const $ pure ReferenceScriptAnyEraNone)
+    ( const $
+        ReferenceScriptAnyEra
+          <$> parseFilePath "tx-out-reference-script-file" "Reference script input file."
+            <|> pure ReferenceScriptAnyEraNone
+    )
+
+-- TODO: After QA confirmms that the new compatibility commands meet their needs
+-- we can remove all remaining legacy commands. We can also remove/move the exising
+-- byron era commands under the new compatiblilty commands.
+data CompatibleTransactionCmds era
+  = CreateCompatibleSignedTransaction
+      (ShelleyBasedEra era)
+      [TxIn]
+      [TxOutAnyEra]
+      !(Maybe (Featured ShelleyToBabbageEra era (Maybe UpdateProposalFile)))
+      !(Maybe (Featured ConwayEraOnwards era [(ProposalFile In, Maybe (ScriptWitnessFiles WitCtxStake))]))
+      [WitnessSigningData]
+      -- ^ Signing keys
+      (Maybe NetworkId)
+      !Coin
+      -- ^ Tx fee
+      !(File () Out)
+
+renderCompatibleTransactionCmd :: CompatibleTransactionCmds era -> Text
+renderCompatibleTransactionCmd _ = ""
+
+data CompatibleTransactionError
+  = CompatibleTxOutError !TxCmdError
+  | CompatibleWitnessError !ReadWitnessSigningDataError
+  | CompatiblePParamsConversionError !ProtocolParametersConversionError
+  | CompatibleBootstrapWitnessError !BootstrapWitnessError
+  | forall err. Error err => CompatibleFileError (FileError err)
+  | CompatibleTxBodyError !TxBodyError
+  | CompatibleProposalError !ProposalError
+
+instance Error CompatibleTransactionError where
+  prettyError = \case
+    CompatibleTxOutError e -> renderTxCmdError e
+    CompatibleWitnessError e -> renderReadWitnessSigningDataError e
+    CompatiblePParamsConversionError e -> prettyError e
+    CompatibleBootstrapWitnessError e -> renderBootstrapWitnessError e
+    CompatibleFileError e -> prettyError e
+    CompatibleTxBodyError e -> prettyError e
+    CompatibleProposalError e -> "Cannot read proposal: " <> pshow e
+
+runCompatibleTransactionCmd
+  :: CompatibleTransactionCmds era -> ExceptT CompatibleTransactionError IO ()
+runCompatibleTransactionCmd
+  ( CreateCompatibleSignedTransaction
+      sbe
+      ins
+      outs
+      mUpdateProposal
+      mProposalProcedure
+      witnesses
+      mNetworkId
+      fee
+      outputFp
+    ) = do
+    sks <- firstExceptT CompatibleWitnessError $ mapM (newExceptT . readWitnessSigningData) witnesses
+
+    allOuts <- firstExceptT CompatibleTxOutError $ mapM (toTxOutInAnyEra sbe) outs
+
+    apiTxBody <-
+      firstExceptT CompatibleTxBodyError $
+        hoistEither $
+          createTransactionBody sbe $
+            defaultTxBodyContent sbe
+              & setTxIns (map (,BuildTxWith (KeyWitness KeyWitnessForSpending)) ins)
+              & setTxOuts allOuts
+              & setTxFee (TxFeeExplicit sbe fee)
+
+    let (sksByron, sksShelley) = partitionSomeWitnesses $ map categoriseSomeSigningWitness sks
+
+    byronWitnesses <-
+      firstExceptT CompatibleBootstrapWitnessError $
+        hoistEither (mkShelleyBootstrapWitnesses sbe mNetworkId apiTxBody sksByron)
+
+    let newShelleyKeyWits = map (makeShelleyKeyWitness sbe apiTxBody) sksShelley
+        allKeyWits = newShelleyKeyWits ++ byronWitnesses
+
+    protocolUpdates <-
+      caseShelleyToBabbageOrConwayEraOnwards
+        ( const $
+            maybe (return $ NoPParamsUpdate sbe) readUpdateProposalFile mUpdateProposal
+        )
+        ( const $
+            maybe (return $ NoPParamsUpdate sbe) readProposalProcedureFile mProposalProcedure
+        )
+        sbe
+
+    signedTx <-
+      firstExceptT CompatiblePParamsConversionError . hoistEither $
+        createCompatibleSignedTx sbe ins allOuts allKeyWits fee protocolUpdates
+
+    firstExceptT CompatibleFileError $
+      newExceptT $
+        writeTxFileTextEnvelopeCddl sbe outputFp signedTx
+
+readUpdateProposalFile
+  :: Featured ShelleyToBabbageEra era (Maybe UpdateProposalFile)
+  -> ExceptT CompatibleTransactionError IO (AnyProtocolUpdate era)
+readUpdateProposalFile (Featured sToB Nothing) =
+  return $ NoPParamsUpdate $ shelleyToBabbageEraToShelleyBasedEra sToB
+readUpdateProposalFile (Featured sToB (Just updateProposalFile)) = do
+  prop <- firstExceptT CompatibleFileError $ readTxUpdateProposal sToB updateProposalFile
+  case prop of
+    TxUpdateProposalNone -> return $ NoPParamsUpdate $ shelleyToBabbageEraToShelleyBasedEra sToB
+    TxUpdateProposal _ proposal -> return $ ShelleyToBabbageProtocolUpdate sToB proposal
+
+readProposalProcedureFile
+  :: Featured ConwayEraOnwards era [(ProposalFile In, Maybe (ScriptWitnessFiles WitCtxStake))]
+  -> ExceptT CompatibleTransactionError IO (AnyProtocolUpdate era)
+readProposalProcedureFile (Featured cEraOnwards []) =
+  let sbe = conwayEraOnwardsToShelleyBasedEra cEraOnwards
+   in return $ NoPParamsUpdate sbe
+readProposalProcedureFile (Featured cEraOnwards proposals) = do
+  props <-
+    mapM
+      (firstExceptT CompatibleProposalError . newExceptT . readProposal cEraOnwards)
+      proposals
+  return $
+    conwayEraOnwardsConstraints cEraOnwards $
+      ConwayEraOnwardsProtocolUpdate cEraOnwards $
+        mkTxProposalProcedures [(govProp, mScriptWit) | (Proposal govProp, mScriptWit) <- props]

--- a/cardano-cli/src/Cardano/CLI/Compatible/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/Compatible/Transaction.hs
@@ -13,10 +13,10 @@ module Cardano.CLI.Compatible.Transaction
   )
 where
 
-import           Cardano.Api hiding (parseFilePath)
+import           Cardano.Api
 import           Cardano.Api.Compatible
 import           Cardano.Api.Ledger hiding (VotingProcedures)
-import           Cardano.Api.Shelley hiding (VotingProcedures, parseFilePath)
+import           Cardano.Api.Shelley hiding (VotingProcedures)
 
 import           Cardano.CLI.Environment
 import           Cardano.CLI.EraBased.Options.Common hiding (pRefScriptFp, pTxOutDatum)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands.hs
@@ -35,6 +35,7 @@ import           Cardano.CLI.EraBased.Options.Transaction
 import           Cardano.CLI.Options.Address
 import           Cardano.CLI.Options.Key
 import           Cardano.CLI.Options.Node
+import           Cardano.CLI.Parser
 
 import           Data.Foldable
 import           Data.Maybe
@@ -43,6 +44,7 @@ import           Data.Typeable (Typeable)
 import           Options.Applicative (Parser)
 import qualified Options.Applicative as Opt
 
+-- TODO: ShelleyBasedEra era is not needed in AnyEraCommandOf
 data AnyEraCommand where
   AnyEraCommandOf :: Typeable era => ShelleyBasedEra era -> Cmds era -> AnyEraCommand
 

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
@@ -358,10 +358,6 @@ pStakeVerificationKeyFile prefix =
             ]
       ]
 
-subParser :: String -> ParserInfo a -> Parser a
-subParser availableCommand pInfo =
-  Opt.hsubparser $ Opt.command availableCommand pInfo <> Opt.metavar availableCommand
-
 subInfoParser :: String -> InfoMod a -> [Maybe (Parser a)] -> Maybe (Parser a)
 subInfoParser name i mps = case catMaybes mps of
   [] -> Nothing
@@ -3695,8 +3691,8 @@ pReferenceScriptSize =
 pFeatured
   :: ()
   => Eon eon
-  => ToCardanoEra peon
-  => peon era
+  => ToCardanoEra f
+  => f era
   -> Parser a
   -> Parser (Maybe (Featured eon era a))
 pFeatured peon p = do

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance.hs
@@ -8,7 +8,7 @@ module Cardano.CLI.EraBased.Options.Governance
   )
 where
 
-import           Cardano.Api
+import           Cardano.Api (CardanoEra, ShelleyToBabbageEra, forEraMaybeEon)
 
 import           Cardano.CLI.EraBased.Commands.Governance
 import           Cardano.CLI.EraBased.Options.Common
@@ -17,11 +17,15 @@ import           Cardano.CLI.EraBased.Options.Governance.Committee
 import           Cardano.CLI.EraBased.Options.Governance.DRep
 import           Cardano.CLI.EraBased.Options.Governance.Poll
 import           Cardano.CLI.EraBased.Options.Governance.Vote
+import           Cardano.CLI.Parser
 
 import           Data.Foldable
 import           Options.Applicative
 import qualified Options.Applicative as Opt
 
+-- First TODO: Change CardanoEra era to ShelleyBasedEra era
+-- Second TODO: Return Parser (GovernanceCmds era) because it's not possible
+-- for this to return Nothing when it's parameterized on ShelleyBasedEra era
 pGovernanceCmds
   :: ()
   => ShelleyBasedEra era

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance.hs
@@ -8,7 +8,7 @@ module Cardano.CLI.EraBased.Options.Governance
   )
 where
 
-import           Cardano.Api (CardanoEra, ShelleyToBabbageEra, forEraMaybeEon)
+import           Cardano.Api (ShelleyBasedEra, ShelleyToBabbageEra, forShelleyBasedEraMaybeEon)
 
 import           Cardano.CLI.EraBased.Commands.Governance
 import           Cardano.CLI.EraBased.Options.Common

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Committee.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Committee.hs
@@ -11,6 +11,7 @@ import qualified Cardano.Api.Ledger as L
 
 import           Cardano.CLI.EraBased.Commands.Governance.Committee
 import           Cardano.CLI.EraBased.Options.Common hiding (pAnchorUrl)
+import           Cardano.CLI.Parser
 import           Cardano.CLI.Read
 import           Cardano.CLI.Types.Key
 

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Poll.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Poll.hs
@@ -7,6 +7,7 @@ import           Cardano.Api
 
 import qualified Cardano.CLI.EraBased.Commands.Governance.Poll as Cmd
 import           Cardano.CLI.EraBased.Options.Common
+import           Cardano.CLI.Parser
 import           Cardano.Prelude (catMaybes, isInfixOf)
 
 import           Control.Monad (when)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Vote.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Vote.hs
@@ -8,8 +8,11 @@ where
 
 import           Cardano.Api
 
-import           Cardano.CLI.EraBased.Commands.Governance.Vote
+import           Cardano.CLI.EraBased.Commands.Governance.Vote (GovernanceVoteCmds (..),
+                   GovernanceVoteCreateCmdArgs (GovernanceVoteCreateCmdArgs),
+                   GovernanceVoteViewCmdArgs (GovernanceVoteViewCmdArgs))
 import           Cardano.CLI.EraBased.Options.Common
+import           Cardano.CLI.Parser
 import           Cardano.CLI.Types.Governance
 
 import           Control.Applicative (optional)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Query.hs
@@ -15,6 +15,7 @@ import           Cardano.Api.Shelley hiding (QueryInShelleyBasedEra (..))
 import           Cardano.CLI.Environment (EnvCli (..))
 import           Cardano.CLI.EraBased.Commands.Query
 import           Cardano.CLI.EraBased.Options.Common
+import           Cardano.CLI.Parser
 import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Key
 

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/StakeAddress.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/StakeAddress.hs
@@ -11,6 +11,7 @@ import           Cardano.Api
 import           Cardano.CLI.Environment
 import           Cardano.CLI.EraBased.Commands.StakeAddress
 import           Cardano.CLI.EraBased.Options.Common
+import           Cardano.CLI.Parser
 
 import           Options.Applicative
 import qualified Options.Applicative as Opt

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/StakePool.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/StakePool.hs
@@ -20,7 +20,6 @@ import           Cardano.CLI.Environment (EnvCli (..))
 import qualified Cardano.CLI.EraBased.Commands.StakePool as Cmd
 import           Cardano.CLI.EraBased.Options.Common
 import           Cardano.CLI.Parser
-import qualified Cardano.Ledger.SafeHash as L
 
 import qualified Data.Foldable as F
 import           Options.Applicative hiding (help, str)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/StakePool.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/StakePool.hs
@@ -19,6 +19,8 @@ import qualified Cardano.CLI.Commands.Hash as Cmd
 import           Cardano.CLI.Environment (EnvCli (..))
 import qualified Cardano.CLI.EraBased.Commands.StakePool as Cmd
 import           Cardano.CLI.EraBased.Options.Common
+import           Cardano.CLI.Parser
+import qualified Cardano.Ledger.SafeHash as L
 
 import qualified Data.Foldable as F
 import           Options.Applicative hiding (help, str)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/TextView.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/TextView.hs
@@ -10,6 +10,7 @@ where
 
 import           Cardano.CLI.EraBased.Commands.TextView
 import           Cardano.CLI.EraBased.Options.Common
+import           Cardano.CLI.Parser
 
 import           Options.Applicative hiding (help, str)
 import qualified Options.Applicative as Opt

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Transaction.hs
@@ -15,6 +15,7 @@ import qualified Cardano.Api.Experimental as Exp
 import           Cardano.CLI.Environment (EnvCli (..))
 import           Cardano.CLI.EraBased.Commands.Transaction
 import           Cardano.CLI.EraBased.Options.Common
+import           Cardano.CLI.Parser
 import           Cardano.CLI.Types.Common
 
 import           Data.Foldable

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Transaction.hs
@@ -16,7 +16,9 @@
 {- HLINT ignore "Avoid lambda using `infix`" -}
 
 module Cardano.CLI.EraBased.Run.Transaction
-  ( runTransactionCmds
+  ( mkShelleyBootstrapWitnesses
+  , partitionSomeWitnesses
+  , runTransactionCmds
   , runTransactionBuildCmd
   , runTransactionBuildRawCmd
   , runTransactionSignCmd

--- a/cardano-cli/src/Cardano/CLI/Options.hs
+++ b/cardano-cli/src/Cardano/CLI/Options.hs
@@ -10,6 +10,7 @@ module Cardano.CLI.Options
 where
 
 import           Cardano.CLI.Byron.Parsers (backwardsCompatibilityCommands, parseByronCommands)
+import           Cardano.CLI.Compatible.Commands
 import           Cardano.CLI.Environment (EnvCli)
 import           Cardano.CLI.EraBased.Commands
 import           Cardano.CLI.EraBased.Options.Common
@@ -20,6 +21,7 @@ import           Cardano.CLI.Options.Hash
 import           Cardano.CLI.Options.Key
 import           Cardano.CLI.Options.Node
 import           Cardano.CLI.Options.Ping (parsePingCmd)
+import           Cardano.CLI.Parser
 import           Cardano.CLI.Render (customRenderHelp)
 import           Cardano.CLI.Run (ClientCommand (..))
 
@@ -78,6 +80,7 @@ parseClientCommand envCli =
     , parseDebug envCli
     , backwardsCompatibilityCommands envCli
     , parseDisplayVersion (opts envCli)
+    , parseCompatibilityCommands envCli
     ]
 
 parseByron :: EnvCli -> Parser ClientCommand
@@ -95,6 +98,12 @@ parseHash = HashCmds <$> pHashCmds
 
 parsePing :: Parser ClientCommand
 parsePing = CliPingCommand <$> parsePingCmd
+
+parseCompatibilityCommands :: EnvCli -> Parser ClientCommand
+parseCompatibilityCommands envCli =
+  subParser "compatible" $
+    Opt.info (CompatibleCommands <$> pAnyCompatibleCommand envCli) $
+      Opt.progDesc "Limited backward compatible commands for testing only."
 
 parseDebug :: EnvCli -> Parser ClientCommand
 parseDebug envCli = CliDebugCmds <$> parseDebugCmds envCli

--- a/cardano-cli/src/Cardano/CLI/Options/Address.hs
+++ b/cardano-cli/src/Cardano/CLI/Options/Address.hs
@@ -11,6 +11,7 @@ where
 import           Cardano.CLI.Commands.Address
 import           Cardano.CLI.Environment (EnvCli (..))
 import           Cardano.CLI.EraBased.Options.Common
+import           Cardano.CLI.Parser
 
 import           Data.Foldable
 import           Options.Applicative hiding (help, str)

--- a/cardano-cli/src/Cardano/CLI/Options/Debug.hs
+++ b/cardano-cli/src/Cardano/CLI/Options/Debug.hs
@@ -18,6 +18,7 @@ import           Cardano.CLI.Commands.Debug.LogEpochState
 import           Cardano.CLI.Commands.Debug.TransactionView
 import           Cardano.CLI.Environment
 import           Cardano.CLI.EraBased.Options.Common
+import           Cardano.CLI.Parser
 
 import           Data.Foldable
 import           Options.Applicative hiding (help, str)

--- a/cardano-cli/src/Cardano/CLI/Options/Hash.hs
+++ b/cardano-cli/src/Cardano/CLI/Options/Hash.hs
@@ -10,6 +10,7 @@ import qualified Cardano.Api.Ledger as L
 
 import qualified Cardano.CLI.Commands.Hash as Cmd
 import           Cardano.CLI.EraBased.Options.Common
+import           Cardano.CLI.Parser
 
 import           Data.Foldable
 import           Options.Applicative

--- a/cardano-cli/src/Cardano/CLI/Options/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/Options/Key.hs
@@ -12,6 +12,7 @@ import           Cardano.Api hiding (QueryInShelleyBasedEra (..))
 
 import           Cardano.CLI.Commands.Key
 import           Cardano.CLI.EraBased.Options.Common
+import           Cardano.CLI.Parser
 import           Cardano.CLI.Types.Common
 
 import           Data.Foldable

--- a/cardano-cli/src/Cardano/CLI/Options/Node.hs
+++ b/cardano-cli/src/Cardano/CLI/Options/Node.hs
@@ -13,6 +13,7 @@ import           Cardano.Api hiding (QueryInShelleyBasedEra (..))
 import           Cardano.CLI.Commands.Node
 import qualified Cardano.CLI.Commands.Node as Cmd
 import           Cardano.CLI.EraBased.Options.Common
+import           Cardano.CLI.Parser
 
 import           Data.Foldable
 import           Options.Applicative hiding (help, str)

--- a/cardano-cli/src/Cardano/CLI/Parser.hs
+++ b/cardano-cli/src/Cardano/CLI/Parser.hs
@@ -12,6 +12,7 @@ module Cardano.CLI.Parser
   , readStringOfMaxLength
   , readViewOutputFormat
   , readURIOfMaxLength
+  , subParser
   , eDNSName
   )
 where
@@ -119,6 +120,10 @@ readRational =
 readerFromAttoParser :: Atto.Parser a -> Opt.ReadM a
 readerFromAttoParser p =
   Opt.eitherReader (Atto.parseOnly (p <* Atto.endOfInput) . BSC.pack)
+
+subParser :: String -> Opt.ParserInfo a -> Opt.Parser a
+subParser availableCommand pInfo =
+  Opt.hsubparser $ Opt.command availableCommand pInfo <> Opt.metavar availableCommand
 
 eDNSName :: String -> Either String ByteString
 eDNSName str =

--- a/cardano-cli/src/Cardano/CLI/Render.hs
+++ b/cardano-cli/src/Cardano/CLI/Render.hs
@@ -2,6 +2,7 @@
 
 module Cardano.CLI.Render
   ( customRenderHelp
+  , renderAnyCmdError
   )
 where
 
@@ -63,3 +64,12 @@ customRenderHelpAsHtml cols =
 
 customRenderHelpAsAnsi :: Int -> ParserHelp -> String
 customRenderHelpAsAnsi = renderHelp
+
+renderAnyCmdError :: Text -> (a -> Doc ann) -> a -> Doc ann
+renderAnyCmdError cmdText renderer shelCliCmdErr =
+  mconcat
+    [ "Command failed: "
+    , pretty cmdText
+    , "  Error: "
+    , renderer shelCliCmdErr
+    ]

--- a/cardano-cli/src/Cardano/CLI/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Run.hs
@@ -77,7 +77,7 @@ runClientCommand = \case
       & firstExceptT NodeCmdError
   ByronCommand cmds ->
     firstExceptT ByronClientError $ runByronClientCommand cmds
-  CompatibaleCommands cmd ->
+  CompatibleCommands cmd ->
     firstExceptT (BackwardCompatibleError (renderAnyCompatibleCommand cmd)) $
       runAnyCompatibleCommand cmd
   HashCmds cmds ->

--- a/cardano-cli/src/Cardano/CLI/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Run.hs
@@ -16,6 +16,8 @@ import           Cardano.Api
 import           Cardano.CLI.Byron.Run (ByronClientCmdError, renderByronClientCmdError,
                    runByronClientCommand)
 import           Cardano.CLI.Commands
+import           Cardano.CLI.Compatible.Commands
+import           Cardano.CLI.Compatible.Run
 import           Cardano.CLI.EraBased.Commands
 import           Cardano.CLI.EraBased.Run
 import           Cardano.CLI.Legacy.Commands
@@ -54,6 +56,10 @@ data ClientCommandErrors
   = ByronClientError ByronClientCmdError
   | AddressCmdError AddressCmdError
   | CmdError Text CmdError
+  | BackwardCompatibleError
+      Text
+      -- ^ Command that was run
+      CompatibleCmdError
   | HashCmdError HashCmdError
   | KeyCmdError KeyCmdError
   | NodeCmdError NodeCmdError
@@ -71,6 +77,9 @@ runClientCommand = \case
       & firstExceptT NodeCmdError
   ByronCommand cmds ->
     firstExceptT ByronClientError $ runByronClientCommand cmds
+  CompatibaleCommands cmd ->
+    firstExceptT (BackwardCompatibleError (renderAnyCompatibleCommand cmd)) $
+      runAnyCompatibleCommand cmd
   HashCmds cmds ->
     firstExceptT HashCmdError $ runHashCmds cmds
   KeyCommands cmds ->
@@ -94,6 +103,8 @@ renderClientCommandError = \case
     renderByronClientCmdError err
   AddressCmdError err ->
     renderAddressCmdError err
+  BackwardCompatibleError cmdText err ->
+    renderCompatibleCmdError cmdText err
   HashCmdError err ->
     prettyError err
   NodeCmdError err ->

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/CmdError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/CmdError.hs
@@ -8,6 +8,7 @@ where
 
 import           Cardano.Api
 
+import           Cardano.CLI.Render
 import           Cardano.CLI.Types.Errors.AddressCmdError
 import           Cardano.CLI.Types.Errors.DelegationError
 import           Cardano.CLI.Types.Errors.GenesisCmdError
@@ -16,7 +17,6 @@ import           Cardano.CLI.Types.Errors.GovernanceCmdError
 import           Cardano.CLI.Types.Errors.GovernanceCommitteeError
 import           Cardano.CLI.Types.Errors.GovernanceQueryError
 import           Cardano.CLI.Types.Errors.GovernanceVoteCmdError
-import           Cardano.CLI.Types.Errors.HashCmdError (HashCmdError)
 import           Cardano.CLI.Types.Errors.KeyCmdError
 import           Cardano.CLI.Types.Errors.NodeCmdError
 import           Cardano.CLI.Types.Errors.QueryCmdError
@@ -37,7 +37,6 @@ data CmdError
   | CmdGovernanceCommitteeError !GovernanceCommitteeError
   | CmdGovernanceQueryError !GovernanceQueryError
   | CmdGovernanceVoteError !GovernanceVoteCmdError
-  | CmdHashError !HashCmdError -- TODO delete me
   | CmdKeyError !KeyCmdError
   | CmdNodeError !NodeCmdError
   | CmdQueryError !QueryCmdError
@@ -57,7 +56,6 @@ renderCmdError cmdText = \case
   CmdGovernanceCommitteeError e -> renderError prettyError e
   CmdGovernanceQueryError e -> renderError prettyError e
   CmdGovernanceVoteError e -> renderError prettyError e
-  CmdHashError e -> renderError prettyError e
   CmdKeyError e -> renderError renderKeyCmdError e
   CmdNodeError e -> renderError renderNodeCmdError e
   CmdQueryError e -> renderError renderQueryCmdError e
@@ -68,10 +66,4 @@ renderCmdError cmdText = \case
   CmdTransactionError e -> renderError renderTxCmdError e
  where
   renderError :: (a -> Doc ann) -> a -> Doc ann
-  renderError renderer shelCliCmdErr =
-    mconcat
-      [ "Command failed: "
-      , pretty cmdText
-      , "  Error: "
-      , renderer shelCliCmdErr
-      ]
+  renderError = renderAnyCmdError cmdText

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -15,6 +15,7 @@ Usage: cardano-cli
                      | ping
                      | debug commands
                      | version
+                     | compatible
                      )
 
 Usage: cardano-cli address (key-gen | key-hash | build | info)
@@ -10542,4 +10543,1113 @@ Usage: cardano-cli version
 Usage: cardano-cli help 
 
   Show all help
+
+Usage: cardano-cli compatible 
+                                ( shelley
+                                | allegra
+                                | mary
+                                | alonzo
+                                | babbage
+                                | conway
+                                )
+
+  Limited backward compatible commands for testing only.
+
+Usage: cardano-cli compatible shelley (transaction | governance)
+
+  Shelley era commands
+
+Usage: cardano-cli compatible shelley transaction signed-transaction
+
+  Transaction commands.
+
+Usage: cardano-cli compatible shelley transaction signed-transaction 
+                                                                       [--tx-in TX-IN]
+                                                                       [--tx-out ADDRESS VALUE]
+                                                                       [--update-proposal-file FILEPATH]
+                                                                       [--signing-key-file FILEPATH
+                                                                         [--address STRING]]
+                                                                       [ --mainnet
+                                                                       | --testnet-magic NATURAL
+                                                                       ]
+                                                                       --fee LOVELACE
+                                                                       --out-file FILEPATH
+
+  Create a simple signed transaction.
+
+Usage: cardano-cli compatible shelley governance 
+                                                   ( create-mir-certificate
+                                                   | create-genesis-key-delegation-certificate
+                                                   | action
+                                                   )
+
+  Governance commands.
+
+Usage: cardano-cli compatible shelley governance create-mir-certificate 
+                                                                          ( ( --reserves
+                                                                            | --treasury
+                                                                            )
+                                                                            (--stake-address ADDRESS)
+                                                                            (--reward LOVELACE)
+                                                                            --out-file FILEPATH
+                                                                          | stake-addresses
+                                                                          | transfer-to-treasury
+                                                                          | transfer-to-rewards
+                                                                          )
+
+  Create an MIR (Move Instantaneous Rewards) certificate
+
+Usage: cardano-cli compatible shelley governance create-mir-certificate stake-addresses 
+                                                                                          ( --reserves
+                                                                                          | --treasury
+                                                                                          )
+                                                                                          (--stake-address ADDRESS)
+                                                                                          (--reward LOVELACE)
+                                                                                          --out-file FILEPATH
+
+  Create an MIR certificate to pay stake addresses
+
+Usage: cardano-cli compatible shelley governance create-mir-certificate transfer-to-treasury --transfer LOVELACE
+                                                                                               --out-file FILEPATH
+
+  Create an MIR certificate to transfer from the reserves pot to the treasury
+  pot
+
+Usage: cardano-cli compatible shelley governance create-mir-certificate transfer-to-rewards --transfer LOVELACE
+                                                                                              --out-file FILEPATH
+
+  Create an MIR certificate to transfer from the treasury pot to the reserves
+  pot
+
+Usage: cardano-cli compatible shelley governance create-genesis-key-delegation-certificate 
+                                                                                             ( --genesis-verification-key STRING
+                                                                                             | --genesis-verification-key-file FILEPATH
+                                                                                             | --genesis-verification-key-hash STRING
+                                                                                             )
+                                                                                             ( --genesis-delegate-verification-key STRING
+                                                                                             | --genesis-delegate-verification-key-file FILEPATH
+                                                                                             | --genesis-delegate-verification-key-hash STRING
+                                                                                             )
+                                                                                             ( --vrf-verification-key STRING
+                                                                                             | --vrf-verification-key-file FILEPATH
+                                                                                             | --vrf-verification-key-hash STRING
+                                                                                             )
+                                                                                             --out-file FILEPATH
+
+  Create a genesis key delegation certificate
+
+Usage: cardano-cli compatible shelley governance action 
+                                                          create-protocol-parameters-update
+
+  Governance action commands.
+
+Usage: cardano-cli compatible shelley governance action create-protocol-parameters-update --epoch NATURAL
+                                                                                            (--genesis-verification-key-file FILEPATH)
+                                                                                            [--min-fee-linear LOVELACE]
+                                                                                            [--min-fee-constant LOVELACE]
+                                                                                            [--max-block-body-size WORD32]
+                                                                                            [--max-tx-size WORD32]
+                                                                                            [--max-block-header-size WORD16]
+                                                                                            [--key-reg-deposit-amt NATURAL]
+                                                                                            [--pool-reg-deposit NATURAL]
+                                                                                            [--pool-retirement-epoch-interval WORD32]
+                                                                                            [--number-of-pools NATURAL]
+                                                                                            [--pool-influence RATIONAL]
+                                                                                            [--treasury-expansion RATIONAL]
+                                                                                            [--monetary-expansion RATIONAL]
+                                                                                            [--min-pool-cost NATURAL]
+                                                                                            [--min-utxo-value NATURAL]
+                                                                                            [--protocol-major-version MAJOR
+                                                                                              --protocol-minor-version MINOR]
+                                                                                            [ --extra-entropy HEX
+                                                                                            | --reset-extra-entropy
+                                                                                            ]
+                                                                                            [--decentralization-parameter RATIONAL]
+                                                                                            --out-file FILEPATH
+
+  Create a protocol parameters update.
+
+Usage: cardano-cli compatible allegra (transaction | governance)
+
+  Allegra era commands
+
+Usage: cardano-cli compatible allegra transaction signed-transaction
+
+  Transaction commands.
+
+Usage: cardano-cli compatible allegra transaction signed-transaction 
+                                                                       [--tx-in TX-IN]
+                                                                       [--tx-out ADDRESS VALUE]
+                                                                       [--update-proposal-file FILEPATH]
+                                                                       [--signing-key-file FILEPATH
+                                                                         [--address STRING]]
+                                                                       [ --mainnet
+                                                                       | --testnet-magic NATURAL
+                                                                       ]
+                                                                       --fee LOVELACE
+                                                                       --out-file FILEPATH
+
+  Create a simple signed transaction.
+
+Usage: cardano-cli compatible allegra governance 
+                                                   ( create-mir-certificate
+                                                   | create-genesis-key-delegation-certificate
+                                                   | action
+                                                   )
+
+  Governance commands.
+
+Usage: cardano-cli compatible allegra governance create-mir-certificate 
+                                                                          ( ( --reserves
+                                                                            | --treasury
+                                                                            )
+                                                                            (--stake-address ADDRESS)
+                                                                            (--reward LOVELACE)
+                                                                            --out-file FILEPATH
+                                                                          | stake-addresses
+                                                                          | transfer-to-treasury
+                                                                          | transfer-to-rewards
+                                                                          )
+
+  Create an MIR (Move Instantaneous Rewards) certificate
+
+Usage: cardano-cli compatible allegra governance create-mir-certificate stake-addresses 
+                                                                                          ( --reserves
+                                                                                          | --treasury
+                                                                                          )
+                                                                                          (--stake-address ADDRESS)
+                                                                                          (--reward LOVELACE)
+                                                                                          --out-file FILEPATH
+
+  Create an MIR certificate to pay stake addresses
+
+Usage: cardano-cli compatible allegra governance create-mir-certificate transfer-to-treasury --transfer LOVELACE
+                                                                                               --out-file FILEPATH
+
+  Create an MIR certificate to transfer from the reserves pot to the treasury
+  pot
+
+Usage: cardano-cli compatible allegra governance create-mir-certificate transfer-to-rewards --transfer LOVELACE
+                                                                                              --out-file FILEPATH
+
+  Create an MIR certificate to transfer from the treasury pot to the reserves
+  pot
+
+Usage: cardano-cli compatible allegra governance create-genesis-key-delegation-certificate 
+                                                                                             ( --genesis-verification-key STRING
+                                                                                             | --genesis-verification-key-file FILEPATH
+                                                                                             | --genesis-verification-key-hash STRING
+                                                                                             )
+                                                                                             ( --genesis-delegate-verification-key STRING
+                                                                                             | --genesis-delegate-verification-key-file FILEPATH
+                                                                                             | --genesis-delegate-verification-key-hash STRING
+                                                                                             )
+                                                                                             ( --vrf-verification-key STRING
+                                                                                             | --vrf-verification-key-file FILEPATH
+                                                                                             | --vrf-verification-key-hash STRING
+                                                                                             )
+                                                                                             --out-file FILEPATH
+
+  Create a genesis key delegation certificate
+
+Usage: cardano-cli compatible allegra governance action 
+                                                          create-protocol-parameters-update
+
+  Governance action commands.
+
+Usage: cardano-cli compatible allegra governance action create-protocol-parameters-update --epoch NATURAL
+                                                                                            (--genesis-verification-key-file FILEPATH)
+                                                                                            [--min-fee-linear LOVELACE]
+                                                                                            [--min-fee-constant LOVELACE]
+                                                                                            [--max-block-body-size WORD32]
+                                                                                            [--max-tx-size WORD32]
+                                                                                            [--max-block-header-size WORD16]
+                                                                                            [--key-reg-deposit-amt NATURAL]
+                                                                                            [--pool-reg-deposit NATURAL]
+                                                                                            [--pool-retirement-epoch-interval WORD32]
+                                                                                            [--number-of-pools NATURAL]
+                                                                                            [--pool-influence RATIONAL]
+                                                                                            [--treasury-expansion RATIONAL]
+                                                                                            [--monetary-expansion RATIONAL]
+                                                                                            [--min-pool-cost NATURAL]
+                                                                                            [--min-utxo-value NATURAL]
+                                                                                            [ --extra-entropy HEX
+                                                                                            | --reset-extra-entropy
+                                                                                            ]
+                                                                                            [--decentralization-parameter RATIONAL]
+                                                                                            [--protocol-major-version MAJOR
+                                                                                              --protocol-minor-version MINOR]
+                                                                                            --out-file FILEPATH
+
+  Create a protocol parameters update.
+
+Usage: cardano-cli compatible mary (transaction | governance)
+
+  Mary era commands
+
+Usage: cardano-cli compatible mary transaction signed-transaction
+
+  Transaction commands.
+
+Usage: cardano-cli compatible mary transaction signed-transaction 
+                                                                    [--tx-in TX-IN]
+                                                                    [--tx-out ADDRESS VALUE]
+                                                                    [--update-proposal-file FILEPATH]
+                                                                    [--signing-key-file FILEPATH
+                                                                      [--address STRING]]
+                                                                    [ --mainnet
+                                                                    | --testnet-magic NATURAL
+                                                                    ]
+                                                                    --fee LOVELACE
+                                                                    --out-file FILEPATH
+
+  Create a simple signed transaction.
+
+Usage: cardano-cli compatible mary governance 
+                                                ( create-mir-certificate
+                                                | create-genesis-key-delegation-certificate
+                                                | action
+                                                )
+
+  Governance commands.
+
+Usage: cardano-cli compatible mary governance create-mir-certificate 
+                                                                       ( ( --reserves
+                                                                         | --treasury
+                                                                         )
+                                                                         (--stake-address ADDRESS)
+                                                                         (--reward LOVELACE)
+                                                                         --out-file FILEPATH
+                                                                       | stake-addresses
+                                                                       | transfer-to-treasury
+                                                                       | transfer-to-rewards
+                                                                       )
+
+  Create an MIR (Move Instantaneous Rewards) certificate
+
+Usage: cardano-cli compatible mary governance create-mir-certificate stake-addresses 
+                                                                                       ( --reserves
+                                                                                       | --treasury
+                                                                                       )
+                                                                                       (--stake-address ADDRESS)
+                                                                                       (--reward LOVELACE)
+                                                                                       --out-file FILEPATH
+
+  Create an MIR certificate to pay stake addresses
+
+Usage: cardano-cli compatible mary governance create-mir-certificate transfer-to-treasury --transfer LOVELACE
+                                                                                            --out-file FILEPATH
+
+  Create an MIR certificate to transfer from the reserves pot to the treasury
+  pot
+
+Usage: cardano-cli compatible mary governance create-mir-certificate transfer-to-rewards --transfer LOVELACE
+                                                                                           --out-file FILEPATH
+
+  Create an MIR certificate to transfer from the treasury pot to the reserves
+  pot
+
+Usage: cardano-cli compatible mary governance create-genesis-key-delegation-certificate 
+                                                                                          ( --genesis-verification-key STRING
+                                                                                          | --genesis-verification-key-file FILEPATH
+                                                                                          | --genesis-verification-key-hash STRING
+                                                                                          )
+                                                                                          ( --genesis-delegate-verification-key STRING
+                                                                                          | --genesis-delegate-verification-key-file FILEPATH
+                                                                                          | --genesis-delegate-verification-key-hash STRING
+                                                                                          )
+                                                                                          ( --vrf-verification-key STRING
+                                                                                          | --vrf-verification-key-file FILEPATH
+                                                                                          | --vrf-verification-key-hash STRING
+                                                                                          )
+                                                                                          --out-file FILEPATH
+
+  Create a genesis key delegation certificate
+
+Usage: cardano-cli compatible mary governance action 
+                                                       create-protocol-parameters-update
+
+  Governance action commands.
+
+Usage: cardano-cli compatible mary governance action create-protocol-parameters-update --epoch NATURAL
+                                                                                         (--genesis-verification-key-file FILEPATH)
+                                                                                         [--min-fee-linear LOVELACE]
+                                                                                         [--min-fee-constant LOVELACE]
+                                                                                         [--max-block-body-size WORD32]
+                                                                                         [--max-tx-size WORD32]
+                                                                                         [--max-block-header-size WORD16]
+                                                                                         [--key-reg-deposit-amt NATURAL]
+                                                                                         [--pool-reg-deposit NATURAL]
+                                                                                         [--pool-retirement-epoch-interval WORD32]
+                                                                                         [--number-of-pools NATURAL]
+                                                                                         [--pool-influence RATIONAL]
+                                                                                         [--treasury-expansion RATIONAL]
+                                                                                         [--monetary-expansion RATIONAL]
+                                                                                         [--min-pool-cost NATURAL]
+                                                                                         [--min-utxo-value NATURAL]
+                                                                                         [ --extra-entropy HEX
+                                                                                         | --reset-extra-entropy
+                                                                                         ]
+                                                                                         [--decentralization-parameter RATIONAL]
+                                                                                         [--protocol-major-version MAJOR
+                                                                                           --protocol-minor-version MINOR]
+                                                                                         --out-file FILEPATH
+
+  Create a protocol parameters update.
+
+Usage: cardano-cli compatible alonzo (transaction | governance)
+
+  Alonzo era commands
+
+Usage: cardano-cli compatible alonzo transaction signed-transaction
+
+  Transaction commands.
+
+Usage: cardano-cli compatible alonzo transaction signed-transaction 
+                                                                      [--tx-in TX-IN]
+                                                                      [--tx-out ADDRESS VALUE
+                                                                        [ --tx-out-datum-hash HASH
+                                                                        | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                                        | --tx-out-datum-hash-file JSON_FILE
+                                                                        | --tx-out-datum-hash-value JSON_VALUE
+                                                                        | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                                        | --tx-out-datum-embed-file JSON_FILE
+                                                                        | --tx-out-datum-embed-value JSON_VALUE
+                                                                        ]]
+                                                                      [--update-proposal-file FILEPATH]
+                                                                      [--signing-key-file FILEPATH
+                                                                        [--address STRING]]
+                                                                      [ --mainnet
+                                                                      | --testnet-magic NATURAL
+                                                                      ]
+                                                                      --fee LOVELACE
+                                                                      --out-file FILEPATH
+
+  Create a simple signed transaction.
+
+Usage: cardano-cli compatible alonzo governance 
+                                                  ( create-mir-certificate
+                                                  | create-genesis-key-delegation-certificate
+                                                  | action
+                                                  )
+
+  Governance commands.
+
+Usage: cardano-cli compatible alonzo governance create-mir-certificate 
+                                                                         ( ( --reserves
+                                                                           | --treasury
+                                                                           )
+                                                                           (--stake-address ADDRESS)
+                                                                           (--reward LOVELACE)
+                                                                           --out-file FILEPATH
+                                                                         | stake-addresses
+                                                                         | transfer-to-treasury
+                                                                         | transfer-to-rewards
+                                                                         )
+
+  Create an MIR (Move Instantaneous Rewards) certificate
+
+Usage: cardano-cli compatible alonzo governance create-mir-certificate stake-addresses 
+                                                                                         ( --reserves
+                                                                                         | --treasury
+                                                                                         )
+                                                                                         (--stake-address ADDRESS)
+                                                                                         (--reward LOVELACE)
+                                                                                         --out-file FILEPATH
+
+  Create an MIR certificate to pay stake addresses
+
+Usage: cardano-cli compatible alonzo governance create-mir-certificate transfer-to-treasury --transfer LOVELACE
+                                                                                              --out-file FILEPATH
+
+  Create an MIR certificate to transfer from the reserves pot to the treasury
+  pot
+
+Usage: cardano-cli compatible alonzo governance create-mir-certificate transfer-to-rewards --transfer LOVELACE
+                                                                                             --out-file FILEPATH
+
+  Create an MIR certificate to transfer from the treasury pot to the reserves
+  pot
+
+Usage: cardano-cli compatible alonzo governance create-genesis-key-delegation-certificate 
+                                                                                            ( --genesis-verification-key STRING
+                                                                                            | --genesis-verification-key-file FILEPATH
+                                                                                            | --genesis-verification-key-hash STRING
+                                                                                            )
+                                                                                            ( --genesis-delegate-verification-key STRING
+                                                                                            | --genesis-delegate-verification-key-file FILEPATH
+                                                                                            | --genesis-delegate-verification-key-hash STRING
+                                                                                            )
+                                                                                            ( --vrf-verification-key STRING
+                                                                                            | --vrf-verification-key-file FILEPATH
+                                                                                            | --vrf-verification-key-hash STRING
+                                                                                            )
+                                                                                            --out-file FILEPATH
+
+  Create a genesis key delegation certificate
+
+Usage: cardano-cli compatible alonzo governance action 
+                                                         create-protocol-parameters-update
+
+  Governance action commands.
+
+Usage: cardano-cli compatible alonzo governance action create-protocol-parameters-update --epoch NATURAL
+                                                                                           (--genesis-verification-key-file FILEPATH)
+                                                                                           [--min-fee-linear LOVELACE]
+                                                                                           [--min-fee-constant LOVELACE]
+                                                                                           [--max-block-body-size WORD32]
+                                                                                           [--max-tx-size WORD32]
+                                                                                           [--max-block-header-size WORD16]
+                                                                                           [--key-reg-deposit-amt NATURAL]
+                                                                                           [--pool-reg-deposit NATURAL]
+                                                                                           [--pool-retirement-epoch-interval WORD32]
+                                                                                           [--number-of-pools NATURAL]
+                                                                                           [--pool-influence RATIONAL]
+                                                                                           [--treasury-expansion RATIONAL]
+                                                                                           [--monetary-expansion RATIONAL]
+                                                                                           [--min-pool-cost NATURAL]
+                                                                                           [ --extra-entropy HEX
+                                                                                           | --reset-extra-entropy
+                                                                                           ]
+                                                                                           [--decentralization-parameter RATIONAL]
+                                                                                           [--price-execution-steps RATIONAL
+                                                                                             --price-execution-memory RATIONAL]
+                                                                                           [--max-tx-execution-units (INT, INT)]
+                                                                                           [--max-block-execution-units (INT, INT)]
+                                                                                           [--max-value-size INT]
+                                                                                           [--collateral-percent INT]
+                                                                                           [--max-collateral-inputs INT]
+                                                                                           [--protocol-major-version MAJOR
+                                                                                             --protocol-minor-version MINOR]
+                                                                                           [--cost-model-file FILE]
+                                                                                           --out-file FILEPATH
+
+  Create a protocol parameters update.
+
+Usage: cardano-cli compatible babbage (transaction | governance)
+
+  Babbage era commands
+
+Usage: cardano-cli compatible babbage transaction signed-transaction
+
+  Transaction commands.
+
+Usage: cardano-cli compatible babbage transaction signed-transaction 
+                                                                       [--tx-in TX-IN]
+                                                                       [--tx-out ADDRESS VALUE
+                                                                         [ --tx-out-datum-hash HASH
+                                                                         | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                                         | --tx-out-datum-hash-file JSON_FILE
+                                                                         | --tx-out-datum-hash-value JSON_VALUE
+                                                                         | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                                         | --tx-out-datum-embed-file JSON_FILE
+                                                                         | --tx-out-datum-embed-value JSON_VALUE
+                                                                         | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                                         | --tx-out-inline-datum-file JSON_FILE
+                                                                         | --tx-out-inline-datum-value JSON_VALUE
+                                                                         ]]
+                                                                       [--update-proposal-file FILEPATH]
+                                                                       [--signing-key-file FILEPATH
+                                                                         [--address STRING]]
+                                                                       [ --mainnet
+                                                                       | --testnet-magic NATURAL
+                                                                       ]
+                                                                       --fee LOVELACE
+                                                                       --out-file FILEPATH
+
+  Create a simple signed transaction.
+
+Usage: cardano-cli compatible babbage governance 
+                                                   ( create-mir-certificate
+                                                   | create-genesis-key-delegation-certificate
+                                                   | action
+                                                   | create-poll
+                                                   | answer-poll
+                                                   | verify-poll
+                                                   )
+
+  Governance commands.
+
+Usage: cardano-cli compatible babbage governance create-mir-certificate 
+                                                                          ( ( --reserves
+                                                                            | --treasury
+                                                                            )
+                                                                            (--stake-address ADDRESS)
+                                                                            (--reward LOVELACE)
+                                                                            --out-file FILEPATH
+                                                                          | stake-addresses
+                                                                          | transfer-to-treasury
+                                                                          | transfer-to-rewards
+                                                                          )
+
+  Create an MIR (Move Instantaneous Rewards) certificate
+
+Usage: cardano-cli compatible babbage governance create-mir-certificate stake-addresses 
+                                                                                          ( --reserves
+                                                                                          | --treasury
+                                                                                          )
+                                                                                          (--stake-address ADDRESS)
+                                                                                          (--reward LOVELACE)
+                                                                                          --out-file FILEPATH
+
+  Create an MIR certificate to pay stake addresses
+
+Usage: cardano-cli compatible babbage governance create-mir-certificate transfer-to-treasury --transfer LOVELACE
+                                                                                               --out-file FILEPATH
+
+  Create an MIR certificate to transfer from the reserves pot to the treasury
+  pot
+
+Usage: cardano-cli compatible babbage governance create-mir-certificate transfer-to-rewards --transfer LOVELACE
+                                                                                              --out-file FILEPATH
+
+  Create an MIR certificate to transfer from the treasury pot to the reserves
+  pot
+
+Usage: cardano-cli compatible babbage governance create-genesis-key-delegation-certificate 
+                                                                                             ( --genesis-verification-key STRING
+                                                                                             | --genesis-verification-key-file FILEPATH
+                                                                                             | --genesis-verification-key-hash STRING
+                                                                                             )
+                                                                                             ( --genesis-delegate-verification-key STRING
+                                                                                             | --genesis-delegate-verification-key-file FILEPATH
+                                                                                             | --genesis-delegate-verification-key-hash STRING
+                                                                                             )
+                                                                                             ( --vrf-verification-key STRING
+                                                                                             | --vrf-verification-key-file FILEPATH
+                                                                                             | --vrf-verification-key-hash STRING
+                                                                                             )
+                                                                                             --out-file FILEPATH
+
+  Create a genesis key delegation certificate
+
+Usage: cardano-cli compatible babbage governance action 
+                                                          create-protocol-parameters-update
+
+  Governance action commands.
+
+Usage: cardano-cli compatible babbage governance action create-protocol-parameters-update --epoch NATURAL
+                                                                                            (--genesis-verification-key-file FILEPATH)
+                                                                                            [--min-fee-linear LOVELACE]
+                                                                                            [--min-fee-constant LOVELACE]
+                                                                                            [--max-block-body-size WORD32]
+                                                                                            [--max-tx-size WORD32]
+                                                                                            [--max-block-header-size WORD16]
+                                                                                            [--key-reg-deposit-amt NATURAL]
+                                                                                            [--pool-reg-deposit NATURAL]
+                                                                                            [--pool-retirement-epoch-interval WORD32]
+                                                                                            [--number-of-pools NATURAL]
+                                                                                            [--pool-influence RATIONAL]
+                                                                                            [--treasury-expansion RATIONAL]
+                                                                                            [--monetary-expansion RATIONAL]
+                                                                                            [--min-pool-cost NATURAL]
+                                                                                            [--price-execution-steps RATIONAL
+                                                                                              --price-execution-memory RATIONAL]
+                                                                                            [--max-tx-execution-units (INT, INT)]
+                                                                                            [--max-block-execution-units (INT, INT)]
+                                                                                            [--max-value-size INT]
+                                                                                            [--collateral-percent INT]
+                                                                                            [--max-collateral-inputs INT]
+                                                                                            [--protocol-major-version MAJOR
+                                                                                              --protocol-minor-version MINOR]
+                                                                                            [--utxo-cost-per-byte LOVELACE]
+                                                                                            [--cost-model-file FILE]
+                                                                                            --out-file FILEPATH
+
+  Create a protocol parameters update.
+
+Usage: cardano-cli compatible babbage governance create-poll --question STRING
+                                                               (--answer STRING)
+                                                               [--nonce UINT]
+                                                               --out-file FILEPATH
+
+  Create an SPO poll
+
+Usage: cardano-cli compatible babbage governance answer-poll --poll-file FILEPATH
+                                                               [--answer INT]
+                                                               [--out-file FILEPATH]
+
+  Answer an SPO poll
+
+Usage: cardano-cli compatible babbage governance verify-poll --poll-file FILEPATH
+                                                               --tx-file FILEPATH
+                                                               [--out-file FILEPATH]
+
+  Verify an answer to a given SPO poll
+
+Usage: cardano-cli compatible conway (transaction | governance)
+
+  Conway era commands
+
+Usage: cardano-cli compatible conway transaction signed-transaction
+
+  Transaction commands.
+
+Usage: cardano-cli compatible conway transaction signed-transaction 
+                                                                      [--tx-in TX-IN]
+                                                                      [--tx-out ADDRESS VALUE
+                                                                        [ --tx-out-datum-hash HASH
+                                                                        | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                                        | --tx-out-datum-hash-file JSON_FILE
+                                                                        | --tx-out-datum-hash-value JSON_VALUE
+                                                                        | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                                        | --tx-out-datum-embed-file JSON_FILE
+                                                                        | --tx-out-datum-embed-value JSON_VALUE
+                                                                        | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                                        | --tx-out-inline-datum-file JSON_FILE
+                                                                        | --tx-out-inline-datum-value JSON_VALUE
+                                                                        ]
+                                                                        [--tx-out-reference-script-file FILEPATH]]
+                                                                      [--proposal-file FILEPATH
+                                                                        [ --proposal-script-file FILEPATH
+                                                                          [
+                                                                            ( --proposal-redeemer-cbor-file CBOR_FILE
+                                                                            | --proposal-redeemer-file JSON_FILE
+                                                                            | --proposal-redeemer-value JSON_VALUE
+                                                                            )
+                                                                            --proposal-execution-units (INT, INT)]
+                                                                        | --proposal-tx-in-reference TX-IN
+                                                                          --proposal-plutus-script-v3
+                                                                          ( --proposal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                                          | --proposal-reference-tx-in-redeemer-file JSON_FILE
+                                                                          | --proposal-reference-tx-in-redeemer-value JSON_VALUE
+                                                                          )
+                                                                          --proposal-reference-tx-in-execution-units (INT, INT)
+                                                                        ]]
+                                                                      [--vote-file FILEPATH
+                                                                        [ --vote-script-file FILEPATH
+                                                                          [
+                                                                            ( --vote-redeemer-cbor-file CBOR_FILE
+                                                                            | --vote-redeemer-file JSON_FILE
+                                                                            | --vote-redeemer-value JSON_VALUE
+                                                                            )
+                                                                            --vote-execution-units (INT, INT)]
+                                                                        | --vote-tx-in-reference TX-IN
+                                                                          --vote-plutus-script-v3
+                                                                          ( --vote-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                                          | --vote-reference-tx-in-redeemer-file JSON_FILE
+                                                                          | --vote-reference-tx-in-redeemer-value JSON_VALUE
+                                                                          )
+                                                                          --vote-reference-tx-in-execution-units (INT, INT)
+                                                                        ]]
+                                                                      [--signing-key-file FILEPATH
+                                                                        [--address STRING]]
+                                                                      [ --mainnet
+                                                                      | --testnet-magic NATURAL
+                                                                      ]
+                                                                      --fee LOVELACE
+                                                                      --out-file FILEPATH
+
+  Create a simple signed transaction.
+
+Usage: cardano-cli compatible conway governance 
+                                                  ( action
+                                                  | committee
+                                                  | drep
+                                                  | vote
+                                                  )
+
+  Governance commands.
+
+Usage: cardano-cli compatible conway governance action 
+                                                         ( create-constitution
+                                                         | update-committee
+                                                         | create-info
+                                                         | create-no-confidence
+                                                         | create-protocol-parameters-update
+                                                         | create-treasury-withdrawal
+                                                         | create-hardfork
+                                                         | view
+                                                         )
+
+  Governance action commands.
+
+Usage: cardano-cli compatible conway governance action create-constitution 
+                                                                             ( --mainnet
+                                                                             | --testnet
+                                                                             )
+                                                                             --governance-action-deposit NATURAL
+                                                                             ( --deposit-return-stake-verification-key STRING
+                                                                             | --deposit-return-stake-verification-key-file FILEPATH
+                                                                             | --deposit-return-stake-key-hash HASH
+                                                                             | --deposit-return-stake-script-file FILEPATH
+                                                                             | --deposit-return-stake-address ADDRESS
+                                                                             )
+                                                                             [--prev-governance-action-tx-id TXID
+                                                                               --prev-governance-action-index WORD16]
+                                                                             --anchor-url TEXT
+                                                                             --anchor-data-hash HASH
+                                                                             [--check-anchor-data]
+                                                                             --constitution-url TEXT
+                                                                             --constitution-hash HASH
+                                                                             [--check-constitution-hash]
+                                                                             [--constitution-script-hash HASH]
+                                                                             --out-file FILEPATH
+
+  Create a constitution.
+
+Usage: cardano-cli compatible conway governance action update-committee 
+                                                                          ( --mainnet
+                                                                          | --testnet
+                                                                          )
+                                                                          --governance-action-deposit NATURAL
+                                                                          ( --deposit-return-stake-verification-key STRING
+                                                                          | --deposit-return-stake-verification-key-file FILEPATH
+                                                                          | --deposit-return-stake-key-hash HASH
+                                                                          | --deposit-return-stake-script-file FILEPATH
+                                                                          | --deposit-return-stake-address ADDRESS
+                                                                          )
+                                                                          --anchor-url TEXT
+                                                                          --anchor-data-hash HASH
+                                                                          [--check-anchor-data]
+                                                                          [ --remove-cc-cold-verification-key STRING
+                                                                          | --remove-cc-cold-verification-key-file FILEPATH
+                                                                          | --remove-cc-cold-verification-key-hash STRING
+                                                                          | --remove-cc-cold-script-hash HASH
+                                                                          ]
+                                                                          [
+                                                                            ( --add-cc-cold-verification-key STRING
+                                                                            | --add-cc-cold-verification-key-file FILEPATH
+                                                                            | --add-cc-cold-verification-key-hash STRING
+                                                                            | --add-cc-cold-script-hash HASH
+                                                                            )
+                                                                            --epoch NATURAL]
+                                                                          --threshold RATIONAL
+                                                                          [--prev-governance-action-tx-id TXID
+                                                                            --prev-governance-action-index WORD16]
+                                                                          --out-file FILEPATH
+
+  Create or update a new committee proposal.
+
+Usage: cardano-cli compatible conway governance action create-info 
+                                                                     ( --mainnet
+                                                                     | --testnet
+                                                                     )
+                                                                     --governance-action-deposit NATURAL
+                                                                     ( --deposit-return-stake-verification-key STRING
+                                                                     | --deposit-return-stake-verification-key-file FILEPATH
+                                                                     | --deposit-return-stake-key-hash HASH
+                                                                     | --deposit-return-stake-script-file FILEPATH
+                                                                     | --deposit-return-stake-address ADDRESS
+                                                                     )
+                                                                     --anchor-url TEXT
+                                                                     --anchor-data-hash HASH
+                                                                     [--check-anchor-data]
+                                                                     --out-file FILEPATH
+
+  Create an info action.
+
+Usage: cardano-cli compatible conway governance action create-no-confidence 
+                                                                              ( --mainnet
+                                                                              | --testnet
+                                                                              )
+                                                                              --governance-action-deposit NATURAL
+                                                                              ( --deposit-return-stake-verification-key STRING
+                                                                              | --deposit-return-stake-verification-key-file FILEPATH
+                                                                              | --deposit-return-stake-key-hash HASH
+                                                                              | --deposit-return-stake-script-file FILEPATH
+                                                                              | --deposit-return-stake-address ADDRESS
+                                                                              )
+                                                                              --anchor-url TEXT
+                                                                              --anchor-data-hash HASH
+                                                                              [--check-anchor-data]
+                                                                              [--prev-governance-action-tx-id TXID
+                                                                                --prev-governance-action-index WORD16]
+                                                                              --out-file FILEPATH
+
+  Create a no confidence proposal.
+
+Usage: cardano-cli compatible conway governance action create-protocol-parameters-update 
+                                                                                           ( --mainnet
+                                                                                           | --testnet
+                                                                                           )
+                                                                                           --governance-action-deposit NATURAL
+                                                                                           ( --deposit-return-stake-verification-key STRING
+                                                                                           | --deposit-return-stake-verification-key-file FILEPATH
+                                                                                           | --deposit-return-stake-key-hash HASH
+                                                                                           | --deposit-return-stake-script-file FILEPATH
+                                                                                           | --deposit-return-stake-address ADDRESS
+                                                                                           )
+                                                                                           --anchor-url TEXT
+                                                                                           --anchor-data-hash HASH
+                                                                                           [--check-anchor-data]
+                                                                                           [--prev-governance-action-tx-id TXID
+                                                                                             --prev-governance-action-index WORD16]
+                                                                                           [--constitution-script-hash HASH]
+                                                                                           [--min-fee-linear LOVELACE]
+                                                                                           [--min-fee-constant LOVELACE]
+                                                                                           [--max-block-body-size WORD32]
+                                                                                           [--max-tx-size WORD32]
+                                                                                           [--max-block-header-size WORD16]
+                                                                                           [--key-reg-deposit-amt NATURAL]
+                                                                                           [--pool-reg-deposit NATURAL]
+                                                                                           [--pool-retirement-epoch-interval WORD32]
+                                                                                           [--number-of-pools NATURAL]
+                                                                                           [--pool-influence RATIONAL]
+                                                                                           [--treasury-expansion RATIONAL]
+                                                                                           [--monetary-expansion RATIONAL]
+                                                                                           [--min-pool-cost NATURAL]
+                                                                                           [--price-execution-steps RATIONAL
+                                                                                             --price-execution-memory RATIONAL]
+                                                                                           [--max-tx-execution-units (INT, INT)]
+                                                                                           [--max-block-execution-units (INT, INT)]
+                                                                                           [--max-value-size INT]
+                                                                                           [--collateral-percent INT]
+                                                                                           [--max-collateral-inputs INT]
+                                                                                           [--utxo-cost-per-byte LOVELACE]
+                                                                                           [--pool-voting-threshold-motion-no-confidence RATIONAL
+                                                                                             --pool-voting-threshold-committee-normal RATIONAL
+                                                                                             --pool-voting-threshold-committee-no-confidence RATIONAL
+                                                                                             --pool-voting-threshold-hard-fork-initiation RATIONAL
+                                                                                             --pool-voting-threshold-pp-security-group RATIONAL]
+                                                                                           [--drep-voting-threshold-motion-no-confidence RATIONAL
+                                                                                             --drep-voting-threshold-committee-normal RATIONAL
+                                                                                             --drep-voting-threshold-committee-no-confidence RATIONAL
+                                                                                             --drep-voting-threshold-update-to-constitution RATIONAL
+                                                                                             --drep-voting-threshold-hard-fork-initiation RATIONAL
+                                                                                             --drep-voting-threshold-pp-network-group RATIONAL
+                                                                                             --drep-voting-threshold-pp-economic-group RATIONAL
+                                                                                             --drep-voting-threshold-pp-technical-group RATIONAL
+                                                                                             --drep-voting-threshold-pp-governance-group RATIONAL
+                                                                                             --drep-voting-threshold-treasury-withdrawal RATIONAL]
+                                                                                           [--min-committee-size INT]
+                                                                                           [--committee-term-length WORD32]
+                                                                                           [--governance-action-lifetime WORD32]
+                                                                                           [--new-governance-action-deposit NATURAL]
+                                                                                           [--drep-deposit LOVELACE]
+                                                                                           [--drep-activity WORD32]
+                                                                                           [--ref-script-cost-per-byte RATIONAL]
+                                                                                           [--cost-model-file FILE]
+                                                                                           --out-file FILEPATH
+
+  Create a protocol parameters update.
+
+Usage: cardano-cli compatible conway governance action create-treasury-withdrawal 
+                                                                                    ( --mainnet
+                                                                                    | --testnet
+                                                                                    )
+                                                                                    --governance-action-deposit NATURAL
+                                                                                    ( --deposit-return-stake-verification-key STRING
+                                                                                    | --deposit-return-stake-verification-key-file FILEPATH
+                                                                                    | --deposit-return-stake-key-hash HASH
+                                                                                    | --deposit-return-stake-script-file FILEPATH
+                                                                                    | --deposit-return-stake-address ADDRESS
+                                                                                    )
+                                                                                    --anchor-url TEXT
+                                                                                    --anchor-data-hash HASH
+                                                                                    [--check-anchor-data]
+                                                                                    (
+                                                                                      ( --funds-receiving-stake-verification-key STRING
+                                                                                      | --funds-receiving-stake-verification-key-file FILEPATH
+                                                                                      | --funds-receiving-stake-key-hash HASH
+                                                                                      | --funds-receiving-stake-script-file FILEPATH
+                                                                                      | --funds-receiving-stake-address ADDRESS
+                                                                                      )
+                                                                                      --transfer LOVELACE)
+                                                                                    [--constitution-script-hash HASH]
+                                                                                    --out-file FILEPATH
+
+  Create a treasury withdrawal.
+
+Usage: cardano-cli compatible conway governance action create-hardfork 
+                                                                         ( --mainnet
+                                                                         | --testnet
+                                                                         )
+                                                                         --governance-action-deposit NATURAL
+                                                                         ( --deposit-return-stake-verification-key STRING
+                                                                         | --deposit-return-stake-verification-key-file FILEPATH
+                                                                         | --deposit-return-stake-key-hash HASH
+                                                                         | --deposit-return-stake-script-file FILEPATH
+                                                                         | --deposit-return-stake-address ADDRESS
+                                                                         )
+                                                                         [--prev-governance-action-tx-id TXID
+                                                                           --prev-governance-action-index WORD16]
+                                                                         --anchor-url TEXT
+                                                                         --anchor-data-hash HASH
+                                                                         [--check-anchor-data]
+                                                                         --protocol-major-version MAJOR
+                                                                         --protocol-minor-version MINOR
+                                                                         --out-file FILEPATH
+
+  Create a hardfork initiation proposal.
+
+Usage: cardano-cli compatible conway governance action view --action-file FILEPATH
+                                                              [ --output-json
+                                                              | --output-yaml
+                                                              ]
+                                                              [--out-file FILEPATH]
+
+  View a governance action.
+
+Usage: cardano-cli compatible conway governance committee 
+                                                            ( key-gen-cold
+                                                            | key-gen-hot
+                                                            | key-hash
+                                                            | create-hot-key-authorization-certificate
+                                                            | create-cold-key-resignation-certificate
+                                                            )
+
+  Committee member commands.
+
+Usage: cardano-cli compatible conway governance committee key-gen-cold 
+                                                                         --cold-verification-key-file FILEPATH
+                                                                         --cold-signing-key-file FILEPATH
+
+  Create a cold key pair for a Constitutional Committee Member
+
+Usage: cardano-cli compatible conway governance committee key-gen-hot --verification-key-file FILEPATH
+                                                                        --signing-key-file FILEPATH
+
+  Create a hot key pair for a Constitutional Committee Member
+
+Usage: cardano-cli compatible conway governance committee key-hash 
+                                                                     ( --verification-key STRING
+                                                                     | --verification-key-file FILEPATH
+                                                                     )
+
+  Print the identifier (hash) of a public key
+
+Usage: cardano-cli compatible conway governance committee create-hot-key-authorization-certificate 
+                                                                                                     ( --cold-verification-key STRING
+                                                                                                     | --cold-verification-key-file FILEPATH
+                                                                                                     | --cold-verification-key-hash STRING
+                                                                                                     | --cold-script-hash HASH
+                                                                                                     | --cold-script-file FILEPATH
+                                                                                                     )
+                                                                                                     ( --hot-verification-key STRING
+                                                                                                     | --hot-verification-key-file FILEPATH
+                                                                                                     | --hot-verification-key-hash STRING
+                                                                                                     | --hot-script-hash HASH
+                                                                                                     | --hot-script-file FILEPATH
+                                                                                                     )
+                                                                                                     --out-file FILEPATH
+
+  Create hot key authorization certificate for a Constitutional Committee Member
+
+Usage: cardano-cli compatible conway governance committee create-cold-key-resignation-certificate 
+                                                                                                    ( --cold-verification-key STRING
+                                                                                                    | --cold-verification-key-file FILEPATH
+                                                                                                    | --cold-verification-key-hash STRING
+                                                                                                    | --cold-script-hash HASH
+                                                                                                    | --cold-script-file FILEPATH
+                                                                                                    )
+                                                                                                    [--resignation-metadata-url TEXT
+                                                                                                      --resignation-metadata-hash HASH
+                                                                                                      [--check-resignation-metadata-hash]]
+                                                                                                    --out-file FILEPATH
+
+  Create cold key resignation certificate for a Constitutional Committee Member
+
+Usage: cardano-cli compatible conway governance drep 
+                                                       ( key-gen
+                                                       | id
+                                                       | registration-certificate
+                                                       | retirement-certificate
+                                                       | update-certificate
+                                                       | metadata-hash
+                                                       )
+
+  DRep member commands.
+
+Usage: cardano-cli compatible conway governance drep key-gen --verification-key-file FILEPATH
+                                                               --signing-key-file FILEPATH
+
+  Generate Delegated Representative verification and signing keys.
+
+Usage: cardano-cli compatible conway governance drep id 
+                                                          ( --drep-verification-key STRING
+                                                          | --drep-verification-key-file FILEPATH
+                                                          )
+                                                          [--output-format STRING]
+                                                          [--out-file FILEPATH]
+
+  Generate a drep id.
+
+Usage: cardano-cli compatible conway governance drep registration-certificate 
+                                                                                ( --drep-script-hash HASH
+                                                                                | --drep-verification-key STRING
+                                                                                | --drep-verification-key-file FILEPATH
+                                                                                | --drep-key-hash HASH
+                                                                                )
+                                                                                --key-reg-deposit-amt NATURAL
+                                                                                [--drep-metadata-url TEXT
+                                                                                  --drep-metadata-hash HASH
+                                                                                  [--check-drep-metadata-hash]]
+                                                                                --out-file FILEPATH
+
+  Create a registration certificate.
+
+Usage: cardano-cli compatible conway governance drep retirement-certificate 
+                                                                              ( --drep-script-hash HASH
+                                                                              | --drep-verification-key STRING
+                                                                              | --drep-verification-key-file FILEPATH
+                                                                              | --drep-key-hash HASH
+                                                                              )
+                                                                              --deposit-amt LOVELACE
+                                                                              --out-file FILEPATH
+
+  Create a DRep retirement certificate.
+
+Usage: cardano-cli compatible conway governance drep update-certificate 
+                                                                          ( --drep-script-hash HASH
+                                                                          | --drep-verification-key STRING
+                                                                          | --drep-verification-key-file FILEPATH
+                                                                          | --drep-key-hash HASH
+                                                                          )
+                                                                          [--drep-metadata-url TEXT
+                                                                            --drep-metadata-hash HASH
+                                                                            [--check-drep-metadata-hash]]
+                                                                          --out-file FILEPATH
+
+  Create a DRep update certificate.
+
+Usage: cardano-cli compatible conway governance drep metadata-hash 
+                                                                     ( --drep-metadata-file FILEPATH
+                                                                     | --drep-metadata-url TEXT
+                                                                     )
+                                                                     [ --expected-hash HASH
+                                                                     | --out-file FILEPATH
+                                                                     ]
+
+  Calculate the hash of a metadata file, optionally checking the obtained hash
+  against an expected value.
+
+Usage: cardano-cli compatible conway governance vote (create | view)
+
+  Vote commands.
+
+Usage: cardano-cli compatible conway governance vote create 
+                                                              ( --yes
+                                                              | --no
+                                                              | --abstain
+                                                              )
+                                                              --governance-action-tx-id TXID
+                                                              --governance-action-index WORD16
+                                                              ( --drep-verification-key STRING
+                                                              | --drep-verification-key-file FILEPATH
+                                                              | --drep-key-hash HASH
+                                                              | --drep-script-hash HASH
+                                                              | --stake-pool-verification-key STRING
+                                                              | --cold-verification-key-file FILEPATH
+                                                              | --stake-pool-id STAKE_POOL_ID
+                                                              | --cc-hot-verification-key STRING
+                                                              | --cc-hot-verification-key-file FILEPATH
+                                                              | --cc-hot-key-hash STRING
+                                                              | --cc-hot-script-hash HASH
+                                                              )
+                                                              [--anchor-url TEXT
+                                                                --anchor-data-hash HASH
+                                                                [--check-anchor-data-hash]]
+                                                              --out-file FILEPATH
+
+  Vote creation.
+
+Usage: cardano-cli compatible conway governance vote view 
+                                                            [ --output-json
+                                                            | --output-yaml
+                                                            ]
+                                                            --vote-file FILEPATH
+                                                            [--out-file FILEPATH]
+
+  Vote viewing.
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible.cli
@@ -1,0 +1,21 @@
+Usage: cardano-cli compatible 
+                                ( shelley
+                                | allegra
+                                | mary
+                                | alonzo
+                                | babbage
+                                | conway
+                                )
+
+  Limited backward compatible commands for testing only.
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  shelley                  Shelley era commands
+  allegra                  Allegra era commands
+  mary                     Mary era commands
+  alonzo                   Alonzo era commands
+  babbage                  Babbage era commands
+  conway                   Conway era commands

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_allegra.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_allegra.cli
@@ -1,0 +1,10 @@
+Usage: cardano-cli compatible allegra (transaction | governance)
+
+  Allegra era commands
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  transaction              Transaction commands.
+  governance               Governance commands.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_allegra_governance.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_allegra_governance.cli
@@ -1,0 +1,17 @@
+Usage: cardano-cli compatible allegra governance 
+                                                   ( create-mir-certificate
+                                                   | create-genesis-key-delegation-certificate
+                                                   | action
+                                                   )
+
+  Governance commands.
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  create-mir-certificate   Create an MIR (Move Instantaneous Rewards)
+                           certificate
+  create-genesis-key-delegation-certificate
+                           Create a genesis key delegation certificate
+  action                   Governance action commands.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_allegra_governance_action.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_allegra_governance_action.cli
@@ -1,0 +1,11 @@
+Usage: cardano-cli compatible allegra governance action 
+                                                          create-protocol-parameters-update
+
+  Governance action commands.
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  create-protocol-parameters-update
+                           Create a protocol parameters update.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_allegra_governance_action_create-protocol-parameters-update.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_allegra_governance_action_create-protocol-parameters-update.cli
@@ -1,0 +1,74 @@
+Usage: cardano-cli compatible allegra governance action create-protocol-parameters-update --epoch NATURAL
+                                                                                            (--genesis-verification-key-file FILEPATH)
+                                                                                            [--min-fee-linear LOVELACE]
+                                                                                            [--min-fee-constant LOVELACE]
+                                                                                            [--max-block-body-size WORD32]
+                                                                                            [--max-tx-size WORD32]
+                                                                                            [--max-block-header-size WORD16]
+                                                                                            [--key-reg-deposit-amt NATURAL]
+                                                                                            [--pool-reg-deposit NATURAL]
+                                                                                            [--pool-retirement-epoch-interval WORD32]
+                                                                                            [--number-of-pools NATURAL]
+                                                                                            [--pool-influence RATIONAL]
+                                                                                            [--treasury-expansion RATIONAL]
+                                                                                            [--monetary-expansion RATIONAL]
+                                                                                            [--min-pool-cost NATURAL]
+                                                                                            [--min-utxo-value NATURAL]
+                                                                                            [ --extra-entropy HEX
+                                                                                            | --reset-extra-entropy
+                                                                                            ]
+                                                                                            [--decentralization-parameter RATIONAL]
+                                                                                            [--protocol-major-version MAJOR
+                                                                                              --protocol-minor-version MINOR]
+                                                                                            --out-file FILEPATH
+
+  Create a protocol parameters update.
+
+Available options:
+  --epoch NATURAL          The epoch number in which the update proposal is
+                           valid.
+  --genesis-verification-key-file FILEPATH
+                           Filepath of the genesis verification key.
+  --min-fee-linear LOVELACE
+                           The linear factor per byte for the minimum fee
+                           calculation.
+  --min-fee-constant LOVELACE
+                           The constant factor for the minimum fee calculation.
+  --max-block-body-size WORD32
+                           Maximal block body size.
+  --max-tx-size WORD32     Maximum transaction size.
+  --max-block-header-size WORD16
+                           Maximum block header size.
+  --key-reg-deposit-amt NATURAL
+                           Key registration deposit amount.
+  --pool-reg-deposit NATURAL
+                           The amount of a pool registration deposit.
+  --pool-retirement-epoch-interval WORD32
+                           Epoch interval of pool retirement.
+  --number-of-pools NATURAL
+                           Desired number of pools.
+  --pool-influence RATIONAL
+                           Pool influence.
+  --treasury-expansion RATIONAL
+                           Treasury expansion.
+  --monetary-expansion RATIONAL
+                           Monetary expansion.
+  --min-pool-cost NATURAL  The minimum allowed cost parameter for stake pools.
+  --min-utxo-value NATURAL The minimum allowed UTxO value (Shelley to Mary
+                           eras).
+  --extra-entropy HEX      Praos extra entropy seed, as a hex byte string.
+  --reset-extra-entropy    Reset the Praos extra entropy to none.
+  --decentralization-parameter RATIONAL
+                           Decentralization parameter.
+  --protocol-major-version MAJOR
+                           Specify the major protocol version to fork into. An
+                           increase indicates a hard fork. It must be the next
+                           natural number after the current version and must be
+                           supported by the node.
+  --protocol-minor-version MINOR
+                           Minor protocol version. An increase indicates a soft
+                           fork (old software can validate but not produce new
+                           blocks). Must be zero when the major protocol version
+                           is increased.
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_allegra_governance_create-genesis-key-delegation-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_allegra_governance_create-genesis-key-delegation-certificate.cli
@@ -1,0 +1,38 @@
+Usage: cardano-cli compatible allegra governance create-genesis-key-delegation-certificate 
+                                                                                             ( --genesis-verification-key STRING
+                                                                                             | --genesis-verification-key-file FILEPATH
+                                                                                             | --genesis-verification-key-hash STRING
+                                                                                             )
+                                                                                             ( --genesis-delegate-verification-key STRING
+                                                                                             | --genesis-delegate-verification-key-file FILEPATH
+                                                                                             | --genesis-delegate-verification-key-hash STRING
+                                                                                             )
+                                                                                             ( --vrf-verification-key STRING
+                                                                                             | --vrf-verification-key-file FILEPATH
+                                                                                             | --vrf-verification-key-hash STRING
+                                                                                             )
+                                                                                             --out-file FILEPATH
+
+  Create a genesis key delegation certificate
+
+Available options:
+  --genesis-verification-key STRING
+                           Genesis verification key (hex-encoded).
+  --genesis-verification-key-file FILEPATH
+                           Filepath of the genesis verification key.
+  --genesis-verification-key-hash STRING
+                           Genesis verification key hash (hex-encoded).
+  --genesis-delegate-verification-key STRING
+                           Genesis delegate verification key (hex-encoded).
+  --genesis-delegate-verification-key-file FILEPATH
+                           Filepath of the genesis delegate verification key.
+  --genesis-delegate-verification-key-hash STRING
+                           Genesis delegate verification key hash (hex-encoded).
+  --vrf-verification-key STRING
+                           VRF verification key (Bech32 or hex-encoded).
+  --vrf-verification-key-file FILEPATH
+                           Filepath of the VRF verification key.
+  --vrf-verification-key-hash STRING
+                           VRF verification key hash (hex-encoded).
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_allegra_governance_create-mir-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_allegra_governance_create-mir-certificate.cli
@@ -1,0 +1,28 @@
+Usage: cardano-cli compatible allegra governance create-mir-certificate 
+                                                                          ( ( --reserves
+                                                                            | --treasury
+                                                                            )
+                                                                            (--stake-address ADDRESS)
+                                                                            (--reward LOVELACE)
+                                                                            --out-file FILEPATH
+                                                                          | stake-addresses
+                                                                          | transfer-to-treasury
+                                                                          | transfer-to-rewards
+                                                                          )
+
+  Create an MIR (Move Instantaneous Rewards) certificate
+
+Available options:
+  --reserves               Use the reserves pot.
+  --treasury               Use the treasury pot.
+  --stake-address ADDRESS  Target stake address (bech32 format).
+  --reward LOVELACE        The reward for the relevant reward account.
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text
+
+Available commands:
+  stake-addresses          Create an MIR certificate to pay stake addresses
+  transfer-to-treasury     Create an MIR certificate to transfer from the
+                           reserves pot to the treasury pot
+  transfer-to-rewards      Create an MIR certificate to transfer from the
+                           treasury pot to the reserves pot

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_allegra_governance_create-mir-certificate_stake-addresses.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_allegra_governance_create-mir-certificate_stake-addresses.cli
@@ -1,0 +1,17 @@
+Usage: cardano-cli compatible allegra governance create-mir-certificate stake-addresses 
+                                                                                          ( --reserves
+                                                                                          | --treasury
+                                                                                          )
+                                                                                          (--stake-address ADDRESS)
+                                                                                          (--reward LOVELACE)
+                                                                                          --out-file FILEPATH
+
+  Create an MIR certificate to pay stake addresses
+
+Available options:
+  --reserves               Use the reserves pot.
+  --treasury               Use the treasury pot.
+  --stake-address ADDRESS  Target stake address (bech32 format).
+  --reward LOVELACE        The reward for the relevant reward account.
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_allegra_governance_create-mir-certificate_transfer-to-rewards.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_allegra_governance_create-mir-certificate_transfer-to-rewards.cli
@@ -1,0 +1,10 @@
+Usage: cardano-cli compatible allegra governance create-mir-certificate transfer-to-rewards --transfer LOVELACE
+                                                                                              --out-file FILEPATH
+
+  Create an MIR certificate to transfer from the treasury pot to the reserves
+  pot
+
+Available options:
+  --transfer LOVELACE      The amount to transfer.
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_allegra_governance_create-mir-certificate_transfer-to-treasury.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_allegra_governance_create-mir-certificate_transfer-to-treasury.cli
@@ -1,0 +1,10 @@
+Usage: cardano-cli compatible allegra governance create-mir-certificate transfer-to-treasury --transfer LOVELACE
+                                                                                               --out-file FILEPATH
+
+  Create an MIR certificate to transfer from the reserves pot to the treasury
+  pot
+
+Available options:
+  --transfer LOVELACE      The amount to transfer.
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_allegra_transaction_signed-transaction.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_allegra_transaction_signed-transaction.cli
@@ -1,0 +1,32 @@
+Usage: cardano-cli compatible allegra transaction signed-transaction 
+                                                                       [--tx-in TX-IN]
+                                                                       [--tx-out ADDRESS VALUE]
+                                                                       [--update-proposal-file FILEPATH]
+                                                                       [--signing-key-file FILEPATH
+                                                                         [--address STRING]]
+                                                                       [ --mainnet
+                                                                       | --testnet-magic NATURAL
+                                                                       ]
+                                                                       --fee LOVELACE
+                                                                       --out-file FILEPATH
+
+  Create a simple signed transaction.
+
+Available options:
+  --tx-in TX-IN            TxId#TxIx
+  --tx-out ADDRESS VALUE   The transaction output as ADDRESS VALUE where ADDRESS
+                           is the Bech32-encoded address followed by the value
+                           in the multi-asset syntax (including simply
+                           Lovelace).
+  --update-proposal-file FILEPATH
+                           Filepath of the update proposal.
+  --signing-key-file FILEPATH
+                           Input filepath of the signing key (one or more).
+  --address STRING         Byron address (Base58-encoded).
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --fee LOVELACE           The fee amount in Lovelace.
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_alonzo.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_alonzo.cli
@@ -1,0 +1,10 @@
+Usage: cardano-cli compatible alonzo (transaction | governance)
+
+  Alonzo era commands
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  transaction              Transaction commands.
+  governance               Governance commands.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_alonzo_governance.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_alonzo_governance.cli
@@ -1,0 +1,17 @@
+Usage: cardano-cli compatible alonzo governance 
+                                                  ( create-mir-certificate
+                                                  | create-genesis-key-delegation-certificate
+                                                  | action
+                                                  )
+
+  Governance commands.
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  create-mir-certificate   Create an MIR (Move Instantaneous Rewards)
+                           certificate
+  create-genesis-key-delegation-certificate
+                           Create a genesis key delegation certificate
+  action                   Governance action commands.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_alonzo_governance_action.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_alonzo_governance_action.cli
@@ -1,0 +1,11 @@
+Usage: cardano-cli compatible alonzo governance action 
+                                                         create-protocol-parameters-update
+
+  Governance action commands.
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  create-protocol-parameters-update
+                           Create a protocol parameters update.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_alonzo_governance_action_create-protocol-parameters-update.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_alonzo_governance_action_create-protocol-parameters-update.cli
@@ -1,0 +1,104 @@
+Usage: cardano-cli compatible alonzo governance action create-protocol-parameters-update --epoch NATURAL
+                                                                                           (--genesis-verification-key-file FILEPATH)
+                                                                                           [--min-fee-linear LOVELACE]
+                                                                                           [--min-fee-constant LOVELACE]
+                                                                                           [--max-block-body-size WORD32]
+                                                                                           [--max-tx-size WORD32]
+                                                                                           [--max-block-header-size WORD16]
+                                                                                           [--key-reg-deposit-amt NATURAL]
+                                                                                           [--pool-reg-deposit NATURAL]
+                                                                                           [--pool-retirement-epoch-interval WORD32]
+                                                                                           [--number-of-pools NATURAL]
+                                                                                           [--pool-influence RATIONAL]
+                                                                                           [--treasury-expansion RATIONAL]
+                                                                                           [--monetary-expansion RATIONAL]
+                                                                                           [--min-pool-cost NATURAL]
+                                                                                           [ --extra-entropy HEX
+                                                                                           | --reset-extra-entropy
+                                                                                           ]
+                                                                                           [--decentralization-parameter RATIONAL]
+                                                                                           [--price-execution-steps RATIONAL
+                                                                                             --price-execution-memory RATIONAL]
+                                                                                           [--max-tx-execution-units (INT, INT)]
+                                                                                           [--max-block-execution-units (INT, INT)]
+                                                                                           [--max-value-size INT]
+                                                                                           [--collateral-percent INT]
+                                                                                           [--max-collateral-inputs INT]
+                                                                                           [--protocol-major-version MAJOR
+                                                                                             --protocol-minor-version MINOR]
+                                                                                           [--cost-model-file FILE]
+                                                                                           --out-file FILEPATH
+
+  Create a protocol parameters update.
+
+Available options:
+  --epoch NATURAL          The epoch number in which the update proposal is
+                           valid.
+  --genesis-verification-key-file FILEPATH
+                           Filepath of the genesis verification key.
+  --min-fee-linear LOVELACE
+                           The linear factor per byte for the minimum fee
+                           calculation.
+  --min-fee-constant LOVELACE
+                           The constant factor for the minimum fee calculation.
+  --max-block-body-size WORD32
+                           Maximal block body size.
+  --max-tx-size WORD32     Maximum transaction size.
+  --max-block-header-size WORD16
+                           Maximum block header size.
+  --key-reg-deposit-amt NATURAL
+                           Key registration deposit amount.
+  --pool-reg-deposit NATURAL
+                           The amount of a pool registration deposit.
+  --pool-retirement-epoch-interval WORD32
+                           Epoch interval of pool retirement.
+  --number-of-pools NATURAL
+                           Desired number of pools.
+  --pool-influence RATIONAL
+                           Pool influence.
+  --treasury-expansion RATIONAL
+                           Treasury expansion.
+  --monetary-expansion RATIONAL
+                           Monetary expansion.
+  --min-pool-cost NATURAL  The minimum allowed cost parameter for stake pools.
+  --extra-entropy HEX      Praos extra entropy seed, as a hex byte string.
+  --reset-extra-entropy    Reset the Praos extra entropy to none.
+  --decentralization-parameter RATIONAL
+                           Decentralization parameter.
+  --price-execution-steps RATIONAL
+                           Step price of execution units for script languages
+                           that use them (from Alonzo era). (Examples: '1.1',
+                           '11/10')
+  --price-execution-memory RATIONAL
+                           Memory price of execution units for script languages
+                           that use them (from Alonzo era). (Examples: '1.1',
+                           '11/10')
+  --max-tx-execution-units (INT, INT)
+                           Max total script execution resources units allowed
+                           per tx (from Alonzo era). They are denominated as
+                           follows (steps, memory).
+  --max-block-execution-units (INT, INT)
+                           Max total script execution resources units allowed
+                           per block (from Alonzo era). They are denominated as
+                           follows (steps, memory).
+  --max-value-size INT     Max size of a multi-asset value in a tx output (from
+                           Alonzo era).
+  --collateral-percent INT The percentage of the script contribution to the
+                           txfee that must be provided as collateral inputs when
+                           including Plutus scripts (from Alonzo era).
+  --max-collateral-inputs INT
+                           The maximum number of collateral inputs allowed in a
+                           transaction (from Alonzo era).
+  --protocol-major-version MAJOR
+                           Specify the major protocol version to fork into. An
+                           increase indicates a hard fork. It must be the next
+                           natural number after the current version and must be
+                           supported by the node.
+  --protocol-minor-version MINOR
+                           Minor protocol version. An increase indicates a soft
+                           fork (old software can validate but not produce new
+                           blocks). Must be zero when the major protocol version
+                           is increased.
+  --cost-model-file FILE   Filepath of the JSON formatted cost model
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_alonzo_governance_create-genesis-key-delegation-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_alonzo_governance_create-genesis-key-delegation-certificate.cli
@@ -1,0 +1,38 @@
+Usage: cardano-cli compatible alonzo governance create-genesis-key-delegation-certificate 
+                                                                                            ( --genesis-verification-key STRING
+                                                                                            | --genesis-verification-key-file FILEPATH
+                                                                                            | --genesis-verification-key-hash STRING
+                                                                                            )
+                                                                                            ( --genesis-delegate-verification-key STRING
+                                                                                            | --genesis-delegate-verification-key-file FILEPATH
+                                                                                            | --genesis-delegate-verification-key-hash STRING
+                                                                                            )
+                                                                                            ( --vrf-verification-key STRING
+                                                                                            | --vrf-verification-key-file FILEPATH
+                                                                                            | --vrf-verification-key-hash STRING
+                                                                                            )
+                                                                                            --out-file FILEPATH
+
+  Create a genesis key delegation certificate
+
+Available options:
+  --genesis-verification-key STRING
+                           Genesis verification key (hex-encoded).
+  --genesis-verification-key-file FILEPATH
+                           Filepath of the genesis verification key.
+  --genesis-verification-key-hash STRING
+                           Genesis verification key hash (hex-encoded).
+  --genesis-delegate-verification-key STRING
+                           Genesis delegate verification key (hex-encoded).
+  --genesis-delegate-verification-key-file FILEPATH
+                           Filepath of the genesis delegate verification key.
+  --genesis-delegate-verification-key-hash STRING
+                           Genesis delegate verification key hash (hex-encoded).
+  --vrf-verification-key STRING
+                           VRF verification key (Bech32 or hex-encoded).
+  --vrf-verification-key-file FILEPATH
+                           Filepath of the VRF verification key.
+  --vrf-verification-key-hash STRING
+                           VRF verification key hash (hex-encoded).
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_alonzo_governance_create-mir-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_alonzo_governance_create-mir-certificate.cli
@@ -1,0 +1,28 @@
+Usage: cardano-cli compatible alonzo governance create-mir-certificate 
+                                                                         ( ( --reserves
+                                                                           | --treasury
+                                                                           )
+                                                                           (--stake-address ADDRESS)
+                                                                           (--reward LOVELACE)
+                                                                           --out-file FILEPATH
+                                                                         | stake-addresses
+                                                                         | transfer-to-treasury
+                                                                         | transfer-to-rewards
+                                                                         )
+
+  Create an MIR (Move Instantaneous Rewards) certificate
+
+Available options:
+  --reserves               Use the reserves pot.
+  --treasury               Use the treasury pot.
+  --stake-address ADDRESS  Target stake address (bech32 format).
+  --reward LOVELACE        The reward for the relevant reward account.
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text
+
+Available commands:
+  stake-addresses          Create an MIR certificate to pay stake addresses
+  transfer-to-treasury     Create an MIR certificate to transfer from the
+                           reserves pot to the treasury pot
+  transfer-to-rewards      Create an MIR certificate to transfer from the
+                           treasury pot to the reserves pot

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_alonzo_governance_create-mir-certificate_stake-addresses.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_alonzo_governance_create-mir-certificate_stake-addresses.cli
@@ -1,0 +1,17 @@
+Usage: cardano-cli compatible alonzo governance create-mir-certificate stake-addresses 
+                                                                                         ( --reserves
+                                                                                         | --treasury
+                                                                                         )
+                                                                                         (--stake-address ADDRESS)
+                                                                                         (--reward LOVELACE)
+                                                                                         --out-file FILEPATH
+
+  Create an MIR certificate to pay stake addresses
+
+Available options:
+  --reserves               Use the reserves pot.
+  --treasury               Use the treasury pot.
+  --stake-address ADDRESS  Target stake address (bech32 format).
+  --reward LOVELACE        The reward for the relevant reward account.
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_alonzo_governance_create-mir-certificate_transfer-to-rewards.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_alonzo_governance_create-mir-certificate_transfer-to-rewards.cli
@@ -1,0 +1,10 @@
+Usage: cardano-cli compatible alonzo governance create-mir-certificate transfer-to-rewards --transfer LOVELACE
+                                                                                             --out-file FILEPATH
+
+  Create an MIR certificate to transfer from the treasury pot to the reserves
+  pot
+
+Available options:
+  --transfer LOVELACE      The amount to transfer.
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_alonzo_governance_create-mir-certificate_transfer-to-treasury.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_alonzo_governance_create-mir-certificate_transfer-to-treasury.cli
@@ -1,0 +1,10 @@
+Usage: cardano-cli compatible alonzo governance create-mir-certificate transfer-to-treasury --transfer LOVELACE
+                                                                                              --out-file FILEPATH
+
+  Create an MIR certificate to transfer from the reserves pot to the treasury
+  pot
+
+Available options:
+  --transfer LOVELACE      The amount to transfer.
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_alonzo_transaction_signed-transaction.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_alonzo_transaction_signed-transaction.cli
@@ -1,0 +1,67 @@
+Usage: cardano-cli compatible alonzo transaction signed-transaction 
+                                                                      [--tx-in TX-IN]
+                                                                      [--tx-out ADDRESS VALUE
+                                                                        [ --tx-out-datum-hash HASH
+                                                                        | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                                        | --tx-out-datum-hash-file JSON_FILE
+                                                                        | --tx-out-datum-hash-value JSON_VALUE
+                                                                        | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                                        | --tx-out-datum-embed-file JSON_FILE
+                                                                        | --tx-out-datum-embed-value JSON_VALUE
+                                                                        ]]
+                                                                      [--update-proposal-file FILEPATH]
+                                                                      [--signing-key-file FILEPATH
+                                                                        [--address STRING]]
+                                                                      [ --mainnet
+                                                                      | --testnet-magic NATURAL
+                                                                      ]
+                                                                      --fee LOVELACE
+                                                                      --out-file FILEPATH
+
+  Create a simple signed transaction.
+
+Available options:
+  --tx-in TX-IN            TxId#TxIx
+  --tx-out ADDRESS VALUE   The transaction output as ADDRESS VALUE where ADDRESS
+                           is the Bech32-encoded address followed by the value
+                           in the multi-asset syntax (including simply
+                           Lovelace).
+  --tx-out-datum-hash HASH The script datum hash for this tx output, as the raw
+                           datum hash (in hex).
+  --tx-out-datum-hash-cbor-file CBOR_FILE
+                           The script datum hash for this tx output, by hashing
+                           the script datum in the file. The file has to be in
+                           CBOR format.
+  --tx-out-datum-hash-file JSON_FILE
+                           The script datum hash for this tx output, by hashing
+                           the script datum in the file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-datum-hash-value JSON_VALUE
+                           The script datum hash for this tx output, by hashing
+                           the script datum given here. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --tx-out-datum-embed-cbor-file CBOR_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file has to be in CBOR format.
+  --tx-out-datum-embed-file JSON_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file must follow the detailed
+                           JSON schema for script data.
+  --tx-out-datum-embed-value JSON_VALUE
+                           The script datum to embed in the tx for this output,
+                           given here. There is no schema: (almost) any JSON
+                           value is supported, including top-level strings and
+                           numbers.
+  --update-proposal-file FILEPATH
+                           Filepath of the update proposal.
+  --signing-key-file FILEPATH
+                           Input filepath of the signing key (one or more).
+  --address STRING         Byron address (Base58-encoded).
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --fee LOVELACE           The fee amount in Lovelace.
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_babbage.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_babbage.cli
@@ -1,0 +1,10 @@
+Usage: cardano-cli compatible babbage (transaction | governance)
+
+  Babbage era commands
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  transaction              Transaction commands.
+  governance               Governance commands.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_babbage_governance.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_babbage_governance.cli
@@ -1,0 +1,23 @@
+Usage: cardano-cli compatible babbage governance 
+                                                   ( create-mir-certificate
+                                                   | create-genesis-key-delegation-certificate
+                                                   | action
+                                                   | create-poll
+                                                   | answer-poll
+                                                   | verify-poll
+                                                   )
+
+  Governance commands.
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  create-mir-certificate   Create an MIR (Move Instantaneous Rewards)
+                           certificate
+  create-genesis-key-delegation-certificate
+                           Create a genesis key delegation certificate
+  action                   Governance action commands.
+  create-poll              Create an SPO poll
+  answer-poll              Answer an SPO poll
+  verify-poll              Verify an answer to a given SPO poll

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_babbage_governance_action.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_babbage_governance_action.cli
@@ -1,0 +1,11 @@
+Usage: cardano-cli compatible babbage governance action 
+                                                          create-protocol-parameters-update
+
+  Governance action commands.
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  create-protocol-parameters-update
+                           Create a protocol parameters update.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_babbage_governance_action_create-protocol-parameters-update.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_babbage_governance_action_create-protocol-parameters-update.cli
@@ -1,0 +1,100 @@
+Usage: cardano-cli compatible babbage governance action create-protocol-parameters-update --epoch NATURAL
+                                                                                            (--genesis-verification-key-file FILEPATH)
+                                                                                            [--min-fee-linear LOVELACE]
+                                                                                            [--min-fee-constant LOVELACE]
+                                                                                            [--max-block-body-size WORD32]
+                                                                                            [--max-tx-size WORD32]
+                                                                                            [--max-block-header-size WORD16]
+                                                                                            [--key-reg-deposit-amt NATURAL]
+                                                                                            [--pool-reg-deposit NATURAL]
+                                                                                            [--pool-retirement-epoch-interval WORD32]
+                                                                                            [--number-of-pools NATURAL]
+                                                                                            [--pool-influence RATIONAL]
+                                                                                            [--treasury-expansion RATIONAL]
+                                                                                            [--monetary-expansion RATIONAL]
+                                                                                            [--min-pool-cost NATURAL]
+                                                                                            [--price-execution-steps RATIONAL
+                                                                                              --price-execution-memory RATIONAL]
+                                                                                            [--max-tx-execution-units (INT, INT)]
+                                                                                            [--max-block-execution-units (INT, INT)]
+                                                                                            [--max-value-size INT]
+                                                                                            [--collateral-percent INT]
+                                                                                            [--max-collateral-inputs INT]
+                                                                                            [--protocol-major-version MAJOR
+                                                                                              --protocol-minor-version MINOR]
+                                                                                            [--utxo-cost-per-byte LOVELACE]
+                                                                                            [--cost-model-file FILE]
+                                                                                            --out-file FILEPATH
+
+  Create a protocol parameters update.
+
+Available options:
+  --epoch NATURAL          The epoch number in which the update proposal is
+                           valid.
+  --genesis-verification-key-file FILEPATH
+                           Filepath of the genesis verification key.
+  --min-fee-linear LOVELACE
+                           The linear factor per byte for the minimum fee
+                           calculation.
+  --min-fee-constant LOVELACE
+                           The constant factor for the minimum fee calculation.
+  --max-block-body-size WORD32
+                           Maximal block body size.
+  --max-tx-size WORD32     Maximum transaction size.
+  --max-block-header-size WORD16
+                           Maximum block header size.
+  --key-reg-deposit-amt NATURAL
+                           Key registration deposit amount.
+  --pool-reg-deposit NATURAL
+                           The amount of a pool registration deposit.
+  --pool-retirement-epoch-interval WORD32
+                           Epoch interval of pool retirement.
+  --number-of-pools NATURAL
+                           Desired number of pools.
+  --pool-influence RATIONAL
+                           Pool influence.
+  --treasury-expansion RATIONAL
+                           Treasury expansion.
+  --monetary-expansion RATIONAL
+                           Monetary expansion.
+  --min-pool-cost NATURAL  The minimum allowed cost parameter for stake pools.
+  --price-execution-steps RATIONAL
+                           Step price of execution units for script languages
+                           that use them (from Alonzo era). (Examples: '1.1',
+                           '11/10')
+  --price-execution-memory RATIONAL
+                           Memory price of execution units for script languages
+                           that use them (from Alonzo era). (Examples: '1.1',
+                           '11/10')
+  --max-tx-execution-units (INT, INT)
+                           Max total script execution resources units allowed
+                           per tx (from Alonzo era). They are denominated as
+                           follows (steps, memory).
+  --max-block-execution-units (INT, INT)
+                           Max total script execution resources units allowed
+                           per block (from Alonzo era). They are denominated as
+                           follows (steps, memory).
+  --max-value-size INT     Max size of a multi-asset value in a tx output (from
+                           Alonzo era).
+  --collateral-percent INT The percentage of the script contribution to the
+                           txfee that must be provided as collateral inputs when
+                           including Plutus scripts (from Alonzo era).
+  --max-collateral-inputs INT
+                           The maximum number of collateral inputs allowed in a
+                           transaction (from Alonzo era).
+  --protocol-major-version MAJOR
+                           Specify the major protocol version to fork into. An
+                           increase indicates a hard fork. It must be the next
+                           natural number after the current version and must be
+                           supported by the node.
+  --protocol-minor-version MINOR
+                           Minor protocol version. An increase indicates a soft
+                           fork (old software can validate but not produce new
+                           blocks). Must be zero when the major protocol version
+                           is increased.
+  --utxo-cost-per-byte LOVELACE
+                           Cost in lovelace per unit of UTxO storage (from
+                           Babbage era).
+  --cost-model-file FILE   Filepath of the JSON formatted cost model
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_babbage_governance_answer-poll.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_babbage_governance_answer-poll.cli
@@ -1,0 +1,12 @@
+Usage: cardano-cli compatible babbage governance answer-poll --poll-file FILEPATH
+                                                               [--answer INT]
+                                                               [--out-file FILEPATH]
+
+  Answer an SPO poll
+
+Available options:
+  --poll-file FILEPATH     Filepath to the ongoing poll.
+  --answer INT             The index of the chosen answer in the poll. Optional.
+                           Asked interactively if omitted.
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_babbage_governance_create-genesis-key-delegation-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_babbage_governance_create-genesis-key-delegation-certificate.cli
@@ -1,0 +1,38 @@
+Usage: cardano-cli compatible babbage governance create-genesis-key-delegation-certificate 
+                                                                                             ( --genesis-verification-key STRING
+                                                                                             | --genesis-verification-key-file FILEPATH
+                                                                                             | --genesis-verification-key-hash STRING
+                                                                                             )
+                                                                                             ( --genesis-delegate-verification-key STRING
+                                                                                             | --genesis-delegate-verification-key-file FILEPATH
+                                                                                             | --genesis-delegate-verification-key-hash STRING
+                                                                                             )
+                                                                                             ( --vrf-verification-key STRING
+                                                                                             | --vrf-verification-key-file FILEPATH
+                                                                                             | --vrf-verification-key-hash STRING
+                                                                                             )
+                                                                                             --out-file FILEPATH
+
+  Create a genesis key delegation certificate
+
+Available options:
+  --genesis-verification-key STRING
+                           Genesis verification key (hex-encoded).
+  --genesis-verification-key-file FILEPATH
+                           Filepath of the genesis verification key.
+  --genesis-verification-key-hash STRING
+                           Genesis verification key hash (hex-encoded).
+  --genesis-delegate-verification-key STRING
+                           Genesis delegate verification key (hex-encoded).
+  --genesis-delegate-verification-key-file FILEPATH
+                           Filepath of the genesis delegate verification key.
+  --genesis-delegate-verification-key-hash STRING
+                           Genesis delegate verification key hash (hex-encoded).
+  --vrf-verification-key STRING
+                           VRF verification key (Bech32 or hex-encoded).
+  --vrf-verification-key-file FILEPATH
+                           Filepath of the VRF verification key.
+  --vrf-verification-key-hash STRING
+                           VRF verification key hash (hex-encoded).
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_babbage_governance_create-mir-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_babbage_governance_create-mir-certificate.cli
@@ -1,0 +1,28 @@
+Usage: cardano-cli compatible babbage governance create-mir-certificate 
+                                                                          ( ( --reserves
+                                                                            | --treasury
+                                                                            )
+                                                                            (--stake-address ADDRESS)
+                                                                            (--reward LOVELACE)
+                                                                            --out-file FILEPATH
+                                                                          | stake-addresses
+                                                                          | transfer-to-treasury
+                                                                          | transfer-to-rewards
+                                                                          )
+
+  Create an MIR (Move Instantaneous Rewards) certificate
+
+Available options:
+  --reserves               Use the reserves pot.
+  --treasury               Use the treasury pot.
+  --stake-address ADDRESS  Target stake address (bech32 format).
+  --reward LOVELACE        The reward for the relevant reward account.
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text
+
+Available commands:
+  stake-addresses          Create an MIR certificate to pay stake addresses
+  transfer-to-treasury     Create an MIR certificate to transfer from the
+                           reserves pot to the treasury pot
+  transfer-to-rewards      Create an MIR certificate to transfer from the
+                           treasury pot to the reserves pot

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_babbage_governance_create-mir-certificate_stake-addresses.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_babbage_governance_create-mir-certificate_stake-addresses.cli
@@ -1,0 +1,17 @@
+Usage: cardano-cli compatible babbage governance create-mir-certificate stake-addresses 
+                                                                                          ( --reserves
+                                                                                          | --treasury
+                                                                                          )
+                                                                                          (--stake-address ADDRESS)
+                                                                                          (--reward LOVELACE)
+                                                                                          --out-file FILEPATH
+
+  Create an MIR certificate to pay stake addresses
+
+Available options:
+  --reserves               Use the reserves pot.
+  --treasury               Use the treasury pot.
+  --stake-address ADDRESS  Target stake address (bech32 format).
+  --reward LOVELACE        The reward for the relevant reward account.
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_babbage_governance_create-mir-certificate_transfer-to-rewards.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_babbage_governance_create-mir-certificate_transfer-to-rewards.cli
@@ -1,0 +1,10 @@
+Usage: cardano-cli compatible babbage governance create-mir-certificate transfer-to-rewards --transfer LOVELACE
+                                                                                              --out-file FILEPATH
+
+  Create an MIR certificate to transfer from the treasury pot to the reserves
+  pot
+
+Available options:
+  --transfer LOVELACE      The amount to transfer.
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_babbage_governance_create-mir-certificate_transfer-to-treasury.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_babbage_governance_create-mir-certificate_transfer-to-treasury.cli
@@ -1,0 +1,10 @@
+Usage: cardano-cli compatible babbage governance create-mir-certificate transfer-to-treasury --transfer LOVELACE
+                                                                                               --out-file FILEPATH
+
+  Create an MIR certificate to transfer from the reserves pot to the treasury
+  pot
+
+Available options:
+  --transfer LOVELACE      The amount to transfer.
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_babbage_governance_create-poll.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_babbage_governance_create-poll.cli
@@ -1,0 +1,14 @@
+Usage: cardano-cli compatible babbage governance create-poll --question STRING
+                                                               (--answer STRING)
+                                                               [--nonce UINT]
+                                                               --out-file FILEPATH
+
+  Create an SPO poll
+
+Available options:
+  --question STRING        The question for the poll.
+  --answer STRING          A possible choice for the poll. The option is
+                           repeatable.
+  --nonce UINT             An (optional) nonce for non-replayability.
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_babbage_governance_verify-poll.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_babbage_governance_verify-poll.cli
@@ -1,0 +1,12 @@
+Usage: cardano-cli compatible babbage governance verify-poll --poll-file FILEPATH
+                                                               --tx-file FILEPATH
+                                                               [--out-file FILEPATH]
+
+  Verify an answer to a given SPO poll
+
+Available options:
+  --poll-file FILEPATH     Filepath to the ongoing poll.
+  --tx-file FILEPATH       Filepath to the JSON TxBody or JSON Tx carrying a
+                           valid poll answer.
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_babbage_transaction_signed-transaction.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_babbage_transaction_signed-transaction.cli
@@ -1,0 +1,83 @@
+Usage: cardano-cli compatible babbage transaction signed-transaction 
+                                                                       [--tx-in TX-IN]
+                                                                       [--tx-out ADDRESS VALUE
+                                                                         [ --tx-out-datum-hash HASH
+                                                                         | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                                         | --tx-out-datum-hash-file JSON_FILE
+                                                                         | --tx-out-datum-hash-value JSON_VALUE
+                                                                         | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                                         | --tx-out-datum-embed-file JSON_FILE
+                                                                         | --tx-out-datum-embed-value JSON_VALUE
+                                                                         | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                                         | --tx-out-inline-datum-file JSON_FILE
+                                                                         | --tx-out-inline-datum-value JSON_VALUE
+                                                                         ]]
+                                                                       [--update-proposal-file FILEPATH]
+                                                                       [--signing-key-file FILEPATH
+                                                                         [--address STRING]]
+                                                                       [ --mainnet
+                                                                       | --testnet-magic NATURAL
+                                                                       ]
+                                                                       --fee LOVELACE
+                                                                       --out-file FILEPATH
+
+  Create a simple signed transaction.
+
+Available options:
+  --tx-in TX-IN            TxId#TxIx
+  --tx-out ADDRESS VALUE   The transaction output as ADDRESS VALUE where ADDRESS
+                           is the Bech32-encoded address followed by the value
+                           in the multi-asset syntax (including simply
+                           Lovelace).
+  --tx-out-datum-hash HASH The script datum hash for this tx output, as the raw
+                           datum hash (in hex).
+  --tx-out-datum-hash-cbor-file CBOR_FILE
+                           The script datum hash for this tx output, by hashing
+                           the script datum in the file. The file has to be in
+                           CBOR format.
+  --tx-out-datum-hash-file JSON_FILE
+                           The script datum hash for this tx output, by hashing
+                           the script datum in the file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-datum-hash-value JSON_VALUE
+                           The script datum hash for this tx output, by hashing
+                           the script datum given here. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --tx-out-datum-embed-cbor-file CBOR_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file has to be in CBOR format.
+  --tx-out-datum-embed-file JSON_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file must follow the detailed
+                           JSON schema for script data.
+  --tx-out-datum-embed-value JSON_VALUE
+                           The script datum to embed in the tx for this output,
+                           given here. There is no schema: (almost) any JSON
+                           value is supported, including top-level strings and
+                           numbers.
+  --tx-out-inline-datum-cbor-file CBOR_FILE
+                           The script datum to embed in the tx output as an
+                           inline datum, in the given file. The file has to be
+                           in CBOR format.
+  --tx-out-inline-datum-file JSON_FILE
+                           The script datum to embed in the tx output as an
+                           inline datum, in the given file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-inline-datum-value JSON_VALUE
+                           The script datum to embed in the tx output as an
+                           inline datum, given here. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --update-proposal-file FILEPATH
+                           Filepath of the update proposal.
+  --signing-key-file FILEPATH
+                           Input filepath of the signing key (one or more).
+  --address STRING         Byron address (Base58-encoded).
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --fee LOVELACE           The fee amount in Lovelace.
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway.cli
@@ -1,0 +1,10 @@
+Usage: cardano-cli compatible conway (transaction | governance)
+
+  Conway era commands
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  transaction              Transaction commands.
+  governance               Governance commands.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_governance.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_governance.cli
@@ -1,0 +1,17 @@
+Usage: cardano-cli compatible conway governance 
+                                                  ( action
+                                                  | committee
+                                                  | drep
+                                                  | vote
+                                                  )
+
+  Governance commands.
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  action                   Governance action commands.
+  committee                Committee member commands.
+  drep                     DRep member commands.
+  vote                     Vote commands.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_governance_action.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_governance_action.cli
@@ -1,0 +1,27 @@
+Usage: cardano-cli compatible conway governance action 
+                                                         ( create-constitution
+                                                         | update-committee
+                                                         | create-info
+                                                         | create-no-confidence
+                                                         | create-protocol-parameters-update
+                                                         | create-treasury-withdrawal
+                                                         | create-hardfork
+                                                         | view
+                                                         )
+
+  Governance action commands.
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  create-constitution      Create a constitution.
+  update-committee         Create or update a new committee proposal.
+  create-info              Create an info action.
+  create-no-confidence     Create a no confidence proposal.
+  create-protocol-parameters-update
+                           Create a protocol parameters update.
+  create-treasury-withdrawal
+                           Create a treasury withdrawal.
+  create-hardfork          Create a hardfork initiation proposal.
+  view                     View a governance action.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_governance_action_create-constitution.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_governance_action_create-constitution.cli
@@ -1,0 +1,64 @@
+Usage: cardano-cli compatible conway governance action create-constitution 
+                                                                             ( --mainnet
+                                                                             | --testnet
+                                                                             )
+                                                                             --governance-action-deposit NATURAL
+                                                                             ( --deposit-return-stake-verification-key STRING
+                                                                             | --deposit-return-stake-verification-key-file FILEPATH
+                                                                             | --deposit-return-stake-key-hash HASH
+                                                                             | --deposit-return-stake-script-file FILEPATH
+                                                                             | --deposit-return-stake-address ADDRESS
+                                                                             )
+                                                                             [--prev-governance-action-tx-id TXID
+                                                                               --prev-governance-action-index WORD16]
+                                                                             --anchor-url TEXT
+                                                                             --anchor-data-hash HASH
+                                                                             [--check-anchor-data]
+                                                                             --constitution-url TEXT
+                                                                             --constitution-hash HASH
+                                                                             [--check-constitution-hash]
+                                                                             [--constitution-script-hash HASH]
+                                                                             --out-file FILEPATH
+
+  Create a constitution.
+
+Available options:
+  --mainnet                Use the mainnet magic id.
+  --testnet                Use the testnet magic id.
+  --governance-action-deposit NATURAL
+                           Deposit required to submit a governance action.
+  --deposit-return-stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --deposit-return-stake-verification-key-file FILEPATH
+                           Filepath of the staking verification key.
+  --deposit-return-stake-key-hash HASH
+                           Stake verification key hash (hex-encoded).
+  --deposit-return-stake-script-file FILEPATH
+                           Filepath of the staking script.
+  --deposit-return-stake-address ADDRESS
+                           Target stake address (bech32 format).
+  --prev-governance-action-tx-id TXID
+                           Txid of the previous governance action.
+  --prev-governance-action-index WORD16
+                           Action index of the previous governance action.
+  --anchor-url TEXT        Anchor URL
+  --anchor-data-hash HASH  Proposal anchor data hash (obtain it with
+                           "cardano-cli hash anchor-data ...")
+  --check-anchor-data      Verify that the expected proposal hash provided in
+                           --anchor-data-hash matches the hash of the file
+                           downloaded from the URL provided in --anchor-url
+                           (this parameter will download the file from the URL)
+  --constitution-url TEXT  Constitution URL.
+  --constitution-hash HASH Hash of the constitution data (obtain it with
+                           "cardano-cli hash anchor-data ...").
+  --check-constitution-hash
+                           Verify that the expected constitution hash provided
+                           in --constitution-hash matches the hash of the file
+                           downloaded from the URL provided in
+                           --constitution-url (this parameter will download the
+                           file from the URL)
+  --constitution-script-hash HASH
+                           Constitution script hash (hex-encoded). Obtain it
+                           with "cardano-cli hash script ...".
+  --out-file FILEPATH      Output filepath of the constitution.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_governance_action_create-hardfork.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_governance_action_create-hardfork.cli
@@ -1,0 +1,60 @@
+Usage: cardano-cli compatible conway governance action create-hardfork 
+                                                                         ( --mainnet
+                                                                         | --testnet
+                                                                         )
+                                                                         --governance-action-deposit NATURAL
+                                                                         ( --deposit-return-stake-verification-key STRING
+                                                                         | --deposit-return-stake-verification-key-file FILEPATH
+                                                                         | --deposit-return-stake-key-hash HASH
+                                                                         | --deposit-return-stake-script-file FILEPATH
+                                                                         | --deposit-return-stake-address ADDRESS
+                                                                         )
+                                                                         [--prev-governance-action-tx-id TXID
+                                                                           --prev-governance-action-index WORD16]
+                                                                         --anchor-url TEXT
+                                                                         --anchor-data-hash HASH
+                                                                         [--check-anchor-data]
+                                                                         --protocol-major-version MAJOR
+                                                                         --protocol-minor-version MINOR
+                                                                         --out-file FILEPATH
+
+  Create a hardfork initiation proposal.
+
+Available options:
+  --mainnet                Use the mainnet magic id.
+  --testnet                Use the testnet magic id.
+  --governance-action-deposit NATURAL
+                           Deposit required to submit a governance action.
+  --deposit-return-stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --deposit-return-stake-verification-key-file FILEPATH
+                           Filepath of the staking verification key.
+  --deposit-return-stake-key-hash HASH
+                           Stake verification key hash (hex-encoded).
+  --deposit-return-stake-script-file FILEPATH
+                           Filepath of the staking script.
+  --deposit-return-stake-address ADDRESS
+                           Target stake address (bech32 format).
+  --prev-governance-action-tx-id TXID
+                           Txid of the previous governance action.
+  --prev-governance-action-index WORD16
+                           Action index of the previous governance action.
+  --anchor-url TEXT        Anchor URL
+  --anchor-data-hash HASH  Proposal anchor data hash (obtain it with
+                           "cardano-cli hash anchor-data ...")
+  --check-anchor-data      Verify that the expected proposal hash provided in
+                           --anchor-data-hash matches the hash of the file
+                           downloaded from the URL provided in --anchor-url
+                           (this parameter will download the file from the URL)
+  --protocol-major-version MAJOR
+                           Specify the major protocol version to fork into. An
+                           increase indicates a hard fork. It must be the next
+                           natural number after the current version and must be
+                           supported by the node.
+  --protocol-minor-version MINOR
+                           Minor protocol version. An increase indicates a soft
+                           fork (old software can validate but not produce new
+                           blocks). Must be zero when the major protocol version
+                           is increased.
+  --out-file FILEPATH      Output filepath of the hardfork proposal.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_governance_action_create-info.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_governance_action_create-info.cli
@@ -1,0 +1,43 @@
+Usage: cardano-cli compatible conway governance action create-info 
+                                                                     ( --mainnet
+                                                                     | --testnet
+                                                                     )
+                                                                     --governance-action-deposit NATURAL
+                                                                     ( --deposit-return-stake-verification-key STRING
+                                                                     | --deposit-return-stake-verification-key-file FILEPATH
+                                                                     | --deposit-return-stake-key-hash HASH
+                                                                     | --deposit-return-stake-script-file FILEPATH
+                                                                     | --deposit-return-stake-address ADDRESS
+                                                                     )
+                                                                     --anchor-url TEXT
+                                                                     --anchor-data-hash HASH
+                                                                     [--check-anchor-data]
+                                                                     --out-file FILEPATH
+
+  Create an info action.
+
+Available options:
+  --mainnet                Use the mainnet magic id.
+  --testnet                Use the testnet magic id.
+  --governance-action-deposit NATURAL
+                           Deposit required to submit a governance action.
+  --deposit-return-stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --deposit-return-stake-verification-key-file FILEPATH
+                           Filepath of the staking verification key.
+  --deposit-return-stake-key-hash HASH
+                           Stake verification key hash (hex-encoded).
+  --deposit-return-stake-script-file FILEPATH
+                           Filepath of the staking script.
+  --deposit-return-stake-address ADDRESS
+                           Target stake address (bech32 format).
+  --anchor-url TEXT        Anchor URL
+  --anchor-data-hash HASH  Proposal anchor data hash (obtain it with
+                           "cardano-cli hash anchor-data ...")
+  --check-anchor-data      Verify that the expected proposal hash provided in
+                           --anchor-data-hash matches the hash of the file
+                           downloaded from the URL provided in --anchor-url
+                           (this parameter will download the file from the URL)
+  --out-file FILEPATH      Path to action file to be used later on with build or
+                           build-raw
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_governance_action_create-no-confidence.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_governance_action_create-no-confidence.cli
@@ -1,0 +1,48 @@
+Usage: cardano-cli compatible conway governance action create-no-confidence 
+                                                                              ( --mainnet
+                                                                              | --testnet
+                                                                              )
+                                                                              --governance-action-deposit NATURAL
+                                                                              ( --deposit-return-stake-verification-key STRING
+                                                                              | --deposit-return-stake-verification-key-file FILEPATH
+                                                                              | --deposit-return-stake-key-hash HASH
+                                                                              | --deposit-return-stake-script-file FILEPATH
+                                                                              | --deposit-return-stake-address ADDRESS
+                                                                              )
+                                                                              --anchor-url TEXT
+                                                                              --anchor-data-hash HASH
+                                                                              [--check-anchor-data]
+                                                                              [--prev-governance-action-tx-id TXID
+                                                                                --prev-governance-action-index WORD16]
+                                                                              --out-file FILEPATH
+
+  Create a no confidence proposal.
+
+Available options:
+  --mainnet                Use the mainnet magic id.
+  --testnet                Use the testnet magic id.
+  --governance-action-deposit NATURAL
+                           Deposit required to submit a governance action.
+  --deposit-return-stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --deposit-return-stake-verification-key-file FILEPATH
+                           Filepath of the staking verification key.
+  --deposit-return-stake-key-hash HASH
+                           Stake verification key hash (hex-encoded).
+  --deposit-return-stake-script-file FILEPATH
+                           Filepath of the staking script.
+  --deposit-return-stake-address ADDRESS
+                           Target stake address (bech32 format).
+  --anchor-url TEXT        Anchor URL
+  --anchor-data-hash HASH  Proposal anchor data hash (obtain it with
+                           "cardano-cli hash anchor-data ...")
+  --check-anchor-data      Verify that the expected proposal hash provided in
+                           --anchor-data-hash matches the hash of the file
+                           downloaded from the URL provided in --anchor-url
+                           (this parameter will download the file from the URL)
+  --prev-governance-action-tx-id TXID
+                           Txid of the previous governance action.
+  --prev-governance-action-index WORD16
+                           Action index of the previous governance action.
+  --out-file FILEPATH      Output filepath of the no confidence proposal.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_governance_action_create-protocol-parameters-update.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_governance_action_create-protocol-parameters-update.cli
@@ -1,0 +1,210 @@
+Usage: cardano-cli compatible conway governance action create-protocol-parameters-update 
+                                                                                           ( --mainnet
+                                                                                           | --testnet
+                                                                                           )
+                                                                                           --governance-action-deposit NATURAL
+                                                                                           ( --deposit-return-stake-verification-key STRING
+                                                                                           | --deposit-return-stake-verification-key-file FILEPATH
+                                                                                           | --deposit-return-stake-key-hash HASH
+                                                                                           | --deposit-return-stake-script-file FILEPATH
+                                                                                           | --deposit-return-stake-address ADDRESS
+                                                                                           )
+                                                                                           --anchor-url TEXT
+                                                                                           --anchor-data-hash HASH
+                                                                                           [--check-anchor-data]
+                                                                                           [--prev-governance-action-tx-id TXID
+                                                                                             --prev-governance-action-index WORD16]
+                                                                                           [--constitution-script-hash HASH]
+                                                                                           [--min-fee-linear LOVELACE]
+                                                                                           [--min-fee-constant LOVELACE]
+                                                                                           [--max-block-body-size WORD32]
+                                                                                           [--max-tx-size WORD32]
+                                                                                           [--max-block-header-size WORD16]
+                                                                                           [--key-reg-deposit-amt NATURAL]
+                                                                                           [--pool-reg-deposit NATURAL]
+                                                                                           [--pool-retirement-epoch-interval WORD32]
+                                                                                           [--number-of-pools NATURAL]
+                                                                                           [--pool-influence RATIONAL]
+                                                                                           [--treasury-expansion RATIONAL]
+                                                                                           [--monetary-expansion RATIONAL]
+                                                                                           [--min-pool-cost NATURAL]
+                                                                                           [--price-execution-steps RATIONAL
+                                                                                             --price-execution-memory RATIONAL]
+                                                                                           [--max-tx-execution-units (INT, INT)]
+                                                                                           [--max-block-execution-units (INT, INT)]
+                                                                                           [--max-value-size INT]
+                                                                                           [--collateral-percent INT]
+                                                                                           [--max-collateral-inputs INT]
+                                                                                           [--utxo-cost-per-byte LOVELACE]
+                                                                                           [--pool-voting-threshold-motion-no-confidence RATIONAL
+                                                                                             --pool-voting-threshold-committee-normal RATIONAL
+                                                                                             --pool-voting-threshold-committee-no-confidence RATIONAL
+                                                                                             --pool-voting-threshold-hard-fork-initiation RATIONAL
+                                                                                             --pool-voting-threshold-pp-security-group RATIONAL]
+                                                                                           [--drep-voting-threshold-motion-no-confidence RATIONAL
+                                                                                             --drep-voting-threshold-committee-normal RATIONAL
+                                                                                             --drep-voting-threshold-committee-no-confidence RATIONAL
+                                                                                             --drep-voting-threshold-update-to-constitution RATIONAL
+                                                                                             --drep-voting-threshold-hard-fork-initiation RATIONAL
+                                                                                             --drep-voting-threshold-pp-network-group RATIONAL
+                                                                                             --drep-voting-threshold-pp-economic-group RATIONAL
+                                                                                             --drep-voting-threshold-pp-technical-group RATIONAL
+                                                                                             --drep-voting-threshold-pp-governance-group RATIONAL
+                                                                                             --drep-voting-threshold-treasury-withdrawal RATIONAL]
+                                                                                           [--min-committee-size INT]
+                                                                                           [--committee-term-length WORD32]
+                                                                                           [--governance-action-lifetime WORD32]
+                                                                                           [--new-governance-action-deposit NATURAL]
+                                                                                           [--drep-deposit LOVELACE]
+                                                                                           [--drep-activity WORD32]
+                                                                                           [--ref-script-cost-per-byte RATIONAL]
+                                                                                           [--cost-model-file FILE]
+                                                                                           --out-file FILEPATH
+
+  Create a protocol parameters update.
+
+Available options:
+  --mainnet                Use the mainnet magic id.
+  --testnet                Use the testnet magic id.
+  --governance-action-deposit NATURAL
+                           Deposit required to submit a governance action.
+  --deposit-return-stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --deposit-return-stake-verification-key-file FILEPATH
+                           Filepath of the staking verification key.
+  --deposit-return-stake-key-hash HASH
+                           Stake verification key hash (hex-encoded).
+  --deposit-return-stake-script-file FILEPATH
+                           Filepath of the staking script.
+  --deposit-return-stake-address ADDRESS
+                           Target stake address (bech32 format).
+  --anchor-url TEXT        Anchor URL
+  --anchor-data-hash HASH  Proposal anchor data hash (obtain it with
+                           "cardano-cli hash anchor-data ...")
+  --check-anchor-data      Verify that the expected proposal hash provided in
+                           --anchor-data-hash matches the hash of the file
+                           downloaded from the URL provided in --anchor-url
+                           (this parameter will download the file from the URL)
+  --prev-governance-action-tx-id TXID
+                           Txid of the previous governance action.
+  --prev-governance-action-index WORD16
+                           Action index of the previous governance action.
+  --constitution-script-hash HASH
+                           Constitution script hash (hex-encoded). Obtain it
+                           with "cardano-cli hash script ...".
+  --min-fee-linear LOVELACE
+                           The linear factor per byte for the minimum fee
+                           calculation.
+  --min-fee-constant LOVELACE
+                           The constant factor for the minimum fee calculation.
+  --max-block-body-size WORD32
+                           Maximal block body size.
+  --max-tx-size WORD32     Maximum transaction size.
+  --max-block-header-size WORD16
+                           Maximum block header size.
+  --key-reg-deposit-amt NATURAL
+                           Key registration deposit amount.
+  --pool-reg-deposit NATURAL
+                           The amount of a pool registration deposit.
+  --pool-retirement-epoch-interval WORD32
+                           Epoch interval of pool retirement.
+  --number-of-pools NATURAL
+                           Desired number of pools.
+  --pool-influence RATIONAL
+                           Pool influence.
+  --treasury-expansion RATIONAL
+                           Treasury expansion.
+  --monetary-expansion RATIONAL
+                           Monetary expansion.
+  --min-pool-cost NATURAL  The minimum allowed cost parameter for stake pools.
+  --price-execution-steps RATIONAL
+                           Step price of execution units for script languages
+                           that use them (from Alonzo era). (Examples: '1.1',
+                           '11/10')
+  --price-execution-memory RATIONAL
+                           Memory price of execution units for script languages
+                           that use them (from Alonzo era). (Examples: '1.1',
+                           '11/10')
+  --max-tx-execution-units (INT, INT)
+                           Max total script execution resources units allowed
+                           per tx (from Alonzo era). They are denominated as
+                           follows (steps, memory).
+  --max-block-execution-units (INT, INT)
+                           Max total script execution resources units allowed
+                           per block (from Alonzo era). They are denominated as
+                           follows (steps, memory).
+  --max-value-size INT     Max size of a multi-asset value in a tx output (from
+                           Alonzo era).
+  --collateral-percent INT The percentage of the script contribution to the
+                           txfee that must be provided as collateral inputs when
+                           including Plutus scripts (from Alonzo era).
+  --max-collateral-inputs INT
+                           The maximum number of collateral inputs allowed in a
+                           transaction (from Alonzo era).
+  --utxo-cost-per-byte LOVELACE
+                           Cost in lovelace per unit of UTxO storage (from
+                           Babbage era).
+  --pool-voting-threshold-motion-no-confidence RATIONAL
+                           Acceptance threshold for stake pool votes on motions
+                           no confidence.
+  --pool-voting-threshold-committee-normal RATIONAL
+                           Acceptance threshold for stake pool votes on normal
+                           committee updates.
+  --pool-voting-threshold-committee-no-confidence RATIONAL
+                           Acceptance threshold for stake pool votes on
+                           committee updates when the committee is in a state of
+                           no confidence.
+  --pool-voting-threshold-hard-fork-initiation RATIONAL
+                           Acceptance threshold for stake pool votes on hard
+                           fork initiations.
+  --pool-voting-threshold-pp-security-group RATIONAL
+                           Acceptance threshold for stake pool votes on protocol
+                           parameters for parameters in the 'security' group.
+  --drep-voting-threshold-motion-no-confidence RATIONAL
+                           Acceptance threshold for DRep votes on motions of no
+                           confidence.
+  --drep-voting-threshold-committee-normal RATIONAL
+                           Acceptance threshold for DRep votes on normal
+                           committee updates.
+  --drep-voting-threshold-committee-no-confidence RATIONAL
+                           Acceptance threshold for DRep votes on committee
+                           updates when the committee is in a state of no
+                           confidence.
+  --drep-voting-threshold-update-to-constitution RATIONAL
+                           Acceptance threshold for DRep votes on constitution
+                           updates.
+  --drep-voting-threshold-hard-fork-initiation RATIONAL
+                           Acceptance threshold for DRep votes on hard fork
+                           initiations.
+  --drep-voting-threshold-pp-network-group RATIONAL
+                           Acceptance threshold for DRep votes on protocol
+                           parameters for parameters in the 'network' group.
+  --drep-voting-threshold-pp-economic-group RATIONAL
+                           Acceptance threshold for DRep votes on protocol
+                           parameters for parameters in the 'economic' group.
+  --drep-voting-threshold-pp-technical-group RATIONAL
+                           Acceptance threshold for DRep votes on protocol
+                           parameters for parameters in the 'technical' group.
+  --drep-voting-threshold-pp-governance-group RATIONAL
+                           Acceptance threshold for DRep votes on protocol
+                           parameters for parameters in the 'governance' group.
+  --drep-voting-threshold-treasury-withdrawal RATIONAL
+                           Acceptance threshold for DRep votes on treasury
+                           withdrawals.
+  --min-committee-size INT Minimal size of the constitutional committee.
+  --committee-term-length WORD32
+                           Maximal term length for members of the constitutional
+                           committee, in epochs.
+  --governance-action-lifetime WORD32
+                           Maximal lifetime of governance actions, in epochs.
+  --new-governance-action-deposit NATURAL
+                           Proposed new value of the deposit required to submit
+                           a governance action.
+  --drep-deposit LOVELACE  DRep deposit amount.
+  --drep-activity WORD32   DRep activity period, in epochs.
+  --ref-script-cost-per-byte RATIONAL
+                           Reference script cost per byte for the minimum fee
+                           calculation.
+  --cost-model-file FILE   Filepath of the JSON formatted cost model
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_governance_action_create-treasury-withdrawal.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_governance_action_create-treasury-withdrawal.cli
@@ -1,0 +1,69 @@
+Usage: cardano-cli compatible conway governance action create-treasury-withdrawal 
+                                                                                    ( --mainnet
+                                                                                    | --testnet
+                                                                                    )
+                                                                                    --governance-action-deposit NATURAL
+                                                                                    ( --deposit-return-stake-verification-key STRING
+                                                                                    | --deposit-return-stake-verification-key-file FILEPATH
+                                                                                    | --deposit-return-stake-key-hash HASH
+                                                                                    | --deposit-return-stake-script-file FILEPATH
+                                                                                    | --deposit-return-stake-address ADDRESS
+                                                                                    )
+                                                                                    --anchor-url TEXT
+                                                                                    --anchor-data-hash HASH
+                                                                                    [--check-anchor-data]
+                                                                                    (
+                                                                                      ( --funds-receiving-stake-verification-key STRING
+                                                                                      | --funds-receiving-stake-verification-key-file FILEPATH
+                                                                                      | --funds-receiving-stake-key-hash HASH
+                                                                                      | --funds-receiving-stake-script-file FILEPATH
+                                                                                      | --funds-receiving-stake-address ADDRESS
+                                                                                      )
+                                                                                      --transfer LOVELACE)
+                                                                                    [--constitution-script-hash HASH]
+                                                                                    --out-file FILEPATH
+
+  Create a treasury withdrawal.
+
+Available options:
+  --mainnet                Use the mainnet magic id.
+  --testnet                Use the testnet magic id.
+  --governance-action-deposit NATURAL
+                           Deposit required to submit a governance action.
+  --deposit-return-stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --deposit-return-stake-verification-key-file FILEPATH
+                           Filepath of the staking verification key.
+  --deposit-return-stake-key-hash HASH
+                           Stake verification key hash (hex-encoded).
+  --deposit-return-stake-script-file FILEPATH
+                           Filepath of the staking script.
+  --deposit-return-stake-address ADDRESS
+                           Target stake address (bech32 format).
+  --anchor-url TEXT        Anchor URL
+  --anchor-data-hash HASH  Proposal anchor data hash (obtain it with
+                           "cardano-cli hash anchor-data ...")
+  --check-anchor-data      Verify that the expected proposal hash provided in
+                           --anchor-data-hash matches the hash of the file
+                           downloaded from the URL provided in --anchor-url
+                           (this parameter will download the file from the URL)
+  --funds-receiving-stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --funds-receiving-stake-verification-key-file FILEPATH
+                           Filepath of the staking verification key.
+  --funds-receiving-stake-key-hash HASH
+                           Stake verification key hash (hex-encoded).
+  --funds-receiving-stake-script-file FILEPATH
+                           Filepath of the staking script.
+  --funds-receiving-stake-address ADDRESS
+                           Target stake address (bech32 format).
+  --transfer LOVELACE      The amount of lovelace the proposal intends to
+                           withdraw from the Treasury. Multiple withdrawals can
+                           be proposed in a single governance action by
+                           repeating the --funds-receiving-stake and --transfer
+                           options as many times as needed.
+  --constitution-script-hash HASH
+                           Constitution script hash (hex-encoded). Obtain it
+                           with "cardano-cli hash script ...".
+  --out-file FILEPATH      Output filepath of the treasury withdrawal.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_governance_action_update-committee.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_governance_action_update-committee.cli
@@ -1,0 +1,82 @@
+Usage: cardano-cli compatible conway governance action update-committee 
+                                                                          ( --mainnet
+                                                                          | --testnet
+                                                                          )
+                                                                          --governance-action-deposit NATURAL
+                                                                          ( --deposit-return-stake-verification-key STRING
+                                                                          | --deposit-return-stake-verification-key-file FILEPATH
+                                                                          | --deposit-return-stake-key-hash HASH
+                                                                          | --deposit-return-stake-script-file FILEPATH
+                                                                          | --deposit-return-stake-address ADDRESS
+                                                                          )
+                                                                          --anchor-url TEXT
+                                                                          --anchor-data-hash HASH
+                                                                          [--check-anchor-data]
+                                                                          [ --remove-cc-cold-verification-key STRING
+                                                                          | --remove-cc-cold-verification-key-file FILEPATH
+                                                                          | --remove-cc-cold-verification-key-hash STRING
+                                                                          | --remove-cc-cold-script-hash HASH
+                                                                          ]
+                                                                          [
+                                                                            ( --add-cc-cold-verification-key STRING
+                                                                            | --add-cc-cold-verification-key-file FILEPATH
+                                                                            | --add-cc-cold-verification-key-hash STRING
+                                                                            | --add-cc-cold-script-hash HASH
+                                                                            )
+                                                                            --epoch NATURAL]
+                                                                          --threshold RATIONAL
+                                                                          [--prev-governance-action-tx-id TXID
+                                                                            --prev-governance-action-index WORD16]
+                                                                          --out-file FILEPATH
+
+  Create or update a new committee proposal.
+
+Available options:
+  --mainnet                Use the mainnet magic id.
+  --testnet                Use the testnet magic id.
+  --governance-action-deposit NATURAL
+                           Deposit required to submit a governance action.
+  --deposit-return-stake-verification-key STRING
+                           Stake verification key (Bech32 or hex-encoded).
+  --deposit-return-stake-verification-key-file FILEPATH
+                           Filepath of the staking verification key.
+  --deposit-return-stake-key-hash HASH
+                           Stake verification key hash (hex-encoded).
+  --deposit-return-stake-script-file FILEPATH
+                           Filepath of the staking script.
+  --deposit-return-stake-address ADDRESS
+                           Target stake address (bech32 format).
+  --anchor-url TEXT        Anchor URL
+  --anchor-data-hash HASH  Proposal anchor data hash (obtain it with
+                           "cardano-cli hash anchor-data ...")
+  --check-anchor-data      Verify that the expected proposal hash provided in
+                           --anchor-data-hash matches the hash of the file
+                           downloaded from the URL provided in --anchor-url
+                           (this parameter will download the file from the URL)
+  --remove-cc-cold-verification-key STRING
+                           Constitutional Committee cold key (hex-encoded).
+  --remove-cc-cold-verification-key-file FILEPATH
+                           Filepath of the Constitutional Committee cold key.
+  --remove-cc-cold-verification-key-hash STRING
+                           Constitutional Committee key hash (hex-encoded).
+  --remove-cc-cold-script-hash HASH
+                           Cold Native or Plutus script file hash (hex-encoded).
+                           Obtain it with "cardano-cli hash script ...".
+  --add-cc-cold-verification-key STRING
+                           Constitutional Committee cold key (hex-encoded).
+  --add-cc-cold-verification-key-file FILEPATH
+                           Filepath of the Constitutional Committee cold key.
+  --add-cc-cold-verification-key-hash STRING
+                           Constitutional Committee key hash (hex-encoded).
+  --add-cc-cold-script-hash HASH
+                           Cold Native or Plutus script file hash (hex-encoded).
+                           Obtain it with "cardano-cli hash script ...".
+  --epoch NATURAL          Committee member expiry epoch
+  --threshold RATIONAL     Threshold of YES votes that are necessary for
+                           approving a governance action.
+  --prev-governance-action-tx-id TXID
+                           Txid of the previous governance action.
+  --prev-governance-action-index WORD16
+                           Action index of the previous governance action.
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_governance_action_view.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_governance_action_view.cli
@@ -1,0 +1,15 @@
+Usage: cardano-cli compatible conway governance action view --action-file FILEPATH
+                                                              [ --output-json
+                                                              | --output-yaml
+                                                              ]
+                                                              [--out-file FILEPATH]
+
+  View a governance action.
+
+Available options:
+  --action-file FILEPATH   Path to action file.
+  --output-json            Format governance action view output to JSON.
+  --output-yaml            Format governance action view output to YAML.
+                           Defaults to JSON if unspecified.
+  --out-file FILEPATH      Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_governance_committee.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_governance_committee.cli
@@ -1,0 +1,25 @@
+Usage: cardano-cli compatible conway governance committee 
+                                                            ( key-gen-cold
+                                                            | key-gen-hot
+                                                            | key-hash
+                                                            | create-hot-key-authorization-certificate
+                                                            | create-cold-key-resignation-certificate
+                                                            )
+
+  Committee member commands.
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  key-gen-cold             Create a cold key pair for a Constitutional Committee
+                           Member
+  key-gen-hot              Create a hot key pair for a Constitutional Committee
+                           Member
+  key-hash                 Print the identifier (hash) of a public key
+  create-hot-key-authorization-certificate
+                           Create hot key authorization certificate for a
+                           Constitutional Committee Member
+  create-cold-key-resignation-certificate
+                           Create cold key resignation certificate for a
+                           Constitutional Committee Member

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_governance_committee_create-cold-key-resignation-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_governance_committee_create-cold-key-resignation-certificate.cli
@@ -1,0 +1,41 @@
+Usage: cardano-cli compatible conway governance committee create-cold-key-resignation-certificate 
+                                                                                                    ( --cold-verification-key STRING
+                                                                                                    | --cold-verification-key-file FILEPATH
+                                                                                                    | --cold-verification-key-hash STRING
+                                                                                                    | --cold-script-hash HASH
+                                                                                                    | --cold-script-file FILEPATH
+                                                                                                    )
+                                                                                                    [--resignation-metadata-url TEXT
+                                                                                                      --resignation-metadata-hash HASH
+                                                                                                      [--check-resignation-metadata-hash]]
+                                                                                                    --out-file FILEPATH
+
+  Create cold key resignation certificate for a Constitutional Committee Member
+
+Available options:
+  --cold-verification-key STRING
+                           Constitutional Committee cold key (hex-encoded).
+  --cold-verification-key-file FILEPATH
+                           Filepath of the Constitutional Committee cold key.
+  --cold-verification-key-hash STRING
+                           Constitutional Committee key hash (hex-encoded).
+  --cold-script-hash HASH  Committee cold Native or Plutus script file hash
+                           (hex-encoded). Obtain it with "cardano-cli hash
+                           script ...".
+  --cold-script-file FILEPATH
+                           Cold Native or Plutus script file
+  --resignation-metadata-url TEXT
+                           Constitutional Committee cold key resignation
+                           certificate URL
+  --resignation-metadata-hash HASH
+                           Constitutional Committee cold key resignation
+                           certificate metadata hash
+  --check-resignation-metadata-hash
+                           Verify that the expected Constitutional Committee
+                           cold key resignation certificate metadata hash
+                           provided in --resignation-metadata-hash matches the
+                           hash of the file downloaded from the URL provided in
+                           --resignation-metadata-url (this parameter will
+                           download the file from the URL)
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_governance_committee_create-hot-key-authorization-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_governance_committee_create-hot-key-authorization-certificate.cli
@@ -1,0 +1,42 @@
+Usage: cardano-cli compatible conway governance committee create-hot-key-authorization-certificate 
+                                                                                                     ( --cold-verification-key STRING
+                                                                                                     | --cold-verification-key-file FILEPATH
+                                                                                                     | --cold-verification-key-hash STRING
+                                                                                                     | --cold-script-hash HASH
+                                                                                                     | --cold-script-file FILEPATH
+                                                                                                     )
+                                                                                                     ( --hot-verification-key STRING
+                                                                                                     | --hot-verification-key-file FILEPATH
+                                                                                                     | --hot-verification-key-hash STRING
+                                                                                                     | --hot-script-hash HASH
+                                                                                                     | --hot-script-file FILEPATH
+                                                                                                     )
+                                                                                                     --out-file FILEPATH
+
+  Create hot key authorization certificate for a Constitutional Committee Member
+
+Available options:
+  --cold-verification-key STRING
+                           Constitutional Committee cold key (hex-encoded).
+  --cold-verification-key-file FILEPATH
+                           Filepath of the Constitutional Committee cold key.
+  --cold-verification-key-hash STRING
+                           Constitutional Committee key hash (hex-encoded).
+  --cold-script-hash HASH  Committee cold Native or Plutus script file hash
+                           (hex-encoded). Obtain it with "cardano-cli hash
+                           script ...".
+  --cold-script-file FILEPATH
+                           Cold Native or Plutus script file
+  --hot-verification-key STRING
+                           Constitutional Committee hot key (hex-encoded).
+  --hot-verification-key-file FILEPATH
+                           Filepath of the Constitutional Committee hot key.
+  --hot-verification-key-hash STRING
+                           Constitutional Committee key hash (hex-encoded).
+  --hot-script-hash HASH   Committee hot Native or Plutus script file hash
+                           (hex-encoded). Obtain it with "cardano-cli hash
+                           script ...".
+  --hot-script-file FILEPATH
+                           Hot Native or Plutus script file
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_governance_committee_key-gen-cold.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_governance_committee_key-gen-cold.cli
@@ -1,0 +1,12 @@
+Usage: cardano-cli compatible conway governance committee key-gen-cold 
+                                                                         --cold-verification-key-file FILEPATH
+                                                                         --cold-signing-key-file FILEPATH
+
+  Create a cold key pair for a Constitutional Committee Member
+
+Available options:
+  --cold-verification-key-file FILEPATH
+                           Filepath of the cold verification key.
+  --cold-signing-key-file FILEPATH
+                           Filepath of the cold signing key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_governance_committee_key-gen-hot.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_governance_committee_key-gen-hot.cli
@@ -1,0 +1,11 @@
+Usage: cardano-cli compatible conway governance committee key-gen-hot --verification-key-file FILEPATH
+                                                                        --signing-key-file FILEPATH
+
+  Create a hot key pair for a Constitutional Committee Member
+
+Available options:
+  --verification-key-file FILEPATH
+                           Output filepath of the verification key.
+  --signing-key-file FILEPATH
+                           Output filepath of the signing key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_governance_committee_key-hash.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_governance_committee_key-hash.cli
@@ -1,0 +1,15 @@
+Usage: cardano-cli compatible conway governance committee key-hash 
+                                                                     ( --verification-key STRING
+                                                                     | --verification-key-file FILEPATH
+                                                                     )
+
+  Print the identifier (hash) of a public key
+
+Available options:
+  --verification-key STRING
+                           Constitutional Committee Member key (hot or cold)
+                           (Bech32-encoded)
+  --verification-key-file FILEPATH
+                           Input filepath of the Constitutional Committee Member
+                           key (hot or cold).
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_governance_drep.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_governance_drep.cli
@@ -1,0 +1,23 @@
+Usage: cardano-cli compatible conway governance drep 
+                                                       ( key-gen
+                                                       | id
+                                                       | registration-certificate
+                                                       | retirement-certificate
+                                                       | update-certificate
+                                                       | metadata-hash
+                                                       )
+
+  DRep member commands.
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  key-gen                  Generate Delegated Representative verification and
+                           signing keys.
+  id                       Generate a drep id.
+  registration-certificate Create a registration certificate.
+  retirement-certificate   Create a DRep retirement certificate.
+  update-certificate       Create a DRep update certificate.
+  metadata-hash            Calculate the hash of a metadata file, optionally
+                           checking the obtained hash against an expected value.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_governance_drep_id.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_governance_drep_id.cli
@@ -1,0 +1,18 @@
+Usage: cardano-cli compatible conway governance drep id 
+                                                          ( --drep-verification-key STRING
+                                                          | --drep-verification-key-file FILEPATH
+                                                          )
+                                                          [--output-format STRING]
+                                                          [--out-file FILEPATH]
+
+  Generate a drep id.
+
+Available options:
+  --drep-verification-key STRING
+                           DRep verification key (Bech32 or hex-encoded).
+  --drep-verification-key-file FILEPATH
+                           Filepath of the DRep verification key.
+  --output-format STRING   Optional drep id output format. Accepted output
+                           formats are "hex" and "bech32" (default is "bech32").
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_governance_drep_key-gen.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_governance_drep_key-gen.cli
@@ -1,0 +1,11 @@
+Usage: cardano-cli compatible conway governance drep key-gen --verification-key-file FILEPATH
+                                                               --signing-key-file FILEPATH
+
+  Generate Delegated Representative verification and signing keys.
+
+Available options:
+  --verification-key-file FILEPATH
+                           Output filepath of the verification key.
+  --signing-key-file FILEPATH
+                           Output filepath of the signing key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_governance_drep_metadata-hash.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_governance_drep_metadata-hash.cli
@@ -1,0 +1,20 @@
+Usage: cardano-cli compatible conway governance drep metadata-hash 
+                                                                     ( --drep-metadata-file FILEPATH
+                                                                     | --drep-metadata-url TEXT
+                                                                     )
+                                                                     [ --expected-hash HASH
+                                                                     | --out-file FILEPATH
+                                                                     ]
+
+  Calculate the hash of a metadata file, optionally checking the obtained hash
+  against an expected value.
+
+Available options:
+  --drep-metadata-file FILEPATH
+                           JSON Metadata file to hash.
+  --drep-metadata-url TEXT URL pointing to the JSON Metadata file to hash.
+  --expected-hash HASH     Expected hash for the DRep metadata, for verification
+                           purposes. If provided, the hash of the DRep metadata
+                           will be compared to this value.
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_governance_drep_registration-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_governance_drep_registration-certificate.cli
@@ -1,0 +1,36 @@
+Usage: cardano-cli compatible conway governance drep registration-certificate 
+                                                                                ( --drep-script-hash HASH
+                                                                                | --drep-verification-key STRING
+                                                                                | --drep-verification-key-file FILEPATH
+                                                                                | --drep-key-hash HASH
+                                                                                )
+                                                                                --key-reg-deposit-amt NATURAL
+                                                                                [--drep-metadata-url TEXT
+                                                                                  --drep-metadata-hash HASH
+                                                                                  [--check-drep-metadata-hash]]
+                                                                                --out-file FILEPATH
+
+  Create a registration certificate.
+
+Available options:
+  --drep-script-hash HASH  DRep script hash (hex-encoded). Obtain it with
+                           "cardano-cli hash script ...".
+  --drep-verification-key STRING
+                           DRep verification key (Bech32 or hex-encoded).
+  --drep-verification-key-file FILEPATH
+                           Filepath of the DRep verification key.
+  --drep-key-hash HASH     DRep verification key hash (either Bech32-encoded or
+                           hex-encoded).
+  --key-reg-deposit-amt NATURAL
+                           Key registration deposit amount.
+  --drep-metadata-url TEXT DRep anchor URL
+  --drep-metadata-hash HASH
+                           DRep anchor data hash.
+  --check-drep-metadata-hash
+                           Verify that the expected DRep metadata hash provided
+                           in --drep-metadata-hash matches the hash of the file
+                           downloaded from the URL provided in
+                           --drep-metadata-url (this parameter will download the
+                           file from the URL)
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_governance_drep_retirement-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_governance_drep_retirement-certificate.cli
@@ -1,0 +1,24 @@
+Usage: cardano-cli compatible conway governance drep retirement-certificate 
+                                                                              ( --drep-script-hash HASH
+                                                                              | --drep-verification-key STRING
+                                                                              | --drep-verification-key-file FILEPATH
+                                                                              | --drep-key-hash HASH
+                                                                              )
+                                                                              --deposit-amt LOVELACE
+                                                                              --out-file FILEPATH
+
+  Create a DRep retirement certificate.
+
+Available options:
+  --drep-script-hash HASH  DRep script hash (hex-encoded). Obtain it with
+                           "cardano-cli hash script ...".
+  --drep-verification-key STRING
+                           DRep verification key (Bech32 or hex-encoded).
+  --drep-verification-key-file FILEPATH
+                           Filepath of the DRep verification key.
+  --drep-key-hash HASH     DRep verification key hash (either Bech32-encoded or
+                           hex-encoded).
+  --deposit-amt LOVELACE   DRep deposit amount (same at registration and
+                           retirement).
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_governance_drep_update-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_governance_drep_update-certificate.cli
@@ -1,0 +1,33 @@
+Usage: cardano-cli compatible conway governance drep update-certificate 
+                                                                          ( --drep-script-hash HASH
+                                                                          | --drep-verification-key STRING
+                                                                          | --drep-verification-key-file FILEPATH
+                                                                          | --drep-key-hash HASH
+                                                                          )
+                                                                          [--drep-metadata-url TEXT
+                                                                            --drep-metadata-hash HASH
+                                                                            [--check-drep-metadata-hash]]
+                                                                          --out-file FILEPATH
+
+  Create a DRep update certificate.
+
+Available options:
+  --drep-script-hash HASH  DRep script hash (hex-encoded). Obtain it with
+                           "cardano-cli hash script ...".
+  --drep-verification-key STRING
+                           DRep verification key (Bech32 or hex-encoded).
+  --drep-verification-key-file FILEPATH
+                           Filepath of the DRep verification key.
+  --drep-key-hash HASH     DRep verification key hash (either Bech32-encoded or
+                           hex-encoded).
+  --drep-metadata-url TEXT DRep anchor URL
+  --drep-metadata-hash HASH
+                           DRep anchor data hash.
+  --check-drep-metadata-hash
+                           Verify that the expected DRep metadata hash provided
+                           in --drep-metadata-hash matches the hash of the file
+                           downloaded from the URL provided in
+                           --drep-metadata-url (this parameter will download the
+                           file from the URL)
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_governance_vote.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_governance_vote.cli
@@ -1,0 +1,10 @@
+Usage: cardano-cli compatible conway governance vote (create | view)
+
+  Vote commands.
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  create                   Vote creation.
+  view                     Vote viewing.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_governance_vote_create.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_governance_vote_create.cli
@@ -1,0 +1,64 @@
+Usage: cardano-cli compatible conway governance vote create 
+                                                              ( --yes
+                                                              | --no
+                                                              | --abstain
+                                                              )
+                                                              --governance-action-tx-id TXID
+                                                              --governance-action-index WORD16
+                                                              ( --drep-verification-key STRING
+                                                              | --drep-verification-key-file FILEPATH
+                                                              | --drep-key-hash HASH
+                                                              | --drep-script-hash HASH
+                                                              | --stake-pool-verification-key STRING
+                                                              | --cold-verification-key-file FILEPATH
+                                                              | --stake-pool-id STAKE_POOL_ID
+                                                              | --cc-hot-verification-key STRING
+                                                              | --cc-hot-verification-key-file FILEPATH
+                                                              | --cc-hot-key-hash STRING
+                                                              | --cc-hot-script-hash HASH
+                                                              )
+                                                              [--anchor-url TEXT
+                                                                --anchor-data-hash HASH
+                                                                [--check-anchor-data-hash]]
+                                                              --out-file FILEPATH
+
+  Vote creation.
+
+Available options:
+  --governance-action-tx-id TXID
+                           Txid of the governance action.
+  --governance-action-index WORD16
+                           Tx's governance action index.
+  --drep-verification-key STRING
+                           DRep verification key (Bech32 or hex-encoded).
+  --drep-verification-key-file FILEPATH
+                           Filepath of the DRep verification key.
+  --drep-key-hash HASH     DRep verification key hash (either Bech32-encoded or
+                           hex-encoded).
+  --drep-script-hash HASH  Cold Native or Plutus script file hash (hex-encoded).
+                           Obtain it with "cardano-cli hash script ...".
+  --stake-pool-verification-key STRING
+                           Stake pool verification key (Bech32 or hex-encoded).
+  --cold-verification-key-file FILEPATH
+                           Filepath of the stake pool verification key.
+  --stake-pool-id STAKE_POOL_ID
+                           Stake pool ID/verification key hash (either
+                           Bech32-encoded or hex-encoded).
+  --cc-hot-verification-key STRING
+                           Constitutional Committee hot key (hex-encoded).
+  --cc-hot-verification-key-file FILEPATH
+                           Filepath of the Constitutional Committee hot key.
+  --cc-hot-key-hash STRING Constitutional Committee key hash (hex-encoded).
+  --cc-hot-script-hash HASH
+                           Cold Native or Plutus script file hash (hex-encoded).
+                           Obtain it with "cardano-cli hash script ...".
+  --anchor-url TEXT        Vote anchor URL
+  --anchor-data-hash HASH  Hash of the vote anchor data (obtain it with
+                           "cardano-cli hash anchor-data ...").
+  --check-anchor-data-hash Verify that the expected vote anchor data hash
+                           provided in --anchor-data-hash matches the hash of
+                           the file downloaded from the URL provided in
+                           --anchor-url (this parameter will download the file
+                           from the URL)
+  --out-file FILEPATH      Output filepath of the vote.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_governance_vote_view.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_governance_vote_view.cli
@@ -1,0 +1,16 @@
+Usage: cardano-cli compatible conway governance vote view 
+                                                            [ --output-json
+                                                            | --output-yaml
+                                                            ]
+                                                            --vote-file FILEPATH
+                                                            [--out-file FILEPATH]
+
+  Vote viewing.
+
+Available options:
+  --output-json            Format governance vote view output to JSON.
+  --output-yaml            Format governance vote view output to YAML. Defaults
+                           to JSON if unspecified.
+  --vote-file FILEPATH     Input filepath of the vote.
+  --out-file FILEPATH      Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_transaction_signed-transaction.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_transaction_signed-transaction.cli
@@ -1,0 +1,178 @@
+Usage: cardano-cli compatible conway transaction signed-transaction 
+                                                                      [--tx-in TX-IN]
+                                                                      [--tx-out ADDRESS VALUE
+                                                                        [ --tx-out-datum-hash HASH
+                                                                        | --tx-out-datum-hash-cbor-file CBOR_FILE
+                                                                        | --tx-out-datum-hash-file JSON_FILE
+                                                                        | --tx-out-datum-hash-value JSON_VALUE
+                                                                        | --tx-out-datum-embed-cbor-file CBOR_FILE
+                                                                        | --tx-out-datum-embed-file JSON_FILE
+                                                                        | --tx-out-datum-embed-value JSON_VALUE
+                                                                        | --tx-out-inline-datum-cbor-file CBOR_FILE
+                                                                        | --tx-out-inline-datum-file JSON_FILE
+                                                                        | --tx-out-inline-datum-value JSON_VALUE
+                                                                        ]
+                                                                        [--tx-out-reference-script-file FILEPATH]]
+                                                                      [--proposal-file FILEPATH
+                                                                        [ --proposal-script-file FILEPATH
+                                                                          [
+                                                                            ( --proposal-redeemer-cbor-file CBOR_FILE
+                                                                            | --proposal-redeemer-file JSON_FILE
+                                                                            | --proposal-redeemer-value JSON_VALUE
+                                                                            )
+                                                                            --proposal-execution-units (INT, INT)]
+                                                                        | --proposal-tx-in-reference TX-IN
+                                                                          --proposal-plutus-script-v3
+                                                                          ( --proposal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                                          | --proposal-reference-tx-in-redeemer-file JSON_FILE
+                                                                          | --proposal-reference-tx-in-redeemer-value JSON_VALUE
+                                                                          )
+                                                                          --proposal-reference-tx-in-execution-units (INT, INT)
+                                                                        ]]
+                                                                      [--vote-file FILEPATH
+                                                                        [ --vote-script-file FILEPATH
+                                                                          [
+                                                                            ( --vote-redeemer-cbor-file CBOR_FILE
+                                                                            | --vote-redeemer-file JSON_FILE
+                                                                            | --vote-redeemer-value JSON_VALUE
+                                                                            )
+                                                                            --vote-execution-units (INT, INT)]
+                                                                        | --vote-tx-in-reference TX-IN
+                                                                          --vote-plutus-script-v3
+                                                                          ( --vote-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                                          | --vote-reference-tx-in-redeemer-file JSON_FILE
+                                                                          | --vote-reference-tx-in-redeemer-value JSON_VALUE
+                                                                          )
+                                                                          --vote-reference-tx-in-execution-units (INT, INT)
+                                                                        ]]
+                                                                      [--signing-key-file FILEPATH
+                                                                        [--address STRING]]
+                                                                      [ --mainnet
+                                                                      | --testnet-magic NATURAL
+                                                                      ]
+                                                                      --fee LOVELACE
+                                                                      --out-file FILEPATH
+
+  Create a simple signed transaction.
+
+Available options:
+  --tx-in TX-IN            TxId#TxIx
+  --tx-out ADDRESS VALUE   The transaction output as ADDRESS VALUE where ADDRESS
+                           is the Bech32-encoded address followed by the value
+                           in the multi-asset syntax (including simply
+                           Lovelace).
+  --tx-out-datum-hash HASH The script datum hash for this tx output, as the raw
+                           datum hash (in hex).
+  --tx-out-datum-hash-cbor-file CBOR_FILE
+                           The script datum hash for this tx output, by hashing
+                           the script datum in the file. The file has to be in
+                           CBOR format.
+  --tx-out-datum-hash-file JSON_FILE
+                           The script datum hash for this tx output, by hashing
+                           the script datum in the file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-datum-hash-value JSON_VALUE
+                           The script datum hash for this tx output, by hashing
+                           the script datum given here. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --tx-out-datum-embed-cbor-file CBOR_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file has to be in CBOR format.
+  --tx-out-datum-embed-file JSON_FILE
+                           The script datum to embed in the tx for this output,
+                           in the given file. The file must follow the detailed
+                           JSON schema for script data.
+  --tx-out-datum-embed-value JSON_VALUE
+                           The script datum to embed in the tx for this output,
+                           given here. There is no schema: (almost) any JSON
+                           value is supported, including top-level strings and
+                           numbers.
+  --tx-out-inline-datum-cbor-file CBOR_FILE
+                           The script datum to embed in the tx output as an
+                           inline datum, in the given file. The file has to be
+                           in CBOR format.
+  --tx-out-inline-datum-file JSON_FILE
+                           The script datum to embed in the tx output as an
+                           inline datum, in the given file. The file must follow
+                           the detailed JSON schema for script data.
+  --tx-out-inline-datum-value JSON_VALUE
+                           The script datum to embed in the tx output as an
+                           inline datum, given here. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --tx-out-reference-script-file FILEPATH
+                           Reference script input file.
+  --proposal-file FILEPATH Filepath of the proposal.
+  --proposal-script-file FILEPATH
+                           The file containing the script to witness a proposal
+  --proposal-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --proposal-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --proposal-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --proposal-execution-units (INT, INT)
+                           The time and space units needed by the script.
+  --proposal-tx-in-reference TX-IN
+                           TxId#TxIx - Specify a reference input. The reference
+                           input must have a plutus reference script attached.
+  --proposal-plutus-script-v3
+                           Specify a plutus script v3 reference script.
+  --proposal-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --proposal-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --proposal-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --proposal-reference-tx-in-execution-units (INT, INT)
+                           The time and space units needed by the script.
+  --vote-file FILEPATH     Filepath of the vote.
+  --vote-script-file FILEPATH
+                           The file containing the script to witness a vote
+  --vote-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --vote-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --vote-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --vote-execution-units (INT, INT)
+                           The time and space units needed by the script.
+  --vote-tx-in-reference TX-IN
+                           TxId#TxIx - Specify a reference input. The reference
+                           input must have a plutus reference script attached.
+  --vote-plutus-script-v3  Specify a plutus script v3 reference script.
+  --vote-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --vote-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --vote-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --vote-reference-tx-in-execution-units (INT, INT)
+                           The time and space units needed by the script.
+  --signing-key-file FILEPATH
+                           Input filepath of the signing key (one or more).
+  --address STRING         Byron address (Base58-encoded).
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --fee LOVELACE           The fee amount in Lovelace.
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_mary.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_mary.cli
@@ -1,0 +1,10 @@
+Usage: cardano-cli compatible mary (transaction | governance)
+
+  Mary era commands
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  transaction              Transaction commands.
+  governance               Governance commands.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_mary_governance.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_mary_governance.cli
@@ -1,0 +1,17 @@
+Usage: cardano-cli compatible mary governance 
+                                                ( create-mir-certificate
+                                                | create-genesis-key-delegation-certificate
+                                                | action
+                                                )
+
+  Governance commands.
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  create-mir-certificate   Create an MIR (Move Instantaneous Rewards)
+                           certificate
+  create-genesis-key-delegation-certificate
+                           Create a genesis key delegation certificate
+  action                   Governance action commands.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_mary_governance_action.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_mary_governance_action.cli
@@ -1,0 +1,11 @@
+Usage: cardano-cli compatible mary governance action 
+                                                       create-protocol-parameters-update
+
+  Governance action commands.
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  create-protocol-parameters-update
+                           Create a protocol parameters update.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_mary_governance_action_create-protocol-parameters-update.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_mary_governance_action_create-protocol-parameters-update.cli
@@ -1,0 +1,74 @@
+Usage: cardano-cli compatible mary governance action create-protocol-parameters-update --epoch NATURAL
+                                                                                         (--genesis-verification-key-file FILEPATH)
+                                                                                         [--min-fee-linear LOVELACE]
+                                                                                         [--min-fee-constant LOVELACE]
+                                                                                         [--max-block-body-size WORD32]
+                                                                                         [--max-tx-size WORD32]
+                                                                                         [--max-block-header-size WORD16]
+                                                                                         [--key-reg-deposit-amt NATURAL]
+                                                                                         [--pool-reg-deposit NATURAL]
+                                                                                         [--pool-retirement-epoch-interval WORD32]
+                                                                                         [--number-of-pools NATURAL]
+                                                                                         [--pool-influence RATIONAL]
+                                                                                         [--treasury-expansion RATIONAL]
+                                                                                         [--monetary-expansion RATIONAL]
+                                                                                         [--min-pool-cost NATURAL]
+                                                                                         [--min-utxo-value NATURAL]
+                                                                                         [ --extra-entropy HEX
+                                                                                         | --reset-extra-entropy
+                                                                                         ]
+                                                                                         [--decentralization-parameter RATIONAL]
+                                                                                         [--protocol-major-version MAJOR
+                                                                                           --protocol-minor-version MINOR]
+                                                                                         --out-file FILEPATH
+
+  Create a protocol parameters update.
+
+Available options:
+  --epoch NATURAL          The epoch number in which the update proposal is
+                           valid.
+  --genesis-verification-key-file FILEPATH
+                           Filepath of the genesis verification key.
+  --min-fee-linear LOVELACE
+                           The linear factor per byte for the minimum fee
+                           calculation.
+  --min-fee-constant LOVELACE
+                           The constant factor for the minimum fee calculation.
+  --max-block-body-size WORD32
+                           Maximal block body size.
+  --max-tx-size WORD32     Maximum transaction size.
+  --max-block-header-size WORD16
+                           Maximum block header size.
+  --key-reg-deposit-amt NATURAL
+                           Key registration deposit amount.
+  --pool-reg-deposit NATURAL
+                           The amount of a pool registration deposit.
+  --pool-retirement-epoch-interval WORD32
+                           Epoch interval of pool retirement.
+  --number-of-pools NATURAL
+                           Desired number of pools.
+  --pool-influence RATIONAL
+                           Pool influence.
+  --treasury-expansion RATIONAL
+                           Treasury expansion.
+  --monetary-expansion RATIONAL
+                           Monetary expansion.
+  --min-pool-cost NATURAL  The minimum allowed cost parameter for stake pools.
+  --min-utxo-value NATURAL The minimum allowed UTxO value (Shelley to Mary
+                           eras).
+  --extra-entropy HEX      Praos extra entropy seed, as a hex byte string.
+  --reset-extra-entropy    Reset the Praos extra entropy to none.
+  --decentralization-parameter RATIONAL
+                           Decentralization parameter.
+  --protocol-major-version MAJOR
+                           Specify the major protocol version to fork into. An
+                           increase indicates a hard fork. It must be the next
+                           natural number after the current version and must be
+                           supported by the node.
+  --protocol-minor-version MINOR
+                           Minor protocol version. An increase indicates a soft
+                           fork (old software can validate but not produce new
+                           blocks). Must be zero when the major protocol version
+                           is increased.
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_mary_governance_create-genesis-key-delegation-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_mary_governance_create-genesis-key-delegation-certificate.cli
@@ -1,0 +1,38 @@
+Usage: cardano-cli compatible mary governance create-genesis-key-delegation-certificate 
+                                                                                          ( --genesis-verification-key STRING
+                                                                                          | --genesis-verification-key-file FILEPATH
+                                                                                          | --genesis-verification-key-hash STRING
+                                                                                          )
+                                                                                          ( --genesis-delegate-verification-key STRING
+                                                                                          | --genesis-delegate-verification-key-file FILEPATH
+                                                                                          | --genesis-delegate-verification-key-hash STRING
+                                                                                          )
+                                                                                          ( --vrf-verification-key STRING
+                                                                                          | --vrf-verification-key-file FILEPATH
+                                                                                          | --vrf-verification-key-hash STRING
+                                                                                          )
+                                                                                          --out-file FILEPATH
+
+  Create a genesis key delegation certificate
+
+Available options:
+  --genesis-verification-key STRING
+                           Genesis verification key (hex-encoded).
+  --genesis-verification-key-file FILEPATH
+                           Filepath of the genesis verification key.
+  --genesis-verification-key-hash STRING
+                           Genesis verification key hash (hex-encoded).
+  --genesis-delegate-verification-key STRING
+                           Genesis delegate verification key (hex-encoded).
+  --genesis-delegate-verification-key-file FILEPATH
+                           Filepath of the genesis delegate verification key.
+  --genesis-delegate-verification-key-hash STRING
+                           Genesis delegate verification key hash (hex-encoded).
+  --vrf-verification-key STRING
+                           VRF verification key (Bech32 or hex-encoded).
+  --vrf-verification-key-file FILEPATH
+                           Filepath of the VRF verification key.
+  --vrf-verification-key-hash STRING
+                           VRF verification key hash (hex-encoded).
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_mary_governance_create-mir-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_mary_governance_create-mir-certificate.cli
@@ -1,0 +1,28 @@
+Usage: cardano-cli compatible mary governance create-mir-certificate 
+                                                                       ( ( --reserves
+                                                                         | --treasury
+                                                                         )
+                                                                         (--stake-address ADDRESS)
+                                                                         (--reward LOVELACE)
+                                                                         --out-file FILEPATH
+                                                                       | stake-addresses
+                                                                       | transfer-to-treasury
+                                                                       | transfer-to-rewards
+                                                                       )
+
+  Create an MIR (Move Instantaneous Rewards) certificate
+
+Available options:
+  --reserves               Use the reserves pot.
+  --treasury               Use the treasury pot.
+  --stake-address ADDRESS  Target stake address (bech32 format).
+  --reward LOVELACE        The reward for the relevant reward account.
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text
+
+Available commands:
+  stake-addresses          Create an MIR certificate to pay stake addresses
+  transfer-to-treasury     Create an MIR certificate to transfer from the
+                           reserves pot to the treasury pot
+  transfer-to-rewards      Create an MIR certificate to transfer from the
+                           treasury pot to the reserves pot

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_mary_governance_create-mir-certificate_stake-addresses.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_mary_governance_create-mir-certificate_stake-addresses.cli
@@ -1,0 +1,17 @@
+Usage: cardano-cli compatible mary governance create-mir-certificate stake-addresses 
+                                                                                       ( --reserves
+                                                                                       | --treasury
+                                                                                       )
+                                                                                       (--stake-address ADDRESS)
+                                                                                       (--reward LOVELACE)
+                                                                                       --out-file FILEPATH
+
+  Create an MIR certificate to pay stake addresses
+
+Available options:
+  --reserves               Use the reserves pot.
+  --treasury               Use the treasury pot.
+  --stake-address ADDRESS  Target stake address (bech32 format).
+  --reward LOVELACE        The reward for the relevant reward account.
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_mary_governance_create-mir-certificate_transfer-to-rewards.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_mary_governance_create-mir-certificate_transfer-to-rewards.cli
@@ -1,0 +1,10 @@
+Usage: cardano-cli compatible mary governance create-mir-certificate transfer-to-rewards --transfer LOVELACE
+                                                                                           --out-file FILEPATH
+
+  Create an MIR certificate to transfer from the treasury pot to the reserves
+  pot
+
+Available options:
+  --transfer LOVELACE      The amount to transfer.
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_mary_governance_create-mir-certificate_transfer-to-treasury.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_mary_governance_create-mir-certificate_transfer-to-treasury.cli
@@ -1,0 +1,10 @@
+Usage: cardano-cli compatible mary governance create-mir-certificate transfer-to-treasury --transfer LOVELACE
+                                                                                            --out-file FILEPATH
+
+  Create an MIR certificate to transfer from the reserves pot to the treasury
+  pot
+
+Available options:
+  --transfer LOVELACE      The amount to transfer.
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_mary_transaction_signed-transaction.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_mary_transaction_signed-transaction.cli
@@ -1,0 +1,32 @@
+Usage: cardano-cli compatible mary transaction signed-transaction 
+                                                                    [--tx-in TX-IN]
+                                                                    [--tx-out ADDRESS VALUE]
+                                                                    [--update-proposal-file FILEPATH]
+                                                                    [--signing-key-file FILEPATH
+                                                                      [--address STRING]]
+                                                                    [ --mainnet
+                                                                    | --testnet-magic NATURAL
+                                                                    ]
+                                                                    --fee LOVELACE
+                                                                    --out-file FILEPATH
+
+  Create a simple signed transaction.
+
+Available options:
+  --tx-in TX-IN            TxId#TxIx
+  --tx-out ADDRESS VALUE   The transaction output as ADDRESS VALUE where ADDRESS
+                           is the Bech32-encoded address followed by the value
+                           in the multi-asset syntax (including simply
+                           Lovelace).
+  --update-proposal-file FILEPATH
+                           Filepath of the update proposal.
+  --signing-key-file FILEPATH
+                           Input filepath of the signing key (one or more).
+  --address STRING         Byron address (Base58-encoded).
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --fee LOVELACE           The fee amount in Lovelace.
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_shelley.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_shelley.cli
@@ -1,0 +1,10 @@
+Usage: cardano-cli compatible shelley (transaction | governance)
+
+  Shelley era commands
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  transaction              Transaction commands.
+  governance               Governance commands.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_shelley_governance.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_shelley_governance.cli
@@ -1,0 +1,17 @@
+Usage: cardano-cli compatible shelley governance 
+                                                   ( create-mir-certificate
+                                                   | create-genesis-key-delegation-certificate
+                                                   | action
+                                                   )
+
+  Governance commands.
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  create-mir-certificate   Create an MIR (Move Instantaneous Rewards)
+                           certificate
+  create-genesis-key-delegation-certificate
+                           Create a genesis key delegation certificate
+  action                   Governance action commands.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_shelley_governance_action.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_shelley_governance_action.cli
@@ -1,0 +1,11 @@
+Usage: cardano-cli compatible shelley governance action 
+                                                          create-protocol-parameters-update
+
+  Governance action commands.
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  create-protocol-parameters-update
+                           Create a protocol parameters update.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_shelley_governance_action_create-protocol-parameters-update.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_shelley_governance_action_create-protocol-parameters-update.cli
@@ -1,0 +1,74 @@
+Usage: cardano-cli compatible shelley governance action create-protocol-parameters-update --epoch NATURAL
+                                                                                            (--genesis-verification-key-file FILEPATH)
+                                                                                            [--min-fee-linear LOVELACE]
+                                                                                            [--min-fee-constant LOVELACE]
+                                                                                            [--max-block-body-size WORD32]
+                                                                                            [--max-tx-size WORD32]
+                                                                                            [--max-block-header-size WORD16]
+                                                                                            [--key-reg-deposit-amt NATURAL]
+                                                                                            [--pool-reg-deposit NATURAL]
+                                                                                            [--pool-retirement-epoch-interval WORD32]
+                                                                                            [--number-of-pools NATURAL]
+                                                                                            [--pool-influence RATIONAL]
+                                                                                            [--treasury-expansion RATIONAL]
+                                                                                            [--monetary-expansion RATIONAL]
+                                                                                            [--min-pool-cost NATURAL]
+                                                                                            [--min-utxo-value NATURAL]
+                                                                                            [--protocol-major-version MAJOR
+                                                                                              --protocol-minor-version MINOR]
+                                                                                            [ --extra-entropy HEX
+                                                                                            | --reset-extra-entropy
+                                                                                            ]
+                                                                                            [--decentralization-parameter RATIONAL]
+                                                                                            --out-file FILEPATH
+
+  Create a protocol parameters update.
+
+Available options:
+  --epoch NATURAL          The epoch number in which the update proposal is
+                           valid.
+  --genesis-verification-key-file FILEPATH
+                           Filepath of the genesis verification key.
+  --min-fee-linear LOVELACE
+                           The linear factor per byte for the minimum fee
+                           calculation.
+  --min-fee-constant LOVELACE
+                           The constant factor for the minimum fee calculation.
+  --max-block-body-size WORD32
+                           Maximal block body size.
+  --max-tx-size WORD32     Maximum transaction size.
+  --max-block-header-size WORD16
+                           Maximum block header size.
+  --key-reg-deposit-amt NATURAL
+                           Key registration deposit amount.
+  --pool-reg-deposit NATURAL
+                           The amount of a pool registration deposit.
+  --pool-retirement-epoch-interval WORD32
+                           Epoch interval of pool retirement.
+  --number-of-pools NATURAL
+                           Desired number of pools.
+  --pool-influence RATIONAL
+                           Pool influence.
+  --treasury-expansion RATIONAL
+                           Treasury expansion.
+  --monetary-expansion RATIONAL
+                           Monetary expansion.
+  --min-pool-cost NATURAL  The minimum allowed cost parameter for stake pools.
+  --min-utxo-value NATURAL The minimum allowed UTxO value (Shelley to Mary
+                           eras).
+  --protocol-major-version MAJOR
+                           Specify the major protocol version to fork into. An
+                           increase indicates a hard fork. It must be the next
+                           natural number after the current version and must be
+                           supported by the node.
+  --protocol-minor-version MINOR
+                           Minor protocol version. An increase indicates a soft
+                           fork (old software can validate but not produce new
+                           blocks). Must be zero when the major protocol version
+                           is increased.
+  --extra-entropy HEX      Praos extra entropy seed, as a hex byte string.
+  --reset-extra-entropy    Reset the Praos extra entropy to none.
+  --decentralization-parameter RATIONAL
+                           Decentralization parameter.
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_shelley_governance_create-genesis-key-delegation-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_shelley_governance_create-genesis-key-delegation-certificate.cli
@@ -1,0 +1,38 @@
+Usage: cardano-cli compatible shelley governance create-genesis-key-delegation-certificate 
+                                                                                             ( --genesis-verification-key STRING
+                                                                                             | --genesis-verification-key-file FILEPATH
+                                                                                             | --genesis-verification-key-hash STRING
+                                                                                             )
+                                                                                             ( --genesis-delegate-verification-key STRING
+                                                                                             | --genesis-delegate-verification-key-file FILEPATH
+                                                                                             | --genesis-delegate-verification-key-hash STRING
+                                                                                             )
+                                                                                             ( --vrf-verification-key STRING
+                                                                                             | --vrf-verification-key-file FILEPATH
+                                                                                             | --vrf-verification-key-hash STRING
+                                                                                             )
+                                                                                             --out-file FILEPATH
+
+  Create a genesis key delegation certificate
+
+Available options:
+  --genesis-verification-key STRING
+                           Genesis verification key (hex-encoded).
+  --genesis-verification-key-file FILEPATH
+                           Filepath of the genesis verification key.
+  --genesis-verification-key-hash STRING
+                           Genesis verification key hash (hex-encoded).
+  --genesis-delegate-verification-key STRING
+                           Genesis delegate verification key (hex-encoded).
+  --genesis-delegate-verification-key-file FILEPATH
+                           Filepath of the genesis delegate verification key.
+  --genesis-delegate-verification-key-hash STRING
+                           Genesis delegate verification key hash (hex-encoded).
+  --vrf-verification-key STRING
+                           VRF verification key (Bech32 or hex-encoded).
+  --vrf-verification-key-file FILEPATH
+                           Filepath of the VRF verification key.
+  --vrf-verification-key-hash STRING
+                           VRF verification key hash (hex-encoded).
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_shelley_governance_create-mir-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_shelley_governance_create-mir-certificate.cli
@@ -1,0 +1,28 @@
+Usage: cardano-cli compatible shelley governance create-mir-certificate 
+                                                                          ( ( --reserves
+                                                                            | --treasury
+                                                                            )
+                                                                            (--stake-address ADDRESS)
+                                                                            (--reward LOVELACE)
+                                                                            --out-file FILEPATH
+                                                                          | stake-addresses
+                                                                          | transfer-to-treasury
+                                                                          | transfer-to-rewards
+                                                                          )
+
+  Create an MIR (Move Instantaneous Rewards) certificate
+
+Available options:
+  --reserves               Use the reserves pot.
+  --treasury               Use the treasury pot.
+  --stake-address ADDRESS  Target stake address (bech32 format).
+  --reward LOVELACE        The reward for the relevant reward account.
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text
+
+Available commands:
+  stake-addresses          Create an MIR certificate to pay stake addresses
+  transfer-to-treasury     Create an MIR certificate to transfer from the
+                           reserves pot to the treasury pot
+  transfer-to-rewards      Create an MIR certificate to transfer from the
+                           treasury pot to the reserves pot

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_shelley_governance_create-mir-certificate_stake-addresses.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_shelley_governance_create-mir-certificate_stake-addresses.cli
@@ -1,0 +1,17 @@
+Usage: cardano-cli compatible shelley governance create-mir-certificate stake-addresses 
+                                                                                          ( --reserves
+                                                                                          | --treasury
+                                                                                          )
+                                                                                          (--stake-address ADDRESS)
+                                                                                          (--reward LOVELACE)
+                                                                                          --out-file FILEPATH
+
+  Create an MIR certificate to pay stake addresses
+
+Available options:
+  --reserves               Use the reserves pot.
+  --treasury               Use the treasury pot.
+  --stake-address ADDRESS  Target stake address (bech32 format).
+  --reward LOVELACE        The reward for the relevant reward account.
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_shelley_governance_create-mir-certificate_transfer-to-rewards.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_shelley_governance_create-mir-certificate_transfer-to-rewards.cli
@@ -1,0 +1,10 @@
+Usage: cardano-cli compatible shelley governance create-mir-certificate transfer-to-rewards --transfer LOVELACE
+                                                                                              --out-file FILEPATH
+
+  Create an MIR certificate to transfer from the treasury pot to the reserves
+  pot
+
+Available options:
+  --transfer LOVELACE      The amount to transfer.
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_shelley_governance_create-mir-certificate_transfer-to-treasury.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_shelley_governance_create-mir-certificate_transfer-to-treasury.cli
@@ -1,0 +1,10 @@
+Usage: cardano-cli compatible shelley governance create-mir-certificate transfer-to-treasury --transfer LOVELACE
+                                                                                               --out-file FILEPATH
+
+  Create an MIR certificate to transfer from the reserves pot to the treasury
+  pot
+
+Available options:
+  --transfer LOVELACE      The amount to transfer.
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_shelley_transaction_signed-transaction.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_shelley_transaction_signed-transaction.cli
@@ -1,0 +1,32 @@
+Usage: cardano-cli compatible shelley transaction signed-transaction 
+                                                                       [--tx-in TX-IN]
+                                                                       [--tx-out ADDRESS VALUE]
+                                                                       [--update-proposal-file FILEPATH]
+                                                                       [--signing-key-file FILEPATH
+                                                                         [--address STRING]]
+                                                                       [ --mainnet
+                                                                       | --testnet-magic NATURAL
+                                                                       ]
+                                                                       --fee LOVELACE
+                                                                       --out-file FILEPATH
+
+  Create a simple signed transaction.
+
+Available options:
+  --tx-in TX-IN            TxId#TxIx
+  --tx-out ADDRESS VALUE   The transaction output as ADDRESS VALUE where ADDRESS
+                           is the Bech32-encoded address followed by the value
+                           in the multi-asset syntax (including simply
+                           Lovelace).
+  --update-proposal-file FILEPATH
+                           Filepath of the update proposal.
+  --signing-key-file FILEPATH
+                           Input filepath of the signing key (one or more).
+  --address STRING         Byron address (Base58-encoded).
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --fee LOVELACE           The fee amount in Lovelace.
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text


### PR DESCRIPTION
Related: #926 
# Changelog

```yaml
- description: |
    Introduce "compatible" command group
  type:
  - feature        # introduces a new feature
  - compatible     # the API has changed but is non-breaking
```

# Context

```
Usage: cardano-cli compatible 
                                ( shelley
                                | allegra
                                | mary
                                | alonzo
                                | babbage
                                | conway
                                )

  Limited backward compatible commands for testing only.

Available options:
  -h,--help                Show this help text

Available commands:
  shelley                  Shelley era commands
  allegra                  Allegra era commands
  mary                     Mary era commands
  alonzo                   Alonzo era commands
  babbage                  Babbage era commands
  conway                   Conway era commands

```
# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
