### PR TITLE
 Remove use of ScriptWitnessFiles in proposal scripts

### DIFF
--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -121,6 +121,8 @@ library
     Cardano.CLI.EraBased.Script.Certificate.Types
     Cardano.CLI.EraBased.Script.Mint.Read
     Cardano.CLI.EraBased.Script.Mint.Types
+    Cardano.CLI.EraBased.Script.Proposal.Read
+    Cardano.CLI.EraBased.Script.Proposal.Types
     Cardano.CLI.EraBased.Script.Read.Common
     Cardano.CLI.EraBased.Script.Spend.Read
     Cardano.CLI.EraBased.Script.Spend.Types

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Transaction.hs
@@ -27,6 +27,7 @@ import           Cardano.Api.Shelley
 
 import           Cardano.CLI.EraBased.Script.Certificate.Types (CliCertificateScriptRequirements)
 import           Cardano.CLI.EraBased.Script.Mint.Types
+import           Cardano.CLI.EraBased.Script.Proposal.Types (CliProposalScriptRequirements)
 import           Cardano.CLI.EraBased.Script.Spend.Types (CliSpendScriptRequirements)
 import           Cardano.CLI.EraBased.Script.Vote.Types
 import           Cardano.CLI.Orphans ()
@@ -84,7 +85,7 @@ data TransactionBuildRawCmdArgs era = TransactionBuildRawCmdArgs
   , mProtocolParamsFile :: !(Maybe ProtocolParamsFile)
   , mUpdateProprosalFile :: !(Maybe (Featured ShelleyToBabbageEra era (Maybe UpdateProposalFile)))
   , voteFiles :: ![(VoteFile In, Maybe CliVoteScriptRequirements)]
-  , proposalFiles :: ![(ProposalFile In, Maybe (ScriptWitnessFiles WitCtxStake))]
+  , proposalFiles :: ![(ProposalFile In, Maybe CliProposalScriptRequirements)]
   , currentTreasuryValueAndDonation :: !(Maybe (TxCurrentTreasuryValue, TxTreasuryDonation))
   , txBodyOutFile :: !(TxBodyFile Out)
   }
@@ -130,7 +131,7 @@ data TransactionBuildCmdArgs era = TransactionBuildCmdArgs
   , metadataFiles :: ![MetadataFile]
   , mUpdateProposalFile :: !(Maybe (Featured ShelleyToBabbageEra era (Maybe UpdateProposalFile)))
   , voteFiles :: ![(VoteFile In, Maybe CliVoteScriptRequirements)]
-  , proposalFiles :: ![(ProposalFile In, Maybe (ScriptWitnessFiles WitCtxStake))]
+  , proposalFiles :: ![(ProposalFile In, Maybe CliProposalScriptRequirements)]
   , treasuryDonation :: !(Maybe TxTreasuryDonation)
   , buildOutputOptions :: !TxBuildOutputOptions
   }
@@ -180,7 +181,7 @@ data TransactionBuildEstimateCmdArgs era = TransactionBuildEstimateCmdArgs
   , metadataFiles :: ![MetadataFile]
   , mUpdateProposalFile :: !(Maybe (Featured ShelleyToBabbageEra era (Maybe UpdateProposalFile)))
   , voteFiles :: ![(VoteFile In, Maybe CliVoteScriptRequirements)]
-  , proposalFiles :: ![(ProposalFile In, Maybe (ScriptWitnessFiles WitCtxStake))]
+  , proposalFiles :: ![(ProposalFile In, Maybe CliProposalScriptRequirements)]
   , currentTreasuryValueAndDonation :: !(Maybe (TxCurrentTreasuryValue, TxTreasuryDonation))
   , txBodyOutFile :: !(TxBodyFile Out)
   }

--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
@@ -1304,7 +1304,7 @@ pVoteFile balExUnits =
       "vote"
       Nothing
       "a vote"
