### PR TITLE
Create ready releases (skip draft state)

### DIFF
--- a/.github/workflows/release-upload.yml
+++ b/.github/workflows/release-upload.yml
@@ -219,7 +219,7 @@ jobs:
       - name: Create Release
         uses: input-output-hk/action-gh-release@v1
         with:
-          draft: true
+          draft: false
           tag_name: ${{ needs.wait_for_hydra.outputs.TARGET_TAG }} # Git tag the release is attached to
           name: ${{ env.SHORT_TAG }} # Release name in GitHub UI
           # TODO generalize


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Don't create releases as draft anymore to skip the manual undraft step.
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

* After every release, I go to the release page, for example https://github.com/IntersectMBO/cardano-cli/releases/edit/cardano-cli-10.3.0.0
* And then I undraft it here (although it doesn't show in this screenshot, because it's done already for 10.3.0.0):

![image](https://github.com/user-attachments/assets/1a6444d1-4c89-4bdb-91ce-ef9d7d76c741)

This PR will avoid this manual step and in particular it will avoid releases not being published if I am rolled over by a bus :laughing: 

# How to trust this PR

The release pipeline has been added in April 2024, in https://github.com/IntersectMBO/cardano-cli/pull/730. Since then, it has been silently working and so I think there's no risk making the releases automatically public.

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] Self-reviewed the diff