### PR TITLE
Parsers: avoid double usage of flip on a single line

### DIFF
--- a/cardano-cli/src/Cardano/CLI/Byron/Parsers.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Parsers.hs
@@ -688,8 +688,9 @@ parseProtocolMagicId arg =
 
 parseProtocolMagic :: Parser ProtocolMagic
 parseProtocolMagic =
-  flip AProtocolMagic RequiresMagic . flip L.Annotated ()
-    <$> parseProtocolMagicId "protocol-magic"
+  mkProtocol <$> parseProtocolMagicId "protocol-magic"
+ where
+  mkProtocol protMagicId = AProtocolMagic (L.Annotated protMagicId ()) RequiresMagic
 
 parseTxFile :: String -> Parser (TxFile In)
 parseTxFile opt =


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Simplify a parser, by making it more readable
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Small improvement found when working on https://github.com/IntersectMBO/cardano-cli/issues/763

# How to trust this PR

Typechecking suffices to make sure this is sound

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] Self-reviewed the diff