### PR TITLE
Hide free instances of `HashCheckParamInfo` into functions

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
@@ -3610,23 +3610,25 @@ pMustCheckHash
             ]
       ]
 
-proposalHashCheckInfo :: HashCheckParamInfo ProposalUrl
-proposalHashCheckInfo =
-  HashCheckParamInfo
-    { flagSuffix = "anchor-data"
-    , dataName = "proposal"
-    , hashParamName = "--anchor-data-hash"
-    , urlParamName = "--anchor-url"
-    }
+pMustCheckProposalHash :: Parser (MustCheckHash ProposalUrl)
+pMustCheckProposalHash =
+  pMustCheckHash
+    HashCheckParamInfo
+      { flagSuffix = "anchor-data"
+      , dataName = "proposal"
+      , hashParamName = "--anchor-data-hash"
+      , urlParamName = "--anchor-url"
+      }
 
-constitutionHashCheckInfo :: HashCheckParamInfo ConstitutionUrl
-constitutionHashCheckInfo =
-  HashCheckParamInfo
-    { flagSuffix = "constitution-hash"
-    , dataName = "constitution"
-    , hashParamName = "--constitution-hash"
-    , urlParamName = "--constitution-url"
-    }
+pMustCheckConstitutionHash :: Parser (MustCheckHash ConstitutionUrl)
+pMustCheckConstitutionHash =
+  pMustCheckHash
+    HashCheckParamInfo
+      { flagSuffix = "constitution-hash"
+      , dataName = "constitution"
+      , hashParamName = "--constitution-hash"
+      , urlParamName = "--constitution-url"
+      }
 
 pPreviousGovernanceAction :: Parser (Maybe (TxId, Word16))
 pPreviousGovernanceAction =

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
@@ -3569,66 +3569,37 @@ pAnchorDataHash =
       , Opt.help "Proposal anchor data hash (obtain it with \"cardano-cli hash anchor-data ...\")"
       ]
 
