### PR TITLE
Update nix cabal version & flake inputs

### DIFF
--- a/.github/workflows/check-cabal-files.yml
+++ b/.github/workflows/check-cabal-files.yml
@@ -18,7 +18,7 @@ jobs:
       uses: input-output-hk/setup-haskell@v1
       id: setup-haskell
       with:
-        cabal-version: "3.10.1.0"
+        cabal-version: "3.14.1.1"
 
     - uses: actions/checkout@v3
 

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         ghc: ["9.6", "9.8", "9.10"]
-        cabal: ["3.12"]
+        cabal: ["3.14"]
         sys:
           - { os: windows-latest, shell: 'C:/msys64/usr/bin/bash.exe -e {0}' }
           - { os: ubuntu-latest, shell: bash }

--- a/.github/workflows/hls.yml
+++ b/.github/workflows/hls.yml
@@ -5,17 +5,17 @@ on:
   push:
     branches:
       - master
- 
+
 permissions:
   contents: read
-  
+
 jobs:
 
   test-hls-works:
     env:
       # Modify this value to "invalidate" the cache.
       HLS_CACHE_VERSION: "2024-06-25"
-  
+
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
@@ -27,7 +27,7 @@ jobs:
           extra_nix_config: |
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
             substituters = https://cache.iog.io/ https://cache.nixos.org/
-          nix_path: nixpkgs=channel:nixos-unstable 
+          nix_path: nixpkgs=channel:nixos-unstable
       - name: Open nix environment
         uses: rrbutani/use-nix-shell-action@v1
       - name: Update dependencies

--- a/.github/workflows/release-upload.yml
+++ b/.github/workflows/release-upload.yml
@@ -159,10 +159,10 @@ jobs:
               derivation+="${{ matrix.arch }}"
               ;;
             "x86_64-linux")
-              derivation+="x86_64-linux.ghc965-x86_64-unknown-linux-musl"
+              derivation+="x86_64-linux.ghc966-x86_64-unknown-linux-musl"
               ;;
             "aarch64-linux")
-              derivation+="x86_64-linux.ghc965-aarch64-unknown-linux-musl"
+              derivation+="x86_64-linux.ghc966-aarch64-unknown-linux-musl"
               ;;
             *)
               echo "Unexpected matrix.arch value: ${{ matrix.arch }}"

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1736937016,
-        "narHash": "sha256-dmLSu2SvSaTDjSE03cU6DwY62J3nWJbVhIn/kKtMwJg=",
+        "lastModified": 1737590273,
+        "narHash": "sha256-zzeaIeeKCVfTxeSLw3oTmguOwH46NJw5LZH8wyWbATQ=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "045875beec586ff57a7333c0563fd5c2b1a308fa",
+        "rev": "be239ff9f54422603b3acf5c4d87b62a0c715196",
         "type": "github"
       },
       "original": {
@@ -36,17 +36,17 @@
     "blst": {
       "flake": false,
       "locked": {
-        "lastModified": 1656163412,
-        "narHash": "sha256-xero1aTe2v4IhWIJaEDUsVDOfE77dOV5zKeHWntHogY=",
+        "lastModified": 1691598027,
+        "narHash": "sha256-oqljy+ZXJAXEB/fJtmB8rlAr4UXM+Z2OkDa20gpILNA=",
         "owner": "supranational",
         "repo": "blst",
-        "rev": "03b5124029979755c752eec45f3c29674b558446",
+        "rev": "3dd0f804b1819e5d03fb22ca2e6fac105932043a",
         "type": "github"
       },
       "original": {
         "owner": "supranational",
+        "ref": "v0.3.11",
         "repo": "blst",
-        "rev": "03b5124029979755c752eec45f3c29674b558446",
         "type": "github"
       }
     },
@@ -170,14 +170,14 @@
         "type": "github"
       }
     },
