### PR TITLE
Add datums and scripts to `friendlyTxImpl`

### DIFF
--- a/cardano-cli/src/Cardano/CLI/Json/Friendly.hs
+++ b/cardano-cli/src/Cardano/CLI/Json/Friendly.hs
@@ -250,7 +250,7 @@ friendlyTxBodyImpl
             ]
               ++ ( monoidForEraInEon @AlonzoEraOnwards
                     era
-                    (`getAlonzoSpecificDetails` tb)
+                    (`getScriptWitnessDetails` tb)
                  )
               ++ ( monoidForEraInEon @ConwayEraOnwards
                     era
@@ -305,9 +305,9 @@ data EraIndependentPlutusScriptPurpose
   | Voting
   | Proposing
 
-getAlonzoSpecificDetails
+getScriptWitnessDetails
   :: forall era. AlonzoEraOnwards era -> TxBody era -> [Aeson.Pair]
-getAlonzoSpecificDetails aeo tb =
+getScriptWitnessDetails aeo tb =
   let ShelleyTx _ ledgerTx = makeSignedTransaction [] tb
    in [ "redeemers" .= friendlyRedeemers ledgerTx
       , "scripts" .= friendlyScriptData ledgerTx

--- a/cardano-cli/src/Cardano/CLI/Json/Friendly.hs
+++ b/cardano-cli/src/Cardano/CLI/Json/Friendly.hs
@@ -311,6 +311,7 @@ getAlonzoSpecificDetails aeo tb =
   let ShelleyTx _ ledgerTx = makeSignedTransaction [] tb
    in [ "redeemers" .= friendlyRedeemers ledgerTx
       , "scripts" .= friendlyScriptData ledgerTx
+      , "datums" .= friendlyDats ledgerTx
       ]
  where
   friendlyRedeemers
@@ -397,6 +398,18 @@ getAlonzoSpecificDetails aeo tb =
               "script data" .= Api.friendlyScript scriptData
             ]
           | (scriptHash, scriptData) <- Map.toList $ tx ^. Ledger.witsTxL . Ledger.scriptTxWitsL]
+
+  friendlyDats :: Ledger.Tx (ShelleyLedgerEra era) -> Aeson.Value
+  friendlyDats tx =
+    alonzoEraOnwardsConstraints aeo $
+      let Ledger.TxDats dats = tx ^. Ledger.witsTxL . Ledger.datsTxWitsL in
+      Aeson.Array $ Vector.fromList $
+          [ Aeson.Object $ KeyMap.fromList [
+              "datum hash" .= datHash,
+              "datum" .= Api.friendlyDatum dat
+            ]
+          | (datHash, dat) <- Map.toList dats
+          ]
 
 friendlyTotalCollateral :: TxTotalCollateral era -> Aeson.Value
 friendlyTotalCollateral TxTotalCollateralNone = Aeson.Null

--- a/cardano-cli/test/cardano-cli-golden/files/golden/alonzo/signed-transaction-view.out
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/alonzo/signed-transaction-view.out
@@ -2,6 +2,7 @@ auxiliary scripts: null
 certificates: null
 collateral inputs:
 - c9765d7d0e3955be8920e6d7a38e1f3f2032eac48c7c59b0b9193caa87727e7e#256
+datums: []
 era: Alonzo
 fee: 213 Lovelace
 inputs:

--- a/cardano-cli/test/cardano-cli-golden/files/golden/alonzo/signed-transaction-view.out
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/alonzo/signed-transaction-view.out
@@ -15,6 +15,7 @@ required signers (payment key hashes needed for scripts):
 - 98717eaba8105a50a2a71831267552e337dfdc893bef5e40b8676d27
 - fafaaac8681b5050a8987f95bce4a7f99362f189879258fdbf733fa4
 return collateral: null
+scripts: []
 total collateral: null
 update proposal: null
 validity range:

--- a/cardano-cli/test/cardano-cli-golden/files/golden/alonzo/transaction-view.out
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/alonzo/transaction-view.out
@@ -2,6 +2,7 @@ auxiliary scripts: null
 certificates: null
 collateral inputs:
 - c9765d7d0e3955be8920e6d7a38e1f3f2032eac48c7c59b0b9193caa87727e7e#256
+datums: []
 era: Alonzo
 fee: 213 Lovelace
 inputs:

--- a/cardano-cli/test/cardano-cli-golden/files/golden/alonzo/transaction-view.out
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/alonzo/transaction-view.out
@@ -15,6 +15,7 @@ required signers (payment key hashes needed for scripts):
 - 98717eaba8105a50a2a71831267552e337dfdc893bef5e40b8676d27
 - fafaaac8681b5050a8987f95bce4a7f99362f189879258fdbf733fa4
 return collateral: null
+scripts: []
 total collateral: null
 update proposal:
   epoch: 190

