### PR TITLE
Add governance action deposits to the output of `query stake-address-info

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -59,4 +59,3 @@ write-ghc-environment-files: always
 -- IMPORTANT
 -- Do NOT add more source-repository-package stanzas here unless they are strictly
 -- temporary! Please read the section in CONTRIBUTING about updating dependencies.
-


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Add governance action deposits to the output of `query stake-address-info`.  This also renames the field stakeDeposit to stakeRegistrationDeposit in the JSON output. 
    
# uncomment types applicable to the change:
  type:
   - feature        # introduces a new feature
   - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Resolves https://github.com/IntersectMBO/cardano-cli/issues/954
Requires https://github.com/IntersectMBO/cardano-api/pull/730

# How to trust this PR

The query now includes a map of (GovActionIds, Deposit) assocoated to the stake address: 

```
❯ cardano-cli conway query stake-address-info --address stake_test1upumkxq6k4th9wtp4zp69gjwwwj5zmskxd6czlyf3xflzgq8yk95h
[
    {
        "address": "stake_test1upumkxq6k4th9wtp4zp69gjwwwj5zmskxd6czlyf3xflzgq8yk95h",
        "delegationDeposit": 2000000,
        "govActionDeposits": [
            {
                "1166b7591577807470bd527edf2a5fac938b8d56842a67684b682b1e8e76d198#0": 100000000000,
                "2f1be5c1aa824dac76b98acb35176defa6357e529cd297ae24353943b46a0cde#0": 100000000000,
                "d098afe0db98605c243c13c8a537a3eb51e6ded5e3a48acca83e7082a0086428#0": 100000000000
            }
        ],
        "rewardAccountBalance": 1194509145192,
        "stakeDelegation": "pool18pn6p9ef58u4ga3wagp44qhzm8f6zncl57g6qgh0pk3yytwz54h",
        "voteDelegation": "keyHash-74519ac5359c003a7ace69c475ae55a86eb8f9fec6cf6feaada1debf"
    }
]
```
or empty if it is not associated to any

```
❯ cardano-cli conway query stake-address-info --address $(< stake.addr)
[
    {
        "address": "stake_test1upfpm2244k8jf00l357t3adp2hzfsuqrwqvleheqjj08uhswme5cn",
        "delegationDeposit": 2000000,
        "govActionDeposits": [
            {}
        ],
        "rewardAccountBalance": 300000000000,
        "stakeDelegation": "pool1l9u9ss9xtww8qkt4zqda84z945f6tgq4753jqhtdr4r8yaw7d6g",
        "voteDelegation": "scriptHash-59aa3f091b3bcef254abfb89aea64973a61b78fdb2ac44839c7ccba8"
    }
]
```

**BABBAGE:** With the latest chantes the query still works in Babbage era: 

```
cardano-cli babbage query stake-address-info --address $(< example/utxo-keys/stake1.addr)
WARNING: Selected era is deprecated and will be removed in the future.
[
    {
        "address": "stake_test1uq07mnmf838hdlu9qpnwjnntrrtvsa6448ud0g32qkm0kecusq4sd",
        "delegation": "pool1xj26f4rqk2t049yu6n4mmg5zstr6sarv63nc5fuw60rx7u0jxef",
        "delegationDeposit": 2000000,
        "rewardAccountBalance": 0
    }
]
```


# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
