### PR TITLE
Remove use of script witness files in voting scripts

### DIFF
--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -124,6 +124,7 @@ library
     Cardano.CLI.EraBased.Script.Spend.Read
     Cardano.CLI.EraBased.Script.Spend.Types
     Cardano.CLI.EraBased.Script.Types
+    Cardano.CLI.EraBased.Script.Vote.Types
     Cardano.CLI.EraBased.Transaction.HashCheck
     Cardano.CLI.Helpers
     Cardano.CLI.IO.Lazy

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -121,9 +121,11 @@ library
     Cardano.CLI.EraBased.Script.Certificate.Types
     Cardano.CLI.EraBased.Script.Mint.Read
     Cardano.CLI.EraBased.Script.Mint.Types
+    Cardano.CLI.EraBased.Script.Read.Common
     Cardano.CLI.EraBased.Script.Spend.Read
     Cardano.CLI.EraBased.Script.Spend.Types
     Cardano.CLI.EraBased.Script.Types
+    Cardano.CLI.EraBased.Script.Vote.Read
     Cardano.CLI.EraBased.Script.Vote.Types
     Cardano.CLI.EraBased.Transaction.HashCheck
     Cardano.CLI.Helpers

--- a/cardano-cli/src/Cardano/CLI/Compatible/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/Compatible/Transaction.hs
@@ -25,6 +25,8 @@ import           Cardano.CLI.EraBased.Run.Transaction
 import           Cardano.CLI.EraBased.Script.Certificate.Read
 import           Cardano.CLI.EraBased.Script.Certificate.Types
 import           Cardano.CLI.EraBased.Script.Types
+import           Cardano.CLI.EraBased.Script.Vote.Types (CliVoteScriptRequirements,
+                   VoteScriptWitness (..))
 import           Cardano.CLI.Parser
 import           Cardano.CLI.Read
 import           Cardano.CLI.Types.Common
@@ -181,7 +183,7 @@ data CompatibleTransactionCmds era
       [TxOutAnyEra]
       !(Maybe (Featured ShelleyToBabbageEra era (Maybe UpdateProposalFile)))
       !(Maybe (Featured ConwayEraOnwards era [(ProposalFile In, Maybe (ScriptWitnessFiles WitCtxStake))]))
-      ![(VoteFile In, Maybe (ScriptWitnessFiles WitCtxStake))]
+      ![(VoteFile In, Maybe CliVoteScriptRequirements)]
       [WitnessSigningData]
       -- ^ Signing keys
       (Maybe NetworkId)
@@ -271,7 +273,7 @@ runCompatibleTransactionCmd
                 readVotingProceduresFiles w mVotes
             votingProcedures <-
               firstExceptT CompatibleVoteMergeError . hoistEither $
-                mkTxVotingProcedures votesAndWits
+                mkTxVotingProcedures [(v, vswScriptWitness <$> mSwit) | (v, mSwit) <- votesAndWits]
             return (prop, VotingProcedures w votingProcedures)
         )
         sbe

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Transaction.hs
@@ -28,6 +28,7 @@ import           Cardano.Api.Shelley
 import           Cardano.CLI.EraBased.Script.Certificate.Types (CliCertificateScriptRequirements)
 import           Cardano.CLI.EraBased.Script.Mint.Types
 import           Cardano.CLI.EraBased.Script.Spend.Types (CliSpendScriptRequirements)
+import           Cardano.CLI.EraBased.Script.Vote.Types
 import           Cardano.CLI.Orphans ()
 import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Governance
@@ -82,7 +83,7 @@ data TransactionBuildRawCmdArgs era = TransactionBuildRawCmdArgs
   , metadataFiles :: ![MetadataFile]
   , mProtocolParamsFile :: !(Maybe ProtocolParamsFile)
   , mUpdateProprosalFile :: !(Maybe (Featured ShelleyToBabbageEra era (Maybe UpdateProposalFile)))
-  , voteFiles :: ![(VoteFile In, Maybe (ScriptWitnessFiles WitCtxStake))]
+  , voteFiles :: ![(VoteFile In, Maybe CliVoteScriptRequirements)]
   , proposalFiles :: ![(ProposalFile In, Maybe (ScriptWitnessFiles WitCtxStake))]
   , currentTreasuryValueAndDonation :: !(Maybe (TxCurrentTreasuryValue, TxTreasuryDonation))
   , txBodyOutFile :: !(TxBodyFile Out)
