### PR TITLE
Add hash checks for `governance committee create-cold-key-resignation-certificate` and `governance vote create`

### DIFF
--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -337,6 +337,7 @@ test-suite cardano-cli-test
     Test.Cli.CreateTestnetData
     Test.Cli.DRepMetadata
     Test.Cli.FilePermissions
+    Test.Cli.Governance.Committee
     Test.Cli.Governance.DRep
     Test.Cli.Governance.Hash
     Test.Cli.Hash

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -340,6 +340,7 @@ test-suite cardano-cli-test
     Test.Cli.Governance.Committee
     Test.Cli.Governance.DRep
     Test.Cli.Governance.Hash
+    Test.Cli.Governance.Vote
     Test.Cli.Hash
     Test.Cli.ITN
     Test.Cli.Json

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/Committee.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/Committee.hs
@@ -17,6 +17,7 @@ import           Cardano.Api
 import qualified Cardano.Api.Ledger as L
 import           Cardano.Api.Shelley
 
+import           Cardano.CLI.Types.Common (PotentiallyCheckedAnchor, ResignationMetadataUrl)
 import           Cardano.CLI.Types.Key
 import           Cardano.CLI.Types.Key.VerificationKey
 
@@ -71,7 +72,13 @@ data GovernanceCommitteeCreateColdKeyResignationCertificateCmdArgs era
   = GovernanceCommitteeCreateColdKeyResignationCertificateCmdArgs
   { eon :: !(ConwayEraOnwards era)
   , vkeyColdKeySource :: !(VerificationKeySource CommitteeColdKey)
-  , anchor :: !(Maybe (L.Anchor (L.EraCrypto (ShelleyLedgerEra era))))
+  , anchor
+      :: !( Maybe
+              ( PotentiallyCheckedAnchor
+                  ResignationMetadataUrl
+                  (L.Anchor (L.EraCrypto (ShelleyLedgerEra era)))
+              )
+          )
   , outFile :: !(File () Out)
   }
   deriving Show

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/Vote.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/Vote.hs
@@ -32,7 +32,13 @@ data GovernanceVoteCreateCmdArgs era
   , voteChoice :: Vote
   , governanceAction :: (TxId, Word16)
   , votingStakeCredentialSource :: AnyVotingStakeVerificationKeyOrHashOrFile
-  , mAnchor :: Maybe (VoteUrl, L.SafeHash L.StandardCrypto L.AnchorData)
+  , mAnchor
+      :: !( Maybe
+              ( PotentiallyCheckedAnchor
+                  VoteUrl
+                  (VoteUrl, L.SafeHash L.StandardCrypto L.AnchorData)
+              )
+          )
   , outFile :: VoteFile Out
   }
 

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
@@ -3612,6 +3612,9 @@ pMustCheckMetadataHash = pMustCheckHash "drep-metadata-hash" "DRep metadata" "--
 pMustCheckStakeMetadataHash :: Parser (MustCheckHash StakePoolMetadataReference)
 pMustCheckStakeMetadataHash = pMustCheckHash "metadata-hash" "stake pool metadata" "--metadata-hash" "--metadata-url"
 
+pMustCheckVoteUrl :: Parser (MustCheckHash VoteUrl)
+pMustCheckVoteUrl = pMustCheckHash "anchor-data-hash" "vote anchor data" "--anchor-data-hash" "--anchor-url"
+
 pMustCheckResignationMetadataHash :: Parser (MustCheckHash ResignationMetadataUrl)
 pMustCheckResignationMetadataHash =
   pMustCheckHash

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
@@ -3612,6 +3612,14 @@ pMustCheckMetadataHash = pMustCheckHash "drep-metadata-hash" "DRep metadata" "--
 pMustCheckStakeMetadataHash :: Parser (MustCheckHash StakePoolMetadataReference)
 pMustCheckStakeMetadataHash = pMustCheckHash "metadata-hash" "stake pool metadata" "--metadata-hash" "--metadata-url"
 
