### PR TITLE
drep id: support key hash

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/DRep.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Governance/DRep.hs
@@ -42,7 +42,7 @@ data GovernanceDRepKeyGenCmdArgs era
 data GovernanceDRepIdCmdArgs era
   = GovernanceDRepIdCmdArgs
   { eon :: !(ConwayEraOnwards era)
-  , vkeySource :: !(VerificationKeyOrFile DRepKey)
+  , vkeySource :: !(VerificationKeyOrHashOrFile DRepKey)
   , idOutputFormat :: !IdOutputFormat
   , mOutFile :: !(Maybe (File () Out))
   }

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/DRep.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/DRep.hs
@@ -75,7 +75,7 @@ pGovernanceDRepKeyIdCmd era = do
     $ Opt.info
       ( fmap GovernanceDRepIdCmd $
           GovernanceDRepIdCmdArgs w
-            <$> pDRepVerificationKeyOrFile
+            <$> pDRepVerificationKeyOrHashOrFile
             <*> pDRepIdOutputFormat
             <*> optional pOutputFile
       )

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/DRep.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/DRep.hs
@@ -83,14 +83,14 @@ runGovernanceDRepIdCmd
     , idOutputFormat
     , mOutFile
     } = do
-    drepVerKey <-
+    drepVerKeyHash <-
       modifyError ReadFileError $
-        readVerificationKeyOrTextEnvFile AsDRepKey vkeySource
+        readVerificationKeyOrHashOrTextEnvFile AsDRepKey vkeySource
 
     content <-
       pure $ case idOutputFormat of
-        IdOutputFormatHex -> serialiseToRawBytesHex $ verificationKeyHash drepVerKey
-        IdOutputFormatBech32 -> Text.encodeUtf8 $ serialiseToBech32 $ verificationKeyHash drepVerKey
+        IdOutputFormatHex -> serialiseToRawBytesHex drepVerKeyHash
+        IdOutputFormatBech32 -> Text.encodeUtf8 $ serialiseToBech32 drepVerKeyHash
 
     lift (writeByteStringOutput mOutFile content)
       & onLeft (left . WriteFileError)

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Governance/DRep.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Governance/DRep.hs
@@ -122,6 +122,24 @@ hprop_golden_governance_drep_id_hex =
 
     H.diffFileVsGoldenFile idFile idGold
 
+-- | Execute me with:
+-- @cabal test cardano-cli-golden --test-options '-p "/golden governance drep id hash/"'@
+hprop_golden_governance_drep_id_hash :: Property
+hprop_golden_governance_drep_id_hash = propertyOnce $ do
+    idGold <- H.note "test/cardano-cli-golden/files/golden/governance/drep/drep.id.hash"
+
+    output <-
+      execCardanoCLI
+        [ "conway"
+        , "governance"
+        , "drep"
+        , "id"
+        , "--drep-key-hash"
+        , "c1a342f0dfb82b93ca2e6b406bacb04802f7d56a99d8f95a80a8b6c5"
+        ]
+
+    H.diffVsGoldenFile output idGold
+
 hprop_golden_governance_drep_extended_key_signing :: Property
 hprop_golden_governance_drep_extended_key_signing =
   propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do

--- a/cardano-cli/test/cardano-cli-golden/files/golden/governance/drep/drep.id.hash
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/governance/drep/drep.id.hash
@@ -1,0 +1,1 @@
+drep1cx359uxlhq4e8j3wddqxht9sfqp004t2n8v0jk5q4zmv27sh0h5

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -7087,6 +7087,7 @@ Usage: cardano-cli conway governance drep key-gen --verification-key-file FILEPA
 Usage: cardano-cli conway governance drep id 
                                                ( --drep-verification-key STRING
                                                | --drep-verification-key-file FILEPATH
+                                               | --drep-key-hash HASH
                                                )
                                                [--output-format STRING]
                                                [--out-file FILEPATH]