--- a/cardano-cli/test/cardano-cli-golden/files/golden/babbage/transaction-view-metadata-detailedschema.out
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/babbage/transaction-view-metadata-detailedschema.out
@@ -33,6 +33,7 @@ redeemers: []
 reference inputs: []
 required signers (payment key hashes needed for scripts): null
 return collateral: null
+scripts: []
 total collateral: null
 update proposal: null
 validity range:

--- a/cardano-cli/test/cardano-cli-golden/files/golden/babbage/transaction-view-metadata-detailedschema.out
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/babbage/transaction-view-metadata-detailedschema.out
@@ -1,6 +1,7 @@
 auxiliary scripts: null
 certificates: null
 collateral inputs: []
+datums: []
 era: Babbage
 fee: 21300 Lovelace
 inputs:

--- a/cardano-cli/test/cardano-cli-golden/files/golden/babbage/transaction-view-metadata-noschema.out
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/babbage/transaction-view-metadata-noschema.out
@@ -1,6 +1,7 @@
 auxiliary scripts: null
 certificates: null
 collateral inputs: []
+datums: []
 era: Babbage
 fee: 21300 Lovelace
 inputs:

--- a/cardano-cli/test/cardano-cli-golden/files/golden/babbage/transaction-view-metadata-noschema.out
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/babbage/transaction-view-metadata-noschema.out
@@ -66,6 +66,7 @@ redeemers: []
 reference inputs: []
 required signers (payment key hashes needed for scripts): null
 return collateral: null
+scripts: []
 total collateral: null
 update proposal: null
 validity range:

--- a/cardano-cli/test/cardano-cli-golden/files/golden/babbage/transaction-view-redeemer.out
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/babbage/transaction-view-redeemer.out
@@ -20,6 +20,12 @@ redeemers:
 reference inputs: []
 required signers (payment key hashes needed for scripts): null
 return collateral: null
+scripts:
+- script data:
+    plutus version: PlutusV1
+    script: 4e4d01000033222220051200120011
+    type: plutus
+  script hash: 67f33146617a5e61936081db3b2117cbf59bd2123748f58ac9678656
 total collateral: null
 update proposal: null
 validity range:

--- a/cardano-cli/test/cardano-cli-golden/files/golden/babbage/transaction-view-redeemer.out
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/babbage/transaction-view-redeemer.out
@@ -2,6 +2,9 @@ auxiliary scripts: null
 certificates: null
 collateral inputs:
 - c9765d7d0e3955be8920e6d7a38e1f3f2032eac48c7c59b0b9193caa87727e7e#256
+datums:
+- datum: I 6666
+  datum hash: 9e478573ab81ea7a8e31891ce0648b81229f408d596a3483e6f4f9b92d3cf710
 era: Babbage
 fee: 213 Lovelace
 inputs:

--- a/cardano-cli/test/cardano-cli-golden/files/golden/conway/tx-proposal.out.json
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/conway/tx-proposal.out.json
@@ -3,6 +3,7 @@
     "certificates": null,
     "collateral inputs": [],
     "currentTreasuryValue": null,
+    "datums": [],
     "era": "Conway",
     "fee": "181517 Lovelace",
     "governance actions": [

--- a/cardano-cli/test/cardano-cli-golden/files/golden/conway/tx-proposal.out.json
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/conway/tx-proposal.out.json
@@ -54,6 +54,7 @@
     "reference inputs": [],
     "required signers (payment key hashes needed for scripts)": null,
     "return collateral": null,
+    "scripts": [],
     "total collateral": null,
     "treasuryDonation": 0,
     "update proposal": null,

--- a/cardano-cli/test/cardano-cli-golden/files/golden/conway/tx-three-votes-view.out.json
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/conway/tx-three-votes-view.out.json
@@ -3,6 +3,7 @@
     "certificates": null,
     "collateral inputs": [],
     "currentTreasuryValue": null,
+    "datums": [],
     "era": "Conway",
     "fee": "185433 Lovelace",
     "governance actions": [],

--- a/cardano-cli/test/cardano-cli-golden/files/golden/conway/tx-three-votes-view.out.json
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/conway/tx-three-votes-view.out.json
@@ -30,6 +30,7 @@
     "reference inputs": [],
     "required signers (payment key hashes needed for scripts)": null,
     "return collateral": null,
+    "scripts": [],
     "total collateral": null,
     "treasuryDonation": 0,
     "update proposal": null,


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Added datums and scripts to `friendlyTxImpl`, which translates into them being showed by `transaction view`.
  type:
  - feature
```

# Context

`friendlyTxBodyImpl` wasn't exposing information about datums nor redeemers. This PR addresses it.

# How to trust this PR

Changes to the tests give a lot of assurance. I would also check the format of the output JSON, and that the info that is displayed is extensive and clear. Also probably good to look at this PR in conjunction with https://github.com/IntersectMBO/cardano-api/pull/689

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