+pMustCheckResignationMetadataHash :: Parser (MustCheckHash ResignationMetadataUrl)
+pMustCheckResignationMetadataHash =
+  pMustCheckHash
+    "resignation-metadata-hash"
+    "Constitutional Committee cold key resignation certificate metadata"
+    "--resignation-metadata-hash"
+    "--resignation-metadata-url"
+
 pPreviousGovernanceAction :: Parser (Maybe (TxId, Word16))
 pPreviousGovernanceAction =
   optional $

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Committee.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Committee.hs
@@ -15,7 +15,7 @@ import           Cardano.CLI.Read
 import           Cardano.CLI.Types.Key
 
 import           Data.Foldable (asum)
-import           Options.Applicative (Parser)
+import           Options.Applicative (Parser, optional)
 import qualified Options.Applicative as Opt
 
 pGovernanceCommitteeCmds
@@ -141,7 +141,11 @@ pGovernanceCommitteeCreateColdKeyResignationCertificateCmd era = do
     GovernanceCommitteeCreateColdKeyResignationCertificateCmd
       <$> ( GovernanceCommitteeCreateColdKeyResignationCertificateCmdArgs w
               <$> pColdCredential
-              <*> pAnchor
+              <*> optional
+                ( pPotentiallyCheckedAnchorData
+                    pMustCheckResignationMetadataHash
+                    pAnchor
+                )
               <*> pOutputFile
           )
 
@@ -169,12 +173,11 @@ pHotCredential =
     , VksScript <$> pScriptFor "hot-script-file" Nothing "Hot Native or Plutus script file"
     ]
 
-pAnchor :: Parser (Maybe (L.Anchor L.StandardCrypto))
+pAnchor :: Parser (L.Anchor L.StandardCrypto)
 pAnchor =
-  Opt.optional $
-    L.Anchor
-      <$> fmap unAnchorUrl pAnchorUrl
-      <*> pSafeHash
+  L.Anchor
+    <$> fmap unAnchorUrl pAnchorUrl
+    <*> pSafeHash
 
 pAnchorUrl :: Parser AnchorUrl
 pAnchorUrl =

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Vote.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Vote.hs
@@ -51,7 +51,11 @@ pGovernanceVoteCreateCmdArgs cOnwards =
     <$> pVoteChoice
     <*> pGovernanceActionId
     <*> pAnyVotingStakeVerificationKeyOrHashOrFile
-    <*> optional pVoteAnchor
+    <*> optional
+      ( pPotentiallyCheckedAnchorData
+          pMustCheckVoteUrl
+          pVoteAnchor
+      )
     <*> pFileOutDirection "out-file" "Output filepath of the vote."
 
 pAnyVotingStakeVerificationKeyOrHashOrFile :: Parser AnyVotingStakeVerificationKeyOrHashOrFile

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Committee.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Committee.hs
@@ -15,7 +15,9 @@ import           Cardano.Api.Shelley
 import           Cardano.CLI.EraBased.Commands.Governance.Committee
 import qualified Cardano.CLI.EraBased.Commands.Governance.Committee as Cmd
 import           Cardano.CLI.Read (readVerificationKeySource)
+import           Cardano.CLI.Run.Hash (carryHashChecks)
 import qualified Cardano.CLI.Run.Key as Key
+import           Cardano.CLI.Types.Common (PotentiallyCheckedAnchor (..))
 import           Cardano.CLI.Types.Errors.GovernanceCommitteeError
 import           Cardano.CLI.Types.Key.VerificationKey
 
@@ -177,8 +179,12 @@ runGovernanceCommitteeColdKeyResignationCertificate
         modifyError' $
           readVerificationKeySource AsCommitteeColdKey unCommitteeColdKeyHash vkeyColdKeySource
 
+      mapM_
+        (withExceptT GovernanceCommitteeHashCheckError . carryHashChecks)
+        anchor
+
       makeCommitteeColdkeyResignationCertificate
