### PR TITLE
Check if stake addresses in proposals are registered onchain

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Transaction.hs
@@ -58,8 +58,7 @@ import           Cardano.CLI.Types.Errors.TxValidationError
 import           Cardano.CLI.Types.Output (renderScriptCosts)
 import           Cardano.CLI.Types.TxFeature
 
-import           Control.Monad (forM)
-import           Control.Monad.Cont (unless)
+import           Control.Monad (forM, unless)
 import           Data.Aeson ((.=))
 import qualified Data.Aeson as Aeson
 import           Data.Aeson.Encode.Pretty (encodePretty)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Transaction.hs
@@ -211,7 +211,7 @@ runTransactionBuildCmd
     -- Extract return addresses from proposals and check that the return address in each proposal is registered
 
     let returnAddrHashes =
-          Set.fromList
+          fromList
             [ StakeCredentialByKey returnAddrHash
             | (proposal, _) <- proposals
             , let (_, returnAddrHash, _) = fromProposalProcedure eon proposal -- fromProposalProcedure needs to be adjusted so that it works with script hashes.

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Transaction.hs
@@ -217,7 +217,7 @@ runTransactionBuildCmd
             , let (_, returnAddrHash, _) = fromProposalProcedure eon proposal -- fromProposalProcedure needs to be adjusted so that it works with script hashes.
             ]
         treasuryWithdrawalAddresses =
