### PR TITLE
Move node commands to top level

### DIFF
--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -62,6 +62,7 @@ library
     Cardano.CLI.Commands.Debug.LogEpochState
     Cardano.CLI.Commands.Debug.TransactionView
     Cardano.CLI.Commands.Hash
+    Cardano.CLI.Commands.Node
     Cardano.CLI.Commands.Ping
     Cardano.CLI.Environment
     Cardano.CLI.EraBased.Commands
@@ -74,7 +75,6 @@ library
     Cardano.CLI.EraBased.Commands.Governance.Poll
     Cardano.CLI.EraBased.Commands.Governance.Vote
     Cardano.CLI.EraBased.Commands.Key
-    Cardano.CLI.EraBased.Commands.Node
     Cardano.CLI.EraBased.Commands.Query
     Cardano.CLI.EraBased.Commands.StakeAddress
     Cardano.CLI.EraBased.Commands.StakePool
@@ -90,7 +90,6 @@ library
     Cardano.CLI.EraBased.Options.Governance.Poll
     Cardano.CLI.EraBased.Options.Governance.Vote
     Cardano.CLI.EraBased.Options.Key
-    Cardano.CLI.EraBased.Options.Node
     Cardano.CLI.EraBased.Options.Query
     Cardano.CLI.EraBased.Options.StakeAddress
     Cardano.CLI.EraBased.Options.StakePool
@@ -110,7 +109,6 @@ library
     Cardano.CLI.EraBased.Run.Governance.Poll
     Cardano.CLI.EraBased.Run.Governance.Vote
     Cardano.CLI.EraBased.Run.Key
-    Cardano.CLI.EraBased.Run.Node
     Cardano.CLI.EraBased.Run.Query
     Cardano.CLI.EraBased.Run.StakeAddress
     Cardano.CLI.EraBased.Run.StakePool
@@ -131,6 +129,7 @@ library
     Cardano.CLI.Options
     Cardano.CLI.Options.Debug
     Cardano.CLI.Options.Hash
+    Cardano.CLI.Options.Node
     Cardano.CLI.Options.Ping
     Cardano.CLI.Orphans
     Cardano.CLI.Parser
@@ -142,6 +141,7 @@ library
     Cardano.CLI.Run.Debug.LogEpochState
     Cardano.CLI.Run.Debug.TransactionView
     Cardano.CLI.Run.Hash
+    Cardano.CLI.Run.Node
     Cardano.CLI.Run.Ping
     Cardano.CLI.TopHandler
     Cardano.CLI.Types.Common

--- a/cardano-cli/src/Cardano/CLI/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Commands.hs
@@ -8,9 +8,9 @@ where
 import           Cardano.CLI.Byron.Commands (ByronCommand)
 import           Cardano.CLI.Commands.Debug
 import           Cardano.CLI.Commands.Hash (HashCmds)
+import           Cardano.CLI.Commands.Node
 import           Cardano.CLI.Commands.Ping (PingCmd (..))
 import           Cardano.CLI.EraBased.Commands
-import           Cardano.CLI.EraBased.Commands.Node
 import           Cardano.CLI.Legacy.Commands
 
 import           Options.Applicative.Types (ParserInfo (..), ParserPrefs (..))

--- a/cardano-cli/src/Cardano/CLI/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Commands.hs
@@ -10,6 +10,7 @@ import           Cardano.CLI.Commands.Debug
 import           Cardano.CLI.Commands.Hash (HashCmds)
 import           Cardano.CLI.Commands.Ping (PingCmd (..))
 import           Cardano.CLI.EraBased.Commands
+import           Cardano.CLI.EraBased.Commands.Node
 import           Cardano.CLI.Legacy.Commands
 
 import           Options.Applicative.Types (ParserInfo (..), ParserPrefs (..))
@@ -21,6 +22,8 @@ data ClientCommand
     ByronCommand ByronCommand
   | -- | Era-agnostic hashing commands
     HashCmds HashCmds
+  | -- | Era agnostic node commands
+    NodeCommands NodeCmds
   | -- | Legacy shelley-based Commands
     LegacyCmds LegacyCmds
   | CliPingCommand PingCmd