-        (CommitteeColdkeyResignationRequirements eon coldVKeyCred anchor)
+        (CommitteeColdkeyResignationRequirements eon coldVKeyCred (pcaAnchor <$> anchor))
         & textEnvelopeToJSON (Just genKeyDelegCertDesc)
         & writeLazyByteStringFile outFile
         & firstExceptT GovernanceCommitteeCmdTextEnvWriteError . newExceptT

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Vote.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Vote.hs
@@ -27,7 +27,6 @@ import           Cardano.CLI.Types.Key
 import           Data.Aeson.Encode.Pretty
 import           Data.Function
 import qualified Data.Yaml.Pretty as Yaml
-import           Lens.Micro (_Just, over)
 
 runGovernanceVoteCmds
   :: ()
@@ -57,9 +56,10 @@ runGovernanceVoteCreateCmd
     let (govActionTxId, govActionIndex) = governanceAction
         sbe = conwayEraOnwardsToShelleyBasedEra eon -- TODO: Conway era - update vote creation related function to take ConwayEraOnwards
         mAnchor' =
-          over
-            (_Just . _pcaAnchor)
-            (\(VoteUrl url, voteHash) -> L.Anchor{L.anchorUrl = url, L.anchorDataHash = voteHash})
+          fmap
+            ( \pca@PotentiallyCheckedAnchor{pcaAnchor = (VoteUrl url, voteHash)} ->
+                pca{pcaAnchor = L.Anchor{L.anchorUrl = url, L.anchorDataHash = voteHash}}
+            )
             mAnchor
 
     mapM_

--- a/cardano-cli/src/Cardano/CLI/Types/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Common.hs
@@ -90,7 +90,6 @@ module Cardano.CLI.Types.Common
   , DRepMetadataUrl
   , ResignationMetadataUrl
   , PotentiallyCheckedAnchor (..)
-  , _pcaAnchor
   )
 where
 
@@ -105,7 +104,6 @@ import           Data.String (IsString)
 import           Data.Text (Text)
 import qualified Data.Text as Text
 import           Data.Word (Word64)
-import           Lens.Micro.Type (Traversal)
 
 -- | Determines the direction in which the MIR certificate will transfer ADA.
 data TransferDirection
@@ -667,12 +665,3 @@ data PotentiallyCheckedAnchor anchorType anchor
   -- ^ Whether to check the hash or not (CheckHash for checking or TrustHash for not checking)
   }
   deriving (Eq, Show)
-
-_pcaAnchor
-  :: Traversal
-      (PotentiallyCheckedAnchor anchorType anchor)
-      (PotentiallyCheckedAnchor anchorType anchor')
-      anchor
-      anchor'
-_pcaAnchor f pca@(PotentiallyCheckedAnchor{pcaAnchor = pcaAnchor'}) =
-  (\newAnchor -> pca{pcaAnchor = newAnchor}) <$> f pcaAnchor'

--- a/cardano-cli/src/Cardano/CLI/Types/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Common.hs
@@ -90,6 +90,7 @@ module Cardano.CLI.Types.Common
   , DRepMetadataUrl
   , ResignationMetadataUrl
   , PotentiallyCheckedAnchor (..)
+  , _pcaAnchor
   )
 where
 
@@ -104,6 +105,7 @@ import           Data.String (IsString)
 import           Data.Text (Text)
 import qualified Data.Text as Text
 import           Data.Word (Word64)
+import           Lens.Micro.Type (Traversal)
 
 -- | Determines the direction in which the MIR certificate will transfer ADA.
 data TransferDirection
@@ -665,3 +667,12 @@ data PotentiallyCheckedAnchor anchorType anchor
   -- ^ Whether to check the hash or not (CheckHash for checking or TrustHash for not checking)
   }
   deriving (Eq, Show)
+
+_pcaAnchor
+  :: Traversal
+      (PotentiallyCheckedAnchor anchorType anchor)
+      (PotentiallyCheckedAnchor anchorType anchor')
+      anchor
+      anchor'
+_pcaAnchor f pca@(PotentiallyCheckedAnchor{pcaAnchor = pcaAnchor'}) =
+  (\newAnchor -> pca{pcaAnchor = newAnchor}) <$> f pcaAnchor'

--- a/cardano-cli/src/Cardano/CLI/Types/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Common.hs
@@ -88,6 +88,7 @@ module Cardano.CLI.Types.Common
   , WitnessSigningData (..)
   , DRepMetadataFile
   , DRepMetadataUrl
+  , ResignationMetadataUrl
   , PotentiallyCheckedAnchor (..)
   )
 where
@@ -142,6 +143,10 @@ data ProposalText
 -- | Tag for differentiating between DRep metadata sources and
 -- sources for other types of anchor data
 data DRepMetadataUrl
+
+-- | Tag for differentiating between resignation metadatata sources and
+-- sources for other types of anchor data
+data ResignationMetadataUrl
 
 newtype VoteUrl = VoteUrl
   { unVoteUrl :: L.Url

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/GovernanceCommitteeError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/GovernanceCommitteeError.hs
@@ -7,7 +7,10 @@ where
 
 import           Cardano.Api
 
+import           Cardano.CLI.Types.Errors.HashCmdError (HashCheckError)
 import           Cardano.CLI.Types.Errors.ScriptDecodeError
+
+import           Control.Exception (displayException)
 
 data GovernanceCommitteeError
   = GovernanceCommitteeCmdKeyDecodeError InputDecodeError
@@ -16,6 +19,7 @@ data GovernanceCommitteeError
   | GovernanceCommitteeCmdTextEnvReadFileError (FileError TextEnvelopeError)
   | GovernanceCommitteeCmdTextEnvWriteError (FileError ())
   | GovernanceCommitteeCmdWriteFileError (FileError ())
+  | GovernanceCommitteeHashCheckError !HashCheckError
   deriving Show
 
 instance Error GovernanceCommitteeError where
@@ -32,3 +36,5 @@ instance Error GovernanceCommitteeError where
       "Cannot write text envelope file: " <> prettyError e
     GovernanceCommitteeCmdScriptReadError e ->
       "Cannot read script file: " <> prettyError e
+    GovernanceCommitteeHashCheckError hashCheckErr ->
+      "Error while checking metadata hash: " <> pretty (displayException hashCheckErr)

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/GovernanceVoteCmdError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/GovernanceVoteCmdError.hs
@@ -8,7 +8,9 @@ import           Cardano.Api.Shelley
 
 import           Cardano.Binary (DecoderError)
 import           Cardano.CLI.Read (VoteError)
+import           Cardano.CLI.Types.Errors.HashCmdError (HashCheckError)
 
+import           Control.Exception (displayException)
 import qualified Data.Text.Lazy.Builder as TL
 import qualified Formatting.Buildable as B
 
@@ -18,6 +20,7 @@ data GovernanceVoteCmdError
   | GovernanceVoteCmdCredentialDecodeError !DecoderError
   | GovernanceVoteCmdWriteError !(FileError ())
   | GovernanceVoteCmdReadVoteTextError !VoteError
+  | GovernanceVoteCmdResignationCertHashCheckError !HashCheckError
   deriving Show
 
 instance Error GovernanceVoteCmdError where
@@ -32,5 +35,8 @@ instance Error GovernanceVoteCmdError where
       "Cannot write vote: " <> prettyError e
     GovernanceVoteCmdReadVoteTextError e ->
       "Cannot read vote text: " <> prettyError e
+    GovernanceVoteCmdResignationCertHashCheckError hashCheckErr ->
+      "Error while checking resignation certificate metadata hash: "
+        <> pretty (displayException hashCheckErr)
    where
     renderDecoderError = pretty . TL.toLazyText . B.build

--- a/cardano-cli/test/cardano-cli-golden/files/golden/governance/committee/governance_committee_checks_wrong_hash_fails.out
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/governance/committee/governance_committee_checks_wrong_hash_fails.out
@@ -1,0 +1,3 @@
+Command failed: governance committee create-cold-key-resignation-certificate  Error: Error while checking metadata hash: Hashes do not match!
+Expected: "ee38a4f5b8b9d8372386cc923bad19d1a0662298cf355bbe947e5eedf127fa9c"
+  Actual: "de38a4f5b8b9d8372386cc923bad19d1a0662298cf355bbe947e5eedf127fa9c"

--- a/cardano-cli/test/cardano-cli-golden/files/golden/governance/vote/governance_vote_create_hash_fails.out
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/governance/vote/governance_vote_create_hash_fails.out
@@ -1,0 +1,3 @@
+Command failed: governance vote create  Error: Error while checking resignation certificate metadata hash: Hashes do not match!
+Expected: "ee38a4f5b8b9d8372386cc923bad19d1a0662298cf355bbe947e5eedf127fa9c"
+  Actual: "de38a4f5b8b9d8372386cc923bad19d1a0662298cf355bbe947e5eedf127fa9c"

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -7054,7 +7054,8 @@ Usage: cardano-cli conway governance vote create (--yes | --no | --abstain)
                                                    | --cc-hot-script-hash HASH
                                                    )
                                                    [--anchor-url TEXT
-                                                     --anchor-data-hash HASH]
+                                                     --anchor-data-hash HASH
+                                                     [--check-anchor-data-hash]]
                                                    --out-file FILEPATH
 
   Vote creation.
@@ -9054,7 +9055,8 @@ Usage: cardano-cli latest governance vote create (--yes | --no | --abstain)
                                                    | --cc-hot-script-hash HASH
                                                    )
                                                    [--anchor-url TEXT
-                                                     --anchor-data-hash HASH]
+                                                     --anchor-data-hash HASH
+                                                     [--check-anchor-data-hash]]
                                                    --out-file FILEPATH
 
   Vote creation.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -6954,7 +6954,8 @@ Usage: cardano-cli conway governance committee create-cold-key-resignation-certi
                                                                                          | --cold-script-file FILEPATH
                                                                                          )
                                                                                          [--resignation-metadata-url TEXT
-                                                                                           --resignation-metadata-hash HASH]
+                                                                                           --resignation-metadata-hash HASH
+                                                                                           [--check-resignation-metadata-hash]]
                                                                                          --out-file FILEPATH
 
   Create cold key resignation certificate for a Constitutional Committee Member
