### PR TITLE
Add governance action deposits to stake-address-info query

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -60,3 +60,10 @@ write-ghc-environment-files: always
 -- Do NOT add more source-repository-package stanzas here unless they are strictly
 -- temporary! Please read the section in CONTRIBUTING about updating dependencies.
 
+source-repository-package
+  type: git
+  location: https://github.com/IntersectMBO/cardano-api
+  tag: 6f8d4cad30416f8e74090e7ad3cb3a249c0eb68a
+  --sha256: sha256-Qx/mALvadNt8wwD+z4r4kPRgdSAJi+WAnTK2M57qop0=
+  subdir:
+    cardano-api

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -364,6 +364,7 @@ test-suite cardano-cli-test
     Test.Cli.Shelley.Run.Hash
     Test.Cli.Shelley.Run.Query
     Test.Cli.Shelley.Transaction.Build
+    Test.Cli.Shelley.Transaction.Compatible.Build
     Test.Cli.VerificationKey
 
   ghc-options:

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -117,6 +117,8 @@ library
     Cardano.CLI.EraBased.Run.StakePool
     Cardano.CLI.EraBased.Run.TextView
     Cardano.CLI.EraBased.Run.Transaction
+    Cardano.CLI.EraBased.Script.Certificate.Read
+    Cardano.CLI.EraBased.Script.Certificate.Types
     Cardano.CLI.EraBased.Script.Mint.Read
     Cardano.CLI.EraBased.Script.Mint.Types
     Cardano.CLI.EraBased.Script.Spend.Read

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -119,6 +119,8 @@ library
     Cardano.CLI.EraBased.Run.Transaction
     Cardano.CLI.EraBased.Script.Mint.Read
     Cardano.CLI.EraBased.Script.Mint.Types
+    Cardano.CLI.EraBased.Script.Spend.Read
+    Cardano.CLI.EraBased.Script.Spend.Types
     Cardano.CLI.EraBased.Transaction.HashCheck
     Cardano.CLI.Helpers
     Cardano.CLI.IO.Lazy

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -121,6 +121,7 @@ library
     Cardano.CLI.EraBased.Script.Mint.Types
     Cardano.CLI.EraBased.Script.Spend.Read
     Cardano.CLI.EraBased.Script.Spend.Types
+    Cardano.CLI.EraBased.Script.Types
     Cardano.CLI.EraBased.Transaction.HashCheck
     Cardano.CLI.Helpers
     Cardano.CLI.IO.Lazy

--- a/cardano-cli/src/Cardano/CLI/Compatible/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/Compatible/Transaction.hs
@@ -65,12 +65,12 @@ pCompatibleSignedTransaction env sbe =
     <$> many pTxInOnly
     <*> many (pTxOutEraAware sbe)
     <*> pFeatured (toCardanoEra sbe) (optional pUpdateProposalFile)
-    <*> pFeatured (toCardanoEra sbe) (many (pProposalFile sbe ManualBalance))
+    <*> pFeatured (toCardanoEra sbe) (many (pProposalFile ManualBalance))
     <*> pVoteFiles sbe ManualBalance
     <*> many pWitnessSigningData
     <*> optional (pNetworkId env)
     <*> pTxFee
-    <*> many (pCertificateFile sbe ManualBalance)
+    <*> many (pCertificateFile ManualBalance)
     <*> pOutputFile
 
 pTxInOnly :: Parser TxIn

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Transaction.hs
@@ -25,6 +25,7 @@ import qualified Cardano.Api.Experimental as Exp
 import           Cardano.Api.Ledger (Coin)
 import           Cardano.Api.Shelley
 
+import           Cardano.CLI.EraBased.Script.Certificate.Types (CliCertificateScriptRequirements)
 import           Cardano.CLI.EraBased.Script.Mint.Types
 import           Cardano.CLI.EraBased.Script.Spend.Types (CliSpendScriptRequirements)
 import           Cardano.CLI.Types.Common
@@ -71,7 +72,7 @@ data TransactionBuildRawCmdArgs era = TransactionBuildRawCmdArgs
   -- ^ Transaction validity upper bound
   , fee :: !Coin
   -- ^ Transaction fee
-  , certificates :: ![(CertificateFile, Maybe (ScriptWitnessFiles WitCtxStake))]
+  , certificates :: ![(CertificateFile, Maybe CliCertificateScriptRequirements)]
   -- ^ Certificates with potential script witness
   , withdrawals :: ![(StakeAddress, Coin, Maybe (ScriptWitnessFiles WitCtxStake))]
   , metadataSchema :: !TxMetadataJsonSchema
@@ -119,7 +120,7 @@ data TransactionBuildCmdArgs era = TransactionBuildCmdArgs
   -- ^ Transaction validity lower bound
   , mValidityUpperBound :: !(TxValidityUpperBound era)
   -- ^ Transaction validity upper bound
-  , certificates :: ![(CertificateFile, Maybe (ScriptWitnessFiles WitCtxStake))]
+  , certificates :: ![(CertificateFile, Maybe CliCertificateScriptRequirements)]
   -- ^ Certificates with potential script witness
   , withdrawals :: ![(StakeAddress, Coin, Maybe (ScriptWitnessFiles WitCtxStake))]
   -- ^ Withdrawals with potential script witness
@@ -165,7 +166,7 @@ data TransactionBuildEstimateCmdArgs era = TransactionBuildEstimateCmdArgs
   -- ^ Transaction validity lower bound
   , mValidityUpperBound :: !(TxValidityUpperBound era)
   -- ^ Transaction validity upper bound
-  , certificates :: ![(CertificateFile, Maybe (ScriptWitnessFiles WitCtxStake))]
+  , certificates :: ![(CertificateFile, Maybe CliCertificateScriptRequirements)]
   -- ^ Certificates with potential script witness
   , withdrawals :: ![(StakeAddress, Coin, Maybe (ScriptWitnessFiles WitCtxStake))]
   -- ^ Withdrawals with potential script witness

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Transaction.hs
@@ -26,6 +26,7 @@ import           Cardano.Api.Ledger (Coin)
 import           Cardano.Api.Shelley
 
 import           Cardano.CLI.EraBased.Script.Mint.Types
+import           Cardano.CLI.EraBased.Script.Spend.Types (CliSpendScriptRequirements)
 import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Governance
 
@@ -49,7 +50,7 @@ data TransactionBuildRawCmdArgs era = TransactionBuildRawCmdArgs
   { eon :: !(ShelleyBasedEra era)
   , mScriptValidity :: !(Maybe ScriptValidity)
   -- ^ Mark script as expected to pass or fail validation
-  , txIns :: ![(TxIn, Maybe (ScriptWitnessFiles WitCtxTxIn))]
+  , txIns :: ![(TxIn, Maybe CliSpendScriptRequirements)]
   -- ^ Transaction inputs with optional spending scripts
   , readOnlyRefIns :: ![TxIn]
   -- ^ Read only reference inputs
@@ -96,7 +97,7 @@ data TransactionBuildCmdArgs era = TransactionBuildCmdArgs
   -- ^ Mark script as expected to pass or fail validation
   , mOverrideWitnesses :: !(Maybe Word)
   -- ^ Override the required number of tx witnesses
-  , txins :: ![(TxIn, Maybe (ScriptWitnessFiles WitCtxTxIn))]
+  , txins :: ![(TxIn, Maybe CliSpendScriptRequirements)]
   -- ^ Transaction inputs with optional spending scripts
   , readOnlyReferenceInputs :: ![TxIn]
   -- ^ Read only reference inputs
@@ -144,7 +145,7 @@ data TransactionBuildEstimateCmdArgs era = TransactionBuildEstimateCmdArgs
   , mByronWitnesses :: !(Maybe Int)
   , protocolParamsFile :: !ProtocolParamsFile
   , totalUTxOValue :: !Value
-  , txins :: ![(TxIn, Maybe (ScriptWitnessFiles WitCtxTxIn))]
+  , txins :: ![(TxIn, Maybe CliSpendScriptRequirements)]
   -- ^ Transaction inputs with optional spending scripts
   , readOnlyReferenceInputs :: ![TxIn]
   -- ^ Read only reference inputs

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
@@ -1034,7 +1034,6 @@ pPlutusMintScriptWitnessData _sbe _witctx autoBalanceExecUnits =
 pSimpleScriptOrPlutusSpendingScriptWitness
   :: ShelleyBasedEra era
   -> BalanceTxExecUnits
-  -- ^ Use the @execution-units@ flag.
   -> String
   -- ^ Script flag prefix
   -> Maybe String
@@ -1060,7 +1059,6 @@ pScriptWitnessFiles
   :: forall witctx
    . WitCtx witctx
   -> BalanceTxExecUnits
-  -- ^ Use the @execution-units@ flag.
   -> String
   -- ^ Script flag prefix
   -> Maybe String
@@ -1590,7 +1588,6 @@ pWithdrawal balance =
 pPlutusStakeReferenceScriptWitnessFilesVotingProposing
   :: String
   -> BalanceTxExecUnits
-  -- ^ Use the @execution-units@ flag.
   -> Parser (ScriptWitnessFiles WitCtxStake)
 pPlutusStakeReferenceScriptWitnessFilesVotingProposing prefix autoBalanceExecUnits =
   PlutusReferenceScriptWitnessFiles
@@ -1606,7 +1603,6 @@ pPlutusStakeReferenceScriptWitnessFilesVotingProposing prefix autoBalanceExecUni
 pPlutusStakeReferenceScriptWitnessFiles
   :: String
   -> BalanceTxExecUnits
-  -- ^ Use the @execution-units@ flag.
   -> Parser (ScriptWitnessFiles WitCtxStake)
 pPlutusStakeReferenceScriptWitnessFiles prefix autoBalanceExecUnits =
   PlutusReferenceScriptWitnessFiles

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
@@ -1037,7 +1037,9 @@ pSimpleScriptOrPlutusSpendingScriptWitness
   -> String
   -- ^ Script flag prefix
   -> Maybe String
+  -- ^ Potential deprecated script flag prefix
   -> String
+  -- ^ Help text
   -> Parser CliSpendScriptRequirements
 pSimpleScriptOrPlutusSpendingScriptWitness sbe autoBalanceExecUnits scriptFlagPrefix scriptFlagPrefixDeprecated help =
   PlutusSpend.createSimpleOrPlutusScriptFromCliArgs

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Transaction.hs
@@ -185,8 +185,8 @@ pTransactionBuildCmd sbe envCli = do
         <*> optional (pMintMultiAsset sbe AutoBalance)
         <*> optional pInvalidBefore
         <*> pInvalidHereafter sbe
-        <*> many (pCertificateFile sbe AutoBalance)
-        <*> many (pWithdrawal sbe AutoBalance)
+        <*> many (pCertificateFile AutoBalance)
+        <*> many (pWithdrawal AutoBalance)
         <*> pTxMetadataJsonSchema
         <*> many
           ( pScriptFor
@@ -245,8 +245,8 @@ pTransactionBuildEstimateCmd eon' _envCli = do
         <*> optional (pMintMultiAsset sbe ManualBalance)
         <*> optional pInvalidBefore
         <*> pInvalidHereafter sbe
-        <*> many (pCertificateFile sbe ManualBalance)
-        <*> many (pWithdrawal sbe ManualBalance)
+        <*> many (pCertificateFile ManualBalance)
+        <*> many (pWithdrawal ManualBalance)
         <*> optional pTotalCollateral
         <*> optional pReferenceScriptSize
         <*> pTxMetadataJsonSchema
@@ -289,8 +289,8 @@ pTransactionBuildRaw era' =
       <*> optional pInvalidBefore
       <*> pInvalidHereafter era'
       <*> pTxFee
-      <*> many (pCertificateFile era' ManualBalance)
-      <*> many (pWithdrawal era' ManualBalance)
+      <*> many (pCertificateFile ManualBalance)
+      <*> many (pWithdrawal ManualBalance)
       <*> pTxMetadataJsonSchema
       <*> many (pScriptFor "auxiliary-script-file" Nothing "Filepath of auxiliary script(s)")
       <*> many pMetadataFile

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Query.hs
@@ -982,24 +982,24 @@ callQueryStakeAddressInfoCmd
         (stakeVoteDelegatees, gaDeposits) <-
           caseShelleyToBabbageOrConwayEraOnwards
             (const $ pure (Map.empty, Map.empty))
-            (\ceo -> do
-              stakeVoteDelegatees <- easyRunQuery (queryStakeVoteDelegatees ceo stakeAddr)
+            ( \ceo -> do
+                stakeVoteDelegatees <- easyRunQuery (queryStakeVoteDelegatees ceo stakeAddr)
 
-              govActionStates :: (Seq.Seq (L.GovActionState (ShelleyLedgerEra era))) <-
-                easyRunQuery $ queryProposals ceo Set.empty
+                govActionStates :: (Seq.Seq (L.GovActionState (ShelleyLedgerEra era))) <-
+                  easyRunQuery $ queryProposals ceo Set.empty
 
-              let gaDeposits =
-                    conwayEraOnwardsConstraints ceo $
-                      Map.fromList
-                        [ (L.gasId gas, L.pProcDeposit proc)
-                        | gas <- toList govActionStates
-                        , let proc = L.gasProposalProcedure gas
-                        , let rewardAccount = L.pProcReturnAddr proc
-                              stakeCredential :: Api.StakeCredential = fromShelleyStakeCredential $ L.raCredential rewardAccount
-                        , stakeCredential == fromShelleyStakeCredential addr
-                        ]
-              
-              return (stakeVoteDelegatees, gaDeposits)
+                let gaDeposits =
+                      conwayEraOnwardsConstraints ceo $
+                        Map.fromList
+                          [ (L.gasId gas, L.pProcDeposit proc)
+                          | gas <- toList govActionStates
+                          , let proc = L.gasProposalProcedure gas
+                          , let rewardAccount = L.pProcReturnAddr proc
+                                stakeCredential :: Api.StakeCredential = fromShelleyStakeCredential $ L.raCredential rewardAccount
+                          , stakeCredential == fromShelleyStakeCredential addr
+                          ]
+
+                return (stakeVoteDelegatees, gaDeposits)
             )
             (convert beo)
 

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Query.hs
@@ -753,7 +753,7 @@ runQueryRefScriptSizeCmd
 
 newtype RefInputScriptSize = RefInputScriptSize {refInputScriptSize :: Int}
   deriving Generic
-  deriving anyclass (ToJSON)
+  deriving anyclass ToJSON
 
 instance Pretty RefInputScriptSize where
   pretty (RefInputScriptSize s) = "Reference inputs scripts size is" <+> pretty s <+> "bytes."

--- a/cardano-cli/src/Cardano/CLI/EraBased/Script/Certificate/Read.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Script/Certificate/Read.hs
@@ -1,0 +1,111 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE TupleSections #-}
+
+module Cardano.CLI.EraBased.Script.Certificate.Read
+  ( readCertificateScriptWitness
+  , readCertificateScriptWitnesses
+  )
+where
+
+import           Cardano.Api
+import           Cardano.Api.Shelley
+
+import           Cardano.CLI.EraBased.Script.Certificate.Types
+import           Cardano.CLI.EraBased.Script.Types
+import           Cardano.CLI.Read
+import           Cardano.CLI.Types.Common
+
+import           Control.Monad
+
+readCertificateScriptWitnesses
+  :: MonadIOTransError (FileError CliScriptWitnessError) t m
+  => ShelleyBasedEra era
+  -> [(CertificateFile, Maybe CliCertificateScriptRequirements)]
+  -> t m [(CertificateFile, Maybe (CertificateScriptWitness era))]
+readCertificateScriptWitnesses sbe =
+  mapM
+    ( \(certFile, mSWit) -> do
+        (certFile,) <$> forM mSWit (readCertificateScriptWitness sbe)
+    )
+
+readCertificateScriptWitness
+  :: MonadIOTransError (FileError CliScriptWitnessError) t m
+  => ShelleyBasedEra era -> CliCertificateScriptRequirements -> t m (CertificateScriptWitness era)
+readCertificateScriptWitness sbe certScriptReq =
+  case certScriptReq of
+    OnDiskSimpleScript scriptFp -> do
+      let sFp = unFile scriptFp
+      s <-
+        modifyError (fmap SimpleScriptWitnessDecodeError) $
+          readFileSimpleScript sFp
+      case s of
+        SimpleScript ss -> do
+          return $
+            CertificateScriptWitness $
+              SimpleScriptWitness (sbeToSimpleScriptLanguageInEra sbe) $
+                SScript ss
+    OnDiskPlutusScript (OnDiskPlutusScriptCliArgs scriptFp redeemerFile execUnits) -> do
+      let plutusScriptFp = unFile scriptFp
+      plutusScript <-
+        modifyError (fmap PlutusScriptWitnessDecodeError) $
+          readFilePlutusScript plutusScriptFp
+      redeemer <-
+        modifyError (FileError plutusScriptFp . PlutusScriptWitnessRedeemerError) $
+          readScriptDataOrFile redeemerFile
+      case plutusScript of
+        AnyPlutusScript lang script -> do
+          let pScript = PScript script
+          sLangSupported <-
+            modifyError (FileError plutusScriptFp)
+              $ hoistMaybe
+                ( PlutusScriptWitnessLanguageNotSupportedInEra
+                    (AnyPlutusScriptVersion lang)
+                    (shelleyBasedEraConstraints sbe $ AnyShelleyBasedEra sbe)
+                )
+              $ scriptLanguageSupportedInEra sbe
+              $ PlutusScriptLanguage lang
+          return $
+            CertificateScriptWitness $
+              PlutusScriptWitness
+                sLangSupported
+                lang
+                pScript
+                NoScriptDatumForStake
+                redeemer
+                execUnits
+    OnDiskPlutusRefScript (PlutusRefScriptCliArgs refTxIn anyPlutusScriptVersion redeemerFile execUnits) -> do
+      case anyPlutusScriptVersion of
+        AnyPlutusScriptVersion lang -> do
+          let pScript = PReferenceScript refTxIn
+          redeemer <-
+            -- TODO: Implement a new error type to capture this. FileError is not representative of cases
+            -- where we do not have access to the script.
+            modifyError
+              ( FileError "Reference script filepath not available"
+                  . PlutusScriptWitnessRedeemerError
+              )
+              $ readScriptDataOrFile redeemerFile
+          sLangSupported <-
+            -- TODO: Implement a new error type to capture this. FileError is not representative of cases
+            -- where we do not have access to the script.
+            modifyError (FileError "Reference script filepath not available")
+              $ hoistMaybe
+                ( PlutusScriptWitnessLanguageNotSupportedInEra
+                    (AnyPlutusScriptVersion lang)
+                    (shelleyBasedEraConstraints sbe $ AnyShelleyBasedEra sbe)
+                )
+              $ scriptLanguageSupportedInEra sbe
+              $ PlutusScriptLanguage lang
+
+          return $
+            CertificateScriptWitness $
+              PlutusScriptWitness
+                sLangSupported
+                lang
+                pScript
+                NoScriptDatumForStake
+                redeemer
+                execUnits

--- a/cardano-cli/src/Cardano/CLI/EraBased/Script/Certificate/Read.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Script/Certificate/Read.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE TupleSections #-}
 
 module Cardano.CLI.EraBased.Script.Certificate.Read

--- a/cardano-cli/src/Cardano/CLI/EraBased/Script/Certificate/Types.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Script/Certificate/Types.hs
@@ -1,0 +1,63 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+
+module Cardano.CLI.EraBased.Script.Certificate.Types
+  ( CertificateScriptWitness (..)
+  , CliCertificateScriptRequirements (..)
+  , PlutusScriptCliArgs (..)
+  , PlutusRefScriptCliArgs (..)
+  , createSimpleOrPlutusScriptFromCliArgs
+  , createPlutusReferenceScriptFromCliArgs
+  )
+where
+
+import           Cardano.Api
+
+import           Cardano.CLI.Types.Common (ScriptDataOrFile)
+
+newtype CertificateScriptWitness era
+  = CertificateScriptWitness {cswScriptWitness :: ScriptWitness WitCtxStake era}
+  deriving Show
+
+data CliCertificateScriptRequirements
+  = OnDiskPlutusScript PlutusScriptCliArgs
+  | OnDiskSimpleScript (File ScriptInAnyLang In)
+  | OnDiskPlutusRefScript PlutusRefScriptCliArgs
+  deriving Show
+
+data PlutusScriptCliArgs
+  = OnDiskPlutusScriptCliArgs
+      (File ScriptInAnyLang In)
+      ScriptDataOrFile
+      -- ^ Redeemer
+      ExecutionUnits
+  deriving Show
+
+createSimpleOrPlutusScriptFromCliArgs
+  :: File ScriptInAnyLang In
+  -> Maybe (ScriptDataOrFile, ExecutionUnits)
+  -> CliCertificateScriptRequirements
+createSimpleOrPlutusScriptFromCliArgs scriptFp (Just (redeemer, execUnits)) =
+  OnDiskPlutusScript $ OnDiskPlutusScriptCliArgs scriptFp redeemer execUnits
+createSimpleOrPlutusScriptFromCliArgs scriptFp Nothing =
+  OnDiskSimpleScript scriptFp
+
+data PlutusRefScriptCliArgs
+  = PlutusRefScriptCliArgs
+      TxIn
+      -- ^ TxIn with reference script
+      AnyPlutusScriptVersion
+      ScriptDataOrFile
+      -- ^ Redeemer
+      ExecutionUnits
+  deriving Show
+
+createPlutusReferenceScriptFromCliArgs
+  :: TxIn
+  -> AnyPlutusScriptVersion
+  -> ScriptDataOrFile
+  -> ExecutionUnits
+  -> CliCertificateScriptRequirements
+createPlutusReferenceScriptFromCliArgs txIn version redeemer execUnits =
+  OnDiskPlutusRefScript $ PlutusRefScriptCliArgs txIn version redeemer execUnits

--- a/cardano-cli/src/Cardano/CLI/EraBased/Script/Mint/Read.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Script/Mint/Read.hs
@@ -11,6 +11,7 @@ import           Cardano.Api
 import           Cardano.Api.Shelley
 
 import           Cardano.CLI.EraBased.Script.Mint.Types
+import           Cardano.CLI.EraBased.Script.Types
 import           Cardano.CLI.Read
 
 readMintScriptWitness

--- a/cardano-cli/src/Cardano/CLI/EraBased/Script/Mint/Read.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Script/Mint/Read.hs
@@ -27,7 +27,7 @@ readMintScriptWitness sbe (OnDiskSimpleOrPlutusScript simpleOrPlutus) =
           let polId = PolicyId $ hashScript s
           return $
             MintScriptWitnessWithPolicyId polId $
-              SimpleScriptWitness (sbeToSimpleScriptLangInEra sbe) $
+              SimpleScriptWitness (sbeToSimpleScriptLanguageInEra sbe) $
                 SScript ss
     OnDiskPlutusScriptCliArgs plutusScriptFp redeemerFile execUnits -> do
       let sFp = unFile plutusScriptFp
@@ -65,7 +65,7 @@ readMintScriptWitness sbe (OnDiskSimpleRefScript (SimpleRefScriptCliArgs refTxIn
   return $
     MintScriptWitnessWithPolicyId polId $
       SimpleScriptWitness
-        (sbeToSimpleScriptLangInEra sbe)
+        (sbeToSimpleScriptLanguageInEra sbe)
         (SReferenceScript refTxIn)
 readMintScriptWitness
   sbe
@@ -100,13 +100,3 @@ readMintScriptWitness
               NoScriptDatumForMint
               redeemer
               execUnits
-
--- TODO: Remove me when exposed from cardano-api
-sbeToSimpleScriptLangInEra
-  :: ShelleyBasedEra era -> ScriptLanguageInEra SimpleScript' era
-sbeToSimpleScriptLangInEra ShelleyBasedEraShelley = SimpleScriptInShelley
-sbeToSimpleScriptLangInEra ShelleyBasedEraAllegra = SimpleScriptInAllegra
-sbeToSimpleScriptLangInEra ShelleyBasedEraMary = SimpleScriptInMary
-sbeToSimpleScriptLangInEra ShelleyBasedEraAlonzo = SimpleScriptInAlonzo
-sbeToSimpleScriptLangInEra ShelleyBasedEraBabbage = SimpleScriptInBabbage
-sbeToSimpleScriptLangInEra ShelleyBasedEraConway = SimpleScriptInConway

--- a/cardano-cli/src/Cardano/CLI/EraBased/Script/Mint/Types.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Script/Mint/Types.hs
@@ -4,8 +4,7 @@
 {-# LANGUAGE LambdaCase #-}
 
 module Cardano.CLI.EraBased.Script.Mint.Types
-  ( CliScriptWitnessError (..)
-  , CliMintScriptRequirements (..)
+  ( CliMintScriptRequirements (..)
   , SimpleOrPlutusScriptCliArgs (..)
   , createSimpleOrPlutusScriptFromCliArgs
   , PlutusRefScriptCliArgs (..)
@@ -19,9 +18,6 @@ where
 import           Cardano.Api
 
 import           Cardano.CLI.Types.Common (ScriptDataOrFile)
-import           Cardano.CLI.Types.Errors.PlutusScriptDecodeError
-import           Cardano.CLI.Types.Errors.ScriptDataError
-import           Cardano.CLI.Types.Errors.ScriptDecodeError
 
 -- We always need the policy id when constructing a transaction that mints.
 -- In the case of reference scripts, the user currently must provide the policy id (script hash)
@@ -89,19 +85,3 @@ createPlutusReferenceScriptFromCliArgs
   -> CliMintScriptRequirements
 createPlutusReferenceScriptFromCliArgs txin scriptVersion scriptData execUnits polid =
   OnDiskPlutusRefScript $ PlutusRefScriptCliArgs txin scriptVersion scriptData execUnits polid
-
-data CliScriptWitnessError
-  = SimpleScriptWitnessDecodeError ScriptDecodeError
-  | PlutusScriptWitnessDecodeError PlutusScriptDecodeError
-  | PlutusScriptWitnessLanguageNotSupportedInEra
-      AnyPlutusScriptVersion
-      AnyShelleyBasedEra
-  | PlutusScriptWitnessRedeemerError ScriptDataError
-
-instance Error CliScriptWitnessError where
-  prettyError = \case
-    SimpleScriptWitnessDecodeError err -> prettyError err
-    PlutusScriptWitnessDecodeError err -> prettyError err
-    PlutusScriptWitnessLanguageNotSupportedInEra version era ->
-      "Plutus script version " <> pshow version <> " is not supported in era " <> pshow era
-    PlutusScriptWitnessRedeemerError err -> renderScriptDataError err

--- a/cardano-cli/src/Cardano/CLI/EraBased/Script/Mint/Types.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Script/Mint/Types.hs
@@ -45,6 +45,7 @@ data SimpleOrPlutusScriptCliArgs
   | OnDiskPlutusScriptCliArgs
       (File ScriptInAnyLang In)
       ScriptDataOrFile
+      -- ^ Redeemer
       ExecutionUnits
   deriving Show
 

--- a/cardano-cli/src/Cardano/CLI/EraBased/Script/Spend/Read.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Script/Spend/Read.hs
@@ -1,0 +1,148 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE TupleSections #-}
+
+module Cardano.CLI.EraBased.Script.Spend.Read
+  ( CliSpendScriptWitnessError
+  , readSpendScriptWitness
+  , readSpendScriptWitnesses
+  )
+where
+
+import           Cardano.Api
+import           Cardano.Api.Shelley
+
+import           Cardano.CLI.EraBased.Script.Mint.Types (CliScriptWitnessError (..))
+import           Cardano.CLI.EraBased.Script.Spend.Types
+import           Cardano.CLI.Read
+
+import           Control.Monad
+
+data CliSpendScriptWitnessError
+  = CliScriptWitnessError CliScriptWitnessError
+  | CliSpendScriptWitnessDatumError ScriptDataError
+
+instance Error CliSpendScriptWitnessError where
+  prettyError = \case
+    CliScriptWitnessError e -> prettyError e
+    CliSpendScriptWitnessDatumError e -> renderScriptDataError e
+
+readSpendScriptWitnesses
+  :: MonadIOTransError (FileError CliSpendScriptWitnessError) t m
+  => ShelleyBasedEra era
+  -> [(TxIn, Maybe CliSpendScriptRequirements)]
+  -> t m [(TxIn, Maybe (SpendScriptWitness era))]
+readSpendScriptWitnesses eon =
+  mapM
+    ( \(txin, mSWit) -> do
+        (txin,) <$> forM mSWit (readSpendScriptWitness eon)
+    )
+
+readSpendScriptWitness
+  :: MonadIOTransError (FileError CliSpendScriptWitnessError) t m
+  => ShelleyBasedEra era -> CliSpendScriptRequirements -> t m (SpendScriptWitness era)
+readSpendScriptWitness sbe spendScriptReq =
+  case spendScriptReq of
+    OnDiskSimpleOrPlutusScript (OnDiskSimpleCliArgs simpleFp) -> do
+      let sFp = unFile simpleFp
+      s <-
+        modifyError (fmap (CliScriptWitnessError . SimpleScriptWitnessDecodeError)) $
+          readFileSimpleScript sFp
+      case s of
+        SimpleScript ss -> do
+          return $
+            SpendScriptWitness $
+              SimpleScriptWitness (sbeToSimpleScriptLanguageInEra sbe) $
+                SScript ss
+    OnDiskSimpleOrPlutusScript
+      (OnDiskPlutusScriptCliArgs plutusScriptFp mScriptDatum redeemerFile execUnits) -> do
+        let sFp = unFile plutusScriptFp
+        plutusScript <-
+          modifyError (fmap (CliScriptWitnessError . PlutusScriptWitnessDecodeError)) $
+            readFilePlutusScript $
+              unFile plutusScriptFp
+        redeemer <-
+          modifyError (FileError sFp . (CliScriptWitnessError . PlutusScriptWitnessRedeemerError)) $
+            readScriptDataOrFile redeemerFile
+        case plutusScript of
+          AnyPlutusScript lang script -> do
+            let pScript = PScript script
+            sLangSupported <-
+              modifyError (FileError sFp)
+                $ hoistMaybe
+                  ( CliScriptWitnessError $
+                      PlutusScriptWitnessLanguageNotSupportedInEra
+                        (AnyPlutusScriptVersion lang)
+                        (shelleyBasedEraConstraints sbe $ AnyShelleyBasedEra sbe)
+                  )
+                $ scriptLanguageSupportedInEra sbe
+                $ PlutusScriptLanguage lang
+            mDatum <- handlePotentialScriptDatum mScriptDatum
+            return $
+              SpendScriptWitness $
+                PlutusScriptWitness
+                  sLangSupported
+                  lang
+                  pScript
+                  mDatum
+                  redeemer
+                  execUnits
+    OnDiskSimpleRefScript (SimpleRefScriptArgs refTxIn) ->
+      return $
+        SpendScriptWitness $
+          SimpleScriptWitness
+            (sbeToSimpleScriptLanguageInEra sbe)
+            (SReferenceScript refTxIn)
+    OnDiskPlutusRefScript
+      (PlutusRefScriptCliArgs refTxIn anyPlutusScriptVersion mScriptDatum redeemerFile execUnits) ->
+        case anyPlutusScriptVersion of
+          AnyPlutusScriptVersion lang -> do
+            let pScript = PReferenceScript refTxIn
+            redeemer <-
+              -- TODO: Implement a new error type to capture this. FileError is not representative of cases
+              -- where we do not have access to the script.
+              modifyError
+                ( FileError "Reference script filepath not available"
+                    . CliScriptWitnessError
+                    . PlutusScriptWitnessRedeemerError
+                )
+                $ readScriptDataOrFile redeemerFile
+            sLangSupported <-
+              -- TODO: Implement a new error type to capture this. FileError is not representative of cases
+              -- where we do not have access to the script.
+              modifyError (FileError "Reference script filepath not available")
+                $ hoistMaybe
+                  ( CliScriptWitnessError $
+                      PlutusScriptWitnessLanguageNotSupportedInEra
+                        (AnyPlutusScriptVersion lang)
+                        (shelleyBasedEraConstraints sbe $ AnyShelleyBasedEra sbe)
+                  )
+                $ scriptLanguageSupportedInEra sbe
+                $ PlutusScriptLanguage lang
+
+            mDatum <- handlePotentialScriptDatum mScriptDatum
+            return $
+              SpendScriptWitness $
+                PlutusScriptWitness
+                  sLangSupported
+                  lang
+                  pScript
+                  mDatum
+                  redeemer
+                  execUnits
+
+handlePotentialScriptDatum
+  :: MonadIOTransError (FileError CliSpendScriptWitnessError) t m
+  => ScriptDatumOrFileSpending
+  -> t m (ScriptDatum WitCtxTxIn)
+handlePotentialScriptDatum InlineDatum = return InlineScriptDatum
+handlePotentialScriptDatum (PotentialDatum mDatum) =
+  ScriptDatumForTxIn
+    <$> forM
+      mDatum
+      ( \datumFp ->
+          modifyError (FileError (show datumFp) . CliSpendScriptWitnessDatumError) $
+            readScriptDataOrFile datumFp
+      )

--- a/cardano-cli/src/Cardano/CLI/EraBased/Script/Spend/Read.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Script/Spend/Read.hs
@@ -14,8 +14,8 @@ where
 import           Cardano.Api
 import           Cardano.Api.Shelley
 
-import           Cardano.CLI.EraBased.Script.Mint.Types (CliScriptWitnessError (..))
 import           Cardano.CLI.EraBased.Script.Spend.Types
+import           Cardano.CLI.EraBased.Script.Types
 import           Cardano.CLI.Read
 
 import           Control.Monad

--- a/cardano-cli/src/Cardano/CLI/EraBased/Script/Spend/Types.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Script/Spend/Types.hs
@@ -1,0 +1,82 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+
+module Cardano.CLI.EraBased.Script.Spend.Types
+  ( CliSpendScriptRequirements (..)
+  , PlutusRefScriptCliArgs (..)
+  , SimpleOrPlutusScriptCliArgs (..)
+  , ScriptDatumOrFileSpending (..)
+  , SimpleRefScriptCliArgs (..)
+  , SpendScriptWitness (..)
+  , createSimpleOrPlutusScriptFromCliArgs
+  , createPlutusReferenceScriptFromCliArgs
+  , createSimpleReferenceScriptFromCliArgs
+  )
+where
+
+import           Cardano.Api
+
+import           Cardano.CLI.Types.Common (ScriptDataOrFile)
+
+newtype SpendScriptWitness era
+  = SpendScriptWitness {sswScriptWitness :: ScriptWitness WitCtxTxIn era}
+  deriving Show
+
+data CliSpendScriptRequirements
+  = OnDiskSimpleOrPlutusScript SimpleOrPlutusScriptCliArgs
+  | OnDiskSimpleRefScript SimpleRefScriptCliArgs
+  | OnDiskPlutusRefScript PlutusRefScriptCliArgs
+  deriving Show
+
+data SimpleOrPlutusScriptCliArgs
+  = OnDiskPlutusScriptCliArgs
+      (File ScriptInAnyLang In)
+      ScriptDatumOrFileSpending
+      -- ^ Optional Datum (CIP-69)
+      ScriptDataOrFile
+      -- ^ Redeemer
+      ExecutionUnits
+  | OnDiskSimpleCliArgs
+      (File ScriptInAnyLang In)
+  deriving Show
+
+createSimpleOrPlutusScriptFromCliArgs
+  :: File ScriptInAnyLang In
+  -> Maybe (ScriptDatumOrFileSpending, ScriptDataOrFile, ExecutionUnits)
+  -> CliSpendScriptRequirements
+createSimpleOrPlutusScriptFromCliArgs scriptFp (Just (datumFile, redeemerFile, execUnits)) =
+  OnDiskSimpleOrPlutusScript $ OnDiskPlutusScriptCliArgs scriptFp datumFile redeemerFile execUnits
+createSimpleOrPlutusScriptFromCliArgs scriptFp Nothing = OnDiskSimpleOrPlutusScript $ OnDiskSimpleCliArgs scriptFp
+
+newtype SimpleRefScriptCliArgs = SimpleRefScriptArgs TxIn deriving Show
+
+createSimpleReferenceScriptFromCliArgs :: TxIn -> CliSpendScriptRequirements
+createSimpleReferenceScriptFromCliArgs = OnDiskSimpleRefScript . SimpleRefScriptArgs
+
+data PlutusRefScriptCliArgs
+  = PlutusRefScriptCliArgs
+      TxIn
+      -- ^ TxIn with reference script
+      AnyPlutusScriptVersion
+      ScriptDatumOrFileSpending
+      -- ^ Optional Datum (CIP-69)
+      ScriptDataOrFile
+      -- ^ Redeemer
+      ExecutionUnits
+  deriving Show
+
+createPlutusReferenceScriptFromCliArgs
+  :: TxIn
+  -> AnyPlutusScriptVersion
+  -> ScriptDatumOrFileSpending
+  -> ScriptDataOrFile
+  -> ExecutionUnits
+  -> CliSpendScriptRequirements
+createPlutusReferenceScriptFromCliArgs txin v mDatum redeemer execUnits =
+  OnDiskPlutusRefScript $ PlutusRefScriptCliArgs txin v mDatum redeemer execUnits
+
+data ScriptDatumOrFileSpending
+  = PotentialDatum (Maybe ScriptDataOrFile)
+  | InlineDatum
+  deriving Show

--- a/cardano-cli/src/Cardano/CLI/EraBased/Script/Types.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Script/Types.hs
@@ -1,0 +1,29 @@
+{-# LANGUAGE LambdaCase #-}
+
+module Cardano.CLI.EraBased.Script.Types
+  ( -- * Errors
+    CliScriptWitnessError (..)
+  )
+where
+
+import           Cardano.Api
+
+import           Cardano.CLI.Types.Errors.PlutusScriptDecodeError
+import           Cardano.CLI.Types.Errors.ScriptDataError
+import           Cardano.CLI.Types.Errors.ScriptDecodeError
+
+data CliScriptWitnessError
+  = SimpleScriptWitnessDecodeError ScriptDecodeError
+  | PlutusScriptWitnessDecodeError PlutusScriptDecodeError
+  | PlutusScriptWitnessLanguageNotSupportedInEra
+      AnyPlutusScriptVersion
+      AnyShelleyBasedEra
+  | PlutusScriptWitnessRedeemerError ScriptDataError
+
+instance Error CliScriptWitnessError where
+  prettyError = \case
+    SimpleScriptWitnessDecodeError err -> prettyError err
+    PlutusScriptWitnessDecodeError err -> prettyError err
+    PlutusScriptWitnessLanguageNotSupportedInEra version era ->
+      "Plutus script version " <> pshow version <> " is not supported in era " <> pshow era
+    PlutusScriptWitnessRedeemerError err -> renderScriptDataError err

--- a/cardano-cli/src/Cardano/CLI/Types/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Common.hs
@@ -431,8 +431,9 @@ data ScriptWitnessFiles witctx where
     -> ScriptRedeemerOrFile
     -> ExecutionUnits
     -> ScriptWitnessFiles witctx
-  -- NB: This no longer is used for minting scripts
-  -- Use MintScriptWitnessWithPolicyId instead
+  -- | This no longer is used for minting or spending
+  -- scripts.
+  -- Use MintScriptWitnessWithPolicyId or SpendScriptWitness instead
   PlutusReferenceScriptWitnessFiles
     :: TxIn
     -> AnyPlutusScriptVersion
@@ -441,8 +442,9 @@ data ScriptWitnessFiles witctx where
     -> ExecutionUnits
     -- ^ For minting reference scripts
     -> ScriptWitnessFiles witctx
-  -- NB: This no longer is used for minting scripts
-  -- Use MintScriptWitnessWithPolicyId instead
+  -- | This no longer is used for minting or spending
+  -- scripts
+  -- Use MintScriptWitnessWithPolicyId or SpendScriptWitness instead
   SimpleReferenceScriptWitnessFiles
     :: TxIn
     -> AnyScriptLanguage

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/TxCmdError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/TxCmdError.hs
@@ -19,8 +19,8 @@ import           Cardano.Api.Consensus (EraMismatch (..))
 import qualified Cardano.Api.Ledger as L
 import           Cardano.Api.Shelley
 
-import           Cardano.CLI.EraBased.Script.Mint.Types
 import           Cardano.CLI.EraBased.Script.Spend.Read
+import           Cardano.CLI.EraBased.Script.Types
 import           Cardano.CLI.Read
 import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Errors.BootstrapWitnessError

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/TxCmdError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/TxCmdError.hs
@@ -20,6 +20,7 @@ import qualified Cardano.Api.Ledger as L
 import           Cardano.Api.Shelley
 
 import           Cardano.CLI.EraBased.Script.Mint.Types
+import           Cardano.CLI.EraBased.Script.Spend.Read
 import           Cardano.CLI.Read
 import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Errors.BootstrapWitnessError
@@ -52,6 +53,7 @@ data TxCmdError
   | TxCmdProtocolParamsError ProtocolParamsError
   | TxCmdScriptFileError (FileError ScriptDecodeError)
   | TxCmdCliScriptWitnessError !(FileError CliScriptWitnessError)
+  | TxCmdCliSpendingScriptWitnessError !(FileError CliSpendScriptWitnessError)
   | TxCmdKeyFileError (FileError InputDecodeError)
   | TxCmdReadTextViewFileError !(FileError TextEnvelopeError)
   | TxCmdReadWitnessSigningDataError !ReadWitnessSigningDataError
@@ -109,6 +111,8 @@ renderTxCmdError = \case
     prettyError fileErr
   TxCmdCliScriptWitnessError cliScriptWitnessErr ->
     prettyError cliScriptWitnessErr
+  TxCmdCliSpendingScriptWitnessError cliSpendScriptWitnessErr ->
+    prettyError cliSpendScriptWitnessErr
   TxCmdKeyFileError fileErr ->
     prettyError fileErr
   TxCmdReadWitnessSigningDataError witSignDataErr ->

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -10857,6 +10857,25 @@ Usage: cardano-cli compatible shelley transaction signed-transaction
                                                                        | --testnet-magic NATURAL
                                                                        ]
                                                                        --fee LOVELACE
+                                                                       [
+                                                                         --certificate-file FILEPATH
+                                                                         [ --certificate-script-file FILEPATH
+                                                                           [
+                                                                             ( --certificate-redeemer-cbor-file CBOR_FILE
+                                                                             | --certificate-redeemer-file JSON_FILE
+                                                                             | --certificate-redeemer-value JSON_VALUE
+                                                                             )
+                                                                             --certificate-execution-units (INT, INT)]
+                                                                         | --certificate-tx-in-reference TX-IN
+                                                                           ( --certificate-plutus-script-v2
+                                                                           | --certificate-plutus-script-v3
+                                                                           )
+                                                                           ( --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                                           | --certificate-reference-tx-in-redeemer-file JSON_FILE
+                                                                           | --certificate-reference-tx-in-redeemer-value JSON_VALUE
+                                                                           )
+                                                                           --certificate-reference-tx-in-execution-units (INT, INT)
+                                                                         ]]
                                                                        --out-file FILEPATH
 
   Create a simple signed transaction.
@@ -10971,6 +10990,25 @@ Usage: cardano-cli compatible allegra transaction signed-transaction
                                                                        | --testnet-magic NATURAL
                                                                        ]
                                                                        --fee LOVELACE
+                                                                       [
+                                                                         --certificate-file FILEPATH
+                                                                         [ --certificate-script-file FILEPATH
+                                                                           [
+                                                                             ( --certificate-redeemer-cbor-file CBOR_FILE
+                                                                             | --certificate-redeemer-file JSON_FILE
+                                                                             | --certificate-redeemer-value JSON_VALUE
+                                                                             )
+                                                                             --certificate-execution-units (INT, INT)]
+                                                                         | --certificate-tx-in-reference TX-IN
+                                                                           ( --certificate-plutus-script-v2
+                                                                           | --certificate-plutus-script-v3
+                                                                           )
+                                                                           ( --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                                           | --certificate-reference-tx-in-redeemer-file JSON_FILE
+                                                                           | --certificate-reference-tx-in-redeemer-value JSON_VALUE
+                                                                           )
+                                                                           --certificate-reference-tx-in-execution-units (INT, INT)
+                                                                         ]]
                                                                        --out-file FILEPATH
 
   Create a simple signed transaction.
@@ -11085,6 +11123,25 @@ Usage: cardano-cli compatible mary transaction signed-transaction
                                                                     | --testnet-magic NATURAL
                                                                     ]
                                                                     --fee LOVELACE
+                                                                    [
+                                                                      --certificate-file FILEPATH
+                                                                      [ --certificate-script-file FILEPATH
+                                                                        [
+                                                                          ( --certificate-redeemer-cbor-file CBOR_FILE
+                                                                          | --certificate-redeemer-file JSON_FILE
+                                                                          | --certificate-redeemer-value JSON_VALUE
+                                                                          )
+                                                                          --certificate-execution-units (INT, INT)]
+                                                                      | --certificate-tx-in-reference TX-IN
+                                                                        ( --certificate-plutus-script-v2
+                                                                        | --certificate-plutus-script-v3
+                                                                        )
+                                                                        ( --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                                        | --certificate-reference-tx-in-redeemer-file JSON_FILE
+                                                                        | --certificate-reference-tx-in-redeemer-value JSON_VALUE
+                                                                        )
+                                                                        --certificate-reference-tx-in-execution-units (INT, INT)
+                                                                      ]]
                                                                     --out-file FILEPATH
 
   Create a simple signed transaction.
@@ -11207,6 +11264,25 @@ Usage: cardano-cli compatible alonzo transaction signed-transaction
                                                                       | --testnet-magic NATURAL
                                                                       ]
                                                                       --fee LOVELACE
+                                                                      [
+                                                                        --certificate-file FILEPATH
+                                                                        [ --certificate-script-file FILEPATH
+                                                                          [
+                                                                            ( --certificate-redeemer-cbor-file CBOR_FILE
+                                                                            | --certificate-redeemer-file JSON_FILE
+                                                                            | --certificate-redeemer-value JSON_VALUE
+                                                                            )
+                                                                            --certificate-execution-units (INT, INT)]
+                                                                        | --certificate-tx-in-reference TX-IN
+                                                                          ( --certificate-plutus-script-v2
+                                                                          | --certificate-plutus-script-v3
+                                                                          )
+                                                                          ( --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                                          | --certificate-reference-tx-in-redeemer-file JSON_FILE
+                                                                          | --certificate-reference-tx-in-redeemer-value JSON_VALUE
+                                                                          )
+                                                                          --certificate-reference-tx-in-execution-units (INT, INT)
+                                                                        ]]
                                                                       --out-file FILEPATH
 
   Create a simple signed transaction.
@@ -11339,6 +11415,25 @@ Usage: cardano-cli compatible babbage transaction signed-transaction
                                                                        | --testnet-magic NATURAL
                                                                        ]
                                                                        --fee LOVELACE
+                                                                       [
+                                                                         --certificate-file FILEPATH
+                                                                         [ --certificate-script-file FILEPATH
+                                                                           [
+                                                                             ( --certificate-redeemer-cbor-file CBOR_FILE
+                                                                             | --certificate-redeemer-file JSON_FILE
+                                                                             | --certificate-redeemer-value JSON_VALUE
+                                                                             )
+                                                                             --certificate-execution-units (INT, INT)]
+                                                                         | --certificate-tx-in-reference TX-IN
+                                                                           ( --certificate-plutus-script-v2
+                                                                           | --certificate-plutus-script-v3
+                                                                           )
+                                                                           ( --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                                           | --certificate-reference-tx-in-redeemer-file JSON_FILE
+                                                                           | --certificate-reference-tx-in-redeemer-value JSON_VALUE
+                                                                           )
+                                                                           --certificate-reference-tx-in-execution-units (INT, INT)
+                                                                         ]]
                                                                        --out-file FILEPATH
 
   Create a simple signed transaction.
@@ -11522,6 +11617,25 @@ Usage: cardano-cli compatible conway transaction signed-transaction
                                                                       | --testnet-magic NATURAL
                                                                       ]
                                                                       --fee LOVELACE
+                                                                      [
+                                                                        --certificate-file FILEPATH
+                                                                        [ --certificate-script-file FILEPATH
+                                                                          [
+                                                                            ( --certificate-redeemer-cbor-file CBOR_FILE
+                                                                            | --certificate-redeemer-file JSON_FILE
+                                                                            | --certificate-redeemer-value JSON_VALUE
+                                                                            )
+                                                                            --certificate-execution-units (INT, INT)]
+                                                                        | --certificate-tx-in-reference TX-IN
+                                                                          ( --certificate-plutus-script-v2
+                                                                          | --certificate-plutus-script-v3
+                                                                          )
+                                                                          ( --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                                          | --certificate-reference-tx-in-redeemer-file JSON_FILE
+                                                                          | --certificate-reference-tx-in-redeemer-value JSON_VALUE
+                                                                          )
+                                                                          --certificate-reference-tx-in-execution-units (INT, INT)
+                                                                        ]]
                                                                       --out-file FILEPATH
 
   Create a simple signed transaction.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_allegra_transaction_signed-transaction.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_allegra_transaction_signed-transaction.cli
@@ -8,6 +8,25 @@ Usage: cardano-cli compatible allegra transaction signed-transaction
                                                                        | --testnet-magic NATURAL
                                                                        ]
                                                                        --fee LOVELACE
+                                                                       [
+                                                                         --certificate-file FILEPATH
+                                                                         [ --certificate-script-file FILEPATH
+                                                                           [
+                                                                             ( --certificate-redeemer-cbor-file CBOR_FILE
+                                                                             | --certificate-redeemer-file JSON_FILE
+                                                                             | --certificate-redeemer-value JSON_VALUE
+                                                                             )
+                                                                             --certificate-execution-units (INT, INT)]
+                                                                         | --certificate-tx-in-reference TX-IN
+                                                                           ( --certificate-plutus-script-v2
+                                                                           | --certificate-plutus-script-v3
+                                                                           )
+                                                                           ( --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                                           | --certificate-reference-tx-in-redeemer-file JSON_FILE
+                                                                           | --certificate-reference-tx-in-redeemer-value JSON_VALUE
+                                                                           )
+                                                                           --certificate-reference-tx-in-execution-units (INT, INT)
+                                                                         ]]
                                                                        --out-file FILEPATH
 
   Create a simple signed transaction.
@@ -28,5 +47,44 @@ Available options:
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
   --fee LOVELACE           The fee amount in Lovelace.
+  --certificate-file FILEPATH
+                           Filepath of the certificate. This encompasses all
+                           types of certificates (stake pool certificates, stake
+                           key certificates etc). Optionally specify a script
+                           witness.
+  --certificate-script-file FILEPATH
+                           The file containing the script to witness the use of
+                           the certificate.
+  --certificate-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --certificate-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --certificate-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --certificate-execution-units (INT, INT)
+                           The time and space units needed by the script.
+  --certificate-tx-in-reference TX-IN
+                           TxId#TxIx - Specify a reference input. The reference
+                           input must have a plutus reference script attached.
+  --certificate-plutus-script-v2
+                           Specify a plutus script v2 reference script.
+  --certificate-plutus-script-v3
+                           Specify a plutus script v3 reference script.
+  --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --certificate-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --certificate-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --certificate-reference-tx-in-execution-units (INT, INT)
+                           The time and space units needed by the script.
   --out-file FILEPATH      The output file.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_alonzo_transaction_signed-transaction.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_alonzo_transaction_signed-transaction.cli
@@ -16,6 +16,25 @@ Usage: cardano-cli compatible alonzo transaction signed-transaction
                                                                       | --testnet-magic NATURAL
                                                                       ]
                                                                       --fee LOVELACE
+                                                                      [
+                                                                        --certificate-file FILEPATH
+                                                                        [ --certificate-script-file FILEPATH
+                                                                          [
+                                                                            ( --certificate-redeemer-cbor-file CBOR_FILE
+                                                                            | --certificate-redeemer-file JSON_FILE
+                                                                            | --certificate-redeemer-value JSON_VALUE
+                                                                            )
+                                                                            --certificate-execution-units (INT, INT)]
+                                                                        | --certificate-tx-in-reference TX-IN
+                                                                          ( --certificate-plutus-script-v2
+                                                                          | --certificate-plutus-script-v3
+                                                                          )
+                                                                          ( --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                                          | --certificate-reference-tx-in-redeemer-file JSON_FILE
+                                                                          | --certificate-reference-tx-in-redeemer-value JSON_VALUE
+                                                                          )
+                                                                          --certificate-reference-tx-in-execution-units (INT, INT)
+                                                                        ]]
                                                                       --out-file FILEPATH
 
   Create a simple signed transaction.
@@ -63,5 +82,44 @@ Available options:
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
   --fee LOVELACE           The fee amount in Lovelace.
+  --certificate-file FILEPATH
+                           Filepath of the certificate. This encompasses all
+                           types of certificates (stake pool certificates, stake
+                           key certificates etc). Optionally specify a script
+                           witness.
+  --certificate-script-file FILEPATH
+                           The file containing the script to witness the use of
+                           the certificate.
+  --certificate-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --certificate-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --certificate-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --certificate-execution-units (INT, INT)
+                           The time and space units needed by the script.
+  --certificate-tx-in-reference TX-IN
+                           TxId#TxIx - Specify a reference input. The reference
+                           input must have a plutus reference script attached.
+  --certificate-plutus-script-v2
+                           Specify a plutus script v2 reference script.
+  --certificate-plutus-script-v3
+                           Specify a plutus script v3 reference script.
+  --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --certificate-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --certificate-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --certificate-reference-tx-in-execution-units (INT, INT)
+                           The time and space units needed by the script.
   --out-file FILEPATH      The output file.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_babbage_transaction_signed-transaction.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_babbage_transaction_signed-transaction.cli
@@ -19,6 +19,25 @@ Usage: cardano-cli compatible babbage transaction signed-transaction
                                                                        | --testnet-magic NATURAL
                                                                        ]
                                                                        --fee LOVELACE
+                                                                       [
+                                                                         --certificate-file FILEPATH
+                                                                         [ --certificate-script-file FILEPATH
+                                                                           [
+                                                                             ( --certificate-redeemer-cbor-file CBOR_FILE
+                                                                             | --certificate-redeemer-file JSON_FILE
+                                                                             | --certificate-redeemer-value JSON_VALUE
+                                                                             )
+                                                                             --certificate-execution-units (INT, INT)]
+                                                                         | --certificate-tx-in-reference TX-IN
+                                                                           ( --certificate-plutus-script-v2
+                                                                           | --certificate-plutus-script-v3
+                                                                           )
+                                                                           ( --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                                           | --certificate-reference-tx-in-redeemer-file JSON_FILE
+                                                                           | --certificate-reference-tx-in-redeemer-value JSON_VALUE
+                                                                           )
+                                                                           --certificate-reference-tx-in-execution-units (INT, INT)
+                                                                         ]]
                                                                        --out-file FILEPATH
 
   Create a simple signed transaction.
@@ -79,5 +98,44 @@ Available options:
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
   --fee LOVELACE           The fee amount in Lovelace.
+  --certificate-file FILEPATH
+                           Filepath of the certificate. This encompasses all
+                           types of certificates (stake pool certificates, stake
+                           key certificates etc). Optionally specify a script
+                           witness.
+  --certificate-script-file FILEPATH
+                           The file containing the script to witness the use of
+                           the certificate.
+  --certificate-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --certificate-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --certificate-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --certificate-execution-units (INT, INT)
+                           The time and space units needed by the script.
+  --certificate-tx-in-reference TX-IN
+                           TxId#TxIx - Specify a reference input. The reference
+                           input must have a plutus reference script attached.
+  --certificate-plutus-script-v2
+                           Specify a plutus script v2 reference script.
+  --certificate-plutus-script-v3
+                           Specify a plutus script v3 reference script.
+  --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --certificate-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --certificate-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --certificate-reference-tx-in-execution-units (INT, INT)
+                           The time and space units needed by the script.
   --out-file FILEPATH      The output file.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_transaction_signed-transaction.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_transaction_signed-transaction.cli
@@ -51,6 +51,25 @@ Usage: cardano-cli compatible conway transaction signed-transaction
                                                                       | --testnet-magic NATURAL
                                                                       ]
                                                                       --fee LOVELACE
+                                                                      [
+                                                                        --certificate-file FILEPATH
+                                                                        [ --certificate-script-file FILEPATH
+                                                                          [
+                                                                            ( --certificate-redeemer-cbor-file CBOR_FILE
+                                                                            | --certificate-redeemer-file JSON_FILE
+                                                                            | --certificate-redeemer-value JSON_VALUE
+                                                                            )
+                                                                            --certificate-execution-units (INT, INT)]
+                                                                        | --certificate-tx-in-reference TX-IN
+                                                                          ( --certificate-plutus-script-v2
+                                                                          | --certificate-plutus-script-v3
+                                                                          )
+                                                                          ( --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                                          | --certificate-reference-tx-in-redeemer-file JSON_FILE
+                                                                          | --certificate-reference-tx-in-redeemer-value JSON_VALUE
+                                                                          )
+                                                                          --certificate-reference-tx-in-execution-units (INT, INT)
+                                                                        ]]
                                                                       --out-file FILEPATH
 
   Create a simple signed transaction.
@@ -174,5 +193,44 @@ Available options:
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
   --fee LOVELACE           The fee amount in Lovelace.
+  --certificate-file FILEPATH
+                           Filepath of the certificate. This encompasses all
+                           types of certificates (stake pool certificates, stake
+                           key certificates etc). Optionally specify a script
+                           witness.
+  --certificate-script-file FILEPATH
+                           The file containing the script to witness the use of
+                           the certificate.
+  --certificate-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --certificate-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --certificate-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --certificate-execution-units (INT, INT)
+                           The time and space units needed by the script.
+  --certificate-tx-in-reference TX-IN
+                           TxId#TxIx - Specify a reference input. The reference
+                           input must have a plutus reference script attached.
+  --certificate-plutus-script-v2
+                           Specify a plutus script v2 reference script.
+  --certificate-plutus-script-v3
+                           Specify a plutus script v3 reference script.
+  --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --certificate-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --certificate-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --certificate-reference-tx-in-execution-units (INT, INT)
+                           The time and space units needed by the script.
   --out-file FILEPATH      The output file.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_mary_transaction_signed-transaction.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_mary_transaction_signed-transaction.cli
@@ -8,6 +8,25 @@ Usage: cardano-cli compatible mary transaction signed-transaction
                                                                     | --testnet-magic NATURAL
                                                                     ]
                                                                     --fee LOVELACE
+                                                                    [
+                                                                      --certificate-file FILEPATH
+                                                                      [ --certificate-script-file FILEPATH
+                                                                        [
+                                                                          ( --certificate-redeemer-cbor-file CBOR_FILE
+                                                                          | --certificate-redeemer-file JSON_FILE
+                                                                          | --certificate-redeemer-value JSON_VALUE
+                                                                          )
+                                                                          --certificate-execution-units (INT, INT)]
+                                                                      | --certificate-tx-in-reference TX-IN
+                                                                        ( --certificate-plutus-script-v2
+                                                                        | --certificate-plutus-script-v3
+                                                                        )
+                                                                        ( --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                                        | --certificate-reference-tx-in-redeemer-file JSON_FILE
+                                                                        | --certificate-reference-tx-in-redeemer-value JSON_VALUE
+                                                                        )
+                                                                        --certificate-reference-tx-in-execution-units (INT, INT)
+                                                                      ]]
                                                                     --out-file FILEPATH
 
   Create a simple signed transaction.
@@ -28,5 +47,44 @@ Available options:
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
   --fee LOVELACE           The fee amount in Lovelace.
+  --certificate-file FILEPATH
+                           Filepath of the certificate. This encompasses all
+                           types of certificates (stake pool certificates, stake
+                           key certificates etc). Optionally specify a script
+                           witness.
+  --certificate-script-file FILEPATH
+                           The file containing the script to witness the use of
+                           the certificate.
+  --certificate-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --certificate-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --certificate-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --certificate-execution-units (INT, INT)
+                           The time and space units needed by the script.
+  --certificate-tx-in-reference TX-IN
+                           TxId#TxIx - Specify a reference input. The reference
+                           input must have a plutus reference script attached.
+  --certificate-plutus-script-v2
+                           Specify a plutus script v2 reference script.
+  --certificate-plutus-script-v3
+                           Specify a plutus script v3 reference script.
+  --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --certificate-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --certificate-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --certificate-reference-tx-in-execution-units (INT, INT)
+                           The time and space units needed by the script.
   --out-file FILEPATH      The output file.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_shelley_transaction_signed-transaction.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_shelley_transaction_signed-transaction.cli
@@ -8,6 +8,25 @@ Usage: cardano-cli compatible shelley transaction signed-transaction
                                                                        | --testnet-magic NATURAL
                                                                        ]
                                                                        --fee LOVELACE
+                                                                       [
+                                                                         --certificate-file FILEPATH
+                                                                         [ --certificate-script-file FILEPATH
+                                                                           [
+                                                                             ( --certificate-redeemer-cbor-file CBOR_FILE
+                                                                             | --certificate-redeemer-file JSON_FILE
+                                                                             | --certificate-redeemer-value JSON_VALUE
+                                                                             )
+                                                                             --certificate-execution-units (INT, INT)]
+                                                                         | --certificate-tx-in-reference TX-IN
+                                                                           ( --certificate-plutus-script-v2
+                                                                           | --certificate-plutus-script-v3
+                                                                           )
+                                                                           ( --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                                                                           | --certificate-reference-tx-in-redeemer-file JSON_FILE
+                                                                           | --certificate-reference-tx-in-redeemer-value JSON_VALUE
+                                                                           )
+                                                                           --certificate-reference-tx-in-execution-units (INT, INT)
+                                                                         ]]
                                                                        --out-file FILEPATH
 
   Create a simple signed transaction.
@@ -28,5 +47,44 @@ Available options:
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
   --fee LOVELACE           The fee amount in Lovelace.
+  --certificate-file FILEPATH
+                           Filepath of the certificate. This encompasses all
+                           types of certificates (stake pool certificates, stake
+                           key certificates etc). Optionally specify a script
+                           witness.
+  --certificate-script-file FILEPATH
+                           The file containing the script to witness the use of
+                           the certificate.
+  --certificate-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --certificate-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --certificate-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --certificate-execution-units (INT, INT)
+                           The time and space units needed by the script.
+  --certificate-tx-in-reference TX-IN
+                           TxId#TxIx - Specify a reference input. The reference
+                           input must have a plutus reference script attached.
+  --certificate-plutus-script-v2
+                           Specify a plutus script v2 reference script.
+  --certificate-plutus-script-v3
+                           Specify a plutus script v3 reference script.
+  --certificate-reference-tx-in-redeemer-cbor-file CBOR_FILE
+                           The script redeemer file. The file has to be in CBOR
+                           format.
+  --certificate-reference-tx-in-redeemer-file JSON_FILE
+                           The script redeemer file. The file must follow the
+                           detailed JSON schema for script data.
+  --certificate-reference-tx-in-redeemer-value JSON_VALUE
+                           The script redeemer value. There is no schema:
+                           (almost) any JSON value is supported, including
+                           top-level strings and numbers.
+  --certificate-reference-tx-in-execution-units (INT, INT)
+                           The time and space units needed by the script.
   --out-file FILEPATH      The output file.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/Shelley/Transaction/Compatible/Build.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/Shelley/Transaction/Compatible/Build.hs
@@ -1,0 +1,102 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Test.Cli.Shelley.Transaction.Compatible.Build where
+
+import           Cardano.Api.Eras
+import           Cardano.Api.Pretty
+
+import           Control.Monad.Catch (MonadCatch)
+import           Control.Monad.IO.Class
+import           Data.Aeson (Value)
+import qualified Data.Aeson as A
+import           Data.Char (toLower)
+import           Data.String (IsString (..))
+import           GHC.Stack
+
+import           Test.Cardano.CLI.Util
+
+import           Hedgehog
+import qualified Hedgehog.Extras as H
+
+inputDir :: FilePath
+inputDir = "test/cardano-cli-test/files/input/shelley/transaction"
+
+-- | Execute me with:
+-- @cabal test cardano-cli-test --test-options '-p "/conway transaction build one voter many votes/"'@
+hprop_compatible_conway_transaction_build_one_voter_many_votes :: Property
+hprop_compatible_conway_transaction_build_one_voter_many_votes = propertyOnce $ H.moduleWorkspace "tmp" $ \tempDir -> do
+  refOutFile <- H.noteTempFile tempDir "reference_tx.traw"
+  outFile <- H.noteTempFile tempDir "tx.traw"
+  let eraName = map toLower . docToString $ pretty ConwayEra
+
+  let args =
+        [ "--tx-in"
+        , "6e8c947816e82627aeccb55300074f2894a2051332f62a1c8954e7b588a18be7#0"
+        , "--tx-out"
+        , "addr_test1vpfwv0ezc5g8a4mkku8hhy3y3vp92t7s3ul8g778g5yegsgalc6gc+24910487859"
+        , "--fee"
+        , "178569"
+        , "--certificate-file"
+        , "test/cardano-cli-golden/files/golden/shelley/stake-address/reg-certificate-2.json"
+        , "--certificate-script-file"
+        , "test/cardano-cli-golden/files/input/AlwaysSucceeds.plutus"
+        , "--certificate-redeemer-value"
+        , "0"
+        , "--certificate-execution-units"
+        , "(0,0)"
+        ]
+
+  -- reference transaction
+  _ <-
+    execCardanoCLI $
+      [ eraName
+      , "transaction"
+      , "build-raw"
+      ]
+        <> args
+        <> [ "--out-file"
+           , refOutFile
+           ]
+
+  -- tested compatible transaction
+  _ <-
+    execCardanoCLI $
+      [ "compatible"
+      , eraName
+      , "transaction"
+      , "signed-transaction"
+      ]
+        <> args
+        <> [ "--out-file"
+           , outFile
+           ]
+
+  assertTxFilesEqual refOutFile outFile
+
+assertTxFilesEqual
+  :: forall m
+   . (HasCallStack, MonadIO m, MonadTest m, MonadCatch m)
+  => FilePath
+  -- ^ expected
+  -> FilePath
+  -- ^ tested
+  -> m ()
+assertTxFilesEqual f1 f2 = withFrozenCallStack $ do
+  tx1 <- viewTx f1
+  tx2 <- viewTx f2
+
+  tx1 === tx2
+ where
+  -- deserialise a transaction from JSON file into a Value
+  viewTx :: HasCallStack => FilePath -> m Value
+  viewTx f =
+    withFrozenCallStack $
+      H.leftFailM $
+        A.eitherDecode . fromString
+          <$> execCardanoCLI
+            [ "debug"
+            , "transaction"
+            , "view"
+            , "--tx-body-file"
+            , f
+            ]