-      <|> pVoteReferencePlutusScriptWitness "vote-" balExUnits
+      <|> pVoteReferencePlutusScriptWitness "vote" balExUnits
 
 pVoteScriptWitness
   :: BalanceTxExecUnits -> String -> Maybe String -> String -> Parser CliVoteScriptRequirements
@@ -1326,14 +1326,15 @@ pVoteScriptWitness bExecUnits scriptFlagPrefix scriptFlagPrefixDeprecated help =
 pVoteReferencePlutusScriptWitness
   :: String -> BalanceTxExecUnits -> Parser CliVoteScriptRequirements
 pVoteReferencePlutusScriptWitness prefix autoBalanceExecUnits =
-  Voting.createPlutusReferenceScriptFromCliArgs
-    <$> pReferenceTxIn prefix "plutus"
-    <*> plutusP prefix PlutusScriptV3 "v3"
-    <*> pScriptRedeemerOrFile (prefix ++ "reference-tx-in")
-    <*> ( case autoBalanceExecUnits of
-            AutoBalance -> pure (ExecutionUnits 0 0)
-            ManualBalance -> pExecutionUnits $ prefix ++ "reference-tx-in"
-        )
+  let appendedPrefix = prefix ++ "-"
+   in Voting.createPlutusReferenceScriptFromCliArgs
+        <$> pReferenceTxIn appendedPrefix "plutus"
+        <*> plutusP appendedPrefix PlutusScriptV3 "v3"
+        <*> pScriptRedeemerOrFile (appendedPrefix ++ "reference-tx-in")
+        <*> ( case autoBalanceExecUnits of
+                AutoBalance -> pure (ExecutionUnits 0 0)
+                ManualBalance -> pExecutionUnits $ appendedPrefix ++ "reference-tx-in"
+            )
 
 pProposalFiles
   :: ShelleyBasedEra era
@@ -1361,7 +1362,7 @@ pProposalFile balExUnits =
       "proposal"
       Nothing
       "a proposal"
-      <|> pProposalReferencePlutusScriptWitness "proposal-" balExUnits
+      <|> pProposalReferencePlutusScriptWitness "proposal" balExUnits
 
 pProposalScriptWitness
   :: BalanceTxExecUnits -> String -> Maybe String -> String -> Parser CliProposalScriptRequirements
@@ -1383,14 +1384,15 @@ pProposalScriptWitness bExecUnits scriptFlagPrefix scriptFlagPrefixDeprecated he
 pProposalReferencePlutusScriptWitness
   :: String -> BalanceTxExecUnits -> Parser CliProposalScriptRequirements
 pProposalReferencePlutusScriptWitness prefix autoBalanceExecUnits =
-  Proposing.createPlutusReferenceScriptFromCliArgs
-    <$> pReferenceTxIn prefix "plutus"
-    <*> plutusP prefix PlutusScriptV3 "v3"
-    <*> pScriptRedeemerOrFile (prefix ++ "reference-tx-in")
-    <*> ( case autoBalanceExecUnits of
-            AutoBalance -> pure (ExecutionUnits 0 0)
-            ManualBalance -> pExecutionUnits $ prefix ++ "reference-tx-in"
-        )
+  let appendedPrefix = prefix ++ "-"
+   in Proposing.createPlutusReferenceScriptFromCliArgs
+        <$> pReferenceTxIn appendedPrefix "plutus"
+        <*> plutusP appendedPrefix PlutusScriptV3 "v3"
+        <*> pScriptRedeemerOrFile (appendedPrefix ++ "reference-tx-in")
+        <*> ( case autoBalanceExecUnits of
+                AutoBalance -> pure (ExecutionUnits 0 0)
+                ManualBalance -> pExecutionUnits $ appendedPrefix ++ "reference-tx-in"
+            )
 
 pCurrentTreasuryValueAndDonation
   :: ShelleyBasedEra era -> Parser (Maybe (TxCurrentTreasuryValue, TxTreasuryDonation))
@@ -1557,7 +1559,7 @@ pCertificateFile balanceExecUnits =
       "certificate"
       Nothing
       "the use of the certificate."
-      <|> pCertificateReferencePlutusScriptWitness "certificate-" bExecUnits
+      <|> pCertificateReferencePlutusScriptWitness "certificate" bExecUnits
 
   helpText =
     mconcat
@@ -1586,14 +1588,15 @@ pCertificatePlutusScriptWitness bExecUnits scriptFlagPrefix scriptFlagPrefixDepr
 pCertificateReferencePlutusScriptWitness
   :: String -> BalanceTxExecUnits -> Parser CliCertificateScriptRequirements
 pCertificateReferencePlutusScriptWitness prefix autoBalanceExecUnits =
-  Certifying.createPlutusReferenceScriptFromCliArgs
-    <$> pReferenceTxIn prefix "plutus"
-    <*> pPlutusScriptLanguage prefix
-    <*> pScriptRedeemerOrFile (prefix ++ "reference-tx-in")
-    <*> ( case autoBalanceExecUnits of
-            AutoBalance -> pure (ExecutionUnits 0 0)
-            ManualBalance -> pExecutionUnits $ prefix ++ "reference-tx-in"
-        )
+  let appendedPrefix = prefix ++ "-"
+   in Certifying.createPlutusReferenceScriptFromCliArgs
+        <$> pReferenceTxIn appendedPrefix "plutus"
+        <*> pPlutusScriptLanguage appendedPrefix
+        <*> pScriptRedeemerOrFile (appendedPrefix ++ "reference-tx-in")
+        <*> ( case autoBalanceExecUnits of
+                AutoBalance -> pure (ExecutionUnits 0 0)
+                ManualBalance -> pExecutionUnits $ appendedPrefix ++ "reference-tx-in"
+            )
 
 pPoolMetadataFile :: Parser (StakePoolMetadataFile In)
 pPoolMetadataFile =
@@ -1663,7 +1666,7 @@ pWithdrawal balance =
       "withdrawal"
       Nothing
       "the withdrawal of rewards."
-      <|> pPlutusStakeReferenceScriptWitnessFiles "withdrawal-" balance
+      <|> pPlutusStakeReferenceScriptWitnessFiles "withdrawal" balance
 
   helpText =
     mconcat
@@ -1697,15 +1700,16 @@ pPlutusStakeReferenceScriptWitnessFiles
   -> BalanceTxExecUnits
   -> Parser (ScriptWitnessFiles WitCtxStake)
 pPlutusStakeReferenceScriptWitnessFiles prefix autoBalanceExecUnits =
-  PlutusReferenceScriptWitnessFiles
-    <$> pReferenceTxIn prefix "plutus"
-    <*> pPlutusScriptLanguage prefix
-    <*> pure NoScriptDatumOrFileForStake
-    <*> pScriptRedeemerOrFile (prefix ++ "reference-tx-in")
-    <*> ( case autoBalanceExecUnits of
-            AutoBalance -> pure (ExecutionUnits 0 0)
-            ManualBalance -> pExecutionUnits $ prefix ++ "reference-tx-in"
-        )
+  let appendedPrefix = prefix ++ "-"
+   in PlutusReferenceScriptWitnessFiles
+        <$> pReferenceTxIn appendedPrefix "plutus"
+        <*> pPlutusScriptLanguage appendedPrefix
+        <*> pure NoScriptDatumOrFileForStake
+        <*> pScriptRedeemerOrFile (appendedPrefix ++ "reference-tx-in")
+        <*> ( case autoBalanceExecUnits of
+                AutoBalance -> pure (ExecutionUnits 0 0)
+                ManualBalance -> pExecutionUnits $ appendedPrefix ++ "reference-tx-in"
+            )
 
 pPlutusScriptLanguage :: String -> Parser AnyPlutusScriptVersion
 pPlutusScriptLanguage prefix = plutusP prefix PlutusScriptV2 "v2" <|> plutusP prefix PlutusScriptV3 "v3"

--- a/cardano-cli/src/Cardano/CLI/EraBased/Script/Proposal/Read.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Script/Proposal/Read.hs
@@ -1,0 +1,120 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+
+module Cardano.CLI.EraBased.Script.Proposal.Read
+  ( readProposalScriptWitness
+  )
+where
+
+import           Cardano.Api
+import           Cardano.Api.Shelley
+
+import           Cardano.CLI.EraBased.Script.Proposal.Types
+import           Cardano.CLI.EraBased.Script.Read.Common
+import           Cardano.CLI.EraBased.Script.Types
+import           Cardano.CLI.Types.Common
+
+readProposalScriptWitness
+  :: MonadIOTransError (FileError CliScriptWitnessError) t m
+  => ConwayEraOnwards era
+  -> (ProposalFile In, Maybe CliProposalScriptRequirements)
+  -> t m (Proposal era, Maybe (ProposalScriptWitness era))
+readProposalScriptWitness w (propFp, Nothing) = do
+  proposal <-
+    conwayEraOnwardsConstraints w $
+      modifyError (fmap TextEnvelopeError) $
+        hoistIOEither $
+          readFileTextEnvelope AsProposal propFp
+  return (proposal, Nothing)
+readProposalScriptWitness w (propFp, Just certScriptReq) = do
+  let sbe = convert w
+  proposal <-
+    conwayEraOnwardsConstraints w $
+      modifyError (fmap TextEnvelopeError) $
+        hoistIOEither $
+          readFileTextEnvelope AsProposal propFp
+  case certScriptReq of
+    OnDiskSimpleScript scriptFp -> do
+      let sFp = unFile scriptFp
+      s <-
+        modifyError (fmap SimpleScriptWitnessDecodeError) $
+          readFileSimpleScript sFp
+      case s of
+        SimpleScript ss -> do
+          return
+            ( proposal
+            , Just $
+                ProposalScriptWitness
+                  ( SimpleScriptWitness (sbeToSimpleScriptLanguageInEra sbe) $
+                      SScript ss
+                  )
+            )
+    OnDiskPlutusScript (OnDiskPlutusScriptCliArgs scriptFp redeemerFile execUnits) -> do
+      let plutusScriptFp = unFile scriptFp
+      plutusScript <-
+        modifyError (fmap PlutusScriptWitnessDecodeError) $
+          readFilePlutusScript plutusScriptFp
+      redeemer <-
+        modifyError (FileError plutusScriptFp . PlutusScriptWitnessRedeemerError) $
+          readScriptDataOrFile redeemerFile
+      case plutusScript of
+        AnyPlutusScript lang script -> do
+          let pScript = PScript script
+          sLangSupported <-
+            modifyError (FileError plutusScriptFp)
+              $ hoistMaybe
+                ( PlutusScriptWitnessLanguageNotSupportedInEra
+                    (AnyPlutusScriptVersion lang)
+                    (shelleyBasedEraConstraints sbe $ AnyShelleyBasedEra sbe)
+                )
+              $ scriptLanguageSupportedInEra sbe
+              $ PlutusScriptLanguage lang
+          return
+            ( proposal
+            , Just $
+                ProposalScriptWitness $
+                  PlutusScriptWitness
+                    sLangSupported
+                    lang
+                    pScript
+                    NoScriptDatumForStake
+                    redeemer
+                    execUnits
+            )
+    OnDiskPlutusRefScript (PlutusRefScriptCliArgs refTxIn anyPlutusScriptVersion redeemerFile execUnits) -> do
+      case anyPlutusScriptVersion of
+        AnyPlutusScriptVersion lang -> do
+          let pScript = PReferenceScript refTxIn
+          redeemer <-
+            -- TODO: Implement a new error type to capture this. FileError is not representative of cases
+            -- where we do not have access to the script.
+            modifyError
+              ( FileError "Reference script filepath not available"
+                  . PlutusScriptWitnessRedeemerError
+              )
+              $ readScriptDataOrFile redeemerFile
+          sLangSupported <-
+            -- TODO: Implement a new error type to capture this. FileError is not representative of cases
+            -- where we do not have access to the script.
+            modifyError (FileError "Reference script filepath not available")
+              $ hoistMaybe
+                ( PlutusScriptWitnessLanguageNotSupportedInEra
+                    (AnyPlutusScriptVersion lang)
+                    (shelleyBasedEraConstraints sbe $ AnyShelleyBasedEra sbe)
+                )
+              $ scriptLanguageSupportedInEra sbe
+              $ PlutusScriptLanguage lang
+
+          return
+            ( proposal
+            , Just $
+                ProposalScriptWitness $
+                  PlutusScriptWitness
+                    sLangSupported
+                    lang
+                    pScript
+                    NoScriptDatumForStake
+                    redeemer
+                    execUnits
+            )

--- a/cardano-cli/src/Cardano/CLI/EraBased/Script/Proposal/Types.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Script/Proposal/Types.hs
@@ -1,0 +1,63 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+
+module Cardano.CLI.EraBased.Script.Proposal.Types
+  ( CliProposalScriptRequirements (..)
+  , PlutusRefScriptCliArgs (..)
+  , PlutusScriptCliArgs (..)
+  , ProposalScriptWitness (..)
+  , createSimpleOrPlutusScriptFromCliArgs
+  , createPlutusReferenceScriptFromCliArgs
+  )
+where
+
+import           Cardano.Api
+
+import           Cardano.CLI.Types.Common (ScriptDataOrFile)
+
+newtype ProposalScriptWitness era
+  = ProposalScriptWitness {pswScriptWitness :: ScriptWitness WitCtxStake era}
+  deriving Show
+
+data CliProposalScriptRequirements
+  = OnDiskPlutusScript PlutusScriptCliArgs
+  | OnDiskSimpleScript (File ScriptInAnyLang In)
+  | OnDiskPlutusRefScript PlutusRefScriptCliArgs
+  deriving Show
+
+data PlutusScriptCliArgs
+  = OnDiskPlutusScriptCliArgs
+      (File ScriptInAnyLang In)
+      ScriptDataOrFile
+      -- ^ Redeemer
+      ExecutionUnits
+  deriving Show
+
+createSimpleOrPlutusScriptFromCliArgs
+  :: File ScriptInAnyLang In
+  -> Maybe (ScriptDataOrFile, ExecutionUnits)
+  -> CliProposalScriptRequirements
+createSimpleOrPlutusScriptFromCliArgs scriptFp (Just (redeemer, execUnits)) =
+  OnDiskPlutusScript $ OnDiskPlutusScriptCliArgs scriptFp redeemer execUnits
+createSimpleOrPlutusScriptFromCliArgs scriptFp Nothing =
+  OnDiskSimpleScript scriptFp
+
+data PlutusRefScriptCliArgs
+  = PlutusRefScriptCliArgs
+      TxIn
+      -- ^ TxIn with reference script
+      AnyPlutusScriptVersion
+      ScriptDataOrFile
+      -- ^ Redeemer
+      ExecutionUnits
+  deriving Show
+
+createPlutusReferenceScriptFromCliArgs
+  :: TxIn
+  -> AnyPlutusScriptVersion
+  -> ScriptDataOrFile
+  -> ExecutionUnits
+  -> CliProposalScriptRequirements
+createPlutusReferenceScriptFromCliArgs txIn version redeemer execUnits =
+  OnDiskPlutusRefScript $ PlutusRefScriptCliArgs txIn version redeemer execUnits


### PR DESCRIPTION
Depends on #1027 

# Changelog

```yaml
- description: |
    Remove use of ScriptWitnessFiles in proposal scripts

  type:
  - refactoring    # QoL changes
```

# Context

Additional context for the PR goes here. If the PR fixes a particular issue please provide a [link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=) to the issue.

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