@@ -8953,7 +8954,8 @@ Usage: cardano-cli latest governance committee create-cold-key-resignation-certi
                                                                                          | --cold-script-file FILEPATH
                                                                                          )
                                                                                          [--resignation-metadata-url TEXT
-                                                                                           --resignation-metadata-hash HASH]
+                                                                                           --resignation-metadata-hash HASH
+                                                                                           [--check-resignation-metadata-hash]]
                                                                                          --out-file FILEPATH
 
   Create cold key resignation certificate for a Constitutional Committee Member

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_committee_create-cold-key-resignation-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_committee_create-cold-key-resignation-certificate.cli
@@ -6,7 +6,8 @@ Usage: cardano-cli conway governance committee create-cold-key-resignation-certi
                                                                                          | --cold-script-file FILEPATH
                                                                                          )
                                                                                          [--resignation-metadata-url TEXT
-                                                                                           --resignation-metadata-hash HASH]
+                                                                                           --resignation-metadata-hash HASH
+                                                                                           [--check-resignation-metadata-hash]]
                                                                                          --out-file FILEPATH
 
   Create cold key resignation certificate for a Constitutional Committee Member
@@ -29,5 +30,12 @@ Available options:
   --resignation-metadata-hash HASH
                            Constitutional Committee cold key resignation
                            certificate metadata hash
