### PR TITLE
Remove direct dependencies from `ouroboros-*`

### DIFF
--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -234,7 +234,6 @@ library
     network-uri,
     optparse-applicative-fork,
     ouroboros-consensus ^>=0.21,
-    ouroboros-consensus-cardano ^>=0.20,
     parsec,
     prettyprinter,
     prettyprinter-ansi-terminal,

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -237,7 +237,6 @@ library
     ouroboros-consensus-cardano ^>=0.20,
     ouroboros-consensus-protocol ^>=0.9.0.2,
     ouroboros-network-api ^>=0.10,
-    ouroboros-network-protocols,
     parsec,
     prettyprinter,
     prettyprinter-ansi-terminal,

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -233,7 +233,6 @@ library
     network,
     network-uri,
     optparse-applicative-fork,
-    ouroboros-consensus ^>=0.21,
     parsec,
     prettyprinter,
     prettyprinter-ansi-terminal,

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -235,7 +235,6 @@ library
     optparse-applicative-fork,
     ouroboros-consensus ^>=0.21,
     ouroboros-consensus-cardano ^>=0.20,
-    ouroboros-consensus-protocol ^>=0.9.0.2,
     parsec,
     prettyprinter,
     prettyprinter-ansi-terminal,

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -236,7 +236,6 @@ library
     ouroboros-consensus ^>=0.21,
     ouroboros-consensus-cardano ^>=0.20,
     ouroboros-consensus-protocol ^>=0.9.0.2,
-    ouroboros-network-api ^>=0.10,
     parsec,
     prettyprinter,
     prettyprinter-ansi-terminal,

--- a/cardano-cli/src/Cardano/CLI/Byron/Tx.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Tx.hs
@@ -26,6 +26,7 @@ where
 import           Cardano.Api
 import qualified Cardano.Api.Byron as Byron
 import qualified Cardano.Api.Ledger as L
+import qualified Cardano.Api.Network as Net.Tx
 
 import qualified Cardano.Binary as Binary
 import           Cardano.CLI.Byron.Key (byronWitnessToVerKey)
@@ -34,7 +35,6 @@ import qualified Cardano.Crypto.Signing as Crypto
 import           Ouroboros.Consensus.Byron.Ledger (ByronBlock, GenTx (..))
 import qualified Ouroboros.Consensus.Byron.Ledger as Byron
 import           Ouroboros.Consensus.Cardano.Block (EraMismatch (..))
-import qualified Ouroboros.Network.Protocol.LocalTxSubmission.Client as Net.Tx
 
 import           Data.Bifunctor (Bifunctor (..))
 import           Data.ByteString (ByteString)

--- a/cardano-cli/src/Cardano/CLI/Byron/Tx.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Tx.hs
@@ -25,6 +25,8 @@ where
 
 import           Cardano.Api
 import qualified Cardano.Api.Byron as Byron
+import           Cardano.Api.Consensus (ByronBlock, EraMismatch (..), GenTx (..))
+import qualified Cardano.Api.Consensus as Byron
 import qualified Cardano.Api.Ledger as L
 import qualified Cardano.Api.Network as Net.Tx
 
@@ -32,9 +34,6 @@ import qualified Cardano.Binary as Binary
 import           Cardano.CLI.Byron.Key (byronWitnessToVerKey)
 import           Cardano.CLI.Types.Common (TxFile)
 import qualified Cardano.Crypto.Signing as Crypto
-import           Ouroboros.Consensus.Byron.Ledger (ByronBlock, GenTx (..))
-import qualified Ouroboros.Consensus.Byron.Ledger as Byron
-import           Ouroboros.Consensus.Cardano.Block (EraMismatch (..))
 
 import           Data.Bifunctor (Bifunctor (..))
 import           Data.ByteString (ByteString)