--- a/cardano-cli/src/Cardano/CLI/Commands/Node.hs
+++ b/cardano-cli/src/Cardano/CLI/Commands/Node.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE LambdaCase #-}
 
-module Cardano.CLI.EraBased.Commands.Node
+module Cardano.CLI.Commands.Node
   ( NodeCmds (..)
   , renderNodeCmds
   , NodeKeyGenColdCmdArgs (..)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands.hs
@@ -13,11 +13,11 @@ where
 
 import           Cardano.Api (ShelleyBasedEra (..), toCardanoEra)
 
+import           Cardano.CLI.Commands.Node
 import           Cardano.CLI.Environment
 import           Cardano.CLI.EraBased.Commands.Address
 import           Cardano.CLI.EraBased.Commands.Genesis
 import           Cardano.CLI.EraBased.Commands.Key
-import           Cardano.CLI.EraBased.Commands.Node
 import           Cardano.CLI.EraBased.Commands.Query
 import           Cardano.CLI.EraBased.Commands.StakeAddress
 import           Cardano.CLI.EraBased.Commands.StakePool hiding (sbe)
@@ -28,12 +28,12 @@ import           Cardano.CLI.EraBased.Options.Common
 import           Cardano.CLI.EraBased.Options.Genesis
 import           Cardano.CLI.EraBased.Options.Governance
 import           Cardano.CLI.EraBased.Options.Key
-import           Cardano.CLI.EraBased.Options.Node
 import           Cardano.CLI.EraBased.Options.Query
 import           Cardano.CLI.EraBased.Options.StakeAddress
 import           Cardano.CLI.EraBased.Options.StakePool
 import           Cardano.CLI.EraBased.Options.TextView
 import           Cardano.CLI.EraBased.Options.Transaction
+import           Cardano.CLI.Options.Node
 
 import           Data.Foldable
 import           Data.Maybe

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands.hs
@@ -121,7 +121,7 @@ pCmds sbe' envCli = do
       , fmap KeyCmds <$> pKeyCmds
       , fmap GenesisCmds <$> pGenesisCmds cEra envCli
       , fmap GovernanceCmds <$> pGovernanceCmds cEra
-      , fmap NodeCmds <$> pNodeCmds
+      , Just (NodeCmds <$> pNodeCmds)
       , fmap QueryCmds <$> pQueryCmds cEra envCli
       , fmap StakeAddressCmds <$> pStakeAddressCmds cEra envCli
       , fmap StakePoolCmds <$> pStakePoolCmds cEra envCli

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands.hs
@@ -54,7 +54,7 @@ data Cmds era
   | KeyCmds (KeyCmds era)
   | GenesisCmds (GenesisCmds era)
   | GovernanceCmds (GovernanceCmds era)
-  | NodeCmds (NodeCmds era)
+  | NodeCmds NodeCmds
   | QueryCmds (QueryCmds era)
   | StakeAddressCmds (StakeAddressCmds era)
   | StakePoolCmds (StakePoolCmds era)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Node.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Node.hs
@@ -21,7 +21,7 @@ import           Cardano.CLI.Types.Key
 
 import           Data.Text (Text)
 
-data NodeCmds era
+data NodeCmds
   = NodeKeyGenColdCmd !NodeKeyGenColdCmdArgs
   | NodeKeyGenKESCmd !NodeKeyGenKESCmdArgs
   | NodeKeyGenVRFCmd !NodeKeyGenVRFCmdArgs
@@ -84,7 +84,7 @@ data NodeIssueOpCertCmdArgs
   }
   deriving Show
 
-renderNodeCmds :: NodeCmds era -> Text
+renderNodeCmds :: NodeCmds -> Text
 renderNodeCmds = \case
   NodeKeyGenColdCmd{} -> "node key-gen"
   NodeKeyGenKESCmd{} -> "node key-gen-KES"

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Node.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Node.hs
@@ -20,60 +20,58 @@ import qualified Options.Applicative as Opt
 {- HLINT ignore "Use <$>" -}
 {- HLINT ignore "Move brackets to avoid $" -}
 
-pNodeCmds :: Maybe (Parser (NodeCmds era))
+pNodeCmds :: Parser NodeCmds
 pNodeCmds =