+  --check-resignation-metadata-hash
+                           Verify that the expected Constitutional Committee
+                           cold key resignation certificate metadata hash
+                           provided in --resignation-metadata-hash matches the
+                           hash of the file downloaded from the URL provided in
+                           --resignation-metadata-url (this parameter will
+                           download the file from the URL)
   --out-file FILEPATH      The output file.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_vote_create.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_vote_create.cli
@@ -14,7 +14,8 @@ Usage: cardano-cli conway governance vote create (--yes | --no | --abstain)
                                                    | --cc-hot-script-hash HASH
                                                    )
                                                    [--anchor-url TEXT
-                                                     --anchor-data-hash HASH]
+                                                     --anchor-data-hash HASH
+                                                     [--check-anchor-data-hash]]
                                                    --out-file FILEPATH
 
   Vote creation.
@@ -50,5 +51,10 @@ Available options:
   --anchor-url TEXT        Vote anchor URL
   --anchor-data-hash HASH  Hash of the vote anchor data (obtain it with
                            "cardano-cli hash anchor-data ...").
+  --check-anchor-data-hash Verify that the expected vote anchor data hash
+                           provided in --anchor-data-hash matches the hash of
+                           the file downloaded from the URL provided in
+                           --anchor-url (this parameter will download the file
+                           from the URL)
   --out-file FILEPATH      Output filepath of the vote.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_governance_committee_create-cold-key-resignation-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_governance_committee_create-cold-key-resignation-certificate.cli
@@ -6,7 +6,8 @@ Usage: cardano-cli latest governance committee create-cold-key-resignation-certi
                                                                                          | --cold-script-file FILEPATH
                                                                                          )
                                                                                          [--resignation-metadata-url TEXT
-                                                                                           --resignation-metadata-hash HASH]
+                                                                                           --resignation-metadata-hash HASH
+                                                                                           [--check-resignation-metadata-hash]]
                                                                                          --out-file FILEPATH
 
   Create cold key resignation certificate for a Constitutional Committee Member
@@ -29,5 +30,12 @@ Available options:
   --resignation-metadata-hash HASH
                            Constitutional Committee cold key resignation
                            certificate metadata hash
+  --check-resignation-metadata-hash
+                           Verify that the expected Constitutional Committee
+                           cold key resignation certificate metadata hash
+                           provided in --resignation-metadata-hash matches the
+                           hash of the file downloaded from the URL provided in
+                           --resignation-metadata-url (this parameter will
+                           download the file from the URL)
   --out-file FILEPATH      The output file.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_governance_vote_create.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_governance_vote_create.cli
@@ -14,7 +14,8 @@ Usage: cardano-cli latest governance vote create (--yes | --no | --abstain)
                                                    | --cc-hot-script-hash HASH
                                                    )
                                                    [--anchor-url TEXT
-                                                     --anchor-data-hash HASH]
+                                                     --anchor-data-hash HASH
+                                                     [--check-anchor-data-hash]]
                                                    --out-file FILEPATH
 
   Vote creation.
@@ -50,5 +51,10 @@ Available options:
   --anchor-url TEXT        Vote anchor URL
   --anchor-data-hash HASH  Hash of the vote anchor data (obtain it with
                            "cardano-cli hash anchor-data ...").
+  --check-anchor-data-hash Verify that the expected vote anchor data hash
+                           provided in --anchor-data-hash matches the hash of
+                           the file downloaded from the URL provided in
+                           --anchor-url (this parameter will download the file
+                           from the URL)
   --out-file FILEPATH      Output filepath of the vote.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/Governance/Committee.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/Governance/Committee.hs
