### PR TITLE
Fix num of `DRep` credentials generated for transient parameter

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Genesis/CreateTestnetData.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Genesis/CreateTestnetData.hs
@@ -270,7 +270,7 @@ runGenesisCreateTestNetDataCmd
             mapAccumM
               (\g' _ -> swap . first getVerificationKey <$> generateInsecureSigningKey g' AsDRepKey)
               g
-              [1 .. numOfStakeDelegators]
+              [1 .. numOfDRepCredentials]
 
     when (0 < numOfDRepCredentials && dRepCredentialGenerationMode == OnDisk) $
       writeREADME drepsDir drepsREADME


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Fixed number of `DRep` credentials generated by `create-testnet-data`.
  type:
  - bugfix
```

# Context

The number of DRep credentials generated by `create-testnet-data` when the `--transient-drep-keys` parameter was used was ignored, and the number used was that for stake delegators. This PR fixes this. This was discovered in this PR: https://github.com/IntersectMBO/cardano-cli/pull/943

# How to trust this PR

You can see that this change makes the branch for transient consistent with the other branch.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff

