### PR TITLE
Update `main` references in GHA

### DIFF
--- a/.github/bin/check-git-dependencies
+++ b/.github/bin/check-git-dependencies
@@ -46,7 +46,7 @@ for row in $(cat tmp/repositories.json | jq -r '.[] | @base64'); do
     branches > branches.txt
 
     commits branches.txt | grep "$tag" || (
-      printf "Commit $tag from $location is not on the main branch or any release branches\n" >> "$base/tmp/dep-repo-result"
+      printf "Commit $tag from $location is not on the master branch or any release branches\n" >> "$base/tmp/dep-repo-result"
       printf "Branches searched:"
       cat branches.txt | sed 's|^|  |g'
     )
@@ -56,7 +56,7 @@ for row in $(cat tmp/repositories.json | jq -r '.[] | @base64'); do
 done
 
 if [ -f tmp/dep-repo-result ]; then
-  printf "${RED}Commits not on the main branch or any release branches detected in dependencies${NC}\n"
+  printf "${RED}Commits not on the master branch or any release branches detected in dependencies${NC}\n"
   printf "${YELLOW}"
   cat tmp/dep-repo-result
   printf "${NC}"

--- a/.github/workflows/github-page.yml
+++ b/.github/workflows/github-page.yml
@@ -3,7 +3,7 @@ name: "Haddock documentation"
 on:
   push:
     branches:
-      - main
+      - master
 
 jobs:
   build:
@@ -58,7 +58,7 @@ jobs:
         path: ./haddocks.tgz
 
     - name: Deploy documentation to gh-pages 🚀
-      if: github.ref == 'refs/heads/main'
+      if: github.ref == 'refs/heads/master'
       uses: peaceiris/actions-gh-pages@v4
       with:
         github_token: ${{ secrets.GITHUB_TOKEN || github.token }}

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -4,12 +4,12 @@ on:
   merge_group:
   pull_request:
   push:
-    # we need this to populate cache for `main` branch to make it available to the child branches, see
+    # we need this to populate cache for `master` branch to make it available to the child branches, see
     # https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache
     branches:
-      - main
+      - master
   # GH caches are removed when not accessed within 7 days - this schedule runs the job every 6 days making
-  # sure that we always have some caches on main
+  # sure that we always have some caches on master
   schedule:
     - cron: '0 0 */6 * *'
 

--- a/.github/workflows/hls.yml
+++ b/.github/workflows/hls.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - main
+      - master
  
 permissions:
   contents: read

--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ See the [Contributing guide](CONTRIBUTING.md) for how to contribute to this proj
 * [Pablo Lamela](https://github.com/palas)
 
 
-[![x86\_64-linux](https://img.shields.io/endpoint?url=https://ci.iog.io/job/IntersectMBO-cardano-cli/main/x86_64-linux.required/shield&style=flat-square&label=x86_64-linux)](https://ci.iog.io/job/IntersectMBO-cardano-cli/main/x86_64-linux.required)
-[![x86\_64-darwin](https://img.shields.io/endpoint?url=https://ci.iog.io/job/IntersectMBO-cardano-cli/main/x86_64-darwin.required/shield&style=flat-square&label=x86_64-darwin)](https://ci.iog.io/job/IntersectMBO-cardano-cli/main/x86_64-darwin.required)
-[![aarch64-darwin](https://img.shields.io/endpoint?url=https://ci.iog.io/job/IntersectMBO-cardano-cli/main/aarch64-darwin.required/shield&style=flat-square&label=aarch64-darwin)](https://ci.iog.io/job/IntersectMBO-cardano-cli/main/aarch64-darwin.required)
-[![GHA Build](https://img.shields.io/github/actions/workflow/status/intersectmbo/cardano-cli/haskell.yml?branch=main&label=GHA%20Build&style=flat-square)](https://github.com/IntersectMBO/cardano-cli/actions/workflows/haskell.yml?query=branch%3Amain)
-[![Haddock](https://img.shields.io/github/actions/workflow/status/intersectmbo/cardano-cli/github-page.yml?branch=main&label=Haddocks&style=flat-square)](https://github.com/IntersectMBO/cardano-cli/actions/workflows/github-page.yml?query=branch%3Amain)
+[![x86\_64-linux](https://img.shields.io/endpoint?url=https://ci.iog.io/job/IntersectMBO-cardano-cli/master/x86_64-linux.required/shield&style=flat-square&label=x86_64-linux)](https://ci.iog.io/job/IntersectMBO-cardano-cli/master/x86_64-linux.required)
+[![x86\_64-darwin](https://img.shields.io/endpoint?url=https://ci.iog.io/job/IntersectMBO-cardano-cli/master/x86_64-darwin.required/shield&style=flat-square&label=x86_64-darwin)](https://ci.iog.io/job/IntersectMBO-cardano-cli/master/x86_64-darwin.required)
+[![aarch64-darwin](https://img.shields.io/endpoint?url=https://ci.iog.io/job/IntersectMBO-cardano-cli/master/aarch64-darwin.required/shield&style=flat-square&label=aarch64-darwin)](https://ci.iog.io/job/IntersectMBO-cardano-cli/master/aarch64-darwin.required)
+[![GHA Build](https://img.shields.io/github/actions/workflow/status/intersectmbo/cardano-cli/haskell.yml?branch=master&label=GHA%20Build&style=flat-square)](https://github.com/IntersectMBO/cardano-cli/actions/workflows/haskell.yml?query=branch%3Amaster)
+[![Haddock](https://img.shields.io/github/actions/workflow/status/intersectmbo/cardano-cli/github-page.yml?branch=master&label=Haddocks&style=flat-square)](https://github.com/IntersectMBO/cardano-cli/actions/workflows/github-page.yml?query=branch%3Amaster)
 [![Release Upload](https://img.shields.io/github/actions/workflow/status/intersectmbo/cardano-cli/release-upload.yml?label=GH%20Release%20Upload&style=flat-square)](https://github.com/IntersectMBO/cardano-cli/actions/workflows/release-upload.yml)
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,4 +1,4 @@
 # Versioning and release process
 
 `cardano-cli` is following `cardano-api` release process.
-For the details, refer to [RELEASING.md document in `cardano-api` repository](https://github.com/input-output-hk/cardano-api/blob/main/RELEASING.md)
+For the details, refer to [RELEASING.md document in `cardano-api` repository](https://github.com/input-output-hk/cardano-api/blob/master/RELEASING.md)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,1 +1,1 @@
-See the security file in the [Cardano engineering handbook](https://github.com/input-output-hk/cardano-engineering-handbook/blob/main/SECURITY.md).
+See the security file in the [Cardano engineering handbook](https://github.com/input-output-hk/cardano-engineering-handbook/blob/master/SECURITY.md).


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Fix dependencies to `main` in GHA
  type:
  - maintenance
```

# Context

This follows up on the renaming of the default branch from `main` to `master`.

# How to trust this PR

If the CI passes it will be a great sign.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
