### PR TITLE
Minting script witness refactor

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -14,7 +14,7 @@ repository cardano-haskell-packages
 -- you need to run if you change them
 index-state:
   , hackage.haskell.org 2024-10-11T15:49:11Z
-  , cardano-haskell-packages 2024-11-12T08:40:13Z
+  , cardano-haskell-packages 2024-11-20T20:05:41Z
 
 packages:
   cardano-cli

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -45,6 +45,7 @@ library
 
   if impl(ghc < 9.6)
     ghc-options: -Wno-redundant-constraints
+    
   hs-source-dirs: src
   exposed-modules:
     Cardano.CLI.Byron.Commands
@@ -172,10 +173,12 @@ library
     Cardano.CLI.Types.Errors.KeyCmdError
     Cardano.CLI.Types.Errors.NodeCmdError
     Cardano.CLI.Types.Errors.NodeEraMismatchError
+    Cardano.CLI.Types.Errors.PlutusScriptDecodeError
     Cardano.CLI.Types.Errors.ProtocolParamsError
     Cardano.CLI.Types.Errors.QueryCmdError
     Cardano.CLI.Types.Errors.QueryCmdLocalStateQueryError
     Cardano.CLI.Types.Errors.RegistrationError
+    Cardano.CLI.Types.Errors.ScriptDataError
     Cardano.CLI.Types.Errors.ScriptDecodeError
     Cardano.CLI.Types.Errors.StakeAddressCmdError
     Cardano.CLI.Types.Errors.StakeAddressDelegationError

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -45,7 +45,6 @@ library
 
   if impl(ghc < 9.6)
     ghc-options: -Wno-redundant-constraints
-    
   hs-source-dirs: src
   exposed-modules:
     Cardano.CLI.Byron.Commands

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -116,6 +116,8 @@ library
     Cardano.CLI.EraBased.Run.StakePool
     Cardano.CLI.EraBased.Run.TextView
     Cardano.CLI.EraBased.Run.Transaction
+    Cardano.CLI.EraBased.Script.Mint.Read
+    Cardano.CLI.EraBased.Script.Mint.Types
     Cardano.CLI.EraBased.Transaction.HashCheck
     Cardano.CLI.Helpers
     Cardano.CLI.IO.Lazy
@@ -135,7 +137,6 @@ library
     Cardano.CLI.Options.Key
     Cardano.CLI.Options.Node
     Cardano.CLI.Options.Ping
-    Cardano.CLI.Plutus.Minting
     Cardano.CLI.Orphans
     Cardano.CLI.Parser
     Cardano.CLI.Read

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -203,7 +203,7 @@ library
     binary,
     bytestring,
     canonical-json,
-    cardano-api ^>=10.2,
+    cardano-api ^>=10.3,
     cardano-binary,
     cardano-crypto,
     cardano-crypto-class ^>=2.1.2,

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -135,6 +135,7 @@ library
     Cardano.CLI.Options.Key
     Cardano.CLI.Options.Node
     Cardano.CLI.Options.Ping
+    Cardano.CLI.Plutus.Minting
     Cardano.CLI.Orphans
     Cardano.CLI.Parser
     Cardano.CLI.Read

--- a/cardano-cli/src/Cardano/CLI/Compatible/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/Compatible/Transaction.hs
@@ -270,18 +270,18 @@ readUpdateProposalFile
   :: Featured ShelleyToBabbageEra era (Maybe UpdateProposalFile)
   -> ExceptT CompatibleTransactionError IO (AnyProtocolUpdate era)
 readUpdateProposalFile (Featured sToB Nothing) =
-  return $ NoPParamsUpdate $ shelleyToBabbageEraToShelleyBasedEra sToB
+  return $ NoPParamsUpdate $ inject sToB
 readUpdateProposalFile (Featured sToB (Just updateProposalFile)) = do
   prop <- firstExceptT CompatibleFileError $ readTxUpdateProposal sToB updateProposalFile
   case prop of
-    TxUpdateProposalNone -> return $ NoPParamsUpdate $ shelleyToBabbageEraToShelleyBasedEra sToB
+    TxUpdateProposalNone -> return $ NoPParamsUpdate $ inject sToB
     TxUpdateProposal _ proposal -> return $ ProtocolUpdate sToB proposal
 
 readProposalProcedureFile
   :: Featured ConwayEraOnwards era [(ProposalFile In, Maybe (ScriptWitnessFiles WitCtxStake))]
   -> ExceptT CompatibleTransactionError IO (AnyProtocolUpdate era)
 readProposalProcedureFile (Featured cEraOnwards []) =
-  let sbe = conwayEraOnwardsToShelleyBasedEra cEraOnwards
+  let sbe = inject cEraOnwards
    in return $ NoPParamsUpdate sbe
 readProposalProcedureFile (Featured cEraOnwards proposals) = do
   props <-

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Transaction.hs
@@ -25,6 +25,7 @@ import qualified Cardano.Api.Experimental as Exp
 import           Cardano.Api.Ledger (Coin)
 import           Cardano.Api.Shelley
 
+import           Cardano.CLI.Plutus.Minting
 import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Governance
 
@@ -61,7 +62,7 @@ data TransactionBuildRawCmdArgs era = TransactionBuildRawCmdArgs
   , requiredSigners :: ![RequiredSigner]
   -- ^ Required signers
   , txouts :: ![TxOutAnyEra]
-  , mValue :: !(Maybe (Value, [ScriptWitnessFiles WitCtxMint]))
+  , mValue :: !(Maybe (Value, [CliMintScriptRequirements]))
   -- ^ Multi-Asset value with script witness
   , mValidityLowerBound :: !(Maybe SlotNo)
   -- ^ Transaction validity lower bound
@@ -111,7 +112,7 @@ data TransactionBuildCmdArgs era = TransactionBuildCmdArgs
   -- ^ Normal outputs
   , changeAddresses :: !TxOutChangeAddress
   -- ^ A change output
-  , mValue :: !(Maybe (Value, [ScriptWitnessFiles WitCtxMint]))
+  , mValue :: !(Maybe (Value, [CliMintScriptRequirements]))
   -- ^ Multi-Asset value with script witness
   , mValidityLowerBound :: !(Maybe SlotNo)
   -- ^ Transaction validity lower bound
@@ -157,7 +158,7 @@ data TransactionBuildEstimateCmdArgs era = TransactionBuildEstimateCmdArgs
   -- ^ Normal outputs
   , changeAddress :: !TxOutChangeAddress
   -- ^ A change output
-  , mValue :: !(Maybe (Value, [ScriptWitnessFiles WitCtxMint]))
+  , mValue :: !(Maybe (Value, [CliMintScriptRequirements]))
   -- ^ Multi-Asset value with script witness
   , mValidityLowerBound :: !(Maybe SlotNo)
   -- ^ Transaction validity lower bound

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Transaction.hs
@@ -25,7 +25,7 @@ import qualified Cardano.Api.Experimental as Exp
 import           Cardano.Api.Ledger (Coin)
 import           Cardano.Api.Shelley
 
-import           Cardano.CLI.Plutus.Minting
+import           Cardano.CLI.EraBased.Script.Mint.Types
 import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Governance
 

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
@@ -2174,20 +2174,20 @@ pMintMultiAsset sbe balanceExecUnits =
  where
   pMintingScript :: Parser CliMintScriptRequirements
   pMintingScript =
-    createOnDiskSimpleOfPlutusScriptCliArgs
+    createSimpleOrPlutusScriptFromCliArgs
       <$> pMintScriptFile
       <*> optional (pPlutusMintScriptWitnessData sbe WitCtxMint balanceExecUnits)
 
   pSimpleReferenceMintingScriptWitness :: Parser CliMintScriptRequirements
   pSimpleReferenceMintingScriptWitness =
-    createOnDiskSimpleReferenceScriptCliArgs
+    createSimpleReferenceScriptFromCliArgs
       <$> pReferenceTxIn "simple-minting-script-" "simple"
       <*> pPolicyId
 
   pPlutusMintReferenceScriptWitnessFiles
     :: BalanceTxExecUnits -> Parser CliMintScriptRequirements
   pPlutusMintReferenceScriptWitnessFiles autoBalanceExecUnits =
-    createOnDiskPlutusReferenceScriptCliArgs
+    createPlutusReferenceScriptFromCliArgs
       <$> pReferenceTxIn "mint-" "plutus"
       <*> pPlutusScriptLanguage "mint-"
       <*> pScriptRedeemerOrFile "mint-reference-tx-in"

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
@@ -1539,7 +1539,6 @@ pPlutusStakeReferenceScriptWitnessFilesVotingProposing prefix autoBalanceExecUni
             AutoBalance -> pure (ExecutionUnits 0 0)
             ManualBalance -> pExecutionUnits $ prefix ++ "reference-tx-in"
         )
-    <*> pure Nothing
 
 pPlutusStakeReferenceScriptWitnessFiles
   :: String
@@ -1556,7 +1555,6 @@ pPlutusStakeReferenceScriptWitnessFiles prefix autoBalanceExecUnits =
             AutoBalance -> pure (ExecutionUnits 0 0)
             ManualBalance -> pExecutionUnits $ prefix ++ "reference-tx-in"
         )
-    <*> pure Nothing
 
 pPlutusScriptLanguage :: String -> Parser AnyPlutusScriptVersion
 pPlutusScriptLanguage prefix = plutusP prefix PlutusScriptV2 "v2" <|> plutusP prefix PlutusScriptV3 "v3"
@@ -1947,14 +1945,14 @@ pTxIn sbe balance =
       -> ScriptWitnessFiles WitCtxTxIn
     createSimpleReferenceScriptWitnessFiles refTxIn =
       let simpleLang = AnyScriptLanguage SimpleScriptLanguage
