### PR TITLE
Fix costs calculation for transaction with more than one certificates with the same stake credential and script witness

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -14,7 +14,7 @@ repository cardano-haskell-packages
 -- you need to run if you change them
 index-state:
   , hackage.haskell.org 2024-12-24T12:56:48Z
-  , cardano-haskell-packages 2025-01-15T09:59:24Z
+  , cardano-haskell-packages 2025-02-01T07:12:29Z
 
 packages:
   cardano-cli

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -212,7 +212,7 @@ library
     binary,
     bytestring,
     canonical-json,
-    cardano-api ^>=10.6,
+    cardano-api ^>=10.8,
     cardano-binary,
     cardano-crypto,
     cardano-crypto-class ^>=2.1.2,

--- a/cardano-cli/src/Cardano/CLI/Json/Friendly.hs
+++ b/cardano-cli/src/Cardano/CLI/Json/Friendly.hs
@@ -223,38 +223,38 @@ friendlyTxBodyImpl era tb = do
         , "withdrawals" .= friendlyWithdrawals txWithdrawals
         ]
           ++ ( monoidForEraInEon @AlonzoEraOnwards
-                era
-                (`getScriptWitnessDetails` tb)
+                 era
+                 (`getScriptWitnessDetails` tb)
              )
           ++ ( monoidForEraInEon @ConwayEraOnwards
-                era
-                ( \cOnwards ->
-                    conwayEraOnwardsConstraints cOnwards $
-                      case txProposalProcedures of
-                        Nothing -> []
-                        Just (Featured _ TxProposalProceduresNone) -> []
-                        Just (Featured _ pp) -> do
-                          let lProposals = toList $ convProposalProcedures pp
-                          ["governance actions" .= (friendlyLedgerProposals cOnwards lProposals)]
-                )
+                 era
+                 ( \cOnwards ->
+                     conwayEraOnwardsConstraints cOnwards $
+                       case txProposalProcedures of
+                         Nothing -> []
+                         Just (Featured _ TxProposalProceduresNone) -> []
+                         Just (Featured _ pp) -> do
+                           let lProposals = toList $ convProposalProcedures pp
+                           ["governance actions" .= (friendlyLedgerProposals cOnwards lProposals)]
+                 )
              )
           ++ ( monoidForEraInEon @ConwayEraOnwards
-                era
-                ( \cOnwards ->
-                    case txVotingProcedures of
-                      Nothing -> []
-                      Just (Featured _ TxVotingProceduresNone) -> []
-                      Just (Featured _ (TxVotingProcedures votes _witnesses)) ->
-                        ["voters" .= friendlyVotingProcedures cOnwards votes]
-                )
+                 era
+                 ( \cOnwards ->
+                     case txVotingProcedures of
+                       Nothing -> []
+                       Just (Featured _ TxVotingProceduresNone) -> []
+                       Just (Featured _ (TxVotingProcedures votes _witnesses)) ->
+                         ["voters" .= friendlyVotingProcedures cOnwards votes]
+                 )
              )
           ++ ( monoidForEraInEon @ConwayEraOnwards
-                era
-                (const ["currentTreasuryValue" .= toJSON (unFeatured <$> txCurrentTreasuryValue)])
+                 era
+                 (const ["currentTreasuryValue" .= toJSON (unFeatured <$> txCurrentTreasuryValue)])
              )
           ++ ( monoidForEraInEon @ConwayEraOnwards
-                era
-                (const ["treasuryDonation" .= toJSON (unFeatured <$> txTreasuryDonation)])
+                 era
+                 (const ["treasuryDonation" .= toJSON (unFeatured <$> txTreasuryDonation)])
              )
       )
  where
@@ -545,9 +545,9 @@ friendlyUpdateProposal = \case
       [ "epoch" .= epoch
       , "updates"
           .= [ object
-                [ "genesis key hash" .= genesisKeyHash
-                , "update" .= friendlyProtocolParametersUpdate parameterUpdate
-                ]
+                 [ "genesis key hash" .= genesisKeyHash
+                 , "update" .= friendlyProtocolParametersUpdate parameterUpdate
+                 ]
              | (genesisKeyHash, parameterUpdate) <- Map.assocs parameterUpdates
              ]
       ]
@@ -802,9 +802,9 @@ friendlyMirTarget sbe = \case
   L.StakeAddressesMIR addresses ->
     "target stake addresses"
       .= [ object
-            [ friendlyStakeCredential credential
-            , "amount" .= friendlyLovelace (L.Coin 0 `L.addDeltaCoin` lovelace)
-            ]
+             [ friendlyStakeCredential credential
+             , "amount" .= friendlyLovelace (L.Coin 0 `L.addDeltaCoin` lovelace)
+             ]
          | (credential, lovelace) <- shelleyBasedEraConstraints sbe $ toList addresses
          ]
   L.SendToOppositePotMIR amount -> "MIR amount" .= friendlyLovelace amount

--- a/cardano-cli/src/Cardano/CLI/Json/Friendly.hs
+++ b/cardano-cli/src/Cardano/CLI/Json/Friendly.hs
@@ -626,7 +626,7 @@ friendlyPrices ExecutionUnitPrices{priceExecutionMemory, priceExecutionSteps} =
 friendlyCertificates :: ShelleyBasedEra era -> TxCertificates ViewTx era -> Aeson.Value
 friendlyCertificates sbe = \case
   TxCertificatesNone -> Null
-  TxCertificates _ cs _ -> array $ map (friendlyCertificate sbe) cs
+  TxCertificates _ cs -> array $ map (friendlyCertificate sbe . fst) $ toList cs
 
 friendlyCertificate :: ShelleyBasedEra era -> Certificate era -> Aeson.Value
 friendlyCertificate sbe =

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1737590273,
-        "narHash": "sha256-zzeaIeeKCVfTxeSLw3oTmguOwH46NJw5LZH8wyWbATQ=",
+        "lastModified": 1738397760,
+        "narHash": "sha256-YpxxJDM8CJ7W8a/avBJFV8UHJexfz7BltG8v0YJMOqg=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "be239ff9f54422603b3acf5c4d87b62a0c715196",
+        "rev": "6ff0fedb79e02d7fcc4309238c233a80c90a0564",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Fix costs calculation for transaction with more than one certificates with the same stake credential and script witness.
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
   - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Fixes:
 - https://github.com/IntersectMBO/cardano-cli/issues/1023

Requires:
 - https://github.com/IntersectMBO/cardano-api/pull/734

Tested in:
 - https://github.com/IntersectMBO/cardano-node/pull/6082

Regression tests executed in:
 - https://github.com/IntersectMBO/cardano-node-tests/actions/runs/12928366127


# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
