### PR TITLE
Add certificates to CLI interface in `compatible transaction-sign` 

### DIFF
--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -364,6 +364,7 @@ test-suite cardano-cli-test
     Test.Cli.Shelley.Run.Hash
     Test.Cli.Shelley.Run.Query
     Test.Cli.Shelley.Transaction.Build
+    Test.Cli.Shelley.Transaction.Compatible.Build
     Test.Cli.VerificationKey
 
   ghc-options:

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -10857,6 +10857,25 @@ Usage: cardano-cli compatible shelley transaction signed-transaction
                                                                        | --testnet-magic NATURAL
                                                                        ]
                                                                        --fee LOVELACE
+                                                                       [
+                                                                         --certificate-file FILEPATH
+                                                                         [ --certificate-script-file FILEPATH
+                                                                           [
+                                                                             ( --certificate-redeemer-cbor-file CBOR_FILE
+                                                                             | --certificate-redeemer-file JSON_FILE
+                                                                             | --certificate-redeemer-value JSON_VALUE
+                                                                             )
+                                                                             --certificate-execution-units (INT, INT)]
+                                                                         | --certificate-tx-in-reference TX-IN
+                                                                           ( --certificate-plutus-script-v2
+                                                                           | --certificate-plutus-script-v3
+                                                                           )
+                                                                           ( --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                                           | --certificate-reference-tx-in-redeemer-file JSON_FILE
+                                                                           | --certificate-reference-tx-in-redeemer-value JSON_VALUE
+                                                                           )
+                                                                           --certificate-reference-tx-in-execution-units (INT, INT)
+                                                                         ]]
                                                                        --out-file FILEPATH
 
   Create a simple signed transaction.
@@ -10971,6 +10990,25 @@ Usage: cardano-cli compatible allegra transaction signed-transaction
                                                                        | --testnet-magic NATURAL
                                                                        ]
                                                                        --fee LOVELACE
+                                                                       [
+                                                                         --certificate-file FILEPATH
+                                                                         [ --certificate-script-file FILEPATH
+                                                                           [
+                                                                             ( --certificate-redeemer-cbor-file CBOR_FILE
+                                                                             | --certificate-redeemer-file JSON_FILE
+                                                                             | --certificate-redeemer-value JSON_VALUE
+                                                                             )
+                                                                             --certificate-execution-units (INT, INT)]
+                                                                         | --certificate-tx-in-reference TX-IN
+                                                                           ( --certificate-plutus-script-v2
+                                                                           | --certificate-plutus-script-v3
+                                                                           )
+                                                                           ( --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                                           | --certificate-reference-tx-in-redeemer-file JSON_FILE
+                                                                           | --certificate-reference-tx-in-redeemer-value JSON_VALUE
+                                                                           )
+                                                                           --certificate-reference-tx-in-execution-units (INT, INT)
+                                                                         ]]
                                                                        --out-file FILEPATH
 
   Create a simple signed transaction.
@@ -11085,6 +11123,25 @@ Usage: cardano-cli compatible mary transaction signed-transaction
                                                                     | --testnet-magic NATURAL
                                                                     ]
                                                                     --fee LOVELACE
+                                                                    [
+                                                                      --certificate-file FILEPATH
+                                                                      [ --certificate-script-file FILEPATH
+                                                                        [
+                                                                          ( --certificate-redeemer-cbor-file CBOR_FILE
+                                                                          | --certificate-redeemer-file JSON_FILE
+                                                                          | --certificate-redeemer-value JSON_VALUE
+                                                                          )
+                                                                          --certificate-execution-units (INT, INT)]
+                                                                      | --certificate-tx-in-reference TX-IN
+                                                                        ( --certificate-plutus-script-v2
+                                                                        | --certificate-plutus-script-v3
+                                                                        )
+                                                                        ( --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                                        | --certificate-reference-tx-in-redeemer-file JSON_FILE
+                                                                        | --certificate-reference-tx-in-redeemer-value JSON_VALUE
+                                                                        )
+                                                                        --certificate-reference-tx-in-execution-units (INT, INT)
+                                                                      ]]
                                                                     --out-file FILEPATH
 
   Create a simple signed transaction.
@@ -11207,6 +11264,25 @@ Usage: cardano-cli compatible alonzo transaction signed-transaction
                                                                       | --testnet-magic NATURAL
                                                                       ]
                                                                       --fee LOVELACE
+                                                                      [
+                                                                        --certificate-file FILEPATH
+                                                                        [ --certificate-script-file FILEPATH
+                                                                          [
+                                                                            ( --certificate-redeemer-cbor-file CBOR_FILE
+                                                                            | --certificate-redeemer-file JSON_FILE
+                                                                            | --certificate-redeemer-value JSON_VALUE
+                                                                            )
+                                                                            --certificate-execution-units (INT, INT)]
+                                                                        | --certificate-tx-in-reference TX-IN
+                                                                          ( --certificate-plutus-script-v2
+                                                                          | --certificate-plutus-script-v3
+                                                                          )
+                                                                          ( --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                                          | --certificate-reference-tx-in-redeemer-file JSON_FILE
+                                                                          | --certificate-reference-tx-in-redeemer-value JSON_VALUE
+                                                                          )
+                                                                          --certificate-reference-tx-in-execution-units (INT, INT)
+                                                                        ]]
                                                                       --out-file FILEPATH
 
   Create a simple signed transaction.
@@ -11339,6 +11415,25 @@ Usage: cardano-cli compatible babbage transaction signed-transaction
                                                                        | --testnet-magic NATURAL
                                                                        ]
                                                                        --fee LOVELACE
+                                                                       [
+                                                                         --certificate-file FILEPATH
+                                                                         [ --certificate-script-file FILEPATH
+                                                                           [
+                                                                             ( --certificate-redeemer-cbor-file CBOR_FILE
+                                                                             | --certificate-redeemer-file JSON_FILE
+                                                                             | --certificate-redeemer-value JSON_VALUE
+                                                                             )
+                                                                             --certificate-execution-units (INT, INT)]
+                                                                         | --certificate-tx-in-reference TX-IN
+                                                                           ( --certificate-plutus-script-v2
+                                                                           | --certificate-plutus-script-v3
+                                                                           )
+                                                                           ( --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                                           | --certificate-reference-tx-in-redeemer-file JSON_FILE
+                                                                           | --certificate-reference-tx-in-redeemer-value JSON_VALUE
+                                                                           )
+                                                                           --certificate-reference-tx-in-execution-units (INT, INT)
+                                                                         ]]
                                                                        --out-file FILEPATH
 
   Create a simple signed transaction.
@@ -11522,6 +11617,25 @@ Usage: cardano-cli compatible conway transaction signed-transaction
                                                                       | --testnet-magic NATURAL
                                                                       ]
                                                                       --fee LOVELACE
+                                                                      [
+                                                                        --certificate-file FILEPATH
+                                                                        [ --certificate-script-file FILEPATH
+                                                                          [
+                                                                            ( --certificate-redeemer-cbor-file CBOR_FILE
+                                                                            | --certificate-redeemer-file JSON_FILE
+                                                                            | --certificate-redeemer-value JSON_VALUE
+                                                                            )
+                                                                            --certificate-execution-units (INT, INT)]
+                                                                        | --certificate-tx-in-reference TX-IN
+                                                                          ( --certificate-plutus-script-v2
+                                                                          | --certificate-plutus-script-v3
+                                                                          )
+                                                                          ( --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                                          | --certificate-reference-tx-in-redeemer-file JSON_FILE
+                                                                          | --certificate-reference-tx-in-redeemer-value JSON_VALUE
+                                                                          )
+                                                                          --certificate-reference-tx-in-execution-units (INT, INT)
+                                                                        ]]
                                                                       --out-file FILEPATH
 
   Create a simple signed transaction.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_allegra_transaction_signed-transaction.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_allegra_transaction_signed-transaction.cli
