### PR TITLE
Remove use of `ScriptWitnessFiles` in spending scripts

### DIFF
--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -119,6 +119,8 @@ library
     Cardano.CLI.EraBased.Run.Transaction
     Cardano.CLI.EraBased.Script.Mint.Read
     Cardano.CLI.EraBased.Script.Mint.Types
+    Cardano.CLI.EraBased.Script.Spend.Read
+    Cardano.CLI.EraBased.Script.Spend.Types
     Cardano.CLI.EraBased.Transaction.HashCheck
     Cardano.CLI.Helpers
     Cardano.CLI.IO.Lazy

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -121,6 +121,7 @@ library
     Cardano.CLI.EraBased.Script.Mint.Types
     Cardano.CLI.EraBased.Script.Spend.Read
     Cardano.CLI.EraBased.Script.Spend.Types
+    Cardano.CLI.EraBased.Script.Types
     Cardano.CLI.EraBased.Transaction.HashCheck
     Cardano.CLI.Helpers
     Cardano.CLI.IO.Lazy

--- a/cardano-cli/src/Cardano/CLI/Compatible/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/Compatible/Transaction.hs
@@ -65,12 +65,12 @@ pCompatibleSignedTransaction env sbe =
     <$> many pTxInOnly
     <*> many (pTxOutEraAware sbe)
     <*> pFeatured (toCardanoEra sbe) (optional pUpdateProposalFile)
-    <*> pFeatured (toCardanoEra sbe) (many (pProposalFile sbe ManualBalance))
+    <*> pFeatured (toCardanoEra sbe) (many (pProposalFile ManualBalance))
     <*> pVoteFiles sbe ManualBalance
     <*> many pWitnessSigningData
     <*> optional (pNetworkId env)
     <*> pTxFee
-    <*> many (pCertificateFile sbe ManualBalance)
+    <*> many (pCertificateFile ManualBalance)
     <*> pOutputFile
 
 pTxInOnly :: Parser TxIn

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Transaction.hs
@@ -26,6 +26,7 @@ import           Cardano.Api.Ledger (Coin)
 import           Cardano.Api.Shelley
 
 import           Cardano.CLI.EraBased.Script.Mint.Types
+import           Cardano.CLI.EraBased.Script.Spend.Types (CliSpendScriptRequirements)
 import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Governance
 