-data HashCheckParamInfo anchorData
-  = HashCheckParamInfo
-  { flagSuffix :: String
-  , dataName :: String
-  , hashParamName :: String
-  , urlParamName :: String
-  }
-
-pMustCheckHash :: HashCheckParamInfo anchorData -> Parser (MustCheckHash anchorData)
-pMustCheckHash
-  ( HashCheckParamInfo
-      { flagSuffix = flagSuffix'
-      , dataName = dataName'
-      , hashParamName = hashParamName'
-      , urlParamName = urlParamName'
-      }
-    ) =
-    asum
-      [ Opt.flag' CheckHash $
-          mconcat
-            [ Opt.long ("check-" ++ flagSuffix')
-            , Opt.help
-                ( "Check the "
-                    ++ dataName'
-                    ++ " hash (from "
-                    ++ hashParamName'
-                    ++ ") by downloading "
-                    ++ dataName'
-                    ++ " data (from "
-                    ++ urlParamName'
-                    ++ ")."
-                )
-            ]
-      , Opt.flag' TrustHash $
-          mconcat
-            [ Opt.long ("trust-" ++ flagSuffix')
-            , Opt.help
-                ("Do not check the " ++ dataName' ++ " hash (from " ++ hashParamName' ++ ") and trust it is correct.")
-            ]
-      ]
+pMustCheckHash :: String -> String -> String -> String -> Parser (MustCheckHash anchorData)
+pMustCheckHash flagSuffix' dataName' hashParamName' urlParamName' =
+  asum
+    [ Opt.flag' CheckHash $
+        mconcat
+          [ Opt.long ("check-" ++ flagSuffix')
+          , Opt.help
+              ( "Check the "
+                  ++ dataName'
+                  ++ " hash (from "
+                  ++ hashParamName'
+                  ++ ") by downloading "
+                  ++ dataName'
+                  ++ " data (from "
+                  ++ urlParamName'
+                  ++ ")."
+              )
+          ]
+    , Opt.flag' TrustHash $
+        mconcat
+          [ Opt.long ("trust-" ++ flagSuffix')
+          , Opt.help
+              ("Do not check the " ++ dataName' ++ " hash (from " ++ hashParamName' ++ ") and trust it is correct.")
+          ]
+    ]
 
 pMustCheckProposalHash :: Parser (MustCheckHash ProposalUrl)
-pMustCheckProposalHash =
-  pMustCheckHash
-    HashCheckParamInfo
-      { flagSuffix = "anchor-data"
-      , dataName = "proposal"
-      , hashParamName = "--anchor-data-hash"
-      , urlParamName = "--anchor-url"
-      }
+pMustCheckProposalHash = pMustCheckHash "anchor-data" "proposal" "--anchor-data-hash" "--anchor-url"
 
 pMustCheckConstitutionHash :: Parser (MustCheckHash ConstitutionUrl)
-pMustCheckConstitutionHash =
-  pMustCheckHash
-    HashCheckParamInfo
-      { flagSuffix = "constitution-hash"
-      , dataName = "constitution"
-      , hashParamName = "--constitution-hash"
-      , urlParamName = "--constitution-url"
-      }
+pMustCheckConstitutionHash = pMustCheckHash "constitution-hash" "constitution" "--constitution-hash" "--constitution-url"
 
 pPreviousGovernanceAction :: Parser (Maybe (TxId, Word16))
 pPreviousGovernanceAction =

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Actions.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Actions.hs
@@ -74,7 +74,7 @@ pGovernanceActionNewInfoCmd era = do
             <*> pStakeIdentifier (Just "deposit-return")
             <*> pAnchorUrl
             <*> pAnchorDataHash
-            <*> pMustCheckHash proposalHashCheckInfo
+            <*> pMustCheckProposalHash
             <*> pFileOutDirection "out-file" "Path to action file to be used later on with build or build-raw "
       )
     $ Opt.progDesc "Create an info action."
@@ -95,10 +95,10 @@ pGovernanceActionNewConstitutionCmd era = do
             <*> pPreviousGovernanceAction
             <*> pAnchorUrl
             <*> pAnchorDataHash
-            <*> pMustCheckHash proposalHashCheckInfo
+            <*> pMustCheckProposalHash
             <*> pConstitutionUrl
             <*> pConstitutionHash
-            <*> pMustCheckHash constitutionHashCheckInfo
+            <*> pMustCheckConstitutionHash
             <*> optional pConstitutionScriptHash
             <*> pFileOutDirection "out-file" "Output filepath of the constitution."
       )
@@ -128,7 +128,7 @@ pUpdateCommitteeCmd eon =
     <*> pStakeIdentifier (Just "deposit-return")
     <*> pAnchorUrl
     <*> pAnchorDataHash
-    <*> pMustCheckHash proposalHashCheckInfo
+    <*> pMustCheckProposalHash
     <*> many pRemoveCommitteeColdVerificationKeySource
     <*> many
       ( (,)
@@ -154,7 +154,7 @@ pGovernanceActionNoConfidenceCmd era = do
             <*> pStakeIdentifier (Just "deposit-return")
             <*> pAnchorUrl
             <*> pAnchorDataHash
-            <*> pMustCheckHash proposalHashCheckInfo
+            <*> pMustCheckProposalHash
             <*> pPreviousGovernanceAction
             <*> pFileOutDirection "out-file" "Output filepath of the no confidence proposal."
       )
@@ -176,7 +176,7 @@ pUpdateProtocolParametersPostConway conwayOnwards =
     <*> pStakeIdentifier (Just "deposit-return")
     <*> pAnchorUrl
     <*> pAnchorDataHash
-    <*> pMustCheckHash proposalHashCheckInfo
+    <*> pMustCheckProposalHash
     <*> pPreviousGovernanceAction
     <*> optional pConstitutionScriptHash
 
@@ -384,7 +384,7 @@ pGovernanceActionTreasuryWithdrawalCmd era = do
             <*> pStakeIdentifier (Just "deposit-return")
             <*> pAnchorUrl
             <*> pAnchorDataHash
-            <*> pMustCheckHash proposalHashCheckInfo
+            <*> pMustCheckProposalHash
             <*> some ((,) <$> pStakeIdentifier (Just "funds-receiving") <*> pTreasuryWithdrawalAmt)
             <*> optional pConstitutionScriptHash
             <*> pFileOutDirection "out-file" "Output filepath of the treasury withdrawal."
@@ -428,7 +428,7 @@ pGovernanceActionHardforkInitCmd era = do
             <*> pPreviousGovernanceAction
             <*> pAnchorUrl
             <*> pAnchorDataHash
-            <*> pMustCheckHash proposalHashCheckInfo
+            <*> pMustCheckProposalHash
             <*> pPV
             <*> pFileOutDirection "out-file" "Output filepath of the hardfork proposal."
       )


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Hid free instances of `HashCheckParamInfo` to improve type safety
  type:
  - refactoring    # QoL changes
```

# Context

This addresses post-merge reviews in https://github.com/IntersectMBO/cardano-cli/pull/915

# How to trust this PR

Ensure this is a refactoring and that the new design is robust.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