@@ -9107,6 +9108,7 @@ Usage: cardano-cli latest governance drep key-gen --verification-key-file FILEPA
 Usage: cardano-cli latest governance drep id 
                                                ( --drep-verification-key STRING
                                                | --drep-verification-key-file FILEPATH
+                                               | --drep-key-hash HASH
                                                )
                                                [--output-format STRING]
                                                [--out-file FILEPATH]
@@ -11729,6 +11731,7 @@ Usage: cardano-cli compatible conway governance drep key-gen --verification-key-
 Usage: cardano-cli compatible conway governance drep id 
                                                           ( --drep-verification-key STRING
                                                           | --drep-verification-key-file FILEPATH
+                                                          | --drep-key-hash HASH
                                                           )
                                                           [--output-format STRING]
                                                           [--out-file FILEPATH]

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_governance_drep_id.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_governance_drep_id.cli
@@ -1,6 +1,7 @@
 Usage: cardano-cli compatible conway governance drep id 
                                                           ( --drep-verification-key STRING
                                                           | --drep-verification-key-file FILEPATH
+                                                          | --drep-key-hash HASH
                                                           )
                                                           [--output-format STRING]
                                                           [--out-file FILEPATH]
@@ -12,6 +13,8 @@ Available options:
                            DRep verification key (Bech32 or hex-encoded).
   --drep-verification-key-file FILEPATH
                            Filepath of the DRep verification key.
+  --drep-key-hash HASH     DRep verification key hash (either Bech32-encoded or
+                           hex-encoded).
   --output-format STRING   Optional drep id output format. Accepted output
                            formats are "hex" and "bech32" (default is "bech32").
   --out-file FILEPATH      The output file.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_drep_id.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_drep_id.cli
@@ -1,6 +1,7 @@
 Usage: cardano-cli conway governance drep id 
                                                ( --drep-verification-key STRING
                                                | --drep-verification-key-file FILEPATH
+                                               | --drep-key-hash HASH
                                                )
                                                [--output-format STRING]
                                                [--out-file FILEPATH]
@@ -12,6 +13,8 @@ Available options:
                            DRep verification key (Bech32 or hex-encoded).
   --drep-verification-key-file FILEPATH
                            Filepath of the DRep verification key.
+  --drep-key-hash HASH     DRep verification key hash (either Bech32-encoded or
+                           hex-encoded).
   --output-format STRING   Optional drep id output format. Accepted output
                            formats are "hex" and "bech32" (default is "bech32").
   --out-file FILEPATH      The output file.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_governance_drep_id.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_governance_drep_id.cli
@@ -1,6 +1,7 @@
 Usage: cardano-cli latest governance drep id 
                                                ( --drep-verification-key STRING
                                                | --drep-verification-key-file FILEPATH
+                                               | --drep-key-hash HASH
                                                )
                                                [--output-format STRING]
                                                [--out-file FILEPATH]
@@ -12,6 +13,8 @@ Available options:
                            DRep verification key (Bech32 or hex-encoded).
   --drep-verification-key-file FILEPATH
                            Filepath of the DRep verification key.
+  --drep-key-hash HASH     DRep verification key hash (either Bech32-encoded or
+                           hex-encoded).
   --output-format STRING   Optional drep id output format. Accepted output
                            formats are "hex" and "bech32" (default is "bech32").
   --out-file FILEPATH      The output file.


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    drep id: support key hash as input
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

While we're still unsure whether we should use https://cips.cardano.org/cip/CIP-0105 or https://cips.cardano.org/cip/CIP-129, we know we have to extend `drep id` to support key hashes and scripts. This PR makes a small forward and implements the former.

Part of fixing https://github.com/IntersectMBO/cardano-cli/issues/883

# How to trust this PR

Observe that we honor the behavior tagged as deprecated in CIP-105 (our existing already follows this behavior flagged "deprecated", so we are being consistent here):

![image](https://github.com/user-attachments/assets/952c0fc0-d22b-4831-90f3-493aa8e52c7c)

* The existing golden tests for `drep id` still pass: we didn't change the default behavior

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [X] Self-reviewed the diff