@@ -8,6 +8,25 @@ Usage: cardano-cli compatible allegra transaction signed-transaction
                                                                        | --testnet-magic NATURAL
                                                                        ]
                                                                        --fee LOVELACE
+                                                                       [
+                                                                         --certificate-file FILEPATH
+                                                                         [ --certificate-script-file FILEPATH
+                                                                           [
+                                                                             ( --certificate-redeemer-cbor-file CBOR_FILE
+                                                                             | --certificate-redeemer-file JSON_FILE
+                                                                             | --certificate-redeemer-value JSON_VALUE
+                                                                             )
+                                                                             --certificate-execution-units (INT, INT)]
+                                                                         | --certificate-tx-in-reference TX-IN
+                                                                           ( --certificate-plutus-script-v2
+                                                                           | --certificate-plutus-script-v3
+                                                                           )
+                                                                           ( --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                                           | --certificate-reference-tx-in-redeemer-file JSON_FILE
+                                                                           | --certificate-reference-tx-in-redeemer-value JSON_VALUE
+                                                                           )
+                                                                           --certificate-reference-tx-in-execution-units (INT, INT)
+                                                                         ]]
                                                                        --out-file FILEPATH
 
   Create a simple signed transaction.
@@ -28,5 +47,44 @@ Available options:
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
   --fee LOVELACE           The fee amount in Lovelace.
+  --certificate-file FILEPATH
+                           Filepath of the certificate. This encompasses all
+                           types of certificates (stake pool certificates, stake
+                           key certificates etc). Optionally specify a script
+                           witness.
+  --certificate-script-file FILEPATH
+                           The file containing the script to witness the use of
+                           the certificate.
+  --certificate-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --certificate-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --certificate-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --certificate-execution-units (INT, INT)
+                           The time and space units needed by the script.
+  --certificate-tx-in-reference TX-IN
+                           TxId#TxIx - Specify a reference input. The reference
+                           input must have a plutus reference script attached.
+  --certificate-plutus-script-v2
+                           Specify a plutus script v2 reference script.
+  --certificate-plutus-script-v3
+                           Specify a plutus script v3 reference script.
+  --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --certificate-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --certificate-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --certificate-reference-tx-in-execution-units (INT, INT)
+                           The time and space units needed by the script.
   --out-file FILEPATH      The output file.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_alonzo_transaction_signed-transaction.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_alonzo_transaction_signed-transaction.cli
@@ -16,6 +16,25 @@ Usage: cardano-cli compatible alonzo transaction signed-transaction
                                                                       | --testnet-magic NATURAL
                                                                       ]
                                                                       --fee LOVELACE
+                                                                      [
+                                                                        --certificate-file FILEPATH
+                                                                        [ --certificate-script-file FILEPATH
+                                                                          [
+                                                                            ( --certificate-redeemer-cbor-file CBOR_FILE
+                                                                            | --certificate-redeemer-file JSON_FILE
+                                                                            | --certificate-redeemer-value JSON_VALUE
+                                                                            )
+                                                                            --certificate-execution-units (INT, INT)]
+                                                                        | --certificate-tx-in-reference TX-IN
+                                                                          ( --certificate-plutus-script-v2
+                                                                          | --certificate-plutus-script-v3
+                                                                          )
+                                                                          ( --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                                          | --certificate-reference-tx-in-redeemer-file JSON_FILE
+                                                                          | --certificate-reference-tx-in-redeemer-value JSON_VALUE
+                                                                          )
+                                                                          --certificate-reference-tx-in-execution-units (INT, INT)
+                                                                        ]]
                                                                       --out-file FILEPATH
 
   Create a simple signed transaction.