--- a/flake.nix
+++ b/flake.nix
@@ -161,18 +161,21 @@
                 ${exportCliPath}
                 cp -r ${filteredProjectBase}/* ..
                '' + (if isDarwin
-                    then '' 
+                    then ''
                        export PATH=${macOS-security}/bin:$PATH
                     ''
                     else '''');
               packages.cardano-cli.components.tests.cardano-cli-test.preCheck = let
                 # This define files included in the directory that will be passed to `H.getProjectBase` for this test:
-                filteredProjectBase = inputs.incl ./. mainnetConfigFiles;
+                filteredProjectBase = inputs.incl ./. (mainnetConfigFiles ++ [
+                  "cardano-cli/test/cardano-cli-golden/files/golden/shelley/stake-address/reg-certificate-2.json"
+                  "cardano-cli/test/cardano-cli-golden/files/input/AlwaysSucceeds.plutus"
+                ]);
               in ''
                 ${exportCliPath}
                 cp -r ${filteredProjectBase}/* ..
                '' + (if isDarwin
-                    then '' 
+                    then ''
                        export PATH=${macOS-security}/bin:$PATH
                     ''
                     else '''');


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Add governance action deposits to the output of `query stake-address-info` 
    
# uncomment types applicable to the change:
  type:
   - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
   - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Resolves https://github.com/IntersectMBO/cardano-cli/issues/954
Requires https://github.com/IntersectMBO/cardano-api/pull/730

# How to trust this PR

The query now includes a map of (GovActionIds, Deposit) assocoated to the stake address: 

```
❯ cardano-cli conway query stake-address-info --address stake_test1upumkxq6k4th9wtp4zp69gjwwwj5zmskxd6czlyf3xflzgq8yk95h
[
    {
        "address": "stake_test1upumkxq6k4th9wtp4zp69gjwwwj5zmskxd6czlyf3xflzgq8yk95h",
        "delegationDeposit": 2000000,
        "govActionDeposits": [
            {
                "1166b7591577807470bd527edf2a5fac938b8d56842a67684b682b1e8e76d198#0": 100000000000,
                "2f1be5c1aa824dac76b98acb35176defa6357e529cd297ae24353943b46a0cde#0": 100000000000,
                "d098afe0db98605c243c13c8a537a3eb51e6ded5e3a48acca83e7082a0086428#0": 100000000000
            }
        ],
        "rewardAccountBalance": 1194509145192,
        "stakeDelegation": "pool18pn6p9ef58u4ga3wagp44qhzm8f6zncl57g6qgh0pk3yytwz54h",
        "voteDelegation": "keyHash-74519ac5359c003a7ace69c475ae55a86eb8f9fec6cf6feaada1debf"
    }
]
```
or empty if it is not associated to any

```
❯ cardano-cli conway query stake-address-info --address $(< stake.addr)
[
    {
        "address": "stake_test1upfpm2244k8jf00l357t3adp2hzfsuqrwqvleheqjj08uhswme5cn",
        "delegationDeposit": 2000000,
        "govActionDeposits": [
            {}
        ],
        "rewardAccountBalance": 300000000000,
        "stakeDelegation": "pool1l9u9ss9xtww8qkt4zqda84z945f6tgq4753jqhtdr4r8yaw7d6g",
        "voteDelegation": "scriptHash-59aa3f091b3bcef254abfb89aea64973a61b78fdb2ac44839c7ccba8"
    }
]
```

**BABBAGE:** With the latest chantes the query still works in Babbage era: 

```
cardano-cli babbage query stake-address-info --address $(< example/utxo-keys/stake1.addr)
WARNING: Selected era is deprecated and will be removed in the future.
[
    {
        "address": "stake_test1uq07mnmf838hdlu9qpnwjnntrrtvsa6448ud0g32qkm0kecusq4sd",
        "delegation": "pool1xj26f4rqk2t049yu6n4mmg5zstr6sarv63nc5fuw60rx7u0jxef",
        "delegationDeposit": 2000000,
        "rewardAccountBalance": 0
    }
]
```


# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