@@ -128,7 +129,7 @@ data TransactionBuildCmdArgs era = TransactionBuildCmdArgs
   -- ^ Auxiliary scripts
   , metadataFiles :: ![MetadataFile]
   , mUpdateProposalFile :: !(Maybe (Featured ShelleyToBabbageEra era (Maybe UpdateProposalFile)))
-  , voteFiles :: ![(VoteFile In, Maybe (ScriptWitnessFiles WitCtxStake))]
+  , voteFiles :: ![(VoteFile In, Maybe CliVoteScriptRequirements)]
   , proposalFiles :: ![(ProposalFile In, Maybe (ScriptWitnessFiles WitCtxStake))]
   , treasuryDonation :: !(Maybe TxTreasuryDonation)
   , buildOutputOptions :: !TxBuildOutputOptions
@@ -178,7 +179,7 @@ data TransactionBuildEstimateCmdArgs era = TransactionBuildEstimateCmdArgs
   -- ^ Auxiliary scripts
   , metadataFiles :: ![MetadataFile]
   , mUpdateProposalFile :: !(Maybe (Featured ShelleyToBabbageEra era (Maybe UpdateProposalFile)))
-  , voteFiles :: ![(VoteFile In, Maybe (ScriptWitnessFiles WitCtxStake))]
+  , voteFiles :: ![(VoteFile In, Maybe CliVoteScriptRequirements)]
   , proposalFiles :: ![(ProposalFile In, Maybe (ScriptWitnessFiles WitCtxStake))]
   , currentTreasuryValueAndDonation :: !(Maybe (TxCurrentTreasuryValue, TxTreasuryDonation))
   , txBodyOutFile :: !(TxBodyFile Out)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Vote.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Governance/Vote.hs
@@ -16,7 +16,7 @@ import qualified Cardano.Api.Ledger as L
 import           Cardano.Api.Shelley
 
 import qualified Cardano.CLI.EraBased.Commands.Governance.Vote as Cmd
-import           Cardano.CLI.Read (readSingleVote)
+import           Cardano.CLI.EraBased.Script.Vote.Read
 import           Cardano.CLI.Run.Hash (carryHashChecks)
 import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Errors.CmdError
@@ -108,8 +108,9 @@ runGovernanceVoteViewCmd
 
     shelleyBasedEraConstraints sbe $ do
       voteProcedures <-