-          Set.fromList
+          fromList
             [ stakeCred
             | (proposal, _) <- proposals
             , let (_, _, govAction) = fromProposalProcedure eon proposal

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Transaction.hs
@@ -59,6 +59,7 @@ import           Cardano.CLI.Types.Output (renderScriptCosts)
 import           Cardano.CLI.Types.TxFeature
 
 import           Control.Monad (forM)
+import           Control.Monad.Cont (unless)
 import           Data.Aeson ((.=))
 import qualified Data.Aeson as Aeson
 import           Data.Aeson.Encode.Pretty (encodePretty)
@@ -207,6 +208,44 @@ runTransactionBuildCmd
           <$> readTxGovernanceActions eon proposalFiles
 
     forM_ proposals (checkProposalHashes eon . fst)
+
+    -- Extract return addresses from proposals and check that the return address in each proposal is registered
+
+    let returnAddrHashes =
+          Set.fromList
+            [ StakeCredentialByKey returnAddrHash
+            | (proposal, _) <- proposals
+            , let (_, returnAddrHash, _) = fromProposalProcedure eon proposal -- fromProposalProcedure needs to be adjusted so that it works with script hashes.
+            ]
+        treasuryWithdrawalAddresses =
+          Set.fromList
+            [ stakeCred
+            | (proposal, _) <- proposals
+            , let (_, _, govAction) = fromProposalProcedure eon proposal
+            , TreasuryWithdrawal withdrawalsList _ <- [govAction] -- Match on TreasuryWithdrawal action
+            , (_, stakeCred, _) <- withdrawalsList -- Extract fund-receiving stake credentials
+            ]
+        allAddrHashes = Set.union returnAddrHashes treasuryWithdrawalAddresses
+
+    (balances, _) <-
+      lift
+        ( executeLocalStateQueryExpr
+            localNodeConnInfo
+            Consensus.VolatileTip
+            (queryStakeAddresses eon allAddrHashes networkId)
+        )
+        & onLeft (left . TxCmdQueryConvenienceError . AcqFailure)
+        & onLeft (left . TxCmdQueryConvenienceError . QceUnsupportedNtcVersion)
+        & onLeft (left . TxCmdTxSubmitErrorEraMismatch)
+
+    let unregisteredAddresses =
+          Set.filter
+            (\stakeCred -> Map.notMember (makeStakeAddress networkId stakeCred) balances)
+            allAddrHashes
+
+    unless (null unregisteredAddresses) $
+      throwError $
+        TxCmdUnregisteredStakeAddress unregisteredAddresses
 
     -- the same collateral input can be used for several plutus scripts
     let filteredTxinsc = nubOrd txinsc

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/TxCmdError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/TxCmdError.hs
@@ -31,6 +31,7 @@ import           Cardano.CLI.Types.Output
 import           Cardano.CLI.Types.TxFeature
 import qualified Cardano.Prelude as List
 
+import           Data.Set (Set)
 import           Data.Text (Text)
 
 {- HLINT ignore "Use let" -}
@@ -88,6 +89,7 @@ data TxCmdError
   | forall era. TxCmdFeeEstimationError (TxFeeEstimationError era)
   | TxCmdPoolMetadataHashError AnchorDataFromCertificateError
   | TxCmdHashCheckError L.Url HashCheckError
+  | TxCmdUnregisteredStakeAddress !(Set StakeCredential)
 
 renderTxCmdError :: TxCmdError -> Doc ann
 renderTxCmdError = \case
@@ -225,6 +227,8 @@ renderTxCmdError = \case
     "Hash of the pool metadata hash is not valid:" <+> prettyError e
   TxCmdHashCheckError url e ->
     "Hash of the file is not valid. Url:" <+> pretty (L.urlToText url) <+> prettyException e
+  TxCmdUnregisteredStakeAddress credentials ->
+    "One or more stake addresses in proposals is not registered:" <+> pshow credentials
 
 prettyPolicyIdList :: [PolicyId] -> Doc ann
 prettyPolicyIdList =

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/TxCmdError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/TxCmdError.hs
@@ -228,7 +228,7 @@ renderTxCmdError = \case
   TxCmdHashCheckError url e ->
     "Hash of the file is not valid. Url:" <+> pretty (L.urlToText url) <+> prettyException e
   TxCmdUnregisteredStakeAddress credentials ->
-    "One or more stake addresses in proposals is not registered:" <+> pshow credentials
+    "Stake credential specified in the proposal is not registered on-chain:" <+> pshow credentials
 
 prettyPolicyIdList :: [PolicyId] -> Doc ann
 prettyPolicyIdList =


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    `transaction build` now checks and fails if stake addresses used for deposit return or treasury withdrawals in proposals are NOT registered on-chain. 
# uncomment types applicable to the change:
  type:
   - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Resolves https://github.com/IntersectMBO/cardano-cli/issues/900

# How to trust this PR

Tested locally with a Treasury Withdrawal action where neither the  deposit return or funds receiving stake addresses are registered: 

```
cardano-cli conway governance action create-treasury-withdrawal \
--testnet --governance-action-deposit 100000000000 -\
-deposit-return-stake-verification-key-file example/utxo-keys/stake4.vkey \
--anchor-url https://tinyurl.com/3wrwb2as \
--anchor-data-hash 52e69500a92d80f2126c836a4903dc582006709f004cf7a28ed648f732dff8d2 \
--funds-receiving-stake-verification-key-file example/utxo-keys/stake4.vkey \
--transfer 1000000000 \
--constitution-script-hash fa24fb305126805cf2164c161d852a0e7330cf988f1fe558cf7d4a64 \
--out-file example/transactions/treasury.action

cardano-cli conway transaction build \
--proposal-script-file ./guardrailscriptV2/guardrail-script.plutus \
--tx-in-collateral fe7c2bd546dbd9b8d07cb677877842538e8d8695f439460804edcc8dec48b4d6#1 \
--proposal-redeemer-value '{}' \
--tx-in fe7c2bd546dbd9b8d07cb677877842538e8d8695f439460804edcc8dec48b4d6#1 \
--change-address addr_test1qpxswhl4wqx9wz7a2xm22f8kykyltcm9vq7gdh6acjpav0nyf3wxwla9x63vwcdnehthn9queenth86fuhzyy5tv23wqjg8gqx \
--proposal-file example/transactions/treasury.action --out-file example/transactions/treasury-tx.raw

Command failed: transaction build  Error: Stake credential specified in the proposal is not registered on-chain: 
fromList [StakeCredentialByKey "baf951461969b293ae04813af76e15b451c2921bbde53580306d817c"]
```
# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details. 
- [x] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
