### PR TITLE
Add mnemonic sentence support

### DIFF
--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -181,6 +181,7 @@ library
     Cardano.CLI.Read
     Cardano.CLI.Render
     Cardano.CLI.Run
+    Cardano.CLI.Run.Mnemonic
     Cardano.CLI.TopHandler
     Cardano.CLI.Type.Common
     Cardano.CLI.Type.Error.AddressCmdError
@@ -256,6 +257,7 @@ library
     exceptions,
     filepath,
     formatting,
+    haskeline,
     http-client,
     http-client-tls,
     http-types,

--- a/cardano-cli/src/Cardano/CLI/EraIndependent/Key/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/EraIndependent/Key/Command.hs
@@ -6,6 +6,10 @@ module Cardano.CLI.EraIndependent.Key.Command
   ( KeyCmds (..)
   , KeyVerificationKeyCmdArgs (..)
   , KeyNonExtendedKeyCmdArgs (..)
+  , KeyGenerateMnemonicCmdArgs (..)
+  , KeyExtendedSigningKeyFromMnemonicArgs (..)
+  , ExtendedSigningType (..)
+  , MnemonicSource (..)
   , KeyConvertByronKeyCmdArgs (..)
   , KeyConvertByronGenesisVKeyCmdArgs (..)
   , KeyConvertITNKeyCmdArgs (..)
@@ -19,12 +23,15 @@ where
 import Cardano.Api.Shelley
 
 import Cardano.CLI.Type.Common
+import Cardano.Prelude (Word32)
 
 import Data.Text (Text)
 
 data KeyCmds
   = KeyVerificationKeyCmd !KeyVerificationKeyCmdArgs
   | KeyNonExtendedKeyCmd !KeyNonExtendedKeyCmdArgs
+  | KeyGenerateMnemonicCmd !KeyGenerateMnemonicCmdArgs
+  | KeyExtendedSigningKeyFromMnemonicCmd !KeyExtendedSigningKeyFromMnemonicArgs
   | KeyConvertByronKeyCmd !KeyConvertByronKeyCmdArgs
   | KeyConvertByronGenesisVKeyCmd !KeyConvertByronGenesisVKeyCmdArgs
   | KeyConvertITNKeyCmd !KeyConvertITNKeyCmdArgs
@@ -50,6 +57,41 @@ data KeyNonExtendedKeyCmdArgs = KeyNonExtendedKeyCmdArgs
   , nonExtendedVkeyFileOut :: !(VerificationKeyFile Out)
   -- ^ Output filepath of the verification key
   }