@@ -63,5 +82,44 @@ Available options:
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
   --fee LOVELACE           The fee amount in Lovelace.
+  --certificate-file FILEPATH
+                           Filepath of the certificate. This encompasses all
+                           types of certificates (stake pool certificates, stake
+                           key certificates etc). Optionally specify a script
+                           witness.
+  --certificate-script-file FILEPATH
+                           The file containing the script to witness the use of
+                           the certificate.
+  --certificate-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --certificate-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --certificate-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --certificate-execution-units (INT, INT)
+                           The time and space units needed by the script.
+  --certificate-tx-in-reference TX-IN
+                           TxId#TxIx - Specify a reference input. The reference
+                           input must have a plutus reference script attached.
+  --certificate-plutus-script-v2
+                           Specify a plutus script v2 reference script.
+  --certificate-plutus-script-v3
+                           Specify a plutus script v3 reference script.
+  --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --certificate-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --certificate-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --certificate-reference-tx-in-execution-units (INT, INT)
+                           The time and space units needed by the script.
   --out-file FILEPATH      The output file.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_babbage_transaction_signed-transaction.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_babbage_transaction_signed-transaction.cli
@@ -19,6 +19,25 @@ Usage: cardano-cli compatible babbage transaction signed-transaction
                                                                        | --testnet-magic NATURAL
                                                                        ]
                                                                        --fee LOVELACE
+                                                                       [
+                                                                         --certificate-file FILEPATH
+                                                                         [ --certificate-script-file FILEPATH
+                                                                           [
+                                                                             ( --certificate-redeemer-cbor-file CBOR_FILE
+                                                                             | --certificate-redeemer-file JSON_FILE
+                                                                             | --certificate-redeemer-value JSON_VALUE
+                                                                             )
+                                                                             --certificate-execution-units (INT, INT)]
+                                                                         | --certificate-tx-in-reference TX-IN
+                                                                           ( --certificate-plutus-script-v2
+                                                                           | --certificate-plutus-script-v3
+                                                                           )
+                                                                           ( --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                                           | --certificate-reference-tx-in-redeemer-file JSON_FILE
+                                                                           | --certificate-reference-tx-in-redeemer-value JSON_VALUE
+                                                                           )
+                                                                           --certificate-reference-tx-in-execution-units (INT, INT)
+                                                                         ]]
                                                                        --out-file FILEPATH
 
   Create a simple signed transaction.
@@ -79,5 +98,44 @@ Available options:
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
   --fee LOVELACE           The fee amount in Lovelace.
+  --certificate-file FILEPATH
+                           Filepath of the certificate. This encompasses all
+                           types of certificates (stake pool certificates, stake
+                           key certificates etc). Optionally specify a script
+                           witness.
+  --certificate-script-file FILEPATH
+                           The file containing the script to witness the use of
+                           the certificate.
+  --certificate-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --certificate-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --certificate-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --certificate-execution-units (INT, INT)
+                           The time and space units needed by the script.
+  --certificate-tx-in-reference TX-IN
+                           TxId#TxIx - Specify a reference input. The reference
+                           input must have a plutus reference script attached.
+  --certificate-plutus-script-v2
+                           Specify a plutus script v2 reference script.
+  --certificate-plutus-script-v3
+                           Specify a plutus script v3 reference script.
+  --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --certificate-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --certificate-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --certificate-reference-tx-in-execution-units (INT, INT)
+                           The time and space units needed by the script.
   --out-file FILEPATH      The output file.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_transaction_signed-transaction.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_transaction_signed-transaction.cli
@@ -51,6 +51,25 @@ Usage: cardano-cli compatible conway transaction signed-transaction
                                                                       | --testnet-magic NATURAL
                                                                       ]
                                                                       --fee LOVELACE
