### PR TITLE
Add metadata validation, hash checking, and URL support to `stake-pool registration-certificate`, and hash checking and URL support to `stake-pool metadata-hash`

### DIFF
--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -351,6 +351,7 @@ test-suite cardano-cli-test
     Test.Cli.Pioneers.Exercise5
     Test.Cli.Pioneers.Exercise6
     Test.Cli.Pipes
+    Test.Cli.Shelley.Certificates.StakePool
     Test.Cli.Shelley.Run.Hash
     Test.Cli.Shelley.Run.Query
     Test.Cli.Shelley.Transaction.Build

--- a/cardano-cli/src/Cardano/CLI/Commands/Hash.hs
+++ b/cardano-cli/src/Cardano/CLI/Commands/Hash.hs
@@ -23,11 +23,11 @@ data HashCmds
   = HashAnchorDataCmd !HashAnchorDataCmdArgs
   | HashScriptCmd !HashScriptCmdArgs
 
-data HashGoal
+data HashGoal hash
   = -- | The hash is written to stdout
     HashToStdout
   | -- | The hash to check against
-    CheckHash !(L.SafeHash L.StandardCrypto L.AnchorData)
+    CheckHash !hash
   | -- | The output file to which the hash is written
     HashToFile !(File () Out)
   deriving Show
@@ -35,7 +35,7 @@ data HashGoal
 data HashAnchorDataCmdArgs
   = HashAnchorDataCmdArgs
   { toHash :: !AnchorDataHashSource
-  , hashGoal :: !HashGoal
+  , hashGoal :: !(HashGoal (L.SafeHash L.StandardCrypto L.AnchorData))
   }
   deriving Show
 

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/DRep.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/DRep.hs
@@ -56,6 +56,7 @@ data GovernanceDRepRegistrationCertificateCmdArgs era
       :: !( Maybe
               ( PotentiallyCheckedAnchor
                   DRepMetadataUrl
+                  (L.Anchor L.StandardCrypto)
               )
           )
   , outFile :: !(File () Out)
@@ -77,6 +78,7 @@ data GovernanceDRepUpdateCertificateCmdArgs era
       :: Maybe
           ( PotentiallyCheckedAnchor
               DRepMetadataUrl
+              (L.Anchor L.StandardCrypto)
           )
   , outFile :: !(File () Out)
   }

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/DRep.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/DRep.hs
@@ -12,13 +12,13 @@ module Cardano.CLI.EraBased.Commands.Governance.DRep
   , GovernanceDRepUpdateCertificateCmdArgs (..)
   , GovernanceDRepMetadataHashCmdArgs (..)
   , DRepMetadataSource (..)
-  , DRepHashGoal (..)
   )
 where
 
 import           Cardano.Api
 import qualified Cardano.Api.Ledger as L
 
+import           Cardano.CLI.Commands.Hash (HashGoal)
 import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Key
 
@@ -87,21 +87,12 @@ data GovernanceDRepMetadataHashCmdArgs era
   = GovernanceDRepMetadataHashCmdArgs
   { eon :: !(ConwayEraOnwards era)
   , drepMetadataSource :: !DRepMetadataSource
-  , hashGoal :: !DRepHashGoal
+  , hashGoal :: !(HashGoal (Hash DRepMetadata))
   }
 
 data DRepMetadataSource
   = DrepMetadataFileIn !(DRepMetadataFile In)
   | DrepMetadataURL !L.Url
-  deriving Show
-
-data DRepHashGoal
-  = -- | The hash is written to stdout
-    DRepHashToStdout
-  | -- | The hash to check against
-    CheckDRepHash !(Hash DRepMetadata)
-  | -- | The output file to which the hash is written
-    DRepHashToFile !(File () Out)
   deriving Show
 
 renderGovernanceDRepCmds

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/StakePool.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/StakePool.hs
@@ -10,7 +10,6 @@ module Cardano.CLI.EraBased.Commands.StakePool
   , StakePoolMetadataHashCmdArgs (..)
   , StakePoolRegistrationCertificateCmdArgs (..)
   , StakePoolMetadataSource (..)
-  , StakePoolMetadataHashGoal (..)
   )
 where
 
@@ -18,6 +17,7 @@ import           Cardano.Api.Ledger (Coin)
 import qualified Cardano.Api.Ledger as L
 import           Cardano.Api.Shelley hiding (QueryInShelleyBasedEra (..))
 
+import           Cardano.CLI.Commands.Hash (HashGoal)
 import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Key
 
@@ -52,22 +52,13 @@ data StakePoolIdCmdArgs era
 data StakePoolMetadataHashCmdArgs era
   = StakePoolMetadataHashCmdArgs
   { poolMetadataSource :: !StakePoolMetadataSource
-  , hashGoal :: !StakePoolMetadataHashGoal
+  , hashGoal :: !(HashGoal (Hash StakePoolMetadata))
   }
   deriving Show
 
 data StakePoolMetadataSource
   = StakePoolMetadataFileIn !(StakePoolMetadataFile In)
   | StakePoolMetadataURL !L.Url
-  deriving Show
-
-data StakePoolMetadataHashGoal
-  = -- | The hash is written to stdout
-    StakePoolMetadataHashToStdout
-  | -- | The hash to check against
-    CheckStakePoolMetadataHash !(Hash StakePoolMetadata)
-  | -- | The output file to which the hash is written
-    StakePoolMetadataHashToFile !(File () Out)
   deriving Show
 
 data StakePoolRegistrationCertificateCmdArgs era

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/StakePool.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/StakePool.hs
@@ -73,7 +73,8 @@ data StakePoolRegistrationCertificateCmdArgs era
   -- ^ Pool owner verification staking key(s).
   , relays :: ![StakePoolRelay]
   -- ^ Stake pool relays.
-  , mMetadata :: !(Maybe StakePoolMetadataReference)
+  , mMetadata
+      :: !(Maybe (PotentiallyCheckedAnchor StakePoolMetadataReference StakePoolMetadataReference))
   -- ^ Stake pool metadata.
   , network :: !NetworkId
   , outFile :: !(File () Out)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/StakePool.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/StakePool.hs
@@ -9,10 +9,13 @@ module Cardano.CLI.EraBased.Commands.StakePool
   , StakePoolIdCmdArgs (..)
   , StakePoolMetadataHashCmdArgs (..)
   , StakePoolRegistrationCertificateCmdArgs (..)
+  , StakePoolMetadataSource (..)
+  , StakePoolMetadataHashGoal (..)
   )
 where
 
 import           Cardano.Api.Ledger (Coin)
+import qualified Cardano.Api.Ledger as L
 import           Cardano.Api.Shelley hiding (QueryInShelleyBasedEra (..))
 
 import           Cardano.CLI.Types.Common
@@ -48,9 +51,23 @@ data StakePoolIdCmdArgs era
 
 data StakePoolMetadataHashCmdArgs era
   = StakePoolMetadataHashCmdArgs
-  { poolMetadataFile :: !(StakePoolMetadataFile In)
-  , mOutFile :: !(Maybe (File () Out))
+  { poolMetadataSource :: !StakePoolMetadataSource
+  , hashGoal :: !StakePoolMetadataHashGoal
   }
+  deriving Show
+
+data StakePoolMetadataSource
+  = StakePoolMetadataFileIn !(StakePoolMetadataFile In)
+  | StakePoolMetadataURL !L.Url
+  deriving Show
+
+data StakePoolMetadataHashGoal
+  = -- | The hash is written to stdout
+    StakePoolMetadataHashToStdout
+  | -- | The hash to check against
+    CheckStakePoolMetadataHash !(Hash StakePoolMetadata)
+  | -- | The output file to which the hash is written
+    StakePoolMetadataHashToFile !(File () Out)
   deriving Show
 
 data StakePoolRegistrationCertificateCmdArgs era

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
@@ -3550,16 +3550,19 @@ pAnchorUrl =
   ProposalUrl
     <$> pUrl "anchor-url" "Anchor URL"
 
-pExpectedHash :: Parser (L.SafeHash L.StandardCrypto L.AnchorData)
-pExpectedHash =
-  Opt.option readSafeHash $
+pExpectedAnchorDataHash :: Parser (L.SafeHash L.StandardCrypto L.AnchorData)
+pExpectedAnchorDataHash = pExpectedHash id "anchor data"
+
+pExpectedHash :: (L.SafeHash L.StandardCrypto L.AnchorData -> a) -> String -> Parser a
+pExpectedHash adaptor hashedDataName =
+  Opt.option (adaptor <$> readSafeHash) $
     mconcat
       [ Opt.long "expected-hash"
       , Opt.metavar "HASH"
       , Opt.help $
           mconcat
-            [ "Expected hash for the anchor data for verification purposes. "
-            , "If provided, the hash of the anchor data will be compared to this value."
+            [ "Expected hash for the " ++ hashedDataName ++ ", for verification purposes. "
+            , "If provided, the hash of the " ++ hashedDataName ++ " will be compared to this value."
             ]
       ]
 

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
@@ -2683,12 +2683,11 @@ pPort =
       , Opt.help "The stake pool relay's port"
       ]
 
-pStakePoolMetadataReference :: Parser (Maybe StakePoolMetadataReference)
+pStakePoolMetadataReference :: Parser StakePoolMetadataReference
 pStakePoolMetadataReference =
-  optional $
-    StakePoolMetadataReference
-      <$> pStakePoolMetadataUrl
-      <*> pStakePoolMetadataHash
+  StakePoolMetadataReference
+    <$> pStakePoolMetadataUrl
+    <*> pStakePoolMetadataHash
 
 pStakePoolMetadataUrl :: Parser Text
 pStakePoolMetadataUrl =
@@ -2724,7 +2723,11 @@ pStakePoolRegistrationParserRequirements envCli =
     <*> pRewardAcctVerificationKeyOrFile
     <*> some pPoolOwnerVerificationKeyOrFile
     <*> many pPoolRelay
-    <*> pStakePoolMetadataReference
+    <*> optional
+      ( pPotentiallyCheckedAnchorData
+          pMustCheckStakeMetadataHash
+          pStakePoolMetadataReference
+      )
     <*> pNetworkId envCli
 
 pProtocolParametersUpdate :: Parser ProtocolParametersUpdate
@@ -3586,9 +3589,9 @@ pMustCheckHash flagSuffix' dataName' hashParamName' urlParamName' =
       ]
 
 pPotentiallyCheckedAnchorData
