### PR TITLE
Make parser of transaction outputs and minting policies stricter

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -57,3 +57,9 @@ write-ghc-environment-files: always
 -- IMPORTANT
 -- Do NOT add more source-repository-package stanzas here unless they are strictly
 -- temporary! Please read the section in CONTRIBUTING about updating dependencies.
+
+source-repository-package
+   type: git
+   location: https://github.com/IntersectMBO/cardano-api
+   subdir: cardano-api
+   tag: 4378724778a70b74e56ab3d040aae6926f455694

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
@@ -2044,7 +2044,7 @@ pNumberOfByronKeyWitnesses =
 
 pTotalUTxOValue :: Parser Value
 pTotalUTxOValue =
-  Opt.option (readerFromParsecParser parseValue) $
+  Opt.option (readerFromParsecParser $ parseValue RoleUTxO) $
     mconcat
       [ Opt.long "total-utxo-value"
       , Opt.metavar "VALUE"
@@ -2136,7 +2136,7 @@ pMintMultiAsset
 pMintMultiAsset sbe balanceExecUnits =
   (,)
     <$> Opt.option
-      (readerFromParsecParser parseValue)
+      (readerFromParsecParser $ parseValue RoleMint)
       ( Opt.long "mint"
           <> Opt.metavar "VALUE"
           <> Opt.help helpText
@@ -3308,7 +3308,7 @@ parseTxOutShelleyBasedEra = do
   -- Accept the old style of separating the address and value in a
   -- transaction output:
   Parsec.option () (Parsec.char '+' >> Parsec.spaces)
-  val <- parseValue
+  val <- parseValue RoleUTxO -- UTxO role works for minting policy
   return (TxOutShelleyBasedEra addr val)
 
 parseShelleyAddress :: Parsec.Parser (Address ShelleyAddr)
@@ -3326,7 +3326,7 @@ parseTxOutAnyEra = do
   -- Accept the old style of separating the address and value in a
   -- transaction output:
   Parsec.option () (Parsec.char '+' >> Parsec.spaces)
-  val <- parseValue
+  val <- parseValue RoleUTxO -- UTxO role works for minting policy
   return (TxOutAnyEra addr val)
 
 --------------------------------------------------------------------------------

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/Shelley/Transaction/Build.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/Shelley/Transaction/Build.hs
@@ -44,3 +44,53 @@ hprop_conway_transaction_build_one_voter_many_votes = propertyOnce $ H.moduleWor
 
   exitCode H.=== ExitFailure 1
   H.assertWith stderr ("This would cause ignoring some of the votes" `isInfixOf`)
+
+-- | This is a test of https://github.com/IntersectMBO/cardano-cli/issues/904
+-- Execute me with:
+-- @cabal test cardano-cli-test --test-options '-p "/conway transaction build raw negative txout/"'@
+hprop_conway_transaction_build_raw_negative_txout :: Property
+hprop_conway_transaction_build_raw_negative_txout = propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir -> do
+  outFile <- H.noteTempFile tempDir "tx.traw"
+
+  (exitCode, _stdout, stderr) <-
+    H.noteShowM $
+      execDetailCardanoCLI
+        [ "conway"
+        , "transaction"
+        , "build-raw"
+        , "--fee"
+        , "200000"
+        , "--tx-in"
+        , "e25450233e4bedd00c8bda15c48c2d4018223bd88271e194052294c4e5be7d55#0"
+        , "--tx-out"
+        , "addr_test1vqfxq2s8yce3tuhjq9ulu2awuk623hzvtft9z8fh6qelzts49vuqw+-1" -- This is the negative txout
+        , "--out-file"
+        , outFile
+        ]
+
+  exitCode H.=== ExitFailure 1
+  H.assertWith stderr ("Value must be positive in a transaction output" `isInfixOf`)
+
+
+-- | This is a test that we allow transaction outputs to contain negative bits, if
+-- the grand total is positive.
+-- @cabal test cardano-cli-test --test-options '-p "/conway transaction build raw negative bits positive total txout/"'@
+hprop_conway_transaction_build_raw_negative_bits_positive_total_txout :: Property
+hprop_conway_transaction_build_raw_negative_bits_positive_total_txout = propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir -> do
+  outFile <- H.noteTempFile tempDir "tx.traw"
+
+  -- This checks that the command succeeds
+  H.noteShowM_ $
+    execCardanoCLI
+      [ "conway"
+      , "transaction"
+      , "build-raw"
+      , "--fee"
+      , "200000"
+      , "--tx-in"
+      , "e25450233e4bedd00c8bda15c48c2d4018223bd88271e194052294c4e5be7d55#0"
+      , "--tx-out"
+      , "addr_test1vqfxq2s8yce3tuhjq9ulu2awuk623hzvtft9z8fh6qelzts49vuqw+-1+3" -- Negative txout (-1) summed with positive txout (+3), so total is positive
+      , "--out-file"
+      , outFile
+      ]


### PR DESCRIPTION
> [!NOTE]
> 
> Requires https://github.com/IntersectMBO/cardano-api/pull/666

# Changelog

```yaml
- description: |
    Make parser of transaction outputs and minting policies stricter
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Fixes https://github.com/IntersectMBO/cardano-cli/issues/904

# How to trust this PR

TBD

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [X] Self-reviewed the diff