### PR TITLE
drep id: have --output-bech32 and --output-hex instead of --output-format STRING

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/DRep.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Governance/DRep.hs
@@ -83,17 +83,19 @@ pGovernanceDRepKeyIdCmd era = do
 
 pDRepIdOutputFormat :: Parser IdOutputFormat
 pDRepIdOutputFormat =
-  Opt.option readIdOutputFormat $
-    mconcat
-      [ Opt.long "output-format"
-      , Opt.metavar "STRING"
-      , Opt.help $
-          mconcat
-            [ "Optional drep id output format. Accepted output formats are \"hex\" "
-            , "and \"bech32\" (default is \"bech32\")."
-            ]
-      , Opt.value IdOutputFormatBech32
-      ]
+  asum [make IdOutputFormatHex "hex", make IdOutputFormatBech32 "bech32"]
+    <|> pure default_
+ where
+  default_ = IdOutputFormatBech32
+  make format flag_ =
+    Opt.flag' format $
+      mconcat
+        [ Opt.help $
+            "Format drep id output as "
+              <> flag_
+              <> (if format == default_ then " (the default)." else ".")
+        , Opt.long ("output-" <> flag_)
+        ]
 
 -- Registration Certificate related
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Governance/DRep.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Governance/DRep.hs
@@ -76,6 +76,8 @@ hprop_golden_governanceDRepKeyGen =
     pure $ showOct (mode .&. 0o777) "" -- we only need the 3 lowest octets here
 #endif
 
+-- | Execute me with:
+-- @cabal test cardano-cli-golden --test-options '-p "/golden governance drep id bech32/"'@
 hprop_golden_governance_drep_id_bech32 :: Property
 hprop_golden_governance_drep_id_bech32 =
   propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
@@ -91,14 +93,15 @@ hprop_golden_governance_drep_id_bech32 =
         , "id"
         , "--drep-verification-key-file"
         , vkeyFile
-        , "--output-format"
-        , "bech32"
+        , "--output-bech32"
         , "--out-file"
         , idFile
         ]
 
     H.diffFileVsGoldenFile idFile idGold
 
+-- | Execute me with:
+-- @cabal test cardano-cli-golden --test-options '-p "/golden governance drep id hex/"'@
 hprop_golden_governance_drep_id_hex :: Property
 hprop_golden_governance_drep_id_hex =
   propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
@@ -114,8 +117,7 @@ hprop_golden_governance_drep_id_hex =
         , "id"
         , "--drep-verification-key-file"
         , vkeyFile
-        , "--output-format"
-        , "hex"
+        , "--output-hex"
         , "--out-file"
         , idFile
         ]

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -7089,7 +7089,7 @@ Usage: cardano-cli conway governance drep id
                                                | --drep-verification-key-file FILEPATH
                                                | --drep-key-hash HASH
                                                )
-                                               [--output-format STRING]
+                                               [--output-hex | --output-bech32]
                                                [--out-file FILEPATH]
 
   Generate a drep id.
@@ -9110,7 +9110,7 @@ Usage: cardano-cli latest governance drep id
                                                | --drep-verification-key-file FILEPATH
                                                | --drep-key-hash HASH
                                                )
-                                               [--output-format STRING]
+                                               [--output-hex | --output-bech32]
                                                [--out-file FILEPATH]
 
   Generate a drep id.
@@ -11733,7 +11733,9 @@ Usage: cardano-cli compatible conway governance drep id
                                                           | --drep-verification-key-file FILEPATH
                                                           | --drep-key-hash HASH
                                                           )
-                                                          [--output-format STRING]
+                                                          [ --output-hex
+                                                          | --output-bech32
+                                                          ]
                                                           [--out-file FILEPATH]
 
   Generate a drep id.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_governance_drep_id.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_governance_drep_id.cli
@@ -3,7 +3,9 @@ Usage: cardano-cli compatible conway governance drep id
                                                           | --drep-verification-key-file FILEPATH
                                                           | --drep-key-hash HASH
                                                           )
-                                                          [--output-format STRING]
+                                                          [ --output-hex
+                                                          | --output-bech32
+                                                          ]
                                                           [--out-file FILEPATH]
 
   Generate a drep id.
@@ -15,7 +17,7 @@ Available options:
                            Filepath of the DRep verification key.
   --drep-key-hash HASH     DRep verification key hash (either Bech32-encoded or
                            hex-encoded).
-  --output-format STRING   Optional drep id output format. Accepted output
-                           formats are "hex" and "bech32" (default is "bech32").
+  --output-hex             Format drep id output as hex.
+  --output-bech32          Format drep id output as bech32 (the default).
   --out-file FILEPATH      The output file.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_drep_id.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_drep_id.cli
@@ -3,7 +3,7 @@ Usage: cardano-cli conway governance drep id
                                                | --drep-verification-key-file FILEPATH
                                                | --drep-key-hash HASH
                                                )
-                                               [--output-format STRING]
+                                               [--output-hex | --output-bech32]
                                                [--out-file FILEPATH]
 
   Generate a drep id.
@@ -15,7 +15,7 @@ Available options:
                            Filepath of the DRep verification key.
   --drep-key-hash HASH     DRep verification key hash (either Bech32-encoded or
                            hex-encoded).
-  --output-format STRING   Optional drep id output format. Accepted output
-                           formats are "hex" and "bech32" (default is "bech32").
+  --output-hex             Format drep id output as hex.
+  --output-bech32          Format drep id output as bech32 (the default).
   --out-file FILEPATH      The output file.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_governance_drep_id.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_governance_drep_id.cli
@@ -3,7 +3,7 @@ Usage: cardano-cli latest governance drep id
                                                | --drep-verification-key-file FILEPATH
                                                | --drep-key-hash HASH
                                                )
-                                               [--output-format STRING]
+                                               [--output-hex | --output-bech32]
                                                [--out-file FILEPATH]
 
   Generate a drep id.
@@ -15,7 +15,7 @@ Available options:
                            Filepath of the DRep verification key.
   --drep-key-hash HASH     DRep verification key hash (either Bech32-encoded or
                            hex-encoded).
-  --output-format STRING   Optional drep id output format. Accepted output
-                           formats are "hex" and "bech32" (default is "bech32").
+  --output-hex             Format drep id output as hex.
+  --output-bech32          Format drep id output as bech32 (the default).
   --out-file FILEPATH      The output file.
   -h,--help                Show this help text


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    drep id: have --output-bech32 and --output-hex instead of --output-format STRING 
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

* Fixes https://github.com/IntersectMBO/cardano-cli/issues/1010
* This is part of being more consistent in the name of our flags: https://github.com/IntersectMBO/cardano-cli/issues/566

# How to trust this PR

Look at the changes to golden files

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] Self-reviewed the diff