-  :: Parser (MustCheckHash anchorDataType)
-  -> Parser (L.Anchor L.StandardCrypto)
-  -> Parser (PotentiallyCheckedAnchor anchorDataType)
+  :: Parser (MustCheckHash anchorType)
+  -> Parser anchor
+  -> Parser (PotentiallyCheckedAnchor anchorType anchor)
 pPotentiallyCheckedAnchorData mustCheckHash anchorData =
   PotentiallyCheckedAnchor
     <$> anchorData
@@ -3602,6 +3605,9 @@ pMustCheckConstitutionHash = pMustCheckHash "constitution-hash" "constitution" "
 
 pMustCheckMetadataHash :: Parser (MustCheckHash DRepMetadataUrl)
 pMustCheckMetadataHash = pMustCheckHash "drep-metadata-hash" "DRep metadata" "--drep-metadata-hash" "--drep-metadata-url"
+
+pMustCheckStakeMetadataHash :: Parser (MustCheckHash StakePoolMetadataReference)
+pMustCheckStakeMetadataHash = pMustCheckHash "metadata-hash" "stake pool metadata" "--metadata-hash" "--metadata-url"
 
 pPreviousGovernanceAction :: Parser (Maybe (TxId, Word16))
 pPreviousGovernanceAction =

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/DRep.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/DRep.hs
@@ -135,16 +135,7 @@ pDrepMetadataUrl =
 
 pExpectedDrepMetadataHash :: Parser (Hash DRepMetadata)
 pExpectedDrepMetadataHash =
-  Opt.option (DRepMetadataHash . extractHash . castSafeHash <$> readSafeHash) $
-    mconcat
-      [ Opt.long "expected-hash"
-      , Opt.metavar "HASH"
-      , Opt.help $
-          mconcat
-            [ "Expected hash for the DRep metadata, for verification purposes. "
-            , "If provided, the hash of the DRep metadata is compared to this value."
-            ]
-      ]
+  pExpectedHash (DRepMetadataHash . extractHash . castSafeHash) "DRep metadata"
 
 pDrepMetadataHash :: Parser (L.SafeHash L.StandardCrypto L.AnchorData)
 pDrepMetadataHash =

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/DRep.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/DRep.hs
@@ -14,12 +14,13 @@ import           Cardano.Api.Ledger (extractHash)
 import qualified Cardano.Api.Ledger as L
 import           Cardano.Api.Shelley (Hash (DRepMetadataHash))
 
+import           Cardano.CLI.Commands.Hash (HashGoal (..))
 import           Cardano.CLI.Environment
 import           Cardano.CLI.EraBased.Commands.Governance.DRep
 import           Cardano.CLI.EraBased.Options.Common
 import           Cardano.CLI.Parser
 import           Cardano.CLI.Read
-import           Cardano.CLI.Types.Common
+import           Cardano.CLI.Types.Common hiding (CheckHash)
 import           Cardano.CLI.Types.Key
 import           Cardano.Ledger.SafeHash (castSafeHash)
 
@@ -210,13 +211,13 @@ pGovernanceDrepMetadataHashCmd era = do
     $ Opt.progDesc
       "Calculate the hash of a metadata file, optionally checking the obtained hash against an expected value."
 
-pDRepHashGoal :: Parser DRepHashGoal
+pDRepHashGoal :: Parser (HashGoal (Hash DRepMetadata))
 pDRepHashGoal =
   asum
-    [ CheckDRepHash <$> pExpectedDrepMetadataHash
-    , DRepHashToFile <$> pOutputFile
+    [ CheckHash <$> pExpectedDrepMetadataHash
+    , HashToFile <$> pOutputFile
     ]
-    <|> pure DRepHashToStdout
+    <|> pure HashToStdout
 
 pDRepMetadataSource :: Parser DRepMetadataSource
 pDRepMetadataSource =

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/StakePool.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/StakePool.hs
@@ -21,6 +21,7 @@ import           Cardano.CLI.EraBased.Options.Common
 import           Cardano.CLI.Read (readSafeHash)
 import qualified Cardano.Crypto.Hash as L
 
+import qualified Data.Foldable as F
 import           Options.Applicative hiding (help, str)
 import qualified Options.Applicative as Opt
 
@@ -73,7 +74,7 @@ pStakePoolMetadataHashCmd =
 
 pPoolMetadataSource :: Parser Cmd.StakePoolMetadataSource
 pPoolMetadataSource =
-  asum
+  F.asum
     [ Cmd.StakePoolMetadataFileIn <$> pPoolMetadataFile
     , Cmd.StakePoolMetadataURL
         <$> pUrl "pool-metadata-url" "URL pointing to the JSON Metadata file to hash."
@@ -81,7 +82,7 @@ pPoolMetadataSource =
 
 pPoolMetadataHashGoal :: Parser Cmd.StakePoolMetadataHashGoal
 pPoolMetadataHashGoal =
-  asum
+  F.asum
     [ Cmd.CheckStakePoolMetadataHash <$> pExpectedStakePoolMetadataHash
     , Cmd.StakePoolMetadataHashToFile <$> pOutputFile
     ]

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/StakePool.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/StakePool.hs
@@ -84,7 +84,11 @@ pStakePoolRegistrationCertificateCmd era envCli = do
             <*> pRewardAcctVerificationKeyOrFile
             <*> some pPoolOwnerVerificationKeyOrFile
             <*> many pPoolRelay
-            <*> pStakePoolMetadataReference
+            <*> optional
+              ( pPotentiallyCheckedAnchorData
+                  pMustCheckStakeMetadataHash
+                  pStakePoolMetadataReference
+              )
             <*> pNetworkId envCli
             <*> pOutputFile
       )

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/StakePool.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/StakePool.hs
@@ -15,6 +15,7 @@ import           Cardano.Api
 import qualified Cardano.Api.Ledger as L
 import           Cardano.Api.Shelley (Hash (StakePoolMetadataHash))
 
+import qualified Cardano.CLI.Commands.Hash as Cmd
 import           Cardano.CLI.Environment (EnvCli (..))
 import qualified Cardano.CLI.EraBased.Commands.StakePool as Cmd
 import           Cardano.CLI.EraBased.Options.Common
@@ -80,13 +81,13 @@ pPoolMetadataSource =
         <$> pUrl "pool-metadata-url" "URL pointing to the JSON Metadata file to hash."
     ]
 
-pPoolMetadataHashGoal :: Parser Cmd.StakePoolMetadataHashGoal
+pPoolMetadataHashGoal :: Parser (Cmd.HashGoal (Hash StakePoolMetadata))
 pPoolMetadataHashGoal =
   F.asum
