### PR TITLE
Add command to calculate plutus script costs from an already constructed transaction

### DIFF
--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -226,6 +226,7 @@ library
     cardano-crypto-wrapper ^>=1.5.1,
     cardano-data >=1.1,
     cardano-git-rev ^>=0.2.2,
+    cardano-ledger-api,
     cardano-ping ^>=0.7,
     cardano-prelude,
     cardano-slotting ^>=0.2.0.0,

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Transaction.hs
@@ -14,6 +14,7 @@ module Cardano.CLI.EraBased.Commands.Transaction
   , TransactionPolicyIdCmdArgs (..)
   , TransactionCalculateMinFeeCmdArgs (..)
   , TransactionCalculateMinValueCmdArgs (..)
+  , TransactionCalculatePlutusScriptCostCmdArgs (..)
   , TransactionHashScriptDataCmdArgs (..)
   , TransactionTxIdCmdArgs (..)
   , TransactionViewCmdArgs (..)
@@ -48,6 +49,7 @@ data TransactionCmds era
   | TransactionPolicyIdCmd !TransactionPolicyIdCmdArgs
   | TransactionCalculateMinFeeCmd !TransactionCalculateMinFeeCmdArgs
   | TransactionCalculateMinValueCmd !(TransactionCalculateMinValueCmdArgs era)
+  | TransactionCalculatePlutusScriptCostCmd !TransactionCalculatePlutusScriptCostCmdArgs
   | TransactionHashScriptDataCmd !TransactionHashScriptDataCmdArgs
   | TransactionTxIdCmd !TransactionTxIdCmdArgs
 
@@ -240,6 +242,12 @@ data TransactionCalculateMinValueCmdArgs era = TransactionCalculateMinValueCmdAr
   }
   deriving Show
 
+data TransactionCalculatePlutusScriptCostCmdArgs = TransactionCalculatePlutusScriptCostCmdArgs
+  { nodeConnInfo :: !LocalNodeConnectInfo
+  , txFileIn :: FilePath
+  , outputFile :: !(Maybe (File () Out))
+  }
+
 newtype TransactionHashScriptDataCmdArgs = TransactionHashScriptDataCmdArgs
   { scriptDataOrFile :: ScriptDataOrFile
   }
@@ -266,5 +274,6 @@ renderTransactionCmds = \case
   TransactionPolicyIdCmd{} -> "transaction policyid"
   TransactionCalculateMinFeeCmd{} -> "transaction calculate-min-fee"
   TransactionCalculateMinValueCmd{} -> "transaction calculate-min-value"
+  TransactionCalculatePlutusScriptCostCmd{} -> "transaction calculate-plutus-script-cost"
   TransactionHashScriptDataCmd{} -> "transaction hash-script-data"
   TransactionTxIdCmd{} -> "transaction txid"

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
@@ -1439,7 +1439,9 @@ pTxBuildOutputOptions =
     OutputScriptCostOnly . File
       <$> parseFilePath
         "calculate-plutus-script-cost"