@@ -1,0 +1,83 @@
+{-# LANGUAGE FlexibleContexts #-}
+
+module Test.Cli.Governance.Committee where
+
+import           Cardano.Api (MonadIO)
+
+import           Control.Monad (void)
+import           Control.Monad.Catch (MonadCatch)
+import           Control.Monad.Trans.Control (MonadBaseControl)
+
+import           Test.Cardano.CLI.Hash (exampleAnchorDataHash, exampleAnchorDataIpfsHash,
+                   exampleAnchorDataPathTest, serveFilesWhile, tamperBase16Hash)
+import           Test.Cardano.CLI.Util (execCardanoCLI, execCardanoCLIWithEnvVars, expectFailure,
+                   noteTempFile, propertyOnce)
+
+import           Hedgehog (MonadTest, Property)
+import qualified Hedgehog as H
+import qualified Hedgehog.Extras as H
+
+-- | Execute me with:
+-- @cabal test cardano-cli-test --test-options '-p "/governance committee checks wrong hash fails/"'@
+hprop_governance_committee_checks_wrong_hash_fails :: Property
+hprop_governance_committee_checks_wrong_hash_fails =
+  propertyOnce . expectFailure . H.moduleWorkspace "tmp" $ \tempDir -> do
+    -- We modify the hash slightly so that the hash check fails
+    alteredHash <- H.evalMaybe $ tamperBase16Hash exampleAnchorDataHash
+    -- We run the test with the altered
+    baseGovernanceGovernanceCommitteeChecksHash
+      alteredHash
+      tempDir
+
+-- | Execute me with:
+-- @cabal test cardano-cli-test --test-options '-p "/governance committee checks right hash works/"'@
+hprop_governance_committee_checks_right_hash_works :: Property
+hprop_governance_committee_checks_right_hash_works =
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir ->
+    baseGovernanceGovernanceCommitteeChecksHash exampleAnchorDataHash tempDir
+
+baseGovernanceGovernanceCommitteeChecksHash
+  :: (MonadBaseControl IO m, MonadTest m, MonadIO m, MonadCatch m) => String -> FilePath -> m ()
+baseGovernanceGovernanceCommitteeChecksHash hash tempDir = do
+  ccColdVKey <- noteTempFile tempDir "cold.vkey"
+  ccColdSKey <- noteTempFile tempDir "cold.skey"
+
+  certFile <- noteTempFile tempDir "hot-auth.cert"
+
+  void $
+    execCardanoCLI
+      [ "conway"
+      , "governance"
+      , "committee"
+      , "key-gen-cold"
+      , "--verification-key-file"
+      , ccColdVKey
+      , "--signing-key-file"
+      , ccColdSKey
+      ]
+
+  let relativeUrl = ["ipfs", exampleAnchorDataIpfsHash]
+
+  -- Create temporary HTTP server with files required by the call to `cardano-cli`
+  -- In this case, the server emulates an IPFS gateway
+  serveFilesWhile
+    [(relativeUrl, exampleAnchorDataPathTest)]
+    ( \port -> do
+        void $
+          execCardanoCLIWithEnvVars
+            [("IPFS_GATEWAY_URI", "http://localhost:" ++ show port ++ "/")]
+            [ "conway"
+            , "governance"
+            , "committee"
+            , "create-cold-key-resignation-certificate"
+            , "--cold-verification-key-file"
+            , ccColdVKey
+            , "--resignation-metadata-url"
+            , "ipfs://" ++ exampleAnchorDataIpfsHash
+            , "--resignation-metadata-hash"
+            , hash
+            , "--check-resignation-metadata-hash"
+            , "--out-file"
+            , certFile
+            ]
+    )

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/Governance/Vote.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/Governance/Vote.hs
@@ -1,0 +1,74 @@
+{-# LANGUAGE FlexibleContexts #-}
+
+module Test.Cli.Governance.Vote where
+
+import           Cardano.Api (MonadIO)
+
+import           Control.Monad (void)
+import           Control.Monad.Catch (MonadCatch)
+import           Control.Monad.Trans.Control (MonadBaseControl)
+
+import           Test.Cardano.CLI.Hash (exampleAnchorDataHash, exampleAnchorDataIpfsHash,
+                   exampleAnchorDataPathTest, serveFilesWhile, tamperBase16Hash)
+import           Test.Cardano.CLI.Util (execCardanoCLIWithEnvVars, expectFailure, noteInputFile,
+                   propertyOnce)
+
+import           Hedgehog (MonadTest, Property)
+import qualified Hedgehog as H
+import qualified Hedgehog.Extras as H
+
+-- | Execute me with:
+-- @cabal test cardano-cli-test --test-options '-p "/governance vote create wrong hash fails/"'@
+hprop_governance_vote_create_wrong_hash_fails :: Property
+hprop_governance_vote_create_wrong_hash_fails =
+  propertyOnce . expectFailure . H.moduleWorkspace "tmp" $ \tempDir -> do
+    -- We modify the hash slightly so that the hash check fails
+    alteredHash <- H.evalMaybe $ tamperBase16Hash exampleAnchorDataHash
+    -- We run the test with the altered
+    baseGovernanceVoteCreateHashCheck
+      alteredHash
+      tempDir
+
+-- | Execute me with:
+-- @cabal test cardano-cli-test --test-options '-p "/governance vote create right hash works/"'@
+hprop_governance_vote_create_right_hash_works :: Property
+hprop_governance_vote_create_right_hash_works =
+  propertyOnce . H.moduleWorkspace "tmp" $ \tempDir ->
+    baseGovernanceVoteCreateHashCheck exampleAnchorDataHash tempDir
+
+baseGovernanceVoteCreateHashCheck
+  :: (MonadBaseControl IO m, MonadTest m, MonadIO m, MonadCatch m) => String -> FilePath -> m ()
+baseGovernanceVoteCreateHashCheck hash tempDir = do
+  vkeyFile <- noteInputFile "test/cardano-cli-test/files/input/drep.vkey"
+  voteFile <- H.noteTempFile tempDir "vote"
+
+  let relativeUrl = ["ipfs", exampleAnchorDataIpfsHash]
+
+  -- Create temporary HTTP server with files required by the call to `cardano-cli`
+  -- In this case, the server emulates an IPFS gateway
+  serveFilesWhile
+    [(relativeUrl, exampleAnchorDataPathTest)]
+    ( \port -> do
+        void $
+          execCardanoCLIWithEnvVars
+            [("IPFS_GATEWAY_URI", "http://localhost:" ++ show port ++ "/")]
+            [ "conway"
+            , "governance"
+            , "vote"
+            , "create"
+            , "--yes"
+            , "--governance-action-tx-id"
+            , "b1015258a99351c143a7a40b7b58f033ace10e3cc09c67780ed5b2b0992aa60a"
+            , "--governance-action-index"
+            , "5"
+            , "--drep-verification-key-file"
+            , vkeyFile
+            , "--out-file"
+            , voteFile
+            , "--anchor-url"
+            , "ipfs://" ++ exampleAnchorDataIpfsHash
+            , "--anchor-data-hash"
+            , hash
+            , "--check-anchor-data-hash"
+            ]
+    )

--- a/cardano-cli/test/cardano-cli-test/files/input/drep.vkey
+++ b/cardano-cli/test/cardano-cli-test/files/input/drep.vkey
@@ -1,0 +1,5 @@
+{
+    "type": "DRepVerificationKey_ed25519",
+    "description": "Delegated Representative Verification Key",
+    "cborHex": "58209eb6ff2ee38b24c4892a6b291ed245afa0d2fac76222e76ee3e205e3c9681540"
+}


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Added hash checks for `governance committee create-cold-key-resignation-certificate` and `governance vote create`
  type:
  - feature
  - test
```

# Context

This is another step forward on addressing https://github.com/IntersectMBO/cardano-cli/issues/882.

This PR adds checks to two commands:
- `governance committee create-cold-key-resignation-certificate`
- `governance vote create`

It also generalizes the `carryHashChecks` function to be able to reuse it more.

# How to trust this PR

There are tests for all new functionality (both positive and negative). Most code is reused, and the one that is not is completely analogous to other PRs.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