-    [ Cmd.CheckStakePoolMetadataHash <$> pExpectedStakePoolMetadataHash
-    , Cmd.StakePoolMetadataHashToFile <$> pOutputFile
+    [ Cmd.CheckHash <$> pExpectedStakePoolMetadataHash
+    , Cmd.HashToFile <$> pOutputFile
     ]
-    <|> pure Cmd.StakePoolMetadataHashToStdout
+    <|> pure Cmd.HashToStdout
 
 pExpectedStakePoolMetadataHash :: Parser (Hash StakePoolMetadata)
 pExpectedStakePoolMetadataHash =

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/StakePool.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/StakePool.hs
@@ -19,8 +19,7 @@ import qualified Cardano.CLI.Commands.Hash as Cmd
 import           Cardano.CLI.Environment (EnvCli (..))
 import qualified Cardano.CLI.EraBased.Commands.StakePool as Cmd
 import           Cardano.CLI.EraBased.Options.Common
-import           Cardano.CLI.Read (readSafeHash)
-import qualified Cardano.Crypto.Hash as L
+import qualified Cardano.Ledger.SafeHash as L
 
 import qualified Data.Foldable as F
 import           Options.Applicative hiding (help, str)
@@ -91,16 +90,7 @@ pPoolMetadataHashGoal =
 
 pExpectedStakePoolMetadataHash :: Parser (Hash StakePoolMetadata)
 pExpectedStakePoolMetadataHash =
-  Opt.option (StakePoolMetadataHash . L.castHash . L.extractHash <$> readSafeHash) $
-    mconcat
-      [ Opt.long "expected-hash"
-      , Opt.metavar "HASH"
-      , Opt.help $
-          mconcat
-            [ "Expected hash for the stake pool metadata for verification purposes. "
-            , "If provided, the hash of the stake pool metadata will be compared to this value."
-            ]
-      ]
+  pExpectedHash (StakePoolMetadataHash . L.extractHash . L.castSafeHash) "stake pool metadata"
 
 pStakePoolRegistrationCertificateCmd
   :: ()

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Actions.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Actions.hs
@@ -526,7 +526,7 @@ carryHashChecks checkHash anchor checkType =
         L.AnchorData
           <$> fetchURLErrorToGovernanceActionError
             checkType
-            (getByteStringFromURL httpsAndIpfsSchemas $ L.anchorUrl anchor)
+            (getByteStringFromURL httpsAndIpfsSchemas $ L.urlToText $ L.anchorUrl anchor)
       let hash = L.hashAnchorData anchorData
       when (hash /= L.anchorDataHash anchor) $
         left $

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/DRep.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/DRep.hs
@@ -187,7 +187,7 @@ runGovernanceDRepMetadataHashCmd
       Cmd.DrepMetadataFileIn metadataFile ->
         firstExceptT ReadFileError . newExceptT $ readByteStringFile metadataFile
       Cmd.DrepMetadataURL urlText ->
-        fetchURLToGovernanceCmdError $ getByteStringFromURL allSchemas urlText
+        fetchURLToGovernanceCmdError $ getByteStringFromURL allSchemas $ L.urlToText urlText
     let (_metadata, metadataHash) = hashDRepMetadata metadataBytes
     case hashGoal of
       Cmd.CheckHash expectedHash
@@ -225,7 +225,7 @@ carryHashChecks potentiallyCheckedAnchor =
         L.AnchorData
           <$> withExceptT
             FetchURLError
-            (getByteStringFromURL httpsAndIpfsSchemas $ L.anchorUrl anchor)
+            (getByteStringFromURL httpsAndIpfsSchemas $ L.urlToText $ L.anchorUrl anchor)
       let hash = L.hashAnchorData anchorData
       when (hash /= L.anchorDataHash anchor) $
         left $

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/DRep.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/DRep.hs
@@ -215,7 +215,7 @@ runGovernanceDRepMetadataHashCmd
 -- | Check the hash of the anchor data against the hash in the anchor if
 -- checkHash is set to CheckHash.
 carryHashChecks
-  :: PotentiallyCheckedAnchor DRepMetadataUrl
+  :: PotentiallyCheckedAnchor DRepMetadataUrl (L.Anchor L.StandardCrypto)
   -- ^ The information about anchor data and whether to check the hash (see 'PotentiallyCheckedAnchor')
   -> ExceptT HashCheckError IO ()
 carryHashChecks potentiallyCheckedAnchor =

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/DRep.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/DRep.hs
@@ -18,7 +18,7 @@ where
 import           Cardano.Api
 import qualified Cardano.Api.Ledger as L
 
-import           Cardano.CLI.EraBased.Commands.Governance.DRep (DRepHashGoal (..))
+import qualified Cardano.CLI.Commands.Hash as Cmd
 import qualified Cardano.CLI.EraBased.Commands.Governance.DRep as Cmd
 import qualified Cardano.CLI.EraBased.Run.Key as Key
 import           Cardano.CLI.Run.Hash (allSchemas, getByteStringFromURL, httpsAndIpfsSchemas)
@@ -190,12 +190,12 @@ runGovernanceDRepMetadataHashCmd
         fetchURLToGovernanceCmdError $ getByteStringFromURL allSchemas urlText
     let (_metadata, metadataHash) = hashDRepMetadata metadataBytes
     case hashGoal of
-      CheckDRepHash expectedHash
+      Cmd.CheckHash expectedHash
         | metadataHash /= expectedHash ->
             left $ GovernanceCmdHashMismatchError expectedHash metadataHash
         | otherwise -> liftIO $ putStrLn "Hashes match!"
-      DRepHashToFile outFile -> writeOutput (Just outFile) metadataHash
-      DRepHashToStdout -> writeOutput Nothing metadataHash
+      Cmd.HashToFile outFile -> writeOutput (Just outFile) metadataHash
+      Cmd.HashToStdout -> writeOutput Nothing metadataHash
    where
     writeOutput
       :: MonadIO m

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/StakePool.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/StakePool.hs
@@ -17,6 +17,7 @@ where
 import qualified Cardano.Api.Ledger as L
 import           Cardano.Api.Shelley
 
+import qualified Cardano.CLI.Commands.Hash as Cmd
 import           Cardano.CLI.EraBased.Commands.StakePool
 import qualified Cardano.CLI.EraBased.Commands.StakePool as Cmd
 import           Cardano.CLI.Run.Hash (allSchemas, getByteStringFromURL, httpsAndIpfsSchemas)
@@ -245,12 +246,12 @@ runStakePoolMetadataHashCmd
         $ validateAndHashStakePoolMetadata metadataBytes
 
     case hashGoal of
-      CheckStakePoolMetadataHash expectedHash
+      Cmd.CheckHash expectedHash
         | metadataHash /= expectedHash ->
             left $ StakePoolCmdHashMismatchError expectedHash metadataHash
         | otherwise -> liftIO $ putStrLn "Hashes match!"
-      StakePoolMetadataHashToFile outFile -> writeOutput (Just outFile) metadataHash
-      StakePoolMetadataHashToStdout -> writeOutput Nothing metadataHash
+      Cmd.HashToFile outFile -> writeOutput (Just outFile) metadataHash
+      Cmd.HashToStdout -> writeOutput Nothing metadataHash
    where
     writeOutput :: Maybe (File () Out) -> Hash StakePoolMetadata -> ExceptT StakePoolCmdError IO ()
     writeOutput mOutFile metadataHash =

--- a/cardano-cli/src/Cardano/CLI/Options/Hash.hs
+++ b/cardano-cli/src/Cardano/CLI/Options/Hash.hs
@@ -6,6 +6,8 @@ module Cardano.CLI.Options.Hash
   )
 where
 
+import qualified Cardano.Api.Ledger as L
+
 import qualified Cardano.CLI.Commands.Hash as Cmd
 import           Cardano.CLI.EraBased.Options.Common
 
@@ -37,7 +39,7 @@ pHashAnchorDataCmd = do
       )
     $ Opt.progDesc "Compute the hash of some anchor data (to then pass it to other commands)."
 
-pHashGoal :: Parser Cmd.HashGoal
+pHashGoal :: Parser (Cmd.HashGoal (L.SafeHash L.StandardCrypto L.AnchorData))
 pHashGoal =
   asum
     [ Cmd.CheckHash <$> pExpectedHash

--- a/cardano-cli/src/Cardano/CLI/Options/Hash.hs
+++ b/cardano-cli/src/Cardano/CLI/Options/Hash.hs
@@ -42,7 +42,7 @@ pHashAnchorDataCmd = do
 pHashGoal :: Parser (Cmd.HashGoal (L.SafeHash L.StandardCrypto L.AnchorData))
 pHashGoal =
   asum
-    [ Cmd.CheckHash <$> pExpectedHash
+    [ Cmd.CheckHash <$> pExpectedAnchorDataHash
     , Cmd.HashToFile <$> pOutputFile
     ]
     <|> pure Cmd.HashToStdout

--- a/cardano-cli/src/Cardano/CLI/Run/Hash.hs
+++ b/cardano-cli/src/Cardano/CLI/Run/Hash.hs
@@ -33,6 +33,7 @@ import qualified Data.ByteString.Lazy.Char8 as BSL8
 import           Data.Char (toLower)
 import           Data.Function
 import           Data.List (intercalate)
+import           Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Text
 import qualified Data.Text.IO as Text
@@ -68,7 +69,7 @@ runHashAnchorDataCmd Cmd.HashAnchorDataCmdArgs{toHash, hashGoal} = do
         return $ Text.encodeUtf8 text
       Cmd.AnchorDataHashSourceText text -> return $ Text.encodeUtf8 text
       Cmd.AnchorDataHashSourceURL urlText ->
-        fetchURLToHashCmdError $ getByteStringFromURL allSchemas urlText
+        fetchURLToHashCmdError $ getByteStringFromURL allSchemas $ L.urlToText urlText
   let hash = L.hashAnchorData anchorData
   case hashGoal of
     CheckHash expectedHash
@@ -100,9 +101,9 @@ allSchemas = [FileSchema, HttpSchema, HttpsSchema, IpfsSchema]
 httpsAndIpfsSchemas :: [SupportedSchemas]
 httpsAndIpfsSchemas = [HttpsSchema, IpfsSchema]
 
-getByteStringFromURL :: [SupportedSchemas] -> L.Url -> ExceptT FetchURLError IO BS.ByteString
+getByteStringFromURL :: [SupportedSchemas] -> Text -> ExceptT FetchURLError IO BS.ByteString
 getByteStringFromURL supportedSchemas urlText = do
-  let urlString = Text.unpack $ L.urlToText urlText
+  let urlString = Text.unpack urlText
   uri <- hoistMaybe (FetchURLInvalidURLError urlString) $ parseAbsoluteURI urlString
   case map toLower $ uriScheme uri of
     "file:"

--- a/cardano-cli/src/Cardano/CLI/Types/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Common.hs
@@ -93,7 +93,6 @@ module Cardano.CLI.Types.Common
 where
 
 import           Cardano.Api hiding (Script)
-import           Cardano.Api.Ledger (Anchor)
 import qualified Cardano.Api.Ledger as L
 
 import qualified Cardano.Chain.Slotting as Byron
@@ -653,9 +652,9 @@ data MustCheckHash a
   | TrustHash
   deriving (Eq, Show)
 
-data PotentiallyCheckedAnchor anchorType
+data PotentiallyCheckedAnchor anchorType anchor
   = PotentiallyCheckedAnchor
-  { pcaAnchor :: Anchor L.StandardCrypto
+  { pcaAnchor :: anchor
   -- ^ The anchor data whose hash is to be checked
   , pcaMustCheck :: MustCheckHash anchorType
   -- ^ Whether to check the hash or not (CheckHash for checking or TrustHash for not checking)

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/StakePoolCmdError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/StakePoolCmdError.hs
@@ -12,14 +12,13 @@ where
 import           Cardano.Api
 import           Cardano.Api.Shelley (Hash (StakePoolMetadataHash))
 
-import           Cardano.CLI.Types.Errors.HashCmdError (FetchURLError, HashCheckError)
+import           Cardano.CLI.Types.Errors.HashCmdError (FetchURLError)
 
 data StakePoolCmdError
   = StakePoolCmdReadFileError !(FileError TextEnvelopeError)
   | StakePoolCmdReadKeyFileError !(FileError InputDecodeError)
   | StakePoolCmdWriteFileError !(FileError ())
   | StakePoolCmdMetadataValidationError !StakePoolMetadataValidationError
-  | StakePoolCmdMetadataHashCheckError !HashCheckError
   | StakePoolCmdHashMismatchError
       !(Hash StakePoolMetadata)
       -- ^ Expected hash
@@ -38,8 +37,6 @@ renderStakePoolCmdError = \case
     prettyError fileErr
   StakePoolCmdWriteFileError fileErr ->
     prettyError fileErr
-  StakePoolCmdMetadataHashCheckError hashCheckErr ->
-    "Error checking stake pool metadata hash: " <> prettyException hashCheckErr
   StakePoolCmdHashMismatchError
     (StakePoolMetadataHash expectedHash)
     (StakePoolMetadataHash actualHash) ->

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/StakePoolCmdError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/StakePoolCmdError.hs
@@ -10,8 +10,9 @@ module Cardano.CLI.Types.Errors.StakePoolCmdError
 where
 
 import           Cardano.Api
+import           Cardano.Api.Shelley (Hash (StakePoolMetadataHash))
 
-import           Cardano.CLI.Types.Errors.HashCmdError (HashCheckError)
+import           Cardano.CLI.Types.Errors.HashCmdError (FetchURLError, HashCheckError)
 
 data StakePoolCmdError
   = StakePoolCmdReadFileError !(FileError TextEnvelopeError)
@@ -19,6 +20,12 @@ data StakePoolCmdError
   | StakePoolCmdWriteFileError !(FileError ())
   | StakePoolCmdMetadataValidationError !StakePoolMetadataValidationError
   | StakePoolCmdMetadataHashCheckError !HashCheckError
+  | StakePoolCmdHashMismatchError
+      !(Hash StakePoolMetadata)
+      -- ^ Expected hash
+      !(Hash StakePoolMetadata)
+      -- ^ Actual hash
+  | StakePoolCmdFetchURLError !FetchURLError
   deriving Show
 
 renderStakePoolCmdError :: StakePoolCmdError -> Doc ann
@@ -33,3 +40,13 @@ renderStakePoolCmdError = \case
     prettyError fileErr
   StakePoolCmdMetadataHashCheckError hashCheckErr ->
     "Error checking stake pool metadata hash: " <> prettyException hashCheckErr
+  StakePoolCmdHashMismatchError
+    (StakePoolMetadataHash expectedHash)
+    (StakePoolMetadataHash actualHash) ->
+      "Hashes do not match!"
+        <> "\nExpected:"
+          <+> pretty (show expectedHash)
+        <> "\n  Actual:"
+          <+> pretty (show actualHash)
+  StakePoolCmdFetchURLError fetchErr ->
+    "Error fetching stake pool metadata: " <> prettyException fetchErr

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/StakePoolCmdError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/StakePoolCmdError.hs
@@ -11,11 +11,14 @@ where
 
 import           Cardano.Api
 
+import           Cardano.CLI.Types.Errors.HashCmdError (HashCheckError)
+
 data StakePoolCmdError
   = StakePoolCmdReadFileError !(FileError TextEnvelopeError)
   | StakePoolCmdReadKeyFileError !(FileError InputDecodeError)
   | StakePoolCmdWriteFileError !(FileError ())
   | StakePoolCmdMetadataValidationError !StakePoolMetadataValidationError
+  | StakePoolCmdMetadataHashCheckError !HashCheckError
   deriving Show
 
 renderStakePoolCmdError :: StakePoolCmdError -> Doc ann
@@ -28,3 +31,5 @@ renderStakePoolCmdError = \case
     prettyError fileErr
   StakePoolCmdWriteFileError fileErr ->
     prettyError fileErr
+  StakePoolCmdMetadataHashCheckError hashCheckErr ->
+    "Error checking stake pool metadata hash: " <> prettyException hashCheckErr

--- a/cardano-cli/src/Cardano/CLI/Types/Key.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Key.hs
@@ -148,7 +148,8 @@ data StakePoolRegistrationParserRequirements
   -- ^ Pool owner verification staking key(s).
   , sprRelays :: [StakePoolRelay]
   -- ^ Stake pool relays.
-  , sprMetadata :: Maybe StakePoolMetadataReference
+  , sprMetadata
+      :: Maybe (PotentiallyCheckedAnchor StakePoolMetadataReference StakePoolMetadataReference)
   -- ^ Stake pool metadata.
   , sprNetworkId :: NetworkId
   }

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Governance/StakeAddress.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Governance/StakeAddress.hs
@@ -236,7 +236,7 @@ hprop_golden_conway_stakeaddress_register_and_delegate_stake_and_vote =
     H.diffFileVsGoldenFile certFile certGold
 
 -- Execute me with:
--- @cabal test cardano-cli-golden --test-options '-p "/golden stake pool metadata hash url wrong metadata fails/"'@
+-- @cabal test cardano-cli-golden --test-options '-p "/golden stake pool metadata hash url wrong hash/"'@
 hprop_golden_stake_pool_metadata_hash_url_wrong_hash :: Property
 hprop_golden_stake_pool_metadata_hash_url_wrong_hash = do
   propertyOnce $ do

--- a/cardano-cli/test/cardano-cli-golden/files/golden/governance/stakeaddress/stake_pool_metadata_hash_url_wrong_hash_fails.out
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/governance/stakeaddress/stake_pool_metadata_hash_url_wrong_hash_fails.out
@@ -1,0 +1,3 @@
+Command failed: stake-pool metadata-hash  Error: Hashes do not match!
+Expected: "9241de08075886a7d09c847c9bbd1719459dac0bd0a2f085e673611ebb9a5965"
+  Actual: "8241de08075886a7d09c847c9bbd1719459dac0bd0a2f085e673611ebb9a5965"

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -1385,7 +1385,8 @@ Usage: cardano-cli shelley stake-pool registration-certificate
                                                                  | --multi-host-pool-relay STRING
                                                                  ]
                                                                  [--metadata-url URL
-                                                                   --metadata-hash HASH]
+                                                                   --metadata-hash HASH
+                                                                   [--check-metadata-hash]]
                                                                  ( --mainnet
                                                                  | --testnet-magic NATURAL
                                                                  )
@@ -2452,7 +2453,8 @@ Usage: cardano-cli allegra stake-pool registration-certificate
                                                                  | --multi-host-pool-relay STRING
                                                                  ]
                                                                  [--metadata-url URL
-                                                                   --metadata-hash HASH]
+                                                                   --metadata-hash HASH
+                                                                   [--check-metadata-hash]]
                                                                  ( --mainnet
                                                                  | --testnet-magic NATURAL
                                                                  )
@@ -3511,7 +3513,8 @@ Usage: cardano-cli mary stake-pool registration-certificate
                                                               | --multi-host-pool-relay STRING
                                                               ]
                                                               [--metadata-url URL
-                                                                --metadata-hash HASH]
+                                                                --metadata-hash HASH
+                                                                [--check-metadata-hash]]
                                                               ( --mainnet
                                                               | --testnet-magic NATURAL
                                                               )
@@ -4581,7 +4584,8 @@ Usage: cardano-cli alonzo stake-pool registration-certificate
                                                                 | --multi-host-pool-relay STRING
                                                                 ]
                                                                 [--metadata-url URL
-                                                                  --metadata-hash HASH]
+                                                                  --metadata-hash HASH
+                                                                  [--check-metadata-hash]]
                                                                 ( --mainnet
                                                                 | --testnet-magic NATURAL
                                                                 )
@@ -5674,7 +5678,8 @@ Usage: cardano-cli babbage stake-pool registration-certificate
                                                                  | --multi-host-pool-relay STRING
                                                                  ]
                                                                  [--metadata-url URL
-                                                                   --metadata-hash HASH]
+                                                                   --metadata-hash HASH
+                                                                   [--check-metadata-hash]]
                                                                  ( --mainnet
                                                                  | --testnet-magic NATURAL
                                                                  )