-    "hackage": {
+    "hackageNix": {
       "flake": false,
       "locked": {
-        "lastModified": 1736382484,
-        "narHash": "sha256-z1wBpMV1uqkZKCo4q4aXVwHcinYtwD0LHI5AEDtpnVA=",
+        "lastModified": 1737678520,
+        "narHash": "sha256-oc5ocFiYAGDkAinwmCGpGnZtMQqBMjB/7hZP22cO9bg=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "db572909cbd9ea2179284e594e04a0ec6e480ce0",
+        "rev": "96603452fa9245c67f6a45d9b2921ae9d3f4a6ab",
         "type": "github"
       },
       "original": {
@@ -195,7 +195,9 @@
         "cardano-shell": "cardano-shell",
         "flake-compat": "flake-compat",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk",
-        "hackage": "hackage",
+        "hackage": [
+          "hackageNix"
+        ],
         "hls-1.10": "hls-1.10",
         "hls-2.0": "hls-2.0",
         "hls-2.2": "hls-2.2",
@@ -226,15 +228,16 @@
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1726447863,
-        "narHash": "sha256-bI1GMzozXWQ/Ckukr8bXnH3QzWZ+vZC0o5RkblCXIyI=",
+        "lastModified": 1726275037,
+        "narHash": "sha256-q0+NlcOGV1eQRN1FjLpt5li6iyPQPeky37hwP5JLqVU=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "d259dac293df908b6749653122cca88b5e459c30",
+        "rev": "a93d40302777a9ce268b3bc57caae3f7fdae1ce1",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
+        "ref": "2024.09.15",
         "repo": "haskell.nix",
         "type": "github"
       }
@@ -474,11 +477,11 @@
         "sodium": "sodium"
       },
       "locked": {
-        "lastModified": 1702362799,
-        "narHash": "sha256-cU8cZXNuo5GRwrSvWqdaqoW5tJ2HWwDEOvWwIVPDPmo=",
+        "lastModified": 1734618971,
+        "narHash": "sha256-5StB/VhWHOj3zlBxshqVFa6cwAE0Mk/wxRo3eEfcy74=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "b426fb9e0b109a9d1dd2e1476f9e0bd8bb715142",
+        "rev": "dc900a3448e805243b0ed196017e8eb631e32240",
         "type": "github"
       },
       "original": {
@@ -734,11 +737,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1688392541,
-        "narHash": "sha256-lHrKvEkCPTUO+7tPfjIcb7Trk6k31rz18vkyqmkeJfY=",
+        "lastModified": 1684171562,
+        "narHash": "sha256-BMUWjVWAUdyMWKk0ATMC9H0Bv4qAV/TXwwPUvTiC5IQ=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "ea4c80b39be4c09702b0cb3b42eab59e2ba4f24b",
+        "rev": "55af203d468a6f5032a519cba4f41acf5a74b638",
         "type": "github"
       },
       "original": {
@@ -769,6 +772,7 @@
       "inputs": {
         "CHaP": "CHaP",
         "flake-utils": "flake-utils",
+        "hackageNix": "hackageNix",
         "haskellNix": "haskellNix",
         "incl": "incl",
         "iohkNix": "iohkNix",
@@ -815,11 +819,11 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1726445918,
-        "narHash": "sha256-M34goAxhRqzDaVXqUo8lLnjZpppJYpr26c+X1Lhj5hU=",
+        "lastModified": 1726100060,
+        "narHash": "sha256-nvxogFYvwoUuqTHKyn1vcOuQFKEGGlXiTNzTDHeOImk=",
         "owner": "input-output-hk",
         "repo": "stackage.nix",
-        "rev": "8299f8d17eef21ec8365536ee9705ff66a3504f3",
+        "rev": "732fcc1460200a3050697a056a0fe9d460d0dbec",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Update nix cabal version & flake inputs
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
   - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Changes:
* pin haskell.nix flake input to a tag - you can do `nix flake update` without worrying about haskell.nix upgrade biting you
* update cabal to 3.14 to avoid building its version from source
* update default ghc cross compilation to 9.6.6

This should also limit the number of GHC versions we're pulling into development shell. This had a side effect of breaking GHA due to running out of disk space: https://github.com/IntersectMBO/cardano-cli/actions/runs/12915728375/job/36018250466?pr=1024

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
