### PR TITLE
Allow and add warning for HTTP anchor-data

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Actions.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Actions.hs
@@ -22,7 +22,7 @@ import           Cardano.CLI.EraBased.Commands.Governance.Actions
 import qualified Cardano.CLI.EraBased.Commands.Governance.Actions as Cmd
 import           Cardano.CLI.Json.Friendly
 import           Cardano.CLI.Read
-import           Cardano.CLI.Run.Hash (getByteStringFromURL, httpsAndIpfsSchemas)
+import           Cardano.CLI.Run.Hash (getByteStringFromURL, httpsAndIpfsSchemes)
 import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Errors.GovernanceActionsError
 import           Cardano.CLI.Types.Errors.HashCmdError (FetchURLError)
@@ -534,7 +534,7 @@ carryHashChecks checkHash anchor checkType =
         L.AnchorData
           <$> fetchURLErrorToGovernanceActionError
             checkType
-            (getByteStringFromURL httpsAndIpfsSchemas $ L.urlToText $ L.anchorUrl anchor)
+            (getByteStringFromURL httpsAndIpfsSchemes $ L.urlToText $ L.anchorUrl anchor)
       let hash = L.hashAnchorData anchorData
       when (hash /= L.anchorDataHash anchor) $
         left $

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/DRep.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/DRep.hs
@@ -20,7 +20,7 @@ import qualified Cardano.Api.Ledger as L
 
 import qualified Cardano.CLI.Commands.Hash as Cmd
 import qualified Cardano.CLI.EraBased.Commands.Governance.DRep as Cmd
-import           Cardano.CLI.Run.Hash (allSchemas, carryHashChecks, getByteStringFromURL)
+import           Cardano.CLI.Run.Hash (allSchemes, carryHashChecks, getByteStringFromURL)
 import qualified Cardano.CLI.Run.Key as Key
 import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Errors.CmdError
@@ -187,7 +187,7 @@ runGovernanceDRepMetadataHashCmd
       Cmd.DrepMetadataFileIn metadataFile ->
         firstExceptT ReadFileError . newExceptT $ readByteStringFile metadataFile
       Cmd.DrepMetadataURL urlText ->
-        fetchURLToGovernanceCmdError $ getByteStringFromURL allSchemas $ L.urlToText urlText
+        fetchURLToGovernanceCmdError $ getByteStringFromURL allSchemes $ L.urlToText urlText
     let (_metadata, metadataHash) = hashDRepMetadata metadataBytes
     case hashGoal of
       Cmd.CheckHash expectedHash

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/StakePool.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/StakePool.hs
@@ -20,7 +20,7 @@ import           Cardano.Api.Shelley
 import qualified Cardano.CLI.Commands.Hash as Cmd
 import           Cardano.CLI.EraBased.Commands.StakePool
 import qualified Cardano.CLI.EraBased.Commands.StakePool as Cmd
-import           Cardano.CLI.Run.Hash (allSchemas, getByteStringFromURL, httpsAndIpfsSchemas)
+import           Cardano.CLI.Run.Hash (allSchemes, getByteStringFromURL, httpsAndIpfsSchemes)
 import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Errors.HashCmdError (FetchURLError (..))
 import           Cardano.CLI.Types.Errors.StakePoolCmdError
@@ -235,7 +235,7 @@ runStakePoolMetadataHashCmd
             . newExceptT
             $ readByteStringFile poolMetadataFile
         StakePoolMetadataURL urlText ->
-          fetchURLToStakePoolCmdError $ getByteStringFromURL allSchemas $ L.urlToText urlText
+          fetchURLToStakePoolCmdError $ getByteStringFromURL allSchemes $ L.urlToText urlText
 
     (_metadata, metadataHash) <-
       firstExceptT StakePoolCmdMetadataValidationError
@@ -275,7 +275,10 @@ carryHashChecks potentiallyCheckedAnchor =
       metadataBytes <-
         withExceptT
           StakePoolCmdFetchURLError
-          (getByteStringFromURL httpsAndIpfsSchemas urlText)
+          ( getByteStringFromURL
+              httpsAndIpfsSchemes
+              urlText
+          )
 
       let expectedHash = stakePoolMetadataHash anchor
 

--- a/cardano-cli/src/Cardano/CLI/Types/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Common.hs
@@ -9,6 +9,7 @@
 module Cardano.CLI.Types.Common
   ( AllOrOnly (..)
   , AddressKeyType (..)
+  , AnchorScheme (..)
   , AnyPlutusScriptVersion (..)
   , BalanceTxExecUnits (..)
   , BlockId (..)
@@ -65,6 +66,7 @@ module Cardano.CLI.Types.Common
   , SomeKeyFile (..)
   , StakeDelegators (..)
   , StakePoolMetadataFile
+  , SupportedSchemes
   , TransferDirection (..)
   , TxBodyFile
   , TxBuildOutputOptions (..)
@@ -135,6 +137,13 @@ newtype ProposalUrl = ProposalUrl
   { unProposalUrl :: L.Url
   }
   deriving (Eq, Show)
+
+-- | Specifies the schemes that are allowed to fetch anchor data.
+type SupportedSchemes = [AnchorScheme]
+
+-- | The different schemes that can be used to fetch anchor data.
+data AnchorScheme = FileScheme | HttpScheme | HttpsScheme | IpfsScheme
+  deriving (Show, Eq)
 
 -- | Tag for tracking proposals submitted as 'Bytestring'
 data ProposalBinary

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/HashCmdError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/HashCmdError.hs
@@ -63,7 +63,7 @@ instance Exception FetchURLError where
   displayException (FetchURLUnsupportedURLSchemeError text) = "Unsupported URL scheme: " <> text
   displayException (FetchURLReadEnvVarError exc) = "Cannot read environment variable: " <> displayException exc
   displayException (FetchURLGetFileFromHttpError err) = displayException err
-  displayException FetchURLIpfsGatewayNotSetError = "IPFS schema requires IPFS_GATEWAY_URI environment variable to be set."
+  displayException FetchURLIpfsGatewayNotSetError = "IPFS scheme requires IPFS_GATEWAY_URI environment variable to be set."
 
 data HttpRequestError
   = BadStatusCodeHRE !Int !String


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Modified anchor-data checking to allow HTTP schema for testing purposes
  type:
  - feature
```

# Context

Having only support for HTTPS and IPFS is cumbersome, because it would require obtaining an SSL/TLS certificate and a domain for running the tests, or publishing to IPFS with every test (whenever the anchor-data changes).

This PR allows HTTP schema but shows a warning when it is used.

It also ensures we use "scheme" throughout and not "schema" (for self-consistency and consistency with IANA nomenclature), and adds documentations for some functions.

# How to trust this PR

There are plenty of tests so, in my opinion, it is mainly about documentation and code structure. I tested the warning manually, let me know if we should add an automated test for it.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