@@ -7574,7 +7579,8 @@ Usage: cardano-cli conway stake-pool registration-certificate
                                                                 | --multi-host-pool-relay STRING
                                                                 ]
                                                                 [--metadata-url URL
-                                                                  --metadata-hash HASH]
+                                                                  --metadata-hash HASH
+                                                                  [--check-metadata-hash]]
                                                                 ( --mainnet
                                                                 | --testnet-magic NATURAL
                                                                 )
@@ -9566,7 +9572,8 @@ Usage: cardano-cli latest stake-pool registration-certificate
                                                                 | --multi-host-pool-relay STRING
                                                                 ]
                                                                 [--metadata-url URL
-                                                                  --metadata-hash HASH]
+                                                                  --metadata-hash HASH
+                                                                  [--check-metadata-hash]]
                                                                 ( --mainnet
                                                                 | --testnet-magic NATURAL
                                                                 )

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -1412,10 +1412,16 @@ Usage: cardano-cli shelley stake-pool id
 
   Build pool id from the offline key
 
-Usage: cardano-cli shelley stake-pool metadata-hash --pool-metadata-file FILEPATH
-                                                      [--out-file FILEPATH]
+Usage: cardano-cli shelley stake-pool metadata-hash 
+                                                      ( --pool-metadata-file FILEPATH
+                                                      | --pool-metadata-url TEXT
+                                                      )
+                                                      [ --expected-hash HASH
+                                                      | --out-file FILEPATH
+                                                      ]
 
-  Print the hash of pool metadata.
+  Calculate the hash of a stake pool metadata file, optionally checking the
+  obtained hash against an expected value.
 
 Usage: cardano-cli shelley text-view decode-cbor
 
@@ -2480,10 +2486,16 @@ Usage: cardano-cli allegra stake-pool id
 
   Build pool id from the offline key
 
-Usage: cardano-cli allegra stake-pool metadata-hash --pool-metadata-file FILEPATH
-                                                      [--out-file FILEPATH]
+Usage: cardano-cli allegra stake-pool metadata-hash 
+                                                      ( --pool-metadata-file FILEPATH
+                                                      | --pool-metadata-url TEXT
+                                                      )
+                                                      [ --expected-hash HASH
+                                                      | --out-file FILEPATH
+                                                      ]
 
-  Print the hash of pool metadata.
+  Calculate the hash of a stake pool metadata file, optionally checking the
+  obtained hash against an expected value.
 
 Usage: cardano-cli allegra text-view decode-cbor
 
@@ -3540,10 +3552,16 @@ Usage: cardano-cli mary stake-pool id
 
   Build pool id from the offline key
 
-Usage: cardano-cli mary stake-pool metadata-hash --pool-metadata-file FILEPATH
-                                                   [--out-file FILEPATH]
+Usage: cardano-cli mary stake-pool metadata-hash 
+                                                   ( --pool-metadata-file FILEPATH
+                                                   | --pool-metadata-url TEXT
+                                                   )
+                                                   [ --expected-hash HASH
+                                                   | --out-file FILEPATH
+                                                   ]
 
-  Print the hash of pool metadata.
+  Calculate the hash of a stake pool metadata file, optionally checking the
+  obtained hash against an expected value.
 
 Usage: cardano-cli mary text-view decode-cbor
 
@@ -4611,10 +4629,16 @@ Usage: cardano-cli alonzo stake-pool id
 
   Build pool id from the offline key
 
-Usage: cardano-cli alonzo stake-pool metadata-hash --pool-metadata-file FILEPATH
-                                                     [--out-file FILEPATH]
+Usage: cardano-cli alonzo stake-pool metadata-hash 
+                                                     ( --pool-metadata-file FILEPATH
+                                                     | --pool-metadata-url TEXT
+                                                     )
+                                                     [ --expected-hash HASH
+                                                     | --out-file FILEPATH
+                                                     ]
 
-  Print the hash of pool metadata.
+  Calculate the hash of a stake pool metadata file, optionally checking the
+  obtained hash against an expected value.
 
 Usage: cardano-cli alonzo text-view decode-cbor
 
@@ -5705,10 +5729,16 @@ Usage: cardano-cli babbage stake-pool id
 
   Build pool id from the offline key
 
-Usage: cardano-cli babbage stake-pool metadata-hash --pool-metadata-file FILEPATH
-                                                      [--out-file FILEPATH]
+Usage: cardano-cli babbage stake-pool metadata-hash 
+                                                      ( --pool-metadata-file FILEPATH
+                                                      | --pool-metadata-url TEXT
+                                                      )
+                                                      [ --expected-hash HASH
+                                                      | --out-file FILEPATH
+                                                      ]
 
-  Print the hash of pool metadata.
+  Calculate the hash of a stake pool metadata file, optionally checking the
+  obtained hash against an expected value.
 
 Usage: cardano-cli babbage text-view decode-cbor
 
@@ -7606,10 +7636,16 @@ Usage: cardano-cli conway stake-pool id
 
   Build pool id from the offline key
 
-Usage: cardano-cli conway stake-pool metadata-hash --pool-metadata-file FILEPATH
-                                                     [--out-file FILEPATH]
+Usage: cardano-cli conway stake-pool metadata-hash 
+                                                     ( --pool-metadata-file FILEPATH
+                                                     | --pool-metadata-url TEXT
+                                                     )
+                                                     [ --expected-hash HASH
+                                                     | --out-file FILEPATH
+                                                     ]
 
-  Print the hash of pool metadata.
+  Calculate the hash of a stake pool metadata file, optionally checking the
+  obtained hash against an expected value.
 
 Usage: cardano-cli conway text-view decode-cbor
 
@@ -9599,10 +9635,16 @@ Usage: cardano-cli latest stake-pool id
 
   Build pool id from the offline key
 
-Usage: cardano-cli latest stake-pool metadata-hash --pool-metadata-file FILEPATH
-                                                     [--out-file FILEPATH]
+Usage: cardano-cli latest stake-pool metadata-hash 
+                                                     ( --pool-metadata-file FILEPATH
+                                                     | --pool-metadata-url TEXT
+                                                     )
+                                                     [ --expected-hash HASH
+                                                     | --out-file FILEPATH
+                                                     ]
 
-  Print the hash of pool metadata.
+  Calculate the hash of a stake pool metadata file, optionally checking the
+  obtained hash against an expected value.
 
 Usage: cardano-cli latest text-view decode-cbor
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_stake-pool.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_stake-pool.cli
@@ -15,4 +15,6 @@ Available commands:
   deregistration-certificate
                            Create a stake pool deregistration certificate
   id                       Build pool id from the offline key
-  metadata-hash            Print the hash of pool metadata.
+  metadata-hash            Calculate the hash of a stake pool metadata file,
+                           optionally checking the obtained hash against an
+                           expected value.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_stake-pool_metadata-hash.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_stake-pool_metadata-hash.cli
@@ -13,7 +13,7 @@ Available options:
   --pool-metadata-file FILEPATH
                            Filepath of the pool metadata.
   --pool-metadata-url TEXT URL pointing to the JSON Metadata file to hash.
-  --expected-hash HASH     Expected hash for the stake pool metadata for
+  --expected-hash HASH     Expected hash for the stake pool metadata, for
                            verification purposes. If provided, the hash of the
                            stake pool metadata will be compared to this value.
   --out-file FILEPATH      The output file.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_stake-pool_metadata-hash.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_stake-pool_metadata-hash.cli
@@ -1,10 +1,20 @@
-Usage: cardano-cli allegra stake-pool metadata-hash --pool-metadata-file FILEPATH
-                                                      [--out-file FILEPATH]
+Usage: cardano-cli allegra stake-pool metadata-hash 
+                                                      ( --pool-metadata-file FILEPATH
+                                                      | --pool-metadata-url TEXT
+                                                      )
+                                                      [ --expected-hash HASH
+                                                      | --out-file FILEPATH
+                                                      ]
 
-  Print the hash of pool metadata.
+  Calculate the hash of a stake pool metadata file, optionally checking the
+  obtained hash against an expected value.
 
 Available options:
   --pool-metadata-file FILEPATH
                            Filepath of the pool metadata.
-  --out-file FILEPATH      Optional output file. Default is to write to stdout.
+  --pool-metadata-url TEXT URL pointing to the JSON Metadata file to hash.
+  --expected-hash HASH     Expected hash for the stake pool metadata for
+                           verification purposes. If provided, the hash of the
+                           stake pool metadata will be compared to this value.
+  --out-file FILEPATH      The output file.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_stake-pool_registration-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_stake-pool_registration-certificate.cli
@@ -22,7 +22,8 @@ Usage: cardano-cli allegra stake-pool registration-certificate
                                                                  | --multi-host-pool-relay STRING
                                                                  ]
                                                                  [--metadata-url URL
-                                                                   --metadata-hash HASH]
+                                                                   --metadata-hash HASH
+                                                                   [--check-metadata-hash]]
                                                                  ( --mainnet
                                                                  | --testnet-magic NATURAL
                                                                  )
@@ -65,6 +66,11 @@ Available options:
                            an SRV DNS record
   --metadata-url URL       Pool metadata URL (maximum length of 64 characters).
   --metadata-hash HASH     Pool metadata hash.
+  --check-metadata-hash    Verify that the expected stake pool metadata hash
+                           provided in --metadata-hash matches the hash of the
+                           file downloaded from the URL provided in
+                           --metadata-url (this parameter will download the file
+                           from the URL)
   --mainnet                Use the mainnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_stake-pool.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_stake-pool.cli
