### PR TITLE
transaction submit: print transaction hash

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Transaction.hs
@@ -1483,7 +1483,9 @@ runTransactionSubmitCmd
 
     res <- liftIO $ submitTxToNodeLocal localNodeConnInfo txInMode
     case res of
-      Net.Tx.SubmitSuccess -> liftIO $ Text.putStrLn "Transaction successfully submitted."
+      Net.Tx.SubmitSuccess -> do
+        liftIO $ Text.hPutStrLn IO.stderr "Transaction successfully submitted. Transaction hash is:"
+        liftIO $ LBS.putStrLn $ Aeson.encode $ TxSubmissionResult $ getTxId $ getTxBody tx
       Net.Tx.SubmitFail reason ->
         case reason of
           TxValidationErrorInCardanoMode err -> left . TxCmdTxSubmitError . Text.pack $ show err

--- a/cardano-cli/src/Cardano/CLI/Types/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Common.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE GeneralisedNewtypeDeriving #-}
@@ -68,6 +69,7 @@ module Cardano.CLI.Types.Common
   , TxBuildOutputOptions (..)
   , TxByronWitnessCount (..)
   , TxFile
+  , TxSubmissionResult (..)
   , TxTreasuryDonation (..)
   , TxInCount (..)
   , TxMempoolQuery (..)
@@ -102,6 +104,7 @@ import           Data.String (IsString)
 import           Data.Text (Text)
 import qualified Data.Text as Text
 import           Data.Word (Word64)
+import           GHC.Generics (Generic)
 
 -- | Determines the direction in which the MIR certificate will transfer ADA.
 data TransferDirection
@@ -663,3 +666,12 @@ data PotentiallyCheckedAnchor anchorType anchor
   -- ^ Whether to check the hash or not (CheckHash for checking or TrustHash for not checking)
   }
   deriving (Eq, Show)
+
+-- | Type used for serialization when printing the hash of a transaction
+-- after having submitted it.
+newtype TxSubmissionResult = TxSubmissionResult {txhash :: TxId}
+  deriving (Show, Generic)
+
+instance FromJSON TxSubmissionResult
+
+instance ToJSON TxSubmissionResult


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    transaction submit: print transaction hash, like this:

    Transaction successfully submitted. Transaction hash is:
    {"txhash":"456c614d5d547b7fe197a4d18fbb86e086cb9080594dabf9059adf08b00cf2bd"}

    Previously it was:

    Transaction successfully submitted.
# uncomment types applicable to the change:
  type:
  - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Fixes https://github.com/IntersectMBO/cardano-cli/issues/896

# How to trust this PR

We added a test in `cardano-testnet`: https://github.com/IntersectMBO/cardano-node/pull/6003

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] Self-reviewed the diff