### PR TITLE
create-testnet-data: correctly compute set of credentials delegating votes to a drep in conway genesis

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Genesis/CreateTestnetData.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Genesis/CreateTestnetData.hs
@@ -273,7 +273,7 @@ runGenesisCreateTestNetDataCmd
             mapAccumM
               (\g' _ -> swap . first getVerificationKey <$> generateInsecureSigningKey g' AsDRepKey)
               g
-              [1 .. numOfStakeDelegators]
+              [1 .. numOfDRepCredentials]
 
     when (0 < numOfDRepCredentials && dRepCredentialGenerationMode == OnDisk) $
       writeREADME drepsDir drepsREADME

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Genesis/CreateTestnetData.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Genesis/CreateTestnetData.hs
@@ -358,7 +358,9 @@ runGenesisCreateTestNetDataCmd
           (first verificationKeytoStakeCredential)
           (zip stakingKeys (case dRepKeys of [] -> []; _ -> cycle dRepKeys))
       -- If there are more staking keys than dreps, some dreps don't receive any delegation
-      drepsWithoutDelegation = [drep | drep <- dRepKeys, drep `notElem` map snd delegs]
+      drepsWithoutDelegation
+        | length stakingKeys >= length dRepKeys = []
+        | otherwise = drop (length stakingKeys) dRepKeys
 
       minDeposit = L.ucppDRepDeposit $ L.cgUpgradePParams conwayGenesis
       cgDelegs = fromList $ map (second (L.DelegVote . L.DRepCredential . verificationKeyToDRepCredential)) delegs


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    create-testnet-data: correctly compute set of credentials delegating votes to a drep in conway genesis
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

There was uncertainty (see [this thread on Slack](https://input-output-rnd.slack.com/archives/G011N23CEAE/p1729154065589149?thread_ts=1729114189.158149&cid=G011N23CEAE) and [here on GitHub](https://github.com/IntersectMBO/cardano-cli/pull/940#discussion_r1804370560)) when fixing some part of `create-testnet-data` when writing https://github.com/IntersectMBO/cardano-cli/pull/940. Because we wanted to merge 940 fast, we proceeded leaving an incorrect value in `create-testnet-data`'s conway genesis, in the presence of dreps; because we needed to synchronize with the ledger team to understand what to do.

This PR corrects the incorrect value.

# How to trust this PR

Here is a before and after comparison of the conway genesis created by `create-testnet-data`:

![image](https://github.com/user-attachments/assets/d91222bf-1fa1-4733-ab29-e0d25d4f108e)

On the left, one can see that the `delegators` fields of the `initialDReps` are all left empty. But this is incorrect: the field `delegs` (above in the screenshot) show that indeed there are votes delegations happening.

On the right, you can see that the `delegators` fields are populated with values corresponding to the ones in `delegs` :heavy_check_mark: 

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] Self-reviewed the diff