@@ -15,4 +15,6 @@ Available commands:
   deregistration-certificate
                            Create a stake pool deregistration certificate
   id                       Build pool id from the offline key
-  metadata-hash            Print the hash of pool metadata.
+  metadata-hash            Calculate the hash of a stake pool metadata file,
+                           optionally checking the obtained hash against an
+                           expected value.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_stake-pool_metadata-hash.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_stake-pool_metadata-hash.cli
@@ -13,7 +13,7 @@ Available options:
   --pool-metadata-file FILEPATH
                            Filepath of the pool metadata.
   --pool-metadata-url TEXT URL pointing to the JSON Metadata file to hash.
-  --expected-hash HASH     Expected hash for the stake pool metadata for
+  --expected-hash HASH     Expected hash for the stake pool metadata, for
                            verification purposes. If provided, the hash of the
                            stake pool metadata will be compared to this value.
   --out-file FILEPATH      The output file.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_stake-pool_metadata-hash.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_stake-pool_metadata-hash.cli
@@ -1,10 +1,20 @@
-Usage: cardano-cli alonzo stake-pool metadata-hash --pool-metadata-file FILEPATH
-                                                     [--out-file FILEPATH]
+Usage: cardano-cli alonzo stake-pool metadata-hash 
+                                                     ( --pool-metadata-file FILEPATH
+                                                     | --pool-metadata-url TEXT
+                                                     )
+                                                     [ --expected-hash HASH
+                                                     | --out-file FILEPATH
+                                                     ]
 
-  Print the hash of pool metadata.
+  Calculate the hash of a stake pool metadata file, optionally checking the
+  obtained hash against an expected value.
 
 Available options:
   --pool-metadata-file FILEPATH
                            Filepath of the pool metadata.
-  --out-file FILEPATH      Optional output file. Default is to write to stdout.
+  --pool-metadata-url TEXT URL pointing to the JSON Metadata file to hash.
+  --expected-hash HASH     Expected hash for the stake pool metadata for
+                           verification purposes. If provided, the hash of the
+                           stake pool metadata will be compared to this value.
+  --out-file FILEPATH      The output file.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_stake-pool_registration-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_stake-pool_registration-certificate.cli
@@ -22,7 +22,8 @@ Usage: cardano-cli alonzo stake-pool registration-certificate
                                                                 | --multi-host-pool-relay STRING
                                                                 ]
                                                                 [--metadata-url URL
-                                                                  --metadata-hash HASH]
+                                                                  --metadata-hash HASH
+                                                                  [--check-metadata-hash]]
                                                                 ( --mainnet
                                                                 | --testnet-magic NATURAL
                                                                 )
@@ -65,6 +66,11 @@ Available options:
                            an SRV DNS record
   --metadata-url URL       Pool metadata URL (maximum length of 64 characters).
   --metadata-hash HASH     Pool metadata hash.
+  --check-metadata-hash    Verify that the expected stake pool metadata hash
+                           provided in --metadata-hash matches the hash of the
+                           file downloaded from the URL provided in
+                           --metadata-url (this parameter will download the file
+                           from the URL)
   --mainnet                Use the mainnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_stake-pool.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_stake-pool.cli
@@ -15,4 +15,6 @@ Available commands:
   deregistration-certificate
                            Create a stake pool deregistration certificate
   id                       Build pool id from the offline key
-  metadata-hash            Print the hash of pool metadata.
+  metadata-hash            Calculate the hash of a stake pool metadata file,
+                           optionally checking the obtained hash against an
+                           expected value.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_stake-pool_metadata-hash.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_stake-pool_metadata-hash.cli
@@ -13,7 +13,7 @@ Available options:
   --pool-metadata-file FILEPATH
                            Filepath of the pool metadata.
   --pool-metadata-url TEXT URL pointing to the JSON Metadata file to hash.
-  --expected-hash HASH     Expected hash for the stake pool metadata for
+  --expected-hash HASH     Expected hash for the stake pool metadata, for
                            verification purposes. If provided, the hash of the
                            stake pool metadata will be compared to this value.
   --out-file FILEPATH      The output file.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_stake-pool_metadata-hash.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_stake-pool_metadata-hash.cli
@@ -1,10 +1,20 @@
-Usage: cardano-cli babbage stake-pool metadata-hash --pool-metadata-file FILEPATH
-                                                      [--out-file FILEPATH]
+Usage: cardano-cli babbage stake-pool metadata-hash 
+                                                      ( --pool-metadata-file FILEPATH
+                                                      | --pool-metadata-url TEXT
+                                                      )
+                                                      [ --expected-hash HASH
+                                                      | --out-file FILEPATH
+                                                      ]
 
-  Print the hash of pool metadata.
+  Calculate the hash of a stake pool metadata file, optionally checking the
+  obtained hash against an expected value.
 
 Available options:
   --pool-metadata-file FILEPATH
                            Filepath of the pool metadata.
-  --out-file FILEPATH      Optional output file. Default is to write to stdout.
+  --pool-metadata-url TEXT URL pointing to the JSON Metadata file to hash.
+  --expected-hash HASH     Expected hash for the stake pool metadata for
+                           verification purposes. If provided, the hash of the
+                           stake pool metadata will be compared to this value.
+  --out-file FILEPATH      The output file.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_stake-pool_registration-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_stake-pool_registration-certificate.cli
@@ -22,7 +22,8 @@ Usage: cardano-cli babbage stake-pool registration-certificate
                                                                  | --multi-host-pool-relay STRING
                                                                  ]
                                                                  [--metadata-url URL
-                                                                   --metadata-hash HASH]
+                                                                   --metadata-hash HASH
+                                                                   [--check-metadata-hash]]
                                                                  ( --mainnet
                                                                  | --testnet-magic NATURAL
                                                                  )
@@ -65,6 +66,11 @@ Available options:
                            an SRV DNS record
   --metadata-url URL       Pool metadata URL (maximum length of 64 characters).
   --metadata-hash HASH     Pool metadata hash.
+  --check-metadata-hash    Verify that the expected stake pool metadata hash
+                           provided in --metadata-hash matches the hash of the
+                           file downloaded from the URL provided in
+                           --metadata-url (this parameter will download the file
+                           from the URL)
   --mainnet                Use the mainnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_drep_metadata-hash.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_drep_metadata-hash.cli
@@ -15,6 +15,6 @@ Available options:
   --drep-metadata-url TEXT URL pointing to the JSON Metadata file to hash.
   --expected-hash HASH     Expected hash for the DRep metadata, for verification
                            purposes. If provided, the hash of the DRep metadata
-                           is compared to this value.
+                           will be compared to this value.
   --out-file FILEPATH      The output file.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_stake-pool.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_stake-pool.cli
@@ -15,4 +15,6 @@ Available commands:
   deregistration-certificate
                            Create a stake pool deregistration certificate
   id                       Build pool id from the offline key
-  metadata-hash            Print the hash of pool metadata.
+  metadata-hash            Calculate the hash of a stake pool metadata file,
+                           optionally checking the obtained hash against an
+                           expected value.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_stake-pool_metadata-hash.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_stake-pool_metadata-hash.cli
@@ -13,7 +13,7 @@ Available options:
   --pool-metadata-file FILEPATH
                            Filepath of the pool metadata.
   --pool-metadata-url TEXT URL pointing to the JSON Metadata file to hash.
-  --expected-hash HASH     Expected hash for the stake pool metadata for
+  --expected-hash HASH     Expected hash for the stake pool metadata, for
                            verification purposes. If provided, the hash of the
                            stake pool metadata will be compared to this value.
   --out-file FILEPATH      The output file.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_stake-pool_metadata-hash.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_stake-pool_metadata-hash.cli
@@ -1,10 +1,20 @@
-Usage: cardano-cli conway stake-pool metadata-hash --pool-metadata-file FILEPATH
-                                                     [--out-file FILEPATH]
+Usage: cardano-cli conway stake-pool metadata-hash 
+                                                     ( --pool-metadata-file FILEPATH
+                                                     | --pool-metadata-url TEXT
+                                                     )
+                                                     [ --expected-hash HASH
+                                                     | --out-file FILEPATH
+                                                     ]
 
-  Print the hash of pool metadata.
+  Calculate the hash of a stake pool metadata file, optionally checking the
+  obtained hash against an expected value.
 
 Available options:
   --pool-metadata-file FILEPATH
                            Filepath of the pool metadata.
-  --out-file FILEPATH      Optional output file. Default is to write to stdout.
+  --pool-metadata-url TEXT URL pointing to the JSON Metadata file to hash.
+  --expected-hash HASH     Expected hash for the stake pool metadata for
+                           verification purposes. If provided, the hash of the
+                           stake pool metadata will be compared to this value.
+  --out-file FILEPATH      The output file.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_stake-pool_registration-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_stake-pool_registration-certificate.cli
@@ -22,7 +22,8 @@ Usage: cardano-cli conway stake-pool registration-certificate
                                                                 | --multi-host-pool-relay STRING
                                                                 ]
                                                                 [--metadata-url URL
-                                                                  --metadata-hash HASH]
+                                                                  --metadata-hash HASH
+                                                                  [--check-metadata-hash]]
                                                                 ( --mainnet
                                                                 | --testnet-magic NATURAL
                                                                 )
@@ -65,6 +66,11 @@ Available options:
                            an SRV DNS record
   --metadata-url URL       Pool metadata URL (maximum length of 64 characters).
   --metadata-hash HASH     Pool metadata hash.