+                                                                      [
+                                                                        --certificate-file FILEPATH
+                                                                        [ --certificate-script-file FILEPATH
+                                                                          [
+                                                                            ( --certificate-redeemer-cbor-file CBOR_FILE
+                                                                            | --certificate-redeemer-file JSON_FILE
+                                                                            | --certificate-redeemer-value JSON_VALUE
+                                                                            )
+                                                                            --certificate-execution-units (INT, INT)]
+                                                                        | --certificate-tx-in-reference TX-IN
+                                                                          ( --certificate-plutus-script-v2
+                                                                          | --certificate-plutus-script-v3
+                                                                          )
+                                                                          ( --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                                          | --certificate-reference-tx-in-redeemer-file JSON_FILE
+                                                                          | --certificate-reference-tx-in-redeemer-value JSON_VALUE
+                                                                          )
+                                                                          --certificate-reference-tx-in-execution-units (INT, INT)
+                                                                        ]]
                                                                       --out-file FILEPATH
 
   Create a simple signed transaction.
@@ -174,5 +193,44 @@ Available options:
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
   --fee LOVELACE           The fee amount in Lovelace.
+  --certificate-file FILEPATH
+                           Filepath of the certificate. This encompasses all
+                           types of certificates (stake pool certificates, stake
+                           key certificates etc). Optionally specify a script
+                           witness.
+  --certificate-script-file FILEPATH
+                           The file containing the script to witness the use of
+                           the certificate.
+  --certificate-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --certificate-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --certificate-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --certificate-execution-units (INT, INT)
+                           The time and space units needed by the script.
+  --certificate-tx-in-reference TX-IN
+                           TxId#TxIx - Specify a reference input. The reference
+                           input must have a plutus reference script attached.
+  --certificate-plutus-script-v2
+                           Specify a plutus script v2 reference script.
+  --certificate-plutus-script-v3
+                           Specify a plutus script v3 reference script.
+  --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --certificate-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --certificate-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --certificate-reference-tx-in-execution-units (INT, INT)
+                           The time and space units needed by the script.
   --out-file FILEPATH      The output file.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_mary_transaction_signed-transaction.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_mary_transaction_signed-transaction.cli
@@ -8,6 +8,25 @@ Usage: cardano-cli compatible mary transaction signed-transaction
                                                                     | --testnet-magic NATURAL
                                                                     ]
                                                                     --fee LOVELACE
+                                                                    [
+                                                                      --certificate-file FILEPATH
+                                                                      [ --certificate-script-file FILEPATH
+                                                                        [
+                                                                          ( --certificate-redeemer-cbor-file CBOR_FILE
+                                                                          | --certificate-redeemer-file JSON_FILE
+                                                                          | --certificate-redeemer-value JSON_VALUE
+                                                                          )
+                                                                          --certificate-execution-units (INT, INT)]
+                                                                      | --certificate-tx-in-reference TX-IN
+                                                                        ( --certificate-plutus-script-v2
+                                                                        | --certificate-plutus-script-v3
+                                                                        )
+                                                                        ( --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                                        | --certificate-reference-tx-in-redeemer-file JSON_FILE
+                                                                        | --certificate-reference-tx-in-redeemer-value JSON_VALUE
+                                                                        )
+                                                                        --certificate-reference-tx-in-execution-units (INT, INT)
+                                                                      ]]
                                                                     --out-file FILEPATH
 
   Create a simple signed transaction.
@@ -28,5 +47,44 @@ Available options:
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
   --fee LOVELACE           The fee amount in Lovelace.
