### PR TITLE
Remove instance which is in API now

### DIFF
--- a/cardano-cli/src/Cardano/CLI/Orphans.hs
+++ b/cardano-cli/src/Cardano/CLI/Orphans.hs
@@ -1,6 +1,3 @@
-{-# LANGUAGE GADTs #-}
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Cardano.CLI.Orphans
@@ -9,7 +6,6 @@ module Cardano.CLI.Orphans
 where
 
 import           Cardano.Api
-import qualified Cardano.Api.Experimental as Exp
 import qualified Cardano.Api.Ledger as L
 import           Cardano.Api.Shelley (scriptDataToJsonDetailedSchema)
 
@@ -33,9 +29,3 @@ instance ToJSON HashableScriptData where
       [ "hash" .= hashScriptDataBytes hsd
       , "json" .= scriptDataToJsonDetailedSchema hsd
       ]
-
--- TODO Delete me when added in API
-instance Convert Exp.Era MaryEraOnwards where
-  convert = \case
-    Exp.BabbageEra -> MaryEraOnwardsBabbage
-    Exp.ConwayEra -> MaryEraOnwardsConway


### PR DESCRIPTION
> [!NOTE]
>
> Requires https://github.com/IntersectMBO/cardano-api/pull/701

This reverts commit c64a1fbf54d1d8005cbd850bc06c4eee3f89dfda.

# Changelog

```yaml
- description: |
    Remove orphan instance that was added to API
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

This instance was temporary (added in https://github.com/IntersectMBO/cardano-cli/pull/988) and we don't need it anymore, now that it's in API.