### PR TITLE
Fix displayed version of cabal gild in GHA

### DIFF
--- a/.github/workflows/check-cabal-gild.yml
+++ b/.github/workflows/check-cabal-gild.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Run cabal-gild over all modified files
         run: |
           rc="0"
-          echo "cabal-gild version: ${{env.CABAL_GILD_VERSION}}"        
+           echo "cabal-gild version: $(cabal-gild --version)"
           for file in $(git ls-files "*.cabal")
           do
             echo "cabal-gild --mode=check --input=$file"
@@ -38,6 +38,6 @@ jobs:
               rc="1"
             fi
           done
-          
+
           exit $rc
 


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Fix displayed version of cabal gild in GHA
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
   - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

This somehow got lost in a rebase.
# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