--- a/cardano-cli/src/Cardano/CLI/Byron/UpdateProposal.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/UpdateProposal.hs
@@ -15,14 +15,13 @@ import           Cardano.Api
 import           Cardano.Api.Byron (AsType (AsByronUpdateProposal), ByronProtocolParametersUpdate,
                    ByronUpdateProposal, makeByronUpdateProposal, toByronLedgerUpdateProposal)
 import qualified Cardano.Api.Byron as Byron
+import           Cardano.Api.Consensus (condense, txId)
 
 import           Cardano.CLI.Byron.Genesis (ByronGenesisError)
 import           Cardano.CLI.Byron.Key (ByronKeyFailure, readByronSigningKey)
 import           Cardano.CLI.Byron.Tx (ByronTxError, nodeSubmitTx)
 import           Cardano.CLI.Helpers (HelpersError, ensureNewFileLBS, renderHelpersError)
 import           Cardano.CLI.Types.Common
-import           Ouroboros.Consensus.Ledger.SupportsMempool (txId)
-import           Ouroboros.Consensus.Util.Condense (condense)
 
 import           Control.Exception (Exception (..))
 import           Control.Tracer (stdoutTracer, traceWith)

--- a/cardano-cli/src/Cardano/CLI/Byron/Vote.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Vote.hs
@@ -12,6 +12,7 @@ module Cardano.CLI.Byron.Vote
 where
 
 import           Cardano.Api.Byron
+import           Cardano.Api.Consensus (condense, txId)
 
 import qualified Cardano.Binary as Binary
 import           Cardano.CLI.Byron.Genesis (ByronGenesisError)
@@ -21,8 +22,6 @@ import           Cardano.CLI.Byron.UpdateProposal (ByronUpdateProposalError,
                    readByronUpdateProposal)
 import           Cardano.CLI.Helpers (HelpersError, ensureNewFileLBS)
 import           Cardano.CLI.Types.Common
-import           Ouroboros.Consensus.Ledger.SupportsMempool (txId)
-import           Ouroboros.Consensus.Util.Condense (condense)
 
 import           Control.Tracer (stdoutTracer, traceWith)
 import           Data.Bifunctor (first)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Query.hs
@@ -31,11 +31,11 @@ module Cardano.CLI.EraBased.Commands.Query
   )
 where
 
+import qualified Cardano.Api.Network as Consensus
 import           Cardano.Api.Shelley hiding (QueryInShelleyBasedEra (..))
 
 import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Key
-import qualified Ouroboros.Network.Protocol.LocalStateQuery.Type as Consensus
 
 import           Data.Set (Set)
 import           Data.Text (Text)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
@@ -14,6 +14,7 @@ module Cardano.CLI.EraBased.Options.Common where
 
 import           Cardano.Api
 import qualified Cardano.Api.Ledger as L
+import qualified Cardano.Api.Network as Consensus
 import           Cardano.Api.Shelley
 
 import           Cardano.CLI.Environment (EnvCli (..), envCliAnyEon)
@@ -23,7 +24,6 @@ import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Governance
 import           Cardano.CLI.Types.Key
 import           Cardano.CLI.Types.Key.VerificationKey
-import qualified Ouroboros.Network.Protocol.LocalStateQuery.Type as Consensus
 
 import           Control.Monad (void, when)
 import qualified Data.Aeson as Aeson

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Genesis.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Genesis.hs
@@ -31,6 +31,7 @@ import           Cardano.Api
 import           Cardano.Api.Byron (toByronLovelace, toByronProtocolMagicId,
                    toByronRequiresNetworkMagic)
 import qualified Cardano.Api.Byron as Byron hiding (GenesisParameters, SigningKey)
+import           Cardano.Api.Consensus (ShelleyGenesisStaking (..))
 import qualified Cardano.Api.Ledger as L
 import           Cardano.Api.Shelley
 