-  subInfoParser
-    "node"
-    ( Opt.progDesc $
-        mconcat
-          [ "Node operation commands."
+  let nodeCmdParsers =
+        asum
+          [ subParser "key-gen" $
+              Opt.info pKeyGenOperator $
+                Opt.progDesc $
+                  mconcat
+                    [ "Create a key pair for a node operator's offline "
+                    , "key and a new certificate issue counter"
+                    ]
+          , subParser "key-gen-KES" $
+              Opt.info pKeyGenKES $
+                Opt.progDesc $
+                  mconcat
+                    [ "Create a key pair for a node KES operational key"
+                    ]
+          , subParser "key-gen-VRF" $
+              Opt.info pKeyGenVRF $
+                Opt.progDesc $
+                  mconcat
+                    [ "Create a key pair for a node VRF operational key"
+                    ]
+          , subParser "key-hash-VRF" . Opt.info pKeyHashVRF $
+              Opt.progDesc $
+                mconcat
+                  [ "Print hash of a node's operational VRF key."
+                  ]
+          , subParser "new-counter" $
+              Opt.info pNewCounter $
+                Opt.progDesc $
+                  mconcat
+                    [ "Create a new certificate issue counter"
+                    ]
+          , subParser "issue-op-cert" $
+              Opt.info pIssueOpCert $
+                Opt.progDesc $
+                  mconcat
+                    [ "Issue a node operational certificate"
+                    ]
           ]
-    )
-    [ Just $
-        subParser "key-gen" $
-          Opt.info pKeyGenOperator $
-            Opt.progDesc $
+   in subParser
+        "node"
+        $ Opt.info
+          nodeCmdParsers
+          ( Opt.progDesc $
               mconcat
-                [ "Create a key pair for a node operator's offline "
-                , "key and a new certificate issue counter"
+                [ "Node operation commands."
                 ]
-    , Just $
-        subParser "key-gen-KES" $
-          Opt.info pKeyGenKES $
-            Opt.progDesc $
-              mconcat
-                [ "Create a key pair for a node KES operational key"
-                ]
-    , Just $
-        subParser "key-gen-VRF" $
-          Opt.info pKeyGenVRF $
-            Opt.progDesc $
-              mconcat
-                [ "Create a key pair for a node VRF operational key"
-                ]
-    , Just $
-        subParser "key-hash-VRF" . Opt.info pKeyHashVRF $
-          Opt.progDesc $
-            mconcat
-              [ "Print hash of a node's operational VRF key."
-              ]
-    , Just $
-        subParser "new-counter" $
-          Opt.info pNewCounter $
-            Opt.progDesc $
-              mconcat
-                [ "Create a new certificate issue counter"
-                ]
-    , Just $
-        subParser "issue-op-cert" $
-          Opt.info pIssueOpCert $
-            Opt.progDesc $
-              mconcat
-                [ "Issue a node operational certificate"
-                ]
-    ]
+          )
 
-pKeyGenOperator :: Parser (NodeCmds era)
+pKeyGenOperator :: Parser NodeCmds
 pKeyGenOperator =
   fmap Cmd.NodeKeyGenColdCmd $
     Cmd.NodeKeyGenColdCmdArgs
@@ -82,7 +80,7 @@ pKeyGenOperator =
       <*> pColdSigningKeyFile
       <*> pOperatorCertIssueCounterFile
 
-pKeyGenKES :: Parser (NodeCmds era)
+pKeyGenKES :: Parser NodeCmds
 pKeyGenKES =
   fmap Cmd.NodeKeyGenKESCmd $
     Cmd.NodeKeyGenKESCmdArgs
@@ -90,7 +88,7 @@ pKeyGenKES =
       <*> pVerificationKeyFileOut
       <*> pSigningKeyFileOut
 
-pKeyGenVRF :: Parser (NodeCmds era)
+pKeyGenVRF :: Parser NodeCmds
 pKeyGenVRF =
   fmap Cmd.NodeKeyGenVRFCmd $
     Cmd.NodeKeyGenVRFCmdArgs
@@ -98,14 +96,14 @@ pKeyGenVRF =
       <*> pVerificationKeyFileOut
       <*> pSigningKeyFileOut
 
-pKeyHashVRF :: Parser (NodeCmds era)
+pKeyHashVRF :: Parser NodeCmds
 pKeyHashVRF =
   fmap Cmd.NodeKeyHashVRFCmd $
     Cmd.NodeKeyHashVRFCmdArgs
       <$> pVerificationKeyOrFileIn AsVrfKey
       <*> pMaybeOutputFile
 
-pNewCounter :: Parser (NodeCmds era)
+pNewCounter :: Parser NodeCmds
 pNewCounter =
   fmap Cmd.NodeNewCounterCmd $
     Cmd.NodeNewCounterCmdArgs
@@ -122,7 +120,7 @@ pCounterValue =
       , Opt.help "The next certificate issue counter value to use."
       ]
 
-pIssueOpCert :: Parser (NodeCmds era)
+pIssueOpCert :: Parser NodeCmds
 pIssueOpCert =
   fmap Cmd.NodeIssueOpCertCmd $
     Cmd.NodeIssueOpCertCmdArgs

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run.hs
@@ -15,13 +15,13 @@ import           Cardano.CLI.EraBased.Run.Address
 import           Cardano.CLI.EraBased.Run.Genesis
 import           Cardano.CLI.EraBased.Run.Governance
 import           Cardano.CLI.EraBased.Run.Key
-import           Cardano.CLI.EraBased.Run.Node
 import           Cardano.CLI.EraBased.Run.Query
 import           Cardano.CLI.EraBased.Run.StakeAddress
 import           Cardano.CLI.EraBased.Run.StakePool
 import           Cardano.CLI.EraBased.Run.TextView
 import           Cardano.CLI.EraBased.Run.Transaction
 import           Cardano.CLI.Helpers (printEraDeprecationWarning)
+import           Cardano.CLI.Run.Node
 import           Cardano.CLI.Types.Errors.CmdError
 
 import           Data.Function ((&))

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Genesis.hs
@@ -44,14 +44,14 @@ import           Cardano.Chain.Update hiding (ProtocolParameters)
 import           Cardano.CLI.Byron.Delegation
 import           Cardano.CLI.Byron.Genesis as Byron
 import qualified Cardano.CLI.Byron.Key as Byron
+import qualified Cardano.CLI.Commands.Node as Cmd
 import           Cardano.CLI.EraBased.Commands.Genesis as Cmd
-import qualified Cardano.CLI.EraBased.Commands.Node as Cmd
 import           Cardano.CLI.EraBased.Run.Genesis.Common
 import qualified Cardano.CLI.EraBased.Run.Genesis.CreateTestnetData as TN
-import           Cardano.CLI.EraBased.Run.Node (runNodeIssueOpCertCmd, runNodeKeyGenColdCmd,
-                   runNodeKeyGenKesCmd, runNodeKeyGenVrfCmd)
 import           Cardano.CLI.EraBased.Run.StakeAddress (runStakeAddressKeyGenCmd)
 import qualified Cardano.CLI.IO.Lazy as Lazy
+import           Cardano.CLI.Run.Node (runNodeIssueOpCertCmd, runNodeKeyGenColdCmd,
+                   runNodeKeyGenKesCmd, runNodeKeyGenVrfCmd)
 import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Errors.GenesisCmdError
 import           Cardano.CLI.Types.Errors.NodeCmdError

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Genesis/CreateTestnetData.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Genesis/CreateTestnetData.hs
@@ -33,17 +33,17 @@ import           Cardano.Api.Shelley
                    VrfKey, alonzoGenesisDefaults, conwayGenesisDefaults, shelleyGenesisDefaults,
                    toShelleyAddr, toShelleyNetwork, toShelleyStakeAddr)
 
