### PR TITLE
Release 10.2.0.0 

### DIFF
--- a/cardano-cli/CHANGELOG.md
+++ b/cardano-cli/CHANGELOG.md
@@ -1,6 +1,74 @@
 # Changelog for cardano-cli
 
+## 10.2.0.0
+
+- Augment of query spo-stake-distribution to include the DRep delegation choices of the Pool's rewards accounts
+  (breaking)
+  [PR 990](https://github.com/IntersectMBO/cardano-cli/pull/990)
+
+- Implement the `query proposals` command
+  (feature, compatible)
+  [PR 984](https://github.com/IntersectMBO/cardano-cli/pull/984)
+
+- More fine grained controls of eras for create-testnet-data. Forbid creating DReps and CC in babbage.
+
+  Remove the `create-testnet-data` altogether in eras earlier than Babbage
+  (breaking)
+  [PR 968](https://github.com/IntersectMBO/cardano-cli/pull/968)
+
+- Update API to 10.4.0.0
+  (breaking)
+  [PR 988](https://github.com/IntersectMBO/cardano-cli/pull/988)
+
+- Modified anchor-data checking to allow HTTP schema for testing purposes
+  (feature)
+  [PR 979](https://github.com/IntersectMBO/cardano-cli/pull/979)
+
+- Minting script witness refactor
+  The type `ScriptWitnessFiles` makes it difficult to accommodate for specific changes to plutus scripts.
+  As a result we introduce `MintScriptWitnessWithPolicyId` as a first step towards deprecating `ScriptWitnessFiles`.
+  This paves the way to more readable code and allows us to introduce specific changes to the different script types i.e simple vs plutus.
+  (breaking, refactoring)
+  [PR 971](https://github.com/IntersectMBO/cardano-cli/pull/971)
+
+- create-testnet-data: create byron genesis
+  (breaking, test)
+  [PR 974](https://github.com/IntersectMBO/cardano-cli/pull/974)
+
+- `transaction build` now checks and fails if stake addresses used for deposit return or treasury withdrawals in proposals are NOT registered on-chain.
+  (feature)
+  [PR 963](https://github.com/IntersectMBO/cardano-cli/pull/963)
+
+- transaction submit: print transaction hash, like this:
+  
+  Transaction successfully submitted. Transaction hash is:
+  {"txhash":"456c614d5d547b7fe197a4d18fbb86e086cb9080594dabf9059adf08b00cf2bd"}
+  
+  Previously it was:
+  
+  Transaction successfully submitted.
+  (feature, breaking)
+  [PR 925](https://github.com/IntersectMBO/cardano-cli/pull/925)
+
+- Add option --committee-keys to `create-testnet-data` to create the cold and hot credential for constitutional committee members
+  (compatible)
+  [PR 961](https://github.com/IntersectMBO/cardano-cli/pull/961)
+
+- Added anchor data hash checks to `transaction build`
+  (feature)
+  [PR 951](https://github.com/IntersectMBO/cardano-cli/pull/951)
+
+- Update cardano-api to [10.2.0.0](https://github.com/IntersectMBO/cardano-api/releases/tag/cardano-api-10.2.0.0)
+  (breaking)
+  [PR 967](https://github.com/IntersectMBO/cardano-cli/pull/967)
+
+- Add the `debug check-node-configuration --node-configuration-file node-config.json` command
+  that reads `node-config.json` and checks that the hashes of genesis files are correct.
+  (feature)
+  [PR 923](https://github.com/IntersectMBO/cardano-cli/pull/923)
+
 ## 10.1.1.0
+
 - Restore stable query cmds
   (bugfix)
   [PR 955](https://github.com/IntersectMBO/cardano-cli/pull/955)

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.4
 name: cardano-cli
-version: 10.1.1.0
+version: 10.2.0.0
 synopsis: The Cardano command-line interface
 description: The Cardano command-line interface.
 copyright: 2020-2023 Input Output Global Inc (IOG).


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Release 10.2.0.0 
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

As discussed during the team meeting, we would like to release the binaries on GitHub only (as opposed to both [GitHub](https://github.com/IntersectMBO/cardano-cli/releases) and [CHaP](https://input-output-hk.github.io/cardano-haskell-packages/) usually), because [CHaP is broken right now](https://github.com/IntersectMBO/cardano-haskell-packages/pull/967).

**Once this PR is merged, I will tag its only commit and trigger the [release pipeline](https://github.com/IntersectMBO/cardano-cli/blob/master/.github/workflows/release-upload.yml) to create the release.**

# How to trust this PR

Changelog was generated in the usual manner.

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] Self-reviewed the diff