-        "Where to write the script cost information."
+        ( "Where to write the script cost information. (Deprecated: this flag is deprecated and will be "
+            <> "removed in a future version. Please, use calculate-plutus-script-cost command instead.)"
+        )
 
 pCertificateFile
   :: BalanceTxExecUnits

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Transaction.hs
@@ -92,6 +92,10 @@ pTransactionCmds era' envCli =
         subParser "calculate-min-required-utxo" $
           Opt.info (pTransactionCalculateMinReqUTxO era') $
             Opt.progDesc "Calculate the minimum required UTxO for a transaction output."
+    , Just $
+        subParser "calculate-plutus-script-cost" $
+          Opt.info (pTransactionCalculatePlutusScriptCost envCli) $
+            Opt.progDesc "Calculate the costs of the Plutus scripts of a given transaction."
     , Just $ pCalculateMinRequiredUtxoBackwardCompatible era'
     , Just $
         subParser "hash-script-data" $
@@ -368,6 +372,21 @@ pTransactionCalculateMinReqUTxO era' =
     TransactionCalculateMinValueCmdArgs era'
       <$> pProtocolParamsFile
       <*> pTxOutShelleyBased
+
+pTransactionCalculatePlutusScriptCost :: EnvCli -> Parser (TransactionCmds era)
+pTransactionCalculatePlutusScriptCost envCli =
+  fmap TransactionCalculatePlutusScriptCostCmd $
+    TransactionCalculatePlutusScriptCostCmdArgs
+      <$> ( LocalNodeConnectInfo
+              <$> pConsensusModeParams
+              <*> pNetworkId envCli
+              <*> pSocketPath envCli
+          )
+      <*> pTxInputFile
+      <*> optional pOutputFile
+ where
+  pTxInputFile :: Parser FilePath
+  pTxInputFile = parseFilePath "tx-file" "Filepath of the transaction whose Plutus scripts to calculate the cost."
 
 pTxHashScriptData :: Parser (TransactionCmds era)
 pTxHashScriptData =

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/TxCmdError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/TxCmdError.hs
@@ -93,6 +93,7 @@ data TxCmdError
   | TxCmdPoolMetadataHashError AnchorDataFromCertificateError
   | TxCmdHashCheckError L.Url HashCheckError
   | TxCmdUnregisteredStakeAddress !(Set StakeCredential)
+  | forall era. TxCmdAlonzoEraOnwardsRequired !(CardanoEra era)
 
 renderTxCmdError :: TxCmdError -> Doc ann
 renderTxCmdError = \case
@@ -234,6 +235,10 @@ renderTxCmdError = \case
     "Hash of the file is not valid. Url:" <+> pretty (L.urlToText url) <+> prettyException e
   TxCmdUnregisteredStakeAddress credentials ->
     "Stake credential specified in the proposal is not registered on-chain:" <+> pshow credentials
+  TxCmdAlonzoEraOnwardsRequired era ->
+    "This command is only available in the Alonzo era and onwards, since earlier eras do not support scripting. Era requested ("
+      <> pretty era
+      <> ") is not supported."
 
 prettyPolicyIdList :: [PolicyId] -> Doc ann
 prettyPolicyIdList =

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -1819,6 +1819,7 @@ Usage: cardano-cli shelley transaction
                                          | policyid
                                          | calculate-min-fee
                                          | calculate-min-required-utxo
+                                         | calculate-plutus-script-cost
                                          | hash-script-data
                                          | txid
                                          )
@@ -2037,6 +2038,18 @@ Usage: cardano-cli shelley transaction calculate-min-required-utxo --protocol-pa
                                                                      [--tx-out-reference-script-file FILEPATH]
 
   Calculate the minimum required UTxO for a transaction output.
+
+Usage: cardano-cli shelley transaction calculate-plutus-script-cost 
+                                                                      [--cardano-mode
+                                                                        [--epoch-slots SLOTS]]
+                                                                      ( --mainnet
+                                                                      | --testnet-magic NATURAL
+                                                                      )
+                                                                      --socket-path SOCKET_PATH
+                                                                      --tx-file FILEPATH
+                                                                      [--out-file FILEPATH]
+
+  Calculate the costs of the Plutus scripts of a given transaction.
 
 Usage: cardano-cli shelley transaction calculate-min-value --protocol-params-file FILEPATH
                                                              --tx-out ADDRESS VALUE
@@ -2902,6 +2915,7 @@ Usage: cardano-cli allegra transaction
                                          | policyid
                                          | calculate-min-fee
                                          | calculate-min-required-utxo
+                                         | calculate-plutus-script-cost
                                          | hash-script-data
                                          | txid
                                          )
@@ -3120,6 +3134,18 @@ Usage: cardano-cli allegra transaction calculate-min-required-utxo --protocol-pa
                                                                      [--tx-out-reference-script-file FILEPATH]
 
   Calculate the minimum required UTxO for a transaction output.
+
+Usage: cardano-cli allegra transaction calculate-plutus-script-cost 
+                                                                      [--cardano-mode
+                                                                        [--epoch-slots SLOTS]]
+                                                                      ( --mainnet
+                                                                      | --testnet-magic NATURAL
+                                                                      )
+                                                                      --socket-path SOCKET_PATH
+                                                                      --tx-file FILEPATH
+                                                                      [--out-file FILEPATH]
+
+  Calculate the costs of the Plutus scripts of a given transaction.
 
 Usage: cardano-cli allegra transaction calculate-min-value --protocol-params-file FILEPATH
                                                              --tx-out ADDRESS VALUE
@@ -3967,6 +3993,7 @@ Usage: cardano-cli mary transaction
                                       | policyid
                                       | calculate-min-fee
                                       | calculate-min-required-utxo
+                                      | calculate-plutus-script-cost
                                       | hash-script-data
                                       | txid
                                       )
@@ -4183,6 +4210,18 @@ Usage: cardano-cli mary transaction calculate-min-required-utxo --protocol-param
                                                                   [--tx-out-reference-script-file FILEPATH]
 
   Calculate the minimum required UTxO for a transaction output.
+
+Usage: cardano-cli mary transaction calculate-plutus-script-cost 
+                                                                   [--cardano-mode
+                                                                     [--epoch-slots SLOTS]]
+                                                                   ( --mainnet
+                                                                   | --testnet-magic NATURAL
+                                                                   )
+                                                                   --socket-path SOCKET_PATH
+                                                                   --tx-file FILEPATH
+                                                                   [--out-file FILEPATH]
+
+  Calculate the costs of the Plutus scripts of a given transaction.
 
 Usage: cardano-cli mary transaction calculate-min-value --protocol-params-file FILEPATH
                                                           --tx-out ADDRESS VALUE
@@ -5053,6 +5092,7 @@ Usage: cardano-cli alonzo transaction
                                         | policyid
                                         | calculate-min-fee
                                         | calculate-min-required-utxo
+                                        | calculate-plutus-script-cost
                                         | hash-script-data
                                         | txid
                                         )
@@ -5271,6 +5311,18 @@ Usage: cardano-cli alonzo transaction calculate-min-required-utxo --protocol-par
                                                                     [--tx-out-reference-script-file FILEPATH]
 
   Calculate the minimum required UTxO for a transaction output.
+
+Usage: cardano-cli alonzo transaction calculate-plutus-script-cost 
+                                                                     [--cardano-mode
+                                                                       [--epoch-slots SLOTS]]
+                                                                     ( --mainnet
+                                                                     | --testnet-magic NATURAL
+                                                                     )
+                                                                     --socket-path SOCKET_PATH
+                                                                     --tx-file FILEPATH
+                                                                     [--out-file FILEPATH]
+
+  Calculate the costs of the Plutus scripts of a given transaction.
 
 Usage: cardano-cli alonzo transaction calculate-min-value --protocol-params-file FILEPATH
                                                             --tx-out ADDRESS VALUE
@@ -6184,6 +6236,7 @@ Usage: cardano-cli babbage transaction
                                          | policyid
                                          | calculate-min-fee
                                          | calculate-min-required-utxo
+                                         | calculate-plutus-script-cost
                                          | hash-script-data
                                          | txid
                                          )
@@ -6660,6 +6713,18 @@ Usage: cardano-cli babbage transaction calculate-min-required-utxo --protocol-pa
                                                                      [--tx-out-reference-script-file FILEPATH]
 
   Calculate the minimum required UTxO for a transaction output.
+
+Usage: cardano-cli babbage transaction calculate-plutus-script-cost 
+                                                                      [--cardano-mode
+                                                                        [--epoch-slots SLOTS]]
+                                                                      ( --mainnet
+                                                                      | --testnet-magic NATURAL
+                                                                      )
+                                                                      --socket-path SOCKET_PATH
+                                                                      --tx-file FILEPATH
+                                                                      [--out-file FILEPATH]
+
+  Calculate the costs of the Plutus scripts of a given transaction.
 
 Usage: cardano-cli babbage transaction calculate-min-value --protocol-params-file FILEPATH
                                                              --tx-out ADDRESS VALUE
@@ -8180,6 +8245,7 @@ Usage: cardano-cli conway transaction
                                         | policyid
                                         | calculate-min-fee
                                         | calculate-min-required-utxo
+                                        | calculate-plutus-script-cost
                                         | hash-script-data
                                         | txid
                                         )
@@ -8748,6 +8814,18 @@ Usage: cardano-cli conway transaction calculate-min-required-utxo --protocol-par
                                                                     [--tx-out-reference-script-file FILEPATH]
 
   Calculate the minimum required UTxO for a transaction output.
+
+Usage: cardano-cli conway transaction calculate-plutus-script-cost 
+                                                                     [--cardano-mode
+                                                                       [--epoch-slots SLOTS]]
+                                                                     ( --mainnet
+                                                                     | --testnet-magic NATURAL
+                                                                     )
+                                                                     --socket-path SOCKET_PATH
+                                                                     --tx-file FILEPATH
+                                                                     [--out-file FILEPATH]
+
+  Calculate the costs of the Plutus scripts of a given transaction.
 
 Usage: cardano-cli conway transaction calculate-min-value --protocol-params-file FILEPATH
                                                             --tx-out ADDRESS VALUE
@@ -10268,6 +10346,7 @@ Usage: cardano-cli latest transaction
                                         | policyid
                                         | calculate-min-fee
                                         | calculate-min-required-utxo
+                                        | calculate-plutus-script-cost
                                         | hash-script-data
                                         | txid
                                         )
@@ -10836,6 +10915,18 @@ Usage: cardano-cli latest transaction calculate-min-required-utxo --protocol-par
                                                                     [--tx-out-reference-script-file FILEPATH]
 
   Calculate the minimum required UTxO for a transaction output.
+
+Usage: cardano-cli latest transaction calculate-plutus-script-cost 
+                                                                     [--cardano-mode
+                                                                       [--epoch-slots SLOTS]]
+                                                                     ( --mainnet
+                                                                     | --testnet-magic NATURAL
+                                                                     )
+                                                                     --socket-path SOCKET_PATH
+                                                                     --tx-file FILEPATH
+                                                                     [--out-file FILEPATH]
+
+  Calculate the costs of the Plutus scripts of a given transaction.
 
 Usage: cardano-cli latest transaction calculate-min-value --protocol-params-file FILEPATH
                                                             --tx-out ADDRESS VALUE

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_transaction.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_transaction.cli
@@ -7,6 +7,7 @@ Usage: cardano-cli allegra transaction
                                          | policyid
                                          | calculate-min-fee
                                          | calculate-min-required-utxo
+                                         | calculate-plutus-script-cost
                                          | hash-script-data
                                          | txid
                                          )
@@ -33,5 +34,8 @@ Available commands:
   calculate-min-required-utxo
                            Calculate the minimum required UTxO for a transaction
                            output.
+  calculate-plutus-script-cost
+                           Calculate the costs of the Plutus scripts of a given
+                           transaction.
   hash-script-data         Calculate the hash of script data.
   txid                     Print a transaction identifier.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_transaction_calculate-plutus-script-cost.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_transaction_calculate-plutus-script-cost.cli
@@ -1,0 +1,30 @@
+Usage: cardano-cli allegra transaction calculate-plutus-script-cost 
+                                                                      [--cardano-mode
+                                                                        [--epoch-slots SLOTS]]
+                                                                      ( --mainnet
+                                                                      | --testnet-magic NATURAL
+                                                                      )
+                                                                      --socket-path SOCKET_PATH
+                                                                      --tx-file FILEPATH
+                                                                      [--out-file FILEPATH]
+
+  Calculate the costs of the Plutus scripts of a given transaction.
+
+Available options:
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --tx-file FILEPATH       Filepath of the transaction whose Plutus scripts to
+                           calculate the cost.
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_transaction.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_transaction.cli
@@ -7,6 +7,7 @@ Usage: cardano-cli alonzo transaction
                                         | policyid
                                         | calculate-min-fee
                                         | calculate-min-required-utxo
+                                        | calculate-plutus-script-cost
                                         | hash-script-data
                                         | txid
                                         )
@@ -33,5 +34,8 @@ Available commands:
   calculate-min-required-utxo
                            Calculate the minimum required UTxO for a transaction
                            output.
+  calculate-plutus-script-cost
+                           Calculate the costs of the Plutus scripts of a given
+                           transaction.
   hash-script-data         Calculate the hash of script data.
   txid                     Print a transaction identifier.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_transaction_calculate-plutus-script-cost.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_transaction_calculate-plutus-script-cost.cli
@@ -1,0 +1,30 @@
+Usage: cardano-cli alonzo transaction calculate-plutus-script-cost 
+                                                                     [--cardano-mode
+                                                                       [--epoch-slots SLOTS]]
+                                                                     ( --mainnet
+                                                                     | --testnet-magic NATURAL
+                                                                     )
+                                                                     --socket-path SOCKET_PATH
+                                                                     --tx-file FILEPATH
+                                                                     [--out-file FILEPATH]
+
+  Calculate the costs of the Plutus scripts of a given transaction.
+
+Available options:
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --tx-file FILEPATH       Filepath of the transaction whose Plutus scripts to
+                           calculate the cost.
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_transaction.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_transaction.cli
@@ -9,6 +9,7 @@ Usage: cardano-cli babbage transaction
                                          | policyid
                                          | calculate-min-fee
                                          | calculate-min-required-utxo
+                                         | calculate-plutus-script-cost
                                          | hash-script-data
                                          | txid
                                          )
@@ -41,5 +42,8 @@ Available commands:
   calculate-min-required-utxo
                            Calculate the minimum required UTxO for a transaction
                            output.
+  calculate-plutus-script-cost
+                           Calculate the costs of the Plutus scripts of a given
+                           transaction.
   hash-script-data         Calculate the hash of script data.
   txid                     Print a transaction identifier.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_transaction_build.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_transaction_build.cli
@@ -394,4 +394,7 @@ Available options:
   --out-file FILEPATH      Output filepath of the JSON TxBody.
   --calculate-plutus-script-cost FILEPATH
                            Where to write the script cost information.
+                           (Deprecated: this flag is deprecated and will be
+                           removed in a future version. Please, use
+                           calculate-plutus-script-cost command instead.)
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_transaction_calculate-plutus-script-cost.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_transaction_calculate-plutus-script-cost.cli
@@ -1,0 +1,30 @@
+Usage: cardano-cli babbage transaction calculate-plutus-script-cost 
+                                                                      [--cardano-mode
+                                                                        [--epoch-slots SLOTS]]
+                                                                      ( --mainnet
+                                                                      | --testnet-magic NATURAL
+                                                                      )
+                                                                      --socket-path SOCKET_PATH
+                                                                      --tx-file FILEPATH
+                                                                      [--out-file FILEPATH]
+
+  Calculate the costs of the Plutus scripts of a given transaction.
+
+Available options:
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --tx-file FILEPATH       Filepath of the transaction whose Plutus scripts to
+                           calculate the cost.
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction.cli
@@ -9,6 +9,7 @@ Usage: cardano-cli conway transaction
                                         | policyid
                                         | calculate-min-fee
                                         | calculate-min-required-utxo
+                                        | calculate-plutus-script-cost
                                         | hash-script-data
                                         | txid
                                         )
@@ -41,5 +42,8 @@ Available commands:
   calculate-min-required-utxo
                            Calculate the minimum required UTxO for a transaction
                            output.
+  calculate-plutus-script-cost
+                           Calculate the costs of the Plutus scripts of a given
+                           transaction.
   hash-script-data         Calculate the hash of script data.
   txid                     Print a transaction identifier.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_build.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_build.cli
@@ -475,4 +475,7 @@ Available options:
   --out-file FILEPATH      Output filepath of the JSON TxBody.
   --calculate-plutus-script-cost FILEPATH
                            Where to write the script cost information.
+                           (Deprecated: this flag is deprecated and will be
+                           removed in a future version. Please, use
+                           calculate-plutus-script-cost command instead.)
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_calculate-plutus-script-cost.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_calculate-plutus-script-cost.cli
@@ -1,0 +1,30 @@
+Usage: cardano-cli conway transaction calculate-plutus-script-cost 
+                                                                     [--cardano-mode
+                                                                       [--epoch-slots SLOTS]]
+                                                                     ( --mainnet
+                                                                     | --testnet-magic NATURAL
+                                                                     )
+                                                                     --socket-path SOCKET_PATH
+                                                                     --tx-file FILEPATH
+                                                                     [--out-file FILEPATH]
+
+  Calculate the costs of the Plutus scripts of a given transaction.
+
+Available options:
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --tx-file FILEPATH       Filepath of the transaction whose Plutus scripts to
+                           calculate the cost.
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_transaction.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_transaction.cli
@@ -9,6 +9,7 @@ Usage: cardano-cli latest transaction
                                         | policyid
                                         | calculate-min-fee
                                         | calculate-min-required-utxo
+                                        | calculate-plutus-script-cost
                                         | hash-script-data
                                         | txid
                                         )
@@ -41,5 +42,8 @@ Available commands:
   calculate-min-required-utxo
                            Calculate the minimum required UTxO for a transaction
                            output.
+  calculate-plutus-script-cost
+                           Calculate the costs of the Plutus scripts of a given
+                           transaction.
   hash-script-data         Calculate the hash of script data.
   txid                     Print a transaction identifier.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_transaction_build.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_transaction_build.cli
@@ -475,4 +475,7 @@ Available options:
   --out-file FILEPATH      Output filepath of the JSON TxBody.
   --calculate-plutus-script-cost FILEPATH
                            Where to write the script cost information.