+import qualified Cardano.CLI.Commands.Node as Cmd
 import           Cardano.CLI.EraBased.Commands.Genesis as Cmd
 import qualified Cardano.CLI.EraBased.Commands.Governance.DRep as DRep
-import qualified Cardano.CLI.EraBased.Commands.Node as Cmd
 import           Cardano.CLI.EraBased.Run.Address (generateAndWriteKeyFiles)
 import           Cardano.CLI.EraBased.Run.Genesis.Common
 import qualified Cardano.CLI.EraBased.Run.Governance.DRep as DRep
 import qualified Cardano.CLI.EraBased.Run.Key as Key
-import           Cardano.CLI.EraBased.Run.Node (runNodeIssueOpCertCmd, runNodeKeyGenColdCmd,
-                   runNodeKeyGenKesCmd, runNodeKeyGenVrfCmd)
 import           Cardano.CLI.EraBased.Run.StakeAddress (runStakeAddressKeyGenCmd)
 import qualified Cardano.CLI.IO.Lazy as Lazy
+import           Cardano.CLI.Run.Node (runNodeIssueOpCertCmd, runNodeKeyGenColdCmd,
+                   runNodeKeyGenKesCmd, runNodeKeyGenVrfCmd)
 import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Errors.GenesisCmdError
 import           Cardano.CLI.Types.Errors.NodeCmdError

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Node.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Node.hs
@@ -30,7 +30,7 @@ import           Data.Word (Word64)
 
 runNodeCmds
   :: ()