+  deriving Show
+
+-- | Generate a mnemonic phrase that can be used to derive signing keys.
+data KeyGenerateMnemonicCmdArgs = KeyGenerateMnemonicCmdArgs
+  { mnemonicOutputFormat :: !(Maybe (File () Out))
+  -- ^ Output format for the mnemonic phrase
+  , mnemonicWords :: !MnemonicSize
+  -- ^ Number of mnemonic words to generate it must be one of: 12, 15, 18, 21, or 24.
+  }
+  deriving Show
+
+-- | Get an extended signing key from a mnemonic.
+data KeyExtendedSigningKeyFromMnemonicArgs = KeyExtendedSigningKeyFromMnemonicArgs
+  { keyOutputFormat :: !KeyOutputFormat
+  , derivedExtendedSigningKeyType :: !ExtendedSigningType
+  , derivationAccountNo :: !Word32
+  , mnemonicSource :: !MnemonicSource
+  , signingKeyFileOut :: !(SigningKeyFile Out)
+  }
+  deriving Show
+
+data MnemonicSource
+  = MnemonicFromFile !(File () In)
+  | MnemonicFromInteractivePrompt
+  deriving Show
+
+-- | Type of the key derived from a mnemonic
+-- together with the payment key number in the derivation path
+-- for cases where it is applicable.
+data ExtendedSigningType
+  = ExtendedSigningPaymentKey !Word32
+  | ExtendedSigningStakeKey !Word32
+  | ExtendedSigningDRepKey
+  | ExtendedSigningCCColdKey
+  | ExtendedSigningCCHotKey
   deriving Show
 
 -- | Convert a Byron payment, genesis or genesis delegate key (signing or
@@ -124,6 +166,10 @@ renderKeyCmds = \case
     "key verification-key"
   KeyNonExtendedKeyCmd{} ->
     "key non-extended-key"
+  KeyGenerateMnemonicCmd{} ->
+    "key generate-mnemonic"
+  KeyExtendedSigningKeyFromMnemonicCmd{} ->
+    "key from-mnemonic"
   KeyConvertByronKeyCmd{} ->
     "key convert-byron-key"
   KeyConvertByronGenesisVKeyCmd{} ->

--- a/cardano-cli/src/Cardano/CLI/Run/Mnemonic.hs
+++ b/cardano-cli/src/Cardano/CLI/Run/Mnemonic.hs
@@ -1,0 +1,221 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+
+module Cardano.CLI.Run.Mnemonic (generateMnemonic, extendedSigningKeyFromMnemonicImpl) where
+
+import Cardano.Api
+  ( AsType
+      ( AsCommitteeColdExtendedKey
+      , AsCommitteeHotExtendedKey
+      , AsDRepExtendedKey
+      , AsPaymentExtendedKey
+      , AsStakeExtendedKey
+      )
+  , ExceptT
+  , File
+  , FileDirection (Out)
+  , HasTextEnvelope
+  , Key (SigningKey)
+  , MnemonicSize (..)
+  , MnemonicToSigningKeyError
+  , MonadIO (..)
+  , SerialiseAsBech32
+  , except
+  , findMnemonicWordsWithPrefix
+  , firstExceptT
+  , left
+  , newExceptT
+  , readTextFile
+  , serialiseToBech32
+  , signingKeyFromMnemonic
+  , signingKeyFromMnemonicWithPaymentKeyIndex
+  , textEnvelopeToJSON
+  , writeLazyByteStringFile
+  , writeTextFile
+  )
+import Cardano.Api qualified as Api
+
+import Cardano.CLI.EraIndependent.Key.Command qualified as Cmd
+import Cardano.CLI.Type.Common (KeyOutputFormat (..), SigningKeyFile)
+import Cardano.CLI.Type.Error.KeyCmdError
+  ( KeyCmdError
+      ( KeyCmdMnemonicError
+      , KeyCmdReadMnemonicFileError
+      , KeyCmdWriteFileError
+      , KeyCmdWrongNumOfMnemonics
+      )
+  )
+import Cardano.Prelude (isSpace)
+
+import Control.Monad (when)
+import Data.Bifunctor (Bifunctor (..))
+import Data.Text (Text)
+import Data.Text qualified as T
+import Data.Word (Word32)
+import System.Console.Haskeline
+  ( Completion
+  , InputT
+  , Settings (..)
+  , completeWord'
+  , defaultBehavior
+  , defaultPrefs
+  , getInputLineWithInitial
+  , runInputTBehaviorWithPrefs
+  , simpleCompletion
+  )
+import System.Console.Haskeline.Completion (CompletionFunc)
+
+-- | Generate a mnemonic and write it to a file or stdout.
+generateMnemonic
+  :: MonadIO m
+  => MnemonicSize
+  -- ^ The number of words in the mnemonic.
+  -> Maybe (File () Out)
+  -- ^ The file to write the mnemonic to. If 'Nothing', write to stdout.
+  -> ExceptT KeyCmdError m ()
+generateMnemonic mnemonicWords mnemonicOutputFormat = do
+  mnemonic <- firstExceptT KeyCmdMnemonicError $ Api.generateMnemonic mnemonicWords
+  let expectedNumOfMnemonicWords = mnemonicSizeToInt mnemonicWords
+      obtainedNumOfMnemonicWords = length mnemonic
+  when (obtainedNumOfMnemonicWords /= expectedNumOfMnemonicWords) $
+    left $
+      KeyCmdWrongNumOfMnemonics expectedNumOfMnemonicWords obtainedNumOfMnemonicWords
+  case mnemonicOutputFormat of
+    Just outFile ->
+      firstExceptT KeyCmdWriteFileError . newExceptT $
+        writeTextFile outFile (T.unwords mnemonic)
+    Nothing -> liftIO $ putStrLn $ T.unpack (T.unwords mnemonic)
+ where
+  mnemonicSizeToInt :: MnemonicSize -> Int
+  mnemonicSizeToInt MS12 = 12
+  mnemonicSizeToInt MS15 = 15
+  mnemonicSizeToInt MS18 = 18
+  mnemonicSizeToInt MS21 = 21
+  mnemonicSizeToInt MS24 = 24
+
+-- | Derive an extended signing key from a mnemonic and write it to a file.
+extendedSigningKeyFromMnemonicImpl
+  :: KeyOutputFormat
+  -- ^ The format in which to write the signing key.
+  -> Cmd.ExtendedSigningType
+  -- ^ The type of the extended signing key to derive with an optional payment key index.
+  -> Word32
+  -- ^ The account index.
+  -> Cmd.MnemonicSource
+  -- ^ The source of the mnemonic (either file or stdin).
+  -> SigningKeyFile Out
+  -- ^ The file to write the signing key to.
+  -> ExceptT KeyCmdError IO ()
+extendedSigningKeyFromMnemonicImpl keyOutputFormat derivedExtendedSigningKeyType derivationAccountNo mnemonicSource signingKeyFileOut =
+  do
+    let writeKeyToFile
+          :: (HasTextEnvelope (SigningKey a), SerialiseAsBech32 (SigningKey a))
+          => SigningKey a -> ExceptT KeyCmdError IO ()
+        writeKeyToFile = writeSigningKeyFile keyOutputFormat signingKeyFileOut
+
+        wrapException :: Either MnemonicToSigningKeyError a -> ExceptT KeyCmdError IO a
+        wrapException = except . first KeyCmdMnemonicError
+
+    mnemonicWords <- readMnemonic mnemonicSource
+
+    case derivedExtendedSigningKeyType of
+      Cmd.ExtendedSigningPaymentKey paymentKeyNo ->
+        writeKeyToFile
+          =<< wrapException
+            ( signingKeyFromMnemonicWithPaymentKeyIndex
+                AsPaymentExtendedKey
+                mnemonicWords
+                derivationAccountNo
+                paymentKeyNo
+            )
+      Cmd.ExtendedSigningStakeKey paymentKeyNo ->
+        writeKeyToFile
+          =<< wrapException
+            ( signingKeyFromMnemonicWithPaymentKeyIndex
+                AsStakeExtendedKey
+                mnemonicWords
+                derivationAccountNo
+                paymentKeyNo
+            )
+      Cmd.ExtendedSigningDRepKey ->
+        writeKeyToFile
+          =<< wrapException (signingKeyFromMnemonic AsDRepExtendedKey mnemonicWords derivationAccountNo)
+      Cmd.ExtendedSigningCCColdKey ->
+        writeKeyToFile
+          =<< wrapException
+            (signingKeyFromMnemonic AsCommitteeColdExtendedKey mnemonicWords derivationAccountNo)
+      Cmd.ExtendedSigningCCHotKey ->
+        writeKeyToFile
+          =<< wrapException
+            (signingKeyFromMnemonic AsCommitteeHotExtendedKey mnemonicWords derivationAccountNo)
+ where
+  writeSigningKeyFile
+    :: (HasTextEnvelope (SigningKey a), SerialiseAsBech32 (SigningKey a))
+    => KeyOutputFormat -> SigningKeyFile Out -> SigningKey a -> ExceptT KeyCmdError IO ()
+  writeSigningKeyFile fmt sKeyPath skey =
+    firstExceptT KeyCmdWriteFileError $
+      case fmt of
+        KeyOutputFormatTextEnvelope ->
+          newExceptT $
+            writeLazyByteStringFile sKeyPath $
+              textEnvelopeToJSON Nothing skey
+        KeyOutputFormatBech32 ->
+          newExceptT $
+            writeTextFile sKeyPath $
+              serialiseToBech32 skey
+
+  readMnemonic :: Cmd.MnemonicSource -> ExceptT KeyCmdError IO [Text]
+  readMnemonic (Cmd.MnemonicFromFile filePath) = do
+    fileText <- firstExceptT KeyCmdReadMnemonicFileError $ except =<< readTextFile filePath
+    return $ map T.pack $ words $ T.unpack fileText
+  readMnemonic Cmd.MnemonicFromInteractivePrompt =
+    liftIO $ do
+      putStrLn $
+        unlines
+          [ ""
+          , "Please enter your mnemonic sentence."
+          , ""
+          , " - It should consist of either: 12, 15, 18, 21, or 24 words."
+          , " - To terminate, press enter on an empty line."
+          , " - To abort you can press CTRL+C."
+          , ""
+          , "(If your terminal supports it, you can use the TAB key for word completion.)"
+          , ""
+          ]
+      runInputTBehaviorWithPrefs defaultBehavior defaultPrefs settings (inputT ("", "") [])
+   where
+    settings :: Monad m => Settings m
+    settings =
+      Settings
+        { complete = completionFunc
+        , historyFile = Nothing
+        , autoAddHistory = False
+        }
+
+    completionFunc :: Monad m => CompletionFunc m
+    completionFunc = completeWord' Nothing isSpace completeMnemonicWord
+
+    completeMnemonicWord :: Monad m => String -> m [Completion]
+    completeMnemonicWord prefix = return $ map (simpleCompletion . T.unpack . fst) $ findMnemonicWordsWithPrefix (T.pack prefix)
+
+    inputT :: (String, String) -> [Text] -> InputT IO [Text]
+    inputT prefill mnemonic = do
+      minput <- getInputLineWithInitial (show (length mnemonic + 1) <> ". ") prefill
+      case minput of
+        Nothing -> return $ reverse mnemonic
+        Just "" -> return $ reverse mnemonic
+        Just input ->
+          let newWords = map (T.toLower . T.pack) $ filter (not . null) $ words input
+           in case span isValidMnemonicWord newWords of
+                (allWords, []) -> inputT ("", "") (reverse allWords ++ mnemonic)
+                (validWords, invalidWord : notValidatedWords) -> do
+                  liftIO $ putStrLn $ "The word \"" <> T.unpack invalidWord <> "\" is not in the memonic dictionary"
+                  let textBeforeCursor = unwords (map T.unpack validWords <> [T.unpack invalidWord])
+                      textAfterCursor =
+                        if null notValidatedWords
+                          then ""
+                          else ' ' : unwords (map T.unpack notValidatedWords)
+                  inputT (textBeforeCursor, textAfterCursor) mnemonic
+
+    isValidMnemonicWord :: Text -> Bool
+    isValidMnemonicWord word = word `elem` map fst (findMnemonicWordsWithPrefix word)

--- a/cardano-cli/src/Cardano/CLI/Type/Error/KeyCmdError.hs
+++ b/cardano-cli/src/Cardano/CLI/Type/Error/KeyCmdError.hs
@@ -21,7 +21,14 @@ import Data.Text (Text)
 data KeyCmdError
   = KeyCmdReadFileError !(FileError TextEnvelopeError)
   | KeyCmdReadKeyFileError !(FileError InputDecodeError)
+  | KeyCmdReadMnemonicFileError !(FileError ())
   | KeyCmdWriteFileError !(FileError ())
+  | KeyCmdMnemonicError MnemonicToSigningKeyError
+  | KeyCmdWrongNumOfMnemonics
+      !Int
+      -- ^ Expected number of mnemonics
+      !Int
+      -- ^ Actual number of mnemonics
   | KeyCmdByronKeyFailure !Byron.ByronKeyFailure
   | -- | Text representation of the parse error. Unfortunately, the actual
     -- error type isn't exported.
@@ -43,8 +50,14 @@ renderKeyCmdError err =
       prettyError fileErr
     KeyCmdReadKeyFileError fileErr ->
       prettyError fileErr
+    KeyCmdReadMnemonicFileError fileErr ->
+      "Error reading mnemonic file: " <> prettyError fileErr
     KeyCmdWriteFileError fileErr ->
       prettyError fileErr
+    KeyCmdMnemonicError mnemonicErr ->
+      "Error converting the mnemonic into a key: " <> prettyError mnemonicErr
+    KeyCmdWrongNumOfMnemonics expected actual ->
+      "Internal error: expected " <> pretty expected <> " mnemonics, but got " <> pretty actual
     KeyCmdByronKeyFailure e ->
       Byron.renderByronKeyFailure e
     KeyCmdByronKeyParseError errTxt ->

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -63,6 +63,8 @@ Usage: cardano-cli address info --address ADDRESS [--out-file FILEPATH]
 Usage: cardano-cli key 
                          ( verification-key
                          | non-extended-key
+                         | generate-mnemonic
+                         | derive-from-mnemonic
                          | convert-byron-key
                          | convert-byron-genesis-vkey
                          | convert-itn-key
@@ -83,6 +85,27 @@ Usage: cardano-cli key non-extended-key --extended-verification-key-file FILEPAT
 
   Get a non-extended verification key from an extended verification key. This
   supports all extended key types.
+
+Usage: cardano-cli key generate-mnemonic [--out-file FILEPATH] --size WORD32
+
+  Generate a mnemonic sentence that can be used for key derivation.
+
+Usage: cardano-cli key derive-from-mnemonic [--key-output-format STRING]
+                                              ( --payment-key-with-number WORD32
+                                              | --stake-key-with-number WORD32
+                                              | --drep-key
+                                              | --cc-cold-key
+                                              | --cc-hot-key
+                                              )
+                                              --account-number WORD32
+                                              ( --mnemonic-from-file FILEPATH
+                                              | --mnemonic-from-interactive-prompt
+                                              )
+                                              --signing-key-file FILEPATH
+
+  Derive an extended signing key from a mnemonic sentence. To ensure the safety
+  of the mnemonic phrase, we recommend that key derivation is performed in an
+  air-gapped environment.
 
 Usage: cardano-cli key convert-byron-key [--password TEXT]
                                            ( --byron-payment-key-type
@@ -1048,6 +1071,8 @@ Usage: cardano-cli shelley address info --address ADDRESS [--out-file FILEPATH]
 Usage: cardano-cli shelley key 
                                  ( verification-key
                                  | non-extended-key
+                                 | generate-mnemonic
+                                 | derive-from-mnemonic
                                  | convert-byron-key
                                  | convert-byron-genesis-vkey
                                  | convert-itn-key
@@ -1068,6 +1093,28 @@ Usage: cardano-cli shelley key non-extended-key --extended-verification-key-file
 
   Get a non-extended verification key from an extended verification key. This
   supports all extended key types.
+
+Usage: cardano-cli shelley key generate-mnemonic [--out-file FILEPATH]
+                                                   --size WORD32
+
+  Generate a mnemonic sentence that can be used for key derivation.
+
+Usage: cardano-cli shelley key derive-from-mnemonic [--key-output-format STRING]
+                                                      ( --payment-key-with-number WORD32
+                                                      | --stake-key-with-number WORD32
+                                                      | --drep-key
+                                                      | --cc-cold-key
+                                                      | --cc-hot-key
+                                                      )
+                                                      --account-number WORD32
+                                                      ( --mnemonic-from-file FILEPATH
+                                                      | --mnemonic-from-interactive-prompt
+                                                      )
+                                                      --signing-key-file FILEPATH
+
+  Derive an extended signing key from a mnemonic sentence. To ensure the safety
+  of the mnemonic phrase, we recommend that key derivation is performed in an
+  air-gapped environment.
 
 Usage: cardano-cli shelley key convert-byron-key [--password TEXT]
                                                    ( --byron-payment-key-type
@@ -2123,6 +2170,8 @@ Usage: cardano-cli allegra address info --address ADDRESS [--out-file FILEPATH]
 Usage: cardano-cli allegra key 
                                  ( verification-key
                                  | non-extended-key
+                                 | generate-mnemonic
+                                 | derive-from-mnemonic
                                  | convert-byron-key
                                  | convert-byron-genesis-vkey
                                  | convert-itn-key
@@ -2143,6 +2192,28 @@ Usage: cardano-cli allegra key non-extended-key --extended-verification-key-file
 
   Get a non-extended verification key from an extended verification key. This
   supports all extended key types.
+
+Usage: cardano-cli allegra key generate-mnemonic [--out-file FILEPATH]
+                                                   --size WORD32
+
+  Generate a mnemonic sentence that can be used for key derivation.
+
+Usage: cardano-cli allegra key derive-from-mnemonic [--key-output-format STRING]
+                                                      ( --payment-key-with-number WORD32
+                                                      | --stake-key-with-number WORD32
+                                                      | --drep-key
+                                                      | --cc-cold-key
+                                                      | --cc-hot-key
+                                                      )
+                                                      --account-number WORD32
+                                                      ( --mnemonic-from-file FILEPATH
+                                                      | --mnemonic-from-interactive-prompt
+                                                      )
+                                                      --signing-key-file FILEPATH
+
+  Derive an extended signing key from a mnemonic sentence. To ensure the safety
+  of the mnemonic phrase, we recommend that key derivation is performed in an
+  air-gapped environment.
 
 Usage: cardano-cli allegra key convert-byron-key [--password TEXT]
                                                    ( --byron-payment-key-type
@@ -3198,6 +3269,8 @@ Usage: cardano-cli mary address info --address ADDRESS [--out-file FILEPATH]
 Usage: cardano-cli mary key 
                               ( verification-key
                               | non-extended-key
+                              | generate-mnemonic
+                              | derive-from-mnemonic
                               | convert-byron-key
                               | convert-byron-genesis-vkey
                               | convert-itn-key
@@ -3218,6 +3291,28 @@ Usage: cardano-cli mary key non-extended-key --extended-verification-key-file FI
 
   Get a non-extended verification key from an extended verification key. This
   supports all extended key types.
+
+Usage: cardano-cli mary key generate-mnemonic [--out-file FILEPATH]
+                                                --size WORD32
+
+  Generate a mnemonic sentence that can be used for key derivation.
+
+Usage: cardano-cli mary key derive-from-mnemonic [--key-output-format STRING]
+                                                   ( --payment-key-with-number WORD32
+                                                   | --stake-key-with-number WORD32
+                                                   | --drep-key
+                                                   | --cc-cold-key
+                                                   | --cc-hot-key
+                                                   )
+                                                   --account-number WORD32
+                                                   ( --mnemonic-from-file FILEPATH
+                                                   | --mnemonic-from-interactive-prompt
+                                                   )
+                                                   --signing-key-file FILEPATH
+
+  Derive an extended signing key from a mnemonic sentence. To ensure the safety
+  of the mnemonic phrase, we recommend that key derivation is performed in an
+  air-gapped environment.
 
 Usage: cardano-cli mary key convert-byron-key [--password TEXT]
                                                 ( --byron-payment-key-type
@@ -4274,6 +4369,8 @@ Usage: cardano-cli alonzo address info --address ADDRESS [--out-file FILEPATH]
 Usage: cardano-cli alonzo key 
                                 ( verification-key
                                 | non-extended-key
+                                | generate-mnemonic
+                                | derive-from-mnemonic
                                 | convert-byron-key
                                 | convert-byron-genesis-vkey
                                 | convert-itn-key
@@ -4294,6 +4391,28 @@ Usage: cardano-cli alonzo key non-extended-key --extended-verification-key-file 
 
   Get a non-extended verification key from an extended verification key. This
   supports all extended key types.
+
+Usage: cardano-cli alonzo key generate-mnemonic [--out-file FILEPATH]
+                                                  --size WORD32
+
+  Generate a mnemonic sentence that can be used for key derivation.
+
+Usage: cardano-cli alonzo key derive-from-mnemonic [--key-output-format STRING]
+                                                     ( --payment-key-with-number WORD32
+                                                     | --stake-key-with-number WORD32
+                                                     | --drep-key
+                                                     | --cc-cold-key
+                                                     | --cc-hot-key
+                                                     )
+                                                     --account-number WORD32
+                                                     ( --mnemonic-from-file FILEPATH
+                                                     | --mnemonic-from-interactive-prompt
+                                                     )
+                                                     --signing-key-file FILEPATH
+
+  Derive an extended signing key from a mnemonic sentence. To ensure the safety
+  of the mnemonic phrase, we recommend that key derivation is performed in an
+  air-gapped environment.
 
 Usage: cardano-cli alonzo key convert-byron-key [--password TEXT]
                                                   ( --byron-payment-key-type
@@ -5375,6 +5494,8 @@ Usage: cardano-cli babbage address info --address ADDRESS [--out-file FILEPATH]
 Usage: cardano-cli babbage key 
                                  ( verification-key
                                  | non-extended-key
+                                 | generate-mnemonic
+                                 | derive-from-mnemonic
                                  | convert-byron-key
                                  | convert-byron-genesis-vkey
                                  | convert-itn-key
@@ -5395,6 +5516,28 @@ Usage: cardano-cli babbage key non-extended-key --extended-verification-key-file
 
   Get a non-extended verification key from an extended verification key. This
   supports all extended key types.
+
+Usage: cardano-cli babbage key generate-mnemonic [--out-file FILEPATH]
+                                                   --size WORD32
+
+  Generate a mnemonic sentence that can be used for key derivation.
+
+Usage: cardano-cli babbage key derive-from-mnemonic [--key-output-format STRING]
+                                                      ( --payment-key-with-number WORD32
+                                                      | --stake-key-with-number WORD32
+                                                      | --drep-key
+                                                      | --cc-cold-key
+                                                      | --cc-hot-key
+                                                      )
+                                                      --account-number WORD32
+                                                      ( --mnemonic-from-file FILEPATH
+                                                      | --mnemonic-from-interactive-prompt
+                                                      )
+                                                      --signing-key-file FILEPATH
+
+  Derive an extended signing key from a mnemonic sentence. To ensure the safety
+  of the mnemonic phrase, we recommend that key derivation is performed in an
+  air-gapped environment.
 
 Usage: cardano-cli babbage key convert-byron-key [--password TEXT]
                                                    ( --byron-payment-key-type
@@ -6777,6 +6920,8 @@ Usage: cardano-cli conway address info --address ADDRESS [--out-file FILEPATH]
 Usage: cardano-cli conway key 
                                 ( verification-key
                                 | non-extended-key
+                                | generate-mnemonic
+                                | derive-from-mnemonic
                                 | convert-byron-key
                                 | convert-byron-genesis-vkey
                                 | convert-itn-key
@@ -6797,6 +6942,28 @@ Usage: cardano-cli conway key non-extended-key --extended-verification-key-file 
 
   Get a non-extended verification key from an extended verification key. This
   supports all extended key types.
+
+Usage: cardano-cli conway key generate-mnemonic [--out-file FILEPATH]
+                                                  --size WORD32
+
+  Generate a mnemonic sentence that can be used for key derivation.
+
+Usage: cardano-cli conway key derive-from-mnemonic [--key-output-format STRING]
+                                                     ( --payment-key-with-number WORD32
+                                                     | --stake-key-with-number WORD32
+                                                     | --drep-key
+                                                     | --cc-cold-key
+                                                     | --cc-hot-key
+                                                     )
+                                                     --account-number WORD32
+                                                     ( --mnemonic-from-file FILEPATH
+                                                     | --mnemonic-from-interactive-prompt
+                                                     )
+                                                     --signing-key-file FILEPATH
+
+  Derive an extended signing key from a mnemonic sentence. To ensure the safety
+  of the mnemonic phrase, we recommend that key derivation is performed in an
+  air-gapped environment.
 
 Usage: cardano-cli conway key convert-byron-key [--password TEXT]
                                                   ( --byron-payment-key-type
@@ -8878,6 +9045,8 @@ Usage: cardano-cli latest address info --address ADDRESS [--out-file FILEPATH]
 Usage: cardano-cli latest key 
                                 ( verification-key
                                 | non-extended-key
+                                | generate-mnemonic
+                                | derive-from-mnemonic
                                 | convert-byron-key
                                 | convert-byron-genesis-vkey
                                 | convert-itn-key
@@ -8898,6 +9067,28 @@ Usage: cardano-cli latest key non-extended-key --extended-verification-key-file 
 
   Get a non-extended verification key from an extended verification key. This
   supports all extended key types.
+
+Usage: cardano-cli latest key generate-mnemonic [--out-file FILEPATH]
+                                                  --size WORD32
+
+  Generate a mnemonic sentence that can be used for key derivation.
+
+Usage: cardano-cli latest key derive-from-mnemonic [--key-output-format STRING]
+                                                     ( --payment-key-with-number WORD32
+                                                     | --stake-key-with-number WORD32
+                                                     | --drep-key
+                                                     | --cc-cold-key
+                                                     | --cc-hot-key
+                                                     )
+                                                     --account-number WORD32
+                                                     ( --mnemonic-from-file FILEPATH
+                                                     | --mnemonic-from-interactive-prompt
+                                                     )
+                                                     --signing-key-file FILEPATH
+
+  Derive an extended signing key from a mnemonic sentence. To ensure the safety
+  of the mnemonic phrase, we recommend that key derivation is performed in an
+  air-gapped environment.
 
 Usage: cardano-cli latest key convert-byron-key [--password TEXT]
                                                   ( --byron-payment-key-type

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_key.cli
@@ -1,6 +1,8 @@
 Usage: cardano-cli allegra key 
                                  ( verification-key
                                  | non-extended-key
+                                 | generate-mnemonic
+                                 | derive-from-mnemonic
                                  | convert-byron-key
                                  | convert-byron-genesis-vkey
                                  | convert-itn-key
@@ -20,6 +22,12 @@ Available commands:
   non-extended-key         Get a non-extended verification key from an extended
                            verification key. This supports all extended key
                            types.
+  generate-mnemonic        Generate a mnemonic sentence that can be used for key
+                           derivation.
+  derive-from-mnemonic     Derive an extended signing key from a mnemonic
+                           sentence. To ensure the safety of the mnemonic
+                           phrase, we recommend that key derivation is performed
+                           in an air-gapped environment.
   convert-byron-key        Convert a Byron payment, genesis or genesis delegate
                            key (signing or verification) to a corresponding
                            Shelley-format key.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_key_derive-from-mnemonic.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_key_derive-from-mnemonic.cli
@@ -1,0 +1,42 @@
+Usage: cardano-cli allegra key derive-from-mnemonic [--key-output-format STRING]
+                                                      ( --payment-key-with-number WORD32
+                                                      | --stake-key-with-number WORD32
+                                                      | --drep-key
+                                                      | --cc-cold-key
+                                                      | --cc-hot-key
+                                                      )
+                                                      --account-number WORD32
+                                                      ( --mnemonic-from-file FILEPATH
+                                                      | --mnemonic-from-interactive-prompt
+                                                      )
+                                                      --signing-key-file FILEPATH
+
+  Derive an extended signing key from a mnemonic sentence. To ensure the safety
+  of the mnemonic phrase, we recommend that key derivation is performed in an
+  air-gapped environment.
+
+Available options:
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32" (default is
+                           "text-envelope").
+  --payment-key-with-number WORD32
+                           Derive an extended payment key with the given payment
+                           address number from the derivation path.
+  --stake-key-with-number WORD32
+                           Derive an extended stake key with the given stake
+                           address number from the derivation path.
+  --drep-key               Derive an extended DRep key.
+  --cc-cold-key            Derive an extended committee cold key.
+  --cc-hot-key             Derive an extended committee hot key.
+  --account-number WORD32  Account number in the derivation path.
+  --mnemonic-from-file FILEPATH
+                           Input text file with the mnemonic.
+  --mnemonic-from-interactive-prompt
+                           Input the mnemonic through an interactive prompt.
+                           This mode also accepts receiving the mnemonic through
+                           standard input directly, for example, by using a
+                           pipe.
+  --signing-key-file FILEPATH
+                           Output filepath of the signing key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_key_generate-mnemonic.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_key_generate-mnemonic.cli
@@ -1,0 +1,11 @@
+Usage: cardano-cli allegra key generate-mnemonic [--out-file FILEPATH]
+                                                   --size WORD32
+
+  Generate a mnemonic sentence that can be used for key derivation.
+
+Available options:
+  --out-file FILEPATH      The output file.
+  --size WORD32            Specify the desired number of words for the
+                           outputmnemonic sentence (valid options are: 12, 15,
+                           18, 21, and 24)
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_key.cli
@@ -1,6 +1,8 @@
 Usage: cardano-cli alonzo key 
                                 ( verification-key
                                 | non-extended-key
+                                | generate-mnemonic
+                                | derive-from-mnemonic
                                 | convert-byron-key
                                 | convert-byron-genesis-vkey
                                 | convert-itn-key
@@ -20,6 +22,12 @@ Available commands:
   non-extended-key         Get a non-extended verification key from an extended
                            verification key. This supports all extended key
                            types.
+  generate-mnemonic        Generate a mnemonic sentence that can be used for key
+                           derivation.
+  derive-from-mnemonic     Derive an extended signing key from a mnemonic
+                           sentence. To ensure the safety of the mnemonic
+                           phrase, we recommend that key derivation is performed
+                           in an air-gapped environment.
   convert-byron-key        Convert a Byron payment, genesis or genesis delegate
                            key (signing or verification) to a corresponding
                            Shelley-format key.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_key_derive-from-mnemonic.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_key_derive-from-mnemonic.cli
@@ -1,0 +1,42 @@
+Usage: cardano-cli alonzo key derive-from-mnemonic [--key-output-format STRING]
+                                                     ( --payment-key-with-number WORD32
+                                                     | --stake-key-with-number WORD32
+                                                     | --drep-key
+                                                     | --cc-cold-key
+                                                     | --cc-hot-key
+                                                     )
+                                                     --account-number WORD32
+                                                     ( --mnemonic-from-file FILEPATH
+                                                     | --mnemonic-from-interactive-prompt
+                                                     )
+                                                     --signing-key-file FILEPATH
+
+  Derive an extended signing key from a mnemonic sentence. To ensure the safety
+  of the mnemonic phrase, we recommend that key derivation is performed in an
+  air-gapped environment.
+
+Available options:
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32" (default is
+                           "text-envelope").
+  --payment-key-with-number WORD32
+                           Derive an extended payment key with the given payment
+                           address number from the derivation path.
+  --stake-key-with-number WORD32
+                           Derive an extended stake key with the given stake
+                           address number from the derivation path.
+  --drep-key               Derive an extended DRep key.
+  --cc-cold-key            Derive an extended committee cold key.
+  --cc-hot-key             Derive an extended committee hot key.
+  --account-number WORD32  Account number in the derivation path.
+  --mnemonic-from-file FILEPATH
+                           Input text file with the mnemonic.
+  --mnemonic-from-interactive-prompt
+                           Input the mnemonic through an interactive prompt.
+                           This mode also accepts receiving the mnemonic through
+                           standard input directly, for example, by using a
+                           pipe.
+  --signing-key-file FILEPATH
+                           Output filepath of the signing key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_key_generate-mnemonic.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_key_generate-mnemonic.cli
@@ -1,0 +1,11 @@
+Usage: cardano-cli alonzo key generate-mnemonic [--out-file FILEPATH]
+                                                  --size WORD32
+
+  Generate a mnemonic sentence that can be used for key derivation.
+
+Available options:
+  --out-file FILEPATH      The output file.
+  --size WORD32            Specify the desired number of words for the
+                           outputmnemonic sentence (valid options are: 12, 15,
+                           18, 21, and 24)
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_key.cli
@@ -1,6 +1,8 @@
 Usage: cardano-cli babbage key 
                                  ( verification-key
                                  | non-extended-key
+                                 | generate-mnemonic
+                                 | derive-from-mnemonic
                                  | convert-byron-key
                                  | convert-byron-genesis-vkey
                                  | convert-itn-key
@@ -20,6 +22,12 @@ Available commands:
   non-extended-key         Get a non-extended verification key from an extended
                            verification key. This supports all extended key
                            types.
+  generate-mnemonic        Generate a mnemonic sentence that can be used for key
+                           derivation.
+  derive-from-mnemonic     Derive an extended signing key from a mnemonic
+                           sentence. To ensure the safety of the mnemonic
+                           phrase, we recommend that key derivation is performed
+                           in an air-gapped environment.
   convert-byron-key        Convert a Byron payment, genesis or genesis delegate
                            key (signing or verification) to a corresponding
                            Shelley-format key.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_key_derive-from-mnemonic.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_key_derive-from-mnemonic.cli
@@ -1,0 +1,42 @@
+Usage: cardano-cli babbage key derive-from-mnemonic [--key-output-format STRING]
+                                                      ( --payment-key-with-number WORD32
+                                                      | --stake-key-with-number WORD32
+                                                      | --drep-key
+                                                      | --cc-cold-key
+                                                      | --cc-hot-key
+                                                      )
+                                                      --account-number WORD32
+                                                      ( --mnemonic-from-file FILEPATH
+                                                      | --mnemonic-from-interactive-prompt
+                                                      )
+                                                      --signing-key-file FILEPATH
+
+  Derive an extended signing key from a mnemonic sentence. To ensure the safety
+  of the mnemonic phrase, we recommend that key derivation is performed in an
+  air-gapped environment.
+
+Available options:
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32" (default is
+                           "text-envelope").
+  --payment-key-with-number WORD32
+                           Derive an extended payment key with the given payment
+                           address number from the derivation path.
+  --stake-key-with-number WORD32
+                           Derive an extended stake key with the given stake
+                           address number from the derivation path.
+  --drep-key               Derive an extended DRep key.
+  --cc-cold-key            Derive an extended committee cold key.
+  --cc-hot-key             Derive an extended committee hot key.
+  --account-number WORD32  Account number in the derivation path.
+  --mnemonic-from-file FILEPATH
+                           Input text file with the mnemonic.
+  --mnemonic-from-interactive-prompt
+                           Input the mnemonic through an interactive prompt.
+                           This mode also accepts receiving the mnemonic through
+                           standard input directly, for example, by using a
+                           pipe.
+  --signing-key-file FILEPATH
+                           Output filepath of the signing key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_key_generate-mnemonic.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_key_generate-mnemonic.cli
@@ -1,0 +1,11 @@
+Usage: cardano-cli babbage key generate-mnemonic [--out-file FILEPATH]
+                                                   --size WORD32
+
+  Generate a mnemonic sentence that can be used for key derivation.
+
+Available options:
+  --out-file FILEPATH      The output file.
+  --size WORD32            Specify the desired number of words for the
+                           outputmnemonic sentence (valid options are: 12, 15,
+                           18, 21, and 24)
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_key.cli
@@ -1,6 +1,8 @@
 Usage: cardano-cli conway key 
                                 ( verification-key
                                 | non-extended-key
+                                | generate-mnemonic
+                                | derive-from-mnemonic
                                 | convert-byron-key
                                 | convert-byron-genesis-vkey
                                 | convert-itn-key
@@ -20,6 +22,12 @@ Available commands:
   non-extended-key         Get a non-extended verification key from an extended
                            verification key. This supports all extended key
                            types.
+  generate-mnemonic        Generate a mnemonic sentence that can be used for key
+                           derivation.
+  derive-from-mnemonic     Derive an extended signing key from a mnemonic
+                           sentence. To ensure the safety of the mnemonic
+                           phrase, we recommend that key derivation is performed
+                           in an air-gapped environment.
   convert-byron-key        Convert a Byron payment, genesis or genesis delegate
                            key (signing or verification) to a corresponding
                            Shelley-format key.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_key_derive-from-mnemonic.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_key_derive-from-mnemonic.cli
@@ -1,0 +1,42 @@
+Usage: cardano-cli conway key derive-from-mnemonic [--key-output-format STRING]
+                                                     ( --payment-key-with-number WORD32
+                                                     | --stake-key-with-number WORD32
+                                                     | --drep-key
+                                                     | --cc-cold-key
+                                                     | --cc-hot-key
+                                                     )
+                                                     --account-number WORD32
+                                                     ( --mnemonic-from-file FILEPATH
+                                                     | --mnemonic-from-interactive-prompt
+                                                     )
+                                                     --signing-key-file FILEPATH
+
+  Derive an extended signing key from a mnemonic sentence. To ensure the safety
+  of the mnemonic phrase, we recommend that key derivation is performed in an
+  air-gapped environment.
+
+Available options:
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32" (default is
+                           "text-envelope").
+  --payment-key-with-number WORD32
+                           Derive an extended payment key with the given payment
+                           address number from the derivation path.
+  --stake-key-with-number WORD32
+                           Derive an extended stake key with the given stake
+                           address number from the derivation path.
+  --drep-key               Derive an extended DRep key.
+  --cc-cold-key            Derive an extended committee cold key.
+  --cc-hot-key             Derive an extended committee hot key.
+  --account-number WORD32  Account number in the derivation path.
+  --mnemonic-from-file FILEPATH
+                           Input text file with the mnemonic.
+  --mnemonic-from-interactive-prompt
+                           Input the mnemonic through an interactive prompt.
+                           This mode also accepts receiving the mnemonic through
+                           standard input directly, for example, by using a
+                           pipe.
+  --signing-key-file FILEPATH
+                           Output filepath of the signing key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_key_generate-mnemonic.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_key_generate-mnemonic.cli
@@ -1,0 +1,11 @@
+Usage: cardano-cli conway key generate-mnemonic [--out-file FILEPATH]
+                                                  --size WORD32
+
+  Generate a mnemonic sentence that can be used for key derivation.
+
+Available options:
+  --out-file FILEPATH      The output file.
+  --size WORD32            Specify the desired number of words for the
+                           outputmnemonic sentence (valid options are: 12, 15,
+                           18, 21, and 24)
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/key.cli
@@ -1,6 +1,8 @@
 Usage: cardano-cli key 
                          ( verification-key
                          | non-extended-key
+                         | generate-mnemonic
+                         | derive-from-mnemonic
                          | convert-byron-key
                          | convert-byron-genesis-vkey
                          | convert-itn-key
@@ -20,6 +22,12 @@ Available commands:
   non-extended-key         Get a non-extended verification key from an extended
                            verification key. This supports all extended key
                            types.
+  generate-mnemonic        Generate a mnemonic sentence that can be used for key
+                           derivation.
+  derive-from-mnemonic     Derive an extended signing key from a mnemonic
+                           sentence. To ensure the safety of the mnemonic
+                           phrase, we recommend that key derivation is performed
+                           in an air-gapped environment.
   convert-byron-key        Convert a Byron payment, genesis or genesis delegate
                            key (signing or verification) to a corresponding
                            Shelley-format key.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/key_derive-from-mnemonic.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/key_derive-from-mnemonic.cli
@@ -1,0 +1,42 @@
+Usage: cardano-cli key derive-from-mnemonic [--key-output-format STRING]
+                                              ( --payment-key-with-number WORD32
+                                              | --stake-key-with-number WORD32
+                                              | --drep-key
+                                              | --cc-cold-key
+                                              | --cc-hot-key
+                                              )
+                                              --account-number WORD32
+                                              ( --mnemonic-from-file FILEPATH
+                                              | --mnemonic-from-interactive-prompt
+                                              )
+                                              --signing-key-file FILEPATH
+
+  Derive an extended signing key from a mnemonic sentence. To ensure the safety
+  of the mnemonic phrase, we recommend that key derivation is performed in an
+  air-gapped environment.
+
+Available options:
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32" (default is
+                           "text-envelope").
+  --payment-key-with-number WORD32
+                           Derive an extended payment key with the given payment
+                           address number from the derivation path.
+  --stake-key-with-number WORD32
+                           Derive an extended stake key with the given stake
+                           address number from the derivation path.
+  --drep-key               Derive an extended DRep key.
+  --cc-cold-key            Derive an extended committee cold key.
+  --cc-hot-key             Derive an extended committee hot key.
+  --account-number WORD32  Account number in the derivation path.
+  --mnemonic-from-file FILEPATH
+                           Input text file with the mnemonic.
+  --mnemonic-from-interactive-prompt
+                           Input the mnemonic through an interactive prompt.
+                           This mode also accepts receiving the mnemonic through
+                           standard input directly, for example, by using a
+                           pipe.
+  --signing-key-file FILEPATH
+                           Output filepath of the signing key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/key_generate-mnemonic.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/key_generate-mnemonic.cli
@@ -1,0 +1,10 @@
+Usage: cardano-cli key generate-mnemonic [--out-file FILEPATH] --size WORD32
+
+  Generate a mnemonic sentence that can be used for key derivation.
+
+Available options:
+  --out-file FILEPATH      The output file.
+  --size WORD32            Specify the desired number of words for the
+                           outputmnemonic sentence (valid options are: 12, 15,
+                           18, 21, and 24)
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_key.cli
@@ -1,6 +1,8 @@
 Usage: cardano-cli latest key 
                                 ( verification-key
                                 | non-extended-key
+                                | generate-mnemonic
+                                | derive-from-mnemonic
                                 | convert-byron-key
                                 | convert-byron-genesis-vkey
                                 | convert-itn-key
@@ -20,6 +22,12 @@ Available commands:
   non-extended-key         Get a non-extended verification key from an extended
                            verification key. This supports all extended key
                            types.
+  generate-mnemonic        Generate a mnemonic sentence that can be used for key
+                           derivation.
+  derive-from-mnemonic     Derive an extended signing key from a mnemonic
+                           sentence. To ensure the safety of the mnemonic
+                           phrase, we recommend that key derivation is performed
+                           in an air-gapped environment.
   convert-byron-key        Convert a Byron payment, genesis or genesis delegate
                            key (signing or verification) to a corresponding
                            Shelley-format key.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_key_derive-from-mnemonic.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_key_derive-from-mnemonic.cli
@@ -1,0 +1,42 @@
+Usage: cardano-cli latest key derive-from-mnemonic [--key-output-format STRING]
+                                                     ( --payment-key-with-number WORD32
+                                                     | --stake-key-with-number WORD32
+                                                     | --drep-key
+                                                     | --cc-cold-key
+                                                     | --cc-hot-key
+                                                     )
+                                                     --account-number WORD32
+                                                     ( --mnemonic-from-file FILEPATH
+                                                     | --mnemonic-from-interactive-prompt
+                                                     )
+                                                     --signing-key-file FILEPATH
+
+  Derive an extended signing key from a mnemonic sentence. To ensure the safety
+  of the mnemonic phrase, we recommend that key derivation is performed in an
+  air-gapped environment.
+
+Available options:
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32" (default is
+                           "text-envelope").
+  --payment-key-with-number WORD32
+                           Derive an extended payment key with the given payment
+                           address number from the derivation path.
+  --stake-key-with-number WORD32
+                           Derive an extended stake key with the given stake
+                           address number from the derivation path.
+  --drep-key               Derive an extended DRep key.
+  --cc-cold-key            Derive an extended committee cold key.
+  --cc-hot-key             Derive an extended committee hot key.
+  --account-number WORD32  Account number in the derivation path.
+  --mnemonic-from-file FILEPATH
+                           Input text file with the mnemonic.
+  --mnemonic-from-interactive-prompt
+                           Input the mnemonic through an interactive prompt.
+                           This mode also accepts receiving the mnemonic through
+                           standard input directly, for example, by using a
+                           pipe.
+  --signing-key-file FILEPATH
+                           Output filepath of the signing key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_key_generate-mnemonic.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_key_generate-mnemonic.cli
@@ -1,0 +1,11 @@
+Usage: cardano-cli latest key generate-mnemonic [--out-file FILEPATH]
+                                                  --size WORD32
+
+  Generate a mnemonic sentence that can be used for key derivation.
+
+Available options:
+  --out-file FILEPATH      The output file.
+  --size WORD32            Specify the desired number of words for the
+                           outputmnemonic sentence (valid options are: 12, 15,
+                           18, 21, and 24)
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_key.cli
@@ -1,6 +1,8 @@
 Usage: cardano-cli mary key 
                               ( verification-key
                               | non-extended-key
+                              | generate-mnemonic
+                              | derive-from-mnemonic
                               | convert-byron-key
                               | convert-byron-genesis-vkey
                               | convert-itn-key
@@ -20,6 +22,12 @@ Available commands:
   non-extended-key         Get a non-extended verification key from an extended
                            verification key. This supports all extended key
                            types.
+  generate-mnemonic        Generate a mnemonic sentence that can be used for key
+                           derivation.
+  derive-from-mnemonic     Derive an extended signing key from a mnemonic
+                           sentence. To ensure the safety of the mnemonic
+                           phrase, we recommend that key derivation is performed
+                           in an air-gapped environment.
   convert-byron-key        Convert a Byron payment, genesis or genesis delegate
                            key (signing or verification) to a corresponding
                            Shelley-format key.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_key_derive-from-mnemonic.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_key_derive-from-mnemonic.cli
@@ -1,0 +1,42 @@
+Usage: cardano-cli mary key derive-from-mnemonic [--key-output-format STRING]
+                                                   ( --payment-key-with-number WORD32
+                                                   | --stake-key-with-number WORD32
+                                                   | --drep-key
+                                                   | --cc-cold-key
+                                                   | --cc-hot-key
+                                                   )
+                                                   --account-number WORD32
+                                                   ( --mnemonic-from-file FILEPATH
+                                                   | --mnemonic-from-interactive-prompt
+                                                   )
+                                                   --signing-key-file FILEPATH
+
+  Derive an extended signing key from a mnemonic sentence. To ensure the safety
+  of the mnemonic phrase, we recommend that key derivation is performed in an
+  air-gapped environment.
+
+Available options:
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32" (default is
+                           "text-envelope").
+  --payment-key-with-number WORD32
+                           Derive an extended payment key with the given payment
+                           address number from the derivation path.
+  --stake-key-with-number WORD32
+                           Derive an extended stake key with the given stake
+                           address number from the derivation path.
+  --drep-key               Derive an extended DRep key.
+  --cc-cold-key            Derive an extended committee cold key.
+  --cc-hot-key             Derive an extended committee hot key.
+  --account-number WORD32  Account number in the derivation path.
+  --mnemonic-from-file FILEPATH
+                           Input text file with the mnemonic.
+  --mnemonic-from-interactive-prompt
+                           Input the mnemonic through an interactive prompt.
+                           This mode also accepts receiving the mnemonic through
+                           standard input directly, for example, by using a
+                           pipe.
+  --signing-key-file FILEPATH
+                           Output filepath of the signing key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_key_generate-mnemonic.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_key_generate-mnemonic.cli
@@ -1,0 +1,11 @@
+Usage: cardano-cli mary key generate-mnemonic [--out-file FILEPATH]
+                                                --size WORD32
+
+  Generate a mnemonic sentence that can be used for key derivation.
+
+Available options:
+  --out-file FILEPATH      The output file.
+  --size WORD32            Specify the desired number of words for the
+                           outputmnemonic sentence (valid options are: 12, 15,
+                           18, 21, and 24)
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_key.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_key.cli
@@ -1,6 +1,8 @@
 Usage: cardano-cli shelley key 
                                  ( verification-key
                                  | non-extended-key
+                                 | generate-mnemonic
+                                 | derive-from-mnemonic
                                  | convert-byron-key
                                  | convert-byron-genesis-vkey
                                  | convert-itn-key
@@ -20,6 +22,12 @@ Available commands:
   non-extended-key         Get a non-extended verification key from an extended
                            verification key. This supports all extended key
                            types.
+  generate-mnemonic        Generate a mnemonic sentence that can be used for key
+                           derivation.
+  derive-from-mnemonic     Derive an extended signing key from a mnemonic
+                           sentence. To ensure the safety of the mnemonic
+                           phrase, we recommend that key derivation is performed
+                           in an air-gapped environment.
   convert-byron-key        Convert a Byron payment, genesis or genesis delegate
                            key (signing or verification) to a corresponding
                            Shelley-format key.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_key_derive-from-mnemonic.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_key_derive-from-mnemonic.cli
@@ -1,0 +1,42 @@
+Usage: cardano-cli shelley key derive-from-mnemonic [--key-output-format STRING]
+                                                      ( --payment-key-with-number WORD32
+                                                      | --stake-key-with-number WORD32
+                                                      | --drep-key
+                                                      | --cc-cold-key
+                                                      | --cc-hot-key
+                                                      )
+                                                      --account-number WORD32
+                                                      ( --mnemonic-from-file FILEPATH
+                                                      | --mnemonic-from-interactive-prompt
+                                                      )
+                                                      --signing-key-file FILEPATH
+
+  Derive an extended signing key from a mnemonic sentence. To ensure the safety
+  of the mnemonic phrase, we recommend that key derivation is performed in an
+  air-gapped environment.
+
+Available options:
+  --key-output-format STRING
+                           Optional key output format. Accepted output formats
+                           are "text-envelope" and "bech32" (default is
+                           "text-envelope").
+  --payment-key-with-number WORD32
+                           Derive an extended payment key with the given payment
+                           address number from the derivation path.
+  --stake-key-with-number WORD32
+                           Derive an extended stake key with the given stake
+                           address number from the derivation path.
+  --drep-key               Derive an extended DRep key.
+  --cc-cold-key            Derive an extended committee cold key.
+  --cc-hot-key             Derive an extended committee hot key.
+  --account-number WORD32  Account number in the derivation path.
+  --mnemonic-from-file FILEPATH
+                           Input text file with the mnemonic.
+  --mnemonic-from-interactive-prompt
+                           Input the mnemonic through an interactive prompt.
+                           This mode also accepts receiving the mnemonic through
+                           standard input directly, for example, by using a
+                           pipe.
+  --signing-key-file FILEPATH
+                           Output filepath of the signing key.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_key_generate-mnemonic.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_key_generate-mnemonic.cli
@@ -1,0 +1,11 @@
+Usage: cardano-cli shelley key generate-mnemonic [--out-file FILEPATH]
+                                                   --size WORD32
+
+  Generate a mnemonic sentence that can be used for key derivation.
+
+Available options:
+  --out-file FILEPATH      The output file.
+  --size WORD32            Specify the desired number of words for the
+                           outputmnemonic sentence (valid options are: 12, 15,
+                           18, 21, and 24)
+  -h,--help                Show this help text


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Added support for mnemonic sentence generation and extended key derivation from mnemonic sentences.
  type:
  - feature
```

# Context

This PR is associated to: https://github.com/IntersectMBO/cardano-api/pull/678.
It is part of an effort to integrate `cardano-addresses` functionalities into the `cardano-cli`.

# How to trust this PR

I would look mainly at the logic, the changes in the help golden files, and probably testing it is the best way.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