-        fmap fst . firstExceptT GovernanceVoteCmdReadVoteFileError . newExceptT $
-          readSingleVote eon (voteFile, Nothing)
+        fmap fst $
+          firstExceptT GovernanceVoteCmdReadVoteFileError $
+            readVoteScriptWitness eon (voteFile, Nothing)
       firstExceptT GovernanceVoteCmdWriteError
         . newExceptT
         . ( case outFormat of

--- a/cardano-cli/src/Cardano/CLI/EraBased/Script/Certificate/Read.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Script/Certificate/Read.hs
@@ -13,9 +13,9 @@ import           Cardano.Api
 import           Cardano.Api.Shelley
 
 import           Cardano.CLI.EraBased.Script.Certificate.Types
+import           Cardano.CLI.EraBased.Script.Read.Common
 import           Cardano.CLI.EraBased.Script.Types
-import           Cardano.CLI.Read
-import           Cardano.CLI.Types.Common
+import           Cardano.CLI.Types.Common (CertificateFile)
 
 import           Control.Monad
 

--- a/cardano-cli/src/Cardano/CLI/EraBased/Script/Mint/Read.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Script/Mint/Read.hs
@@ -11,8 +11,8 @@ import           Cardano.Api
 import           Cardano.Api.Shelley
 
 import           Cardano.CLI.EraBased.Script.Mint.Types
+import           Cardano.CLI.EraBased.Script.Read.Common
 import           Cardano.CLI.EraBased.Script.Types
-import           Cardano.CLI.Read
 
 readMintScriptWitness
   :: MonadIOTransError (FileError CliScriptWitnessError) t m

--- a/cardano-cli/src/Cardano/CLI/EraBased/Script/Read/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Script/Read/Common.hs
@@ -1,0 +1,151 @@
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE LambdaCase #-}
+
+module Cardano.CLI.EraBased.Script.Read.Common
+  ( -- * Plutus Script Related
+    readScriptDataOrFile
+  , readScriptDatumOrFile
+  , readScriptRedeemerOrFile
+  , readFilePlutusScript
+
+    -- * Simple Script Related
+  , readFileSimpleScript
+  )
+where
+
+import           Cardano.Api as Api
+
+import           Cardano.CLI.EraBased.Script.Types
+import           Cardano.CLI.Types.Common
+import           Cardano.CLI.Types.Errors.PlutusScriptDecodeError
+import           Cardano.CLI.Types.Errors.ScriptDataError
+import           Cardano.CLI.Types.Errors.ScriptDecodeError
+
+
+import           Prelude
+
+import qualified Data.Aeson as Aeson
+import           Data.Bifunctor
+import qualified Data.ByteString as BS
+
+import qualified Data.ByteString.Lazy.Char8 as LBS
+
+import qualified Data.Text as Text
+
+
+deserialisePlutusScript
+  :: BS.ByteString
+  -> Either PlutusScriptDecodeError AnyPlutusScript
+deserialisePlutusScript bs = do
+  te <- first PlutusScriptJsonDecodeError $ deserialiseFromJSON AsTextEnvelope bs
+  case teType te of
+    TextEnvelopeType s -> case s of
+      sVer@"PlutusScriptV1" -> deserialiseAnyPlutusScriptVersion sVer PlutusScriptV1 te
+      sVer@"PlutusScriptV2" -> deserialiseAnyPlutusScriptVersion sVer PlutusScriptV2 te
+      sVer@"PlutusScriptV3" -> deserialiseAnyPlutusScriptVersion sVer PlutusScriptV3 te
+      unknownScriptVersion ->
+        Left . PlutusScriptDecodeErrorUnknownVersion $ Text.pack unknownScriptVersion
+ where
+  deserialiseAnyPlutusScriptVersion
+    :: IsPlutusScriptLanguage lang
+    => String
+    -> PlutusScriptVersion lang
+    -> TextEnvelope
+    -> Either PlutusScriptDecodeError AnyPlutusScript
+  deserialiseAnyPlutusScriptVersion v lang tEnv =
+    if v == show lang
+      then
+        first PlutusScriptDecodeTextEnvelopeError $
+          deserialiseFromTextEnvelopeAnyOf [teTypes (AnyPlutusScriptVersion lang)] tEnv
+      else Left $ PlutusScriptDecodeErrorVersionMismatch (Text.pack v) (AnyPlutusScriptVersion lang)
+
+  teTypes :: AnyPlutusScriptVersion -> FromSomeType HasTextEnvelope AnyPlutusScript
+  teTypes =
+    \case
+      AnyPlutusScriptVersion PlutusScriptV1 ->
+        FromSomeType (AsPlutusScript AsPlutusScriptV1) (AnyPlutusScript PlutusScriptV1)
+      AnyPlutusScriptVersion PlutusScriptV2 ->
+        FromSomeType (AsPlutusScript AsPlutusScriptV2) (AnyPlutusScript PlutusScriptV2)
+      AnyPlutusScriptVersion PlutusScriptV3 ->
+        FromSomeType (AsPlutusScript AsPlutusScriptV3) (AnyPlutusScript PlutusScriptV3)
+
+deserialiseSimpleScript
+  :: BS.ByteString
+  -> Either ScriptDecodeError (Script SimpleScript')
+deserialiseSimpleScript bs =
+  case deserialiseFromJSON AsTextEnvelope bs of
+    Left _ ->
+      -- In addition to the TextEnvelope format, we also try to
+      -- deserialize the JSON representation of SimpleScripts.
+      case Aeson.eitherDecodeStrict' bs of
+        Left err -> Left (ScriptDecodeSimpleScriptError $ JsonDecodeError err)
+        Right script -> Right $ SimpleScript script
+    Right te ->
+      case deserialiseFromTextEnvelopeAnyOf [teType'] te of
+        Left err -> Left (ScriptDecodeTextEnvelopeError err)
+        Right script -> Right script
+ where
+  teType' :: FromSomeType HasTextEnvelope (Script SimpleScript')
+  teType' = FromSomeType (AsScript AsSimpleScript) id
+
+readFilePlutusScript
+  :: MonadIOTransError (FileError PlutusScriptDecodeError) t m
+  => FilePath
+  -> t m AnyPlutusScript
+readFilePlutusScript plutusScriptFp = do
+  bs <-
+    handleIOExceptionsLiftWith (FileIOError plutusScriptFp) . liftIO $
+      BS.readFile plutusScriptFp
+  modifyError (FileError plutusScriptFp) $
+    hoistEither $
+      deserialisePlutusScript bs
+
+readFileSimpleScript
+  :: MonadIOTransError (FileError ScriptDecodeError) t m
+  => FilePath
+  -> t m (Script SimpleScript')
+readFileSimpleScript file = do
+  scriptBytes <- handleIOExceptionsLiftWith (FileIOError file) . liftIO $ BS.readFile file
+  modifyError (FileError file) $
+    hoistEither $
+      deserialiseSimpleScript scriptBytes
+
+readScriptDataOrFile
+  :: MonadIO m
+  => ScriptDataOrFile
+  -> ExceptT ScriptDataError m HashableScriptData
+readScriptDataOrFile (ScriptDataValue d) = return d
+readScriptDataOrFile (ScriptDataJsonFile fp) = do
+  sDataBs <- handleIOExceptT (ScriptDataErrorFile . FileIOError fp) $ LBS.readFile fp
+  sDataValue <- hoistEither . first (ScriptDataErrorJsonParse fp) $ Aeson.eitherDecode sDataBs
+  hoistEither
+    . first ScriptDataErrorJsonBytes
+    $ scriptDataJsonToHashable ScriptDataJsonDetailedSchema sDataValue
+readScriptDataOrFile (ScriptDataCborFile fp) = do
+  origBs <- handleIOExceptT (ScriptDataErrorFile . FileIOError fp) (BS.readFile fp)
+  hSd <-
+    firstExceptT (ScriptDataErrorMetadataDecode fp) $
+      hoistEither $
+        deserialiseFromCBOR AsHashableScriptData origBs
+  firstExceptT (ScriptDataErrorValidation fp) $
+    hoistEither $
+      validateScriptData $
+        getScriptData hSd
+  return hSd
+
+readScriptDatumOrFile
+  :: ScriptDatumOrFile witctx
+  -> ExceptT ScriptDataError IO (ScriptDatum witctx)
+readScriptDatumOrFile (ScriptDatumOrFileForTxIn Nothing) = pure $ ScriptDatumForTxIn Nothing
+readScriptDatumOrFile (ScriptDatumOrFileForTxIn (Just df)) =
+  ScriptDatumForTxIn . Just
+    <$> readScriptDataOrFile df
+readScriptDatumOrFile InlineDatumPresentAtTxIn = pure InlineScriptDatum
+readScriptDatumOrFile NoScriptDatumOrFileForMint = pure NoScriptDatumForMint
+readScriptDatumOrFile NoScriptDatumOrFileForStake = pure NoScriptDatumForStake
+
+readScriptRedeemerOrFile
+  :: ScriptRedeemerOrFile
+  -> ExceptT ScriptDataError IO ScriptRedeemer
+readScriptRedeemerOrFile = readScriptDataOrFile

--- a/cardano-cli/src/Cardano/CLI/EraBased/Script/Read/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Script/Read/Common.hs
@@ -22,17 +22,13 @@ import           Cardano.CLI.Types.Errors.PlutusScriptDecodeError
 import           Cardano.CLI.Types.Errors.ScriptDataError
 import           Cardano.CLI.Types.Errors.ScriptDecodeError
 
-
 import           Prelude
 
 import qualified Data.Aeson as Aeson
 import           Data.Bifunctor
 import qualified Data.ByteString as BS
-
 import qualified Data.ByteString.Lazy.Char8 as LBS
-
 import qualified Data.Text as Text
-
 
 deserialisePlutusScript
   :: BS.ByteString

--- a/cardano-cli/src/Cardano/CLI/EraBased/Script/Spend/Read.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Script/Spend/Read.hs
@@ -14,6 +14,7 @@ where
 import           Cardano.Api
 import           Cardano.Api.Shelley
 
+import           Cardano.CLI.EraBased.Script.Read.Common
 import           Cardano.CLI.EraBased.Script.Spend.Types
 import           Cardano.CLI.EraBased.Script.Types
 import           Cardano.CLI.Read

--- a/cardano-cli/src/Cardano/CLI/EraBased/Script/Types.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Script/Types.hs
@@ -1,8 +1,11 @@
+{-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
 
 module Cardano.CLI.EraBased.Script.Types
-  ( -- * Errors
-    CliScriptWitnessError (..)
+  ( AnyPlutusScript (..)
+
+    -- * Errors
+  , CliScriptWitnessError (..)
   )
 where
 
@@ -12,17 +15,25 @@ import           Cardano.CLI.Types.Errors.PlutusScriptDecodeError
 import           Cardano.CLI.Types.Errors.ScriptDataError
 import           Cardano.CLI.Types.Errors.ScriptDecodeError
 
+-- TODO: Move to cardano-api
+data AnyPlutusScript where
+  AnyPlutusScript
+    :: IsPlutusScriptLanguage lang => PlutusScriptVersion lang -> PlutusScript lang -> AnyPlutusScript
+
 data CliScriptWitnessError
   = SimpleScriptWitnessDecodeError ScriptDecodeError
+  | TextEnvelopeError TextEnvelopeError
   | PlutusScriptWitnessDecodeError PlutusScriptDecodeError
   | PlutusScriptWitnessLanguageNotSupportedInEra
       AnyPlutusScriptVersion
       AnyShelleyBasedEra
   | PlutusScriptWitnessRedeemerError ScriptDataError
+  deriving Show
 
 instance Error CliScriptWitnessError where
   prettyError = \case
     SimpleScriptWitnessDecodeError err -> prettyError err
+    TextEnvelopeError err -> prettyError err
     PlutusScriptWitnessDecodeError err -> prettyError err
     PlutusScriptWitnessLanguageNotSupportedInEra version era ->
       "Plutus script version " <> pshow version <> " is not supported in era " <> pshow era

--- a/cardano-cli/src/Cardano/CLI/EraBased/Script/Vote/Read.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Script/Vote/Read.hs
@@ -1,0 +1,120 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+
+module Cardano.CLI.EraBased.Script.Vote.Read
+  ( readVoteScriptWitness
+  )
+where
+
+import           Cardano.Api
+import           Cardano.Api.Shelley
+
+import           Cardano.CLI.EraBased.Script.Read.Common
+import           Cardano.CLI.EraBased.Script.Types
+import           Cardano.CLI.EraBased.Script.Vote.Types
+import           Cardano.CLI.Types.Governance
+
+readVoteScriptWitness
+  :: MonadIOTransError (FileError CliScriptWitnessError) t m
+  => ConwayEraOnwards era
+  -> (VoteFile In, Maybe CliVoteScriptRequirements)
+  -> t m (VotingProcedures era, Maybe (VoteScriptWitness era))
+readVoteScriptWitness w (voteFp, Nothing) = do
+  votProceds <-
+    conwayEraOnwardsConstraints w $
+      modifyError (fmap TextEnvelopeError) $
+        hoistIOEither $
+          readFileTextEnvelope AsVotingProcedures voteFp
+  return (votProceds, Nothing)
+readVoteScriptWitness w (voteFp, Just certScriptReq) = do
+  let sbe = convert w
+  votProceds <-
+    conwayEraOnwardsConstraints w $
+      modifyError (fmap TextEnvelopeError) $
+        hoistIOEither $
+          readFileTextEnvelope AsVotingProcedures voteFp
+  case certScriptReq of
+    OnDiskSimpleScript scriptFp -> do
+      let sFp = unFile scriptFp
+      s <-
+        modifyError (fmap SimpleScriptWitnessDecodeError) $
+          readFileSimpleScript sFp
+      case s of
+        SimpleScript ss -> do
+          return 
+            ( votProceds
+            , Just $
+                VoteScriptWitness
+                  ( SimpleScriptWitness (sbeToSimpleScriptLanguageInEra sbe) $
+                      SScript ss
+                  )
+            )
+    OnDiskPlutusScript (OnDiskPlutusScriptCliArgs scriptFp redeemerFile execUnits) -> do
+      let plutusScriptFp = unFile scriptFp
+      plutusScript <-
+        modifyError (fmap PlutusScriptWitnessDecodeError) $
+          readFilePlutusScript plutusScriptFp
+      redeemer <-
+        modifyError (FileError plutusScriptFp . PlutusScriptWitnessRedeemerError) $
+          readScriptDataOrFile redeemerFile
+      case plutusScript of
+        AnyPlutusScript lang script -> do
+          let pScript = PScript script
+          sLangSupported <-
+            modifyError (FileError plutusScriptFp)
+              $ hoistMaybe
+                ( PlutusScriptWitnessLanguageNotSupportedInEra
+                    (AnyPlutusScriptVersion lang)
+                    (shelleyBasedEraConstraints sbe $ AnyShelleyBasedEra sbe)
+                )
+              $ scriptLanguageSupportedInEra sbe
+              $ PlutusScriptLanguage lang
+          return
+            ( votProceds
+            , Just $
+                VoteScriptWitness $
+                  PlutusScriptWitness
+                    sLangSupported
+                    lang
+                    pScript
+                    NoScriptDatumForStake
+                    redeemer
+                    execUnits
+            )
+    OnDiskPlutusRefScript (PlutusRefScriptCliArgs refTxIn anyPlutusScriptVersion redeemerFile execUnits) -> do
+      case anyPlutusScriptVersion of
+        AnyPlutusScriptVersion lang -> do
+          let pScript = PReferenceScript refTxIn
+          redeemer <-
+            -- TODO: Implement a new error type to capture this. FileError is not representative of cases
+            -- where we do not have access to the script.
+            modifyError
+              ( FileError "Reference script filepath not available"
+                  . PlutusScriptWitnessRedeemerError
+              )
+              $ readScriptDataOrFile redeemerFile
+          sLangSupported <-
+            -- TODO: Implement a new error type to capture this. FileError is not representative of cases
+            -- where we do not have access to the script.
+            modifyError (FileError "Reference script filepath not available")
+              $ hoistMaybe
+                ( PlutusScriptWitnessLanguageNotSupportedInEra
+                    (AnyPlutusScriptVersion lang)
+                    (shelleyBasedEraConstraints sbe $ AnyShelleyBasedEra sbe)
+                )
+              $ scriptLanguageSupportedInEra sbe
+              $ PlutusScriptLanguage lang
+
+          return
+            ( votProceds
+            , Just $
+                VoteScriptWitness $
+                  PlutusScriptWitness
+                    sLangSupported
+                    lang
+                    pScript
+                    NoScriptDatumForStake
+                    redeemer
+                    execUnits
+            )

--- a/cardano-cli/src/Cardano/CLI/EraBased/Script/Vote/Read.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Script/Vote/Read.hs
@@ -42,7 +42,7 @@ readVoteScriptWitness w (voteFp, Just certScriptReq) = do
           readFileSimpleScript sFp
       case s of
         SimpleScript ss -> do
-          return 
+          return
             ( votProceds
             , Just $
                 VoteScriptWitness

--- a/cardano-cli/src/Cardano/CLI/EraBased/Script/Vote/Types.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Script/Vote/Types.hs
@@ -1,0 +1,63 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+
+module Cardano.CLI.EraBased.Script.Vote.Types
+  ( CliVoteScriptRequirements (..)
+  , PlutusRefScriptCliArgs (..)
+  , PlutusScriptCliArgs (..)
+  , VoteScriptWitness (..)
+  , createSimpleOrPlutusScriptFromCliArgs
+  , createPlutusReferenceScriptFromCliArgs
+  )
+where
+
+import           Cardano.Api
+
+import           Cardano.CLI.Types.Common (ScriptDataOrFile)
+
+newtype VoteScriptWitness era
+  = VoteScriptWitness {vswScriptWitness :: ScriptWitness WitCtxStake era}
+  deriving Show
+
+data CliVoteScriptRequirements
+  = OnDiskPlutusScript PlutusScriptCliArgs
+  | OnDiskSimpleScript (File ScriptInAnyLang In)
+  | OnDiskPlutusRefScript PlutusRefScriptCliArgs
+  deriving Show
+
+data PlutusScriptCliArgs
+  = OnDiskPlutusScriptCliArgs
+      (File ScriptInAnyLang In)
+      ScriptDataOrFile
+      -- ^ Redeemer
+      ExecutionUnits
+  deriving Show
+
+createSimpleOrPlutusScriptFromCliArgs
+  :: File ScriptInAnyLang In
+  -> Maybe (ScriptDataOrFile, ExecutionUnits)
+  -> CliVoteScriptRequirements
+createSimpleOrPlutusScriptFromCliArgs scriptFp (Just (redeemer, execUnits)) =
+  OnDiskPlutusScript $ OnDiskPlutusScriptCliArgs scriptFp redeemer execUnits
+createSimpleOrPlutusScriptFromCliArgs scriptFp Nothing =
+  OnDiskSimpleScript scriptFp
+
+data PlutusRefScriptCliArgs
+  = PlutusRefScriptCliArgs
+      TxIn
+      -- ^ TxIn with reference script
+      AnyPlutusScriptVersion
+      ScriptDataOrFile
+      -- ^ Redeemer
+      ExecutionUnits
+  deriving Show
+
+createPlutusReferenceScriptFromCliArgs
+  :: TxIn
+  -> AnyPlutusScriptVersion
+  -> ScriptDataOrFile
+  -> ExecutionUnits
+  -> CliVoteScriptRequirements
+createPlutusReferenceScriptFromCliArgs txIn version redeemer execUnits =
+  OnDiskPlutusRefScript $ PlutusRefScriptCliArgs txIn version redeemer execUnits

--- a/cardano-cli/src/Cardano/CLI/Read.hs
+++ b/cardano-cli/src/Cardano/CLI/Read.hs
@@ -291,7 +291,6 @@ readScriptWitnessFilesTuple era = mapM readSwitFile
     return (tIn, b, Just sWit)
   readSwitFile (tIn, b, Nothing) = return (tIn, b, Nothing)
 
--- TODO: Left off here. Move this to Cardano.CLI.EraBased.Script.Read.Common
 readScriptWitness
   :: ShelleyBasedEra era
   -> ScriptWitnessFiles witctx

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/GovernanceVoteCmdError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/GovernanceVoteCmdError.hs
@@ -7,6 +7,7 @@ module Cardano.CLI.Types.Errors.GovernanceVoteCmdError where
 import           Cardano.Api.Shelley
 
 import           Cardano.Binary (DecoderError)
+import           Cardano.CLI.EraBased.Script.Types
 import           Cardano.CLI.Read (VoteError)
 import           Cardano.CLI.Types.Errors.HashCmdError (HashCheckError)
 
@@ -16,7 +17,7 @@ import qualified Formatting.Buildable as B
 
 data GovernanceVoteCmdError
   = GovernanceVoteCmdReadVerificationKeyError !(FileError InputDecodeError)
-  | GovernanceVoteCmdReadVoteFileError !VoteError
+  | GovernanceVoteCmdReadVoteFileError !(FileError CliScriptWitnessError)
   | GovernanceVoteCmdCredentialDecodeError !DecoderError
   | GovernanceVoteCmdWriteError !(FileError ())
   | GovernanceVoteCmdReadVoteTextError !VoteError

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/PlutusScriptDecodeError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/PlutusScriptDecodeError.hs
@@ -18,6 +18,7 @@ data PlutusScriptDecodeError
       -- ^ Script version
       !AnyPlutusScriptVersion
       -- ^ Attempted to decode with version
+  deriving Show
 
 instance Error PlutusScriptDecodeError where
   prettyError = \case

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/ErrorsSpec.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/ErrorsSpec.hs
@@ -17,6 +17,7 @@ import           Cardano.Api.Shelley
 import           Cardano.Binary
 import           Cardano.CLI.EraBased.Run.Governance.Actions
 import           Cardano.CLI.EraBased.Run.Governance.Committee
+import           Cardano.CLI.EraBased.Script.Types
 import           Cardano.CLI.Read
 import           Cardano.CLI.Types.Errors.DelegationError
 import           Cardano.CLI.Types.Errors.GovernanceCmdError
@@ -233,8 +234,8 @@ test_VoteReadError =
     ,
       ( "GovernanceVoteCmdReadVoteFileError"
       , GovernanceVoteCmdReadVoteFileError $
-          VoteErrorFile $
-            FileError "path/file.txt" $
+          FileError "path/file.txt" $
+            TextEnvelopeError $
               TextEnvelopeAesonDecodeError "some error description"
       )
     ,


### PR DESCRIPTION
# Changelog

```yaml
- description: |
   Remove use of ScriptWitnessFiles in voting scripts
  type:
    - refactoring    # QoL changes
```

# Context

Additional context for the PR goes here. If the PR fixes a particular issue please provide a [link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=) to the issue.

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