+  --certificate-file FILEPATH
+                           Filepath of the certificate. This encompasses all
+                           types of certificates (stake pool certificates, stake
+                           key certificates etc). Optionally specify a script
+                           witness.
+  --certificate-script-file FILEPATH
+                           The file containing the script to witness the use of
+                           the certificate.
+  --certificate-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --certificate-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --certificate-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --certificate-execution-units (INT, INT)
+                           The time and space units needed by the script.
+  --certificate-tx-in-reference TX-IN
+                           TxId#TxIx - Specify a reference input. The reference
+                           input must have a plutus reference script attached.
+  --certificate-plutus-script-v2
+                           Specify a plutus script v2 reference script.
+  --certificate-plutus-script-v3
+                           Specify a plutus script v3 reference script.
+  --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --certificate-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --certificate-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --certificate-reference-tx-in-execution-units (INT, INT)
+                           The time and space units needed by the script.
   --out-file FILEPATH      The output file.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_shelley_transaction_signed-transaction.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_shelley_transaction_signed-transaction.cli
@@ -8,6 +8,25 @@ Usage: cardano-cli compatible shelley transaction signed-transaction
                                                                        | --testnet-magic NATURAL
                                                                        ]
                                                                        --fee LOVELACE
+                                                                       [
+                                                                         --certificate-file FILEPATH
+                                                                         [ --certificate-script-file FILEPATH
+                                                                           [
+                                                                             ( --certificate-redeemer-cbor-file CBOR_FILE
+                                                                             | --certificate-redeemer-file JSON_FILE
+                                                                             | --certificate-redeemer-value JSON_VALUE
+                                                                             )
+                                                                             --certificate-execution-units (INT, INT)]
+                                                                         | --certificate-tx-in-reference TX-IN
+                                                                           ( --certificate-plutus-script-v2
+                                                                           | --certificate-plutus-script-v3
+                                                                           )
+                                                                           ( --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                                           | --certificate-reference-tx-in-redeemer-file JSON_FILE
+                                                                           | --certificate-reference-tx-in-redeemer-value JSON_VALUE
+                                                                           )
+                                                                           --certificate-reference-tx-in-execution-units (INT, INT)
+                                                                         ]]
                                                                        --out-file FILEPATH
 
   Create a simple signed transaction.
@@ -28,5 +47,44 @@ Available options:
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
   --fee LOVELACE           The fee amount in Lovelace.
+  --certificate-file FILEPATH
+                           Filepath of the certificate. This encompasses all
+                           types of certificates (stake pool certificates, stake
+                           key certificates etc). Optionally specify a script
+                           witness.
+  --certificate-script-file FILEPATH
+                           The file containing the script to witness the use of
+                           the certificate.
+  --certificate-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --certificate-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --certificate-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --certificate-execution-units (INT, INT)
+                           The time and space units needed by the script.
+  --certificate-tx-in-reference TX-IN
+                           TxId#TxIx - Specify a reference input. The reference
+                           input must have a plutus reference script attached.
+  --certificate-plutus-script-v2
+                           Specify a plutus script v2 reference script.
+  --certificate-plutus-script-v3
+                           Specify a plutus script v3 reference script.
+  --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --certificate-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --certificate-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --certificate-reference-tx-in-execution-units (INT, INT)
+                           The time and space units needed by the script.
   --out-file FILEPATH      The output file.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/Shelley/Transaction/Compatible/Build.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/Shelley/Transaction/Compatible/Build.hs