-  => Cmd.NodeCmds era
+  => Cmd.NodeCmds
   -> ExceptT NodeCmdError IO ()
 runNodeCmds = \case
   Cmd.NodeKeyGenColdCmd args -> runNodeKeyGenColdCmd args

--- a/cardano-cli/src/Cardano/CLI/Options.hs
+++ b/cardano-cli/src/Cardano/CLI/Options.hs
@@ -13,6 +13,7 @@ import           Cardano.CLI.Byron.Parsers (backwardsCompatibilityCommands, pars
 import           Cardano.CLI.Environment (EnvCli)
 import           Cardano.CLI.EraBased.Commands
 import           Cardano.CLI.EraBased.Options.Common
+import           Cardano.CLI.EraBased.Options.Node
 import           Cardano.CLI.Legacy.Options (parseLegacyCmds)
 import           Cardano.CLI.Options.Debug
 import           Cardano.CLI.Options.Hash
@@ -47,13 +48,19 @@ pref =
       , helpRenderHelp customRenderHelp
       ]
 
+-- The node related commands are shelley era agnostic for the time being.
+-- There is no need to guard them by the era argument.
+nodeCmdsTopLevel :: Parser ClientCommand
+nodeCmdsTopLevel = NodeCommands <$> pNodeCmds
+
 parseClientCommand :: EnvCli -> Parser ClientCommand
 parseClientCommand envCli =
   asum
     -- There are name clashes between Shelley commands and the Byron backwards
     -- compat commands (e.g. "genesis"), and we need to prefer the Shelley ones
     -- so we list it first.
