### PR TITLE
create-testnet-data: move Byron handling to its own file

### DIFF
--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -102,6 +102,7 @@ library
     Cardano.CLI.EraBased.Options.Transaction
     Cardano.CLI.EraBased.Run
     Cardano.CLI.EraBased.Run.Genesis
+    Cardano.CLI.EraBased.Run.Genesis.Byron
     Cardano.CLI.EraBased.Run.Genesis.Common
     Cardano.CLI.EraBased.Run.Genesis.CreateTestnetData
     Cardano.CLI.EraBased.Run.Governance

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Genesis/Byron.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Genesis/Byron.hs
@@ -1,0 +1,75 @@
+{-# LANGUAGE NumericUnderscores #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE TypeApplications #-}
+
+module Cardano.CLI.EraBased.Run.Genesis.Byron where
+
+import           Cardano.Api.Byron (rationalToLovelacePortion)
+import qualified Cardano.Api.Byron as Byron hiding (GenesisParameters)
+import qualified Cardano.Api.Ledger as L
+import qualified Cardano.Api.Shelley as Shelley
+
+import qualified Cardano.CLI.Byron.Genesis as Byron
+import qualified Cardano.Crypto.ProtocolMagic as Crypto
+
+import           Data.Aeson (toJSON, (.=))
+import qualified Data.Aeson as Aeson
+import           Data.Maybe (fromJust)
+import           Data.Ratio ((%))
+import           GHC.Word (Word32)
+
+-- | We need to pass these values to create the Byron genesis file.
+-- The values here don't matter as the testnet conditions are ultimately determined
+-- by the Shelley genesis.
+defaultProtocolParamsJsonValue :: Aeson.Value
+defaultProtocolParamsJsonValue =
+  Aeson.object
+    [ "heavyDelThd" .= toJSON @String "300000000000"
+    , "maxBlockSize" .= toJSON @String "2000000"
+    , "maxTxSize" .= toJSON @String "4096"
+    , "maxHeaderSize" .= toJSON @String "2000000"
+    , "maxProposalSize" .= toJSON @String "700"
+    , "mpcThd" .= toJSON @String "20000000000000"
+    , "scriptVersion" .= toJSON @Int 0
+    , "slotDuration" .= toJSON @String "1000"
+    , "softforkRule"
+        .= Aeson.object
+          [ "initThd" .= toJSON @String "900000000000000"
+          , "minThd" .= toJSON @String "600000000000000"
+          , "thdDecrement" .= toJSON @String "50000000000000"
+          ]
+    , "txFeePolicy"
+        .= Aeson.object
+          [ "multiplier" .= toJSON @String "43946000000"
+          , "summand" .= toJSON @String "155381000000000"
+          ]
+    , "unlockStakeEpoch" .= toJSON @String "18446744073709551615"
+    , "updateImplicit" .= toJSON @String "10000"
+    , "updateProposalThd" .= toJSON @String "100000000000000"
+    , "updateVoteThd" .= toJSON @String "1000000000000"
+    ]
+
+mkGenesisParameters
+  :: Word -> Word32 -> FilePath -> Shelley.ShelleyGenesis c -> Byron.GenesisParameters
+mkGenesisParameters numPools actualNetworkWord32 byronGenesisFp shelleyGenesis =
+  Byron.GenesisParameters{..}
+ where
+  -- All arbitrary values come from cardano-testnet
+  byronPoolNumber = max 1 numPools -- byron genesis creation needs a >= 1 number of pools
+  gpStartTime = Shelley.sgSystemStart shelleyGenesis
+  gpProtocolParamsFile = byronGenesisFp
+  gpK = Byron.BlockCount 10
+  protocolMagicId = Crypto.ProtocolMagicId actualNetworkWord32
+  gpProtocolMagic = Crypto.AProtocolMagic (L.Annotated protocolMagicId ()) Crypto.RequiresMagic
+  gpTestnetBalance =
+    Byron.TestnetBalanceOptions
+      0 -- poor adresses
+      byronPoolNumber -- delegate addresses (BFT nodes)
+      (fromJust $ Byron.toByronLovelace $ L.Coin $ 3_000_000_000 * fromIntegral byronPoolNumber)
+      1
+  gpFakeAvvmOptions =
+    Byron.FakeAvvmOptions
+      0 -- avvm entry count
+      (fromJust $ Byron.toByronLovelace $ L.Coin 0) -- avvm entry balance
+  gpAvvmBalanceFactor = rationalToLovelacePortion $ 1 % 1
+  gpSeed = Nothing


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    create-testnet-data: move Byron handling to its own file
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

* Follow-up of https://github.com/IntersectMBO/cardano-cli/pull/974
  * I know more documentation was asked in 974, but I'd need to dig the node's implementation to obtain it; and I'm not sure it's a worthwhile usage of my time, given that Byron will eventually be phased out. Reviewers> LMK if you think differently. 
* Fixes https://github.com/IntersectMBO/cardano-cli/issues/976

# How to trust this PR

This is just code moved around: no functional change.

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] Self-reviewed the diff