@@ -1,0 +1,102 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Test.Cli.Shelley.Transaction.Compatible.Build where
+
+import           Cardano.Api.Eras
+import           Cardano.Api.Pretty
+
+import           Control.Monad.Catch (MonadCatch)
+import           Control.Monad.IO.Class
+import           Data.Aeson (Value)
+import qualified Data.Aeson as A
+import           Data.Char (toLower)
+import           Data.String (IsString (..))
+import           GHC.Stack
+
+import           Test.Cardano.CLI.Util
+
+import           Hedgehog
+import qualified Hedgehog.Extras as H
+
+inputDir :: FilePath
+inputDir = "test/cardano-cli-test/files/input/shelley/transaction"
+
+-- | Execute me with:
+-- @cabal test cardano-cli-test --test-options '-p "/conway transaction build one voter many votes/"'@
+hprop_compatible_conway_transaction_build_one_voter_many_votes :: Property
+hprop_compatible_conway_transaction_build_one_voter_many_votes = propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir -> do
+  refOutFile <- H.noteTempFile tempDir "reference_tx.traw"
+  outFile <- H.noteTempFile tempDir "tx.traw"
+  let eraName = map toLower . docToString $ pretty ConwayEra
+
+  let args =
+        [ "--tx-in"
+        , "6e8c947816e82627aeccb55300074f2894a2051332f62a1c8954e7b588a18be7#0"
+        , "--tx-out"
+        , "addr_test1vpfwv0ezc5g8a4mkku8hhy3y3vp92t7s3ul8g778g5yegsgalc6gc+24910487859"
+        , "--fee"
+        , "178569"
+        , "--certificate-file"
+        , "test/cardano-cli-golden/files/golden/shelley/stake-address/reg-certificate-2.json"
+        , "--certificate-script-file"
+        , "test/cardano-cli-golden/files/input/AlwaysSucceeds.plutus"
+        , "--certificate-redeemer-value"
+        , "0"
+        , "--certificate-execution-units"
+        , "(0,0)"
+        ]
+
+  -- reference transaction
+  _ <-
+    execCardanoCLI $
+      [ eraName
+      , "transaction"
+      , "build-raw"
+      ]
+        <> args
+        <> [ "--out-file"
+           , refOutFile
+           ]
+
+  -- tested compatible transaction
+  _ <-
+    execCardanoCLI $
+      [ "compatible"
+      , eraName
+      , "transaction"
+      , "signed-transaction"
+      ]
+        <> args
+        <> [ "--out-file"
+           , outFile
+           ]
+
+  assertTxFilesEqual refOutFile outFile
+
+assertTxFilesEqual
+  :: forall m
+   . (HasCallStack, MonadIO m, MonadTest m, MonadCatch m)
+  => FilePath
+  -- ^ expected
+  -> FilePath
+  -- ^ tested
+  -> m ()
+assertTxFilesEqual f1 f2 = withFrozenCallStack $ do
+  tx1 <- viewTx f1
+  tx2 <- viewTx f2
+
+  tx1 === tx2
+ where
+  -- deserialise a transaction from JSON file into a Value
+  viewTx :: HasCallStack => FilePath -> m Value
+  viewTx f =
+    withFrozenCallStack $
+      H.leftFailM $
+        A.eitherDecode . fromString
+          <$> execCardanoCLI
+            [ "debug"
+            , "transaction"
+            , "view"
+            , "--tx-body-file"
+            , f
+            ]

--- a/flake.nix
+++ b/flake.nix
@@ -161,18 +161,21 @@
                 ${exportCliPath}
                 cp -r ${filteredProjectBase}/* ..
                '' + (if isDarwin
-                    then '' 
+                    then ''
                        export PATH=${macOS-security}/bin:$PATH
                     ''
                     else '''');
               packages.cardano-cli.components.tests.cardano-cli-test.preCheck = let
                 # This define files included in the directory that will be passed to `H.getProjectBase` for this test:
-                filteredProjectBase = inputs.incl ./. mainnetConfigFiles;
+                filteredProjectBase = inputs.incl ./. (mainnetConfigFiles ++ [
+                  "cardano-cli/test/cardano-cli-golden/files/golden/shelley/stake-address/reg-certificate-2.json"
+                  "cardano-cli/test/cardano-cli-golden/files/input/AlwaysSucceeds.plutus"
+                ]);
               in ''
                 ${exportCliPath}
                 cp -r ${filteredProjectBase}/* ..
                '' + (if isDarwin
-                    then '' 
+                    then ''
                        export PATH=${macOS-security}/bin:$PATH
                     ''
                     else '''');


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Add certificates to CLI interface in `compatible transaction-sign` 
# uncomment types applicable to the change:
  type:
   - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
   - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Requires:
- https://github.com/IntersectMBO/cardano-api/pull/691

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
