### PR TITLE
Refactor node connection passing to make it use `LocalNodeConnectInfo` type

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Query.hs
@@ -38,6 +38,7 @@ import qualified Cardano.Api.Ledger as L
 import qualified Cardano.Api.Network as Consensus
 import           Cardano.Api.Shelley hiding (QueryInShelleyBasedEra (..))
 
+import           Cardano.CLI.Orphans ()
 import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Key
 
@@ -75,9 +76,7 @@ data QueryCmds era
 
 -- | Fields that are common to most queries
 data QueryCommons = QueryCommons
-  { nodeSocketPath :: !SocketPath
-  , consensusModeParams :: !ConsensusModeParams
-  , networkId :: !NetworkId
+  { nodeConnInfo :: !LocalNodeConnectInfo
   , target :: !(Consensus.Target ChainPoint)
   }
   deriving (Generic, Show)
@@ -94,9 +93,7 @@ data QueryLeadershipScheduleCmdArgs = QueryLeadershipScheduleCmdArgs
   deriving (Generic, Show)
 
 data QueryProtocolParametersCmdArgs = QueryProtocolParametersCmdArgs
-  { nodeSocketPath :: !SocketPath
-  , consensusModeParams :: !ConsensusModeParams
-  , networkId :: !NetworkId
+  { nodeConnInfo :: !LocalNodeConnectInfo
   , mOutFile :: !(Maybe (File () Out))
   }
   deriving (Generic, Show)
@@ -177,9 +174,7 @@ data QueryPoolStateCmdArgs = QueryPoolStateCmdArgs
   deriving (Generic, Show)
 
 data QueryTxMempoolCmdArgs = QueryTxMempoolCmdArgs
-  { nodeSocketPath :: !SocketPath
-  , consensusModeParams :: !ConsensusModeParams
-  , networkId :: !NetworkId
+  { nodeConnInfo :: !LocalNodeConnectInfo
   , query :: !TxMempoolQuery
   , mOutFile :: !(Maybe (File () Out))
   }
@@ -284,7 +279,7 @@ renderQueryCmds = \case
     "query kes-period-info"
   QueryPoolStateCmd{} ->
     "query pool-state"
-  QueryTxMempoolCmd (QueryTxMempoolCmdArgs _ _ _ q _) ->
+  QueryTxMempoolCmd (QueryTxMempoolCmdArgs _ q _) ->
     "query tx-mempool" <> renderTxMempoolQuery q
   QuerySlotNumberCmd{} ->
     "query slot-number"

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Transaction.hs
@@ -28,6 +28,7 @@ import           Cardano.Api.Shelley
 import           Cardano.CLI.EraBased.Script.Certificate.Types (CliCertificateScriptRequirements)
 import           Cardano.CLI.EraBased.Script.Mint.Types
 import           Cardano.CLI.EraBased.Script.Spend.Types (CliSpendScriptRequirements)
+import           Cardano.CLI.Orphans ()
 import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Governance
 
@@ -91,9 +92,7 @@ data TransactionBuildRawCmdArgs era = TransactionBuildRawCmdArgs
 -- | Like 'TransactionBuildRaw' but without the fee, and with a change output.
 data TransactionBuildCmdArgs era = TransactionBuildCmdArgs
   { currentEra :: !(Exp.Era era)
-  , nodeSocketPath :: !SocketPath
-  , consensusModeParams :: !ConsensusModeParams
-  , networkId :: !NetworkId
+  , nodeConnInfo :: !LocalNodeConnectInfo
   , mScriptValidity :: !(Maybe ScriptValidity)
   -- ^ Mark script as expected to pass or fail validation
   , mOverrideWitnesses :: !(Maybe Word)
@@ -209,9 +208,7 @@ data TransactionSignWitnessCmdArgs = TransactionSignWitnessCmdArgs
   deriving Show
 
 data TransactionSubmitCmdArgs = TransactionSubmitCmdArgs
-  { nodeSocketPath :: !SocketPath
-  , consensusModeParams :: !ConsensusModeParams
-  , networkId :: !NetworkId
+  { nodeConnInfo :: !LocalNodeConnectInfo
   , txFile :: !FilePath
   }
   deriving Show

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Query.hs
@@ -301,9 +301,11 @@ pQueryProtocolParametersCmd :: EnvCli -> Parser (QueryCmds era)
 pQueryProtocolParametersCmd envCli =
   fmap QueryProtocolParametersCmd $
     QueryProtocolParametersCmdArgs
-      <$> pSocketPath envCli
-      <*> pConsensusModeParams
-      <*> pNetworkId envCli
+      <$> ( LocalNodeConnectInfo
+              <$> pConsensusModeParams
+              <*> pNetworkId envCli
+              <*> pSocketPath envCli
+          )
       <*> pMaybeOutputFile
 
 pQueryTipCmd :: ShelleyBasedEra era -> EnvCli -> Parser (QueryCmds era)
@@ -400,9 +402,11 @@ pQueryTxMempoolCmd :: EnvCli -> Parser (QueryCmds era)
 pQueryTxMempoolCmd envCli =
   fmap QueryTxMempoolCmd $
     QueryTxMempoolCmdArgs
-      <$> pSocketPath envCli
-      <*> pConsensusModeParams
-      <*> pNetworkId envCli
+      <$> ( LocalNodeConnectInfo
+              <$> pConsensusModeParams
+              <*> pNetworkId envCli
+              <*> pSocketPath envCli
+          )
       <*> pTxMempoolQuery
       <*> pMaybeOutputFile
  where
@@ -699,7 +703,9 @@ pQueryCommons
   -> Parser QueryCommons
 pQueryCommons w envCli =
   QueryCommons
-    <$> pSocketPath envCli
-    <*> pConsensusModeParams
-    <*> pNetworkId envCli
+    <$> ( LocalNodeConnectInfo
+            <$> pConsensusModeParams
+            <*> pNetworkId envCli
+            <*> pSocketPath envCli
+        )
     <*> pTarget w

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Transaction.hs
@@ -169,9 +169,11 @@ pTransactionBuildCmd sbe envCli = do
   pCmd era' = do
     fmap TransactionBuildCmd $
       TransactionBuildCmdArgs era'
-        <$> pSocketPath envCli
-        <*> pConsensusModeParams
-        <*> pNetworkId envCli
+        <$> ( LocalNodeConnectInfo
+                <$> pConsensusModeParams
+                <*> pNetworkId envCli
+                <*> pSocketPath envCli
+            )
         <*> optional pScriptValidity
         <*> optional pWitnessOverride
         <*> some (pTxIn sbe AutoBalance)
@@ -331,9 +333,11 @@ pTransactionSubmit :: EnvCli -> Parser (TransactionCmds era)
 pTransactionSubmit envCli =
   fmap TransactionSubmitCmd $
     TransactionSubmitCmdArgs
-      <$> pSocketPath envCli
-      <*> pConsensusModeParams
-      <*> pNetworkId envCli
+      <$> ( LocalNodeConnectInfo
+              <$> pConsensusModeParams
+              <*> pNetworkId envCli
+              <*> pSocketPath envCli
+          )
       <*> pTxSubmitFile
 
 pTransactionPolicyId :: Parser (TransactionCmds era)

--- a/cardano-cli/src/Cardano/CLI/Orphans.hs
+++ b/cardano-cli/src/Cardano/CLI/Orphans.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Cardano.CLI.Orphans
@@ -32,3 +32,6 @@ instance ToJSON HashableScriptData where
       [ "hash" .= hashScriptDataBytes hsd
       , "json" .= scriptDataToJsonDetailedSchema hsd
       ]
+
+-- TODO move LocalNodeConnectInfo instances to cardano-api
+deriving instance Show LocalNodeConnectInfo

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -224,60 +224,63 @@ Usage: cardano-cli query
   Node query commands. Will query the local node whose Unix domain socket is
   obtained from the CARDANO_NODE_SOCKET_PATH environment variable.
 
-Usage: cardano-cli query protocol-parameters --socket-path SOCKET_PATH
+Usage: cardano-cli query protocol-parameters 
                                                [--cardano-mode
                                                  [--epoch-slots SLOTS]]
                                                ( --mainnet
                                                | --testnet-magic NATURAL
                                                )
+                                               --socket-path SOCKET_PATH
                                                [--out-file FILEPATH]
 
   Get the node's current protocol parameters
 
-Usage: cardano-cli query tip --socket-path SOCKET_PATH
-                               [--cardano-mode [--epoch-slots SLOTS]]
+Usage: cardano-cli query tip [--cardano-mode [--epoch-slots SLOTS]]
                                (--mainnet | --testnet-magic NATURAL)
+                               --socket-path SOCKET_PATH
                                [--volatile-tip | --immutable-tip]
                                [--out-file FILEPATH]
 
   Get the node's current tip (slot no, hash, block no)
 
-Usage: cardano-cli query stake-pools --socket-path SOCKET_PATH
-                                       [--cardano-mode [--epoch-slots SLOTS]]
+Usage: cardano-cli query stake-pools [--cardano-mode [--epoch-slots SLOTS]]
                                        (--mainnet | --testnet-magic NATURAL)
+                                       --socket-path SOCKET_PATH
                                        [--volatile-tip | --immutable-tip]
                                        [--output-json | --output-text]
                                        [--out-file FILEPATH]
 
   Get the node's current set of stake pool ids
 
-Usage: cardano-cli query stake-distribution --socket-path SOCKET_PATH
+Usage: cardano-cli query stake-distribution 
                                               [--cardano-mode
                                                 [--epoch-slots SLOTS]]
                                               ( --mainnet
                                               | --testnet-magic NATURAL
                                               )
+                                              --socket-path SOCKET_PATH
                                               [--volatile-tip | --immutable-tip]
                                               [--output-json | --output-text]
                                               [--out-file FILEPATH]
 
   Get the node's current aggregated stake distribution
 
-Usage: cardano-cli query stake-address-info --socket-path SOCKET_PATH
+Usage: cardano-cli query stake-address-info 
                                               [--cardano-mode
                                                 [--epoch-slots SLOTS]]
                                               ( --mainnet
                                               | --testnet-magic NATURAL
                                               )
+                                              --socket-path SOCKET_PATH
                                               [--volatile-tip | --immutable-tip]
                                               --address ADDRESS
                                               [--out-file FILEPATH]
 
   Get the current delegations and reward accounts filtered by stake address.
 
-Usage: cardano-cli query utxo --socket-path SOCKET_PATH
-                                [--cardano-mode [--epoch-slots SLOTS]]
+Usage: cardano-cli query utxo [--cardano-mode [--epoch-slots SLOTS]]
                                 (--mainnet | --testnet-magic NATURAL)
+                                --socket-path SOCKET_PATH
                                 [--volatile-tip | --immutable-tip]
                                 ( --whole-utxo
                                 | (--address ADDRESS)
@@ -288,27 +291,27 @@ Usage: cardano-cli query utxo --socket-path SOCKET_PATH
 
   Get a portion of the current UTxO: by tx in, by address or the whole.
 
-Usage: cardano-cli query ledger-state --socket-path SOCKET_PATH
-                                        [--cardano-mode [--epoch-slots SLOTS]]
+Usage: cardano-cli query ledger-state [--cardano-mode [--epoch-slots SLOTS]]
                                         (--mainnet | --testnet-magic NATURAL)
+                                        --socket-path SOCKET_PATH
                                         [--volatile-tip | --immutable-tip]
                                         [--out-file FILEPATH]
 
   Dump the current ledger state of the node (Ledger.NewEpochState -- advanced
   command)
 
-Usage: cardano-cli query protocol-state --socket-path SOCKET_PATH
-                                          [--cardano-mode [--epoch-slots SLOTS]]
+Usage: cardano-cli query protocol-state [--cardano-mode [--epoch-slots SLOTS]]
                                           (--mainnet | --testnet-magic NATURAL)
+                                          --socket-path SOCKET_PATH
                                           [--volatile-tip | --immutable-tip]
                                           [--out-file FILEPATH]
 
   Dump the current protocol state of the node (Ledger.ChainDepState -- advanced
   command)
 
-Usage: cardano-cli query stake-snapshot --socket-path SOCKET_PATH
-                                          [--cardano-mode [--epoch-slots SLOTS]]
+Usage: cardano-cli query stake-snapshot [--cardano-mode [--epoch-slots SLOTS]]
                                           (--mainnet | --testnet-magic NATURAL)
+                                          --socket-path SOCKET_PATH
                                           [--volatile-tip | --immutable-tip]
                                           ( --all-stake-pools
                                           | (--stake-pool-id STAKE_POOL_ID)
@@ -318,9 +321,9 @@ Usage: cardano-cli query stake-snapshot --socket-path SOCKET_PATH
   Obtain the three stake snapshots for a pool, plus the total active stake
   (advanced command)
 
-Usage: cardano-cli query pool-params --socket-path SOCKET_PATH
-                                       [--cardano-mode [--epoch-slots SLOTS]]
+Usage: cardano-cli query pool-params [--cardano-mode [--epoch-slots SLOTS]]
                                        (--mainnet | --testnet-magic NATURAL)
+                                       --socket-path SOCKET_PATH
                                        [--volatile-tip | --immutable-tip]
                                        ( --all-stake-pools
                                        | (--stake-pool-id STAKE_POOL_ID)
@@ -331,12 +334,13 @@ Usage: cardano-cli query pool-params --socket-path SOCKET_PATH
   (Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced
   command)
 
-Usage: cardano-cli query leadership-schedule --socket-path SOCKET_PATH
+Usage: cardano-cli query leadership-schedule 
                                                [--cardano-mode
                                                  [--epoch-slots SLOTS]]
                                                ( --mainnet
                                                | --testnet-magic NATURAL
                                                )
+                                               --socket-path SOCKET_PATH
                                                [ --volatile-tip
                                                | --immutable-tip
                                                ]
@@ -352,10 +356,9 @@ Usage: cardano-cli query leadership-schedule --socket-path SOCKET_PATH
 
   Get the slots the node is expected to mint a block in (advanced command)
 
-Usage: cardano-cli query kes-period-info --socket-path SOCKET_PATH
-                                           [--cardano-mode
-                                             [--epoch-slots SLOTS]]
+Usage: cardano-cli query kes-period-info [--cardano-mode [--epoch-slots SLOTS]]
                                            (--mainnet | --testnet-magic NATURAL)
+                                           --socket-path SOCKET_PATH
                                            [--volatile-tip | --immutable-tip]
                                            --op-cert-file FILEPATH
                                            [--out-file FILEPATH]
@@ -363,9 +366,9 @@ Usage: cardano-cli query kes-period-info --socket-path SOCKET_PATH
   Get information about the current KES period and your node's operational
   certificate.
 
-Usage: cardano-cli query pool-state --socket-path SOCKET_PATH
-                                      [--cardano-mode [--epoch-slots SLOTS]]
+Usage: cardano-cli query pool-state [--cardano-mode [--epoch-slots SLOTS]]
                                       (--mainnet | --testnet-magic NATURAL)
+                                      --socket-path SOCKET_PATH
                                       [--volatile-tip | --immutable-tip]
                                       ( --all-stake-pools
                                       | (--stake-pool-id STAKE_POOL_ID)
@@ -374,9 +377,9 @@ Usage: cardano-cli query pool-state --socket-path SOCKET_PATH
 
   Dump the pool state
 
-Usage: cardano-cli query tx-mempool --socket-path SOCKET_PATH
-                                      [--cardano-mode [--epoch-slots SLOTS]]
+Usage: cardano-cli query tx-mempool [--cardano-mode [--epoch-slots SLOTS]]
                                       (--mainnet | --testnet-magic NATURAL)
+                                      --socket-path SOCKET_PATH
                                       (info | next-tx | tx-exists)
                                       [--out-file FILEPATH]
 
@@ -394,20 +397,21 @@ Usage: cardano-cli query tx-mempool tx-exists TX_ID
 
   Query if a particular transaction exists in the mempool
 
-Usage: cardano-cli query slot-number --socket-path SOCKET_PATH
-                                       [--cardano-mode [--epoch-slots SLOTS]]
+Usage: cardano-cli query slot-number [--cardano-mode [--epoch-slots SLOTS]]
                                        (--mainnet | --testnet-magic NATURAL)
+                                       --socket-path SOCKET_PATH
                                        [--volatile-tip | --immutable-tip]
                                        TIMESTAMP
 
   Query slot number for UTC timestamp
 
-Usage: cardano-cli query ledger-peer-snapshot --socket-path SOCKET_PATH
+Usage: cardano-cli query ledger-peer-snapshot 
                                                 [--cardano-mode
                                                   [--epoch-slots SLOTS]]
                                                 ( --mainnet
                                                 | --testnet-magic NATURAL
                                                 )
+                                                --socket-path SOCKET_PATH
                                                 [ --volatile-tip
                                                 | --immutable-tip
                                                 ]
@@ -1389,40 +1393,43 @@ Usage: cardano-cli shelley query
   Node query commands. Will query the local node whose Unix domain socket is
   obtained from the CARDANO_NODE_SOCKET_PATH environment variable.
 
-Usage: cardano-cli shelley query protocol-parameters --socket-path SOCKET_PATH
+Usage: cardano-cli shelley query protocol-parameters 
                                                        [--cardano-mode
                                                          [--epoch-slots SLOTS]]
                                                        ( --mainnet
                                                        | --testnet-magic NATURAL
                                                        )
+                                                       --socket-path SOCKET_PATH
                                                        [--out-file FILEPATH]
 
   Get the node's current protocol parameters
 
-Usage: cardano-cli shelley query tip --socket-path SOCKET_PATH
-                                       [--cardano-mode [--epoch-slots SLOTS]]
+Usage: cardano-cli shelley query tip [--cardano-mode [--epoch-slots SLOTS]]
                                        (--mainnet | --testnet-magic NATURAL)
+                                       --socket-path SOCKET_PATH
                                        [--out-file FILEPATH]
 
   Get the node's current tip (slot no, hash, block no)
 
-Usage: cardano-cli shelley query stake-pools --socket-path SOCKET_PATH
+Usage: cardano-cli shelley query stake-pools 
                                                [--cardano-mode
                                                  [--epoch-slots SLOTS]]
                                                ( --mainnet
                                                | --testnet-magic NATURAL
                                                )
+                                               --socket-path SOCKET_PATH
                                                [--output-json | --output-text]
                                                [--out-file FILEPATH]
 
   Get the node's current set of stake pool ids
 
-Usage: cardano-cli shelley query stake-distribution --socket-path SOCKET_PATH
+Usage: cardano-cli shelley query stake-distribution 
                                                       [--cardano-mode
                                                         [--epoch-slots SLOTS]]
                                                       ( --mainnet
                                                       | --testnet-magic NATURAL
                                                       )
+                                                      --socket-path SOCKET_PATH
                                                       [ --output-json
                                                       | --output-text
                                                       ]
@@ -1430,20 +1437,21 @@ Usage: cardano-cli shelley query stake-distribution --socket-path SOCKET_PATH
 
   Get the node's current aggregated stake distribution
 
-Usage: cardano-cli shelley query stake-address-info --socket-path SOCKET_PATH
+Usage: cardano-cli shelley query stake-address-info 
                                                       [--cardano-mode
                                                         [--epoch-slots SLOTS]]
                                                       ( --mainnet
                                                       | --testnet-magic NATURAL
                                                       )
+                                                      --socket-path SOCKET_PATH
                                                       --address ADDRESS
                                                       [--out-file FILEPATH]
 
   Get the current delegations and reward accounts filtered by stake address.
 
-Usage: cardano-cli shelley query utxo --socket-path SOCKET_PATH
-                                        [--cardano-mode [--epoch-slots SLOTS]]
+Usage: cardano-cli shelley query utxo [--cardano-mode [--epoch-slots SLOTS]]
                                         (--mainnet | --testnet-magic NATURAL)
+                                        --socket-path SOCKET_PATH
                                         ( --whole-utxo
                                         | (--address ADDRESS)
                                         | (--tx-in TX-IN)
@@ -1453,45 +1461,49 @@ Usage: cardano-cli shelley query utxo --socket-path SOCKET_PATH
 
   Get a portion of the current UTxO: by tx in, by address or the whole.
 
-Usage: cardano-cli shelley query ledger-state --socket-path SOCKET_PATH
+Usage: cardano-cli shelley query ledger-state 
                                                 [--cardano-mode
                                                   [--epoch-slots SLOTS]]
                                                 ( --mainnet
                                                 | --testnet-magic NATURAL
                                                 )
+                                                --socket-path SOCKET_PATH
                                                 [--out-file FILEPATH]
 
   Dump the current ledger state of the node (Ledger.NewEpochState -- advanced
   command)
 
-Usage: cardano-cli shelley query ledger-peer-snapshot --socket-path SOCKET_PATH
+Usage: cardano-cli shelley query ledger-peer-snapshot 
                                                         [--cardano-mode
                                                           [--epoch-slots SLOTS]]
                                                         ( --mainnet
                                                         | --testnet-magic NATURAL
                                                         )
+                                                        --socket-path SOCKET_PATH
                                                         [--out-file FILEPATH]
 
   Dump the current snapshot of ledger peers.These are the largest pools that
   cumulatively hold 90% of total stake.
 
-Usage: cardano-cli shelley query protocol-state --socket-path SOCKET_PATH
+Usage: cardano-cli shelley query protocol-state 
                                                   [--cardano-mode
                                                     [--epoch-slots SLOTS]]
                                                   ( --mainnet
                                                   | --testnet-magic NATURAL
                                                   )
+                                                  --socket-path SOCKET_PATH
                                                   [--out-file FILEPATH]
 
   Dump the current protocol state of the node (Ledger.ChainDepState -- advanced
   command)
 
-Usage: cardano-cli shelley query stake-snapshot --socket-path SOCKET_PATH
+Usage: cardano-cli shelley query stake-snapshot 
                                                   [--cardano-mode
                                                     [--epoch-slots SLOTS]]
                                                   ( --mainnet
                                                   | --testnet-magic NATURAL
                                                   )
+                                                  --socket-path SOCKET_PATH
                                                   ( --all-stake-pools
                                                   | (--stake-pool-id STAKE_POOL_ID)
                                                   )
@@ -1500,12 +1512,13 @@ Usage: cardano-cli shelley query stake-snapshot --socket-path SOCKET_PATH
   Obtain the three stake snapshots for a pool, plus the total active stake
   (advanced command)
 
-Usage: cardano-cli shelley query pool-params --socket-path SOCKET_PATH
+Usage: cardano-cli shelley query pool-params 
                                                [--cardano-mode
                                                  [--epoch-slots SLOTS]]
                                                ( --mainnet
                                                | --testnet-magic NATURAL
                                                )
+                                               --socket-path SOCKET_PATH
                                                ( --all-stake-pools
                                                | (--stake-pool-id STAKE_POOL_ID)
                                                )
@@ -1515,12 +1528,13 @@ Usage: cardano-cli shelley query pool-params --socket-path SOCKET_PATH
   (Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced
   command)
 
-Usage: cardano-cli shelley query leadership-schedule --socket-path SOCKET_PATH
+Usage: cardano-cli shelley query leadership-schedule 
                                                        [--cardano-mode
                                                          [--epoch-slots SLOTS]]
                                                        ( --mainnet
                                                        | --testnet-magic NATURAL
                                                        )
+                                                       --socket-path SOCKET_PATH
                                                        --genesis FILEPATH
                                                        ( --stake-pool-verification-key STRING
                                                        | --cold-verification-key-file FILEPATH
@@ -1535,24 +1549,26 @@ Usage: cardano-cli shelley query leadership-schedule --socket-path SOCKET_PATH
 
   Get the slots the node is expected to mint a block in (advanced command)
 
-Usage: cardano-cli shelley query kes-period-info --socket-path SOCKET_PATH
+Usage: cardano-cli shelley query kes-period-info 
                                                    [--cardano-mode
                                                      [--epoch-slots SLOTS]]
                                                    ( --mainnet
                                                    | --testnet-magic NATURAL
                                                    )
+                                                   --socket-path SOCKET_PATH
                                                    --op-cert-file FILEPATH
                                                    [--out-file FILEPATH]
 
   Get information about the current KES period and your node's operational
   certificate.
 
-Usage: cardano-cli shelley query pool-state --socket-path SOCKET_PATH
+Usage: cardano-cli shelley query pool-state 
                                               [--cardano-mode
                                                 [--epoch-slots SLOTS]]
                                               ( --mainnet
                                               | --testnet-magic NATURAL
                                               )
+                                              --socket-path SOCKET_PATH
                                               ( --all-stake-pools
                                               | (--stake-pool-id STAKE_POOL_ID)
                                               )
@@ -1560,12 +1576,13 @@ Usage: cardano-cli shelley query pool-state --socket-path SOCKET_PATH
 
   Dump the pool state
 
-Usage: cardano-cli shelley query tx-mempool --socket-path SOCKET_PATH
+Usage: cardano-cli shelley query tx-mempool 
                                               [--cardano-mode
                                                 [--epoch-slots SLOTS]]
                                               ( --mainnet
                                               | --testnet-magic NATURAL
                                               )
+                                              --socket-path SOCKET_PATH
                                               (info | next-tx | tx-exists)
                                               [--out-file FILEPATH]
 
@@ -1583,22 +1600,24 @@ Usage: cardano-cli shelley query tx-mempool tx-exists TX_ID
 
   Query if a particular transaction exists in the mempool
 
-Usage: cardano-cli shelley query slot-number --socket-path SOCKET_PATH
+Usage: cardano-cli shelley query slot-number 
                                                [--cardano-mode
                                                  [--epoch-slots SLOTS]]
                                                ( --mainnet
                                                | --testnet-magic NATURAL
                                                )
+                                               --socket-path SOCKET_PATH
                                                TIMESTAMP
 
   Query slot number for UTC timestamp
 
-Usage: cardano-cli shelley query ref-script-size --socket-path SOCKET_PATH
+Usage: cardano-cli shelley query ref-script-size 
                                                    [--cardano-mode
                                                      [--epoch-slots SLOTS]]
                                                    ( --mainnet
                                                    | --testnet-magic NATURAL
                                                    )
+                                                   --socket-path SOCKET_PATH
                                                    (--tx-in TX-IN)
                                                    [ --output-json
                                                    | --output-text
@@ -1943,12 +1962,13 @@ Usage: cardano-cli shelley transaction sign-witness --tx-body-file FILEPATH
 
   Assemble a tx body and witness(es) to form a transaction
 
-Usage: cardano-cli shelley transaction submit --socket-path SOCKET_PATH
+Usage: cardano-cli shelley transaction submit 
                                                 [--cardano-mode
                                                   [--epoch-slots SLOTS]]
                                                 ( --mainnet
                                                 | --testnet-magic NATURAL
                                                 )
+                                                --socket-path SOCKET_PATH
                                                 --tx-file FILEPATH
 
   Submit a transaction to the local node whose Unix domain socket is obtained
@@ -2453,40 +2473,43 @@ Usage: cardano-cli allegra query
   Node query commands. Will query the local node whose Unix domain socket is
   obtained from the CARDANO_NODE_SOCKET_PATH environment variable.
 
-Usage: cardano-cli allegra query protocol-parameters --socket-path SOCKET_PATH
+Usage: cardano-cli allegra query protocol-parameters 
                                                        [--cardano-mode
                                                          [--epoch-slots SLOTS]]
                                                        ( --mainnet
                                                        | --testnet-magic NATURAL
                                                        )
+                                                       --socket-path SOCKET_PATH
                                                        [--out-file FILEPATH]
 
   Get the node's current protocol parameters
 
-Usage: cardano-cli allegra query tip --socket-path SOCKET_PATH
-                                       [--cardano-mode [--epoch-slots SLOTS]]
+Usage: cardano-cli allegra query tip [--cardano-mode [--epoch-slots SLOTS]]
                                        (--mainnet | --testnet-magic NATURAL)
+                                       --socket-path SOCKET_PATH
                                        [--out-file FILEPATH]
 
   Get the node's current tip (slot no, hash, block no)
 
-Usage: cardano-cli allegra query stake-pools --socket-path SOCKET_PATH
+Usage: cardano-cli allegra query stake-pools 
                                                [--cardano-mode
                                                  [--epoch-slots SLOTS]]
                                                ( --mainnet
                                                | --testnet-magic NATURAL
                                                )
+                                               --socket-path SOCKET_PATH
                                                [--output-json | --output-text]
                                                [--out-file FILEPATH]
 
   Get the node's current set of stake pool ids
 
-Usage: cardano-cli allegra query stake-distribution --socket-path SOCKET_PATH
+Usage: cardano-cli allegra query stake-distribution 
                                                       [--cardano-mode
                                                         [--epoch-slots SLOTS]]
                                                       ( --mainnet
                                                       | --testnet-magic NATURAL
                                                       )
+                                                      --socket-path SOCKET_PATH
                                                       [ --output-json
                                                       | --output-text
                                                       ]
@@ -2494,20 +2517,21 @@ Usage: cardano-cli allegra query stake-distribution --socket-path SOCKET_PATH
 
   Get the node's current aggregated stake distribution
 
-Usage: cardano-cli allegra query stake-address-info --socket-path SOCKET_PATH
+Usage: cardano-cli allegra query stake-address-info 
                                                       [--cardano-mode
                                                         [--epoch-slots SLOTS]]
                                                       ( --mainnet
                                                       | --testnet-magic NATURAL
                                                       )
+                                                      --socket-path SOCKET_PATH
                                                       --address ADDRESS
                                                       [--out-file FILEPATH]
 
   Get the current delegations and reward accounts filtered by stake address.
 
-Usage: cardano-cli allegra query utxo --socket-path SOCKET_PATH
-                                        [--cardano-mode [--epoch-slots SLOTS]]
+Usage: cardano-cli allegra query utxo [--cardano-mode [--epoch-slots SLOTS]]
                                         (--mainnet | --testnet-magic NATURAL)
+                                        --socket-path SOCKET_PATH
                                         ( --whole-utxo
                                         | (--address ADDRESS)
                                         | (--tx-in TX-IN)
@@ -2517,45 +2541,49 @@ Usage: cardano-cli allegra query utxo --socket-path SOCKET_PATH
 
   Get a portion of the current UTxO: by tx in, by address or the whole.
 
-Usage: cardano-cli allegra query ledger-state --socket-path SOCKET_PATH
+Usage: cardano-cli allegra query ledger-state 
                                                 [--cardano-mode
                                                   [--epoch-slots SLOTS]]
                                                 ( --mainnet
                                                 | --testnet-magic NATURAL
                                                 )
+                                                --socket-path SOCKET_PATH
                                                 [--out-file FILEPATH]
 
   Dump the current ledger state of the node (Ledger.NewEpochState -- advanced
   command)
 
-Usage: cardano-cli allegra query ledger-peer-snapshot --socket-path SOCKET_PATH
+Usage: cardano-cli allegra query ledger-peer-snapshot 
                                                         [--cardano-mode
                                                           [--epoch-slots SLOTS]]
                                                         ( --mainnet
                                                         | --testnet-magic NATURAL
                                                         )
+                                                        --socket-path SOCKET_PATH
                                                         [--out-file FILEPATH]
 
   Dump the current snapshot of ledger peers.These are the largest pools that
   cumulatively hold 90% of total stake.
 
-Usage: cardano-cli allegra query protocol-state --socket-path SOCKET_PATH
+Usage: cardano-cli allegra query protocol-state 
                                                   [--cardano-mode
                                                     [--epoch-slots SLOTS]]
                                                   ( --mainnet
                                                   | --testnet-magic NATURAL
                                                   )
+                                                  --socket-path SOCKET_PATH
                                                   [--out-file FILEPATH]
 
   Dump the current protocol state of the node (Ledger.ChainDepState -- advanced
   command)
 
-Usage: cardano-cli allegra query stake-snapshot --socket-path SOCKET_PATH
+Usage: cardano-cli allegra query stake-snapshot 
                                                   [--cardano-mode
                                                     [--epoch-slots SLOTS]]
                                                   ( --mainnet
                                                   | --testnet-magic NATURAL
                                                   )
+                                                  --socket-path SOCKET_PATH
                                                   ( --all-stake-pools
                                                   | (--stake-pool-id STAKE_POOL_ID)
                                                   )
@@ -2564,12 +2592,13 @@ Usage: cardano-cli allegra query stake-snapshot --socket-path SOCKET_PATH
   Obtain the three stake snapshots for a pool, plus the total active stake
   (advanced command)
 
-Usage: cardano-cli allegra query pool-params --socket-path SOCKET_PATH
+Usage: cardano-cli allegra query pool-params 
                                                [--cardano-mode
                                                  [--epoch-slots SLOTS]]
                                                ( --mainnet
                                                | --testnet-magic NATURAL
                                                )
+                                               --socket-path SOCKET_PATH
                                                ( --all-stake-pools
                                                | (--stake-pool-id STAKE_POOL_ID)
                                                )
@@ -2579,12 +2608,13 @@ Usage: cardano-cli allegra query pool-params --socket-path SOCKET_PATH
   (Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced
   command)
 
-Usage: cardano-cli allegra query leadership-schedule --socket-path SOCKET_PATH
+Usage: cardano-cli allegra query leadership-schedule 
                                                        [--cardano-mode
                                                          [--epoch-slots SLOTS]]
                                                        ( --mainnet
                                                        | --testnet-magic NATURAL
                                                        )
+                                                       --socket-path SOCKET_PATH
                                                        --genesis FILEPATH
                                                        ( --stake-pool-verification-key STRING
                                                        | --cold-verification-key-file FILEPATH
@@ -2599,24 +2629,26 @@ Usage: cardano-cli allegra query leadership-schedule --socket-path SOCKET_PATH
 
   Get the slots the node is expected to mint a block in (advanced command)
 
-Usage: cardano-cli allegra query kes-period-info --socket-path SOCKET_PATH
+Usage: cardano-cli allegra query kes-period-info 
                                                    [--cardano-mode
                                                      [--epoch-slots SLOTS]]
                                                    ( --mainnet
                                                    | --testnet-magic NATURAL
                                                    )
+                                                   --socket-path SOCKET_PATH
                                                    --op-cert-file FILEPATH
                                                    [--out-file FILEPATH]
 
   Get information about the current KES period and your node's operational
   certificate.
 
-Usage: cardano-cli allegra query pool-state --socket-path SOCKET_PATH
+Usage: cardano-cli allegra query pool-state 
                                               [--cardano-mode
                                                 [--epoch-slots SLOTS]]
                                               ( --mainnet
                                               | --testnet-magic NATURAL
                                               )
+                                              --socket-path SOCKET_PATH
                                               ( --all-stake-pools
                                               | (--stake-pool-id STAKE_POOL_ID)
                                               )
@@ -2624,12 +2656,13 @@ Usage: cardano-cli allegra query pool-state --socket-path SOCKET_PATH
 
   Dump the pool state
 
-Usage: cardano-cli allegra query tx-mempool --socket-path SOCKET_PATH
+Usage: cardano-cli allegra query tx-mempool 
                                               [--cardano-mode
                                                 [--epoch-slots SLOTS]]
                                               ( --mainnet
                                               | --testnet-magic NATURAL
                                               )
+                                              --socket-path SOCKET_PATH
                                               (info | next-tx | tx-exists)
                                               [--out-file FILEPATH]
 
@@ -2647,22 +2680,24 @@ Usage: cardano-cli allegra query tx-mempool tx-exists TX_ID
 
   Query if a particular transaction exists in the mempool
 
-Usage: cardano-cli allegra query slot-number --socket-path SOCKET_PATH
+Usage: cardano-cli allegra query slot-number 
                                                [--cardano-mode
                                                  [--epoch-slots SLOTS]]
                                                ( --mainnet
                                                | --testnet-magic NATURAL
                                                )
+                                               --socket-path SOCKET_PATH
                                                TIMESTAMP
 
   Query slot number for UTC timestamp
 
-Usage: cardano-cli allegra query ref-script-size --socket-path SOCKET_PATH
+Usage: cardano-cli allegra query ref-script-size 
                                                    [--cardano-mode
                                                      [--epoch-slots SLOTS]]
                                                    ( --mainnet
                                                    | --testnet-magic NATURAL
                                                    )
+                                                   --socket-path SOCKET_PATH
                                                    (--tx-in TX-IN)
                                                    [ --output-json
                                                    | --output-text
@@ -3007,12 +3042,13 @@ Usage: cardano-cli allegra transaction sign-witness --tx-body-file FILEPATH
 
   Assemble a tx body and witness(es) to form a transaction
 
-Usage: cardano-cli allegra transaction submit --socket-path SOCKET_PATH
+Usage: cardano-cli allegra transaction submit 
                                                 [--cardano-mode
                                                   [--epoch-slots SLOTS]]
                                                 ( --mainnet
                                                 | --testnet-magic NATURAL
                                                 )
+                                                --socket-path SOCKET_PATH
                                                 --tx-file FILEPATH
 
   Submit a transaction to the local node whose Unix domain socket is obtained
@@ -3515,40 +3551,41 @@ Usage: cardano-cli mary query
   Node query commands. Will query the local node whose Unix domain socket is
   obtained from the CARDANO_NODE_SOCKET_PATH environment variable.
 
-Usage: cardano-cli mary query protocol-parameters --socket-path SOCKET_PATH
+Usage: cardano-cli mary query protocol-parameters 
                                                     [--cardano-mode
                                                       [--epoch-slots SLOTS]]
                                                     ( --mainnet
                                                     | --testnet-magic NATURAL
                                                     )
+                                                    --socket-path SOCKET_PATH
                                                     [--out-file FILEPATH]
 
   Get the node's current protocol parameters
 
-Usage: cardano-cli mary query tip --socket-path SOCKET_PATH
-                                    [--cardano-mode [--epoch-slots SLOTS]]
+Usage: cardano-cli mary query tip [--cardano-mode [--epoch-slots SLOTS]]
                                     (--mainnet | --testnet-magic NATURAL)
+                                    --socket-path SOCKET_PATH
                                     [--out-file FILEPATH]
 
   Get the node's current tip (slot no, hash, block no)
 
-Usage: cardano-cli mary query stake-pools --socket-path SOCKET_PATH
-                                            [--cardano-mode
-                                              [--epoch-slots SLOTS]]
+Usage: cardano-cli mary query stake-pools [--cardano-mode [--epoch-slots SLOTS]]
                                             ( --mainnet
                                             | --testnet-magic NATURAL
                                             )
+                                            --socket-path SOCKET_PATH
                                             [--output-json | --output-text]
                                             [--out-file FILEPATH]
 
   Get the node's current set of stake pool ids
 
-Usage: cardano-cli mary query stake-distribution --socket-path SOCKET_PATH
+Usage: cardano-cli mary query stake-distribution 
                                                    [--cardano-mode
                                                      [--epoch-slots SLOTS]]
                                                    ( --mainnet
                                                    | --testnet-magic NATURAL
                                                    )
+                                                   --socket-path SOCKET_PATH
                                                    [ --output-json
                                                    | --output-text
                                                    ]
@@ -3556,20 +3593,21 @@ Usage: cardano-cli mary query stake-distribution --socket-path SOCKET_PATH
 
   Get the node's current aggregated stake distribution
 
-Usage: cardano-cli mary query stake-address-info --socket-path SOCKET_PATH
+Usage: cardano-cli mary query stake-address-info 
                                                    [--cardano-mode
                                                      [--epoch-slots SLOTS]]
                                                    ( --mainnet
                                                    | --testnet-magic NATURAL
                                                    )
+                                                   --socket-path SOCKET_PATH
                                                    --address ADDRESS
                                                    [--out-file FILEPATH]
 
   Get the current delegations and reward accounts filtered by stake address.
 
-Usage: cardano-cli mary query utxo --socket-path SOCKET_PATH
-                                     [--cardano-mode [--epoch-slots SLOTS]]
+Usage: cardano-cli mary query utxo [--cardano-mode [--epoch-slots SLOTS]]
                                      (--mainnet | --testnet-magic NATURAL)
+                                     --socket-path SOCKET_PATH
                                      ( --whole-utxo
                                      | (--address ADDRESS)
                                      | (--tx-in TX-IN)
@@ -3579,45 +3617,49 @@ Usage: cardano-cli mary query utxo --socket-path SOCKET_PATH
 
   Get a portion of the current UTxO: by tx in, by address or the whole.
 
-Usage: cardano-cli mary query ledger-state --socket-path SOCKET_PATH
+Usage: cardano-cli mary query ledger-state 
                                              [--cardano-mode
                                                [--epoch-slots SLOTS]]
                                              ( --mainnet
                                              | --testnet-magic NATURAL
                                              )
+                                             --socket-path SOCKET_PATH
                                              [--out-file FILEPATH]
 
   Dump the current ledger state of the node (Ledger.NewEpochState -- advanced
   command)
 
-Usage: cardano-cli mary query ledger-peer-snapshot --socket-path SOCKET_PATH
+Usage: cardano-cli mary query ledger-peer-snapshot 
                                                      [--cardano-mode
                                                        [--epoch-slots SLOTS]]
                                                      ( --mainnet
                                                      | --testnet-magic NATURAL
                                                      )
+                                                     --socket-path SOCKET_PATH
                                                      [--out-file FILEPATH]
 
   Dump the current snapshot of ledger peers.These are the largest pools that
   cumulatively hold 90% of total stake.
 
-Usage: cardano-cli mary query protocol-state --socket-path SOCKET_PATH
+Usage: cardano-cli mary query protocol-state 
                                                [--cardano-mode
                                                  [--epoch-slots SLOTS]]
                                                ( --mainnet
                                                | --testnet-magic NATURAL
                                                )
+                                               --socket-path SOCKET_PATH
                                                [--out-file FILEPATH]
 
   Dump the current protocol state of the node (Ledger.ChainDepState -- advanced
   command)
 
-Usage: cardano-cli mary query stake-snapshot --socket-path SOCKET_PATH
+Usage: cardano-cli mary query stake-snapshot 
                                                [--cardano-mode
                                                  [--epoch-slots SLOTS]]
                                                ( --mainnet
                                                | --testnet-magic NATURAL
                                                )
+                                               --socket-path SOCKET_PATH
                                                ( --all-stake-pools
                                                | (--stake-pool-id STAKE_POOL_ID)
                                                )
@@ -3626,12 +3668,11 @@ Usage: cardano-cli mary query stake-snapshot --socket-path SOCKET_PATH
   Obtain the three stake snapshots for a pool, plus the total active stake
   (advanced command)
 
-Usage: cardano-cli mary query pool-params --socket-path SOCKET_PATH
-                                            [--cardano-mode
-                                              [--epoch-slots SLOTS]]
+Usage: cardano-cli mary query pool-params [--cardano-mode [--epoch-slots SLOTS]]
                                             ( --mainnet
                                             | --testnet-magic NATURAL
                                             )
+                                            --socket-path SOCKET_PATH
                                             ( --all-stake-pools
                                             | (--stake-pool-id STAKE_POOL_ID)
                                             )
@@ -3641,12 +3682,13 @@ Usage: cardano-cli mary query pool-params --socket-path SOCKET_PATH
   (Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced
   command)
 
-Usage: cardano-cli mary query leadership-schedule --socket-path SOCKET_PATH
+Usage: cardano-cli mary query leadership-schedule 
                                                     [--cardano-mode
                                                       [--epoch-slots SLOTS]]
                                                     ( --mainnet
                                                     | --testnet-magic NATURAL
                                                     )
+                                                    --socket-path SOCKET_PATH
                                                     --genesis FILEPATH
                                                     ( --stake-pool-verification-key STRING
                                                     | --cold-verification-key-file FILEPATH
@@ -3661,22 +3703,22 @@ Usage: cardano-cli mary query leadership-schedule --socket-path SOCKET_PATH
 
   Get the slots the node is expected to mint a block in (advanced command)
 
-Usage: cardano-cli mary query kes-period-info --socket-path SOCKET_PATH
+Usage: cardano-cli mary query kes-period-info 
                                                 [--cardano-mode
                                                   [--epoch-slots SLOTS]]
                                                 ( --mainnet
                                                 | --testnet-magic NATURAL
                                                 )
+                                                --socket-path SOCKET_PATH
                                                 --op-cert-file FILEPATH
                                                 [--out-file FILEPATH]
 
   Get information about the current KES period and your node's operational
   certificate.
 
-Usage: cardano-cli mary query pool-state --socket-path SOCKET_PATH
-                                           [--cardano-mode
-                                             [--epoch-slots SLOTS]]
+Usage: cardano-cli mary query pool-state [--cardano-mode [--epoch-slots SLOTS]]
                                            (--mainnet | --testnet-magic NATURAL)
+                                           --socket-path SOCKET_PATH
                                            ( --all-stake-pools
                                            | (--stake-pool-id STAKE_POOL_ID)
                                            )
@@ -3684,10 +3726,9 @@ Usage: cardano-cli mary query pool-state --socket-path SOCKET_PATH
 
   Dump the pool state
 
-Usage: cardano-cli mary query tx-mempool --socket-path SOCKET_PATH
-                                           [--cardano-mode
-                                             [--epoch-slots SLOTS]]
+Usage: cardano-cli mary query tx-mempool [--cardano-mode [--epoch-slots SLOTS]]
                                            (--mainnet | --testnet-magic NATURAL)
+                                           --socket-path SOCKET_PATH
                                            (info | next-tx | tx-exists)
                                            [--out-file FILEPATH]
 
@@ -3705,22 +3746,22 @@ Usage: cardano-cli mary query tx-mempool tx-exists TX_ID
 
   Query if a particular transaction exists in the mempool
 
-Usage: cardano-cli mary query slot-number --socket-path SOCKET_PATH
-                                            [--cardano-mode
-                                              [--epoch-slots SLOTS]]
+Usage: cardano-cli mary query slot-number [--cardano-mode [--epoch-slots SLOTS]]
                                             ( --mainnet
                                             | --testnet-magic NATURAL
                                             )
+                                            --socket-path SOCKET_PATH
                                             TIMESTAMP
 
   Query slot number for UTC timestamp
 
-Usage: cardano-cli mary query ref-script-size --socket-path SOCKET_PATH
+Usage: cardano-cli mary query ref-script-size 
                                                 [--cardano-mode
                                                   [--epoch-slots SLOTS]]
                                                 ( --mainnet
                                                 | --testnet-magic NATURAL
                                                 )
+                                                --socket-path SOCKET_PATH
                                                 (--tx-in TX-IN)
                                                 [--output-json | --output-text]
                                                 [--out-file FILEPATH]
@@ -4061,12 +4102,13 @@ Usage: cardano-cli mary transaction sign-witness --tx-body-file FILEPATH
 
   Assemble a tx body and witness(es) to form a transaction
 
-Usage: cardano-cli mary transaction submit --socket-path SOCKET_PATH
+Usage: cardano-cli mary transaction submit 
                                              [--cardano-mode
                                                [--epoch-slots SLOTS]]
                                              ( --mainnet
                                              | --testnet-magic NATURAL
                                              )
+                                             --socket-path SOCKET_PATH
                                              --tx-file FILEPATH
 
   Submit a transaction to the local node whose Unix domain socket is obtained
@@ -4576,40 +4618,43 @@ Usage: cardano-cli alonzo query
   Node query commands. Will query the local node whose Unix domain socket is
   obtained from the CARDANO_NODE_SOCKET_PATH environment variable.
 
-Usage: cardano-cli alonzo query protocol-parameters --socket-path SOCKET_PATH
+Usage: cardano-cli alonzo query protocol-parameters 
                                                       [--cardano-mode
                                                         [--epoch-slots SLOTS]]
                                                       ( --mainnet
                                                       | --testnet-magic NATURAL
                                                       )
+                                                      --socket-path SOCKET_PATH
                                                       [--out-file FILEPATH]
 
   Get the node's current protocol parameters
 
-Usage: cardano-cli alonzo query tip --socket-path SOCKET_PATH
-                                      [--cardano-mode [--epoch-slots SLOTS]]
+Usage: cardano-cli alonzo query tip [--cardano-mode [--epoch-slots SLOTS]]
                                       (--mainnet | --testnet-magic NATURAL)
+                                      --socket-path SOCKET_PATH
                                       [--out-file FILEPATH]
 
   Get the node's current tip (slot no, hash, block no)
 
-Usage: cardano-cli alonzo query stake-pools --socket-path SOCKET_PATH
+Usage: cardano-cli alonzo query stake-pools 
                                               [--cardano-mode
                                                 [--epoch-slots SLOTS]]
                                               ( --mainnet
                                               | --testnet-magic NATURAL
                                               )
+                                              --socket-path SOCKET_PATH
                                               [--output-json | --output-text]
                                               [--out-file FILEPATH]
 
   Get the node's current set of stake pool ids
 
-Usage: cardano-cli alonzo query stake-distribution --socket-path SOCKET_PATH
+Usage: cardano-cli alonzo query stake-distribution 
                                                      [--cardano-mode
                                                        [--epoch-slots SLOTS]]
                                                      ( --mainnet
                                                      | --testnet-magic NATURAL
                                                      )
+                                                     --socket-path SOCKET_PATH
                                                      [ --output-json
                                                      | --output-text
                                                      ]
@@ -4617,20 +4662,21 @@ Usage: cardano-cli alonzo query stake-distribution --socket-path SOCKET_PATH
 
   Get the node's current aggregated stake distribution
 
-Usage: cardano-cli alonzo query stake-address-info --socket-path SOCKET_PATH
+Usage: cardano-cli alonzo query stake-address-info 
                                                      [--cardano-mode
                                                        [--epoch-slots SLOTS]]
                                                      ( --mainnet
                                                      | --testnet-magic NATURAL
                                                      )
+                                                     --socket-path SOCKET_PATH
                                                      --address ADDRESS
                                                      [--out-file FILEPATH]
 
   Get the current delegations and reward accounts filtered by stake address.
 
-Usage: cardano-cli alonzo query utxo --socket-path SOCKET_PATH
-                                       [--cardano-mode [--epoch-slots SLOTS]]
+Usage: cardano-cli alonzo query utxo [--cardano-mode [--epoch-slots SLOTS]]
                                        (--mainnet | --testnet-magic NATURAL)
+                                       --socket-path SOCKET_PATH
                                        ( --whole-utxo
                                        | (--address ADDRESS)
                                        | (--tx-in TX-IN)
@@ -4640,45 +4686,49 @@ Usage: cardano-cli alonzo query utxo --socket-path SOCKET_PATH
 
   Get a portion of the current UTxO: by tx in, by address or the whole.
 
-Usage: cardano-cli alonzo query ledger-state --socket-path SOCKET_PATH
+Usage: cardano-cli alonzo query ledger-state 
                                                [--cardano-mode
                                                  [--epoch-slots SLOTS]]
                                                ( --mainnet
                                                | --testnet-magic NATURAL
                                                )
+                                               --socket-path SOCKET_PATH
                                                [--out-file FILEPATH]
 
   Dump the current ledger state of the node (Ledger.NewEpochState -- advanced
   command)
 
-Usage: cardano-cli alonzo query ledger-peer-snapshot --socket-path SOCKET_PATH
+Usage: cardano-cli alonzo query ledger-peer-snapshot 
                                                        [--cardano-mode
                                                          [--epoch-slots SLOTS]]
                                                        ( --mainnet
                                                        | --testnet-magic NATURAL
                                                        )
+                                                       --socket-path SOCKET_PATH
                                                        [--out-file FILEPATH]
 
   Dump the current snapshot of ledger peers.These are the largest pools that
   cumulatively hold 90% of total stake.
 
-Usage: cardano-cli alonzo query protocol-state --socket-path SOCKET_PATH
+Usage: cardano-cli alonzo query protocol-state 
                                                  [--cardano-mode
                                                    [--epoch-slots SLOTS]]
                                                  ( --mainnet
                                                  | --testnet-magic NATURAL
                                                  )
+                                                 --socket-path SOCKET_PATH
                                                  [--out-file FILEPATH]
 
   Dump the current protocol state of the node (Ledger.ChainDepState -- advanced
   command)
 
-Usage: cardano-cli alonzo query stake-snapshot --socket-path SOCKET_PATH
+Usage: cardano-cli alonzo query stake-snapshot 
                                                  [--cardano-mode
                                                    [--epoch-slots SLOTS]]
                                                  ( --mainnet
                                                  | --testnet-magic NATURAL
                                                  )
+                                                 --socket-path SOCKET_PATH
                                                  ( --all-stake-pools
                                                  | (--stake-pool-id STAKE_POOL_ID)
                                                  )
@@ -4687,12 +4737,13 @@ Usage: cardano-cli alonzo query stake-snapshot --socket-path SOCKET_PATH
   Obtain the three stake snapshots for a pool, plus the total active stake
   (advanced command)
 
-Usage: cardano-cli alonzo query pool-params --socket-path SOCKET_PATH
+Usage: cardano-cli alonzo query pool-params 
                                               [--cardano-mode
                                                 [--epoch-slots SLOTS]]
                                               ( --mainnet
                                               | --testnet-magic NATURAL
                                               )
+                                              --socket-path SOCKET_PATH
                                               ( --all-stake-pools
                                               | (--stake-pool-id STAKE_POOL_ID)
                                               )
@@ -4702,12 +4753,13 @@ Usage: cardano-cli alonzo query pool-params --socket-path SOCKET_PATH
   (Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced
   command)
 
-Usage: cardano-cli alonzo query leadership-schedule --socket-path SOCKET_PATH
+Usage: cardano-cli alonzo query leadership-schedule 
                                                       [--cardano-mode
                                                         [--epoch-slots SLOTS]]
                                                       ( --mainnet
                                                       | --testnet-magic NATURAL
                                                       )
+                                                      --socket-path SOCKET_PATH
                                                       --genesis FILEPATH
                                                       ( --stake-pool-verification-key STRING
                                                       | --cold-verification-key-file FILEPATH
@@ -4722,24 +4774,26 @@ Usage: cardano-cli alonzo query leadership-schedule --socket-path SOCKET_PATH
 
   Get the slots the node is expected to mint a block in (advanced command)
 
-Usage: cardano-cli alonzo query kes-period-info --socket-path SOCKET_PATH
+Usage: cardano-cli alonzo query kes-period-info 
                                                   [--cardano-mode
                                                     [--epoch-slots SLOTS]]
                                                   ( --mainnet
                                                   | --testnet-magic NATURAL
                                                   )
+                                                  --socket-path SOCKET_PATH
                                                   --op-cert-file FILEPATH
                                                   [--out-file FILEPATH]
 
   Get information about the current KES period and your node's operational
   certificate.
 
-Usage: cardano-cli alonzo query pool-state --socket-path SOCKET_PATH
+Usage: cardano-cli alonzo query pool-state 
                                              [--cardano-mode
                                                [--epoch-slots SLOTS]]
                                              ( --mainnet
                                              | --testnet-magic NATURAL
                                              )
+                                             --socket-path SOCKET_PATH
                                              ( --all-stake-pools
                                              | (--stake-pool-id STAKE_POOL_ID)
                                              )
@@ -4747,12 +4801,13 @@ Usage: cardano-cli alonzo query pool-state --socket-path SOCKET_PATH
 
   Dump the pool state
 
-Usage: cardano-cli alonzo query tx-mempool --socket-path SOCKET_PATH
+Usage: cardano-cli alonzo query tx-mempool 
                                              [--cardano-mode
                                                [--epoch-slots SLOTS]]
                                              ( --mainnet
                                              | --testnet-magic NATURAL
                                              )
+                                             --socket-path SOCKET_PATH
                                              (info | next-tx | tx-exists)
                                              [--out-file FILEPATH]
 
@@ -4770,22 +4825,24 @@ Usage: cardano-cli alonzo query tx-mempool tx-exists TX_ID
 
   Query if a particular transaction exists in the mempool
 
-Usage: cardano-cli alonzo query slot-number --socket-path SOCKET_PATH
+Usage: cardano-cli alonzo query slot-number 
                                               [--cardano-mode
                                                 [--epoch-slots SLOTS]]
                                               ( --mainnet
                                               | --testnet-magic NATURAL
                                               )
+                                              --socket-path SOCKET_PATH
                                               TIMESTAMP
 
   Query slot number for UTC timestamp
 
-Usage: cardano-cli alonzo query ref-script-size --socket-path SOCKET_PATH
+Usage: cardano-cli alonzo query ref-script-size 
                                                   [--cardano-mode
                                                     [--epoch-slots SLOTS]]
                                                   ( --mainnet
                                                   | --testnet-magic NATURAL
                                                   )
+                                                  --socket-path SOCKET_PATH
                                                   (--tx-in TX-IN)
                                                   [ --output-json
                                                   | --output-text
@@ -5130,12 +5187,13 @@ Usage: cardano-cli alonzo transaction sign-witness --tx-body-file FILEPATH
 
   Assemble a tx body and witness(es) to form a transaction
 
-Usage: cardano-cli alonzo transaction submit --socket-path SOCKET_PATH
+Usage: cardano-cli alonzo transaction submit 
                                                [--cardano-mode
                                                  [--epoch-slots SLOTS]]
                                                ( --mainnet
                                                | --testnet-magic NATURAL
                                                )
+                                               --socket-path SOCKET_PATH
                                                --tx-file FILEPATH
 
   Submit a transaction to the local node whose Unix domain socket is obtained
@@ -5686,40 +5744,43 @@ Usage: cardano-cli babbage query
   Node query commands. Will query the local node whose Unix domain socket is
   obtained from the CARDANO_NODE_SOCKET_PATH environment variable.
 
-Usage: cardano-cli babbage query protocol-parameters --socket-path SOCKET_PATH
+Usage: cardano-cli babbage query protocol-parameters 
                                                        [--cardano-mode
                                                          [--epoch-slots SLOTS]]
                                                        ( --mainnet
                                                        | --testnet-magic NATURAL
                                                        )
+                                                       --socket-path SOCKET_PATH
                                                        [--out-file FILEPATH]
 
   Get the node's current protocol parameters
 
-Usage: cardano-cli babbage query tip --socket-path SOCKET_PATH
-                                       [--cardano-mode [--epoch-slots SLOTS]]
+Usage: cardano-cli babbage query tip [--cardano-mode [--epoch-slots SLOTS]]
                                        (--mainnet | --testnet-magic NATURAL)
+                                       --socket-path SOCKET_PATH
                                        [--out-file FILEPATH]
 
   Get the node's current tip (slot no, hash, block no)
 
-Usage: cardano-cli babbage query stake-pools --socket-path SOCKET_PATH
+Usage: cardano-cli babbage query stake-pools 
                                                [--cardano-mode
                                                  [--epoch-slots SLOTS]]
                                                ( --mainnet
                                                | --testnet-magic NATURAL
                                                )
+                                               --socket-path SOCKET_PATH
                                                [--output-json | --output-text]
                                                [--out-file FILEPATH]
 
   Get the node's current set of stake pool ids
 
-Usage: cardano-cli babbage query stake-distribution --socket-path SOCKET_PATH
+Usage: cardano-cli babbage query stake-distribution 
                                                       [--cardano-mode
                                                         [--epoch-slots SLOTS]]
                                                       ( --mainnet
                                                       | --testnet-magic NATURAL
                                                       )
+                                                      --socket-path SOCKET_PATH
                                                       [ --output-json
                                                       | --output-text
                                                       ]
@@ -5727,20 +5788,21 @@ Usage: cardano-cli babbage query stake-distribution --socket-path SOCKET_PATH
 
   Get the node's current aggregated stake distribution
 
-Usage: cardano-cli babbage query stake-address-info --socket-path SOCKET_PATH
+Usage: cardano-cli babbage query stake-address-info 
                                                       [--cardano-mode
                                                         [--epoch-slots SLOTS]]
                                                       ( --mainnet
                                                       | --testnet-magic NATURAL
                                                       )
+                                                      --socket-path SOCKET_PATH
                                                       --address ADDRESS
                                                       [--out-file FILEPATH]
 
   Get the current delegations and reward accounts filtered by stake address.
 
-Usage: cardano-cli babbage query utxo --socket-path SOCKET_PATH
-                                        [--cardano-mode [--epoch-slots SLOTS]]
+Usage: cardano-cli babbage query utxo [--cardano-mode [--epoch-slots SLOTS]]
                                         (--mainnet | --testnet-magic NATURAL)
+                                        --socket-path SOCKET_PATH
                                         ( --whole-utxo
                                         | (--address ADDRESS)
                                         | (--tx-in TX-IN)
@@ -5750,45 +5812,49 @@ Usage: cardano-cli babbage query utxo --socket-path SOCKET_PATH
 
   Get a portion of the current UTxO: by tx in, by address or the whole.
 
-Usage: cardano-cli babbage query ledger-state --socket-path SOCKET_PATH
+Usage: cardano-cli babbage query ledger-state 
                                                 [--cardano-mode
                                                   [--epoch-slots SLOTS]]
                                                 ( --mainnet
                                                 | --testnet-magic NATURAL
                                                 )
+                                                --socket-path SOCKET_PATH
                                                 [--out-file FILEPATH]
 
   Dump the current ledger state of the node (Ledger.NewEpochState -- advanced
   command)
 
-Usage: cardano-cli babbage query ledger-peer-snapshot --socket-path SOCKET_PATH
+Usage: cardano-cli babbage query ledger-peer-snapshot 
                                                         [--cardano-mode
                                                           [--epoch-slots SLOTS]]
                                                         ( --mainnet
                                                         | --testnet-magic NATURAL
                                                         )
+                                                        --socket-path SOCKET_PATH
                                                         [--out-file FILEPATH]
 
   Dump the current snapshot of ledger peers.These are the largest pools that
   cumulatively hold 90% of total stake.
 
-Usage: cardano-cli babbage query protocol-state --socket-path SOCKET_PATH
+Usage: cardano-cli babbage query protocol-state 
                                                   [--cardano-mode
                                                     [--epoch-slots SLOTS]]
                                                   ( --mainnet
                                                   | --testnet-magic NATURAL
                                                   )
+                                                  --socket-path SOCKET_PATH
                                                   [--out-file FILEPATH]
 
   Dump the current protocol state of the node (Ledger.ChainDepState -- advanced
   command)
 
-Usage: cardano-cli babbage query stake-snapshot --socket-path SOCKET_PATH
+Usage: cardano-cli babbage query stake-snapshot 
                                                   [--cardano-mode
                                                     [--epoch-slots SLOTS]]
                                                   ( --mainnet
                                                   | --testnet-magic NATURAL
                                                   )
+                                                  --socket-path SOCKET_PATH
                                                   ( --all-stake-pools
                                                   | (--stake-pool-id STAKE_POOL_ID)
                                                   )
@@ -5797,12 +5863,13 @@ Usage: cardano-cli babbage query stake-snapshot --socket-path SOCKET_PATH
   Obtain the three stake snapshots for a pool, plus the total active stake
   (advanced command)
 
-Usage: cardano-cli babbage query pool-params --socket-path SOCKET_PATH
+Usage: cardano-cli babbage query pool-params 
                                                [--cardano-mode
                                                  [--epoch-slots SLOTS]]
                                                ( --mainnet
                                                | --testnet-magic NATURAL
                                                )
+                                               --socket-path SOCKET_PATH
                                                ( --all-stake-pools
                                                | (--stake-pool-id STAKE_POOL_ID)
                                                )
@@ -5812,12 +5879,13 @@ Usage: cardano-cli babbage query pool-params --socket-path SOCKET_PATH
   (Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced
   command)
 
-Usage: cardano-cli babbage query leadership-schedule --socket-path SOCKET_PATH
+Usage: cardano-cli babbage query leadership-schedule 
                                                        [--cardano-mode
                                                          [--epoch-slots SLOTS]]
                                                        ( --mainnet
                                                        | --testnet-magic NATURAL
                                                        )
+                                                       --socket-path SOCKET_PATH
                                                        --genesis FILEPATH
                                                        ( --stake-pool-verification-key STRING
                                                        | --cold-verification-key-file FILEPATH
@@ -5832,24 +5900,26 @@ Usage: cardano-cli babbage query leadership-schedule --socket-path SOCKET_PATH
 
   Get the slots the node is expected to mint a block in (advanced command)
 
-Usage: cardano-cli babbage query kes-period-info --socket-path SOCKET_PATH
+Usage: cardano-cli babbage query kes-period-info 
                                                    [--cardano-mode
                                                      [--epoch-slots SLOTS]]
                                                    ( --mainnet
                                                    | --testnet-magic NATURAL
                                                    )
+                                                   --socket-path SOCKET_PATH
                                                    --op-cert-file FILEPATH
                                                    [--out-file FILEPATH]
 
   Get information about the current KES period and your node's operational
   certificate.
 
-Usage: cardano-cli babbage query pool-state --socket-path SOCKET_PATH
+Usage: cardano-cli babbage query pool-state 
                                               [--cardano-mode
                                                 [--epoch-slots SLOTS]]
                                               ( --mainnet
                                               | --testnet-magic NATURAL
                                               )
+                                              --socket-path SOCKET_PATH
                                               ( --all-stake-pools
                                               | (--stake-pool-id STAKE_POOL_ID)
                                               )
@@ -5857,12 +5927,13 @@ Usage: cardano-cli babbage query pool-state --socket-path SOCKET_PATH
 
   Dump the pool state
 
-Usage: cardano-cli babbage query tx-mempool --socket-path SOCKET_PATH
+Usage: cardano-cli babbage query tx-mempool 
                                               [--cardano-mode
                                                 [--epoch-slots SLOTS]]
                                               ( --mainnet
                                               | --testnet-magic NATURAL
                                               )
+                                              --socket-path SOCKET_PATH
                                               (info | next-tx | tx-exists)
                                               [--out-file FILEPATH]
 
@@ -5880,22 +5951,24 @@ Usage: cardano-cli babbage query tx-mempool tx-exists TX_ID
 
   Query if a particular transaction exists in the mempool
 
-Usage: cardano-cli babbage query slot-number --socket-path SOCKET_PATH
+Usage: cardano-cli babbage query slot-number 
                                                [--cardano-mode
                                                  [--epoch-slots SLOTS]]
                                                ( --mainnet
                                                | --testnet-magic NATURAL
                                                )
+                                               --socket-path SOCKET_PATH
                                                TIMESTAMP
 
   Query slot number for UTC timestamp
 
-Usage: cardano-cli babbage query ref-script-size --socket-path SOCKET_PATH
+Usage: cardano-cli babbage query ref-script-size 
                                                    [--cardano-mode
                                                      [--epoch-slots SLOTS]]
                                                    ( --mainnet
                                                    | --testnet-magic NATURAL
                                                    )
+                                                   --socket-path SOCKET_PATH
                                                    (--tx-in TX-IN)
                                                    [ --output-json
                                                    | --output-text
@@ -6207,12 +6280,13 @@ Usage: cardano-cli babbage transaction build-raw
 
   Please note the order[93;22;23;24m of some cmd options is crucial. If used incorrectly may produce undesired tx body. See nested [] notation above for details.[0;22;23;24m
 
-Usage: cardano-cli babbage transaction build --socket-path SOCKET_PATH
+Usage: cardano-cli babbage transaction build 
                                                [--cardano-mode
                                                  [--epoch-slots SLOTS]]
                                                ( --mainnet
                                                | --testnet-magic NATURAL
                                                )
+                                               --socket-path SOCKET_PATH
                                                [ --script-valid
                                                | --script-invalid
                                                ]
@@ -6499,12 +6573,13 @@ Usage: cardano-cli babbage transaction sign-witness --tx-body-file FILEPATH
 
   Assemble a tx body and witness(es) to form a transaction
 
-Usage: cardano-cli babbage transaction submit --socket-path SOCKET_PATH
+Usage: cardano-cli babbage transaction submit 
                                                 [--cardano-mode
                                                   [--epoch-slots SLOTS]]
                                                 ( --mainnet
                                                 | --testnet-magic NATURAL
                                                 )
+                                                --socket-path SOCKET_PATH
                                                 --tx-file FILEPATH
 
   Submit a transaction to the local node whose Unix domain socket is obtained
@@ -7345,42 +7420,45 @@ Usage: cardano-cli conway query
   Node query commands. Will query the local node whose Unix domain socket is
   obtained from the CARDANO_NODE_SOCKET_PATH environment variable.
 
-Usage: cardano-cli conway query protocol-parameters --socket-path SOCKET_PATH
+Usage: cardano-cli conway query protocol-parameters 
                                                       [--cardano-mode
                                                         [--epoch-slots SLOTS]]
                                                       ( --mainnet
                                                       | --testnet-magic NATURAL
                                                       )
+                                                      --socket-path SOCKET_PATH
                                                       [--out-file FILEPATH]
 
   Get the node's current protocol parameters
 
-Usage: cardano-cli conway query tip --socket-path SOCKET_PATH
-                                      [--cardano-mode [--epoch-slots SLOTS]]
+Usage: cardano-cli conway query tip [--cardano-mode [--epoch-slots SLOTS]]
                                       (--mainnet | --testnet-magic NATURAL)
+                                      --socket-path SOCKET_PATH
                                       [--volatile-tip | --immutable-tip]
                                       [--out-file FILEPATH]
 
   Get the node's current tip (slot no, hash, block no)
 
-Usage: cardano-cli conway query stake-pools --socket-path SOCKET_PATH
+Usage: cardano-cli conway query stake-pools 
                                               [--cardano-mode
                                                 [--epoch-slots SLOTS]]
                                               ( --mainnet
                                               | --testnet-magic NATURAL
                                               )
+                                              --socket-path SOCKET_PATH
                                               [--volatile-tip | --immutable-tip]
                                               [--output-json | --output-text]
                                               [--out-file FILEPATH]
 
   Get the node's current set of stake pool ids
 
-Usage: cardano-cli conway query stake-distribution --socket-path SOCKET_PATH
+Usage: cardano-cli conway query stake-distribution 
                                                      [--cardano-mode
                                                        [--epoch-slots SLOTS]]
                                                      ( --mainnet
                                                      | --testnet-magic NATURAL
                                                      )
+                                                     --socket-path SOCKET_PATH
                                                      [ --volatile-tip
                                                      | --immutable-tip
                                                      ]
@@ -7391,12 +7469,13 @@ Usage: cardano-cli conway query stake-distribution --socket-path SOCKET_PATH
 
   Get the node's current aggregated stake distribution
 
-Usage: cardano-cli conway query stake-address-info --socket-path SOCKET_PATH
+Usage: cardano-cli conway query stake-address-info 
                                                      [--cardano-mode
                                                        [--epoch-slots SLOTS]]
                                                      ( --mainnet
                                                      | --testnet-magic NATURAL
                                                      )
+                                                     --socket-path SOCKET_PATH
                                                      [ --volatile-tip
                                                      | --immutable-tip
                                                      ]
@@ -7405,9 +7484,9 @@ Usage: cardano-cli conway query stake-address-info --socket-path SOCKET_PATH
 
   Get the current delegations and reward accounts filtered by stake address.
 
-Usage: cardano-cli conway query utxo --socket-path SOCKET_PATH
-                                       [--cardano-mode [--epoch-slots SLOTS]]
+Usage: cardano-cli conway query utxo [--cardano-mode [--epoch-slots SLOTS]]
                                        (--mainnet | --testnet-magic NATURAL)
+                                       --socket-path SOCKET_PATH
                                        [--volatile-tip | --immutable-tip]
                                        ( --whole-utxo
                                        | (--address ADDRESS)
@@ -7418,12 +7497,13 @@ Usage: cardano-cli conway query utxo --socket-path SOCKET_PATH
 
   Get a portion of the current UTxO: by tx in, by address or the whole.
 
-Usage: cardano-cli conway query ledger-state --socket-path SOCKET_PATH
+Usage: cardano-cli conway query ledger-state 
                                                [--cardano-mode
                                                  [--epoch-slots SLOTS]]
                                                ( --mainnet
                                                | --testnet-magic NATURAL
                                                )
+                                               --socket-path SOCKET_PATH
                                                [ --volatile-tip
                                                | --immutable-tip
                                                ]
@@ -7432,12 +7512,13 @@ Usage: cardano-cli conway query ledger-state --socket-path SOCKET_PATH
   Dump the current ledger state of the node (Ledger.NewEpochState -- advanced
   command)
 
-Usage: cardano-cli conway query ledger-peer-snapshot --socket-path SOCKET_PATH
+Usage: cardano-cli conway query ledger-peer-snapshot 
                                                        [--cardano-mode
                                                          [--epoch-slots SLOTS]]
                                                        ( --mainnet
                                                        | --testnet-magic NATURAL
                                                        )
+                                                       --socket-path SOCKET_PATH
                                                        [ --volatile-tip
                                                        | --immutable-tip
                                                        ]
@@ -7446,12 +7527,13 @@ Usage: cardano-cli conway query ledger-peer-snapshot --socket-path SOCKET_PATH
   Dump the current snapshot of ledger peers.These are the largest pools that
   cumulatively hold 90% of total stake.
 
-Usage: cardano-cli conway query protocol-state --socket-path SOCKET_PATH
+Usage: cardano-cli conway query protocol-state 
                                                  [--cardano-mode
                                                    [--epoch-slots SLOTS]]
                                                  ( --mainnet
                                                  | --testnet-magic NATURAL
                                                  )
+                                                 --socket-path SOCKET_PATH
                                                  [ --volatile-tip
                                                  | --immutable-tip
                                                  ]
@@ -7460,12 +7542,13 @@ Usage: cardano-cli conway query protocol-state --socket-path SOCKET_PATH
   Dump the current protocol state of the node (Ledger.ChainDepState -- advanced
   command)
 
-Usage: cardano-cli conway query stake-snapshot --socket-path SOCKET_PATH
+Usage: cardano-cli conway query stake-snapshot 
                                                  [--cardano-mode
                                                    [--epoch-slots SLOTS]]
                                                  ( --mainnet
                                                  | --testnet-magic NATURAL
                                                  )
+                                                 --socket-path SOCKET_PATH
                                                  [ --volatile-tip
                                                  | --immutable-tip
                                                  ]
@@ -7477,12 +7560,13 @@ Usage: cardano-cli conway query stake-snapshot --socket-path SOCKET_PATH
   Obtain the three stake snapshots for a pool, plus the total active stake
   (advanced command)
 
-Usage: cardano-cli conway query pool-params --socket-path SOCKET_PATH
+Usage: cardano-cli conway query pool-params 
                                               [--cardano-mode
                                                 [--epoch-slots SLOTS]]
                                               ( --mainnet
                                               | --testnet-magic NATURAL
                                               )
+                                              --socket-path SOCKET_PATH
                                               [--volatile-tip | --immutable-tip]
                                               ( --all-stake-pools
                                               | (--stake-pool-id STAKE_POOL_ID)
@@ -7493,12 +7577,13 @@ Usage: cardano-cli conway query pool-params --socket-path SOCKET_PATH
   (Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced
   command)
 
-Usage: cardano-cli conway query leadership-schedule --socket-path SOCKET_PATH
+Usage: cardano-cli conway query leadership-schedule 
                                                       [--cardano-mode
                                                         [--epoch-slots SLOTS]]
                                                       ( --mainnet
                                                       | --testnet-magic NATURAL
                                                       )
+                                                      --socket-path SOCKET_PATH
                                                       [ --volatile-tip
                                                       | --immutable-tip
                                                       ]
@@ -7516,12 +7601,13 @@ Usage: cardano-cli conway query leadership-schedule --socket-path SOCKET_PATH
 
   Get the slots the node is expected to mint a block in (advanced command)
 
-Usage: cardano-cli conway query kes-period-info --socket-path SOCKET_PATH
+Usage: cardano-cli conway query kes-period-info 
                                                   [--cardano-mode
                                                     [--epoch-slots SLOTS]]
                                                   ( --mainnet
                                                   | --testnet-magic NATURAL
                                                   )
+                                                  --socket-path SOCKET_PATH
                                                   [ --volatile-tip
                                                   | --immutable-tip
                                                   ]
@@ -7531,12 +7617,13 @@ Usage: cardano-cli conway query kes-period-info --socket-path SOCKET_PATH
   Get information about the current KES period and your node's operational
   certificate.
 
-Usage: cardano-cli conway query pool-state --socket-path SOCKET_PATH
+Usage: cardano-cli conway query pool-state 
                                              [--cardano-mode
                                                [--epoch-slots SLOTS]]
                                              ( --mainnet
                                              | --testnet-magic NATURAL
                                              )
+                                             --socket-path SOCKET_PATH
                                              [--volatile-tip | --immutable-tip]
                                              ( --all-stake-pools
                                              | (--stake-pool-id STAKE_POOL_ID)
@@ -7545,12 +7632,13 @@ Usage: cardano-cli conway query pool-state --socket-path SOCKET_PATH
 
   Dump the pool state
 
-Usage: cardano-cli conway query tx-mempool --socket-path SOCKET_PATH
+Usage: cardano-cli conway query tx-mempool 
                                              [--cardano-mode
                                                [--epoch-slots SLOTS]]
                                              ( --mainnet
                                              | --testnet-magic NATURAL
                                              )
+                                             --socket-path SOCKET_PATH
                                              (info | next-tx | tx-exists)
                                              [--out-file FILEPATH]
 
@@ -7568,23 +7656,25 @@ Usage: cardano-cli conway query tx-mempool tx-exists TX_ID
 
   Query if a particular transaction exists in the mempool
 
-Usage: cardano-cli conway query slot-number --socket-path SOCKET_PATH
+Usage: cardano-cli conway query slot-number 
                                               [--cardano-mode
                                                 [--epoch-slots SLOTS]]
                                               ( --mainnet
                                               | --testnet-magic NATURAL
                                               )
+                                              --socket-path SOCKET_PATH
                                               [--volatile-tip | --immutable-tip]
                                               TIMESTAMP
 
   Query slot number for UTC timestamp
 
-Usage: cardano-cli conway query ref-script-size --socket-path SOCKET_PATH
+Usage: cardano-cli conway query ref-script-size 
                                                   [--cardano-mode
                                                     [--epoch-slots SLOTS]]
                                                   ( --mainnet
                                                   | --testnet-magic NATURAL
                                                   )
+                                                  --socket-path SOCKET_PATH
                                                   [ --volatile-tip
                                                   | --immutable-tip
                                                   ]
@@ -7597,12 +7687,13 @@ Usage: cardano-cli conway query ref-script-size --socket-path SOCKET_PATH
   Calculate the reference input scripts size in bytes for provided transaction
   inputs.
 
-Usage: cardano-cli conway query constitution --socket-path SOCKET_PATH
+Usage: cardano-cli conway query constitution 
                                                [--cardano-mode
                                                  [--epoch-slots SLOTS]]
                                                ( --mainnet
                                                | --testnet-magic NATURAL
                                                )
+                                               --socket-path SOCKET_PATH
                                                [ --volatile-tip
                                                | --immutable-tip
                                                ]
@@ -7610,23 +7701,23 @@ Usage: cardano-cli conway query constitution --socket-path SOCKET_PATH
 
   Get the constitution
 
-Usage: cardano-cli conway query gov-state --socket-path SOCKET_PATH
-                                            [--cardano-mode
-                                              [--epoch-slots SLOTS]]
+Usage: cardano-cli conway query gov-state [--cardano-mode [--epoch-slots SLOTS]]
                                             ( --mainnet
                                             | --testnet-magic NATURAL
                                             )
+                                            --socket-path SOCKET_PATH
                                             [--volatile-tip | --immutable-tip]
                                             [--out-file FILEPATH]
 
   Get the governance state
 
-Usage: cardano-cli conway query drep-state --socket-path SOCKET_PATH
+Usage: cardano-cli conway query drep-state 
                                              [--cardano-mode
                                                [--epoch-slots SLOTS]]
                                              ( --mainnet
                                              | --testnet-magic NATURAL
                                              )
+                                             --socket-path SOCKET_PATH
                                              [--volatile-tip | --immutable-tip]
                                              ( --all-dreps
                                              | 
@@ -7642,12 +7733,12 @@ Usage: cardano-cli conway query drep-state --socket-path SOCKET_PATH
   Get the DRep state.
 
 Usage: cardano-cli conway query drep-stake-distribution 
-                                                          --socket-path SOCKET_PATH
                                                           [--cardano-mode
                                                             [--epoch-slots SLOTS]]
                                                           ( --mainnet
                                                           | --testnet-magic NATURAL
                                                           )
+                                                          --socket-path SOCKET_PATH
                                                           [ --volatile-tip
                                                           | --immutable-tip
                                                           ]
@@ -7663,12 +7754,13 @@ Usage: cardano-cli conway query drep-stake-distribution
 
   Get the DRep stake distribution.
 
-Usage: cardano-cli conway query spo-stake-distribution --socket-path SOCKET_PATH
+Usage: cardano-cli conway query spo-stake-distribution 
                                                          [--cardano-mode
                                                            [--epoch-slots SLOTS]]
                                                          ( --mainnet
                                                          | --testnet-magic NATURAL
                                                          )
+                                                         --socket-path SOCKET_PATH
                                                          [ --volatile-tip
                                                          | --immutable-tip
                                                          ]
@@ -7683,12 +7775,13 @@ Usage: cardano-cli conway query spo-stake-distribution --socket-path SOCKET_PATH
 
   Get the SPO stake distribution.
 
-Usage: cardano-cli conway query committee-state --socket-path SOCKET_PATH
+Usage: cardano-cli conway query committee-state 
                                                   [--cardano-mode
                                                     [--epoch-slots SLOTS]]
                                                   ( --mainnet
                                                   | --testnet-magic NATURAL
                                                   )
+                                                  --socket-path SOCKET_PATH
                                                   [ --volatile-tip
                                                   | --immutable-tip
                                                   ]
@@ -7710,21 +7803,19 @@ Usage: cardano-cli conway query committee-state --socket-path SOCKET_PATH
 
   Get the committee state
 
-Usage: cardano-cli conway query treasury --socket-path SOCKET_PATH
-                                           [--cardano-mode
-                                             [--epoch-slots SLOTS]]
+Usage: cardano-cli conway query treasury [--cardano-mode [--epoch-slots SLOTS]]
                                            (--mainnet | --testnet-magic NATURAL)
+                                           --socket-path SOCKET_PATH
                                            [--volatile-tip | --immutable-tip]
                                            [--out-file FILEPATH]
 
   Get the treasury value
 
-Usage: cardano-cli conway query proposals --socket-path SOCKET_PATH
-                                            [--cardano-mode
-                                              [--epoch-slots SLOTS]]
+Usage: cardano-cli conway query proposals [--cardano-mode [--epoch-slots SLOTS]]
                                             ( --mainnet
                                             | --testnet-magic NATURAL
                                             )
+                                            --socket-path SOCKET_PATH
                                             [--volatile-tip | --immutable-tip]
                                             ( --all-proposals
                                             | (--governance-action-tx-id TXID
@@ -8185,12 +8276,13 @@ Usage: cardano-cli conway transaction build-raw
 
   Please note the order[93;22;23;24m of some cmd options is crucial. If used incorrectly may produce undesired tx body. See nested [] notation above for details.[0;22;23;24m
 
-Usage: cardano-cli conway transaction build --socket-path SOCKET_PATH
+Usage: cardano-cli conway transaction build 
                                               [--cardano-mode
                                                 [--epoch-slots SLOTS]]
                                               ( --mainnet
                                               | --testnet-magic NATURAL
                                               )
+                                              --socket-path SOCKET_PATH
                                               [ --script-valid
                                               | --script-invalid
                                               ]
@@ -8536,12 +8628,13 @@ Usage: cardano-cli conway transaction sign-witness --tx-body-file FILEPATH
 
   Assemble a tx body and witness(es) to form a transaction
 
-Usage: cardano-cli conway transaction submit --socket-path SOCKET_PATH
+Usage: cardano-cli conway transaction submit 
                                                [--cardano-mode
                                                  [--epoch-slots SLOTS]]
                                                ( --mainnet
                                                | --testnet-magic NATURAL
                                                )
+                                               --socket-path SOCKET_PATH
                                                --tx-file FILEPATH
 
   Submit a transaction to the local node whose Unix domain socket is obtained
@@ -9382,42 +9475,45 @@ Usage: cardano-cli latest query
   Node query commands. Will query the local node whose Unix domain socket is
   obtained from the CARDANO_NODE_SOCKET_PATH environment variable.
 
-Usage: cardano-cli latest query protocol-parameters --socket-path SOCKET_PATH
+Usage: cardano-cli latest query protocol-parameters 
                                                       [--cardano-mode
                                                         [--epoch-slots SLOTS]]
                                                       ( --mainnet
                                                       | --testnet-magic NATURAL
                                                       )
+                                                      --socket-path SOCKET_PATH
                                                       [--out-file FILEPATH]
 
   Get the node's current protocol parameters
 
-Usage: cardano-cli latest query tip --socket-path SOCKET_PATH
-                                      [--cardano-mode [--epoch-slots SLOTS]]
+Usage: cardano-cli latest query tip [--cardano-mode [--epoch-slots SLOTS]]
                                       (--mainnet | --testnet-magic NATURAL)
+                                      --socket-path SOCKET_PATH
                                       [--volatile-tip | --immutable-tip]
                                       [--out-file FILEPATH]
 
   Get the node's current tip (slot no, hash, block no)
 
-Usage: cardano-cli latest query stake-pools --socket-path SOCKET_PATH
+Usage: cardano-cli latest query stake-pools 
                                               [--cardano-mode
                                                 [--epoch-slots SLOTS]]
                                               ( --mainnet
                                               | --testnet-magic NATURAL
                                               )
+                                              --socket-path SOCKET_PATH
                                               [--volatile-tip | --immutable-tip]
                                               [--output-json | --output-text]
                                               [--out-file FILEPATH]
 
   Get the node's current set of stake pool ids
 
-Usage: cardano-cli latest query stake-distribution --socket-path SOCKET_PATH
+Usage: cardano-cli latest query stake-distribution 
                                                      [--cardano-mode
                                                        [--epoch-slots SLOTS]]
                                                      ( --mainnet
                                                      | --testnet-magic NATURAL
                                                      )
+                                                     --socket-path SOCKET_PATH
                                                      [ --volatile-tip
                                                      | --immutable-tip
                                                      ]
@@ -9428,12 +9524,13 @@ Usage: cardano-cli latest query stake-distribution --socket-path SOCKET_PATH
 
   Get the node's current aggregated stake distribution
 
-Usage: cardano-cli latest query stake-address-info --socket-path SOCKET_PATH
+Usage: cardano-cli latest query stake-address-info 
                                                      [--cardano-mode
                                                        [--epoch-slots SLOTS]]
                                                      ( --mainnet
                                                      | --testnet-magic NATURAL
                                                      )
+                                                     --socket-path SOCKET_PATH
                                                      [ --volatile-tip
                                                      | --immutable-tip
                                                      ]
@@ -9442,9 +9539,9 @@ Usage: cardano-cli latest query stake-address-info --socket-path SOCKET_PATH
 
   Get the current delegations and reward accounts filtered by stake address.
 
-Usage: cardano-cli latest query utxo --socket-path SOCKET_PATH
-                                       [--cardano-mode [--epoch-slots SLOTS]]
+Usage: cardano-cli latest query utxo [--cardano-mode [--epoch-slots SLOTS]]
                                        (--mainnet | --testnet-magic NATURAL)
+                                       --socket-path SOCKET_PATH
                                        [--volatile-tip | --immutable-tip]
                                        ( --whole-utxo
                                        | (--address ADDRESS)
@@ -9455,12 +9552,13 @@ Usage: cardano-cli latest query utxo --socket-path SOCKET_PATH
 
   Get a portion of the current UTxO: by tx in, by address or the whole.
 
-Usage: cardano-cli latest query ledger-state --socket-path SOCKET_PATH
+Usage: cardano-cli latest query ledger-state 
                                                [--cardano-mode
                                                  [--epoch-slots SLOTS]]
                                                ( --mainnet
                                                | --testnet-magic NATURAL
                                                )
+                                               --socket-path SOCKET_PATH
                                                [ --volatile-tip
                                                | --immutable-tip
                                                ]
@@ -9469,12 +9567,13 @@ Usage: cardano-cli latest query ledger-state --socket-path SOCKET_PATH
   Dump the current ledger state of the node (Ledger.NewEpochState -- advanced
   command)
 
-Usage: cardano-cli latest query ledger-peer-snapshot --socket-path SOCKET_PATH
+Usage: cardano-cli latest query ledger-peer-snapshot 
                                                        [--cardano-mode
                                                          [--epoch-slots SLOTS]]
                                                        ( --mainnet
                                                        | --testnet-magic NATURAL
                                                        )
+                                                       --socket-path SOCKET_PATH
                                                        [ --volatile-tip
                                                        | --immutable-tip
                                                        ]
@@ -9483,12 +9582,13 @@ Usage: cardano-cli latest query ledger-peer-snapshot --socket-path SOCKET_PATH
   Dump the current snapshot of ledger peers.These are the largest pools that
   cumulatively hold 90% of total stake.
 
-Usage: cardano-cli latest query protocol-state --socket-path SOCKET_PATH
+Usage: cardano-cli latest query protocol-state 
                                                  [--cardano-mode
                                                    [--epoch-slots SLOTS]]
                                                  ( --mainnet
                                                  | --testnet-magic NATURAL
                                                  )
+                                                 --socket-path SOCKET_PATH
                                                  [ --volatile-tip
                                                  | --immutable-tip
                                                  ]
@@ -9497,12 +9597,13 @@ Usage: cardano-cli latest query protocol-state --socket-path SOCKET_PATH
   Dump the current protocol state of the node (Ledger.ChainDepState -- advanced
   command)
 
-Usage: cardano-cli latest query stake-snapshot --socket-path SOCKET_PATH
+Usage: cardano-cli latest query stake-snapshot 
                                                  [--cardano-mode
                                                    [--epoch-slots SLOTS]]
                                                  ( --mainnet
                                                  | --testnet-magic NATURAL
                                                  )
+                                                 --socket-path SOCKET_PATH
                                                  [ --volatile-tip
                                                  | --immutable-tip
                                                  ]
@@ -9514,12 +9615,13 @@ Usage: cardano-cli latest query stake-snapshot --socket-path SOCKET_PATH
   Obtain the three stake snapshots for a pool, plus the total active stake
   (advanced command)
 
-Usage: cardano-cli latest query pool-params --socket-path SOCKET_PATH
+Usage: cardano-cli latest query pool-params 
                                               [--cardano-mode
                                                 [--epoch-slots SLOTS]]
                                               ( --mainnet
                                               | --testnet-magic NATURAL
                                               )
+                                              --socket-path SOCKET_PATH
                                               [--volatile-tip | --immutable-tip]
                                               ( --all-stake-pools
                                               | (--stake-pool-id STAKE_POOL_ID)
@@ -9530,12 +9632,13 @@ Usage: cardano-cli latest query pool-params --socket-path SOCKET_PATH
   (Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced
   command)
 
-Usage: cardano-cli latest query leadership-schedule --socket-path SOCKET_PATH
+Usage: cardano-cli latest query leadership-schedule 
                                                       [--cardano-mode
                                                         [--epoch-slots SLOTS]]
                                                       ( --mainnet
                                                       | --testnet-magic NATURAL
                                                       )
+                                                      --socket-path SOCKET_PATH
                                                       [ --volatile-tip
                                                       | --immutable-tip
                                                       ]
@@ -9553,12 +9656,13 @@ Usage: cardano-cli latest query leadership-schedule --socket-path SOCKET_PATH
 
   Get the slots the node is expected to mint a block in (advanced command)
 
-Usage: cardano-cli latest query kes-period-info --socket-path SOCKET_PATH
+Usage: cardano-cli latest query kes-period-info 
                                                   [--cardano-mode
                                                     [--epoch-slots SLOTS]]
                                                   ( --mainnet
                                                   | --testnet-magic NATURAL
                                                   )
+                                                  --socket-path SOCKET_PATH
                                                   [ --volatile-tip
                                                   | --immutable-tip
                                                   ]
@@ -9568,12 +9672,13 @@ Usage: cardano-cli latest query kes-period-info --socket-path SOCKET_PATH
   Get information about the current KES period and your node's operational
   certificate.
 
-Usage: cardano-cli latest query pool-state --socket-path SOCKET_PATH
+Usage: cardano-cli latest query pool-state 
                                              [--cardano-mode
                                                [--epoch-slots SLOTS]]
                                              ( --mainnet
                                              | --testnet-magic NATURAL
                                              )
+                                             --socket-path SOCKET_PATH
                                              [--volatile-tip | --immutable-tip]
                                              ( --all-stake-pools
                                              | (--stake-pool-id STAKE_POOL_ID)
@@ -9582,12 +9687,13 @@ Usage: cardano-cli latest query pool-state --socket-path SOCKET_PATH
 
   Dump the pool state
 
-Usage: cardano-cli latest query tx-mempool --socket-path SOCKET_PATH
+Usage: cardano-cli latest query tx-mempool 
                                              [--cardano-mode
                                                [--epoch-slots SLOTS]]
                                              ( --mainnet
                                              | --testnet-magic NATURAL
                                              )
+                                             --socket-path SOCKET_PATH
                                              (info | next-tx | tx-exists)
                                              [--out-file FILEPATH]
 
@@ -9605,23 +9711,25 @@ Usage: cardano-cli latest query tx-mempool tx-exists TX_ID
 
   Query if a particular transaction exists in the mempool
 
-Usage: cardano-cli latest query slot-number --socket-path SOCKET_PATH
+Usage: cardano-cli latest query slot-number 
                                               [--cardano-mode
                                                 [--epoch-slots SLOTS]]
                                               ( --mainnet
                                               | --testnet-magic NATURAL
                                               )
+                                              --socket-path SOCKET_PATH
                                               [--volatile-tip | --immutable-tip]
                                               TIMESTAMP
 
   Query slot number for UTC timestamp
 
-Usage: cardano-cli latest query ref-script-size --socket-path SOCKET_PATH
+Usage: cardano-cli latest query ref-script-size 
                                                   [--cardano-mode
                                                     [--epoch-slots SLOTS]]
                                                   ( --mainnet
                                                   | --testnet-magic NATURAL
                                                   )
+                                                  --socket-path SOCKET_PATH
                                                   [ --volatile-tip
                                                   | --immutable-tip
                                                   ]
@@ -9634,12 +9742,13 @@ Usage: cardano-cli latest query ref-script-size --socket-path SOCKET_PATH
   Calculate the reference input scripts size in bytes for provided transaction
   inputs.
 
-Usage: cardano-cli latest query constitution --socket-path SOCKET_PATH
+Usage: cardano-cli latest query constitution 
                                                [--cardano-mode
                                                  [--epoch-slots SLOTS]]
                                                ( --mainnet
                                                | --testnet-magic NATURAL
                                                )
+                                               --socket-path SOCKET_PATH
                                                [ --volatile-tip
                                                | --immutable-tip
                                                ]
@@ -9647,23 +9756,23 @@ Usage: cardano-cli latest query constitution --socket-path SOCKET_PATH
 
   Get the constitution
 
-Usage: cardano-cli latest query gov-state --socket-path SOCKET_PATH
-                                            [--cardano-mode
-                                              [--epoch-slots SLOTS]]
+Usage: cardano-cli latest query gov-state [--cardano-mode [--epoch-slots SLOTS]]
                                             ( --mainnet
                                             | --testnet-magic NATURAL
                                             )
+                                            --socket-path SOCKET_PATH
                                             [--volatile-tip | --immutable-tip]
                                             [--out-file FILEPATH]
 
   Get the governance state
 
-Usage: cardano-cli latest query drep-state --socket-path SOCKET_PATH
+Usage: cardano-cli latest query drep-state 
                                              [--cardano-mode
                                                [--epoch-slots SLOTS]]
                                              ( --mainnet
                                              | --testnet-magic NATURAL
                                              )
+                                             --socket-path SOCKET_PATH
                                              [--volatile-tip | --immutable-tip]
                                              ( --all-dreps
                                              | 
@@ -9679,12 +9788,12 @@ Usage: cardano-cli latest query drep-state --socket-path SOCKET_PATH
   Get the DRep state.
 
 Usage: cardano-cli latest query drep-stake-distribution 
-                                                          --socket-path SOCKET_PATH
                                                           [--cardano-mode
                                                             [--epoch-slots SLOTS]]
                                                           ( --mainnet
                                                           | --testnet-magic NATURAL
                                                           )
+                                                          --socket-path SOCKET_PATH
                                                           [ --volatile-tip
                                                           | --immutable-tip
                                                           ]
@@ -9700,12 +9809,13 @@ Usage: cardano-cli latest query drep-stake-distribution
 
   Get the DRep stake distribution.
 
-Usage: cardano-cli latest query spo-stake-distribution --socket-path SOCKET_PATH
+Usage: cardano-cli latest query spo-stake-distribution 
                                                          [--cardano-mode
                                                            [--epoch-slots SLOTS]]
                                                          ( --mainnet
                                                          | --testnet-magic NATURAL
                                                          )
+                                                         --socket-path SOCKET_PATH
                                                          [ --volatile-tip
                                                          | --immutable-tip
                                                          ]
@@ -9720,12 +9830,13 @@ Usage: cardano-cli latest query spo-stake-distribution --socket-path SOCKET_PATH
 
   Get the SPO stake distribution.
 
-Usage: cardano-cli latest query committee-state --socket-path SOCKET_PATH
+Usage: cardano-cli latest query committee-state 
                                                   [--cardano-mode
                                                     [--epoch-slots SLOTS]]
                                                   ( --mainnet
                                                   | --testnet-magic NATURAL
                                                   )
+                                                  --socket-path SOCKET_PATH
                                                   [ --volatile-tip
                                                   | --immutable-tip
                                                   ]
@@ -9747,21 +9858,19 @@ Usage: cardano-cli latest query committee-state --socket-path SOCKET_PATH
 
   Get the committee state
 
-Usage: cardano-cli latest query treasury --socket-path SOCKET_PATH
-                                           [--cardano-mode
-                                             [--epoch-slots SLOTS]]
+Usage: cardano-cli latest query treasury [--cardano-mode [--epoch-slots SLOTS]]
                                            (--mainnet | --testnet-magic NATURAL)
+                                           --socket-path SOCKET_PATH
                                            [--volatile-tip | --immutable-tip]
                                            [--out-file FILEPATH]
 
   Get the treasury value
 
-Usage: cardano-cli latest query proposals --socket-path SOCKET_PATH
-                                            [--cardano-mode
-                                              [--epoch-slots SLOTS]]
+Usage: cardano-cli latest query proposals [--cardano-mode [--epoch-slots SLOTS]]
                                             ( --mainnet
                                             | --testnet-magic NATURAL
                                             )
+                                            --socket-path SOCKET_PATH
                                             [--volatile-tip | --immutable-tip]
                                             ( --all-proposals
                                             | (--governance-action-tx-id TXID
@@ -10222,12 +10331,13 @@ Usage: cardano-cli latest transaction build-raw
 
   Please note the order[93;22;23;24m of some cmd options is crucial. If used incorrectly may produce undesired tx body. See nested [] notation above for details.[0;22;23;24m
 
-Usage: cardano-cli latest transaction build --socket-path SOCKET_PATH
+Usage: cardano-cli latest transaction build 
                                               [--cardano-mode
                                                 [--epoch-slots SLOTS]]
                                               ( --mainnet
                                               | --testnet-magic NATURAL
                                               )
+                                              --socket-path SOCKET_PATH
                                               [ --script-valid
                                               | --script-invalid
                                               ]
@@ -10573,12 +10683,13 @@ Usage: cardano-cli latest transaction sign-witness --tx-body-file FILEPATH
 
   Assemble a tx body and witness(es) to form a transaction
 
-Usage: cardano-cli latest transaction submit --socket-path SOCKET_PATH
+Usage: cardano-cli latest transaction submit 
                                                [--cardano-mode
                                                  [--epoch-slots SLOTS]]
                                                ( --mainnet
                                                | --testnet-magic NATURAL
                                                )
+                                               --socket-path SOCKET_PATH
                                                --tx-file FILEPATH
 
   Submit a transaction to the local node whose Unix domain socket is obtained

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_kes-period-info.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_kes-period-info.cli
@@ -1,9 +1,10 @@
-Usage: cardano-cli allegra query kes-period-info --socket-path SOCKET_PATH
+Usage: cardano-cli allegra query kes-period-info 
                                                    [--cardano-mode
                                                      [--epoch-slots SLOTS]]
                                                    ( --mainnet
                                                    | --testnet-magic NATURAL
                                                    )
+                                                   --socket-path SOCKET_PATH
                                                    --op-cert-file FILEPATH
                                                    [--out-file FILEPATH]
 
@@ -11,11 +12,6 @@ Usage: cardano-cli allegra query kes-period-info --socket-path SOCKET_PATH
   certificate.
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -24,6 +20,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --op-cert-file FILEPATH  Filepath of the node's operational certificate.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_leadership-schedule.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_leadership-schedule.cli
@@ -1,9 +1,10 @@
-Usage: cardano-cli allegra query leadership-schedule --socket-path SOCKET_PATH
+Usage: cardano-cli allegra query leadership-schedule 
                                                        [--cardano-mode
                                                          [--epoch-slots SLOTS]]
                                                        ( --mainnet
                                                        | --testnet-magic NATURAL
                                                        )
+                                                       --socket-path SOCKET_PATH
                                                        --genesis FILEPATH
                                                        ( --stake-pool-verification-key STRING
                                                        | --cold-verification-key-file FILEPATH
@@ -19,11 +20,6 @@ Usage: cardano-cli allegra query leadership-schedule --socket-path SOCKET_PATH
   Get the slots the node is expected to mint a block in (advanced command)
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -32,6 +28,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --genesis FILEPATH       Shelley genesis filepath
   --stake-pool-verification-key STRING
                            Stake pool verification key (Bech32 or hex-encoded).

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_ledger-peer-snapshot.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_ledger-peer-snapshot.cli
@@ -1,20 +1,16 @@
-Usage: cardano-cli allegra query ledger-peer-snapshot --socket-path SOCKET_PATH
+Usage: cardano-cli allegra query ledger-peer-snapshot 
                                                         [--cardano-mode
                                                           [--epoch-slots SLOTS]]
                                                         ( --mainnet
                                                         | --testnet-magic NATURAL
                                                         )
+                                                        --socket-path SOCKET_PATH
                                                         [--out-file FILEPATH]
 
   Dump the current snapshot of ledger peers.These are the largest pools that
   cumulatively hold 90% of total stake.
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -23,5 +19,10 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_ledger-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_ledger-state.cli
@@ -1,20 +1,16 @@
-Usage: cardano-cli allegra query ledger-state --socket-path SOCKET_PATH
+Usage: cardano-cli allegra query ledger-state 
                                                 [--cardano-mode
                                                   [--epoch-slots SLOTS]]
                                                 ( --mainnet
                                                 | --testnet-magic NATURAL
                                                 )
+                                                --socket-path SOCKET_PATH
                                                 [--out-file FILEPATH]
 
   Dump the current ledger state of the node (Ledger.NewEpochState -- advanced
   command)
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -23,5 +19,10 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_pool-params.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_pool-params.cli
@@ -1,9 +1,10 @@
-Usage: cardano-cli allegra query pool-params --socket-path SOCKET_PATH
+Usage: cardano-cli allegra query pool-params 
                                                [--cardano-mode
                                                  [--epoch-slots SLOTS]]
                                                ( --mainnet
                                                | --testnet-magic NATURAL
                                                )
+                                               --socket-path SOCKET_PATH
                                                ( --all-stake-pools
                                                | (--stake-pool-id STAKE_POOL_ID)
                                                )
@@ -14,11 +15,6 @@ Usage: cardano-cli allegra query pool-params --socket-path SOCKET_PATH
   command)
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -27,6 +23,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --all-stake-pools        Query for all stake pools
   --stake-pool-id STAKE_POOL_ID
                            Stake pool ID/verification key hash (either

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_pool-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_pool-state.cli
@@ -1,9 +1,10 @@
-Usage: cardano-cli allegra query pool-state --socket-path SOCKET_PATH
+Usage: cardano-cli allegra query pool-state 
                                               [--cardano-mode
                                                 [--epoch-slots SLOTS]]
                                               ( --mainnet
                                               | --testnet-magic NATURAL
                                               )
+                                              --socket-path SOCKET_PATH
                                               ( --all-stake-pools
                                               | (--stake-pool-id STAKE_POOL_ID)
                                               )
@@ -12,11 +13,6 @@ Usage: cardano-cli allegra query pool-state --socket-path SOCKET_PATH
   Dump the pool state
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -25,6 +21,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --all-stake-pools        Query for all stake pools
   --stake-pool-id STAKE_POOL_ID
                            Stake pool ID/verification key hash (either

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_protocol-parameters.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_protocol-parameters.cli
@@ -1,19 +1,15 @@
-Usage: cardano-cli allegra query protocol-parameters --socket-path SOCKET_PATH
+Usage: cardano-cli allegra query protocol-parameters 
                                                        [--cardano-mode
                                                          [--epoch-slots SLOTS]]
                                                        ( --mainnet
                                                        | --testnet-magic NATURAL
                                                        )
+                                                       --socket-path SOCKET_PATH
                                                        [--out-file FILEPATH]
 
   Get the node's current protocol parameters
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -22,5 +18,10 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_protocol-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_protocol-state.cli
@@ -1,20 +1,16 @@
-Usage: cardano-cli allegra query protocol-state --socket-path SOCKET_PATH
+Usage: cardano-cli allegra query protocol-state 
                                                   [--cardano-mode
                                                     [--epoch-slots SLOTS]]
                                                   ( --mainnet
                                                   | --testnet-magic NATURAL
                                                   )
+                                                  --socket-path SOCKET_PATH
                                                   [--out-file FILEPATH]
 
   Dump the current protocol state of the node (Ledger.ChainDepState -- advanced
   command)
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -23,5 +19,10 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_ref-script-size.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_ref-script-size.cli
@@ -1,9 +1,10 @@
-Usage: cardano-cli allegra query ref-script-size --socket-path SOCKET_PATH
+Usage: cardano-cli allegra query ref-script-size 
                                                    [--cardano-mode
                                                      [--epoch-slots SLOTS]]
                                                    ( --mainnet
                                                    | --testnet-magic NATURAL
                                                    )
+                                                   --socket-path SOCKET_PATH
                                                    (--tx-in TX-IN)
                                                    [ --output-json
                                                    | --output-text
@@ -14,11 +15,6 @@ Usage: cardano-cli allegra query ref-script-size --socket-path SOCKET_PATH
   inputs.
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -27,6 +23,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --tx-in TX-IN            Transaction input (TxId#TxIx).
   --output-json            Format reference inputs query output to JSON. Default
                            format when writing to a file

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_slot-number.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_slot-number.cli
@@ -1,19 +1,15 @@
-Usage: cardano-cli allegra query slot-number --socket-path SOCKET_PATH
+Usage: cardano-cli allegra query slot-number 
                                                [--cardano-mode
                                                  [--epoch-slots SLOTS]]
                                                ( --mainnet
                                                | --testnet-magic NATURAL
                                                )
+                                               --socket-path SOCKET_PATH
                                                TIMESTAMP
 
   Query slot number for UTC timestamp
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -22,5 +18,10 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   TIMESTAMP                UTC timestamp in YYYY-MM-DDThh:mm:ssZ format
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_stake-address-info.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_stake-address-info.cli
@@ -1,20 +1,16 @@
-Usage: cardano-cli allegra query stake-address-info --socket-path SOCKET_PATH
+Usage: cardano-cli allegra query stake-address-info 
                                                       [--cardano-mode
                                                         [--epoch-slots SLOTS]]
                                                       ( --mainnet
                                                       | --testnet-magic NATURAL
                                                       )
+                                                      --socket-path SOCKET_PATH
                                                       --address ADDRESS
                                                       [--out-file FILEPATH]
 
   Get the current delegations and reward accounts filtered by stake address.
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -23,6 +19,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --address ADDRESS        Filter by Cardano stake address (Bech32-encoded).
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_stake-distribution.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_stake-distribution.cli
@@ -1,9 +1,10 @@
-Usage: cardano-cli allegra query stake-distribution --socket-path SOCKET_PATH
+Usage: cardano-cli allegra query stake-distribution 
                                                       [--cardano-mode
                                                         [--epoch-slots SLOTS]]
                                                       ( --mainnet
                                                       | --testnet-magic NATURAL
                                                       )
+                                                      --socket-path SOCKET_PATH
                                                       [ --output-json
                                                       | --output-text
                                                       ]
@@ -12,11 +13,6 @@ Usage: cardano-cli allegra query stake-distribution --socket-path SOCKET_PATH
   Get the node's current aggregated stake distribution
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -25,6 +21,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --output-json            Format stake-distribution query output to JSON.
                            Default format when writing to a file
   --output-text            Format stake-distribution query output to TEXT.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_stake-pools.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_stake-pools.cli
@@ -1,20 +1,16 @@
-Usage: cardano-cli allegra query stake-pools --socket-path SOCKET_PATH
+Usage: cardano-cli allegra query stake-pools 
                                                [--cardano-mode
                                                  [--epoch-slots SLOTS]]
                                                ( --mainnet
                                                | --testnet-magic NATURAL
                                                )
+                                               --socket-path SOCKET_PATH
                                                [--output-json | --output-text]
                                                [--out-file FILEPATH]
 
   Get the node's current set of stake pool ids
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -23,6 +19,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --output-json            Format stake-pools query output to JSON. Default
                            format when writing to a file
   --output-text            Format stake-pools query output to TEXT. Default

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_stake-snapshot.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_stake-snapshot.cli
@@ -1,9 +1,10 @@
-Usage: cardano-cli allegra query stake-snapshot --socket-path SOCKET_PATH
+Usage: cardano-cli allegra query stake-snapshot 
                                                   [--cardano-mode
                                                     [--epoch-slots SLOTS]]
                                                   ( --mainnet
                                                   | --testnet-magic NATURAL
                                                   )
+                                                  --socket-path SOCKET_PATH
                                                   ( --all-stake-pools
                                                   | (--stake-pool-id STAKE_POOL_ID)
                                                   )
@@ -13,11 +14,6 @@ Usage: cardano-cli allegra query stake-snapshot --socket-path SOCKET_PATH
   (advanced command)
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -26,6 +22,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --all-stake-pools        Query for all stake pools
   --stake-pool-id STAKE_POOL_ID
                            Stake pool ID/verification key hash (either

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_tip.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_tip.cli
@@ -1,16 +1,11 @@
-Usage: cardano-cli allegra query tip --socket-path SOCKET_PATH
-                                       [--cardano-mode [--epoch-slots SLOTS]]
+Usage: cardano-cli allegra query tip [--cardano-mode [--epoch-slots SLOTS]]
                                        (--mainnet | --testnet-magic NATURAL)
+                                       --socket-path SOCKET_PATH
                                        [--out-file FILEPATH]
 
   Get the node's current tip (slot no, hash, block no)
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -19,5 +14,10 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_tx-mempool.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_tx-mempool.cli
@@ -1,20 +1,16 @@
-Usage: cardano-cli allegra query tx-mempool --socket-path SOCKET_PATH
+Usage: cardano-cli allegra query tx-mempool 
                                               [--cardano-mode
                                                 [--epoch-slots SLOTS]]
                                               ( --mainnet
                                               | --testnet-magic NATURAL
                                               )
+                                              --socket-path SOCKET_PATH
                                               (info | next-tx | tx-exists)
                                               [--out-file FILEPATH]
 
   Local Mempool info
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -23,6 +19,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_tx-mempool_info.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_tx-mempool_info.cli
@@ -1,11 +1,12 @@
-Missing: --socket-path SOCKET_PATH (--mainnet | --testnet-magic NATURAL)
+Missing: (--mainnet | --testnet-magic NATURAL) --socket-path SOCKET_PATH
 
-Usage: cardano-cli allegra query tx-mempool --socket-path SOCKET_PATH
+Usage: cardano-cli allegra query tx-mempool 
                                               [--cardano-mode
                                                 [--epoch-slots SLOTS]]
                                               ( --mainnet
                                               | --testnet-magic NATURAL
                                               )
+                                              --socket-path SOCKET_PATH
                                               (info | next-tx | tx-exists)
                                               [--out-file FILEPATH]
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_tx-mempool_next-tx.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_tx-mempool_next-tx.cli
@@ -1,11 +1,12 @@
-Missing: --socket-path SOCKET_PATH (--mainnet | --testnet-magic NATURAL)
+Missing: (--mainnet | --testnet-magic NATURAL) --socket-path SOCKET_PATH
 
-Usage: cardano-cli allegra query tx-mempool --socket-path SOCKET_PATH
+Usage: cardano-cli allegra query tx-mempool 
                                               [--cardano-mode
                                                 [--epoch-slots SLOTS]]
                                               ( --mainnet
                                               | --testnet-magic NATURAL
                                               )
+                                              --socket-path SOCKET_PATH
                                               (info | next-tx | tx-exists)
                                               [--out-file FILEPATH]
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_tx-mempool_tx-exists_TX_ID.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_tx-mempool_tx-exists_TX_ID.cli
@@ -1,11 +1,12 @@
-Missing: --socket-path SOCKET_PATH (--mainnet | --testnet-magic NATURAL)
+Missing: (--mainnet | --testnet-magic NATURAL) --socket-path SOCKET_PATH
 
-Usage: cardano-cli allegra query tx-mempool --socket-path SOCKET_PATH
+Usage: cardano-cli allegra query tx-mempool 
                                               [--cardano-mode
                                                 [--epoch-slots SLOTS]]
                                               ( --mainnet
                                               | --testnet-magic NATURAL
                                               )
+                                              --socket-path SOCKET_PATH
                                               (info | next-tx | tx-exists)
                                               [--out-file FILEPATH]
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_utxo.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_utxo.cli
@@ -1,6 +1,6 @@
-Usage: cardano-cli allegra query utxo --socket-path SOCKET_PATH
-                                        [--cardano-mode [--epoch-slots SLOTS]]
+Usage: cardano-cli allegra query utxo [--cardano-mode [--epoch-slots SLOTS]]
                                         (--mainnet | --testnet-magic NATURAL)
+                                        --socket-path SOCKET_PATH
                                         ( --whole-utxo
                                         | (--address ADDRESS)
                                         | (--tx-in TX-IN)
@@ -11,11 +11,6 @@ Usage: cardano-cli allegra query utxo --socket-path SOCKET_PATH
   Get a portion of the current UTxO: by tx in, by address or the whole.
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -24,6 +19,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --whole-utxo             Return the whole UTxO (only appropriate on small
                            testnets).
   --address ADDRESS        Filter by Cardano address(es) (Bech32-encoded).

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_transaction_submit.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_transaction_submit.cli
@@ -1,20 +1,16 @@
-Usage: cardano-cli allegra transaction submit --socket-path SOCKET_PATH
+Usage: cardano-cli allegra transaction submit 
                                                 [--cardano-mode
                                                   [--epoch-slots SLOTS]]
                                                 ( --mainnet
                                                 | --testnet-magic NATURAL
                                                 )
+                                                --socket-path SOCKET_PATH
                                                 --tx-file FILEPATH
 
   Submit a transaction to the local node whose Unix domain socket is obtained
   from the CARDANO_NODE_SOCKET_PATH environment variable.
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -23,5 +19,10 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --tx-file FILEPATH       Filepath of the transaction you intend to submit.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_kes-period-info.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_kes-period-info.cli
@@ -1,9 +1,10 @@
-Usage: cardano-cli alonzo query kes-period-info --socket-path SOCKET_PATH
+Usage: cardano-cli alonzo query kes-period-info 
                                                   [--cardano-mode
                                                     [--epoch-slots SLOTS]]
                                                   ( --mainnet
                                                   | --testnet-magic NATURAL
                                                   )
+                                                  --socket-path SOCKET_PATH
                                                   --op-cert-file FILEPATH
                                                   [--out-file FILEPATH]
 
@@ -11,11 +12,6 @@ Usage: cardano-cli alonzo query kes-period-info --socket-path SOCKET_PATH
   certificate.
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -24,6 +20,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --op-cert-file FILEPATH  Filepath of the node's operational certificate.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_leadership-schedule.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_leadership-schedule.cli
@@ -1,9 +1,10 @@
-Usage: cardano-cli alonzo query leadership-schedule --socket-path SOCKET_PATH
+Usage: cardano-cli alonzo query leadership-schedule 
                                                       [--cardano-mode
                                                         [--epoch-slots SLOTS]]
                                                       ( --mainnet
                                                       | --testnet-magic NATURAL
                                                       )
+                                                      --socket-path SOCKET_PATH
                                                       --genesis FILEPATH
                                                       ( --stake-pool-verification-key STRING
                                                       | --cold-verification-key-file FILEPATH
@@ -19,11 +20,6 @@ Usage: cardano-cli alonzo query leadership-schedule --socket-path SOCKET_PATH
   Get the slots the node is expected to mint a block in (advanced command)
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -32,6 +28,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --genesis FILEPATH       Shelley genesis filepath
   --stake-pool-verification-key STRING
                            Stake pool verification key (Bech32 or hex-encoded).

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_ledger-peer-snapshot.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_ledger-peer-snapshot.cli
@@ -1,20 +1,16 @@
-Usage: cardano-cli alonzo query ledger-peer-snapshot --socket-path SOCKET_PATH
+Usage: cardano-cli alonzo query ledger-peer-snapshot 
                                                        [--cardano-mode
                                                          [--epoch-slots SLOTS]]
                                                        ( --mainnet
                                                        | --testnet-magic NATURAL
                                                        )
+                                                       --socket-path SOCKET_PATH
                                                        [--out-file FILEPATH]
 
   Dump the current snapshot of ledger peers.These are the largest pools that
   cumulatively hold 90% of total stake.
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -23,5 +19,10 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_ledger-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_ledger-state.cli
@@ -1,20 +1,16 @@
-Usage: cardano-cli alonzo query ledger-state --socket-path SOCKET_PATH
+Usage: cardano-cli alonzo query ledger-state 
                                                [--cardano-mode
                                                  [--epoch-slots SLOTS]]
                                                ( --mainnet
                                                | --testnet-magic NATURAL
                                                )
+                                               --socket-path SOCKET_PATH
                                                [--out-file FILEPATH]
 
   Dump the current ledger state of the node (Ledger.NewEpochState -- advanced
   command)
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -23,5 +19,10 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_pool-params.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_pool-params.cli
@@ -1,9 +1,10 @@
-Usage: cardano-cli alonzo query pool-params --socket-path SOCKET_PATH
+Usage: cardano-cli alonzo query pool-params 
                                               [--cardano-mode
                                                 [--epoch-slots SLOTS]]
                                               ( --mainnet
                                               | --testnet-magic NATURAL
                                               )
+                                              --socket-path SOCKET_PATH
                                               ( --all-stake-pools
                                               | (--stake-pool-id STAKE_POOL_ID)
                                               )
@@ -14,11 +15,6 @@ Usage: cardano-cli alonzo query pool-params --socket-path SOCKET_PATH
   command)
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -27,6 +23,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --all-stake-pools        Query for all stake pools
   --stake-pool-id STAKE_POOL_ID
                            Stake pool ID/verification key hash (either

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_pool-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_pool-state.cli
@@ -1,9 +1,10 @@
-Usage: cardano-cli alonzo query pool-state --socket-path SOCKET_PATH
+Usage: cardano-cli alonzo query pool-state 
                                              [--cardano-mode
                                                [--epoch-slots SLOTS]]
                                              ( --mainnet
                                              | --testnet-magic NATURAL
                                              )
+                                             --socket-path SOCKET_PATH
                                              ( --all-stake-pools
                                              | (--stake-pool-id STAKE_POOL_ID)
                                              )
@@ -12,11 +13,6 @@ Usage: cardano-cli alonzo query pool-state --socket-path SOCKET_PATH
   Dump the pool state
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -25,6 +21,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --all-stake-pools        Query for all stake pools
   --stake-pool-id STAKE_POOL_ID
                            Stake pool ID/verification key hash (either

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_protocol-parameters.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_protocol-parameters.cli
@@ -1,19 +1,15 @@
-Usage: cardano-cli alonzo query protocol-parameters --socket-path SOCKET_PATH
+Usage: cardano-cli alonzo query protocol-parameters 
                                                       [--cardano-mode
                                                         [--epoch-slots SLOTS]]
                                                       ( --mainnet
                                                       | --testnet-magic NATURAL
                                                       )
+                                                      --socket-path SOCKET_PATH
                                                       [--out-file FILEPATH]
 
   Get the node's current protocol parameters
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -22,5 +18,10 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_protocol-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_protocol-state.cli
@@ -1,20 +1,16 @@
-Usage: cardano-cli alonzo query protocol-state --socket-path SOCKET_PATH
+Usage: cardano-cli alonzo query protocol-state 
                                                  [--cardano-mode
                                                    [--epoch-slots SLOTS]]
                                                  ( --mainnet
                                                  | --testnet-magic NATURAL
                                                  )
+                                                 --socket-path SOCKET_PATH
                                                  [--out-file FILEPATH]
 
   Dump the current protocol state of the node (Ledger.ChainDepState -- advanced
   command)
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -23,5 +19,10 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_ref-script-size.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_ref-script-size.cli
@@ -1,9 +1,10 @@
-Usage: cardano-cli alonzo query ref-script-size --socket-path SOCKET_PATH
+Usage: cardano-cli alonzo query ref-script-size 
                                                   [--cardano-mode
                                                     [--epoch-slots SLOTS]]
                                                   ( --mainnet
                                                   | --testnet-magic NATURAL
                                                   )
+                                                  --socket-path SOCKET_PATH
                                                   (--tx-in TX-IN)
                                                   [ --output-json
                                                   | --output-text
@@ -14,11 +15,6 @@ Usage: cardano-cli alonzo query ref-script-size --socket-path SOCKET_PATH
   inputs.
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -27,6 +23,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --tx-in TX-IN            Transaction input (TxId#TxIx).
   --output-json            Format reference inputs query output to JSON. Default
                            format when writing to a file

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_slot-number.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_slot-number.cli
@@ -1,19 +1,15 @@
-Usage: cardano-cli alonzo query slot-number --socket-path SOCKET_PATH
+Usage: cardano-cli alonzo query slot-number 
                                               [--cardano-mode
                                                 [--epoch-slots SLOTS]]
                                               ( --mainnet
                                               | --testnet-magic NATURAL
                                               )
+                                              --socket-path SOCKET_PATH
                                               TIMESTAMP
 
   Query slot number for UTC timestamp
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -22,5 +18,10 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   TIMESTAMP                UTC timestamp in YYYY-MM-DDThh:mm:ssZ format
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_stake-address-info.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_stake-address-info.cli
@@ -1,20 +1,16 @@
-Usage: cardano-cli alonzo query stake-address-info --socket-path SOCKET_PATH
+Usage: cardano-cli alonzo query stake-address-info 
                                                      [--cardano-mode
                                                        [--epoch-slots SLOTS]]
                                                      ( --mainnet
                                                      | --testnet-magic NATURAL
                                                      )
+                                                     --socket-path SOCKET_PATH
                                                      --address ADDRESS
                                                      [--out-file FILEPATH]
 
   Get the current delegations and reward accounts filtered by stake address.
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -23,6 +19,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --address ADDRESS        Filter by Cardano stake address (Bech32-encoded).
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_stake-distribution.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_stake-distribution.cli
@@ -1,9 +1,10 @@
-Usage: cardano-cli alonzo query stake-distribution --socket-path SOCKET_PATH
+Usage: cardano-cli alonzo query stake-distribution 
                                                      [--cardano-mode
                                                        [--epoch-slots SLOTS]]
                                                      ( --mainnet
                                                      | --testnet-magic NATURAL
                                                      )
+                                                     --socket-path SOCKET_PATH
                                                      [ --output-json
                                                      | --output-text
                                                      ]
@@ -12,11 +13,6 @@ Usage: cardano-cli alonzo query stake-distribution --socket-path SOCKET_PATH
   Get the node's current aggregated stake distribution
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -25,6 +21,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --output-json            Format stake-distribution query output to JSON.
                            Default format when writing to a file
   --output-text            Format stake-distribution query output to TEXT.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_stake-pools.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_stake-pools.cli
@@ -1,20 +1,16 @@
-Usage: cardano-cli alonzo query stake-pools --socket-path SOCKET_PATH
+Usage: cardano-cli alonzo query stake-pools 
                                               [--cardano-mode
                                                 [--epoch-slots SLOTS]]
                                               ( --mainnet
                                               | --testnet-magic NATURAL
                                               )
+                                              --socket-path SOCKET_PATH
                                               [--output-json | --output-text]
                                               [--out-file FILEPATH]
 
   Get the node's current set of stake pool ids
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -23,6 +19,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --output-json            Format stake-pools query output to JSON. Default
                            format when writing to a file
   --output-text            Format stake-pools query output to TEXT. Default

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_stake-snapshot.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_stake-snapshot.cli
@@ -1,9 +1,10 @@
-Usage: cardano-cli alonzo query stake-snapshot --socket-path SOCKET_PATH
+Usage: cardano-cli alonzo query stake-snapshot 
                                                  [--cardano-mode
                                                    [--epoch-slots SLOTS]]
                                                  ( --mainnet
                                                  | --testnet-magic NATURAL
                                                  )
+                                                 --socket-path SOCKET_PATH
                                                  ( --all-stake-pools
                                                  | (--stake-pool-id STAKE_POOL_ID)
                                                  )
@@ -13,11 +14,6 @@ Usage: cardano-cli alonzo query stake-snapshot --socket-path SOCKET_PATH
   (advanced command)
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -26,6 +22,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --all-stake-pools        Query for all stake pools
   --stake-pool-id STAKE_POOL_ID
                            Stake pool ID/verification key hash (either

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_tip.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_tip.cli
@@ -1,16 +1,11 @@
-Usage: cardano-cli alonzo query tip --socket-path SOCKET_PATH
-                                      [--cardano-mode [--epoch-slots SLOTS]]
+Usage: cardano-cli alonzo query tip [--cardano-mode [--epoch-slots SLOTS]]
                                       (--mainnet | --testnet-magic NATURAL)
+                                      --socket-path SOCKET_PATH
                                       [--out-file FILEPATH]
 
   Get the node's current tip (slot no, hash, block no)
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -19,5 +14,10 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_tx-mempool.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_tx-mempool.cli
@@ -1,20 +1,16 @@
-Usage: cardano-cli alonzo query tx-mempool --socket-path SOCKET_PATH
+Usage: cardano-cli alonzo query tx-mempool 
                                              [--cardano-mode
                                                [--epoch-slots SLOTS]]
                                              ( --mainnet
                                              | --testnet-magic NATURAL
                                              )
+                                             --socket-path SOCKET_PATH
                                              (info | next-tx | tx-exists)
                                              [--out-file FILEPATH]
 
   Local Mempool info
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -23,6 +19,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_tx-mempool_info.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_tx-mempool_info.cli
@@ -1,11 +1,12 @@
-Missing: --socket-path SOCKET_PATH (--mainnet | --testnet-magic NATURAL)
+Missing: (--mainnet | --testnet-magic NATURAL) --socket-path SOCKET_PATH
 
-Usage: cardano-cli alonzo query tx-mempool --socket-path SOCKET_PATH
+Usage: cardano-cli alonzo query tx-mempool 
                                              [--cardano-mode
                                                [--epoch-slots SLOTS]]
                                              ( --mainnet
                                              | --testnet-magic NATURAL
                                              )
+                                             --socket-path SOCKET_PATH
                                              (info | next-tx | tx-exists)
                                              [--out-file FILEPATH]
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_tx-mempool_next-tx.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_tx-mempool_next-tx.cli
@@ -1,11 +1,12 @@
-Missing: --socket-path SOCKET_PATH (--mainnet | --testnet-magic NATURAL)
+Missing: (--mainnet | --testnet-magic NATURAL) --socket-path SOCKET_PATH
 
-Usage: cardano-cli alonzo query tx-mempool --socket-path SOCKET_PATH
+Usage: cardano-cli alonzo query tx-mempool 
                                              [--cardano-mode
                                                [--epoch-slots SLOTS]]
                                              ( --mainnet
                                              | --testnet-magic NATURAL
                                              )
+                                             --socket-path SOCKET_PATH
                                              (info | next-tx | tx-exists)
                                              [--out-file FILEPATH]
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_tx-mempool_tx-exists_TX_ID.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_tx-mempool_tx-exists_TX_ID.cli
@@ -1,11 +1,12 @@
-Missing: --socket-path SOCKET_PATH (--mainnet | --testnet-magic NATURAL)
+Missing: (--mainnet | --testnet-magic NATURAL) --socket-path SOCKET_PATH
 
-Usage: cardano-cli alonzo query tx-mempool --socket-path SOCKET_PATH
+Usage: cardano-cli alonzo query tx-mempool 
                                              [--cardano-mode
                                                [--epoch-slots SLOTS]]
                                              ( --mainnet
                                              | --testnet-magic NATURAL
                                              )
+                                             --socket-path SOCKET_PATH
                                              (info | next-tx | tx-exists)
                                              [--out-file FILEPATH]
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_utxo.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_utxo.cli
@@ -1,6 +1,6 @@
-Usage: cardano-cli alonzo query utxo --socket-path SOCKET_PATH
-                                       [--cardano-mode [--epoch-slots SLOTS]]
+Usage: cardano-cli alonzo query utxo [--cardano-mode [--epoch-slots SLOTS]]
                                        (--mainnet | --testnet-magic NATURAL)
+                                       --socket-path SOCKET_PATH
                                        ( --whole-utxo
                                        | (--address ADDRESS)
                                        | (--tx-in TX-IN)
@@ -11,11 +11,6 @@ Usage: cardano-cli alonzo query utxo --socket-path SOCKET_PATH
   Get a portion of the current UTxO: by tx in, by address or the whole.
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -24,6 +19,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --whole-utxo             Return the whole UTxO (only appropriate on small
                            testnets).
   --address ADDRESS        Filter by Cardano address(es) (Bech32-encoded).

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_transaction_submit.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_transaction_submit.cli
@@ -1,20 +1,16 @@
-Usage: cardano-cli alonzo transaction submit --socket-path SOCKET_PATH
+Usage: cardano-cli alonzo transaction submit 
                                                [--cardano-mode
                                                  [--epoch-slots SLOTS]]
                                                ( --mainnet
                                                | --testnet-magic NATURAL
                                                )
+                                               --socket-path SOCKET_PATH
                                                --tx-file FILEPATH
 
   Submit a transaction to the local node whose Unix domain socket is obtained
   from the CARDANO_NODE_SOCKET_PATH environment variable.
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -23,5 +19,10 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --tx-file FILEPATH       Filepath of the transaction you intend to submit.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_kes-period-info.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_kes-period-info.cli
@@ -1,9 +1,10 @@
-Usage: cardano-cli babbage query kes-period-info --socket-path SOCKET_PATH
+Usage: cardano-cli babbage query kes-period-info 
                                                    [--cardano-mode
                                                      [--epoch-slots SLOTS]]
                                                    ( --mainnet
                                                    | --testnet-magic NATURAL
                                                    )
+                                                   --socket-path SOCKET_PATH
                                                    --op-cert-file FILEPATH
                                                    [--out-file FILEPATH]
 
@@ -11,11 +12,6 @@ Usage: cardano-cli babbage query kes-period-info --socket-path SOCKET_PATH
   certificate.
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -24,6 +20,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --op-cert-file FILEPATH  Filepath of the node's operational certificate.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_leadership-schedule.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_leadership-schedule.cli
@@ -1,9 +1,10 @@
-Usage: cardano-cli babbage query leadership-schedule --socket-path SOCKET_PATH
+Usage: cardano-cli babbage query leadership-schedule 
                                                        [--cardano-mode
                                                          [--epoch-slots SLOTS]]
                                                        ( --mainnet
                                                        | --testnet-magic NATURAL
                                                        )
+                                                       --socket-path SOCKET_PATH
                                                        --genesis FILEPATH
                                                        ( --stake-pool-verification-key STRING
                                                        | --cold-verification-key-file FILEPATH
@@ -19,11 +20,6 @@ Usage: cardano-cli babbage query leadership-schedule --socket-path SOCKET_PATH
   Get the slots the node is expected to mint a block in (advanced command)
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -32,6 +28,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --genesis FILEPATH       Shelley genesis filepath
   --stake-pool-verification-key STRING
                            Stake pool verification key (Bech32 or hex-encoded).

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_ledger-peer-snapshot.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_ledger-peer-snapshot.cli
@@ -1,20 +1,16 @@
-Usage: cardano-cli babbage query ledger-peer-snapshot --socket-path SOCKET_PATH
+Usage: cardano-cli babbage query ledger-peer-snapshot 
                                                         [--cardano-mode
                                                           [--epoch-slots SLOTS]]
                                                         ( --mainnet
                                                         | --testnet-magic NATURAL
                                                         )
+                                                        --socket-path SOCKET_PATH
                                                         [--out-file FILEPATH]
 
   Dump the current snapshot of ledger peers.These are the largest pools that
   cumulatively hold 90% of total stake.
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -23,5 +19,10 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_ledger-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_ledger-state.cli
@@ -1,20 +1,16 @@
-Usage: cardano-cli babbage query ledger-state --socket-path SOCKET_PATH
+Usage: cardano-cli babbage query ledger-state 
                                                 [--cardano-mode
                                                   [--epoch-slots SLOTS]]
                                                 ( --mainnet
                                                 | --testnet-magic NATURAL
                                                 )
+                                                --socket-path SOCKET_PATH
                                                 [--out-file FILEPATH]
 
   Dump the current ledger state of the node (Ledger.NewEpochState -- advanced
   command)
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -23,5 +19,10 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_pool-params.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_pool-params.cli
@@ -1,9 +1,10 @@
-Usage: cardano-cli babbage query pool-params --socket-path SOCKET_PATH
+Usage: cardano-cli babbage query pool-params 
                                                [--cardano-mode
                                                  [--epoch-slots SLOTS]]
                                                ( --mainnet
                                                | --testnet-magic NATURAL
                                                )
+                                               --socket-path SOCKET_PATH
                                                ( --all-stake-pools
                                                | (--stake-pool-id STAKE_POOL_ID)
                                                )
@@ -14,11 +15,6 @@ Usage: cardano-cli babbage query pool-params --socket-path SOCKET_PATH
   command)
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -27,6 +23,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --all-stake-pools        Query for all stake pools
   --stake-pool-id STAKE_POOL_ID
                            Stake pool ID/verification key hash (either

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_pool-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_pool-state.cli
@@ -1,9 +1,10 @@
-Usage: cardano-cli babbage query pool-state --socket-path SOCKET_PATH
+Usage: cardano-cli babbage query pool-state 
                                               [--cardano-mode
                                                 [--epoch-slots SLOTS]]
                                               ( --mainnet
                                               | --testnet-magic NATURAL
                                               )
+                                              --socket-path SOCKET_PATH
                                               ( --all-stake-pools
                                               | (--stake-pool-id STAKE_POOL_ID)
                                               )
@@ -12,11 +13,6 @@ Usage: cardano-cli babbage query pool-state --socket-path SOCKET_PATH
   Dump the pool state
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -25,6 +21,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --all-stake-pools        Query for all stake pools
   --stake-pool-id STAKE_POOL_ID
                            Stake pool ID/verification key hash (either

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_protocol-parameters.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_protocol-parameters.cli
@@ -1,19 +1,15 @@
-Usage: cardano-cli babbage query protocol-parameters --socket-path SOCKET_PATH
+Usage: cardano-cli babbage query protocol-parameters 
                                                        [--cardano-mode
                                                          [--epoch-slots SLOTS]]
                                                        ( --mainnet
                                                        | --testnet-magic NATURAL
                                                        )
+                                                       --socket-path SOCKET_PATH
                                                        [--out-file FILEPATH]
 
   Get the node's current protocol parameters
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -22,5 +18,10 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_protocol-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_protocol-state.cli
@@ -1,20 +1,16 @@
-Usage: cardano-cli babbage query protocol-state --socket-path SOCKET_PATH
+Usage: cardano-cli babbage query protocol-state 
                                                   [--cardano-mode
                                                     [--epoch-slots SLOTS]]
                                                   ( --mainnet
                                                   | --testnet-magic NATURAL
                                                   )
+                                                  --socket-path SOCKET_PATH
                                                   [--out-file FILEPATH]
 
   Dump the current protocol state of the node (Ledger.ChainDepState -- advanced
   command)
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -23,5 +19,10 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_ref-script-size.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_ref-script-size.cli
@@ -1,9 +1,10 @@
-Usage: cardano-cli babbage query ref-script-size --socket-path SOCKET_PATH
+Usage: cardano-cli babbage query ref-script-size 
                                                    [--cardano-mode
                                                      [--epoch-slots SLOTS]]
                                                    ( --mainnet
                                                    | --testnet-magic NATURAL
                                                    )
+                                                   --socket-path SOCKET_PATH
                                                    (--tx-in TX-IN)
                                                    [ --output-json
                                                    | --output-text
@@ -14,11 +15,6 @@ Usage: cardano-cli babbage query ref-script-size --socket-path SOCKET_PATH
   inputs.
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -27,6 +23,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --tx-in TX-IN            Transaction input (TxId#TxIx).
   --output-json            Format reference inputs query output to JSON. Default
                            format when writing to a file

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_slot-number.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_slot-number.cli
@@ -1,19 +1,15 @@
-Usage: cardano-cli babbage query slot-number --socket-path SOCKET_PATH
+Usage: cardano-cli babbage query slot-number 
                                                [--cardano-mode
                                                  [--epoch-slots SLOTS]]
                                                ( --mainnet
                                                | --testnet-magic NATURAL
                                                )
+                                               --socket-path SOCKET_PATH
                                                TIMESTAMP
 
   Query slot number for UTC timestamp
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -22,5 +18,10 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   TIMESTAMP                UTC timestamp in YYYY-MM-DDThh:mm:ssZ format
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_stake-address-info.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_stake-address-info.cli
@@ -1,20 +1,16 @@
-Usage: cardano-cli babbage query stake-address-info --socket-path SOCKET_PATH
+Usage: cardano-cli babbage query stake-address-info 
                                                       [--cardano-mode
                                                         [--epoch-slots SLOTS]]
                                                       ( --mainnet
                                                       | --testnet-magic NATURAL
                                                       )
+                                                      --socket-path SOCKET_PATH
                                                       --address ADDRESS
                                                       [--out-file FILEPATH]
 
   Get the current delegations and reward accounts filtered by stake address.
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -23,6 +19,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --address ADDRESS        Filter by Cardano stake address (Bech32-encoded).
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_stake-distribution.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_stake-distribution.cli
@@ -1,9 +1,10 @@
-Usage: cardano-cli babbage query stake-distribution --socket-path SOCKET_PATH
+Usage: cardano-cli babbage query stake-distribution 
                                                       [--cardano-mode
                                                         [--epoch-slots SLOTS]]
                                                       ( --mainnet
                                                       | --testnet-magic NATURAL
                                                       )
+                                                      --socket-path SOCKET_PATH
                                                       [ --output-json
                                                       | --output-text
                                                       ]
@@ -12,11 +13,6 @@ Usage: cardano-cli babbage query stake-distribution --socket-path SOCKET_PATH
   Get the node's current aggregated stake distribution
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -25,6 +21,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --output-json            Format stake-distribution query output to JSON.
                            Default format when writing to a file
   --output-text            Format stake-distribution query output to TEXT.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_stake-pools.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_stake-pools.cli
@@ -1,20 +1,16 @@
-Usage: cardano-cli babbage query stake-pools --socket-path SOCKET_PATH
+Usage: cardano-cli babbage query stake-pools 
                                                [--cardano-mode
                                                  [--epoch-slots SLOTS]]
                                                ( --mainnet
                                                | --testnet-magic NATURAL
                                                )
+                                               --socket-path SOCKET_PATH
                                                [--output-json | --output-text]
                                                [--out-file FILEPATH]
 
   Get the node's current set of stake pool ids
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -23,6 +19,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --output-json            Format stake-pools query output to JSON. Default
                            format when writing to a file
   --output-text            Format stake-pools query output to TEXT. Default

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_stake-snapshot.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_stake-snapshot.cli
@@ -1,9 +1,10 @@
-Usage: cardano-cli babbage query stake-snapshot --socket-path SOCKET_PATH
+Usage: cardano-cli babbage query stake-snapshot 
                                                   [--cardano-mode
                                                     [--epoch-slots SLOTS]]
                                                   ( --mainnet
                                                   | --testnet-magic NATURAL
                                                   )
+                                                  --socket-path SOCKET_PATH
                                                   ( --all-stake-pools
                                                   | (--stake-pool-id STAKE_POOL_ID)
                                                   )
@@ -13,11 +14,6 @@ Usage: cardano-cli babbage query stake-snapshot --socket-path SOCKET_PATH
   (advanced command)
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -26,6 +22,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --all-stake-pools        Query for all stake pools
   --stake-pool-id STAKE_POOL_ID
                            Stake pool ID/verification key hash (either

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_tip.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_tip.cli
@@ -1,16 +1,11 @@
-Usage: cardano-cli babbage query tip --socket-path SOCKET_PATH
-                                       [--cardano-mode [--epoch-slots SLOTS]]
+Usage: cardano-cli babbage query tip [--cardano-mode [--epoch-slots SLOTS]]
                                        (--mainnet | --testnet-magic NATURAL)
+                                       --socket-path SOCKET_PATH
                                        [--out-file FILEPATH]
 
   Get the node's current tip (slot no, hash, block no)
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -19,5 +14,10 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_tx-mempool.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_tx-mempool.cli
@@ -1,20 +1,16 @@
-Usage: cardano-cli babbage query tx-mempool --socket-path SOCKET_PATH
+Usage: cardano-cli babbage query tx-mempool 
                                               [--cardano-mode
                                                 [--epoch-slots SLOTS]]
                                               ( --mainnet
                                               | --testnet-magic NATURAL
                                               )
+                                              --socket-path SOCKET_PATH
                                               (info | next-tx | tx-exists)
                                               [--out-file FILEPATH]
 
   Local Mempool info
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -23,6 +19,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_tx-mempool_info.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_tx-mempool_info.cli
@@ -1,11 +1,12 @@
-Missing: --socket-path SOCKET_PATH (--mainnet | --testnet-magic NATURAL)
+Missing: (--mainnet | --testnet-magic NATURAL) --socket-path SOCKET_PATH
 
-Usage: cardano-cli babbage query tx-mempool --socket-path SOCKET_PATH
+Usage: cardano-cli babbage query tx-mempool 
                                               [--cardano-mode
                                                 [--epoch-slots SLOTS]]
                                               ( --mainnet
                                               | --testnet-magic NATURAL
                                               )
+                                              --socket-path SOCKET_PATH
                                               (info | next-tx | tx-exists)
                                               [--out-file FILEPATH]
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_tx-mempool_next-tx.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_tx-mempool_next-tx.cli
@@ -1,11 +1,12 @@
-Missing: --socket-path SOCKET_PATH (--mainnet | --testnet-magic NATURAL)
+Missing: (--mainnet | --testnet-magic NATURAL) --socket-path SOCKET_PATH
 
-Usage: cardano-cli babbage query tx-mempool --socket-path SOCKET_PATH
+Usage: cardano-cli babbage query tx-mempool 
                                               [--cardano-mode
                                                 [--epoch-slots SLOTS]]
                                               ( --mainnet
                                               | --testnet-magic NATURAL
                                               )
+                                              --socket-path SOCKET_PATH
                                               (info | next-tx | tx-exists)
                                               [--out-file FILEPATH]
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_tx-mempool_tx-exists_TX_ID.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_tx-mempool_tx-exists_TX_ID.cli
@@ -1,11 +1,12 @@
-Missing: --socket-path SOCKET_PATH (--mainnet | --testnet-magic NATURAL)
+Missing: (--mainnet | --testnet-magic NATURAL) --socket-path SOCKET_PATH
 
-Usage: cardano-cli babbage query tx-mempool --socket-path SOCKET_PATH
+Usage: cardano-cli babbage query tx-mempool 
                                               [--cardano-mode
                                                 [--epoch-slots SLOTS]]
                                               ( --mainnet
                                               | --testnet-magic NATURAL
                                               )
+                                              --socket-path SOCKET_PATH
                                               (info | next-tx | tx-exists)
                                               [--out-file FILEPATH]
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_utxo.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_utxo.cli
@@ -1,6 +1,6 @@
-Usage: cardano-cli babbage query utxo --socket-path SOCKET_PATH
-                                        [--cardano-mode [--epoch-slots SLOTS]]
+Usage: cardano-cli babbage query utxo [--cardano-mode [--epoch-slots SLOTS]]
                                         (--mainnet | --testnet-magic NATURAL)
+                                        --socket-path SOCKET_PATH
                                         ( --whole-utxo
                                         | (--address ADDRESS)
                                         | (--tx-in TX-IN)
@@ -11,11 +11,6 @@ Usage: cardano-cli babbage query utxo --socket-path SOCKET_PATH
   Get a portion of the current UTxO: by tx in, by address or the whole.
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -24,6 +19,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --whole-utxo             Return the whole UTxO (only appropriate on small
                            testnets).
   --address ADDRESS        Filter by Cardano address(es) (Bech32-encoded).

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_transaction_build.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_transaction_build.cli
@@ -1,9 +1,10 @@
-Usage: cardano-cli babbage transaction build --socket-path SOCKET_PATH
+Usage: cardano-cli babbage transaction build 
                                                [--cardano-mode
                                                  [--epoch-slots SLOTS]]
                                                ( --mainnet
                                                | --testnet-magic NATURAL
                                                )
+                                               --socket-path SOCKET_PATH
                                                [ --script-valid
                                                | --script-invalid
                                                ]
@@ -123,11 +124,6 @@ Usage: cardano-cli babbage transaction build --socket-path SOCKET_PATH
   Please note the order[93;22;23;24m of some cmd options is crucial. If used incorrectly may produce undesired tx body. See nested [] notation above for details.[0;22;23;24m
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -136,6 +132,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --script-valid           Assertion that the script is valid. (default)
   --script-invalid         Assertion that the script is invalid. If a
                            transaction is submitted with such a script, the

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_transaction_submit.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_transaction_submit.cli
@@ -1,20 +1,16 @@
-Usage: cardano-cli babbage transaction submit --socket-path SOCKET_PATH
+Usage: cardano-cli babbage transaction submit 
                                                 [--cardano-mode
                                                   [--epoch-slots SLOTS]]
                                                 ( --mainnet
                                                 | --testnet-magic NATURAL
                                                 )
+                                                --socket-path SOCKET_PATH
                                                 --tx-file FILEPATH
 
   Submit a transaction to the local node whose Unix domain socket is obtained
   from the CARDANO_NODE_SOCKET_PATH environment variable.
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -23,5 +19,10 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --tx-file FILEPATH       Filepath of the transaction you intend to submit.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_committee-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_committee-state.cli
@@ -1,9 +1,10 @@
-Usage: cardano-cli conway query committee-state --socket-path SOCKET_PATH
+Usage: cardano-cli conway query committee-state 
                                                   [--cardano-mode
                                                     [--epoch-slots SLOTS]]
                                                   ( --mainnet
                                                   | --testnet-magic NATURAL
                                                   )
+                                                  --socket-path SOCKET_PATH
                                                   [ --volatile-tip
                                                   | --immutable-tip
                                                   ]
@@ -26,11 +27,6 @@ Usage: cardano-cli conway query committee-state --socket-path SOCKET_PATH
   Get the committee state
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -39,6 +35,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_constitution.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_constitution.cli
@@ -1,9 +1,10 @@
-Usage: cardano-cli conway query constitution --socket-path SOCKET_PATH
+Usage: cardano-cli conway query constitution 
                                                [--cardano-mode
                                                  [--epoch-slots SLOTS]]
                                                ( --mainnet
                                                | --testnet-magic NATURAL
                                                )
+                                               --socket-path SOCKET_PATH
                                                [ --volatile-tip
                                                | --immutable-tip
                                                ]
@@ -12,11 +13,6 @@ Usage: cardano-cli conway query constitution --socket-path SOCKET_PATH
   Get the constitution
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -25,6 +21,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_drep-stake-distribution.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_drep-stake-distribution.cli
@@ -1,10 +1,10 @@
 Usage: cardano-cli conway query drep-stake-distribution 
-                                                          --socket-path SOCKET_PATH
                                                           [--cardano-mode
                                                             [--epoch-slots SLOTS]]
                                                           ( --mainnet
                                                           | --testnet-magic NATURAL
                                                           )
+                                                          --socket-path SOCKET_PATH
                                                           [ --volatile-tip
                                                           | --immutable-tip
                                                           ]
@@ -21,11 +21,6 @@ Usage: cardano-cli conway query drep-stake-distribution
   Get the DRep stake distribution.
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -34,6 +29,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_drep-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_drep-state.cli
@@ -1,9 +1,10 @@
-Usage: cardano-cli conway query drep-state --socket-path SOCKET_PATH
+Usage: cardano-cli conway query drep-state 
                                              [--cardano-mode
                                                [--epoch-slots SLOTS]]
                                              ( --mainnet
                                              | --testnet-magic NATURAL
                                              )
+                                             --socket-path SOCKET_PATH
                                              [--volatile-tip | --immutable-tip]
                                              ( --all-dreps
                                              | 
@@ -19,11 +20,6 @@ Usage: cardano-cli conway query drep-state --socket-path SOCKET_PATH
   Get the DRep state.
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -32,6 +28,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_gov-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_gov-state.cli
@@ -1,20 +1,14 @@
-Usage: cardano-cli conway query gov-state --socket-path SOCKET_PATH
-                                            [--cardano-mode
-                                              [--epoch-slots SLOTS]]
+Usage: cardano-cli conway query gov-state [--cardano-mode [--epoch-slots SLOTS]]
                                             ( --mainnet
                                             | --testnet-magic NATURAL
                                             )
+                                            --socket-path SOCKET_PATH
                                             [--volatile-tip | --immutable-tip]
                                             [--out-file FILEPATH]
 
   Get the governance state
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -23,6 +17,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_kes-period-info.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_kes-period-info.cli
@@ -1,9 +1,10 @@
-Usage: cardano-cli conway query kes-period-info --socket-path SOCKET_PATH
+Usage: cardano-cli conway query kes-period-info 
                                                   [--cardano-mode
                                                     [--epoch-slots SLOTS]]
                                                   ( --mainnet
                                                   | --testnet-magic NATURAL
                                                   )
+                                                  --socket-path SOCKET_PATH
                                                   [ --volatile-tip
                                                   | --immutable-tip
                                                   ]
@@ -14,11 +15,6 @@ Usage: cardano-cli conway query kes-period-info --socket-path SOCKET_PATH
   certificate.
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -27,6 +23,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_leadership-schedule.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_leadership-schedule.cli
@@ -1,9 +1,10 @@
-Usage: cardano-cli conway query leadership-schedule --socket-path SOCKET_PATH
+Usage: cardano-cli conway query leadership-schedule 
                                                       [--cardano-mode
                                                         [--epoch-slots SLOTS]]
                                                       ( --mainnet
                                                       | --testnet-magic NATURAL
                                                       )
+                                                      --socket-path SOCKET_PATH
                                                       [ --volatile-tip
                                                       | --immutable-tip
                                                       ]
@@ -22,11 +23,6 @@ Usage: cardano-cli conway query leadership-schedule --socket-path SOCKET_PATH
   Get the slots the node is expected to mint a block in (advanced command)
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -35,6 +31,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_ledger-peer-snapshot.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_ledger-peer-snapshot.cli
@@ -1,9 +1,10 @@
-Usage: cardano-cli conway query ledger-peer-snapshot --socket-path SOCKET_PATH
+Usage: cardano-cli conway query ledger-peer-snapshot 
                                                        [--cardano-mode
                                                          [--epoch-slots SLOTS]]
                                                        ( --mainnet
                                                        | --testnet-magic NATURAL
                                                        )
+                                                       --socket-path SOCKET_PATH
                                                        [ --volatile-tip
                                                        | --immutable-tip
                                                        ]
@@ -13,11 +14,6 @@ Usage: cardano-cli conway query ledger-peer-snapshot --socket-path SOCKET_PATH
   cumulatively hold 90% of total stake.
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -26,6 +22,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_ledger-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_ledger-state.cli
@@ -1,9 +1,10 @@
-Usage: cardano-cli conway query ledger-state --socket-path SOCKET_PATH
+Usage: cardano-cli conway query ledger-state 
                                                [--cardano-mode
                                                  [--epoch-slots SLOTS]]
                                                ( --mainnet
                                                | --testnet-magic NATURAL
                                                )
+                                               --socket-path SOCKET_PATH
                                                [ --volatile-tip
                                                | --immutable-tip
                                                ]
@@ -13,11 +14,6 @@ Usage: cardano-cli conway query ledger-state --socket-path SOCKET_PATH
   command)
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -26,6 +22,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_pool-params.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_pool-params.cli
@@ -1,9 +1,10 @@
-Usage: cardano-cli conway query pool-params --socket-path SOCKET_PATH
+Usage: cardano-cli conway query pool-params 
                                               [--cardano-mode
                                                 [--epoch-slots SLOTS]]
                                               ( --mainnet
                                               | --testnet-magic NATURAL
                                               )
+                                              --socket-path SOCKET_PATH
                                               [--volatile-tip | --immutable-tip]
                                               ( --all-stake-pools
                                               | (--stake-pool-id STAKE_POOL_ID)
@@ -15,11 +16,6 @@ Usage: cardano-cli conway query pool-params --socket-path SOCKET_PATH
   command)
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -28,6 +24,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_pool-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_pool-state.cli
@@ -1,9 +1,10 @@
-Usage: cardano-cli conway query pool-state --socket-path SOCKET_PATH
+Usage: cardano-cli conway query pool-state 
                                              [--cardano-mode
                                                [--epoch-slots SLOTS]]
                                              ( --mainnet
                                              | --testnet-magic NATURAL
                                              )
+                                             --socket-path SOCKET_PATH
                                              [--volatile-tip | --immutable-tip]
                                              ( --all-stake-pools
                                              | (--stake-pool-id STAKE_POOL_ID)
@@ -13,11 +14,6 @@ Usage: cardano-cli conway query pool-state --socket-path SOCKET_PATH
   Dump the pool state
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -26,6 +22,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_proposals.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_proposals.cli
@@ -1,9 +1,8 @@
-Usage: cardano-cli conway query proposals --socket-path SOCKET_PATH
-                                            [--cardano-mode
-                                              [--epoch-slots SLOTS]]
+Usage: cardano-cli conway query proposals [--cardano-mode [--epoch-slots SLOTS]]
                                             ( --mainnet
                                             | --testnet-magic NATURAL
                                             )
+                                            --socket-path SOCKET_PATH
                                             [--volatile-tip | --immutable-tip]
                                             ( --all-proposals
                                             | (--governance-action-tx-id TXID
@@ -16,11 +15,6 @@ Usage: cardano-cli conway query proposals --socket-path SOCKET_PATH
   until the next epoch.
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -29,6 +23,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_protocol-parameters.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_protocol-parameters.cli
@@ -1,19 +1,15 @@
-Usage: cardano-cli conway query protocol-parameters --socket-path SOCKET_PATH
+Usage: cardano-cli conway query protocol-parameters 
                                                       [--cardano-mode
                                                         [--epoch-slots SLOTS]]
                                                       ( --mainnet
                                                       | --testnet-magic NATURAL
                                                       )
+                                                      --socket-path SOCKET_PATH
                                                       [--out-file FILEPATH]
 
   Get the node's current protocol parameters
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -22,5 +18,10 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_protocol-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_protocol-state.cli
@@ -1,9 +1,10 @@
-Usage: cardano-cli conway query protocol-state --socket-path SOCKET_PATH
+Usage: cardano-cli conway query protocol-state 
                                                  [--cardano-mode
                                                    [--epoch-slots SLOTS]]
                                                  ( --mainnet
                                                  | --testnet-magic NATURAL
                                                  )
+                                                 --socket-path SOCKET_PATH
                                                  [ --volatile-tip
                                                  | --immutable-tip
                                                  ]
@@ -13,11 +14,6 @@ Usage: cardano-cli conway query protocol-state --socket-path SOCKET_PATH
   command)
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -26,6 +22,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_ref-script-size.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_ref-script-size.cli
@@ -1,9 +1,10 @@
-Usage: cardano-cli conway query ref-script-size --socket-path SOCKET_PATH
+Usage: cardano-cli conway query ref-script-size 
                                                   [--cardano-mode
                                                     [--epoch-slots SLOTS]]
                                                   ( --mainnet
                                                   | --testnet-magic NATURAL
                                                   )
+                                                  --socket-path SOCKET_PATH
                                                   [ --volatile-tip
                                                   | --immutable-tip
                                                   ]
@@ -17,11 +18,6 @@ Usage: cardano-cli conway query ref-script-size --socket-path SOCKET_PATH
   inputs.
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -30,6 +26,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_slot-number.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_slot-number.cli
@@ -1,20 +1,16 @@
-Usage: cardano-cli conway query slot-number --socket-path SOCKET_PATH
+Usage: cardano-cli conway query slot-number 
                                               [--cardano-mode
                                                 [--epoch-slots SLOTS]]
                                               ( --mainnet
                                               | --testnet-magic NATURAL
                                               )
+                                              --socket-path SOCKET_PATH
                                               [--volatile-tip | --immutable-tip]
                                               TIMESTAMP
 
   Query slot number for UTC timestamp
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -23,6 +19,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_spo-stake-distribution.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_spo-stake-distribution.cli
@@ -1,9 +1,10 @@
-Usage: cardano-cli conway query spo-stake-distribution --socket-path SOCKET_PATH
+Usage: cardano-cli conway query spo-stake-distribution 
                                                          [--cardano-mode
                                                            [--epoch-slots SLOTS]]
                                                          ( --mainnet
                                                          | --testnet-magic NATURAL
                                                          )
+                                                         --socket-path SOCKET_PATH
                                                          [ --volatile-tip
                                                          | --immutable-tip
                                                          ]
@@ -19,11 +20,6 @@ Usage: cardano-cli conway query spo-stake-distribution --socket-path SOCKET_PATH
   Get the SPO stake distribution.
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -32,6 +28,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_stake-address-info.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_stake-address-info.cli
@@ -1,9 +1,10 @@
-Usage: cardano-cli conway query stake-address-info --socket-path SOCKET_PATH
+Usage: cardano-cli conway query stake-address-info 
                                                      [--cardano-mode
                                                        [--epoch-slots SLOTS]]
                                                      ( --mainnet
                                                      | --testnet-magic NATURAL
                                                      )
+                                                     --socket-path SOCKET_PATH
                                                      [ --volatile-tip
                                                      | --immutable-tip
                                                      ]
@@ -13,11 +14,6 @@ Usage: cardano-cli conway query stake-address-info --socket-path SOCKET_PATH
   Get the current delegations and reward accounts filtered by stake address.
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -26,6 +22,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_stake-distribution.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_stake-distribution.cli
@@ -1,9 +1,10 @@
-Usage: cardano-cli conway query stake-distribution --socket-path SOCKET_PATH
+Usage: cardano-cli conway query stake-distribution 
                                                      [--cardano-mode
                                                        [--epoch-slots SLOTS]]
                                                      ( --mainnet
                                                      | --testnet-magic NATURAL
                                                      )
+                                                     --socket-path SOCKET_PATH
                                                      [ --volatile-tip
                                                      | --immutable-tip
                                                      ]
@@ -15,11 +16,6 @@ Usage: cardano-cli conway query stake-distribution --socket-path SOCKET_PATH
   Get the node's current aggregated stake distribution
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -28,6 +24,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_stake-pools.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_stake-pools.cli
@@ -1,9 +1,10 @@
-Usage: cardano-cli conway query stake-pools --socket-path SOCKET_PATH
+Usage: cardano-cli conway query stake-pools 
                                               [--cardano-mode
                                                 [--epoch-slots SLOTS]]
                                               ( --mainnet
                                               | --testnet-magic NATURAL
                                               )
+                                              --socket-path SOCKET_PATH
                                               [--volatile-tip | --immutable-tip]
                                               [--output-json | --output-text]
                                               [--out-file FILEPATH]
@@ -11,11 +12,6 @@ Usage: cardano-cli conway query stake-pools --socket-path SOCKET_PATH
   Get the node's current set of stake pool ids
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -24,6 +20,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_stake-snapshot.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_stake-snapshot.cli
@@ -1,9 +1,10 @@
-Usage: cardano-cli conway query stake-snapshot --socket-path SOCKET_PATH
+Usage: cardano-cli conway query stake-snapshot 
                                                  [--cardano-mode
                                                    [--epoch-slots SLOTS]]
                                                  ( --mainnet
                                                  | --testnet-magic NATURAL
                                                  )
+                                                 --socket-path SOCKET_PATH
                                                  [ --volatile-tip
                                                  | --immutable-tip
                                                  ]
@@ -16,11 +17,6 @@ Usage: cardano-cli conway query stake-snapshot --socket-path SOCKET_PATH
   (advanced command)
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -29,6 +25,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_tip.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_tip.cli
@@ -1,17 +1,12 @@
-Usage: cardano-cli conway query tip --socket-path SOCKET_PATH
-                                      [--cardano-mode [--epoch-slots SLOTS]]
+Usage: cardano-cli conway query tip [--cardano-mode [--epoch-slots SLOTS]]
                                       (--mainnet | --testnet-magic NATURAL)
+                                      --socket-path SOCKET_PATH
                                       [--volatile-tip | --immutable-tip]
                                       [--out-file FILEPATH]
 
   Get the node's current tip (slot no, hash, block no)
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -20,6 +15,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_treasury.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_treasury.cli
@@ -1,18 +1,12 @@
-Usage: cardano-cli conway query treasury --socket-path SOCKET_PATH
-                                           [--cardano-mode
-                                             [--epoch-slots SLOTS]]
+Usage: cardano-cli conway query treasury [--cardano-mode [--epoch-slots SLOTS]]
                                            (--mainnet | --testnet-magic NATURAL)
+                                           --socket-path SOCKET_PATH
                                            [--volatile-tip | --immutable-tip]
                                            [--out-file FILEPATH]
 
   Get the treasury value
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -21,6 +15,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_tx-mempool.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_tx-mempool.cli
@@ -1,20 +1,16 @@
-Usage: cardano-cli conway query tx-mempool --socket-path SOCKET_PATH
+Usage: cardano-cli conway query tx-mempool 
                                              [--cardano-mode
                                                [--epoch-slots SLOTS]]
                                              ( --mainnet
                                              | --testnet-magic NATURAL
                                              )
+                                             --socket-path SOCKET_PATH
                                              (info | next-tx | tx-exists)
                                              [--out-file FILEPATH]
 
   Local Mempool info
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -23,6 +19,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_tx-mempool_info.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_tx-mempool_info.cli
@@ -1,11 +1,12 @@
-Missing: --socket-path SOCKET_PATH (--mainnet | --testnet-magic NATURAL)
+Missing: (--mainnet | --testnet-magic NATURAL) --socket-path SOCKET_PATH
 
-Usage: cardano-cli conway query tx-mempool --socket-path SOCKET_PATH
+Usage: cardano-cli conway query tx-mempool 
                                              [--cardano-mode
                                                [--epoch-slots SLOTS]]
                                              ( --mainnet
                                              | --testnet-magic NATURAL
                                              )
+                                             --socket-path SOCKET_PATH
                                              (info | next-tx | tx-exists)
                                              [--out-file FILEPATH]
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_tx-mempool_next-tx.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_tx-mempool_next-tx.cli
@@ -1,11 +1,12 @@
-Missing: --socket-path SOCKET_PATH (--mainnet | --testnet-magic NATURAL)
+Missing: (--mainnet | --testnet-magic NATURAL) --socket-path SOCKET_PATH
 
-Usage: cardano-cli conway query tx-mempool --socket-path SOCKET_PATH
+Usage: cardano-cli conway query tx-mempool 
                                              [--cardano-mode
                                                [--epoch-slots SLOTS]]
                                              ( --mainnet
                                              | --testnet-magic NATURAL
                                              )
+                                             --socket-path SOCKET_PATH
                                              (info | next-tx | tx-exists)
                                              [--out-file FILEPATH]
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_tx-mempool_tx-exists_TX_ID.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_tx-mempool_tx-exists_TX_ID.cli
@@ -1,11 +1,12 @@
-Missing: --socket-path SOCKET_PATH (--mainnet | --testnet-magic NATURAL)
+Missing: (--mainnet | --testnet-magic NATURAL) --socket-path SOCKET_PATH
 
-Usage: cardano-cli conway query tx-mempool --socket-path SOCKET_PATH
+Usage: cardano-cli conway query tx-mempool 
                                              [--cardano-mode
                                                [--epoch-slots SLOTS]]
                                              ( --mainnet
                                              | --testnet-magic NATURAL
                                              )
+                                             --socket-path SOCKET_PATH
                                              (info | next-tx | tx-exists)
                                              [--out-file FILEPATH]
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_utxo.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_utxo.cli
@@ -1,6 +1,6 @@
-Usage: cardano-cli conway query utxo --socket-path SOCKET_PATH
-                                       [--cardano-mode [--epoch-slots SLOTS]]
+Usage: cardano-cli conway query utxo [--cardano-mode [--epoch-slots SLOTS]]
                                        (--mainnet | --testnet-magic NATURAL)
+                                       --socket-path SOCKET_PATH
                                        [--volatile-tip | --immutable-tip]
                                        ( --whole-utxo
                                        | (--address ADDRESS)
@@ -12,11 +12,6 @@ Usage: cardano-cli conway query utxo --socket-path SOCKET_PATH
   Get a portion of the current UTxO: by tx in, by address or the whole.
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -25,6 +20,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_build.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_build.cli
@@ -1,9 +1,10 @@
-Usage: cardano-cli conway transaction build --socket-path SOCKET_PATH
+Usage: cardano-cli conway transaction build 
                                               [--cardano-mode
                                                 [--epoch-slots SLOTS]]
                                               ( --mainnet
                                               | --testnet-magic NATURAL
                                               )
+                                              --socket-path SOCKET_PATH
                                               [ --script-valid
                                               | --script-invalid
                                               ]
@@ -149,11 +150,6 @@ Usage: cardano-cli conway transaction build --socket-path SOCKET_PATH
   Please note the order[93;22;23;24m of some cmd options is crucial. If used incorrectly may produce undesired tx body. See nested [] notation above for details.[0;22;23;24m
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -162,6 +158,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --script-valid           Assertion that the script is valid. (default)
   --script-invalid         Assertion that the script is invalid. If a
                            transaction is submitted with such a script, the

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_submit.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_submit.cli
@@ -1,20 +1,16 @@
-Usage: cardano-cli conway transaction submit --socket-path SOCKET_PATH
+Usage: cardano-cli conway transaction submit 
                                                [--cardano-mode
                                                  [--epoch-slots SLOTS]]
                                                ( --mainnet
                                                | --testnet-magic NATURAL
                                                )
+                                               --socket-path SOCKET_PATH
                                                --tx-file FILEPATH
 
   Submit a transaction to the local node whose Unix domain socket is obtained
   from the CARDANO_NODE_SOCKET_PATH environment variable.
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -23,5 +19,10 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --tx-file FILEPATH       Filepath of the transaction you intend to submit.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_committee-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_committee-state.cli
@@ -1,9 +1,10 @@
-Usage: cardano-cli latest query committee-state --socket-path SOCKET_PATH
+Usage: cardano-cli latest query committee-state 
                                                   [--cardano-mode
                                                     [--epoch-slots SLOTS]]
                                                   ( --mainnet
                                                   | --testnet-magic NATURAL
                                                   )
+                                                  --socket-path SOCKET_PATH
                                                   [ --volatile-tip
                                                   | --immutable-tip
                                                   ]
@@ -26,11 +27,6 @@ Usage: cardano-cli latest query committee-state --socket-path SOCKET_PATH
   Get the committee state
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -39,6 +35,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_constitution.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_constitution.cli
@@ -1,9 +1,10 @@
-Usage: cardano-cli latest query constitution --socket-path SOCKET_PATH
+Usage: cardano-cli latest query constitution 
                                                [--cardano-mode
                                                  [--epoch-slots SLOTS]]
                                                ( --mainnet
                                                | --testnet-magic NATURAL
                                                )
+                                               --socket-path SOCKET_PATH
                                                [ --volatile-tip
                                                | --immutable-tip
                                                ]
@@ -12,11 +13,6 @@ Usage: cardano-cli latest query constitution --socket-path SOCKET_PATH
   Get the constitution
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -25,6 +21,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_drep-stake-distribution.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_drep-stake-distribution.cli
@@ -1,10 +1,10 @@
 Usage: cardano-cli latest query drep-stake-distribution 
-                                                          --socket-path SOCKET_PATH
                                                           [--cardano-mode
                                                             [--epoch-slots SLOTS]]
                                                           ( --mainnet
                                                           | --testnet-magic NATURAL
                                                           )
+                                                          --socket-path SOCKET_PATH
                                                           [ --volatile-tip
                                                           | --immutable-tip
                                                           ]
@@ -21,11 +21,6 @@ Usage: cardano-cli latest query drep-stake-distribution
   Get the DRep stake distribution.
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -34,6 +29,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_drep-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_drep-state.cli
@@ -1,9 +1,10 @@
-Usage: cardano-cli latest query drep-state --socket-path SOCKET_PATH
+Usage: cardano-cli latest query drep-state 
                                              [--cardano-mode
                                                [--epoch-slots SLOTS]]
                                              ( --mainnet
                                              | --testnet-magic NATURAL
                                              )
+                                             --socket-path SOCKET_PATH
                                              [--volatile-tip | --immutable-tip]
                                              ( --all-dreps
                                              | 
@@ -19,11 +20,6 @@ Usage: cardano-cli latest query drep-state --socket-path SOCKET_PATH
   Get the DRep state.
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -32,6 +28,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_gov-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_gov-state.cli
@@ -1,20 +1,14 @@
-Usage: cardano-cli latest query gov-state --socket-path SOCKET_PATH
-                                            [--cardano-mode
-                                              [--epoch-slots SLOTS]]
+Usage: cardano-cli latest query gov-state [--cardano-mode [--epoch-slots SLOTS]]
                                             ( --mainnet
                                             | --testnet-magic NATURAL
                                             )
+                                            --socket-path SOCKET_PATH
                                             [--volatile-tip | --immutable-tip]
                                             [--out-file FILEPATH]
 
   Get the governance state
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -23,6 +17,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_kes-period-info.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_kes-period-info.cli
@@ -1,9 +1,10 @@
-Usage: cardano-cli latest query kes-period-info --socket-path SOCKET_PATH
+Usage: cardano-cli latest query kes-period-info 
                                                   [--cardano-mode
                                                     [--epoch-slots SLOTS]]
                                                   ( --mainnet
                                                   | --testnet-magic NATURAL
                                                   )
+                                                  --socket-path SOCKET_PATH
                                                   [ --volatile-tip
                                                   | --immutable-tip
                                                   ]
@@ -14,11 +15,6 @@ Usage: cardano-cli latest query kes-period-info --socket-path SOCKET_PATH
   certificate.
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -27,6 +23,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_leadership-schedule.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_leadership-schedule.cli
@@ -1,9 +1,10 @@
-Usage: cardano-cli latest query leadership-schedule --socket-path SOCKET_PATH
+Usage: cardano-cli latest query leadership-schedule 
                                                       [--cardano-mode
                                                         [--epoch-slots SLOTS]]
                                                       ( --mainnet
                                                       | --testnet-magic NATURAL
                                                       )
+                                                      --socket-path SOCKET_PATH
                                                       [ --volatile-tip
                                                       | --immutable-tip
                                                       ]
@@ -22,11 +23,6 @@ Usage: cardano-cli latest query leadership-schedule --socket-path SOCKET_PATH
   Get the slots the node is expected to mint a block in (advanced command)
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -35,6 +31,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_ledger-peer-snapshot.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_ledger-peer-snapshot.cli
@@ -1,9 +1,10 @@
-Usage: cardano-cli latest query ledger-peer-snapshot --socket-path SOCKET_PATH
+Usage: cardano-cli latest query ledger-peer-snapshot 
                                                        [--cardano-mode
                                                          [--epoch-slots SLOTS]]
                                                        ( --mainnet
                                                        | --testnet-magic NATURAL
                                                        )
+                                                       --socket-path SOCKET_PATH
                                                        [ --volatile-tip
                                                        | --immutable-tip
                                                        ]
@@ -13,11 +14,6 @@ Usage: cardano-cli latest query ledger-peer-snapshot --socket-path SOCKET_PATH
   cumulatively hold 90% of total stake.
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -26,6 +22,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_ledger-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_ledger-state.cli
@@ -1,9 +1,10 @@
-Usage: cardano-cli latest query ledger-state --socket-path SOCKET_PATH
+Usage: cardano-cli latest query ledger-state 
                                                [--cardano-mode
                                                  [--epoch-slots SLOTS]]
                                                ( --mainnet
                                                | --testnet-magic NATURAL
                                                )
+                                               --socket-path SOCKET_PATH
                                                [ --volatile-tip
                                                | --immutable-tip
                                                ]
@@ -13,11 +14,6 @@ Usage: cardano-cli latest query ledger-state --socket-path SOCKET_PATH
   command)
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -26,6 +22,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_pool-params.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_pool-params.cli
@@ -1,9 +1,10 @@
-Usage: cardano-cli latest query pool-params --socket-path SOCKET_PATH
+Usage: cardano-cli latest query pool-params 
                                               [--cardano-mode
                                                 [--epoch-slots SLOTS]]
                                               ( --mainnet
                                               | --testnet-magic NATURAL
                                               )
+                                              --socket-path SOCKET_PATH
                                               [--volatile-tip | --immutable-tip]
                                               ( --all-stake-pools
                                               | (--stake-pool-id STAKE_POOL_ID)
@@ -15,11 +16,6 @@ Usage: cardano-cli latest query pool-params --socket-path SOCKET_PATH
   command)
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -28,6 +24,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_pool-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_pool-state.cli
@@ -1,9 +1,10 @@
-Usage: cardano-cli latest query pool-state --socket-path SOCKET_PATH
+Usage: cardano-cli latest query pool-state 
                                              [--cardano-mode
                                                [--epoch-slots SLOTS]]
                                              ( --mainnet
                                              | --testnet-magic NATURAL
                                              )
+                                             --socket-path SOCKET_PATH
                                              [--volatile-tip | --immutable-tip]
                                              ( --all-stake-pools
                                              | (--stake-pool-id STAKE_POOL_ID)
@@ -13,11 +14,6 @@ Usage: cardano-cli latest query pool-state --socket-path SOCKET_PATH
   Dump the pool state
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -26,6 +22,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_proposals.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_proposals.cli
@@ -1,9 +1,8 @@
-Usage: cardano-cli latest query proposals --socket-path SOCKET_PATH
-                                            [--cardano-mode
-                                              [--epoch-slots SLOTS]]
+Usage: cardano-cli latest query proposals [--cardano-mode [--epoch-slots SLOTS]]
                                             ( --mainnet
                                             | --testnet-magic NATURAL
                                             )
+                                            --socket-path SOCKET_PATH
                                             [--volatile-tip | --immutable-tip]
                                             ( --all-proposals
                                             | (--governance-action-tx-id TXID
@@ -16,11 +15,6 @@ Usage: cardano-cli latest query proposals --socket-path SOCKET_PATH
   until the next epoch.
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -29,6 +23,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_protocol-parameters.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_protocol-parameters.cli
@@ -1,19 +1,15 @@
-Usage: cardano-cli latest query protocol-parameters --socket-path SOCKET_PATH
+Usage: cardano-cli latest query protocol-parameters 
                                                       [--cardano-mode
                                                         [--epoch-slots SLOTS]]
                                                       ( --mainnet
                                                       | --testnet-magic NATURAL
                                                       )
+                                                      --socket-path SOCKET_PATH
                                                       [--out-file FILEPATH]
 
   Get the node's current protocol parameters
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -22,5 +18,10 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_protocol-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_protocol-state.cli
@@ -1,9 +1,10 @@
-Usage: cardano-cli latest query protocol-state --socket-path SOCKET_PATH
+Usage: cardano-cli latest query protocol-state 
                                                  [--cardano-mode
                                                    [--epoch-slots SLOTS]]
                                                  ( --mainnet
                                                  | --testnet-magic NATURAL
                                                  )
+                                                 --socket-path SOCKET_PATH
                                                  [ --volatile-tip
                                                  | --immutable-tip
                                                  ]
@@ -13,11 +14,6 @@ Usage: cardano-cli latest query protocol-state --socket-path SOCKET_PATH
   command)
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -26,6 +22,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_ref-script-size.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_ref-script-size.cli
@@ -1,9 +1,10 @@
-Usage: cardano-cli latest query ref-script-size --socket-path SOCKET_PATH
+Usage: cardano-cli latest query ref-script-size 
                                                   [--cardano-mode
                                                     [--epoch-slots SLOTS]]
                                                   ( --mainnet
                                                   | --testnet-magic NATURAL
                                                   )
+                                                  --socket-path SOCKET_PATH
                                                   [ --volatile-tip
                                                   | --immutable-tip
                                                   ]
@@ -17,11 +18,6 @@ Usage: cardano-cli latest query ref-script-size --socket-path SOCKET_PATH
   inputs.
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -30,6 +26,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_slot-number.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_slot-number.cli
@@ -1,20 +1,16 @@
-Usage: cardano-cli latest query slot-number --socket-path SOCKET_PATH
+Usage: cardano-cli latest query slot-number 
                                               [--cardano-mode
                                                 [--epoch-slots SLOTS]]
                                               ( --mainnet
                                               | --testnet-magic NATURAL
                                               )
+                                              --socket-path SOCKET_PATH
                                               [--volatile-tip | --immutable-tip]
                                               TIMESTAMP
 
   Query slot number for UTC timestamp
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -23,6 +19,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_spo-stake-distribution.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_spo-stake-distribution.cli
@@ -1,9 +1,10 @@
-Usage: cardano-cli latest query spo-stake-distribution --socket-path SOCKET_PATH
+Usage: cardano-cli latest query spo-stake-distribution 
                                                          [--cardano-mode
                                                            [--epoch-slots SLOTS]]
                                                          ( --mainnet
                                                          | --testnet-magic NATURAL
                                                          )
+                                                         --socket-path SOCKET_PATH
                                                          [ --volatile-tip
                                                          | --immutable-tip
                                                          ]
@@ -19,11 +20,6 @@ Usage: cardano-cli latest query spo-stake-distribution --socket-path SOCKET_PATH
   Get the SPO stake distribution.
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -32,6 +28,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_stake-address-info.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_stake-address-info.cli
@@ -1,9 +1,10 @@
-Usage: cardano-cli latest query stake-address-info --socket-path SOCKET_PATH
+Usage: cardano-cli latest query stake-address-info 
                                                      [--cardano-mode
                                                        [--epoch-slots SLOTS]]
                                                      ( --mainnet
                                                      | --testnet-magic NATURAL
                                                      )
+                                                     --socket-path SOCKET_PATH
                                                      [ --volatile-tip
                                                      | --immutable-tip
                                                      ]
@@ -13,11 +14,6 @@ Usage: cardano-cli latest query stake-address-info --socket-path SOCKET_PATH
   Get the current delegations and reward accounts filtered by stake address.
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -26,6 +22,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_stake-distribution.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_stake-distribution.cli
@@ -1,9 +1,10 @@
-Usage: cardano-cli latest query stake-distribution --socket-path SOCKET_PATH
+Usage: cardano-cli latest query stake-distribution 
                                                      [--cardano-mode
                                                        [--epoch-slots SLOTS]]
                                                      ( --mainnet
                                                      | --testnet-magic NATURAL
                                                      )
+                                                     --socket-path SOCKET_PATH
                                                      [ --volatile-tip
                                                      | --immutable-tip
                                                      ]
@@ -15,11 +16,6 @@ Usage: cardano-cli latest query stake-distribution --socket-path SOCKET_PATH
   Get the node's current aggregated stake distribution
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -28,6 +24,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_stake-pools.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_stake-pools.cli
@@ -1,9 +1,10 @@
-Usage: cardano-cli latest query stake-pools --socket-path SOCKET_PATH
+Usage: cardano-cli latest query stake-pools 
                                               [--cardano-mode
                                                 [--epoch-slots SLOTS]]
                                               ( --mainnet
                                               | --testnet-magic NATURAL
                                               )
+                                              --socket-path SOCKET_PATH
                                               [--volatile-tip | --immutable-tip]
                                               [--output-json | --output-text]
                                               [--out-file FILEPATH]
@@ -11,11 +12,6 @@ Usage: cardano-cli latest query stake-pools --socket-path SOCKET_PATH
   Get the node's current set of stake pool ids
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -24,6 +20,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_stake-snapshot.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_stake-snapshot.cli
@@ -1,9 +1,10 @@
-Usage: cardano-cli latest query stake-snapshot --socket-path SOCKET_PATH
+Usage: cardano-cli latest query stake-snapshot 
                                                  [--cardano-mode
                                                    [--epoch-slots SLOTS]]
                                                  ( --mainnet
                                                  | --testnet-magic NATURAL
                                                  )
+                                                 --socket-path SOCKET_PATH
                                                  [ --volatile-tip
                                                  | --immutable-tip
                                                  ]
@@ -16,11 +17,6 @@ Usage: cardano-cli latest query stake-snapshot --socket-path SOCKET_PATH
   (advanced command)
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -29,6 +25,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_tip.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_tip.cli
@@ -1,17 +1,12 @@
-Usage: cardano-cli latest query tip --socket-path SOCKET_PATH
-                                      [--cardano-mode [--epoch-slots SLOTS]]
+Usage: cardano-cli latest query tip [--cardano-mode [--epoch-slots SLOTS]]
                                       (--mainnet | --testnet-magic NATURAL)
+                                      --socket-path SOCKET_PATH
                                       [--volatile-tip | --immutable-tip]
                                       [--out-file FILEPATH]
 
   Get the node's current tip (slot no, hash, block no)
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -20,6 +15,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_treasury.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_treasury.cli
@@ -1,18 +1,12 @@
-Usage: cardano-cli latest query treasury --socket-path SOCKET_PATH
-                                           [--cardano-mode
-                                             [--epoch-slots SLOTS]]
+Usage: cardano-cli latest query treasury [--cardano-mode [--epoch-slots SLOTS]]
                                            (--mainnet | --testnet-magic NATURAL)
+                                           --socket-path SOCKET_PATH
                                            [--volatile-tip | --immutable-tip]
                                            [--out-file FILEPATH]
 
   Get the treasury value
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -21,6 +15,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_tx-mempool.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_tx-mempool.cli
@@ -1,20 +1,16 @@
-Usage: cardano-cli latest query tx-mempool --socket-path SOCKET_PATH
+Usage: cardano-cli latest query tx-mempool 
                                              [--cardano-mode
                                                [--epoch-slots SLOTS]]
                                              ( --mainnet
                                              | --testnet-magic NATURAL
                                              )
+                                             --socket-path SOCKET_PATH
                                              (info | next-tx | tx-exists)
                                              [--out-file FILEPATH]
 
   Local Mempool info
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -23,6 +19,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_tx-mempool_info.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_tx-mempool_info.cli
@@ -1,11 +1,12 @@
-Missing: --socket-path SOCKET_PATH (--mainnet | --testnet-magic NATURAL)
+Missing: (--mainnet | --testnet-magic NATURAL) --socket-path SOCKET_PATH
 
-Usage: cardano-cli latest query tx-mempool --socket-path SOCKET_PATH
+Usage: cardano-cli latest query tx-mempool 
                                              [--cardano-mode
                                                [--epoch-slots SLOTS]]
                                              ( --mainnet
                                              | --testnet-magic NATURAL
                                              )
+                                             --socket-path SOCKET_PATH
                                              (info | next-tx | tx-exists)
                                              [--out-file FILEPATH]
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_tx-mempool_next-tx.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_tx-mempool_next-tx.cli
@@ -1,11 +1,12 @@
-Missing: --socket-path SOCKET_PATH (--mainnet | --testnet-magic NATURAL)
+Missing: (--mainnet | --testnet-magic NATURAL) --socket-path SOCKET_PATH
 
-Usage: cardano-cli latest query tx-mempool --socket-path SOCKET_PATH
+Usage: cardano-cli latest query tx-mempool 
                                              [--cardano-mode
                                                [--epoch-slots SLOTS]]
                                              ( --mainnet
                                              | --testnet-magic NATURAL
                                              )
+                                             --socket-path SOCKET_PATH
                                              (info | next-tx | tx-exists)
                                              [--out-file FILEPATH]
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_tx-mempool_tx-exists_TX_ID.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_tx-mempool_tx-exists_TX_ID.cli
@@ -1,11 +1,12 @@
-Missing: --socket-path SOCKET_PATH (--mainnet | --testnet-magic NATURAL)
+Missing: (--mainnet | --testnet-magic NATURAL) --socket-path SOCKET_PATH
 
-Usage: cardano-cli latest query tx-mempool --socket-path SOCKET_PATH
+Usage: cardano-cli latest query tx-mempool 
                                              [--cardano-mode
                                                [--epoch-slots SLOTS]]
                                              ( --mainnet
                                              | --testnet-magic NATURAL
                                              )
+                                             --socket-path SOCKET_PATH
                                              (info | next-tx | tx-exists)
                                              [--out-file FILEPATH]
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_utxo.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_utxo.cli
@@ -1,6 +1,6 @@
-Usage: cardano-cli latest query utxo --socket-path SOCKET_PATH
-                                       [--cardano-mode [--epoch-slots SLOTS]]
+Usage: cardano-cli latest query utxo [--cardano-mode [--epoch-slots SLOTS]]
                                        (--mainnet | --testnet-magic NATURAL)
+                                       --socket-path SOCKET_PATH
                                        [--volatile-tip | --immutable-tip]
                                        ( --whole-utxo
                                        | (--address ADDRESS)
@@ -12,11 +12,6 @@ Usage: cardano-cli latest query utxo --socket-path SOCKET_PATH
   Get a portion of the current UTxO: by tx in, by address or the whole.
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -25,6 +20,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_transaction_build.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_transaction_build.cli
@@ -1,9 +1,10 @@
-Usage: cardano-cli latest transaction build --socket-path SOCKET_PATH
+Usage: cardano-cli latest transaction build 
                                               [--cardano-mode
                                                 [--epoch-slots SLOTS]]
                                               ( --mainnet
                                               | --testnet-magic NATURAL
                                               )
+                                              --socket-path SOCKET_PATH
                                               [ --script-valid
                                               | --script-invalid
                                               ]
@@ -149,11 +150,6 @@ Usage: cardano-cli latest transaction build --socket-path SOCKET_PATH
   Please note the order[93;22;23;24m of some cmd options is crucial. If used incorrectly may produce undesired tx body. See nested [] notation above for details.[0;22;23;24m
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -162,6 +158,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --script-valid           Assertion that the script is valid. (default)
   --script-invalid         Assertion that the script is invalid. If a
                            transaction is submitted with such a script, the

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_transaction_submit.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_transaction_submit.cli
@@ -1,20 +1,16 @@
-Usage: cardano-cli latest transaction submit --socket-path SOCKET_PATH
+Usage: cardano-cli latest transaction submit 
                                                [--cardano-mode
                                                  [--epoch-slots SLOTS]]
                                                ( --mainnet
                                                | --testnet-magic NATURAL
                                                )
+                                               --socket-path SOCKET_PATH
                                                --tx-file FILEPATH
 
   Submit a transaction to the local node whose Unix domain socket is obtained
   from the CARDANO_NODE_SOCKET_PATH environment variable.
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -23,5 +19,10 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --tx-file FILEPATH       Filepath of the transaction you intend to submit.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_kes-period-info.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_kes-period-info.cli
@@ -1,9 +1,10 @@
-Usage: cardano-cli mary query kes-period-info --socket-path SOCKET_PATH
+Usage: cardano-cli mary query kes-period-info 
                                                 [--cardano-mode
                                                   [--epoch-slots SLOTS]]
                                                 ( --mainnet
                                                 | --testnet-magic NATURAL
                                                 )
+                                                --socket-path SOCKET_PATH
                                                 --op-cert-file FILEPATH
                                                 [--out-file FILEPATH]
 
@@ -11,11 +12,6 @@ Usage: cardano-cli mary query kes-period-info --socket-path SOCKET_PATH
   certificate.
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -24,6 +20,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --op-cert-file FILEPATH  Filepath of the node's operational certificate.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_leadership-schedule.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_leadership-schedule.cli
@@ -1,9 +1,10 @@
-Usage: cardano-cli mary query leadership-schedule --socket-path SOCKET_PATH
+Usage: cardano-cli mary query leadership-schedule 
                                                     [--cardano-mode
                                                       [--epoch-slots SLOTS]]
                                                     ( --mainnet
                                                     | --testnet-magic NATURAL
                                                     )
+                                                    --socket-path SOCKET_PATH
                                                     --genesis FILEPATH
                                                     ( --stake-pool-verification-key STRING
                                                     | --cold-verification-key-file FILEPATH
@@ -19,11 +20,6 @@ Usage: cardano-cli mary query leadership-schedule --socket-path SOCKET_PATH
   Get the slots the node is expected to mint a block in (advanced command)
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -32,6 +28,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --genesis FILEPATH       Shelley genesis filepath
   --stake-pool-verification-key STRING
                            Stake pool verification key (Bech32 or hex-encoded).

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_ledger-peer-snapshot.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_ledger-peer-snapshot.cli
@@ -1,20 +1,16 @@
-Usage: cardano-cli mary query ledger-peer-snapshot --socket-path SOCKET_PATH
+Usage: cardano-cli mary query ledger-peer-snapshot 
                                                      [--cardano-mode
                                                        [--epoch-slots SLOTS]]
                                                      ( --mainnet
                                                      | --testnet-magic NATURAL
                                                      )
+                                                     --socket-path SOCKET_PATH
                                                      [--out-file FILEPATH]
 
   Dump the current snapshot of ledger peers.These are the largest pools that
   cumulatively hold 90% of total stake.
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -23,5 +19,10 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_ledger-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_ledger-state.cli
@@ -1,20 +1,16 @@
-Usage: cardano-cli mary query ledger-state --socket-path SOCKET_PATH
+Usage: cardano-cli mary query ledger-state 
                                              [--cardano-mode
                                                [--epoch-slots SLOTS]]
                                              ( --mainnet
                                              | --testnet-magic NATURAL
                                              )
+                                             --socket-path SOCKET_PATH
                                              [--out-file FILEPATH]
 
   Dump the current ledger state of the node (Ledger.NewEpochState -- advanced
   command)
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -23,5 +19,10 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_pool-params.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_pool-params.cli
@@ -1,9 +1,8 @@
-Usage: cardano-cli mary query pool-params --socket-path SOCKET_PATH
-                                            [--cardano-mode
-                                              [--epoch-slots SLOTS]]
+Usage: cardano-cli mary query pool-params [--cardano-mode [--epoch-slots SLOTS]]
                                             ( --mainnet
                                             | --testnet-magic NATURAL
                                             )
+                                            --socket-path SOCKET_PATH
                                             ( --all-stake-pools
                                             | (--stake-pool-id STAKE_POOL_ID)
                                             )
@@ -14,11 +13,6 @@ Usage: cardano-cli mary query pool-params --socket-path SOCKET_PATH
   command)
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -27,6 +21,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --all-stake-pools        Query for all stake pools
   --stake-pool-id STAKE_POOL_ID
                            Stake pool ID/verification key hash (either

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_pool-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_pool-state.cli
@@ -1,7 +1,6 @@
-Usage: cardano-cli mary query pool-state --socket-path SOCKET_PATH
-                                           [--cardano-mode
-                                             [--epoch-slots SLOTS]]
+Usage: cardano-cli mary query pool-state [--cardano-mode [--epoch-slots SLOTS]]
                                            (--mainnet | --testnet-magic NATURAL)
+                                           --socket-path SOCKET_PATH
                                            ( --all-stake-pools
                                            | (--stake-pool-id STAKE_POOL_ID)
                                            )
@@ -10,11 +9,6 @@ Usage: cardano-cli mary query pool-state --socket-path SOCKET_PATH
   Dump the pool state
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -23,6 +17,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --all-stake-pools        Query for all stake pools
   --stake-pool-id STAKE_POOL_ID
                            Stake pool ID/verification key hash (either

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_protocol-parameters.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_protocol-parameters.cli
@@ -1,19 +1,15 @@
-Usage: cardano-cli mary query protocol-parameters --socket-path SOCKET_PATH
+Usage: cardano-cli mary query protocol-parameters 
                                                     [--cardano-mode
                                                       [--epoch-slots SLOTS]]
                                                     ( --mainnet
                                                     | --testnet-magic NATURAL
                                                     )
+                                                    --socket-path SOCKET_PATH
                                                     [--out-file FILEPATH]
 
   Get the node's current protocol parameters
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -22,5 +18,10 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_protocol-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_protocol-state.cli
@@ -1,20 +1,16 @@
-Usage: cardano-cli mary query protocol-state --socket-path SOCKET_PATH
+Usage: cardano-cli mary query protocol-state 
                                                [--cardano-mode
                                                  [--epoch-slots SLOTS]]
                                                ( --mainnet
                                                | --testnet-magic NATURAL
                                                )
+                                               --socket-path SOCKET_PATH
                                                [--out-file FILEPATH]
 
   Dump the current protocol state of the node (Ledger.ChainDepState -- advanced
   command)
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -23,5 +19,10 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_ref-script-size.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_ref-script-size.cli
@@ -1,9 +1,10 @@
-Usage: cardano-cli mary query ref-script-size --socket-path SOCKET_PATH
+Usage: cardano-cli mary query ref-script-size 
                                                 [--cardano-mode
                                                   [--epoch-slots SLOTS]]
                                                 ( --mainnet
                                                 | --testnet-magic NATURAL
                                                 )
+                                                --socket-path SOCKET_PATH
                                                 (--tx-in TX-IN)
                                                 [--output-json | --output-text]
                                                 [--out-file FILEPATH]
@@ -12,11 +13,6 @@ Usage: cardano-cli mary query ref-script-size --socket-path SOCKET_PATH
   inputs.
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -25,6 +21,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --tx-in TX-IN            Transaction input (TxId#TxIx).
   --output-json            Format reference inputs query output to JSON. Default
                            format when writing to a file

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_slot-number.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_slot-number.cli
@@ -1,19 +1,13 @@
-Usage: cardano-cli mary query slot-number --socket-path SOCKET_PATH
-                                            [--cardano-mode
-                                              [--epoch-slots SLOTS]]
+Usage: cardano-cli mary query slot-number [--cardano-mode [--epoch-slots SLOTS]]
                                             ( --mainnet
                                             | --testnet-magic NATURAL
                                             )
+                                            --socket-path SOCKET_PATH
                                             TIMESTAMP
 
   Query slot number for UTC timestamp
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -22,5 +16,10 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   TIMESTAMP                UTC timestamp in YYYY-MM-DDThh:mm:ssZ format
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_stake-address-info.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_stake-address-info.cli
@@ -1,20 +1,16 @@
-Usage: cardano-cli mary query stake-address-info --socket-path SOCKET_PATH
+Usage: cardano-cli mary query stake-address-info 
                                                    [--cardano-mode
                                                      [--epoch-slots SLOTS]]
                                                    ( --mainnet
                                                    | --testnet-magic NATURAL
                                                    )
+                                                   --socket-path SOCKET_PATH
                                                    --address ADDRESS
                                                    [--out-file FILEPATH]
 
   Get the current delegations and reward accounts filtered by stake address.
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -23,6 +19,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --address ADDRESS        Filter by Cardano stake address (Bech32-encoded).
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_stake-distribution.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_stake-distribution.cli
@@ -1,9 +1,10 @@
-Usage: cardano-cli mary query stake-distribution --socket-path SOCKET_PATH
+Usage: cardano-cli mary query stake-distribution 
                                                    [--cardano-mode
                                                      [--epoch-slots SLOTS]]
                                                    ( --mainnet
                                                    | --testnet-magic NATURAL
                                                    )
+                                                   --socket-path SOCKET_PATH
                                                    [ --output-json
                                                    | --output-text
                                                    ]
@@ -12,11 +13,6 @@ Usage: cardano-cli mary query stake-distribution --socket-path SOCKET_PATH
   Get the node's current aggregated stake distribution
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -25,6 +21,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --output-json            Format stake-distribution query output to JSON.
                            Default format when writing to a file
   --output-text            Format stake-distribution query output to TEXT.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_stake-pools.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_stake-pools.cli
@@ -1,20 +1,14 @@
-Usage: cardano-cli mary query stake-pools --socket-path SOCKET_PATH
-                                            [--cardano-mode
-                                              [--epoch-slots SLOTS]]
+Usage: cardano-cli mary query stake-pools [--cardano-mode [--epoch-slots SLOTS]]
                                             ( --mainnet
                                             | --testnet-magic NATURAL
                                             )
+                                            --socket-path SOCKET_PATH
                                             [--output-json | --output-text]
                                             [--out-file FILEPATH]
 
   Get the node's current set of stake pool ids
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -23,6 +17,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --output-json            Format stake-pools query output to JSON. Default
                            format when writing to a file
   --output-text            Format stake-pools query output to TEXT. Default

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_stake-snapshot.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_stake-snapshot.cli
@@ -1,9 +1,10 @@
-Usage: cardano-cli mary query stake-snapshot --socket-path SOCKET_PATH
+Usage: cardano-cli mary query stake-snapshot 
                                                [--cardano-mode
                                                  [--epoch-slots SLOTS]]
                                                ( --mainnet
                                                | --testnet-magic NATURAL
                                                )
+                                               --socket-path SOCKET_PATH
                                                ( --all-stake-pools
                                                | (--stake-pool-id STAKE_POOL_ID)
                                                )
@@ -13,11 +14,6 @@ Usage: cardano-cli mary query stake-snapshot --socket-path SOCKET_PATH
   (advanced command)
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -26,6 +22,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --all-stake-pools        Query for all stake pools
   --stake-pool-id STAKE_POOL_ID
                            Stake pool ID/verification key hash (either

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_tip.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_tip.cli
@@ -1,16 +1,11 @@
-Usage: cardano-cli mary query tip --socket-path SOCKET_PATH
-                                    [--cardano-mode [--epoch-slots SLOTS]]
+Usage: cardano-cli mary query tip [--cardano-mode [--epoch-slots SLOTS]]
                                     (--mainnet | --testnet-magic NATURAL)
+                                    --socket-path SOCKET_PATH
                                     [--out-file FILEPATH]
 
   Get the node's current tip (slot no, hash, block no)
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -19,5 +14,10 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_tx-mempool.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_tx-mempool.cli
@@ -1,18 +1,12 @@
-Usage: cardano-cli mary query tx-mempool --socket-path SOCKET_PATH
-                                           [--cardano-mode
-                                             [--epoch-slots SLOTS]]
+Usage: cardano-cli mary query tx-mempool [--cardano-mode [--epoch-slots SLOTS]]
                                            (--mainnet | --testnet-magic NATURAL)
+                                           --socket-path SOCKET_PATH
                                            (info | next-tx | tx-exists)
                                            [--out-file FILEPATH]
 
   Local Mempool info
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -21,6 +15,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_tx-mempool_info.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_tx-mempool_info.cli
@@ -1,9 +1,8 @@
-Missing: --socket-path SOCKET_PATH (--mainnet | --testnet-magic NATURAL)
+Missing: (--mainnet | --testnet-magic NATURAL) --socket-path SOCKET_PATH
 
-Usage: cardano-cli mary query tx-mempool --socket-path SOCKET_PATH
-                                           [--cardano-mode
-                                             [--epoch-slots SLOTS]]
+Usage: cardano-cli mary query tx-mempool [--cardano-mode [--epoch-slots SLOTS]]
                                            (--mainnet | --testnet-magic NATURAL)
+                                           --socket-path SOCKET_PATH
                                            (info | next-tx | tx-exists)
                                            [--out-file FILEPATH]
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_tx-mempool_next-tx.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_tx-mempool_next-tx.cli
@@ -1,9 +1,8 @@
-Missing: --socket-path SOCKET_PATH (--mainnet | --testnet-magic NATURAL)
+Missing: (--mainnet | --testnet-magic NATURAL) --socket-path SOCKET_PATH
 
-Usage: cardano-cli mary query tx-mempool --socket-path SOCKET_PATH
-                                           [--cardano-mode
-                                             [--epoch-slots SLOTS]]
+Usage: cardano-cli mary query tx-mempool [--cardano-mode [--epoch-slots SLOTS]]
                                            (--mainnet | --testnet-magic NATURAL)
+                                           --socket-path SOCKET_PATH
                                            (info | next-tx | tx-exists)
                                            [--out-file FILEPATH]
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_tx-mempool_tx-exists_TX_ID.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_tx-mempool_tx-exists_TX_ID.cli
@@ -1,9 +1,8 @@
-Missing: --socket-path SOCKET_PATH (--mainnet | --testnet-magic NATURAL)
+Missing: (--mainnet | --testnet-magic NATURAL) --socket-path SOCKET_PATH
 
-Usage: cardano-cli mary query tx-mempool --socket-path SOCKET_PATH
-                                           [--cardano-mode
-                                             [--epoch-slots SLOTS]]
+Usage: cardano-cli mary query tx-mempool [--cardano-mode [--epoch-slots SLOTS]]
                                            (--mainnet | --testnet-magic NATURAL)
+                                           --socket-path SOCKET_PATH
                                            (info | next-tx | tx-exists)
                                            [--out-file FILEPATH]
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_utxo.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_utxo.cli
@@ -1,6 +1,6 @@
-Usage: cardano-cli mary query utxo --socket-path SOCKET_PATH
-                                     [--cardano-mode [--epoch-slots SLOTS]]
+Usage: cardano-cli mary query utxo [--cardano-mode [--epoch-slots SLOTS]]
                                      (--mainnet | --testnet-magic NATURAL)
+                                     --socket-path SOCKET_PATH
                                      ( --whole-utxo
                                      | (--address ADDRESS)
                                      | (--tx-in TX-IN)
@@ -11,11 +11,6 @@ Usage: cardano-cli mary query utxo --socket-path SOCKET_PATH
   Get a portion of the current UTxO: by tx in, by address or the whole.
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -24,6 +19,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --whole-utxo             Return the whole UTxO (only appropriate on small
                            testnets).
   --address ADDRESS        Filter by Cardano address(es) (Bech32-encoded).

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_transaction_submit.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_transaction_submit.cli
@@ -1,20 +1,16 @@
-Usage: cardano-cli mary transaction submit --socket-path SOCKET_PATH
+Usage: cardano-cli mary transaction submit 
                                              [--cardano-mode
                                                [--epoch-slots SLOTS]]
                                              ( --mainnet
                                              | --testnet-magic NATURAL
                                              )
+                                             --socket-path SOCKET_PATH
                                              --tx-file FILEPATH
 
   Submit a transaction to the local node whose Unix domain socket is obtained
   from the CARDANO_NODE_SOCKET_PATH environment variable.
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -23,5 +19,10 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --tx-file FILEPATH       Filepath of the transaction you intend to submit.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/query_kes-period-info.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/query_kes-period-info.cli
@@ -1,7 +1,6 @@
-Usage: cardano-cli query kes-period-info --socket-path SOCKET_PATH
-                                           [--cardano-mode
-                                             [--epoch-slots SLOTS]]
+Usage: cardano-cli query kes-period-info [--cardano-mode [--epoch-slots SLOTS]]
                                            (--mainnet | --testnet-magic NATURAL)
+                                           --socket-path SOCKET_PATH
                                            [--volatile-tip | --immutable-tip]
                                            --op-cert-file FILEPATH
                                            [--out-file FILEPATH]
@@ -10,11 +9,6 @@ Usage: cardano-cli query kes-period-info --socket-path SOCKET_PATH
   certificate.
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -23,6 +17,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/query_leadership-schedule.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/query_leadership-schedule.cli
@@ -1,9 +1,10 @@
-Usage: cardano-cli query leadership-schedule --socket-path SOCKET_PATH
+Usage: cardano-cli query leadership-schedule 
                                                [--cardano-mode
                                                  [--epoch-slots SLOTS]]
                                                ( --mainnet
                                                | --testnet-magic NATURAL
                                                )
+                                               --socket-path SOCKET_PATH
                                                [ --volatile-tip
                                                | --immutable-tip
                                                ]
@@ -20,11 +21,6 @@ Usage: cardano-cli query leadership-schedule --socket-path SOCKET_PATH
   Get the slots the node is expected to mint a block in (advanced command)
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -33,6 +29,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/query_ledger-peer-snapshot.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/query_ledger-peer-snapshot.cli
@@ -1,9 +1,10 @@
-Usage: cardano-cli query ledger-peer-snapshot --socket-path SOCKET_PATH
+Usage: cardano-cli query ledger-peer-snapshot 
                                                 [--cardano-mode
                                                   [--epoch-slots SLOTS]]
                                                 ( --mainnet
                                                 | --testnet-magic NATURAL
                                                 )
+                                                --socket-path SOCKET_PATH
                                                 [ --volatile-tip
                                                 | --immutable-tip
                                                 ]
@@ -13,11 +14,6 @@ Usage: cardano-cli query ledger-peer-snapshot --socket-path SOCKET_PATH
   that cumulatively hold 90% of total stake.
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -26,6 +22,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/query_ledger-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/query_ledger-state.cli
@@ -1,6 +1,6 @@
-Usage: cardano-cli query ledger-state --socket-path SOCKET_PATH
-                                        [--cardano-mode [--epoch-slots SLOTS]]
+Usage: cardano-cli query ledger-state [--cardano-mode [--epoch-slots SLOTS]]
                                         (--mainnet | --testnet-magic NATURAL)
+                                        --socket-path SOCKET_PATH
                                         [--volatile-tip | --immutable-tip]
                                         [--out-file FILEPATH]
 
@@ -8,11 +8,6 @@ Usage: cardano-cli query ledger-state --socket-path SOCKET_PATH
   command)
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -21,6 +16,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/query_pool-params.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/query_pool-params.cli
@@ -1,6 +1,6 @@
-Usage: cardano-cli query pool-params --socket-path SOCKET_PATH
-                                       [--cardano-mode [--epoch-slots SLOTS]]
+Usage: cardano-cli query pool-params [--cardano-mode [--epoch-slots SLOTS]]
                                        (--mainnet | --testnet-magic NATURAL)
+                                       --socket-path SOCKET_PATH
                                        [--volatile-tip | --immutable-tip]
                                        ( --all-stake-pools
                                        | (--stake-pool-id STAKE_POOL_ID)
@@ -12,11 +12,6 @@ Usage: cardano-cli query pool-params --socket-path SOCKET_PATH
   command)
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -25,6 +20,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/query_pool-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/query_pool-state.cli
@@ -1,6 +1,6 @@
-Usage: cardano-cli query pool-state --socket-path SOCKET_PATH
-                                      [--cardano-mode [--epoch-slots SLOTS]]
+Usage: cardano-cli query pool-state [--cardano-mode [--epoch-slots SLOTS]]
                                       (--mainnet | --testnet-magic NATURAL)
+                                      --socket-path SOCKET_PATH
                                       [--volatile-tip | --immutable-tip]
                                       ( --all-stake-pools
                                       | (--stake-pool-id STAKE_POOL_ID)
@@ -10,11 +10,6 @@ Usage: cardano-cli query pool-state --socket-path SOCKET_PATH
   Dump the pool state
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -23,6 +18,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/query_protocol-parameters.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/query_protocol-parameters.cli
@@ -1,19 +1,15 @@
-Usage: cardano-cli query protocol-parameters --socket-path SOCKET_PATH
+Usage: cardano-cli query protocol-parameters 
                                                [--cardano-mode
                                                  [--epoch-slots SLOTS]]
                                                ( --mainnet
                                                | --testnet-magic NATURAL
                                                )
+                                               --socket-path SOCKET_PATH
                                                [--out-file FILEPATH]
 
   Get the node's current protocol parameters
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -22,5 +18,10 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/query_protocol-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/query_protocol-state.cli
@@ -1,6 +1,6 @@
-Usage: cardano-cli query protocol-state --socket-path SOCKET_PATH
-                                          [--cardano-mode [--epoch-slots SLOTS]]
+Usage: cardano-cli query protocol-state [--cardano-mode [--epoch-slots SLOTS]]
                                           (--mainnet | --testnet-magic NATURAL)
+                                          --socket-path SOCKET_PATH
                                           [--volatile-tip | --immutable-tip]
                                           [--out-file FILEPATH]
 
@@ -8,11 +8,6 @@ Usage: cardano-cli query protocol-state --socket-path SOCKET_PATH
   command)
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -21,6 +16,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/query_slot-number.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/query_slot-number.cli
@@ -1,17 +1,12 @@
-Usage: cardano-cli query slot-number --socket-path SOCKET_PATH
-                                       [--cardano-mode [--epoch-slots SLOTS]]
+Usage: cardano-cli query slot-number [--cardano-mode [--epoch-slots SLOTS]]
                                        (--mainnet | --testnet-magic NATURAL)
+                                       --socket-path SOCKET_PATH
                                        [--volatile-tip | --immutable-tip]
                                        TIMESTAMP
 
   Query slot number for UTC timestamp
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -20,6 +15,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/query_stake-address-info.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/query_stake-address-info.cli
@@ -1,9 +1,10 @@
-Usage: cardano-cli query stake-address-info --socket-path SOCKET_PATH
+Usage: cardano-cli query stake-address-info 
                                               [--cardano-mode
                                                 [--epoch-slots SLOTS]]
                                               ( --mainnet
                                               | --testnet-magic NATURAL
                                               )
+                                              --socket-path SOCKET_PATH
                                               [--volatile-tip | --immutable-tip]
                                               --address ADDRESS
                                               [--out-file FILEPATH]
@@ -11,11 +12,6 @@ Usage: cardano-cli query stake-address-info --socket-path SOCKET_PATH
   Get the current delegations and reward accounts filtered by stake address.
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -24,6 +20,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/query_stake-distribution.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/query_stake-distribution.cli
@@ -1,9 +1,10 @@
-Usage: cardano-cli query stake-distribution --socket-path SOCKET_PATH
+Usage: cardano-cli query stake-distribution 
                                               [--cardano-mode
                                                 [--epoch-slots SLOTS]]
                                               ( --mainnet
                                               | --testnet-magic NATURAL
                                               )
+                                              --socket-path SOCKET_PATH
                                               [--volatile-tip | --immutable-tip]
                                               [--output-json | --output-text]
                                               [--out-file FILEPATH]
@@ -11,11 +12,6 @@ Usage: cardano-cli query stake-distribution --socket-path SOCKET_PATH
   Get the node's current aggregated stake distribution
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -24,6 +20,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/query_stake-pools.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/query_stake-pools.cli
@@ -1,6 +1,6 @@
-Usage: cardano-cli query stake-pools --socket-path SOCKET_PATH
-                                       [--cardano-mode [--epoch-slots SLOTS]]
+Usage: cardano-cli query stake-pools [--cardano-mode [--epoch-slots SLOTS]]
                                        (--mainnet | --testnet-magic NATURAL)
+                                       --socket-path SOCKET_PATH
                                        [--volatile-tip | --immutable-tip]
                                        [--output-json | --output-text]
                                        [--out-file FILEPATH]
@@ -8,11 +8,6 @@ Usage: cardano-cli query stake-pools --socket-path SOCKET_PATH
   Get the node's current set of stake pool ids
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -21,6 +16,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/query_stake-snapshot.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/query_stake-snapshot.cli
@@ -1,6 +1,6 @@
-Usage: cardano-cli query stake-snapshot --socket-path SOCKET_PATH
-                                          [--cardano-mode [--epoch-slots SLOTS]]
+Usage: cardano-cli query stake-snapshot [--cardano-mode [--epoch-slots SLOTS]]
                                           (--mainnet | --testnet-magic NATURAL)
+                                          --socket-path SOCKET_PATH
                                           [--volatile-tip | --immutable-tip]
                                           ( --all-stake-pools
                                           | (--stake-pool-id STAKE_POOL_ID)
@@ -11,11 +11,6 @@ Usage: cardano-cli query stake-snapshot --socket-path SOCKET_PATH
   (advanced command)
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -24,6 +19,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/query_tip.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/query_tip.cli
@@ -1,17 +1,12 @@
-Usage: cardano-cli query tip --socket-path SOCKET_PATH
-                               [--cardano-mode [--epoch-slots SLOTS]]
+Usage: cardano-cli query tip [--cardano-mode [--epoch-slots SLOTS]]
                                (--mainnet | --testnet-magic NATURAL)
+                               --socket-path SOCKET_PATH
                                [--volatile-tip | --immutable-tip]
                                [--out-file FILEPATH]
 
   Get the node's current tip (slot no, hash, block no)
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -20,6 +15,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/query_tx-mempool.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/query_tx-mempool.cli
@@ -1,17 +1,12 @@
-Usage: cardano-cli query tx-mempool --socket-path SOCKET_PATH
-                                      [--cardano-mode [--epoch-slots SLOTS]]
+Usage: cardano-cli query tx-mempool [--cardano-mode [--epoch-slots SLOTS]]
                                       (--mainnet | --testnet-magic NATURAL)
+                                      --socket-path SOCKET_PATH
                                       (info | next-tx | tx-exists)
                                       [--out-file FILEPATH]
 
   Local Mempool info
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -20,6 +15,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/query_tx-mempool_info.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/query_tx-mempool_info.cli
@@ -1,8 +1,8 @@
-Missing: --socket-path SOCKET_PATH (--mainnet | --testnet-magic NATURAL)
+Missing: (--mainnet | --testnet-magic NATURAL) --socket-path SOCKET_PATH
 
-Usage: cardano-cli query tx-mempool --socket-path SOCKET_PATH
-                                      [--cardano-mode [--epoch-slots SLOTS]]
+Usage: cardano-cli query tx-mempool [--cardano-mode [--epoch-slots SLOTS]]
                                       (--mainnet | --testnet-magic NATURAL)
+                                      --socket-path SOCKET_PATH
                                       (info | next-tx | tx-exists)
                                       [--out-file FILEPATH]
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/query_tx-mempool_next-tx.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/query_tx-mempool_next-tx.cli
@@ -1,8 +1,8 @@
-Missing: --socket-path SOCKET_PATH (--mainnet | --testnet-magic NATURAL)
+Missing: (--mainnet | --testnet-magic NATURAL) --socket-path SOCKET_PATH
 
-Usage: cardano-cli query tx-mempool --socket-path SOCKET_PATH
-                                      [--cardano-mode [--epoch-slots SLOTS]]
+Usage: cardano-cli query tx-mempool [--cardano-mode [--epoch-slots SLOTS]]
                                       (--mainnet | --testnet-magic NATURAL)
+                                      --socket-path SOCKET_PATH
                                       (info | next-tx | tx-exists)
                                       [--out-file FILEPATH]
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/query_tx-mempool_tx-exists_TX_ID.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/query_tx-mempool_tx-exists_TX_ID.cli
@@ -1,8 +1,8 @@
-Missing: --socket-path SOCKET_PATH (--mainnet | --testnet-magic NATURAL)
+Missing: (--mainnet | --testnet-magic NATURAL) --socket-path SOCKET_PATH
 
-Usage: cardano-cli query tx-mempool --socket-path SOCKET_PATH
-                                      [--cardano-mode [--epoch-slots SLOTS]]
+Usage: cardano-cli query tx-mempool [--cardano-mode [--epoch-slots SLOTS]]
                                       (--mainnet | --testnet-magic NATURAL)
+                                      --socket-path SOCKET_PATH
                                       (info | next-tx | tx-exists)
                                       [--out-file FILEPATH]
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/query_utxo.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/query_utxo.cli
@@ -1,6 +1,6 @@
-Usage: cardano-cli query utxo --socket-path SOCKET_PATH
-                                [--cardano-mode [--epoch-slots SLOTS]]
+Usage: cardano-cli query utxo [--cardano-mode [--epoch-slots SLOTS]]
                                 (--mainnet | --testnet-magic NATURAL)
+                                --socket-path SOCKET_PATH
                                 [--volatile-tip | --immutable-tip]
                                 ( --whole-utxo
                                 | (--address ADDRESS)
@@ -12,11 +12,6 @@ Usage: cardano-cli query utxo --socket-path SOCKET_PATH
   Get a portion of the current UTxO: by tx in, by address or the whole.
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -25,6 +20,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --volatile-tip           Use the volatile tip as a target. (This is the
                            default)
   --immutable-tip          Use the immutable tip as a target.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_kes-period-info.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_kes-period-info.cli
@@ -1,9 +1,10 @@
-Usage: cardano-cli shelley query kes-period-info --socket-path SOCKET_PATH
+Usage: cardano-cli shelley query kes-period-info 
                                                    [--cardano-mode
                                                      [--epoch-slots SLOTS]]
                                                    ( --mainnet
                                                    | --testnet-magic NATURAL
                                                    )
+                                                   --socket-path SOCKET_PATH
                                                    --op-cert-file FILEPATH
                                                    [--out-file FILEPATH]
 
@@ -11,11 +12,6 @@ Usage: cardano-cli shelley query kes-period-info --socket-path SOCKET_PATH
   certificate.
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -24,6 +20,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --op-cert-file FILEPATH  Filepath of the node's operational certificate.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_leadership-schedule.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_leadership-schedule.cli
@@ -1,9 +1,10 @@
-Usage: cardano-cli shelley query leadership-schedule --socket-path SOCKET_PATH
+Usage: cardano-cli shelley query leadership-schedule 
                                                        [--cardano-mode
                                                          [--epoch-slots SLOTS]]
                                                        ( --mainnet
                                                        | --testnet-magic NATURAL
                                                        )
+                                                       --socket-path SOCKET_PATH
                                                        --genesis FILEPATH
                                                        ( --stake-pool-verification-key STRING
                                                        | --cold-verification-key-file FILEPATH
@@ -19,11 +20,6 @@ Usage: cardano-cli shelley query leadership-schedule --socket-path SOCKET_PATH
   Get the slots the node is expected to mint a block in (advanced command)
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -32,6 +28,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --genesis FILEPATH       Shelley genesis filepath
   --stake-pool-verification-key STRING
                            Stake pool verification key (Bech32 or hex-encoded).

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_ledger-peer-snapshot.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_ledger-peer-snapshot.cli
@@ -1,20 +1,16 @@
-Usage: cardano-cli shelley query ledger-peer-snapshot --socket-path SOCKET_PATH
+Usage: cardano-cli shelley query ledger-peer-snapshot 
                                                         [--cardano-mode
                                                           [--epoch-slots SLOTS]]
                                                         ( --mainnet
                                                         | --testnet-magic NATURAL
                                                         )
+                                                        --socket-path SOCKET_PATH
                                                         [--out-file FILEPATH]
 
   Dump the current snapshot of ledger peers.These are the largest pools that
   cumulatively hold 90% of total stake.
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -23,5 +19,10 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_ledger-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_ledger-state.cli
@@ -1,20 +1,16 @@
-Usage: cardano-cli shelley query ledger-state --socket-path SOCKET_PATH
+Usage: cardano-cli shelley query ledger-state 
                                                 [--cardano-mode
                                                   [--epoch-slots SLOTS]]
                                                 ( --mainnet
                                                 | --testnet-magic NATURAL
                                                 )
+                                                --socket-path SOCKET_PATH
                                                 [--out-file FILEPATH]
 
   Dump the current ledger state of the node (Ledger.NewEpochState -- advanced
   command)
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -23,5 +19,10 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_pool-params.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_pool-params.cli
@@ -1,9 +1,10 @@
-Usage: cardano-cli shelley query pool-params --socket-path SOCKET_PATH
+Usage: cardano-cli shelley query pool-params 
                                                [--cardano-mode
                                                  [--epoch-slots SLOTS]]
                                                ( --mainnet
                                                | --testnet-magic NATURAL
                                                )
+                                               --socket-path SOCKET_PATH
                                                ( --all-stake-pools
                                                | (--stake-pool-id STAKE_POOL_ID)
                                                )
@@ -14,11 +15,6 @@ Usage: cardano-cli shelley query pool-params --socket-path SOCKET_PATH
   command)
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -27,6 +23,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --all-stake-pools        Query for all stake pools
   --stake-pool-id STAKE_POOL_ID
                            Stake pool ID/verification key hash (either

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_pool-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_pool-state.cli
@@ -1,9 +1,10 @@
-Usage: cardano-cli shelley query pool-state --socket-path SOCKET_PATH
+Usage: cardano-cli shelley query pool-state 
                                               [--cardano-mode
                                                 [--epoch-slots SLOTS]]
                                               ( --mainnet
                                               | --testnet-magic NATURAL
                                               )
+                                              --socket-path SOCKET_PATH
                                               ( --all-stake-pools
                                               | (--stake-pool-id STAKE_POOL_ID)
                                               )
@@ -12,11 +13,6 @@ Usage: cardano-cli shelley query pool-state --socket-path SOCKET_PATH
   Dump the pool state
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -25,6 +21,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --all-stake-pools        Query for all stake pools
   --stake-pool-id STAKE_POOL_ID
                            Stake pool ID/verification key hash (either

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_protocol-parameters.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_protocol-parameters.cli
@@ -1,19 +1,15 @@
-Usage: cardano-cli shelley query protocol-parameters --socket-path SOCKET_PATH
+Usage: cardano-cli shelley query protocol-parameters 
                                                        [--cardano-mode
                                                          [--epoch-slots SLOTS]]
                                                        ( --mainnet
                                                        | --testnet-magic NATURAL
                                                        )
+                                                       --socket-path SOCKET_PATH
                                                        [--out-file FILEPATH]
 
   Get the node's current protocol parameters
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -22,5 +18,10 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_protocol-state.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_protocol-state.cli
@@ -1,20 +1,16 @@
-Usage: cardano-cli shelley query protocol-state --socket-path SOCKET_PATH
+Usage: cardano-cli shelley query protocol-state 
                                                   [--cardano-mode
                                                     [--epoch-slots SLOTS]]
                                                   ( --mainnet
                                                   | --testnet-magic NATURAL
                                                   )
+                                                  --socket-path SOCKET_PATH
                                                   [--out-file FILEPATH]
 
   Dump the current protocol state of the node (Ledger.ChainDepState -- advanced
   command)
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -23,5 +19,10 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_ref-script-size.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_ref-script-size.cli
@@ -1,9 +1,10 @@
-Usage: cardano-cli shelley query ref-script-size --socket-path SOCKET_PATH
+Usage: cardano-cli shelley query ref-script-size 
                                                    [--cardano-mode
                                                      [--epoch-slots SLOTS]]
                                                    ( --mainnet
                                                    | --testnet-magic NATURAL
                                                    )
+                                                   --socket-path SOCKET_PATH
                                                    (--tx-in TX-IN)
                                                    [ --output-json
                                                    | --output-text
@@ -14,11 +15,6 @@ Usage: cardano-cli shelley query ref-script-size --socket-path SOCKET_PATH
   inputs.
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -27,6 +23,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --tx-in TX-IN            Transaction input (TxId#TxIx).
   --output-json            Format reference inputs query output to JSON. Default
                            format when writing to a file

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_slot-number.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_slot-number.cli
@@ -1,19 +1,15 @@
-Usage: cardano-cli shelley query slot-number --socket-path SOCKET_PATH
+Usage: cardano-cli shelley query slot-number 
                                                [--cardano-mode
                                                  [--epoch-slots SLOTS]]
                                                ( --mainnet
                                                | --testnet-magic NATURAL
                                                )
+                                               --socket-path SOCKET_PATH
                                                TIMESTAMP
 
   Query slot number for UTC timestamp
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -22,5 +18,10 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   TIMESTAMP                UTC timestamp in YYYY-MM-DDThh:mm:ssZ format
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_stake-address-info.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_stake-address-info.cli
@@ -1,20 +1,16 @@
-Usage: cardano-cli shelley query stake-address-info --socket-path SOCKET_PATH
+Usage: cardano-cli shelley query stake-address-info 
                                                       [--cardano-mode
                                                         [--epoch-slots SLOTS]]
                                                       ( --mainnet
                                                       | --testnet-magic NATURAL
                                                       )
+                                                      --socket-path SOCKET_PATH
                                                       --address ADDRESS
                                                       [--out-file FILEPATH]
 
   Get the current delegations and reward accounts filtered by stake address.
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -23,6 +19,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --address ADDRESS        Filter by Cardano stake address (Bech32-encoded).
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_stake-distribution.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_stake-distribution.cli
@@ -1,9 +1,10 @@
-Usage: cardano-cli shelley query stake-distribution --socket-path SOCKET_PATH
+Usage: cardano-cli shelley query stake-distribution 
                                                       [--cardano-mode
                                                         [--epoch-slots SLOTS]]
                                                       ( --mainnet
                                                       | --testnet-magic NATURAL
                                                       )
+                                                      --socket-path SOCKET_PATH
                                                       [ --output-json
                                                       | --output-text
                                                       ]
@@ -12,11 +13,6 @@ Usage: cardano-cli shelley query stake-distribution --socket-path SOCKET_PATH
   Get the node's current aggregated stake distribution
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -25,6 +21,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --output-json            Format stake-distribution query output to JSON.
                            Default format when writing to a file
   --output-text            Format stake-distribution query output to TEXT.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_stake-pools.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_stake-pools.cli
@@ -1,20 +1,16 @@
-Usage: cardano-cli shelley query stake-pools --socket-path SOCKET_PATH
+Usage: cardano-cli shelley query stake-pools 
                                                [--cardano-mode
                                                  [--epoch-slots SLOTS]]
                                                ( --mainnet
                                                | --testnet-magic NATURAL
                                                )
+                                               --socket-path SOCKET_PATH
                                                [--output-json | --output-text]
                                                [--out-file FILEPATH]
 
   Get the node's current set of stake pool ids
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -23,6 +19,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --output-json            Format stake-pools query output to JSON. Default
                            format when writing to a file
   --output-text            Format stake-pools query output to TEXT. Default

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_stake-snapshot.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_stake-snapshot.cli
@@ -1,9 +1,10 @@
-Usage: cardano-cli shelley query stake-snapshot --socket-path SOCKET_PATH
+Usage: cardano-cli shelley query stake-snapshot 
                                                   [--cardano-mode
                                                     [--epoch-slots SLOTS]]
                                                   ( --mainnet
                                                   | --testnet-magic NATURAL
                                                   )
+                                                  --socket-path SOCKET_PATH
                                                   ( --all-stake-pools
                                                   | (--stake-pool-id STAKE_POOL_ID)
                                                   )
@@ -13,11 +14,6 @@ Usage: cardano-cli shelley query stake-snapshot --socket-path SOCKET_PATH
   (advanced command)
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -26,6 +22,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --all-stake-pools        Query for all stake pools
   --stake-pool-id STAKE_POOL_ID
                            Stake pool ID/verification key hash (either

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_tip.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_tip.cli
@@ -1,16 +1,11 @@
-Usage: cardano-cli shelley query tip --socket-path SOCKET_PATH
-                                       [--cardano-mode [--epoch-slots SLOTS]]
+Usage: cardano-cli shelley query tip [--cardano-mode [--epoch-slots SLOTS]]
                                        (--mainnet | --testnet-magic NATURAL)
+                                       --socket-path SOCKET_PATH
                                        [--out-file FILEPATH]
 
   Get the node's current tip (slot no, hash, block no)
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -19,5 +14,10 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_tx-mempool.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_tx-mempool.cli
@@ -1,20 +1,16 @@
-Usage: cardano-cli shelley query tx-mempool --socket-path SOCKET_PATH
+Usage: cardano-cli shelley query tx-mempool 
                                               [--cardano-mode
                                                 [--epoch-slots SLOTS]]
                                               ( --mainnet
                                               | --testnet-magic NATURAL
                                               )
+                                              --socket-path SOCKET_PATH
                                               (info | next-tx | tx-exists)
                                               [--out-file FILEPATH]
 
   Local Mempool info
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -23,6 +19,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_tx-mempool_info.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_tx-mempool_info.cli
@@ -1,11 +1,12 @@
-Missing: --socket-path SOCKET_PATH (--mainnet | --testnet-magic NATURAL)
+Missing: (--mainnet | --testnet-magic NATURAL) --socket-path SOCKET_PATH
 
-Usage: cardano-cli shelley query tx-mempool --socket-path SOCKET_PATH
+Usage: cardano-cli shelley query tx-mempool 
                                               [--cardano-mode
                                                 [--epoch-slots SLOTS]]
                                               ( --mainnet
                                               | --testnet-magic NATURAL
                                               )
+                                              --socket-path SOCKET_PATH
                                               (info | next-tx | tx-exists)
                                               [--out-file FILEPATH]
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_tx-mempool_next-tx.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_tx-mempool_next-tx.cli
@@ -1,11 +1,12 @@
-Missing: --socket-path SOCKET_PATH (--mainnet | --testnet-magic NATURAL)
+Missing: (--mainnet | --testnet-magic NATURAL) --socket-path SOCKET_PATH
 
-Usage: cardano-cli shelley query tx-mempool --socket-path SOCKET_PATH
+Usage: cardano-cli shelley query tx-mempool 
                                               [--cardano-mode
                                                 [--epoch-slots SLOTS]]
                                               ( --mainnet
                                               | --testnet-magic NATURAL
                                               )
+                                              --socket-path SOCKET_PATH
                                               (info | next-tx | tx-exists)
                                               [--out-file FILEPATH]
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_tx-mempool_tx-exists_TX_ID.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_tx-mempool_tx-exists_TX_ID.cli
@@ -1,11 +1,12 @@
-Missing: --socket-path SOCKET_PATH (--mainnet | --testnet-magic NATURAL)
+Missing: (--mainnet | --testnet-magic NATURAL) --socket-path SOCKET_PATH
 
-Usage: cardano-cli shelley query tx-mempool --socket-path SOCKET_PATH
+Usage: cardano-cli shelley query tx-mempool 
                                               [--cardano-mode
                                                 [--epoch-slots SLOTS]]
                                               ( --mainnet
                                               | --testnet-magic NATURAL
                                               )
+                                              --socket-path SOCKET_PATH
                                               (info | next-tx | tx-exists)
                                               [--out-file FILEPATH]
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_utxo.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_utxo.cli
@@ -1,6 +1,6 @@
-Usage: cardano-cli shelley query utxo --socket-path SOCKET_PATH
-                                        [--cardano-mode [--epoch-slots SLOTS]]
+Usage: cardano-cli shelley query utxo [--cardano-mode [--epoch-slots SLOTS]]
                                         (--mainnet | --testnet-magic NATURAL)
+                                        --socket-path SOCKET_PATH
                                         ( --whole-utxo
                                         | (--address ADDRESS)
                                         | (--tx-in TX-IN)
@@ -11,11 +11,6 @@ Usage: cardano-cli shelley query utxo --socket-path SOCKET_PATH
   Get a portion of the current UTxO: by tx in, by address or the whole.
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -24,6 +19,11 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --whole-utxo             Return the whole UTxO (only appropriate on small
                            testnets).
   --address ADDRESS        Filter by Cardano address(es) (Bech32-encoded).

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_transaction_submit.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_transaction_submit.cli
@@ -1,20 +1,16 @@
-Usage: cardano-cli shelley transaction submit --socket-path SOCKET_PATH
+Usage: cardano-cli shelley transaction submit 
                                                 [--cardano-mode
                                                   [--epoch-slots SLOTS]]
                                                 ( --mainnet
                                                 | --testnet-magic NATURAL
                                                 )
+                                                --socket-path SOCKET_PATH
                                                 --tx-file FILEPATH
 
   Submit a transaction to the local node whose Unix domain socket is obtained
   from the CARDANO_NODE_SOCKET_PATH environment variable.
 
 Available options:
-  --socket-path SOCKET_PATH
-                           Path to the node socket. This overrides the
-                           CARDANO_NODE_SOCKET_PATH environment variable. The
-                           argument is optional if CARDANO_NODE_SOCKET_PATH is
-                           defined and mandatory otherwise.
   --cardano-mode           For talking to a node running in full Cardano mode
                            (default).
   --epoch-slots SLOTS      The number of slots per epoch for the Byron era.
@@ -23,5 +19,10 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --socket-path SOCKET_PATH
+                           Path to the node socket. This overrides the
+                           CARDANO_NODE_SOCKET_PATH environment variable. The
+                           argument is optional if CARDANO_NODE_SOCKET_PATH is
+                           defined and mandatory otherwise.
   --tx-file FILEPATH       Filepath of the transaction you intend to submit.
   -h,--help                Show this help text


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Refactor node connection passing to make it use `LocalNodeConnectInfo` type
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
   - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

This is just a compatible refactoring to reduce boilerplate. `LocalNodeConnectInfo` is now used for carrying node connection info, instead of three separate fields.

The change in golden files, is just a change of the order where `--socket-path` appears in CLI help.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