-    [ parseLegacy envCli
+    [ nodeCmdsTopLevel
+    , parseLegacy envCli
     , parseByron envCli
     , parseAnyEra envCli
     , parseHash

--- a/cardano-cli/src/Cardano/CLI/Options.hs
+++ b/cardano-cli/src/Cardano/CLI/Options.hs
@@ -13,10 +13,10 @@ import           Cardano.CLI.Byron.Parsers (backwardsCompatibilityCommands, pars
 import           Cardano.CLI.Environment (EnvCli)
 import           Cardano.CLI.EraBased.Commands
 import           Cardano.CLI.EraBased.Options.Common
-import           Cardano.CLI.EraBased.Options.Node
 import           Cardano.CLI.Legacy.Options (parseLegacyCmds)
 import           Cardano.CLI.Options.Debug
 import           Cardano.CLI.Options.Hash
+import           Cardano.CLI.Options.Node
 import           Cardano.CLI.Options.Ping (parsePingCmd)
 import           Cardano.CLI.Render (customRenderHelp)
 import           Cardano.CLI.Run (ClientCommand (..))

--- a/cardano-cli/src/Cardano/CLI/Options/Node.hs
+++ b/cardano-cli/src/Cardano/CLI/Options/Node.hs
@@ -3,17 +3,18 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-module Cardano.CLI.EraBased.Options.Node
+module Cardano.CLI.Options.Node
   ( pNodeCmds
   )
 where
 
 import           Cardano.Api hiding (QueryInShelleyBasedEra (..))
 
-import           Cardano.CLI.EraBased.Commands.Node
-import qualified Cardano.CLI.EraBased.Commands.Node as Cmd
+import           Cardano.CLI.Commands.Node
+import qualified Cardano.CLI.Commands.Node as Cmd
 import           Cardano.CLI.EraBased.Options.Common
 
+import           Data.Foldable
 import           Options.Applicative hiding (help, str)
 import qualified Options.Applicative as Opt
 

--- a/cardano-cli/src/Cardano/CLI/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Run.hs
@@ -18,6 +18,7 @@ import           Cardano.CLI.Byron.Run (ByronClientCmdError, renderByronClientCm
 import           Cardano.CLI.Commands
 import           Cardano.CLI.EraBased.Commands
 import           Cardano.CLI.EraBased.Run
+import           Cardano.CLI.EraBased.Run.Node
 import           Cardano.CLI.Legacy.Commands
 import           Cardano.CLI.Legacy.Run (runLegacyCmds)
 import           Cardano.CLI.Render (customRenderHelp)
@@ -27,9 +28,11 @@ import           Cardano.CLI.Run.Ping (PingClientCmdError (..), renderPingClient
                    runPingCmd)
 import           Cardano.CLI.Types.Errors.CmdError
 import           Cardano.CLI.Types.Errors.HashCmdError
+import           Cardano.CLI.Types.Errors.NodeCmdError
 import           Cardano.Git.Rev (gitRev)
 
 import           Control.Monad (forM_)
+import           Data.Function
 import qualified Data.List as L
 import           Data.Text (Text)
 import qualified Data.Text as Text
@@ -47,6 +50,7 @@ data ClientCommandErrors
   = ByronClientError ByronClientCmdError
   | CmdError Text CmdError
   | HashCmdError HashCmdError
+  | NodeCmdError NodeCmdError
   | PingClientError PingClientCmdError
   | DebugCmdError DebugCmdError
 
@@ -54,6 +58,9 @@ runClientCommand :: ClientCommand -> ExceptT ClientCommandErrors IO ()
 runClientCommand = \case
   AnyEraCommand cmds ->
     firstExceptT (CmdError (renderAnyEraCommand cmds)) $ runAnyEraCommand cmds
+  NodeCommands cmds ->
+    runNodeCmds cmds
+      & firstExceptT NodeCmdError
   ByronCommand cmds ->
     firstExceptT ByronClientError $ runByronClientCommand cmds
   HashCmds cmds ->
@@ -77,6 +84,8 @@ renderClientCommandError = \case
     renderByronClientCmdError err
   HashCmdError err ->
     prettyError err
+  NodeCmdError err ->
+    renderNodeCmdError err
   PingClientError err ->
     renderPingClientCmdError err
   DebugCmdError err ->

--- a/cardano-cli/src/Cardano/CLI/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Run.hs
@@ -18,12 +18,12 @@ import           Cardano.CLI.Byron.Run (ByronClientCmdError, renderByronClientCm
 import           Cardano.CLI.Commands
 import           Cardano.CLI.EraBased.Commands
 import           Cardano.CLI.EraBased.Run
-import           Cardano.CLI.EraBased.Run.Node
 import           Cardano.CLI.Legacy.Commands
 import           Cardano.CLI.Legacy.Run (runLegacyCmds)
 import           Cardano.CLI.Render (customRenderHelp)
 import           Cardano.CLI.Run.Debug
 import           Cardano.CLI.Run.Hash (runHashCmds)
+import           Cardano.CLI.Run.Node
 import           Cardano.CLI.Run.Ping (PingClientCmdError (..), renderPingClientCmdError,
                    runPingCmd)
 import           Cardano.CLI.Types.Errors.CmdError

--- a/cardano-cli/src/Cardano/CLI/Run/Node.hs
+++ b/cardano-cli/src/Cardano/CLI/Run/Node.hs
@@ -3,7 +3,7 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
 
-module Cardano.CLI.EraBased.Run.Node
+module Cardano.CLI.Run.Node
   ( runNodeCmds
   , runNodeIssueOpCertCmd
   , runNodeKeyGenColdCmd
@@ -17,7 +17,7 @@ where
 import           Cardano.Api
 import           Cardano.Api.Shelley
 
-import qualified Cardano.CLI.EraBased.Commands.Node as Cmd
+import qualified Cardano.CLI.Commands.Node as Cmd
 import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Errors.NodeCmdError
 import           Cardano.CLI.Types.Key

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -1,5 +1,6 @@
 Usage: cardano-cli 
-                     ( legacy
+                     ( node
+                     | legacy
                      | byron
                      | shelley
                      | allegra
@@ -13,6 +14,66 @@ Usage: cardano-cli
                      | debug commands
                      | version
                      )
+
+Usage: cardano-cli node 
+                          ( key-gen
+                          | key-gen-KES
+                          | key-gen-VRF
+                          | key-hash-VRF
+                          | new-counter
+                          | issue-op-cert
+                          )
+
+  Node operation commands.
+
+Usage: cardano-cli node key-gen [--key-output-format STRING]
+                                  --cold-verification-key-file FILEPATH
+                                  --cold-signing-key-file FILEPATH
+                                  --operational-certificate-issue-counter-file FILEPATH
+
+  Create a key pair for a node operator's offline key and a new certificate
+  issue counter
+
+Usage: cardano-cli node key-gen-KES [--key-output-format STRING]
+                                      --verification-key-file FILEPATH
+                                      --signing-key-file FILEPATH
+
+  Create a key pair for a node KES operational key
+
+Usage: cardano-cli node key-gen-VRF [--key-output-format STRING]
+                                      --verification-key-file FILEPATH
+                                      --signing-key-file FILEPATH
+
+  Create a key pair for a node VRF operational key
+
+Usage: cardano-cli node key-hash-VRF 
+                                       ( --verification-key STRING
+                                       | --verification-key-file FILEPATH
+                                       )
+                                       [--out-file FILEPATH]
+
+  Print hash of a node's operational VRF key.
+
+Usage: cardano-cli node new-counter 
+                                      ( --stake-pool-verification-key STRING
+                                      | --genesis-delegate-verification-key STRING
+                                      | --cold-verification-key-file FILEPATH
+                                      )
+                                      --counter-value INT
+                                      --operational-certificate-issue-counter-file FILEPATH
+
+  Create a new certificate issue counter
+
+Usage: cardano-cli node issue-op-cert 
+                                        ( --kes-verification-key STRING
+                                        | --kes-verification-key-file FILEPATH
+                                        )
+                                        --cold-signing-key-file FILEPATH
+                                        --operational-certificate-issue-counter-file FILEPATH
+                                        --kes-period NATURAL
+                                        --out-file FILEPATH
+
+  Issue a node operational certificate
 
 Usage: cardano-cli legacy Legacy commands
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/node.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/node.cli
@@ -1,0 +1,22 @@
+Usage: cardano-cli node 
+                          ( key-gen
+                          | key-gen-KES
+                          | key-gen-VRF
+                          | key-hash-VRF
+                          | new-counter
+                          | issue-op-cert
+                          )
+
+  Node operation commands.
+
+Available options:
+  -h,--help                Show this help text
+
+Available commands:
+  key-gen                  Create a key pair for a node operator's offline key
+                           and a new certificate issue counter
+  key-gen-KES              Create a key pair for a node KES operational key
+  key-gen-VRF              Create a key pair for a node VRF operational key
+  key-hash-VRF             Print hash of a node's operational VRF key.
+  new-counter              Create a new certificate issue counter
+  issue-op-cert            Issue a node operational certificate

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/node_issue-op-cert.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/node_issue-op-cert.cli
@@ -1,0 +1,24 @@
+Usage: cardano-cli node issue-op-cert 
+                                        ( --kes-verification-key STRING
+                                        | --kes-verification-key-file FILEPATH
+                                        )
+                                        --cold-signing-key-file FILEPATH
+                                        --operational-certificate-issue-counter-file FILEPATH
+                                        --kes-period NATURAL
+                                        --out-file FILEPATH
+
+  Issue a node operational certificate
+
+Available options:
+  --kes-verification-key STRING
+                           A Bech32 or hex-encoded hot KES verification key.
+  --kes-verification-key-file FILEPATH
+                           Filepath of the hot KES verification key.
+  --cold-signing-key-file FILEPATH
+                           Filepath of the cold signing key.
+  --operational-certificate-issue-counter-file FILEPATH
+                           The file with the issue counter for the operational
+                           certificate.
+  --kes-period NATURAL     The start of the KES key validity period.
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/node_key-gen-KES.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/node_key-gen-KES.cli
@@ -1,0 +1,16 @@
+Usage: cardano-cli node key-gen-KES [--key-output-format STRING]
+                                      --verification-key-file FILEPATH
+                                      --signing-key-file FILEPATH
+
+  Create a key pair for a node KES operational key
+
+Available options:
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32" (default is
+                           "text-envelope").
+  --verification-key-file FILEPATH
+                           Output filepath of the verification key.
+  --signing-key-file FILEPATH
+                           Output filepath of the signing key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/node_key-gen-VRF.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/node_key-gen-VRF.cli
@@ -1,0 +1,16 @@
+Usage: cardano-cli node key-gen-VRF [--key-output-format STRING]
+                                      --verification-key-file FILEPATH
+                                      --signing-key-file FILEPATH
+
+  Create a key pair for a node VRF operational key
+
+Available options:
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32" (default is
+                           "text-envelope").
+  --verification-key-file FILEPATH
+                           Output filepath of the verification key.
+  --signing-key-file FILEPATH
+                           Output filepath of the signing key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/node_key-gen.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/node_key-gen.cli
@@ -1,0 +1,21 @@
+Usage: cardano-cli node key-gen [--key-output-format STRING]
+                                  --cold-verification-key-file FILEPATH
+                                  --cold-signing-key-file FILEPATH
+                                  --operational-certificate-issue-counter-file FILEPATH
+
+  Create a key pair for a node operator's offline key and a new certificate
+  issue counter
+
+Available options:
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32" (default is
+                           "text-envelope").
+  --cold-verification-key-file FILEPATH
+                           Filepath of the cold verification key.
+  --cold-signing-key-file FILEPATH
+                           Filepath of the cold signing key.
+  --operational-certificate-issue-counter-file FILEPATH
+                           The file with the issue counter for the operational
+                           certificate.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/node_key-hash-VRF.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/node_key-hash-VRF.cli
@@ -1,0 +1,15 @@
+Usage: cardano-cli node key-hash-VRF 
+                                       ( --verification-key STRING
+                                       | --verification-key-file FILEPATH
+                                       )
+                                       [--out-file FILEPATH]
+
+  Print hash of a node's operational VRF key.
+
+Available options:
+  --verification-key STRING
+                           Verification key (Bech32 or hex-encoded).
+  --verification-key-file FILEPATH
+                           Input filepath of the verification key.
+  --out-file FILEPATH      Optional output file. Default is to write to stdout.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/node_new-counter.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/node_new-counter.cli
@@ -1,0 +1,22 @@
+Usage: cardano-cli node new-counter 
+                                      ( --stake-pool-verification-key STRING
+                                      | --genesis-delegate-verification-key STRING
+                                      | --cold-verification-key-file FILEPATH
+                                      )
+                                      --counter-value INT
+                                      --operational-certificate-issue-counter-file FILEPATH
+
+  Create a new certificate issue counter
+
+Available options:
+  --stake-pool-verification-key STRING
+                           Stake pool verification key (Bech32 or hex-encoded).
+  --genesis-delegate-verification-key STRING
+                           Genesis delegate verification key (hex-encoded).
+  --cold-verification-key-file FILEPATH
+                           Filepath of the cold verification key.
+  --counter-value INT      The next certificate issue counter value to use.
+  --operational-certificate-issue-counter-file FILEPATH
+                           The file with the issue counter for the operational
+                           certificate.
+  -h,--help                Show this help text


### PR DESCRIPTION
Partly resolves: #926
# Changelog

```yaml
- description: |
    The node commands are era agnostic and should be moved to the top level
# uncomment types applicable to the change:
  type:
  - feature        # introduces a new featur
  - compatible     # the API has changed but is non-breaking
```

# Context

Additional context for the PR goes here. If the PR fixes a particular issue please provide a [link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=) to the issue.

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