+  --check-metadata-hash    Verify that the expected stake pool metadata hash
+                           provided in --metadata-hash matches the hash of the
+                           file downloaded from the URL provided in
+                           --metadata-url (this parameter will download the file
+                           from the URL)
   --mainnet                Use the mainnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/hash_anchor-data.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/hash_anchor-data.cli
@@ -15,7 +15,7 @@ Available options:
   --file-binary FILEPATH   Binary file to hash
   --file-text FILEPATH     Text file to hash
   --url TEXT               A URL to the file to hash (HTTP(S) and IPFS only)
-  --expected-hash HASH     Expected hash for the anchor data for verification
+  --expected-hash HASH     Expected hash for the anchor data, for verification
                            purposes. If provided, the hash of the anchor data
                            will be compared to this value.
   --out-file FILEPATH      The output file.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_governance_drep_metadata-hash.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_governance_drep_metadata-hash.cli
@@ -15,6 +15,6 @@ Available options:
   --drep-metadata-url TEXT URL pointing to the JSON Metadata file to hash.
   --expected-hash HASH     Expected hash for the DRep metadata, for verification
                            purposes. If provided, the hash of the DRep metadata
-                           is compared to this value.
+                           will be compared to this value.
   --out-file FILEPATH      The output file.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_stake-pool.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_stake-pool.cli
@@ -15,4 +15,6 @@ Available commands:
   deregistration-certificate
                            Create a stake pool deregistration certificate
   id                       Build pool id from the offline key
-  metadata-hash            Print the hash of pool metadata.
+  metadata-hash            Calculate the hash of a stake pool metadata file,
+                           optionally checking the obtained hash against an
+                           expected value.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_stake-pool_metadata-hash.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_stake-pool_metadata-hash.cli
@@ -13,7 +13,7 @@ Available options:
   --pool-metadata-file FILEPATH
                            Filepath of the pool metadata.
   --pool-metadata-url TEXT URL pointing to the JSON Metadata file to hash.
-  --expected-hash HASH     Expected hash for the stake pool metadata for
+  --expected-hash HASH     Expected hash for the stake pool metadata, for
                            verification purposes. If provided, the hash of the
                            stake pool metadata will be compared to this value.
   --out-file FILEPATH      The output file.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_stake-pool_metadata-hash.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_stake-pool_metadata-hash.cli
@@ -1,10 +1,20 @@
-Usage: cardano-cli latest stake-pool metadata-hash --pool-metadata-file FILEPATH
-                                                     [--out-file FILEPATH]
+Usage: cardano-cli latest stake-pool metadata-hash 
+                                                     ( --pool-metadata-file FILEPATH
+                                                     | --pool-metadata-url TEXT
+                                                     )
+                                                     [ --expected-hash HASH
+                                                     | --out-file FILEPATH
+                                                     ]
 
-  Print the hash of pool metadata.
+  Calculate the hash of a stake pool metadata file, optionally checking the
+  obtained hash against an expected value.
 
 Available options:
   --pool-metadata-file FILEPATH
                            Filepath of the pool metadata.
-  --out-file FILEPATH      Optional output file. Default is to write to stdout.
+  --pool-metadata-url TEXT URL pointing to the JSON Metadata file to hash.
+  --expected-hash HASH     Expected hash for the stake pool metadata for
+                           verification purposes. If provided, the hash of the
+                           stake pool metadata will be compared to this value.
+  --out-file FILEPATH      The output file.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_stake-pool_registration-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_stake-pool_registration-certificate.cli
@@ -22,7 +22,8 @@ Usage: cardano-cli latest stake-pool registration-certificate
                                                                 | --multi-host-pool-relay STRING
                                                                 ]
                                                                 [--metadata-url URL
-                                                                  --metadata-hash HASH]
+                                                                  --metadata-hash HASH
+                                                                  [--check-metadata-hash]]
                                                                 ( --mainnet
                                                                 | --testnet-magic NATURAL
                                                                 )
@@ -65,6 +66,11 @@ Available options:
                            an SRV DNS record
   --metadata-url URL       Pool metadata URL (maximum length of 64 characters).
   --metadata-hash HASH     Pool metadata hash.
+  --check-metadata-hash    Verify that the expected stake pool metadata hash
+                           provided in --metadata-hash matches the hash of the
+                           file downloaded from the URL provided in
+                           --metadata-url (this parameter will download the file
+                           from the URL)
   --mainnet                Use the mainnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_stake-pool.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_stake-pool.cli
@@ -15,4 +15,6 @@ Available commands:
   deregistration-certificate
                            Create a stake pool deregistration certificate
   id                       Build pool id from the offline key
-  metadata-hash            Print the hash of pool metadata.
+  metadata-hash            Calculate the hash of a stake pool metadata file,
+                           optionally checking the obtained hash against an
+                           expected value.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_stake-pool_metadata-hash.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_stake-pool_metadata-hash.cli
@@ -13,7 +13,7 @@ Available options:
   --pool-metadata-file FILEPATH
                            Filepath of the pool metadata.
   --pool-metadata-url TEXT URL pointing to the JSON Metadata file to hash.
-  --expected-hash HASH     Expected hash for the stake pool metadata for
+  --expected-hash HASH     Expected hash for the stake pool metadata, for
                            verification purposes. If provided, the hash of the
                            stake pool metadata will be compared to this value.
   --out-file FILEPATH      The output file.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_stake-pool_metadata-hash.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_stake-pool_metadata-hash.cli
@@ -1,10 +1,20 @@
-Usage: cardano-cli mary stake-pool metadata-hash --pool-metadata-file FILEPATH
-                                                   [--out-file FILEPATH]
+Usage: cardano-cli mary stake-pool metadata-hash 
+                                                   ( --pool-metadata-file FILEPATH
+                                                   | --pool-metadata-url TEXT
+                                                   )
+                                                   [ --expected-hash HASH
+                                                   | --out-file FILEPATH
+                                                   ]
 
-  Print the hash of pool metadata.
+  Calculate the hash of a stake pool metadata file, optionally checking the
+  obtained hash against an expected value.
 
 Available options:
   --pool-metadata-file FILEPATH
                            Filepath of the pool metadata.
-  --out-file FILEPATH      Optional output file. Default is to write to stdout.
+  --pool-metadata-url TEXT URL pointing to the JSON Metadata file to hash.
+  --expected-hash HASH     Expected hash for the stake pool metadata for
+                           verification purposes. If provided, the hash of the
+                           stake pool metadata will be compared to this value.
+  --out-file FILEPATH      The output file.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_stake-pool_registration-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_stake-pool_registration-certificate.cli
@@ -22,7 +22,8 @@ Usage: cardano-cli mary stake-pool registration-certificate
                                                               | --multi-host-pool-relay STRING
                                                               ]
                                                               [--metadata-url URL
-                                                                --metadata-hash HASH]
+                                                                --metadata-hash HASH
+                                                                [--check-metadata-hash]]
                                                               ( --mainnet
                                                               | --testnet-magic NATURAL
                                                               )
@@ -65,6 +66,11 @@ Available options:
                            an SRV DNS record
   --metadata-url URL       Pool metadata URL (maximum length of 64 characters).
   --metadata-hash HASH     Pool metadata hash.
+  --check-metadata-hash    Verify that the expected stake pool metadata hash
+                           provided in --metadata-hash matches the hash of the
+                           file downloaded from the URL provided in
+                           --metadata-url (this parameter will download the file
+                           from the URL)
   --mainnet                Use the mainnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_stake-pool.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_stake-pool.cli
@@ -15,4 +15,6 @@ Available commands:
   deregistration-certificate
                            Create a stake pool deregistration certificate
   id                       Build pool id from the offline key
-  metadata-hash            Print the hash of pool metadata.
+  metadata-hash            Calculate the hash of a stake pool metadata file,
+                           optionally checking the obtained hash against an
+                           expected value.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_stake-pool_metadata-hash.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_stake-pool_metadata-hash.cli
@@ -1,10 +1,20 @@
-Usage: cardano-cli shelley stake-pool metadata-hash --pool-metadata-file FILEPATH
-                                                      [--out-file FILEPATH]
+Usage: cardano-cli shelley stake-pool metadata-hash 
+                                                      ( --pool-metadata-file FILEPATH
+                                                      | --pool-metadata-url TEXT
+                                                      )
+                                                      [ --expected-hash HASH
+                                                      | --out-file FILEPATH
+                                                      ]
 
-  Print the hash of pool metadata.
+  Calculate the hash of a stake pool metadata file, optionally checking the
+  obtained hash against an expected value.
 
 Available options:
   --pool-metadata-file FILEPATH
                            Filepath of the pool metadata.
-  --out-file FILEPATH      Optional output file. Default is to write to stdout.
+  --pool-metadata-url TEXT URL pointing to the JSON Metadata file to hash.
+  --expected-hash HASH     Expected hash for the stake pool metadata for
+                           verification purposes. If provided, the hash of the
+                           stake pool metadata will be compared to this value.
+  --out-file FILEPATH      The output file.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_stake-pool_metadata-hash.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_stake-pool_metadata-hash.cli
@@ -13,7 +13,7 @@ Available options:
   --pool-metadata-file FILEPATH
                            Filepath of the pool metadata.
   --pool-metadata-url TEXT URL pointing to the JSON Metadata file to hash.