+                           (Deprecated: this flag is deprecated and will be
+                           removed in a future version. Please, use
+                           calculate-plutus-script-cost command instead.)
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_transaction_calculate-plutus-script-cost.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_transaction_calculate-plutus-script-cost.cli
@@ -1,0 +1,30 @@
+Usage: cardano-cli latest transaction calculate-plutus-script-cost 
+                                                                     [--cardano-mode
+                                                                       [--epoch-slots SLOTS]]
+                                                                     ( --mainnet
+                                                                     | --testnet-magic NATURAL
+                                                                     )
+                                                                     --socket-path SOCKET_PATH
+                                                                     --tx-file FILEPATH
+                                                                     [--out-file FILEPATH]
+
+  Calculate the costs of the Plutus scripts of a given transaction.
+
+Available options:
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --tx-file FILEPATH       Filepath of the transaction whose Plutus scripts to
+                           calculate the cost.
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_transaction.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_transaction.cli
@@ -7,6 +7,7 @@ Usage: cardano-cli mary transaction
                                       | policyid
                                       | calculate-min-fee
                                       | calculate-min-required-utxo
+                                      | calculate-plutus-script-cost
                                       | hash-script-data
                                       | txid
                                       )
@@ -33,5 +34,8 @@ Available commands:
   calculate-min-required-utxo
                            Calculate the minimum required UTxO for a transaction
                            output.
+  calculate-plutus-script-cost
+                           Calculate the costs of the Plutus scripts of a given
+                           transaction.
   hash-script-data         Calculate the hash of script data.
   txid                     Print a transaction identifier.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_transaction_calculate-plutus-script-cost.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_transaction_calculate-plutus-script-cost.cli
@@ -1,0 +1,30 @@
+Usage: cardano-cli mary transaction calculate-plutus-script-cost 
+                                                                   [--cardano-mode
+                                                                     [--epoch-slots SLOTS]]
+                                                                   ( --mainnet
+                                                                   | --testnet-magic NATURAL
+                                                                   )
+                                                                   --socket-path SOCKET_PATH
+                                                                   --tx-file FILEPATH
+                                                                   [--out-file FILEPATH]
+
+  Calculate the costs of the Plutus scripts of a given transaction.
+
+Available options:
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --tx-file FILEPATH       Filepath of the transaction whose Plutus scripts to
+                           calculate the cost.
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_transaction.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_transaction.cli
@@ -7,6 +7,7 @@ Usage: cardano-cli shelley transaction
                                          | policyid
                                          | calculate-min-fee
                                          | calculate-min-required-utxo
+                                         | calculate-plutus-script-cost
                                          | hash-script-data
                                          | txid
                                          )
@@ -33,5 +34,8 @@ Available commands:
   calculate-min-required-utxo
                            Calculate the minimum required UTxO for a transaction
                            output.
+  calculate-plutus-script-cost
+                           Calculate the costs of the Plutus scripts of a given
+                           transaction.
   hash-script-data         Calculate the hash of script data.
   txid                     Print a transaction identifier.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_transaction_calculate-plutus-script-cost.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_transaction_calculate-plutus-script-cost.cli
@@ -1,0 +1,30 @@
+Usage: cardano-cli shelley transaction calculate-plutus-script-cost 
+                                                                      [--cardano-mode
+                                                                        [--epoch-slots SLOTS]]
+                                                                      ( --mainnet
+                                                                      | --testnet-magic NATURAL
+                                                                      )
+                                                                      --socket-path SOCKET_PATH
+                                                                      --tx-file FILEPATH
+                                                                      [--out-file FILEPATH]
+
+  Calculate the costs of the Plutus scripts of a given transaction.
+
+Available options:
+  --cardano-mode           For talking to a node running in full Cardano mode
+                           (default).
+  --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
+                           (default: 21600)
+  --mainnet                Use the mainnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
+                           CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
+  --tx-file FILEPATH       Filepath of the transaction whose Plutus scripts to
+                           calculate the cost.
+  --out-file FILEPATH      The output file.
+  -h,--help                Show this help text


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Add command to calculate plutus script costs from an already constructed transaction.
  type:
  - feature
```

# Context

This is a first step towards addressing this issue: https://github.com/IntersectMBO/cardano-cli/issues/945.

This PR in `cardano-api` provides the required functionality: https://github.com/IntersectMBO/cardano-api/pull/735. This PR must wait for the functionality in the `cardano-api` PR to get in a release, and the source repo stanza must be removed before merging.

# How to trust this PR

Ensure the untyped bits are correct: serialisation, documentation, and interface design.

Check in conjunction with these PRs:
- `cardano-api`: https://github.com/IntersectMBO/cardano-api/pull/735
- `cardano-node`: https://github.com/IntersectMBO/cardano-node/pull/6097

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