@@ -55,7 +56,6 @@ import qualified Cardano.Crypto.Hash as Crypto
 import qualified Cardano.Crypto.Signing as Byron
 import           Cardano.Prelude (canonicalEncodePretty)
 import           Cardano.Slotting.Slot (EpochSize (EpochSize))
-import           Ouroboros.Consensus.Shelley.Node (ShelleyGenesisStaking (..))
 
 import           Control.DeepSeq (NFData, force)
 import           Control.Exception (evaluate)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Genesis/CreateTestnetData.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Genesis/CreateTestnetData.hs
@@ -22,6 +22,7 @@ module Cardano.CLI.EraBased.Run.Genesis.CreateTestnetData
 where
 
 import           Cardano.Api hiding (ConwayEra)
+import           Cardano.Api.Consensus (ShelleyGenesisStaking (..))
 import           Cardano.Api.Ledger (StrictMaybe (SNothing))
 import qualified Cardano.Api.Ledger as L
 import           Cardano.Api.Shelley (Hash (..), KESPeriod (KESPeriod),
@@ -49,7 +50,6 @@ import           Cardano.CLI.Types.Errors.GenesisCmdError
 import           Cardano.CLI.Types.Errors.NodeCmdError
 import           Cardano.CLI.Types.Errors.StakePoolCmdError
 import           Cardano.CLI.Types.Key
-import           Ouroboros.Consensus.Shelley.Node (ShelleyGenesisStaking (..))
 
 import           Control.DeepSeq (NFData, deepseq)
 import           Control.Monad (forM, forM_, unless, void, when)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Query.hs
@@ -59,8 +59,7 @@ import qualified Cardano.CLI.Types.Output as O
 import           Cardano.Crypto.Hash (hashToBytesAsHex)
 import qualified Cardano.Crypto.Hash.Blake2b as Blake2b
 import           Cardano.Slotting.EpochInfo (EpochInfo (..), epochInfoSlotToUTCTime, hoistEpochInfo)
-import           Ouroboros.Consensus.BlockchainTime.WallClock.Types (RelativeTime (..),
-                   toRelativeTime)
+import           Cardano.Slotting.Time (RelativeTime (..), toRelativeTime)
 
 import           Control.Monad (forM, forM_, join)
 import           Data.Aeson as Aeson

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Query.hs
@@ -41,6 +41,7 @@ import           Cardano.Api hiding (QueryInShelleyBasedEra (..))
 import qualified Cardano.Api as Api
 import           Cardano.Api.Ledger (strictMaybeToMaybe)
 import qualified Cardano.Api.Ledger as L
+import qualified Cardano.Api.Network as Consensus
 import           Cardano.Api.Shelley hiding (QueryInShelleyBasedEra (..))
 
 import qualified Cardano.CLI.EraBased.Commands.Query as Cmd
@@ -64,7 +65,6 @@ import qualified Ouroboros.Consensus.Protocol.Abstract as Consensus
 import qualified Ouroboros.Consensus.Protocol.Praos.Common as Consensus
 import           Ouroboros.Consensus.Protocol.TPraos (StandardCrypto)
 import           Ouroboros.Network.Block (Serialised (..))
-import qualified Ouroboros.Network.Protocol.LocalStateQuery.Type as Consensus
 
 import           Control.Monad (forM, forM_, join)
 import           Data.Aeson as Aeson

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Query.hs
@@ -41,6 +41,7 @@ import           Cardano.Api hiding (QueryInShelleyBasedEra (..))
 import qualified Cardano.Api as Api
 import           Cardano.Api.Ledger (strictMaybeToMaybe)
 import qualified Cardano.Api.Ledger as L
+import           Cardano.Api.Network (Serialised (..))
 import qualified Cardano.Api.Network as Consensus
 import           Cardano.Api.Shelley hiding (QueryInShelleyBasedEra (..))
 
@@ -64,7 +65,6 @@ import qualified Ouroboros.Consensus.HardFork.History as Consensus
 import qualified Ouroboros.Consensus.Protocol.Abstract as Consensus
 import qualified Ouroboros.Consensus.Protocol.Praos.Common as Consensus
 import           Ouroboros.Consensus.Protocol.TPraos (StandardCrypto)
-import           Ouroboros.Network.Block (Serialised (..))
 
 import           Control.Monad (forM, forM_, join)
 import           Data.Aeson as Aeson

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Query.hs
@@ -39,7 +39,8 @@ where
 
 import           Cardano.Api hiding (QueryInShelleyBasedEra (..))
 import qualified Cardano.Api as Api
-import           Cardano.Api.Ledger (strictMaybeToMaybe)
+import qualified Cardano.Api.Consensus as Consensus
+import           Cardano.Api.Ledger (StandardCrypto, strictMaybeToMaybe)
 import qualified Cardano.Api.Ledger as L
 import           Cardano.Api.Network (Serialised (..))
 import qualified Cardano.Api.Network as Consensus
@@ -60,11 +61,6 @@ import qualified Cardano.Crypto.Hash.Blake2b as Blake2b
 import           Cardano.Slotting.EpochInfo (EpochInfo (..), epochInfoSlotToUTCTime, hoistEpochInfo)
 import           Ouroboros.Consensus.BlockchainTime.WallClock.Types (RelativeTime (..),
                    toRelativeTime)
-import qualified Ouroboros.Consensus.Cardano.Block as Consensus
-import qualified Ouroboros.Consensus.HardFork.History as Consensus
-import qualified Ouroboros.Consensus.Protocol.Abstract as Consensus
-import qualified Ouroboros.Consensus.Protocol.Praos.Common as Consensus
-import           Ouroboros.Consensus.Protocol.TPraos (StandardCrypto)
 
 import           Control.Monad (forM, forM_, join)
 import           Data.Aeson as Aeson

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Transaction.hs
@@ -39,6 +39,8 @@ import           Cardano.Api
 import qualified Cardano.Api.Byron as Byron
 import qualified Cardano.Api.Experimental as Exp
 import qualified Cardano.Api.Ledger as L
+import qualified Cardano.Api.Network as Consensus
+import qualified Cardano.Api.Network as Net.Tx
 import           Cardano.Api.Shelley
 
 import qualified Cardano.Binary as CBOR
@@ -55,8 +57,6 @@ import           Cardano.CLI.Types.Errors.TxCmdError
 import           Cardano.CLI.Types.Errors.TxValidationError
 import           Cardano.CLI.Types.Output (renderScriptCosts)
 import           Cardano.CLI.Types.TxFeature
-import qualified Ouroboros.Network.Protocol.LocalStateQuery.Type as Consensus
-import qualified Ouroboros.Network.Protocol.LocalTxSubmission.Client as Net.Tx
 
 import           Control.Monad (forM)
 import           Data.Aeson ((.=))

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/GovernanceQueryError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/GovernanceQueryError.hs
@@ -3,9 +3,8 @@
 module Cardano.CLI.Types.Errors.GovernanceQueryError where
 
 import           Cardano.Api
+import           Cardano.Api.Consensus (EraMismatch)
 import           Cardano.Api.Shelley
-
-import           Ouroboros.Consensus.Cardano.Block (EraMismatch)
 
 data GovernanceQueryError
   = GovernanceQueryWriteFileError !(FileError ())

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/QueryCmdError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/QueryCmdError.hs
@@ -15,14 +15,13 @@ module Cardano.CLI.Types.Errors.QueryCmdError
 where
 
 import           Cardano.Api hiding (QueryInShelleyBasedEra (..))
-import           Cardano.Api.Consensus as Consensus (EraMismatch (..))
+import           Cardano.Api.Consensus as Consensus (EraMismatch (..), PastHorizonException)
 import           Cardano.Api.Shelley hiding (QueryInShelleyBasedEra (..))
 
 import           Cardano.Binary (DecoderError)
 import           Cardano.CLI.Helpers (HelpersError (..), renderHelpersError)
 import           Cardano.CLI.Types.Errors.GenesisCmdError
 import           Cardano.CLI.Types.Errors.QueryCmdLocalStateQueryError
-import qualified Ouroboros.Consensus.HardFork.History.Qry as Qry
 
 import qualified Data.ByteString.Lazy.Char8 as LBS
 import           Data.Text.Lazy.Builder (toLazyText)
@@ -39,7 +38,7 @@ data QueryCmdError
   | QueryCmdAcquireFailure !AcquiringFailure
   | QueryCmdByronEra
   | QueryCmdEraMismatch !EraMismatch
-  | QueryCmdPastHorizon !Qry.PastHorizonException
+  | QueryCmdPastHorizon !Consensus.PastHorizonException
   | QueryCmdSystemStartUnavailable
   | QueryCmdGenesisReadError !GenesisCmdError
   | QueryCmdLeaderShipError !LeadershipError

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/QueryCmdError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/QueryCmdError.hs
@@ -15,13 +15,13 @@ module Cardano.CLI.Types.Errors.QueryCmdError
 where
 
 import           Cardano.Api hiding (QueryInShelleyBasedEra (..))
+import           Cardano.Api.Consensus as Consensus (EraMismatch (..))
 import           Cardano.Api.Shelley hiding (QueryInShelleyBasedEra (..))
 
 import           Cardano.Binary (DecoderError)
 import           Cardano.CLI.Helpers (HelpersError (..), renderHelpersError)
 import           Cardano.CLI.Types.Errors.GenesisCmdError
 import           Cardano.CLI.Types.Errors.QueryCmdLocalStateQueryError
-import           Ouroboros.Consensus.Cardano.Block as Consensus (EraMismatch (..))
 import qualified Ouroboros.Consensus.HardFork.History.Qry as Qry
 
 import qualified Data.ByteString.Lazy.Char8 as LBS

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/QueryCmdLocalStateQueryError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/QueryCmdLocalStateQueryError.hs
@@ -8,9 +8,9 @@ module Cardano.CLI.Types.Errors.QueryCmdLocalStateQueryError
 where
 
 import           Cardano.Api
+import           Cardano.Api.Consensus (EraMismatch (..))
 
 import           Cardano.CLI.Types.Errors.NodeEraMismatchError
-import           Ouroboros.Consensus.Cardano.Block (EraMismatch (..))
 
 -- | An error that can occur while querying a node's local state.
 newtype QueryCmdLocalStateQueryError

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/TxCmdError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/TxCmdError.hs
@@ -15,6 +15,7 @@ module Cardano.CLI.Types.Errors.TxCmdError
 where
 
 import           Cardano.Api
+import           Cardano.Api.Consensus (EraMismatch (..))
 import qualified Cardano.Api.Ledger as L
 import           Cardano.Api.Shelley
 
@@ -29,7 +30,6 @@ import           Cardano.CLI.Types.Errors.TxValidationError
 import           Cardano.CLI.Types.Output
 import           Cardano.CLI.Types.TxFeature
 import qualified Cardano.Prelude as List
-import           Ouroboros.Consensus.Cardano.Block (EraMismatch (..))
 
 import           Data.Text (Text)
 


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Removed dependencies from `ouroboros-*`.
# uncomment types applicable to the change:
  type:
  - refactoring
```

# Context

As part of the work targeted at addressing issues pointed out in https://github.com/IntersectMBO/cardano-api/issues/608, this PR aims to remove all direct dependencies of `cardano-cli` from consensus and network.

# How to trust this PR

Make sure it is just a refactoring.

Look at it in conjunction with: https://github.com/IntersectMBO/cardano-api/pull/667

Take advantage that there are one commit for each dependency, (same for the corresponding PR in `cardano-api`)

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
