### PR TITLE
create-testnet-data's implementation: explain why drepDelegs can be left empty

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Genesis/CreateTestnetData.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Genesis/CreateTestnetData.hs
@@ -516,7 +516,9 @@ runGenesisCreateTestNetDataCmd
                     { L.drepExpiry = EpochNo 1_000
                     , L.drepAnchor = SNothing
                     , L.drepDeposit = max (L.Coin 1_000_000) minDeposit
-                    , L.drepDelegs = Set.empty
+                    , L.drepDelegs = Set.empty -- We don't need to populate this field (field "initialDReps"."keyHash-*"."delegators" in the JSON)
+                    -- because its content is derived from the "delegs" field ("cgDelegs" above)
+                    -- More context is provided here: https://github.com/IntersectMBO/cardano-cli/pull/987
                     }
                 )
             )


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    create-testnet-data's implementation: explain why drepDelegs can be left empty
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  - documentation  # change in code docs, haddocks...
```

# Context

Document with a comment why https://github.com/IntersectMBO/cardano-cli/pull/987 is not required

# How to trust this PR

It's comments only

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] Self-reviewed the diff