@@ -49,7 +50,7 @@ data TransactionBuildRawCmdArgs era = TransactionBuildRawCmdArgs
   { eon :: !(ShelleyBasedEra era)
   , mScriptValidity :: !(Maybe ScriptValidity)
   -- ^ Mark script as expected to pass or fail validation
-  , txIns :: ![(TxIn, Maybe (ScriptWitnessFiles WitCtxTxIn))]
+  , txIns :: ![(TxIn, Maybe CliSpendScriptRequirements)]
   -- ^ Transaction inputs with optional spending scripts
   , readOnlyRefIns :: ![TxIn]
   -- ^ Read only reference inputs
@@ -96,7 +97,7 @@ data TransactionBuildCmdArgs era = TransactionBuildCmdArgs
   -- ^ Mark script as expected to pass or fail validation
   , mOverrideWitnesses :: !(Maybe Word)
   -- ^ Override the required number of tx witnesses
-  , txins :: ![(TxIn, Maybe (ScriptWitnessFiles WitCtxTxIn))]
+  , txins :: ![(TxIn, Maybe CliSpendScriptRequirements)]
   -- ^ Transaction inputs with optional spending scripts
   , readOnlyReferenceInputs :: ![TxIn]
   -- ^ Read only reference inputs
@@ -144,7 +145,7 @@ data TransactionBuildEstimateCmdArgs era = TransactionBuildEstimateCmdArgs
   , mByronWitnesses :: !(Maybe Int)
   , protocolParamsFile :: !ProtocolParamsFile
   , totalUTxOValue :: !Value
-  , txins :: ![(TxIn, Maybe (ScriptWitnessFiles WitCtxTxIn))]
+  , txins :: ![(TxIn, Maybe CliSpendScriptRequirements)]
   -- ^ Transaction inputs with optional spending scripts
   , readOnlyReferenceInputs :: ![TxIn]
   -- ^ Read only reference inputs

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
@@ -1034,7 +1034,6 @@ pPlutusMintScriptWitnessData _sbe _witctx autoBalanceExecUnits =
 pSimpleScriptOrPlutusSpendingScriptWitness
   :: ShelleyBasedEra era
   -> BalanceTxExecUnits
-  -- ^ Use the @execution-units@ flag.
   -> String
   -- ^ Script flag prefix
   -> Maybe String
@@ -1060,7 +1059,6 @@ pScriptWitnessFiles
   :: forall witctx
    . WitCtx witctx
   -> BalanceTxExecUnits
-  -- ^ Use the @execution-units@ flag.
   -> String
   -- ^ Script flag prefix
   -> Maybe String
@@ -1590,7 +1588,6 @@ pWithdrawal balance =
 pPlutusStakeReferenceScriptWitnessFilesVotingProposing
   :: String
   -> BalanceTxExecUnits
-  -- ^ Use the @execution-units@ flag.
   -> Parser (ScriptWitnessFiles WitCtxStake)
 pPlutusStakeReferenceScriptWitnessFilesVotingProposing prefix autoBalanceExecUnits =
   PlutusReferenceScriptWitnessFiles
@@ -1606,7 +1603,6 @@ pPlutusStakeReferenceScriptWitnessFilesVotingProposing prefix autoBalanceExecUni
 pPlutusStakeReferenceScriptWitnessFiles
   :: String
   -> BalanceTxExecUnits
-  -- ^ Use the @execution-units@ flag.
   -> Parser (ScriptWitnessFiles WitCtxStake)
 pPlutusStakeReferenceScriptWitnessFiles prefix autoBalanceExecUnits =
   PlutusReferenceScriptWitnessFiles

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
@@ -1037,7 +1037,9 @@ pSimpleScriptOrPlutusSpendingScriptWitness
   -> String
   -- ^ Script flag prefix
   -> Maybe String
+  -- ^ Potential deprecated script flag prefix
   -> String
+  -- ^ Help text
   -> Parser CliSpendScriptRequirements
 pSimpleScriptOrPlutusSpendingScriptWitness sbe autoBalanceExecUnits scriptFlagPrefix scriptFlagPrefixDeprecated help =
   PlutusSpend.createSimpleOrPlutusScriptFromCliArgs

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Transaction.hs
@@ -185,8 +185,8 @@ pTransactionBuildCmd sbe envCli = do
         <*> optional (pMintMultiAsset sbe AutoBalance)
         <*> optional pInvalidBefore
         <*> pInvalidHereafter sbe
-        <*> many (pCertificateFile sbe AutoBalance)
-        <*> many (pWithdrawal sbe AutoBalance)
+        <*> many (pCertificateFile AutoBalance)
+        <*> many (pWithdrawal AutoBalance)
         <*> pTxMetadataJsonSchema
         <*> many
           ( pScriptFor
@@ -245,8 +245,8 @@ pTransactionBuildEstimateCmd eon' _envCli = do
         <*> optional (pMintMultiAsset sbe ManualBalance)
         <*> optional pInvalidBefore
         <*> pInvalidHereafter sbe
-        <*> many (pCertificateFile sbe ManualBalance)
-        <*> many (pWithdrawal sbe ManualBalance)
+        <*> many (pCertificateFile ManualBalance)
+        <*> many (pWithdrawal ManualBalance)
         <*> optional pTotalCollateral
         <*> optional pReferenceScriptSize
         <*> pTxMetadataJsonSchema
@@ -289,8 +289,8 @@ pTransactionBuildRaw era' =
       <*> optional pInvalidBefore
       <*> pInvalidHereafter era'
       <*> pTxFee
-      <*> many (pCertificateFile era' ManualBalance)
-      <*> many (pWithdrawal era' ManualBalance)
+      <*> many (pCertificateFile ManualBalance)
+      <*> many (pWithdrawal ManualBalance)
       <*> pTxMetadataJsonSchema
       <*> many (pScriptFor "auxiliary-script-file" Nothing "Filepath of auxiliary script(s)")
       <*> many pMetadataFile

--- a/cardano-cli/src/Cardano/CLI/EraBased/Script/Mint/Read.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Script/Mint/Read.hs
@@ -11,6 +11,7 @@ import           Cardano.Api
 import           Cardano.Api.Shelley
 
 import           Cardano.CLI.EraBased.Script.Mint.Types
+import           Cardano.CLI.EraBased.Script.Types
 import           Cardano.CLI.Read
 
 readMintScriptWitness

--- a/cardano-cli/src/Cardano/CLI/EraBased/Script/Mint/Read.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Script/Mint/Read.hs
@@ -27,7 +27,7 @@ readMintScriptWitness sbe (OnDiskSimpleOrPlutusScript simpleOrPlutus) =
           let polId = PolicyId $ hashScript s
           return $
             MintScriptWitnessWithPolicyId polId $
-              SimpleScriptWitness (sbeToSimpleScriptLangInEra sbe) $
+              SimpleScriptWitness (sbeToSimpleScriptLanguageInEra sbe) $
                 SScript ss
     OnDiskPlutusScriptCliArgs plutusScriptFp redeemerFile execUnits -> do
       let sFp = unFile plutusScriptFp
@@ -65,7 +65,7 @@ readMintScriptWitness sbe (OnDiskSimpleRefScript (SimpleRefScriptCliArgs refTxIn
   return $
     MintScriptWitnessWithPolicyId polId $
       SimpleScriptWitness
-        (sbeToSimpleScriptLangInEra sbe)
+        (sbeToSimpleScriptLanguageInEra sbe)
         (SReferenceScript refTxIn)
 readMintScriptWitness
   sbe
@@ -100,13 +100,3 @@ readMintScriptWitness
               NoScriptDatumForMint
               redeemer
               execUnits
-
--- TODO: Remove me when exposed from cardano-api
-sbeToSimpleScriptLangInEra
-  :: ShelleyBasedEra era -> ScriptLanguageInEra SimpleScript' era
-sbeToSimpleScriptLangInEra ShelleyBasedEraShelley = SimpleScriptInShelley
-sbeToSimpleScriptLangInEra ShelleyBasedEraAllegra = SimpleScriptInAllegra
-sbeToSimpleScriptLangInEra ShelleyBasedEraMary = SimpleScriptInMary
-sbeToSimpleScriptLangInEra ShelleyBasedEraAlonzo = SimpleScriptInAlonzo
-sbeToSimpleScriptLangInEra ShelleyBasedEraBabbage = SimpleScriptInBabbage
-sbeToSimpleScriptLangInEra ShelleyBasedEraConway = SimpleScriptInConway

--- a/cardano-cli/src/Cardano/CLI/EraBased/Script/Mint/Types.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Script/Mint/Types.hs
@@ -4,8 +4,7 @@
 {-# LANGUAGE LambdaCase #-}
 
 module Cardano.CLI.EraBased.Script.Mint.Types
-  ( CliScriptWitnessError (..)
-  , CliMintScriptRequirements (..)
+  ( CliMintScriptRequirements (..)
   , SimpleOrPlutusScriptCliArgs (..)
   , createSimpleOrPlutusScriptFromCliArgs
   , PlutusRefScriptCliArgs (..)
@@ -19,9 +18,6 @@ where
 import           Cardano.Api
 
 import           Cardano.CLI.Types.Common (ScriptDataOrFile)
-import           Cardano.CLI.Types.Errors.PlutusScriptDecodeError
-import           Cardano.CLI.Types.Errors.ScriptDataError
-import           Cardano.CLI.Types.Errors.ScriptDecodeError
 
 -- We always need the policy id when constructing a transaction that mints.
 -- In the case of reference scripts, the user currently must provide the policy id (script hash)
@@ -89,19 +85,3 @@ createPlutusReferenceScriptFromCliArgs
   -> CliMintScriptRequirements
 createPlutusReferenceScriptFromCliArgs txin scriptVersion scriptData execUnits polid =
   OnDiskPlutusRefScript $ PlutusRefScriptCliArgs txin scriptVersion scriptData execUnits polid
-
-data CliScriptWitnessError
-  = SimpleScriptWitnessDecodeError ScriptDecodeError
-  | PlutusScriptWitnessDecodeError PlutusScriptDecodeError
-  | PlutusScriptWitnessLanguageNotSupportedInEra
-      AnyPlutusScriptVersion
-      AnyShelleyBasedEra
-  | PlutusScriptWitnessRedeemerError ScriptDataError
-
-instance Error CliScriptWitnessError where
-  prettyError = \case
-    SimpleScriptWitnessDecodeError err -> prettyError err
-    PlutusScriptWitnessDecodeError err -> prettyError err
-    PlutusScriptWitnessLanguageNotSupportedInEra version era ->
-      "Plutus script version " <> pshow version <> " is not supported in era " <> pshow era
-    PlutusScriptWitnessRedeemerError err -> renderScriptDataError err

--- a/cardano-cli/src/Cardano/CLI/EraBased/Script/Mint/Types.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Script/Mint/Types.hs
@@ -45,6 +45,7 @@ data SimpleOrPlutusScriptCliArgs
   | OnDiskPlutusScriptCliArgs
       (File ScriptInAnyLang In)
       ScriptDataOrFile
+      -- ^ Redeemer
       ExecutionUnits
   deriving Show
 

--- a/cardano-cli/src/Cardano/CLI/EraBased/Script/Spend/Read.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Script/Spend/Read.hs
@@ -1,0 +1,148 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE TupleSections #-}
+
+module Cardano.CLI.EraBased.Script.Spend.Read
+  ( CliSpendScriptWitnessError
+  , readSpendScriptWitness
+  , readSpendScriptWitnesses
+  )
+where
+
+import           Cardano.Api
+import           Cardano.Api.Shelley
+
+import           Cardano.CLI.EraBased.Script.Mint.Types (CliScriptWitnessError (..))
+import           Cardano.CLI.EraBased.Script.Spend.Types
+import           Cardano.CLI.Read
+
+import           Control.Monad
+
+data CliSpendScriptWitnessError
+  = CliScriptWitnessError CliScriptWitnessError
+  | CliSpendScriptWitnessDatumError ScriptDataError
+
+instance Error CliSpendScriptWitnessError where
+  prettyError = \case
+    CliScriptWitnessError e -> prettyError e
+    CliSpendScriptWitnessDatumError e -> renderScriptDataError e
+
+readSpendScriptWitnesses
+  :: MonadIOTransError (FileError CliSpendScriptWitnessError) t m
+  => ShelleyBasedEra era
+  -> [(TxIn, Maybe CliSpendScriptRequirements)]
+  -> t m [(TxIn, Maybe (SpendScriptWitness era))]
+readSpendScriptWitnesses eon =
+  mapM
+    ( \(txin, mSWit) -> do
+        (txin,) <$> forM mSWit (readSpendScriptWitness eon)
+    )
+
+readSpendScriptWitness
+  :: MonadIOTransError (FileError CliSpendScriptWitnessError) t m
+  => ShelleyBasedEra era -> CliSpendScriptRequirements -> t m (SpendScriptWitness era)
+readSpendScriptWitness sbe spendScriptReq =
+  case spendScriptReq of
+    OnDiskSimpleOrPlutusScript (OnDiskSimpleCliArgs simpleFp) -> do
+      let sFp = unFile simpleFp
+      s <-
+        modifyError (fmap (CliScriptWitnessError . SimpleScriptWitnessDecodeError)) $
+          readFileSimpleScript sFp
+      case s of
+        SimpleScript ss -> do
+          return $
+            SpendScriptWitness $
+              SimpleScriptWitness (sbeToSimpleScriptLanguageInEra sbe) $
+                SScript ss
+    OnDiskSimpleOrPlutusScript
+      (OnDiskPlutusScriptCliArgs plutusScriptFp mScriptDatum redeemerFile execUnits) -> do
+        let sFp = unFile plutusScriptFp
+        plutusScript <-
+          modifyError (fmap (CliScriptWitnessError . PlutusScriptWitnessDecodeError)) $
+            readFilePlutusScript $
+              unFile plutusScriptFp
+        redeemer <-
+          modifyError (FileError sFp . (CliScriptWitnessError . PlutusScriptWitnessRedeemerError)) $
+            readScriptDataOrFile redeemerFile
+        case plutusScript of
+          AnyPlutusScript lang script -> do
+            let pScript = PScript script
+            sLangSupported <-
+              modifyError (FileError sFp)
+                $ hoistMaybe
+                  ( CliScriptWitnessError $
+                      PlutusScriptWitnessLanguageNotSupportedInEra
+                        (AnyPlutusScriptVersion lang)
+                        (shelleyBasedEraConstraints sbe $ AnyShelleyBasedEra sbe)
+                  )
+                $ scriptLanguageSupportedInEra sbe
+                $ PlutusScriptLanguage lang
+            mDatum <- handlePotentialScriptDatum mScriptDatum
+            return $
+              SpendScriptWitness $
+                PlutusScriptWitness
+                  sLangSupported
+                  lang
+                  pScript
+                  mDatum
+                  redeemer
+                  execUnits
+    OnDiskSimpleRefScript (SimpleRefScriptArgs refTxIn) ->
+      return $
+        SpendScriptWitness $
+          SimpleScriptWitness
+            (sbeToSimpleScriptLanguageInEra sbe)
+            (SReferenceScript refTxIn)
+    OnDiskPlutusRefScript
+      (PlutusRefScriptCliArgs refTxIn anyPlutusScriptVersion mScriptDatum redeemerFile execUnits) ->
+        case anyPlutusScriptVersion of
+          AnyPlutusScriptVersion lang -> do
+            let pScript = PReferenceScript refTxIn
+            redeemer <-
+              -- TODO: Implement a new error type to capture this. FileError is not representative of cases
+              -- where we do not have access to the script.
+              modifyError
+                ( FileError "Reference script filepath not available"
+                    . CliScriptWitnessError
+                    . PlutusScriptWitnessRedeemerError
+                )
+                $ readScriptDataOrFile redeemerFile
+            sLangSupported <-
+              -- TODO: Implement a new error type to capture this. FileError is not representative of cases
+              -- where we do not have access to the script.
+              modifyError (FileError "Reference script filepath not available")
+                $ hoistMaybe
+                  ( CliScriptWitnessError $
+                      PlutusScriptWitnessLanguageNotSupportedInEra
+                        (AnyPlutusScriptVersion lang)
+                        (shelleyBasedEraConstraints sbe $ AnyShelleyBasedEra sbe)
+                  )
+                $ scriptLanguageSupportedInEra sbe
+                $ PlutusScriptLanguage lang
+
+            mDatum <- handlePotentialScriptDatum mScriptDatum
+            return $
+              SpendScriptWitness $
+                PlutusScriptWitness
+                  sLangSupported
+                  lang
+                  pScript
+                  mDatum
+                  redeemer
+                  execUnits
+
+handlePotentialScriptDatum
+  :: MonadIOTransError (FileError CliSpendScriptWitnessError) t m
+  => ScriptDatumOrFileSpending
+  -> t m (ScriptDatum WitCtxTxIn)
+handlePotentialScriptDatum InlineDatum = return InlineScriptDatum
+handlePotentialScriptDatum (PotentialDatum mDatum) =
+  ScriptDatumForTxIn
+    <$> forM
+      mDatum
+      ( \datumFp ->
+          modifyError (FileError (show datumFp) . CliSpendScriptWitnessDatumError) $
+            readScriptDataOrFile datumFp
+      )

--- a/cardano-cli/src/Cardano/CLI/EraBased/Script/Spend/Read.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Script/Spend/Read.hs
@@ -14,8 +14,8 @@ where
 import           Cardano.Api
 import           Cardano.Api.Shelley
 
-import           Cardano.CLI.EraBased.Script.Mint.Types (CliScriptWitnessError (..))
 import           Cardano.CLI.EraBased.Script.Spend.Types
+import           Cardano.CLI.EraBased.Script.Types
 import           Cardano.CLI.Read
 
 import           Control.Monad

--- a/cardano-cli/src/Cardano/CLI/EraBased/Script/Spend/Types.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Script/Spend/Types.hs
@@ -1,0 +1,82 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+
+module Cardano.CLI.EraBased.Script.Spend.Types
+  ( CliSpendScriptRequirements (..)
+  , PlutusRefScriptCliArgs (..)
+  , SimpleOrPlutusScriptCliArgs (..)
+  , ScriptDatumOrFileSpending (..)
+  , SimpleRefScriptCliArgs (..)
+  , SpendScriptWitness (..)
+  , createSimpleOrPlutusScriptFromCliArgs
+  , createPlutusReferenceScriptFromCliArgs
+  , createSimpleReferenceScriptFromCliArgs
+  )
+where
+
+import           Cardano.Api
+
+import           Cardano.CLI.Types.Common (ScriptDataOrFile)
+
+newtype SpendScriptWitness era
+  = SpendScriptWitness {sswScriptWitness :: ScriptWitness WitCtxTxIn era}
+  deriving Show
+
+data CliSpendScriptRequirements
+  = OnDiskSimpleOrPlutusScript SimpleOrPlutusScriptCliArgs
+  | OnDiskSimpleRefScript SimpleRefScriptCliArgs
+  | OnDiskPlutusRefScript PlutusRefScriptCliArgs
+  deriving Show
+
+data SimpleOrPlutusScriptCliArgs
+  = OnDiskPlutusScriptCliArgs
+      (File ScriptInAnyLang In)
+      ScriptDatumOrFileSpending
+      -- ^ Optional Datum (CIP-69)
+      ScriptDataOrFile
+      -- ^ Redeemer
+      ExecutionUnits
+  | OnDiskSimpleCliArgs
+      (File ScriptInAnyLang In)
+  deriving Show
+
+createSimpleOrPlutusScriptFromCliArgs
+  :: File ScriptInAnyLang In
+  -> Maybe (ScriptDatumOrFileSpending, ScriptDataOrFile, ExecutionUnits)
+  -> CliSpendScriptRequirements
+createSimpleOrPlutusScriptFromCliArgs scriptFp (Just (datumFile, redeemerFile, execUnits)) =
+  OnDiskSimpleOrPlutusScript $ OnDiskPlutusScriptCliArgs scriptFp datumFile redeemerFile execUnits
+createSimpleOrPlutusScriptFromCliArgs scriptFp Nothing = OnDiskSimpleOrPlutusScript $ OnDiskSimpleCliArgs scriptFp
+
+newtype SimpleRefScriptCliArgs = SimpleRefScriptArgs TxIn deriving Show
+
+createSimpleReferenceScriptFromCliArgs :: TxIn -> CliSpendScriptRequirements
+createSimpleReferenceScriptFromCliArgs = OnDiskSimpleRefScript . SimpleRefScriptArgs
+
+data PlutusRefScriptCliArgs
+  = PlutusRefScriptCliArgs
+      TxIn
+      -- ^ TxIn with reference script
+      AnyPlutusScriptVersion
+      ScriptDatumOrFileSpending
+      -- ^ Optional Datum (CIP-69)
+      ScriptDataOrFile
+      -- ^ Redeemer
+      ExecutionUnits
+  deriving Show
+
+createPlutusReferenceScriptFromCliArgs
+  :: TxIn
+  -> AnyPlutusScriptVersion
+  -> ScriptDatumOrFileSpending
+  -> ScriptDataOrFile
+  -> ExecutionUnits
+  -> CliSpendScriptRequirements
+createPlutusReferenceScriptFromCliArgs txin v mDatum redeemer execUnits =
+  OnDiskPlutusRefScript $ PlutusRefScriptCliArgs txin v mDatum redeemer execUnits
+
+data ScriptDatumOrFileSpending
+  = PotentialDatum (Maybe ScriptDataOrFile)
+  | InlineDatum
+  deriving Show

--- a/cardano-cli/src/Cardano/CLI/EraBased/Script/Types.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Script/Types.hs
@@ -1,0 +1,29 @@
+{-# LANGUAGE LambdaCase #-}
+
+module Cardano.CLI.EraBased.Script.Types
+  ( -- * Errors
+    CliScriptWitnessError (..)
+  )
+where
+
+import           Cardano.Api
+
+import           Cardano.CLI.Types.Errors.PlutusScriptDecodeError
+import           Cardano.CLI.Types.Errors.ScriptDataError
+import           Cardano.CLI.Types.Errors.ScriptDecodeError
+
+data CliScriptWitnessError
+  = SimpleScriptWitnessDecodeError ScriptDecodeError
+  | PlutusScriptWitnessDecodeError PlutusScriptDecodeError
+  | PlutusScriptWitnessLanguageNotSupportedInEra
+      AnyPlutusScriptVersion
+      AnyShelleyBasedEra
+  | PlutusScriptWitnessRedeemerError ScriptDataError
+
+instance Error CliScriptWitnessError where
+  prettyError = \case
+    SimpleScriptWitnessDecodeError err -> prettyError err
+    PlutusScriptWitnessDecodeError err -> prettyError err
+    PlutusScriptWitnessLanguageNotSupportedInEra version era ->
+      "Plutus script version " <> pshow version <> " is not supported in era " <> pshow era
+    PlutusScriptWitnessRedeemerError err -> renderScriptDataError err

--- a/cardano-cli/src/Cardano/CLI/Types/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Common.hs
@@ -431,8 +431,9 @@ data ScriptWitnessFiles witctx where
     -> ScriptRedeemerOrFile
     -> ExecutionUnits
     -> ScriptWitnessFiles witctx
-  -- NB: This no longer is used for minting scripts
-  -- Use MintScriptWitnessWithPolicyId instead
+  -- | This no longer is used for minting or spending
+  -- scripts.
+  -- Use MintScriptWitnessWithPolicyId or SpendScriptWitness instead
   PlutusReferenceScriptWitnessFiles
     :: TxIn
     -> AnyPlutusScriptVersion
@@ -441,8 +442,9 @@ data ScriptWitnessFiles witctx where
     -> ExecutionUnits
     -- ^ For minting reference scripts
     -> ScriptWitnessFiles witctx
-  -- NB: This no longer is used for minting scripts
-  -- Use MintScriptWitnessWithPolicyId instead
+  -- | This no longer is used for minting or spending
+  -- scripts
+  -- Use MintScriptWitnessWithPolicyId or SpendScriptWitness instead
   SimpleReferenceScriptWitnessFiles
     :: TxIn
     -> AnyScriptLanguage

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/TxCmdError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/TxCmdError.hs
@@ -19,8 +19,8 @@ import           Cardano.Api.Consensus (EraMismatch (..))
 import qualified Cardano.Api.Ledger as L
 import           Cardano.Api.Shelley
 
-import           Cardano.CLI.EraBased.Script.Mint.Types
 import           Cardano.CLI.EraBased.Script.Spend.Read
+import           Cardano.CLI.EraBased.Script.Types
 import           Cardano.CLI.Read
 import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Errors.BootstrapWitnessError

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/TxCmdError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/TxCmdError.hs
@@ -20,6 +20,7 @@ import qualified Cardano.Api.Ledger as L
 import           Cardano.Api.Shelley
 
 import           Cardano.CLI.EraBased.Script.Mint.Types
+import           Cardano.CLI.EraBased.Script.Spend.Read
 import           Cardano.CLI.Read
 import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Errors.BootstrapWitnessError
@@ -52,6 +53,7 @@ data TxCmdError
   | TxCmdProtocolParamsError ProtocolParamsError
   | TxCmdScriptFileError (FileError ScriptDecodeError)
   | TxCmdCliScriptWitnessError !(FileError CliScriptWitnessError)
+  | TxCmdCliSpendingScriptWitnessError !(FileError CliSpendScriptWitnessError)
   | TxCmdKeyFileError (FileError InputDecodeError)
   | TxCmdReadTextViewFileError !(FileError TextEnvelopeError)
   | TxCmdReadWitnessSigningDataError !ReadWitnessSigningDataError
@@ -109,6 +111,8 @@ renderTxCmdError = \case
     prettyError fileErr
   TxCmdCliScriptWitnessError cliScriptWitnessErr ->
     prettyError cliScriptWitnessErr
+  TxCmdCliSpendingScriptWitnessError cliSpendScriptWitnessErr ->
+    prettyError cliSpendScriptWitnessErr
   TxCmdKeyFileError fileErr ->
     prettyError fileErr
   TxCmdReadWitnessSigningDataError witSignDataErr ->


### PR DESCRIPTION
# Changelog

```yaml
- description: |
   Remove use of ScriptWitnessFiles in spending scripts
  type:
  - refactoring    # QoL changes
```

# Context

Additional context for the PR goes here. If the PR fixes a particular issue please provide a [link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=) to the issue.

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