-       in SimpleReferenceScriptWitnessFiles refTxIn simpleLang Nothing
+       in SimpleReferenceScriptWitnessFiles refTxIn simpleLang
 
   pPlutusReferenceScriptWitness
     :: ShelleyBasedEra era -> BalanceTxExecUnits -> Parser (ScriptWitnessFiles WitCtxTxIn)
   pPlutusReferenceScriptWitness sbe' autoBalanceExecUnits =
     caseShelleyToBabbageOrConwayEraOnwards
       ( const $
-          createPlutusReferenceScriptWitnessFiles
+          PlutusReferenceScriptWitnessFiles
             <$> pReferenceTxIn "spending-" "plutus"
             <*> pPlutusScriptLanguage "spending-"
             <*> pScriptDatumOrFile "spending-reference-tx-in" WitCtxTxIn
@@ -1965,7 +1963,7 @@ pTxIn sbe balance =
                 )
       )
       ( const $
-          createPlutusReferenceScriptWitnessFiles
+          PlutusReferenceScriptWitnessFiles
             <$> pReferenceTxIn "spending-" "plutus"
             <*> pPlutusScriptLanguage "spending-"
             <*> pScriptDatumOrFileCip69 "spending-reference-tx-in" WitCtxTxIn
@@ -1976,16 +1974,6 @@ pTxIn sbe balance =
                 )
       )
       sbe'
-   where
-    createPlutusReferenceScriptWitnessFiles
-      :: TxIn
-      -> AnyPlutusScriptVersion
-      -> ScriptDatumOrFile WitCtxTxIn
-      -> ScriptRedeemerOrFile
-      -> ExecutionUnits
-      -> ScriptWitnessFiles WitCtxTxIn
-    createPlutusReferenceScriptWitnessFiles refIn sLang sDatum sRedeemer execUnits =
-      PlutusReferenceScriptWitnessFiles refIn sLang sDatum sRedeemer execUnits Nothing
 
   pEmbeddedPlutusScriptWitness :: Parser (ScriptWitnessFiles WitCtxTxIn)
   pEmbeddedPlutusScriptWitness =

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
@@ -18,8 +18,8 @@ import qualified Cardano.Api.Network as Consensus
 import           Cardano.Api.Shelley
 
 import           Cardano.CLI.Environment (EnvCli (..), envCliAnyEon)
+import           Cardano.CLI.EraBased.Script.Mint.Types
 import           Cardano.CLI.Parser
-import           Cardano.CLI.Plutus.Minting
 import           Cardano.CLI.Read
 import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Governance

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Actions.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/Actions.hs
@@ -185,11 +185,11 @@ pUpdateProtocolParametersCmd
 pUpdateProtocolParametersCmd =
   caseShelleyToBabbageOrConwayEraOnwards
     ( \shelleyToBab ->
-        let sbe = shelleyToBabbageEraToShelleyBasedEra shelleyToBab
+        let sbe = inject shelleyToBab
          in subParser "create-protocol-parameters-update"
               $ Opt.info
                 ( Cmd.GovernanceActionProtocolParametersUpdateCmdArgs
-                    (shelleyToBabbageEraToShelleyBasedEra shelleyToBab)
+                    (inject shelleyToBab)
                     <$> fmap Just (pUpdateProtocolParametersPreConway shelleyToBab)
                     <*> pure Nothing
                     <*> dpGovActionProtocolParametersUpdate sbe
@@ -199,11 +199,11 @@ pUpdateProtocolParametersCmd =
               $ Opt.progDesc "Create a protocol parameters update."
     )
     ( \conwayOnwards ->
-        let sbe = conwayEraOnwardsToShelleyBasedEra conwayOnwards
+        let sbe = inject conwayOnwards
          in subParser "create-protocol-parameters-update"
               $ Opt.info
                 ( Cmd.GovernanceActionProtocolParametersUpdateCmdArgs
-                    (conwayEraOnwardsToShelleyBasedEra conwayOnwards)
+                    (inject conwayOnwards)
                     Nothing
                     <$> fmap Just (pUpdateProtocolParametersPostConway conwayOnwards)
                     <*> dpGovActionProtocolParametersUpdate sbe

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Query.hs
@@ -678,7 +678,7 @@ pQueryTreasuryValueCmd era envCli = do
       <*> optional pOutputFile
 
 pQueryNoArgCmdArgs
-  :: ()
+  :: forall era. ()
   => ConwayEraOnwards era
   -> EnvCli
   -> Parser (QueryNoArgCmdArgs era)
@@ -687,5 +687,5 @@ pQueryNoArgCmdArgs w envCli =
     <$> pSocketPath envCli
     <*> pConsensusModeParams
     <*> pNetworkId envCli
-    <*> pTarget (conwayEraOnwardsToShelleyBasedEra w)
+    <*> pTarget (inject w :: ShelleyBasedEra era)
     <*> optional pOutputFile

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Query.hs
@@ -678,7 +678,8 @@ pQueryTreasuryValueCmd era envCli = do
       <*> optional pOutputFile
 
 pQueryNoArgCmdArgs
-  :: forall era. ()
+  :: forall era
+   . ()
   => ConwayEraOnwards era
   -> EnvCli
   -> Parser (QueryNoArgCmdArgs era)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/StakeAddress.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/StakeAddress.hs
@@ -121,7 +121,7 @@ pStakeAddressDeregistrationCertificateCmd =
     ( \shelleyToBabbage ->
         subParser "deregistration-certificate"
           $ Opt.info
-            ( StakeAddressDeregistrationCertificateCmd (shelleyToBabbageEraToShelleyBasedEra shelleyToBabbage)
+            ( StakeAddressDeregistrationCertificateCmd (inject shelleyToBabbage)
                 <$> pStakeIdentifier Nothing
                 <*> pure Nothing
                 <*> pOutputFile
@@ -131,7 +131,7 @@ pStakeAddressDeregistrationCertificateCmd =
     ( \conwayOnwards ->
         subParser "deregistration-certificate"
           $ Opt.info
-            ( StakeAddressDeregistrationCertificateCmd (conwayEraOnwardsToShelleyBasedEra conwayOnwards)
+            ( StakeAddressDeregistrationCertificateCmd (inject conwayOnwards)
                 <$> pStakeIdentifier Nothing
                 <*> fmap Just pKeyRegistDeposit
                 <*> pOutputFile

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Transaction.hs
@@ -227,7 +227,7 @@ pTransactionBuildEstimateCmd eon' _envCli = do
  where
   pCmd :: Exp.Era era -> Parser (TransactionCmds era)
   pCmd era' = do
-    let sbe = Exp.eraToSbe era'
+    let sbe = inject era'
     fmap TransactionBuildEstimateCmd $
       TransactionBuildEstimateCmdArgs era'
         <$> optional pScriptValidity

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance.hs
@@ -65,7 +65,8 @@ runGovernanceCmds = \case
     runGovernanceVoteCmds cmds
 
 runGovernanceMIRCertificatePayStakeAddrs
-  :: forall era. ShelleyToBabbageEra era
+  :: forall era
+   . ShelleyToBabbageEra era
   -> L.MIRPot
   -> [StakeAddress]
   -- ^ Stake addresses
@@ -104,7 +105,8 @@ runGovernanceMIRCertificatePayStakeAddrs w mirPot sAddrs rwdAmts oFp = do
   mirCertDesc = "Move Instantaneous Rewards Certificate"
 
 runGovernanceCreateMirCertificateTransferToTreasuryCmd
-  :: forall era. ()
+  :: forall era
+   . ()
   => ShelleyToBabbageEra era
   -> Lovelace
   -> File () Out
@@ -125,7 +127,8 @@ runGovernanceCreateMirCertificateTransferToTreasuryCmd w ll oFp = do
   mirCertDesc = "MIR Certificate Send To Treasury"
 
 runGovernanceCreateMirCertificateTransferToReservesCmd
-  :: forall era. ()
+  :: forall era
+   . ()
   => ShelleyToBabbageEra era
   -> Lovelace
   -> File () Out

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance.hs
@@ -65,7 +65,7 @@ runGovernanceCmds = \case
     runGovernanceVoteCmds cmds
 
 runGovernanceMIRCertificatePayStakeAddrs
-  :: ShelleyToBabbageEra era
+  :: forall era. ShelleyToBabbageEra era
   -> L.MIRPot
   -> [StakeAddress]
   -- ^ Stake addresses
@@ -92,10 +92,11 @@ runGovernanceMIRCertificatePayStakeAddrs w mirPot sAddrs rwdAmts oFp = do
         makeMIRCertificate $
           MirCertificateRequirements w mirPot $
             shelleyToBabbageEraConstraints w mirTarget
+      sbe :: ShelleyBasedEra era = inject w
 
   firstExceptT GovernanceCmdTextEnvWriteError
     . newExceptT
-    $ shelleyBasedEraConstraints (shelleyToBabbageEraToShelleyBasedEra w)
+    $ shelleyBasedEraConstraints sbe
     $ writeLazyByteStringFile oFp
     $ textEnvelopeToJSON (Just mirCertDesc) mirCert
  where
@@ -103,7 +104,7 @@ runGovernanceMIRCertificatePayStakeAddrs w mirPot sAddrs rwdAmts oFp = do
   mirCertDesc = "Move Instantaneous Rewards Certificate"
 
 runGovernanceCreateMirCertificateTransferToTreasuryCmd
-  :: ()
+  :: forall era. ()
   => ShelleyToBabbageEra era
   -> Lovelace
   -> File () Out
@@ -112,10 +113,11 @@ runGovernanceCreateMirCertificateTransferToTreasuryCmd w ll oFp = do
   let mirTarget = L.SendToOppositePotMIR ll
 
   let mirCert = makeMIRCertificate $ MirCertificateRequirements w L.ReservesMIR mirTarget
+      sbe :: ShelleyBasedEra era = inject w
 
   firstExceptT GovernanceCmdTextEnvWriteError
     . newExceptT
-    $ shelleyBasedEraConstraints (shelleyToBabbageEraToShelleyBasedEra w)
+    $ shelleyBasedEraConstraints sbe
     $ writeLazyByteStringFile oFp
     $ textEnvelopeToJSON (Just mirCertDesc) mirCert
  where
@@ -123,7 +125,7 @@ runGovernanceCreateMirCertificateTransferToTreasuryCmd w ll oFp = do
   mirCertDesc = "MIR Certificate Send To Treasury"
 
 runGovernanceCreateMirCertificateTransferToReservesCmd
-  :: ()
+  :: forall era. ()
   => ShelleyToBabbageEra era
   -> Lovelace
   -> File () Out
@@ -132,10 +134,11 @@ runGovernanceCreateMirCertificateTransferToReservesCmd w ll oFp = do
   let mirTarget = L.SendToOppositePotMIR ll
 
   let mirCert = makeMIRCertificate $ MirCertificateRequirements w L.TreasuryMIR mirTarget
+      sbe :: ShelleyBasedEra era = inject w
 
   firstExceptT GovernanceCmdTextEnvWriteError
     . newExceptT
-    $ shelleyBasedEraConstraints (shelleyToBabbageEraToShelleyBasedEra w)
+    $ shelleyBasedEraConstraints sbe
     $ writeLazyByteStringFile oFp
     $ textEnvelopeToJSON (Just mirCertDesc) mirCert
  where

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Actions.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Actions.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeFamilies #-}
 
 module Cardano.CLI.EraBased.Run.Governance.Actions
@@ -77,7 +78,7 @@ runGovernanceActionViewCmd
         proposal
 
 runGovernanceActionInfoCmd
-  :: ()
+  :: forall era. ()
   => GovernanceActionInfoCmdArgs era
   -> ExceptT GovernanceActionsError IO ()
 runGovernanceActionInfoCmd
@@ -103,7 +104,7 @@ runGovernanceActionInfoCmd
 
     carryHashChecks checkProposalHash proposalAnchor ProposalCheck
 
-    let sbe = conwayEraOnwardsToShelleyBasedEra eon
+    let sbe :: ShelleyBasedEra era = inject eon
         govAction = InfoAct
         proposalProcedure = createProposalProcedure sbe networkId deposit depositStakeCredential govAction proposalAnchor
 
@@ -117,7 +118,7 @@ fetchURLErrorToGovernanceActionError adt = withExceptT (GovernanceActionsProposa
 
 -- TODO: Conway era - update with new ledger types from cardano-ledger-conway-1.7.0.0
 runGovernanceActionCreateNoConfidenceCmd
-  :: ()
+  :: forall era. ()
   => GovernanceActionCreateNoConfidenceCmdArgs era
   -> ExceptT GovernanceActionsError IO ()
 runGovernanceActionCreateNoConfidenceCmd
@@ -144,7 +145,7 @@ runGovernanceActionCreateNoConfidenceCmd
 
     carryHashChecks checkProposalHash proposalAnchor ProposalCheck
 
-    let sbe = conwayEraOnwardsToShelleyBasedEra eon
+    let sbe :: ShelleyBasedEra era = inject eon
         previousGovernanceAction =
           MotionOfNoConfidence $
             L.maybeToStrictMaybe $
@@ -165,7 +166,7 @@ runGovernanceActionCreateNoConfidenceCmd
         writeFileTextEnvelope outFile (Just "Motion of no confidence proposal") proposalProcedure
 
 runGovernanceActionCreateConstitutionCmd
-  :: ()
+  :: forall era. ()
   => GovernanceActionCreateConstitutionCmdArgs era
   -> ExceptT GovernanceActionsError IO ()
 runGovernanceActionCreateConstitutionCmd
@@ -210,7 +211,7 @@ runGovernanceActionCreateConstitutionCmd
             prevGovActId
             constitutionAnchor
             (toShelleyScriptHash <$> L.maybeToStrictMaybe constitutionScript)
-        sbe = conwayEraOnwardsToShelleyBasedEra eon
+        sbe :: ShelleyBasedEra era = inject eon
         proposalProcedure = createProposalProcedure sbe networkId deposit depositStakeCredential govAct proposalAnchor
 
     carryHashChecks checkConstitutionHash constitutionAnchor ConstitutionCheck
@@ -225,7 +226,7 @@ runGovernanceActionCreateConstitutionCmd
 -- TODO: Conway era - After ledger bump update this function
 -- with the new ledger types
 runGovernanceActionUpdateCommitteeCmd
-  :: ()
+  :: forall era. ()
   => GovernanceActionUpdateCommitteeCmdArgs era
   -> ExceptT GovernanceActionsError IO ()
 runGovernanceActionUpdateCommitteeCmd
@@ -243,7 +244,7 @@ runGovernanceActionUpdateCommitteeCmd
     , Cmd.mPrevGovernanceActionId
     , Cmd.outFile
     } = do
-    let sbe = conwayEraOnwardsToShelleyBasedEra eon
+    let sbe :: ShelleyBasedEra era = inject eon
         govActIdentifier =
           L.maybeToStrictMaybe $
             shelleyBasedEraConstraints sbe $
@@ -301,7 +302,7 @@ runGovernanceActionUpdateCommitteeCmd
           proposal
 
 runGovernanceActionCreateProtocolParametersUpdateCmd
-  :: ()
+  :: forall era. ()
   => Cmd.GovernanceActionProtocolParametersUpdateCmdArgs era
   -> ExceptT GovernanceActionsError IO ()
 runGovernanceActionCreateProtocolParametersUpdateCmd eraBasedPParams' = do
@@ -309,7 +310,7 @@ runGovernanceActionCreateProtocolParametersUpdateCmd eraBasedPParams' = do
   caseShelleyToBabbageOrConwayEraOnwards
     ( \sToB -> do
         let oFp = uppFilePath eraBasedPParams'
-            anyEra = AnyShelleyBasedEra $ shelleyToBabbageEraToShelleyBasedEra sToB
+            anyEra = AnyShelleyBasedEra (inject sToB :: ShelleyBasedEra era)
         UpdateProtocolParametersPreConway _stB expEpoch genesisVerKeys <-
           hoistMaybe (GovernanceActionsValueUpdateProtocolParametersNotFound anyEra) $
             uppPreConway eraBasedPParams'
@@ -335,7 +336,7 @@ runGovernanceActionCreateProtocolParametersUpdateCmd eraBasedPParams' = do
     )
     ( \conwayOnwards -> do
         let oFp = uppFilePath eraBasedPParams'
-            anyEra = AnyShelleyBasedEra $ conwayEraOnwardsToShelleyBasedEra conwayOnwards
+            anyEra = AnyShelleyBasedEra (inject conwayOnwards :: ShelleyBasedEra era)
 
         UpdateProtocolParametersConwayOnwards
           _cOnwards
@@ -413,7 +414,7 @@ addCostModelsToEraBasedProtocolParametersUpdate
     ConwayEraBasedProtocolParametersUpdate common (aOn{alCostModels = SJust cmdls}) inB inC
 
 runGovernanceActionTreasuryWithdrawalCmd
-  :: ()
+  :: forall era. ()
   => GovernanceActionTreasuryWithdrawalCmdArgs era
   -> ExceptT GovernanceActionsError IO ()
 runGovernanceActionTreasuryWithdrawalCmd
@@ -446,7 +447,7 @@ runGovernanceActionTreasuryWithdrawalCmd
         firstExceptT GovernanceActionsReadStakeCredErrror $ getStakeCredentialFromIdentifier stakeIdentifier
       pure (networkId, stakeCredential, lovelace)
 
-    let sbe = conwayEraOnwardsToShelleyBasedEra eon
+    let sbe :: ShelleyBasedEra era = inject eon
         treasuryWithdrawals =
           TreasuryWithdrawal
             withdrawals
@@ -465,7 +466,7 @@ runGovernanceActionTreasuryWithdrawalCmd
         writeFileTextEnvelope outFile (Just "Treasury withdrawal proposal") proposal
 
 runGovernanceActionHardforkInitCmd
-  :: ()
+  :: forall era. ()
   => GovernanceActionHardforkInitCmdArgs era
   -> ExceptT GovernanceActionsError IO ()
 runGovernanceActionHardforkInitCmd
@@ -493,7 +494,7 @@ runGovernanceActionHardforkInitCmd
 
     carryHashChecks checkProposalHash proposalAnchor ProposalCheck
 
-    let sbe = conwayEraOnwardsToShelleyBasedEra eon
+    let sbe :: ShelleyBasedEra era = inject eon
         govActIdentifier =
           L.maybeToStrictMaybe $
             shelleyBasedEraConstraints sbe $

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Actions.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Actions.hs
@@ -78,7 +78,8 @@ runGovernanceActionViewCmd
         proposal
 
 runGovernanceActionInfoCmd
-  :: forall era. ()
+  :: forall era
+   . ()
   => GovernanceActionInfoCmdArgs era
   -> ExceptT GovernanceActionsError IO ()
 runGovernanceActionInfoCmd
@@ -118,7 +119,8 @@ fetchURLErrorToGovernanceActionError adt = withExceptT (GovernanceActionsProposa
 
 -- TODO: Conway era - update with new ledger types from cardano-ledger-conway-1.7.0.0
 runGovernanceActionCreateNoConfidenceCmd
-  :: forall era. ()
+  :: forall era
+   . ()
   => GovernanceActionCreateNoConfidenceCmdArgs era
   -> ExceptT GovernanceActionsError IO ()
 runGovernanceActionCreateNoConfidenceCmd
@@ -166,7 +168,8 @@ runGovernanceActionCreateNoConfidenceCmd
         writeFileTextEnvelope outFile (Just "Motion of no confidence proposal") proposalProcedure
 
 runGovernanceActionCreateConstitutionCmd
-  :: forall era. ()
+  :: forall era
+   . ()
   => GovernanceActionCreateConstitutionCmdArgs era
   -> ExceptT GovernanceActionsError IO ()
 runGovernanceActionCreateConstitutionCmd
@@ -226,7 +229,8 @@ runGovernanceActionCreateConstitutionCmd
 -- TODO: Conway era - After ledger bump update this function
 -- with the new ledger types
 runGovernanceActionUpdateCommitteeCmd
-  :: forall era. ()
+  :: forall era
+   . ()
   => GovernanceActionUpdateCommitteeCmdArgs era
   -> ExceptT GovernanceActionsError IO ()
 runGovernanceActionUpdateCommitteeCmd
@@ -302,7 +306,8 @@ runGovernanceActionUpdateCommitteeCmd
           proposal
 
 runGovernanceActionCreateProtocolParametersUpdateCmd
-  :: forall era. ()
+  :: forall era
+   . ()
   => Cmd.GovernanceActionProtocolParametersUpdateCmdArgs era
   -> ExceptT GovernanceActionsError IO ()
 runGovernanceActionCreateProtocolParametersUpdateCmd eraBasedPParams' = do
@@ -414,7 +419,8 @@ addCostModelsToEraBasedProtocolParametersUpdate
     ConwayEraBasedProtocolParametersUpdate common (aOn{alCostModels = SJust cmdls}) inB inC
 
 runGovernanceActionTreasuryWithdrawalCmd
-  :: forall era. ()
+  :: forall era
+   . ()
   => GovernanceActionTreasuryWithdrawalCmdArgs era
   -> ExceptT GovernanceActionsError IO ()
 runGovernanceActionTreasuryWithdrawalCmd
@@ -466,7 +472,8 @@ runGovernanceActionTreasuryWithdrawalCmd
         writeFileTextEnvelope outFile (Just "Treasury withdrawal proposal") proposal
 
 runGovernanceActionHardforkInitCmd
-  :: forall era. ()
+  :: forall era
+   . ()
   => GovernanceActionHardforkInitCmdArgs era
   -> ExceptT GovernanceActionsError IO ()
 runGovernanceActionHardforkInitCmd

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/GenesisKeyDelegationCertificate.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/GenesisKeyDelegationCertificate.hs
@@ -15,7 +15,8 @@ import           Cardano.CLI.Types.Errors.GovernanceCmdError
 import           Cardano.CLI.Types.Key
 
 runGovernanceGenesisKeyDelegationCertificate
-  :: forall era. ShelleyToBabbageEra era
+  :: forall era
+   . ShelleyToBabbageEra era
   -> VerificationKeyOrHashOrFile GenesisKey
   -> VerificationKeyOrHashOrFile GenesisDelegateKey
   -> VerificationKeyOrHashOrFile VrfKey

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/GenesisKeyDelegationCertificate.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/GenesisKeyDelegationCertificate.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 module Cardano.CLI.EraBased.Run.Governance.GenesisKeyDelegationCertificate
   ( runGovernanceGenesisKeyDelegationCertificate
@@ -13,7 +15,7 @@ import           Cardano.CLI.Types.Errors.GovernanceCmdError
 import           Cardano.CLI.Types.Key
 
 runGovernanceGenesisKeyDelegationCertificate
-  :: ShelleyToBabbageEra era
+  :: forall era. ShelleyToBabbageEra era
   -> VerificationKeyOrHashOrFile GenesisKey
   -> VerificationKeyOrHashOrFile GenesisDelegateKey
   -> VerificationKeyOrHashOrFile VrfKey
@@ -41,7 +43,7 @@ runGovernanceGenesisKeyDelegationCertificate
     firstExceptT GovernanceCmdTextEnvWriteError
       . newExceptT
       $ writeLazyByteStringFile oFp
-      $ shelleyBasedEraConstraints (shelleyToBabbageEraToShelleyBasedEra stb)
+      $ shelleyBasedEraConstraints (inject stb :: ShelleyBasedEra era)
       $ textEnvelopeToJSON (Just genKeyDelegCertDesc) genKeyDelegCert
    where
     genKeyDelegCertDesc :: TextEnvelopeDescr

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Vote.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Vote.hs
@@ -41,7 +41,8 @@ runGovernanceVoteCmds = \case
       & firstExceptT CmdGovernanceVoteError
 
 runGovernanceVoteCreateCmd
-  :: forall era. ()
+  :: forall era
+   . ()
   => Cmd.GovernanceVoteCreateCmdArgs era
   -> ExceptT GovernanceVoteCmdError IO ()
 runGovernanceVoteCreateCmd
@@ -92,7 +93,8 @@ runGovernanceVoteCreateCmd
         writeFileTextEnvelope outFile Nothing votingProcedures
 
 runGovernanceVoteViewCmd
-  :: forall era. ()
+  :: forall era
+   . ()
   => Cmd.GovernanceVoteViewCmdArgs era
   -> ExceptT GovernanceVoteCmdError IO ()
 runGovernanceVoteViewCmd

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Vote.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Vote.hs
@@ -41,7 +41,7 @@ runGovernanceVoteCmds = \case
       & firstExceptT CmdGovernanceVoteError
 
 runGovernanceVoteCreateCmd
-  :: ()
+  :: forall era. ()
   => Cmd.GovernanceVoteCreateCmdArgs era
   -> ExceptT GovernanceVoteCmdError IO ()
 runGovernanceVoteCreateCmd
@@ -54,7 +54,7 @@ runGovernanceVoteCreateCmd
     , outFile
     } = do
     let (govActionTxId, govActionIndex) = governanceAction
-        sbe = conwayEraOnwardsToShelleyBasedEra eon -- TODO: Conway era - update vote creation related function to take ConwayEraOnwards
+        sbe :: ShelleyBasedEra era = inject eon -- TODO: Conway era - update vote creation related function to take ConwayEraOnwards
         mAnchor' =
           fmap
             ( \pca@PotentiallyCheckedAnchor{pcaAnchor = (VoteUrl url, voteHash)} ->
@@ -92,7 +92,7 @@ runGovernanceVoteCreateCmd
         writeFileTextEnvelope outFile Nothing votingProcedures
 
 runGovernanceVoteViewCmd
-  :: ()
+  :: forall era. ()
   => Cmd.GovernanceVoteViewCmdArgs era
   -> ExceptT GovernanceVoteCmdError IO ()
 runGovernanceVoteViewCmd
@@ -102,7 +102,7 @@ runGovernanceVoteViewCmd
     , voteFile
     , mOutFile
     } = do
-    let sbe = conwayEraOnwardsToShelleyBasedEra eon
+    let sbe :: ShelleyBasedEra era = inject eon
 
     shelleyBasedEraConstraints sbe $ do
       voteProcedures <-

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Transaction.hs
@@ -48,9 +48,10 @@ import           Cardano.CLI.EraBased.Commands.Transaction
 import qualified Cardano.CLI.EraBased.Commands.Transaction as Cmd
 import           Cardano.CLI.EraBased.Run.Genesis.Common (readProtocolParameters)
 import           Cardano.CLI.EraBased.Run.Query
+import           Cardano.CLI.EraBased.Script.Mint.Read
+import           Cardano.CLI.EraBased.Script.Mint.Types
 import           Cardano.CLI.EraBased.Transaction.HashCheck (checkCertificateHashes,
                    checkProposalHashes, checkVotingProcedureHashes)
-import           Cardano.CLI.Plutus.Minting
 import           Cardano.CLI.Read
 import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Errors.BootstrapWitnessError

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Transaction.hs
@@ -762,7 +762,7 @@ runTxBuildRaw
   -- ^ Tx upper bound
   -> Lovelace
   -- ^ Tx fee
-  -> (Value, [MintScriptWitWithPolId era])
+  -> (Value, [MintScriptWitnessWithPolicyId era])
   -- ^ Multi-Asset value(s)
   -> [(Certificate era, Maybe (ScriptWitness WitCtxStake era))]
   -- ^ Certificate with potential script witness
@@ -848,7 +848,7 @@ constructTxBodyContent
   -- ^ Tx lower bound
   -> TxValidityUpperBound era
   -- ^ Tx upper bound
-  -> (Value, [MintScriptWitWithPolId era])
+  -> (Value, [MintScriptWitnessWithPolicyId era])
   -- ^ Multi-Asset value(s)
   -> [(Certificate era, Maybe (ScriptWitness WitCtxStake era))]
   -- ^ Certificate with potential script witness
@@ -988,7 +988,7 @@ runTxBuild
   -- ^ Normal outputs
   -> TxOutChangeAddress
   -- ^ A change output
-  -> (Value, [MintScriptWitWithPolId era])
+  -> (Value, [MintScriptWitnessWithPolicyId era])
   -- ^ Multi-Asset value(s)
   -> Maybe SlotNo
   -- ^ Tx lower bound
@@ -1393,7 +1393,7 @@ toTxAlonzoDatum supp cliDatum =
 createTxMintValue
   :: forall era
    . ShelleyBasedEra era
-  -> (Value, [MintScriptWitWithPolId era])
+  -> (Value, [MintScriptWitnessWithPolicyId era])
   -> Either TxCmdError (TxMintValue BuildTx era)
 createTxMintValue era (val, scriptWitnesses) =
   if List.null (toList val) && List.null scriptWitnesses
@@ -1408,7 +1408,7 @@ createTxMintValue era (val, scriptWitnesses) =
                   fromList [pid | (AssetId pid _, _) <- toList val]
 
             let witnessesProvidedMap :: Map PolicyId (ScriptWitness WitCtxMint era)
-                witnessesProvidedMap = fromList $ [(polid, sWit) | MintScriptWitWithPolId polid sWit <- scriptWitnesses]
+                witnessesProvidedMap = fromList $ [(polid, sWit) | MintScriptWitnessWithPolicyId polid sWit <- scriptWitnesses]
                 witnessesProvidedSet = Map.keysSet witnessesProvidedMap
 
             -- Check not too many, nor too few:

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Transaction.hs
@@ -136,7 +136,7 @@ runTransactionBuildCmd
     , treasuryDonation -- Maybe TxTreasuryDonation
     , buildOutputOptions
     } = do
-    let eon = Exp.eraToSbe currentEra
+    let eon = inject currentEra
         era' = toCardanoEra eon
 
     -- The user can specify an era prior to the era that the node is currently in.
@@ -388,8 +388,8 @@ runTransactionBuildEstimateCmd -- TODO change type
     , currentTreasuryValueAndDonation
     , txBodyOutFile
     } = do
-    let sbe = Exp.eraToSbe currentEra
-        meo = babbageEraOnwardsToMaryEraOnwards $ Exp.eraToBabbageEraOnwards currentEra
+    let sbe = inject currentEra
+        meo = babbageEraOnwardsToMaryEraOnwards $ inject currentEra
 
     ledgerPParams <-
       firstExceptT TxCmdProtocolParamsError $ readProtocolParameters sbe protocolParamsFile

--- a/cardano-cli/src/Cardano/CLI/EraBased/Script/Mint/Read.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Script/Mint/Read.hs
@@ -66,7 +66,7 @@ readMintScriptWitness sbe (OnDiskSimpleRefScript (SimpleRefScriptCliArgs refTxIn
     MintScriptWitnessWithPolicyId polId $
       SimpleScriptWitness
         (sbeToSimpleScriptLangInEra sbe)
-        (SReferenceScript refTxIn $ Just $ unPolicyId polId)
+        (SReferenceScript refTxIn)
 readMintScriptWitness
   sbe
   ( OnDiskPlutusRefScript
@@ -74,7 +74,7 @@ readMintScriptWitness
     ) = do
     case anyPlutusScriptVersion of
       AnyPlutusScriptVersion lang -> do
-        let pScript = PReferenceScript refTxIn $ Just $ unPolicyId polId
+        let pScript = PReferenceScript refTxIn
         redeemer <-
           -- TODO: Implement a new error type to capture this. FileError is not representative of cases
           -- where we do not have access to the script.

--- a/cardano-cli/src/Cardano/CLI/EraBased/Script/Mint/Read.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Script/Mint/Read.hs
@@ -1,106 +1,17 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE LambdaCase #-}
 
-module Cardano.CLI.Plutus.Minting
-  ( CliMintScriptRequirements (..)
-  , MintScriptWitnessWithPolicyId (..)
-  , createSimpleOrPlutusScriptFromCliArgs
-  , createSimpleReferenceScriptFromCliArgs
-  , createPlutusReferenceScriptFromCliArgs
-  , CliScriptWitnessError
-  , readMintScriptWitness
+module Cardano.CLI.EraBased.Script.Mint.Read
+  ( readMintScriptWitness
   )
 where
 
 import           Cardano.Api
 import           Cardano.Api.Shelley
 
+import           Cardano.CLI.EraBased.Script.Mint.Types
 import           Cardano.CLI.Read
-import           Cardano.CLI.Types.Common (ScriptDataOrFile)
-
--- We always need the policy id when constructing a transaction that mints.
--- In the case of reference scripts, the user currently must provide the policy id (script hash)
--- in order to correctly construct the transaction.
-data MintScriptWitnessWithPolicyId era
-  = MintScriptWitnessWithPolicyId
-  { mswPolId :: PolicyId
-  , mswScriptWitness :: ScriptWitness WitCtxMint era
-  }
-  deriving Show
-
-data CliMintScriptRequirements
-  = OnDiskSimpleOrPlutusScript OnDiskSimpleOrPlutusScriptCliArgs
-  | OnDiskSimpleRefScript SimpleRefScriptCliArgs
-  | OnDiskPlutusRefScript PlutusRefScriptCliArgs
-  deriving Show
-
-data OnDiskSimpleOrPlutusScriptCliArgs
-  = OnDiskSimpleScriptCliArgs
-      (File ScriptInAnyLang In)
-  | OnDiskPlutusScriptCliArgs
-      (File ScriptInAnyLang In)
-      ScriptDataOrFile
-      ExecutionUnits
-  deriving Show
-
-createSimpleOrPlutusScriptFromCliArgs
-  :: File ScriptInAnyLang In
-  -> Maybe (ScriptDataOrFile, ExecutionUnits)
-  -> CliMintScriptRequirements
-createSimpleOrPlutusScriptFromCliArgs scriptFp Nothing =
-  OnDiskSimpleOrPlutusScript $ OnDiskSimpleScriptCliArgs scriptFp
-createSimpleOrPlutusScriptFromCliArgs scriptFp (Just (redeemerFile, execUnits)) =
-  OnDiskSimpleOrPlutusScript $ OnDiskPlutusScriptCliArgs scriptFp redeemerFile execUnits
-
-data SimpleRefScriptCliArgs
-  = SimpleRefScriptCliArgs
-      TxIn
-      PolicyId
-  deriving Show
-
-createSimpleReferenceScriptFromCliArgs
-  :: TxIn
-  -> PolicyId
-  -> CliMintScriptRequirements
-createSimpleReferenceScriptFromCliArgs txin polid =
-  OnDiskSimpleRefScript $ SimpleRefScriptCliArgs txin polid
-
-data PlutusRefScriptCliArgs
-  = PlutusRefScriptCliArgs
-      TxIn
-      AnyPlutusScriptVersion
-      ScriptDataOrFile
-      ExecutionUnits
-      PolicyId
-  deriving Show
-
-createPlutusReferenceScriptFromCliArgs
-  :: TxIn
-  -> AnyPlutusScriptVersion
-  -> ScriptDataOrFile
-  -> ExecutionUnits
-  -> PolicyId
-  -> CliMintScriptRequirements
-createPlutusReferenceScriptFromCliArgs txin scriptVersion scriptData execUnits polid =
-  OnDiskPlutusRefScript $ PlutusRefScriptCliArgs txin scriptVersion scriptData execUnits polid
-
-data CliScriptWitnessError
-  = SimpleScriptWitnessDecodeError ScriptDecodeError
-  | PlutusScriptWitnessDecodeError PlutusScriptDecodeError
-  | PlutusScriptWitnessLanguageNotSupportedInEra
-      AnyPlutusScriptVersion
-      AnyShelleyBasedEra
-  | PlutusScriptWitnessRedeemerError ScriptDataError
-
-instance Error CliScriptWitnessError where
-  prettyError = \case
-    SimpleScriptWitnessDecodeError err -> prettyError err
-    PlutusScriptWitnessDecodeError err -> prettyError err
-    PlutusScriptWitnessLanguageNotSupportedInEra version era ->
-      "Plutus script version " <> pshow version <> " is not supported in era " <> pshow era
-    PlutusScriptWitnessRedeemerError err -> renderScriptDataError err
 
 readMintScriptWitness
   :: MonadIOTransError (FileError CliScriptWitnessError) t m
@@ -190,6 +101,7 @@ readMintScriptWitness
               redeemer
               execUnits
 
+-- TODO: Remove me when exposed from cardano-api
 sbeToSimpleScriptLangInEra
   :: ShelleyBasedEra era -> ScriptLanguageInEra SimpleScript' era
 sbeToSimpleScriptLangInEra ShelleyBasedEraShelley = SimpleScriptInShelley

--- a/cardano-cli/src/Cardano/CLI/EraBased/Script/Mint/Types.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Script/Mint/Types.hs
@@ -18,8 +18,10 @@ where
 
 import           Cardano.Api
 
-import           Cardano.CLI.Read
 import           Cardano.CLI.Types.Common (ScriptDataOrFile)
+import           Cardano.CLI.Types.Errors.PlutusScriptDecodeError
+import           Cardano.CLI.Types.Errors.ScriptDataError
+import           Cardano.CLI.Types.Errors.ScriptDecodeError
 
 -- We always need the policy id when constructing a transaction that mints.
 -- In the case of reference scripts, the user currently must provide the policy id (script hash)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Script/Mint/Types.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Script/Mint/Types.hs
@@ -1,0 +1,104 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+
+module Cardano.CLI.EraBased.Script.Mint.Types
+  ( CliScriptWitnessError (..)
+  , CliMintScriptRequirements (..)
+  , SimpleOrPlutusScriptCliArgs (..)
+  , createSimpleOrPlutusScriptFromCliArgs
+  , PlutusRefScriptCliArgs (..)
+  , createPlutusReferenceScriptFromCliArgs
+  , SimpleRefScriptCliArgs (..)
+  , createSimpleReferenceScriptFromCliArgs
+  , MintScriptWitnessWithPolicyId (..)
+  )
+where
+
+import           Cardano.Api
+
+import           Cardano.CLI.Read
+import           Cardano.CLI.Types.Common (ScriptDataOrFile)
+
+-- We always need the policy id when constructing a transaction that mints.
+-- In the case of reference scripts, the user currently must provide the policy id (script hash)
+-- in order to correctly construct the transaction.
+data MintScriptWitnessWithPolicyId era
+  = MintScriptWitnessWithPolicyId
+  { mswPolId :: PolicyId
+  , mswScriptWitness :: ScriptWitness WitCtxMint era
+  }
+  deriving Show
+
+data CliMintScriptRequirements
+  = OnDiskSimpleOrPlutusScript SimpleOrPlutusScriptCliArgs
+  | OnDiskSimpleRefScript SimpleRefScriptCliArgs
+  | OnDiskPlutusRefScript PlutusRefScriptCliArgs
+  deriving Show
+
+data SimpleOrPlutusScriptCliArgs
+  = OnDiskSimpleScriptCliArgs
+      (File ScriptInAnyLang In)
+  | OnDiskPlutusScriptCliArgs
+      (File ScriptInAnyLang In)
+      ScriptDataOrFile
+      ExecutionUnits
+  deriving Show
+
+createSimpleOrPlutusScriptFromCliArgs
+  :: File ScriptInAnyLang In
+  -> Maybe (ScriptDataOrFile, ExecutionUnits)
+  -> CliMintScriptRequirements
+createSimpleOrPlutusScriptFromCliArgs scriptFp Nothing =
+  OnDiskSimpleOrPlutusScript $ OnDiskSimpleScriptCliArgs scriptFp
+createSimpleOrPlutusScriptFromCliArgs scriptFp (Just (redeemerFile, execUnits)) =
+  OnDiskSimpleOrPlutusScript $ OnDiskPlutusScriptCliArgs scriptFp redeemerFile execUnits
+
+data SimpleRefScriptCliArgs
+  = SimpleRefScriptCliArgs
+      TxIn
+      PolicyId
+  deriving Show
+
+createSimpleReferenceScriptFromCliArgs
+  :: TxIn
+  -> PolicyId
+  -> CliMintScriptRequirements
+createSimpleReferenceScriptFromCliArgs txin polid =
+  OnDiskSimpleRefScript $ SimpleRefScriptCliArgs txin polid
+
+data PlutusRefScriptCliArgs
+  = PlutusRefScriptCliArgs
+      TxIn
+      AnyPlutusScriptVersion
+      ScriptDataOrFile
+      ExecutionUnits
+      PolicyId
+  deriving Show
+
+createPlutusReferenceScriptFromCliArgs
+  :: TxIn
+  -> AnyPlutusScriptVersion
+  -> ScriptDataOrFile
+  -> ExecutionUnits
+  -> PolicyId
+  -> CliMintScriptRequirements
+createPlutusReferenceScriptFromCliArgs txin scriptVersion scriptData execUnits polid =
+  OnDiskPlutusRefScript $ PlutusRefScriptCliArgs txin scriptVersion scriptData execUnits polid
+
+data CliScriptWitnessError
+  = SimpleScriptWitnessDecodeError ScriptDecodeError
+  | PlutusScriptWitnessDecodeError PlutusScriptDecodeError
+  | PlutusScriptWitnessLanguageNotSupportedInEra
+      AnyPlutusScriptVersion
+      AnyShelleyBasedEra
+  | PlutusScriptWitnessRedeemerError ScriptDataError
+
+instance Error CliScriptWitnessError where
+  prettyError = \case
+    SimpleScriptWitnessDecodeError err -> prettyError err
+    PlutusScriptWitnessDecodeError err -> prettyError err
+    PlutusScriptWitnessLanguageNotSupportedInEra version era ->
+      "Plutus script version " <> pshow version <> " is not supported in era " <> pshow era
+    PlutusScriptWitnessRedeemerError err -> renderScriptDataError err

--- a/cardano-cli/src/Cardano/CLI/Json/Friendly.hs
+++ b/cardano-cli/src/Cardano/CLI/Json/Friendly.hs
@@ -786,10 +786,10 @@ friendlyFee = \case
 friendlyLovelace :: Lovelace -> Aeson.Value
 friendlyLovelace value = String $ docToText (pretty value)
 
-friendlyMintValue :: TxMintValue ViewTx era -> Aeson.Value
+friendlyMintValue :: forall era. TxMintValue ViewTx era -> Aeson.Value
 friendlyMintValue = \case
   TxMintNone -> Null
-  TxMintValue sbe v _ -> friendlyValue (maryEraOnwardsToShelleyBasedEra sbe) v
+  TxMintValue sbe v _ -> friendlyValue ((inject sbe) :: ShelleyBasedEra era) v
 
 friendlyTxOutValue :: TxOutValue era -> Aeson.Value
 friendlyTxOutValue = \case

--- a/cardano-cli/src/Cardano/CLI/Json/Friendly.hs
+++ b/cardano-cli/src/Cardano/CLI/Json/Friendly.hs
@@ -789,7 +789,7 @@ friendlyLovelace value = String $ docToText (pretty value)
 friendlyMintValue :: forall era. TxMintValue ViewTx era -> Aeson.Value
 friendlyMintValue = \case
   TxMintNone -> Null
-  TxMintValue sbe v _ -> friendlyValue ((inject sbe) :: ShelleyBasedEra era) v
+  txMintValue@(TxMintValue w _) -> friendlyValue @era (inject w) $ txMintValueToValue txMintValue
 
 friendlyTxOutValue :: TxOutValue era -> Aeson.Value
 friendlyTxOutValue = \case

--- a/cardano-cli/src/Cardano/CLI/Plutus/Minting.hs
+++ b/cardano-cli/src/Cardano/CLI/Plutus/Minting.hs
@@ -1,0 +1,200 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+
+module Cardano.CLI.Plutus.Minting
+  ( CliMintScriptRequirements (..)
+  , MintScriptWitWithPolId (..)
+  , createOnDiskSimpleOfPlutusScriptCliArgs
+  , createOnDiskSimpleReferenceScriptCliArgs
+  , createOnDiskPlutusReferenceScriptCliArgs
+  , CliScriptWitnessError
+  , readMintScriptWitness
+  )
+where
+
+import           Cardano.Api
+import           Cardano.Api.Shelley
+
+import           Cardano.CLI.Read
+import           Cardano.CLI.Types.Common (ScriptDataOrFile)
+
+-- We always need the policy id when constructing a transaction that mints.
+-- In the case of reference scripts, the user currently must provide the policy id (script hash)
+-- in order to correctly construct the transaction.
+data MintScriptWitWithPolId era
+  = MintScriptWitWithPolId
+  { mswPolId :: PolicyId
+  , mswScriptWitness :: ScriptWitness WitCtxMint era
+  }
+  deriving Show
+
+data OnDiskSimpleOrPlutusScriptCliArgs
+  = OnDiskSimpleScriptCliArgs
+      (File ScriptInAnyLang In)
+  | OnDiskPlutusScriptCliArgs
+      (File ScriptInAnyLang In)
+      ScriptDataOrFile
+      ExecutionUnits
+  deriving Show
+
+createOnDiskSimpleOfPlutusScriptCliArgs
+  :: File ScriptInAnyLang In
+  -> Maybe (ScriptDataOrFile, ExecutionUnits)
+  -> CliMintScriptRequirements
+createOnDiskSimpleOfPlutusScriptCliArgs scriptFp Nothing =
+  OnDiskSimpleOrPlutusScript $ OnDiskSimpleScriptCliArgs scriptFp
+createOnDiskSimpleOfPlutusScriptCliArgs scriptFp (Just (redeemerFile, execUnits)) =
+  OnDiskSimpleOrPlutusScript $ OnDiskPlutusScriptCliArgs scriptFp redeemerFile execUnits
+
+data SimpleRefScriptCliArgs
+  = SimpleRefScriptCliArgs
+      TxIn
+      PolicyId
+  deriving Show
+
+createOnDiskSimpleReferenceScriptCliArgs
+  :: TxIn
+  -> PolicyId
+  -> CliMintScriptRequirements
+createOnDiskSimpleReferenceScriptCliArgs txin polid =
+  OnDiskSimpleRefScript $ SimpleRefScriptCliArgs txin polid
+
+data PlutusRefScriptCliArgs
+  = PlutusRefScriptCliArgs
+      TxIn
+      AnyPlutusScriptVersion
+      ScriptDataOrFile
+      ExecutionUnits
+      PolicyId
+  deriving Show
+
+createOnDiskPlutusReferenceScriptCliArgs
+  :: TxIn
+  -> AnyPlutusScriptVersion
+  -> ScriptDataOrFile
+  -> ExecutionUnits
+  -> PolicyId
+  -> CliMintScriptRequirements
+createOnDiskPlutusReferenceScriptCliArgs txin scriptVersion scriptData execUnits polid =
+  OnDiskPlutusRefScript $ PlutusRefScriptCliArgs txin scriptVersion scriptData execUnits polid
+
+data CliMintScriptRequirements
+  = OnDiskSimpleOrPlutusScript OnDiskSimpleOrPlutusScriptCliArgs
+  | OnDiskSimpleRefScript SimpleRefScriptCliArgs
+  | OnDiskPlutusRefScript PlutusRefScriptCliArgs
+  deriving Show
+
+data CliScriptWitnessError
+  = SimpleScriptWitnessDecodeError ScriptDecodeError
+  | PlutusScriptWitnessDecodeError PlutusScriptDecodeError
+  | PlutusScriptWitnessLanguageNotSupportedInEra
+      AnyPlutusScriptVersion
+      AnyShelleyBasedEra
+  | PlutusScriptWitnessRedeemerError ScriptDataError
+
+instance Error CliScriptWitnessError where
+  prettyError = \case
+    SimpleScriptWitnessDecodeError err -> prettyError err
+    PlutusScriptWitnessDecodeError err -> prettyError err
+    PlutusScriptWitnessLanguageNotSupportedInEra version era ->
+      "Plutus script version " <> pshow version <> " is not supported in era " <> pshow era
+    PlutusScriptWitnessRedeemerError err -> renderScriptDataError err
+
+readMintScriptWitness
+  :: MonadIOTransError (FileError CliScriptWitnessError) t m
+  => ShelleyBasedEra era -> CliMintScriptRequirements -> t m (MintScriptWitWithPolId era)
+readMintScriptWitness sbe (OnDiskSimpleOrPlutusScript simpleOrPlutus) =
+  case simpleOrPlutus of
+    OnDiskSimpleScriptCliArgs simpleFp -> do
+      let sFp = unFile simpleFp
+      s <-
+        modifyError (fmap SimpleScriptWitnessDecodeError) $ readFileSimpleScript sFp
+      case s of
+        SimpleScript ss -> do
+          let polId = PolicyId $ hashScript s
+          return $
+            MintScriptWitWithPolId polId $
+              SimpleScriptWitness (sbeToSimpleScriptLangInEra sbe) $
+                SScript ss
+    OnDiskPlutusScriptCliArgs plutusScriptFp redeemerFile execUnits -> do
+      let sFp = unFile plutusScriptFp
+      plutusScript <-
+        modifyError (fmap PlutusScriptWitnessDecodeError) $
+          readFilePlutusScript $
+            unFile plutusScriptFp
+
+      redeemer <-
+        modifyError (FileError sFp . PlutusScriptWitnessRedeemerError) $
+          readScriptDataOrFile redeemerFile
+      case plutusScript of
+        AnyPlutusScript lang script -> do
+          let pScript = PScript script
+              polId = PolicyId $ hashScript $ PlutusScript lang script
+          sLangSupported <-
+            modifyError (FileError sFp)
+              $ hoistMaybe
+                ( PlutusScriptWitnessLanguageNotSupportedInEra
+                    (AnyPlutusScriptVersion lang)
+                    (shelleyBasedEraConstraints sbe $ AnyShelleyBasedEra sbe)
+                )
+              $ scriptLanguageSupportedInEra sbe
+              $ PlutusScriptLanguage lang
+          return $
+            MintScriptWitWithPolId polId $
+              PlutusScriptWitness
+                sLangSupported
+                lang
+                pScript
+                NoScriptDatumForMint
+                redeemer
+                execUnits
+readMintScriptWitness sbe (OnDiskSimpleRefScript (SimpleRefScriptCliArgs refTxIn polId)) =
+  return $
+    MintScriptWitWithPolId polId $
+      SimpleScriptWitness
+        (sbeToSimpleScriptLangInEra sbe)
+        (SReferenceScript refTxIn $ Just $ unPolicyId polId)
+readMintScriptWitness
+  sbe
+  ( OnDiskPlutusRefScript
+      (PlutusRefScriptCliArgs refTxIn anyPlutusScriptVersion redeemerFile execUnits polId)
+    ) = do
+    case anyPlutusScriptVersion of
+      AnyPlutusScriptVersion lang -> do
+        let pScript = PReferenceScript refTxIn $ Just $ unPolicyId polId
+        redeemer <-
+          -- TODO: Implement a new error type to capture this. FileError is not representative of cases
+          -- where we do not have access to the script.
+          modifyError (FileError "Reference script filepath not available" . PlutusScriptWitnessRedeemerError) $
+            readScriptDataOrFile redeemerFile
+        sLangSupported <-
+          -- TODO: Implement a new error type to capture this. FileError is not representative of cases
+          -- where we do not have access to the script.
+          modifyError (FileError "Reference script filepath not available")
+            $ hoistMaybe
+              ( PlutusScriptWitnessLanguageNotSupportedInEra
+                  (AnyPlutusScriptVersion lang)
+                  (shelleyBasedEraConstraints sbe $ AnyShelleyBasedEra sbe)
+              )
+            $ scriptLanguageSupportedInEra sbe
+            $ PlutusScriptLanguage lang
+        return $
+          MintScriptWitWithPolId polId $
+            PlutusScriptWitness
+              sLangSupported
+              lang
+              pScript
+              NoScriptDatumForMint
+              redeemer
+              execUnits
+
+sbeToSimpleScriptLangInEra
+  :: ShelleyBasedEra era -> ScriptLanguageInEra SimpleScript' era
+sbeToSimpleScriptLangInEra ShelleyBasedEraShelley = SimpleScriptInShelley
+sbeToSimpleScriptLangInEra ShelleyBasedEraAllegra = SimpleScriptInAllegra
+sbeToSimpleScriptLangInEra ShelleyBasedEraMary = SimpleScriptInMary
+sbeToSimpleScriptLangInEra ShelleyBasedEraAlonzo = SimpleScriptInAlonzo
+sbeToSimpleScriptLangInEra ShelleyBasedEraBabbage = SimpleScriptInBabbage
+sbeToSimpleScriptLangInEra ShelleyBasedEraConway = SimpleScriptInConway

--- a/cardano-cli/src/Cardano/CLI/Read.hs
+++ b/cardano-cli/src/Cardano/CLI/Read.hs
@@ -359,7 +359,6 @@ readScriptWitness
       datumOrFile
       redeemerOrFile
       execUnits
-      mPid
     ) = do
     caseShelleyToAlonzoOrBabbageEraOnwards
       ( const $
@@ -381,7 +380,7 @@ readScriptWitness
                   PlutusScriptWitness
                     sLangInEra
                     version
-                    (PReferenceScript refTxIn (unPolicyId <$> mPid))
+                    (PReferenceScript refTxIn)
                     datum
                     redeemer
                     execUnits
@@ -397,7 +396,6 @@ readScriptWitness
   ( SimpleReferenceScriptWitnessFiles
       refTxIn
       anyScrLang@(AnyScriptLanguage anyScriptLanguage)
-      mPid
     ) = do
     caseShelleyToAlonzoOrBabbageEraOnwards
       ( const $
@@ -411,7 +409,7 @@ readScriptWitness
               case languageOfScriptLanguageInEra sLangInEra of
                 SimpleScriptLanguage ->
                   return . SimpleScriptWitness sLangInEra $
-                    SReferenceScript refTxIn (unPolicyId <$> mPid)
+                    SReferenceScript refTxIn
                 PlutusScriptLanguage{} ->
                   error "readScriptWitness: Should not be possible to specify a plutus script"
             Nothing ->
@@ -629,9 +627,9 @@ deserialisePlutusScript bs = do
     -> Either PlutusScriptDecodeError AnyPlutusScript
   deserialiseAnyPlutusScriptVersion v lang tEnv =
     if v == show lang
-      then case deserialiseFromTextEnvelopeAnyOf [teTypes (AnyPlutusScriptVersion lang)] tEnv of
-        Left err -> Left (PlutusScriptDecodeTextEnvelopeError err)
-        Right script -> Right script
+      then
+        first PlutusScriptDecodeTextEnvelopeError $
+          deserialiseFromTextEnvelopeAnyOf [teTypes (AnyPlutusScriptVersion lang)] tEnv
       else Left $ PlutusScriptDecodeErrorVersionMismatch (Text.pack v) (AnyPlutusScriptVersion lang)
 
   teTypes :: AnyPlutusScriptVersion -> FromSomeType HasTextEnvelope AnyPlutusScript

--- a/cardano-cli/src/Cardano/CLI/Read.hs
+++ b/cardano-cli/src/Cardano/CLI/Read.hs
@@ -919,7 +919,7 @@ readSingleVote w (voteFp, mScriptWitFiles) = do
   case mScriptWitFiles of
     Nothing -> pure $ (,Nothing) <$> votProceds
     sWitFile -> do
-      let sbe = conwayEraOnwardsToShelleyBasedEra w
+      let sbe = inject w
       runExceptT $ do
         sWits <-
           firstExceptT VoteErrorScriptWitness $
@@ -965,7 +965,7 @@ readProposal w (fp, mScriptWit) = do
   case mScriptWit of
     Nothing -> pure $ (,Nothing) <$> prop
     sWitFile -> do
-      let sbe = conwayEraOnwardsToShelleyBasedEra w
+      let sbe = inject w
       runExceptT $ do
         sWit <-
           firstExceptT ProposalErrorScriptWitness $

--- a/cardano-cli/src/Cardano/CLI/Types/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Common.hs
@@ -9,6 +9,7 @@
 module Cardano.CLI.Types.Common
   ( AllOrOnly (..)
   , AddressKeyType (..)
+  , AnyPlutusScriptVersion (..)
   , BalanceTxExecUnits (..)
   , BlockId (..)
   , ByronKeyFormat (..)
@@ -416,7 +417,7 @@ data ScriptWitnessFiles witctx where
   -- TODO: Need to figure out how to exclude PlutusV1 scripts at the type level
   PlutusReferenceScriptWitnessFiles
     :: TxIn
-    -> AnyScriptLanguage
+    -> AnyPlutusScriptVersion
     -> ScriptDatumOrFile witctx
     -> ScriptRedeemerOrFile
     -> ExecutionUnits

--- a/cardano-cli/src/Cardano/CLI/Types/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Common.hs
@@ -399,11 +399,19 @@ type ScriptRedeemerOrFile = ScriptDataOrFile
 -- the script witness data representation.
 --
 -- It is era-independent, but witness context-dependent.
---
--- TODO: Potentially update to WitnessFiles so we can get
--- rid of Maybe (ScriptWitnessFiles). This will be clearer
--- in conveying that we either expect a script witness
--- or a key witness is provided at the signing stage.
+-- NB: This is in the process of being deprecated because it is difficult
+-- to accomodate for changes for specific plutus script purposes. As an
+-- example when minting a multi-asset with a plutus script we need the policy
+-- id of the said script. This is fine when we have access to the plutus script however
+-- in the case of a reference script we demand the user provides the policy id.
+-- Enshrining that change in the 'ScriptWitnessFiles' is difficult because only
+-- minting scripts require this but not the other kinds of plutus scripts (spending, certifying etc.)
+-- Another example is CIP-69 where datums are no longer required for spending scripts. This is
+-- further complicated by the fact at the parsing level we make user facing simplifications e.g `--mint-script-file`
+-- which says nothing about the script type (simple vs plutus) or script version.
+-- As a result need to separate the different script purposes into
+-- their own separate data definitions where we can make changes specific to that script purpose
+-- more easily without affecting the rest of the api.
 data ScriptWitnessFiles witctx where
   SimpleScriptWitnessFile
     :: ScriptFile
@@ -414,21 +422,21 @@ data ScriptWitnessFiles witctx where
     -> ScriptRedeemerOrFile
     -> ExecutionUnits
     -> ScriptWitnessFiles witctx
-  -- TODO: Need to figure out how to exclude PlutusV1 scripts at the type level
+  -- NB: This no longer is used for minting scripts
+  -- Use MintScriptWitnessWithPolicyId instead
   PlutusReferenceScriptWitnessFiles
     :: TxIn
     -> AnyPlutusScriptVersion
     -> ScriptDatumOrFile witctx
     -> ScriptRedeemerOrFile
     -> ExecutionUnits
-    -> Maybe PolicyId
     -- ^ For minting reference scripts
     -> ScriptWitnessFiles witctx
+  -- NB: This no longer is used for minting scripts
+  -- Use MintScriptWitnessWithPolicyId instead
   SimpleReferenceScriptWitnessFiles
     :: TxIn
     -> AnyScriptLanguage
-    -> Maybe PolicyId
-    -- ^ For minting reference scripts
     -> ScriptWitnessFiles witctx
 
 deriving instance Show (ScriptWitnessFiles witctx)

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/PlutusScriptDecodeError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/PlutusScriptDecodeError.hs
@@ -1,11 +1,13 @@
 {-# LANGUAGE LambdaCase #-}
 
-module Cardano.CLI.Types.Errors.PlutusScriptDecodeError 
-  ( PlutusScriptDecodeError(..)
-  ) where 
+module Cardano.CLI.Types.Errors.PlutusScriptDecodeError
+  ( PlutusScriptDecodeError (..)
+  )
+where
 
-import Cardano.Api
-import Data.Text (Text)
+import           Cardano.Api
+
+import           Data.Text (Text)
 
 data PlutusScriptDecodeError
   = PlutusScriptDecodeErrorUnknownVersion !Text

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/PlutusScriptDecodeError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/PlutusScriptDecodeError.hs
@@ -1,0 +1,32 @@
+{-# LANGUAGE LambdaCase #-}
+
+module Cardano.CLI.Types.Errors.PlutusScriptDecodeError 
+  ( PlutusScriptDecodeError(..)
+  ) where 
+
+import Cardano.Api
+import Data.Text (Text)
+
+data PlutusScriptDecodeError
+  = PlutusScriptDecodeErrorUnknownVersion !Text
+  | PlutusScriptJsonDecodeError !JsonDecodeError
+  | PlutusScriptDecodeTextEnvelopeError !TextEnvelopeError
+  | PlutusScriptDecodeErrorVersionMismatch
+      !Text
+      -- ^ Script version
+      !AnyPlutusScriptVersion
+      -- ^ Attempted to decode with version
+
+instance Error PlutusScriptDecodeError where
+  prettyError = \case
+    PlutusScriptDecodeErrorUnknownVersion version ->
+      "Unknown Plutus script version: " <> pretty version
+    PlutusScriptJsonDecodeError err ->
+      prettyError err
+    PlutusScriptDecodeTextEnvelopeError err ->
+      prettyError err
+    PlutusScriptDecodeErrorVersionMismatch version (AnyPlutusScriptVersion v) ->
+      "Version mismatch in code: script version that was read"
+        <> pretty version
+        <> " but tried to decode script version: "
+        <> pshow v

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/ScriptDataError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/ScriptDataError.hs
@@ -1,15 +1,14 @@
 {-# LANGUAGE LambdaCase #-}
 
-module Cardano.CLI.Types.Errors.ScriptDataError 
-  ( ScriptDataError(..)
+module Cardano.CLI.Types.Errors.ScriptDataError
+  ( ScriptDataError (..)
   , renderScriptDataError
-  ) where 
-
-
+  )
+where
 
 import           Cardano.Api
-import qualified Cardano.Binary as CBOR
 
+import qualified Cardano.Binary as CBOR
 
 data ScriptDataError
   = ScriptDataErrorFile (FileError ())

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/ScriptDataError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/ScriptDataError.hs
@@ -1,0 +1,36 @@
+{-# LANGUAGE LambdaCase #-}
+
+module Cardano.CLI.Types.Errors.ScriptDataError 
+  ( ScriptDataError(..)
+  , renderScriptDataError
+  ) where 
+
+
+
+import           Cardano.Api
+import qualified Cardano.Binary as CBOR
+
+
+data ScriptDataError
+  = ScriptDataErrorFile (FileError ())
+  | ScriptDataErrorJsonParse !FilePath !String
+  | ScriptDataErrorConversion !FilePath !ScriptDataJsonError
+  | ScriptDataErrorValidation !FilePath !ScriptDataRangeError
+  | ScriptDataErrorMetadataDecode !FilePath !CBOR.DecoderError
+  | ScriptDataErrorJsonBytes !ScriptDataJsonBytesError
+  deriving Show
+
+renderScriptDataError :: ScriptDataError -> Doc ann
+renderScriptDataError = \case
+  ScriptDataErrorFile err ->
+    prettyError err
+  ScriptDataErrorJsonParse fp jsonErr ->
+    "Invalid JSON format in file: " <> pshow fp <> "\nJSON parse error: " <> pretty jsonErr
+  ScriptDataErrorConversion fp sDataJsonErr ->
+    "Error reading metadata at: " <> pshow fp <> "\n" <> prettyError sDataJsonErr
+  ScriptDataErrorValidation fp sDataRangeErr ->
+    "Error validating script data at: " <> pshow fp <> ":\n" <> prettyError sDataRangeErr
+  ScriptDataErrorMetadataDecode fp decoderErr ->
+    "Error decoding CBOR metadata at: " <> pshow fp <> " Error: " <> pshow decoderErr
+  ScriptDataErrorJsonBytes e ->
+    prettyError e

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/ScriptDecodeError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/ScriptDecodeError.hs
@@ -7,6 +7,8 @@ where
 
 import           Cardano.Api
 
+import           Data.Text
+
 --
 -- Handling decoding the variety of script languages and formats
 --
@@ -14,6 +16,7 @@ import           Cardano.Api
 data ScriptDecodeError
   = ScriptDecodeTextEnvelopeError TextEnvelopeError
   | ScriptDecodeSimpleScriptError JsonDecodeError
+  | ScriptDecodeUnknownPlutusScriptVersion Text
   deriving Show
 
 instance Error ScriptDecodeError where
@@ -22,3 +25,5 @@ instance Error ScriptDecodeError where
       "Error decoding script: " <> prettyError err
     ScriptDecodeSimpleScriptError err ->
       "Syntax error in script: " <> prettyError err
+    ScriptDecodeUnknownPlutusScriptVersion version ->
+      "Unknown Plutus script version: " <> pshow version

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/TxCmdError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/TxCmdError.hs
@@ -19,7 +19,7 @@ import           Cardano.Api.Consensus (EraMismatch (..))
 import qualified Cardano.Api.Ledger as L
 import           Cardano.Api.Shelley
 
-import           Cardano.CLI.Plutus.Minting
+import           Cardano.CLI.EraBased.Script.Mint.Types
 import           Cardano.CLI.Read
 import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Errors.BootstrapWitnessError

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/TxCmdError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/TxCmdError.hs
@@ -19,6 +19,7 @@ import           Cardano.Api.Consensus (EraMismatch (..))
 import qualified Cardano.Api.Ledger as L
 import           Cardano.Api.Shelley
 
+import           Cardano.CLI.Plutus.Minting
 import           Cardano.CLI.Read
 import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Errors.BootstrapWitnessError
@@ -50,6 +51,7 @@ data TxCmdError
   | TxCmdScriptWitnessError ScriptWitnessError
   | TxCmdProtocolParamsError ProtocolParamsError
   | TxCmdScriptFileError (FileError ScriptDecodeError)
+  | TxCmdCliScriptWitnessError !(FileError CliScriptWitnessError)
   | TxCmdKeyFileError (FileError InputDecodeError)
   | TxCmdReadTextViewFileError !(FileError TextEnvelopeError)
   | TxCmdReadWitnessSigningDataError !ReadWitnessSigningDataError
@@ -105,6 +107,8 @@ renderTxCmdError = \case
     prettyError fileErr
   TxCmdScriptFileError fileErr ->
     prettyError fileErr
+  TxCmdCliScriptWitnessError cliScriptWitnessErr ->
+    prettyError cliScriptWitnessErr
   TxCmdKeyFileError fileErr ->
     prettyError fileErr
   TxCmdReadWitnessSigningDataError witSignDataErr ->

--- a/cardano-cli/src/Cardano/CLI/Types/Output.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Output.hs
@@ -383,7 +383,7 @@ renderScriptCosts (UTxO utxo) eUnitPrices scriptMapping executionCostMapping =
                 Left err -> Left (PlutusScriptCostErrExecError sWitInd (Just scriptHash) err) : accum
             -- TODO: Create a new sum type to encapsulate the fact that we can also
             -- have a txin and render the txin in the case of reference scripts.
-            Just (AnyScriptWitness (PlutusScriptWitness _ _ (PReferenceScript refTxIn _) _ _ _)) ->
+            Just (AnyScriptWitness (PlutusScriptWitness _ _ (PReferenceScript refTxIn) _ _ _)) ->
               case Map.lookup refTxIn utxo of
                 Nothing -> Left (PlutusScriptCostErrRefInputNotInUTxO refTxIn) : accum
                 Just (TxOut _ _ _ refScript) ->

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1731401651,
-        "narHash": "sha256-tXaUck9+0Ob4h6GBlbhYMI4ekW5e8biVJU5jPT/rjus=",
+        "lastModified": 1732134025,
+        "narHash": "sha256-BBz3q09+DqDMYnLLgqXYyAxj9amVibxuEevHzgqL6UM=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "82b295d6147a566c28dbcf038c54040f06f7e6b4",
+        "rev": "d36fcfb3c0f2632bdaf4637c72e91b93f7eada56",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Minting script witness refactor
    The type `ScriptWitnessFiles` makes it difficult to accommodate for specific changes to plutus scripts. 
    As a result we introduce `MintScriptWitnessWithPolicyId` as a first step towards deprecating `ScriptWitnessFiles`. 
    This paves the way to more readable code and allows us to introduce specific changes to the different script types i.e simple vs plutus.

  type:
  # - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Additional context for the PR goes here. If the PR fixes a particular issue please provide a [link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=) to the issue.

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
