### PR TITLE
Remove use of script witness files in certifying scripts

### DIFF
--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -117,6 +117,8 @@ library
     Cardano.CLI.EraBased.Run.StakePool
     Cardano.CLI.EraBased.Run.TextView
     Cardano.CLI.EraBased.Run.Transaction
+    Cardano.CLI.EraBased.Script.Certificate.Read
+    Cardano.CLI.EraBased.Script.Certificate.Types
     Cardano.CLI.EraBased.Script.Mint.Read
     Cardano.CLI.EraBased.Script.Mint.Types
     Cardano.CLI.EraBased.Script.Spend.Read

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Transaction.hs
@@ -25,6 +25,7 @@ import qualified Cardano.Api.Experimental as Exp
 import           Cardano.Api.Ledger (Coin)
 import           Cardano.Api.Shelley
 
+import           Cardano.CLI.EraBased.Script.Certificate.Types (CliCertificateScriptRequirements)
 import           Cardano.CLI.EraBased.Script.Mint.Types
 import           Cardano.CLI.EraBased.Script.Spend.Types (CliSpendScriptRequirements)
 import           Cardano.CLI.Types.Common
@@ -71,7 +72,7 @@ data TransactionBuildRawCmdArgs era = TransactionBuildRawCmdArgs
   -- ^ Transaction validity upper bound
   , fee :: !Coin
   -- ^ Transaction fee
-  , certificates :: ![(CertificateFile, Maybe (ScriptWitnessFiles WitCtxStake))]
+  , certificates :: ![(CertificateFile, Maybe CliCertificateScriptRequirements)]
   -- ^ Certificates with potential script witness
   , withdrawals :: ![(StakeAddress, Coin, Maybe (ScriptWitnessFiles WitCtxStake))]
   , metadataSchema :: !TxMetadataJsonSchema
@@ -119,7 +120,7 @@ data TransactionBuildCmdArgs era = TransactionBuildCmdArgs
   -- ^ Transaction validity lower bound
   , mValidityUpperBound :: !(TxValidityUpperBound era)
   -- ^ Transaction validity upper bound
-  , certificates :: ![(CertificateFile, Maybe (ScriptWitnessFiles WitCtxStake))]
+  , certificates :: ![(CertificateFile, Maybe CliCertificateScriptRequirements)]
   -- ^ Certificates with potential script witness
   , withdrawals :: ![(StakeAddress, Coin, Maybe (ScriptWitnessFiles WitCtxStake))]
   -- ^ Withdrawals with potential script witness
@@ -165,7 +166,7 @@ data TransactionBuildEstimateCmdArgs era = TransactionBuildEstimateCmdArgs
   -- ^ Transaction validity lower bound
   , mValidityUpperBound :: !(TxValidityUpperBound era)
   -- ^ Transaction validity upper bound
-  , certificates :: ![(CertificateFile, Maybe (ScriptWitnessFiles WitCtxStake))]
+  , certificates :: ![(CertificateFile, Maybe CliCertificateScriptRequirements)]
   -- ^ Certificates with potential script witness
   , withdrawals :: ![(StakeAddress, Coin, Maybe (ScriptWitnessFiles WitCtxStake))]
   -- ^ Withdrawals with potential script witness

--- a/cardano-cli/src/Cardano/CLI/EraBased/Script/Certificate/Read.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Script/Certificate/Read.hs
@@ -1,0 +1,111 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE TupleSections #-}
+
+module Cardano.CLI.EraBased.Script.Certificate.Read
+  ( readCertificateScriptWitness
+  , readCertificateScriptWitnesses
+  )
+where
+
+import           Cardano.Api
+import           Cardano.Api.Shelley
+
+import           Cardano.CLI.EraBased.Script.Certificate.Types
+import           Cardano.CLI.EraBased.Script.Types
+import           Cardano.CLI.Read
+import           Cardano.CLI.Types.Common
+
+import           Control.Monad
+
+readCertificateScriptWitnesses
+  :: MonadIOTransError (FileError CliScriptWitnessError) t m
+  => ShelleyBasedEra era
+  -> [(CertificateFile, Maybe CliCertificateScriptRequirements)]
+  -> t m [(CertificateFile, Maybe (CertificateScriptWitness era))]
+readCertificateScriptWitnesses sbe =
+  mapM
+    ( \(certFile, mSWit) -> do
+        (certFile,) <$> forM mSWit (readCertificateScriptWitness sbe)
+    )
+
+readCertificateScriptWitness
+  :: MonadIOTransError (FileError CliScriptWitnessError) t m
+  => ShelleyBasedEra era -> CliCertificateScriptRequirements -> t m (CertificateScriptWitness era)
+readCertificateScriptWitness sbe certScriptReq =
+  case certScriptReq of
+    OnDiskSimpleScript scriptFp -> do
+      let sFp = unFile scriptFp
+      s <-
+        modifyError (fmap SimpleScriptWitnessDecodeError) $
+          readFileSimpleScript sFp
+      case s of
+        SimpleScript ss -> do
+          return $
+            CertificateScriptWitness $
+              SimpleScriptWitness (sbeToSimpleScriptLanguageInEra sbe) $
+                SScript ss
+    OnDiskPlutusScript (OnDiskPlutusScriptCliArgs scriptFp redeemerFile execUnits) -> do
+      let plutusScriptFp = unFile scriptFp
+      plutusScript <-
+        modifyError (fmap PlutusScriptWitnessDecodeError) $
+          readFilePlutusScript plutusScriptFp
+      redeemer <-
+        modifyError (FileError plutusScriptFp . PlutusScriptWitnessRedeemerError) $
+          readScriptDataOrFile redeemerFile
+      case plutusScript of
+        AnyPlutusScript lang script -> do
+          let pScript = PScript script
+          sLangSupported <-
+            modifyError (FileError plutusScriptFp)
+              $ hoistMaybe
+                ( PlutusScriptWitnessLanguageNotSupportedInEra
+                    (AnyPlutusScriptVersion lang)
+                    (shelleyBasedEraConstraints sbe $ AnyShelleyBasedEra sbe)
+                )
+              $ scriptLanguageSupportedInEra sbe
+              $ PlutusScriptLanguage lang
+          return $
+            CertificateScriptWitness $
+              PlutusScriptWitness
+                sLangSupported
+                lang
+                pScript
+                NoScriptDatumForStake
+                redeemer
+                execUnits
+    OnDiskPlutusRefScript (PlutusRefScriptCliArgs refTxIn anyPlutusScriptVersion redeemerFile execUnits) -> do
+      case anyPlutusScriptVersion of
+        AnyPlutusScriptVersion lang -> do
+          let pScript = PReferenceScript refTxIn
+          redeemer <-
+            -- TODO: Implement a new error type to capture this. FileError is not representative of cases
+            -- where we do not have access to the script.
+            modifyError
+              ( FileError "Reference script filepath not available"
+                  . PlutusScriptWitnessRedeemerError
+              )
+              $ readScriptDataOrFile redeemerFile
+          sLangSupported <-
+            -- TODO: Implement a new error type to capture this. FileError is not representative of cases
+            -- where we do not have access to the script.
+            modifyError (FileError "Reference script filepath not available")
+              $ hoistMaybe
+                ( PlutusScriptWitnessLanguageNotSupportedInEra
+                    (AnyPlutusScriptVersion lang)
+                    (shelleyBasedEraConstraints sbe $ AnyShelleyBasedEra sbe)
+                )
+              $ scriptLanguageSupportedInEra sbe
+              $ PlutusScriptLanguage lang
+
+          return $
+            CertificateScriptWitness $
+              PlutusScriptWitness
+                sLangSupported
+                lang
+                pScript
+                NoScriptDatumForStake
+                redeemer
+                execUnits

--- a/cardano-cli/src/Cardano/CLI/EraBased/Script/Certificate/Read.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Script/Certificate/Read.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE TupleSections #-}
 
 module Cardano.CLI.EraBased.Script.Certificate.Read

--- a/cardano-cli/src/Cardano/CLI/EraBased/Script/Certificate/Types.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Script/Certificate/Types.hs
@@ -1,0 +1,63 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+
+module Cardano.CLI.EraBased.Script.Certificate.Types
+  ( CertificateScriptWitness (..)
+  , CliCertificateScriptRequirements (..)
+  , PlutusScriptCliArgs (..)
+  , PlutusRefScriptCliArgs (..)
+  , createSimpleOrPlutusScriptFromCliArgs
+  , createPlutusReferenceScriptFromCliArgs
+  )
+where
+
+import           Cardano.Api
+
+import           Cardano.CLI.Types.Common (ScriptDataOrFile)
+
+newtype CertificateScriptWitness era
+  = CertificateScriptWitness {cswScriptWitness :: ScriptWitness WitCtxStake era}
+  deriving Show
+
+data CliCertificateScriptRequirements
+  = OnDiskPlutusScript PlutusScriptCliArgs
+  | OnDiskSimpleScript (File ScriptInAnyLang In)
+  | OnDiskPlutusRefScript PlutusRefScriptCliArgs
+  deriving Show
+
+data PlutusScriptCliArgs
+  = OnDiskPlutusScriptCliArgs
+      (File ScriptInAnyLang In)
+      ScriptDataOrFile
+      -- ^ Redeemer
+      ExecutionUnits
+  deriving Show
+
+createSimpleOrPlutusScriptFromCliArgs
+  :: File ScriptInAnyLang In
+  -> Maybe (ScriptDataOrFile, ExecutionUnits)
+  -> CliCertificateScriptRequirements
+createSimpleOrPlutusScriptFromCliArgs scriptFp (Just (redeemer, execUnits)) =
+  OnDiskPlutusScript $ OnDiskPlutusScriptCliArgs scriptFp redeemer execUnits
+createSimpleOrPlutusScriptFromCliArgs scriptFp Nothing =
+  OnDiskSimpleScript scriptFp
+
+data PlutusRefScriptCliArgs
+  = PlutusRefScriptCliArgs
+      TxIn
+      -- ^ TxIn with reference script
+      AnyPlutusScriptVersion
+      ScriptDataOrFile
+      -- ^ Redeemer
+      ExecutionUnits
+  deriving Show
+
+createPlutusReferenceScriptFromCliArgs
+  :: TxIn
+  -> AnyPlutusScriptVersion
+  -> ScriptDataOrFile
+  -> ExecutionUnits
+  -> CliCertificateScriptRequirements
+createPlutusReferenceScriptFromCliArgs txIn version redeemer execUnits =
+  OnDiskPlutusRefScript $ PlutusRefScriptCliArgs txIn version redeemer execUnits


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Remove use of ScriptWitnessFiles in certifying scripts
  type:
  - refactoring    # QoL changes
```

# Context

Additional context for the PR goes here. If the PR fixes a particular issue please provide a [link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=) to the issue.

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