-  --expected-hash HASH     Expected hash for the stake pool metadata for
+  --expected-hash HASH     Expected hash for the stake pool metadata, for
                            verification purposes. If provided, the hash of the
                            stake pool metadata will be compared to this value.
   --out-file FILEPATH      The output file.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_stake-pool_registration-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_stake-pool_registration-certificate.cli
@@ -22,7 +22,8 @@ Usage: cardano-cli shelley stake-pool registration-certificate
                                                                  | --multi-host-pool-relay STRING
                                                                  ]
                                                                  [--metadata-url URL
-                                                                   --metadata-hash HASH]
+                                                                   --metadata-hash HASH
+                                                                   [--check-metadata-hash]]
                                                                  ( --mainnet
                                                                  | --testnet-magic NATURAL
                                                                  )
@@ -65,6 +66,11 @@ Available options:
                            an SRV DNS record
   --metadata-url URL       Pool metadata URL (maximum length of 64 characters).
   --metadata-hash HASH     Pool metadata hash.
+  --check-metadata-hash    Verify that the expected stake pool metadata hash
+                           provided in --metadata-hash matches the hash of the
+                           file downloaded from the URL provided in
+                           --metadata-url (this parameter will download the file
+                           from the URL)
   --mainnet                Use the mainnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the

--- a/cardano-cli/test/cardano-cli-golden/files/input/example_stake_pool_metadata.json
+++ b/cardano-cli/test/cardano-cli-golden/files/input/example_stake_pool_metadata.json
@@ -1,0 +1,1 @@
+{"homepage":"https://iohk.io","name":"Genesis Pool C","ticker":"GPC","description":"Lorem Ipsum Dolor Sit Amet."}

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/Shelley/Certificates/StakePool.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/Shelley/Certificates/StakePool.hs
@@ -1,0 +1,150 @@
+{-# LANGUAGE FlexibleContexts #-}
+
+module Test.Cli.Shelley.Certificates.StakePool where
+
+import           Cardano.Api (MonadIO)
+
+import           Control.Monad (void)
+import           Control.Monad.Catch (MonadCatch)
+import           Control.Monad.Trans.Control (MonadBaseControl)
+
+import           Test.Cardano.CLI.Hash (serveFilesWhile, tamperBase16Hash)
+import           Test.Cardano.CLI.Util (execCardanoCLI, execCardanoCLIWithEnvVars, expectFailure,
+                   noteTempFile, propertyOnce)
+
+import           Hedgehog (MonadTest)
+import qualified Hedgehog as H
+import qualified Hedgehog.Extras as H
+import           Hedgehog.Internal.Property (Property)
+
+exampleStakePoolMetadataHash :: String
+exampleStakePoolMetadataHash = "8241de08075886a7d09c847c9bbd1719459dac0bd0a2f085e673611ebb9a5965"
+
+exampleStakePoolMetadataPathTest :: String
+exampleStakePoolMetadataPathTest = "test/cardano-cli-test/files/input/example_stake_pool_metadata.json"
+
+exampleStakePoolMetadataIpfsHash :: String
+exampleStakePoolMetadataIpfsHash = "QmR1HAT4Hb4HjjqcgoXwupYXMF6t8h7MoSP24HMfV8t38a"
+
+-- Execute me with:
+-- @cabal test cardano-cli-test --test-options '-p "/stake pool certificate hash check wrong hash fails/"'@
+hprop_stake_pool_certificate_hash_check_wrong_hash_fails :: Property
+hprop_stake_pool_certificate_hash_check_wrong_hash_fails =
+  propertyOnce . expectFailure . H.moduleWorkspace "tmp" $ \tempDir -> do
+    -- We modify the hash slightly so that the hash check fails
+    alteredHash <- H.evalMaybe $ tamperBase16Hash exampleStakePoolMetadataHash
+    -- We run the test with the modified hash
+    baseStakePoolCertificateHashCheck
+      alteredHash
+      tempDir
+
+-- Execute me with:
+-- @cabal test cardano-cli-test --test-options '-p "/stake pool certificate hash check right hash works/"'@
+hprop_stake_pool_certificate_hash_check_right_hash_works :: Property
+hprop_stake_pool_certificate_hash_check_right_hash_works =
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir ->
+    baseStakePoolCertificateHashCheck exampleStakePoolMetadataHash tempDir
+
+baseStakePoolCertificateHashCheck
+  :: (MonadBaseControl IO m, MonadTest m, MonadIO m, MonadCatch m)
+  => String
+  -- ^ The hash to check against. Changing this value allows us to test the
+  -- behavior of the command both when the hash is correct and when it is incorrect
+  -- reusing the same code.
+  -> FilePath
+  -- ^ Temporary directory for files generated during the test
+  -> m ()
+baseStakePoolCertificateHashCheck hash tempDir = do
+  -- Key filepaths
+  coldVerKey <- noteTempFile tempDir "cold-verification-key-file"
+  coldSignKey <- noteTempFile tempDir "cold-signing-key-file"
+  operationalCertCounter <- noteTempFile tempDir "operational-certificate-counter-file"
+  vrfVerKey <- noteTempFile tempDir "vrf-verification-key-file"
+  vrfSignKey <- noteTempFile tempDir "vrf-signing-key-file"
+  poolRewardAccountAndOwnerVerKey <- noteTempFile tempDir "reward-account-verification-key-file"
+  poolRewardAccountSignKey <- noteTempFile tempDir "reward-account-signing-key-file"
+  registrationCertificate <- noteTempFile tempDir "stake-pool-registration-certificate"
+
+  -- Create cold key pair
+  void $
+    execCardanoCLI
+      [ "latest"
+      , "node"
+      , "key-gen"
+      , "--cold-verification-key-file"
+      , coldVerKey
+      , "--cold-signing-key-file"
+      , coldSignKey
+      , "--operational-certificate-issue-counter"
+      , operationalCertCounter
+      ]
+
+  H.assertFilesExist [coldSignKey, coldVerKey, operationalCertCounter]
+
+  -- Generate stake key pair
+  void $
+    execCardanoCLI
+      [ "latest"
+      , "stake-address"
+      , "key-gen"
+      , "--verification-key-file"
+      , poolRewardAccountAndOwnerVerKey
+      , "--signing-key-file"
+      , poolRewardAccountSignKey
+      ]
+
+  H.assertFilesExist [poolRewardAccountAndOwnerVerKey, poolRewardAccountSignKey]
+
+  -- Generate vrf verification key
+  void $
+    execCardanoCLI
+      [ "latest"
+      , "node"
+      , "key-gen-VRF"
+      , "--verification-key-file"
+      , vrfVerKey
+      , "--signing-key-file"
+      , vrfSignKey
+      ]
+
+  H.assertFilesExist [vrfSignKey, vrfVerKey]
+
+  let relativeUrl = ["ipfs", exampleStakePoolMetadataIpfsHash]
+
+  -- Create temporary HTTP server with files required by the call to `cardano-cli`
+  -- In this case, the server emulates an IPFS gateway
+  serveFilesWhile
+    [ (relativeUrl, exampleStakePoolMetadataPathTest)
+    ]
+    ( \port -> do
+        -- Create stake pool registration certificate
+        void $
+          execCardanoCLIWithEnvVars
+            [("IPFS_GATEWAY_URI", "http://localhost:" ++ show port ++ "/")]
+            [ "babbage"
+            , "stake-pool"
+            , "registration-certificate"
+            , "--cold-verification-key-file"
+            , coldVerKey
+            , "--vrf-verification-key-file"
+            , vrfVerKey
+            , "--mainnet"
+            , "--pool-cost"
+            , "1000"
+            , "--pool-pledge"
+            , "5000"
+            , "--pool-margin"
+            , "0.1"
+            , "--pool-reward-account-verification-key-file"
+            , poolRewardAccountAndOwnerVerKey
+            , "--pool-owner-stake-verification-key-file"
+            , poolRewardAccountAndOwnerVerKey
+            , "--metadata-url"
+            , "ipfs://" ++ exampleStakePoolMetadataIpfsHash
+            , "--metadata-hash"
+            , hash
+            , "--check-metadata-hash"
+            , "--out-file"
+            , registrationCertificate
+            ]
+    )

--- a/cardano-cli/test/cardano-cli-test/files/input/example_stake_pool_metadata.json
+++ b/cardano-cli/test/cardano-cli-test/files/input/example_stake_pool_metadata.json
@@ -1,0 +1,1 @@
+{"homepage":"https://iohk.io","name":"Genesis Pool C","ticker":"GPC","description":"Lorem Ipsum Dolor Sit Amet."}


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Added metadata, metadata hash validation and URL support to `stake-pool registration-certificate`; and hash checking and URL support to `stake-pool metadata-hash`.
  type:
  - feature        # introduces a new feature
  - test           # fixes/modifies tests
```

# Context

This is part of the work to address https://github.com/IntersectMBO/cardano-cli/issues/882.

This PR adds and optional check to `stake-pool registration-certificate` to verify that the hash input matches metadata given in a particular URL.

It also adds URL support to `stake-pool metadata-hash` for consistency with other hashing commands (see https://github.com/IntersectMBO/cardano-cli/pull/895, and https://github.com/IntersectMBO/cardano-cli/pull/927).

# How to trust this PR

There are plenty of tests and code reuse. Most of the changes are also tests and changes to golden files, the actual code changes are few and very similar to the ones in previous PRs.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
