### PR TITLE
Fix autobalancing when deregistering stake address

### DIFF
--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -235,6 +235,7 @@ library
     ouroboros-network-api ^>=0.10,
     ouroboros-network-protocols,
     parsec,
+    pretty-simple,
     prettyprinter,
     prettyprinter-ansi-terminal,
     random,


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    <insert-changelog-description-here>
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Fix: https://github.com/IntersectMBO/cardano-cli/issues/942
See the last commit of https://github.com/IntersectMBO/cardano-node/pull/6017 for a reproducer

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
