### PR TITLE
create-testnet-data: fix generation of Conway genesis w.r.t. delegation of voting power

### DIFF
--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -371,6 +371,7 @@ test-suite cardano-cli-golden
   type: exitcode-stdio-1.0
   build-depends:
     aeson >=1.5.6.0,
+    aeson-pretty,
     base16-bytestring,
     bytestring,
     cardano-api:{cardano-api, gen},
@@ -378,6 +379,7 @@ test-suite cardano-cli-golden
     cardano-cli,
     cardano-cli:cardano-cli-test-lib,
     cardano-crypto-wrapper,
+    cardano-data,
     cardano-strict-containers ^>=0.1,
     cborg,
     containers,


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Fix that the `initialDReps` fields in the `conway-genesis.json` file generated by `create-testnet-data` was incomplete.
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  - bugfix         # fixes a defect
  - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

While testing https://github.com/IntersectMBO/cardano-cli/issues/911, I noticed that the SPO created by `create-testnet-data` doesn't delegate its voting power to a DRep.

So I looked at `create-testnet-data` and found that only the `--stake-delegators` created by `create-testnet-data` delegate to DReps (whereas the SPO is created by `--pools`). But then, starting with `--stake-delegators`, there is a bug (introduced in https://github.com/IntersectMBO/cardano-cli/pull/940/files#diff-46f6afb73150af450b10d232ebdca10061efd5a69e268f5b0870439aca3b19e0) that causes an incorrect `conway-genesis` to be created.

This PR fixes that

# How to trust this PR

TBD

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff