### PR TITLE
Organise hash and ping commands

### DIFF
--- a/cardano-cli/src/Cardano/CLI/Commands.hs
+++ b/cardano-cli/src/Cardano/CLI/Commands.hs
@@ -11,7 +11,7 @@ import           Cardano.CLI.Commands.Debug
 import           Cardano.CLI.Commands.Hash (HashCmds)
 import           Cardano.CLI.Commands.Key
 import           Cardano.CLI.Commands.Node
-import           Cardano.CLI.Commands.Ping (PingCmd (..))
+import           Cardano.CLI.Commands.Ping (PingCmd)
 import           Cardano.CLI.Compatible.Commands
 import           Cardano.CLI.EraBased.Commands.Query
 import           Cardano.CLI.EraBased.Commands.TopLevelCommands

--- a/cardano-cli/src/Cardano/CLI/Options.hs
+++ b/cardano-cli/src/Cardano/CLI/Options.hs
@@ -80,11 +80,11 @@ parseClientCommand envCli =
     [ addressCmdsTopLevel envCli
     , keyCmdsTopLevel
     , nodeCmdsTopLevel
+    , parseHash
     , queryCmdsTopLevel envCli
     , parseLegacy envCli
     , parseByron envCli
     , parseAnyEra envCli
-    , parseHash
     , parseDebug envCli
     , backwardsCompatibilityCommands envCli
     , parseDisplayVersion (opts envCli)

--- a/cardano-cli/src/Cardano/CLI/Options.hs
+++ b/cardano-cli/src/Cardano/CLI/Options.hs
@@ -85,7 +85,6 @@ parseClientCommand envCli =
     , parseByron envCli
     , parseAnyEra envCli
     , parseHash
-    , parsePing
     , parseDebug envCli
     , backwardsCompatibilityCommands envCli
     , parseDisplayVersion (opts envCli)
@@ -104,9 +103,6 @@ parseByron mNetworkId =
 
 parseHash :: Parser ClientCommand
 parseHash = HashCmds <$> pHashCmds
-
-parsePing :: Parser ClientCommand
-parsePing = CliPingCommand <$> parsePingCmd
 
 parseCompatibilityCommands :: EnvCli -> Parser ClientCommand
 parseCompatibilityCommands envCli =
@@ -143,6 +139,7 @@ parseDisplayVersion allParserInfo =
               "version"
               "Show the cardano-cli version"
               (pure DisplayVersion)
+          , parsePingCmd
           ]
     , flag' DisplayVersion $
         mconcat

--- a/cardano-cli/src/Cardano/CLI/Options/Ping.hs
+++ b/cardano-cli/src/Cardano/CLI/Options/Ping.hs
@@ -7,6 +7,7 @@ module Cardano.CLI.Options.Ping
   )
 where
 
+import           Cardano.CLI.Commands (ClientCommand (CliPingCommand))
 import           Cardano.CLI.Commands.Ping
 import           Cardano.CLI.EraBased.Options.Common (integralReader)
 import qualified Cardano.Network.Ping as CNP
@@ -15,20 +16,16 @@ import           Control.Applicative ((<|>))
 import qualified Options.Applicative as Opt
 import qualified Prettyprinter as PP
 
-parsePingCmd :: Opt.Parser PingCmd
+parsePingCmd :: Opt.Mod Opt.CommandFields ClientCommand
 parsePingCmd =
-  Opt.hsubparser $
-    mconcat
-      [ Opt.metavar "ping"
-      , Opt.command "ping" $
-          Opt.info pPing $
-            Opt.progDescDoc $
-              Just $
-                mconcat
-                  [ PP.pretty @String "Ping a cardano node either using node-to-node or node-to-client protocol. "
-                  , PP.pretty @String "It negotiates a handshake and keeps sending keep alive messages."
-                  ]
-      ]
+  Opt.command "ping" $
+    Opt.info (CliPingCommand <$> pPing) $
+      Opt.progDescDoc $
+        Just $
+          mconcat
+            [ PP.pretty @String "Ping a cardano node either using node-to-node or node-to-client protocol. "
+            , PP.pretty @String "It negotiates a handshake and keeps sending keep alive messages."
+            ]
 
 pHost :: Opt.Parser String
 pHost =

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Help.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Help.hs
@@ -101,14 +101,18 @@ hprop_golden_HelpCmds =
             [ "help"
             ]
 
-      let lines = Text.lines $ Text.pack help
-      let usages = List.filter (not . null) $ fmap extractCmd $ maybeToList . selectCmd =<< lines
+      let lines = Text.lines (Text.pack help)
+      let usages = [] : List.filter (not . null) (fmap extractCmd $ maybeToList . selectCmd =<< lines)
 
       forM_ usages $ \usage -> do
         H.noteShow_ usage
         let expectedCmdHelpFp =
-              "test/cardano-cli-golden/files/golden/help" </> Text.unpack (Text.intercalate "_" usage) <> ".cli"
+              "test/cardano-cli-golden/files/golden" </> subPath usage
 
         cmdHelp <- filterAnsi . third <$> H.execDetailCardanoCLI (fmap Text.unpack usage)
 
         H.diffVsGoldenFile cmdHelp expectedCmdHelpFp
+ where
+  subPath :: [Text] -> FilePath
+  subPath [] = "base_help.cli"
+  subPath usage = "help" </> Text.unpack (Text.intercalate "_" usage) <> ".cli"

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Help.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Help.hs
@@ -114,5 +114,14 @@ hprop_golden_HelpCmds =
         H.diffVsGoldenFile cmdHelp expectedCmdHelpFp
  where
   subPath :: [Text] -> FilePath
-  subPath [] = "base_help.cli"
-  subPath usage = "help" </> Text.unpack (Text.intercalate "_" usage) <> ".cli"
+  subPath [] =
+    -- This is the case where the usage is empty (just calling `cardano-cli` without parameters),
+    -- which results in the main help output. We store that in a file named "base_help.cli".
+    -- We need to make an exception because otherwise the file would be named ".cli" and would
+    -- be invisible. We also put it outside of the "help" directory to avoid potential clashes
+    -- with other files.
+    "base_help.cli"
+  subPath usage =
+    -- For all other cases, we store the help output in a file named after the command sequence
+    -- separated by underscores, under a directory named "help".
+    "help" </> Text.unpack (Text.intercalate "_" usage) <> ".cli"

--- a/cardano-cli/test/cardano-cli-golden/files/golden/base_help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/base_help.cli
@@ -1,0 +1,67 @@
+cardano-cli - General purpose command-line utility to interact with
+cardano-node. Provides specific commands to manage keys, addresses, build &
+submit transactions, certificates, etc.
+
+Usage: cardano-cli 
+                     ( address
+                     | key
+                     | node
+                     | hash
+                     | query
+                     | legacy
+                     | byron
+                     | shelley
+                     | allegra
+                     | mary
+                     | alonzo
+                     | babbage
+                     | conway
+                     | latest
+                     | debug commands
+                     | version
+                     | compatible
+                     )
+
+Available options:
+  --version                Show the cardano-cli version
+  -h,--help                Show this help text
+
+Available commands:
+  address                  Payment address commands.
+  key                      Key utility commands.
+  node                     Node operation commands.
+  hash                     Compute the hash to pass to the various --*-hash
+                           arguments of commands.
+  query                    Node query commands. Will query the local node whose
+                           Unix domain socket is obtained from the
+                           CARDANO_NODE_SOCKET_PATH environment variable.
+  legacy                   Legacy commands
+
+Byron specific commands
+  byron                    Byron specific commands
+
+Available commands:
+  shelley                  Shelley era commands - DEPRECATED - will be removed
+                           in the future
+  allegra                  Allegra era commands - DEPRECATED - will be removed
+                           in the future
+  mary                     Mary era commands - DEPRECATED - will be removed in
+                           the future
+  alonzo                   Alonzo era commands - DEPRECATED - will be removed in
+                           the future
+  babbage                  Babbage era commands - DEPRECATED - will be removed
+                           in the future
+  conway                   Conway era commands
+  latest                   Latest era commands (Conway)
+
+debug commands
+  debug                    Debug commands
+
+Miscellaneous commands
+  help                     Show all help
+  version                  Show the cardano-cli version
+  ping                     Ping a cardano node either using node-to-node or node-to-client protocol. It negotiates a handshake and keeps sending keep alive messages.
+
+Available commands:
+  compatible               Limited backward compatible commands for testing
+                           only.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -2,6 +2,7 @@ Usage: cardano-cli
                      ( address
                      | key
                      | node
+                     | hash
                      | query
                      | legacy
                      | byron
@@ -12,7 +13,6 @@ Usage: cardano-cli
                      | babbage
                      | conway
                      | latest
-                     | hash
                      | debug commands
                      | version
                      | compatible
@@ -201,6 +201,30 @@ Usage: cardano-cli node issue-op-cert
                                         --out-file FILEPATH
 
   Issue a node operational certificate
+
+Usage: cardano-cli hash (anchor-data | script | genesis-file)
+
+  Compute the hash to pass to the various --*-hash arguments of commands.
+
+Usage: cardano-cli hash anchor-data 
+                                      ( --text TEXT
+                                      | --file-binary FILEPATH
+                                      | --file-text FILEPATH
+                                      | --url TEXT
+                                      )
+                                      [ --expected-hash HASH
+                                      | --out-file FILEPATH
+                                      ]
+
+  Compute the hash of some anchor data (to then pass it to other commands).
+
+Usage: cardano-cli hash script --script-file FILEPATH [--out-file FILEPATH]
+
+  Compute the hash of a script (to then pass it to other commands).
+
+Usage: cardano-cli hash genesis-file --genesis FILEPATH
+
+  Compute the hash of a genesis file.
 
 Usage: cardano-cli query 
                            ( protocol-parameters
@@ -10764,30 +10788,6 @@ Usage: cardano-cli latest transaction txid
                                              [--output-json | --output-text]
 
   Print a transaction identifier.
-
-Usage: cardano-cli hash (anchor-data | script | genesis-file)
-
-  Compute the hash to pass to the various --*-hash arguments of commands.
-
-Usage: cardano-cli hash anchor-data 
-                                      ( --text TEXT
-                                      | --file-binary FILEPATH
-                                      | --file-text FILEPATH
-                                      | --url TEXT
-                                      )
-                                      [ --expected-hash HASH
-                                      | --out-file FILEPATH
-                                      ]
-
-  Compute the hash of some anchor data (to then pass it to other commands).
-
-Usage: cardano-cli hash script --script-file FILEPATH [--out-file FILEPATH]
-
-  Compute the hash of a script (to then pass it to other commands).
-
-Usage: cardano-cli hash genesis-file --genesis FILEPATH
-
-  Compute the hash of a genesis file.
 
 Usage: cardano-cli debug 
                            ( log-epoch-state

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -13,7 +13,6 @@ Usage: cardano-cli
                      | conway
                      | latest
                      | hash
-                     | ping
                      | debug commands
                      | version
                      | compatible
@@ -10790,17 +10789,6 @@ Usage: cardano-cli hash genesis-file --genesis FILEPATH
 
   Compute the hash of a genesis file.
 
-Usage: cardano-cli ping [-c|--count COUNT]
-                          ((-h|--host HOST) | (-u|--unixsock SOCKET))
-                          [-p|--port PORT]
-                          [-m|--magic MAGIC]
-                          [-j|--json]
-                          [-q|--quiet]
-                          [-Q|--query-versions]
-                          [-t|--tip]
-
-  Ping a cardano node either using node-to-node or node-to-client protocol. It negotiates a handshake and keeps sending keep alive messages.
-
 Usage: cardano-cli debug 
                            ( log-epoch-state
                            | check-node-configuration
@@ -10930,6 +10918,17 @@ Usage: cardano-cli validate-cbor
 Usage: cardano-cli pretty-print-cbor --filepath FILEPATH
 
   Pretty print a CBOR file.
+
+Usage: cardano-cli ping [-c|--count COUNT]
+                          ((-h|--host HOST) | (-u|--unixsock SOCKET))
+                          [-p|--port PORT]
+                          [-m|--magic MAGIC]
+                          [-j|--json]
+                          [-q|--quiet]
+                          [-Q|--query-versions]
+                          [-t|--tip]
+
+  Ping a cardano node either using node-to-node or node-to-client protocol. It negotiates a handshake and keeps sending keep alive messages.
 
 Usage: cardano-cli version 
 

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/ping.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/ping.cli
@@ -22,4 +22,3 @@ Available options:
   -Q,--query-versions      Query the supported protocol versions using the
                            handshake protocol and terminate the connection.
   -t,--tip                 Request tip then exit.
-  -h,--help                Show this help text


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Re-organised `hash` and `ping` commands in help text
  type:
  - documentation
```

# Context

There are a lot of commands in the root level of the `cardano-cli`, this small tweak aims to improve the readability of the main help message, and make things easier to find.

# How to trust this PR

I would check the changes to the help golden files, and ensure the code was re-organised correctly and sensibly.

This is the new output of `cardano-cli --help`:

```
$ cardano-cli --help
cardano-cli - General purpose command-line utility to interact with
cardano-node. Provides specific commands to manage keys, addresses, build &
submit transactions, certificates, etc.

Usage: cardano-cli 
                     ( address
                     | key
                     | node
                     | hash
                     | query
                     | legacy
                     | byron
                     | shelley
                     | allegra
                     | mary
                     | alonzo
                     | babbage
                     | conway
                     | latest
                     | debug commands
                     | version
                     | compatible
                     )

Available options:
  --version                Show the cardano-cli version
  -h,--help                Show this help text

Available commands:
  address                  Payment address commands.
  key                      Key utility commands.
  node                     Node operation commands.
  hash                     Compute the hash to pass to the various --*-hash
                           arguments of commands.
  query                    Node query commands. Will query the local node whose
                           Unix domain socket is obtained from the
                           CARDANO_NODE_SOCKET_PATH environment variable.
  legacy                   Legacy commands

Byron specific commands
  byron                    Byron specific commands

Available commands:
  shelley                  Shelley era commands - DEPRECATED - will be removed
                           in the future
  allegra                  Allegra era commands - DEPRECATED - will be removed
                           in the future
  mary                     Mary era commands - DEPRECATED - will be removed in
                           the future
  alonzo                   Alonzo era commands - DEPRECATED - will be removed in
                           the future
  babbage                  Babbage era commands - DEPRECATED - will be removed
                           in the future
  conway                   Conway era commands
  latest                   Latest era commands (Conway)

debug commands
  debug                    Debug commands

Miscellaneous commands
  help                     Show all help
  version                  Show the cardano-cli version
  ping                     Ping a cardano node either using node-to-node or node-to-client protocol. It negotiates a handshake and keeps sending keep alive messages.

Available commands:
  compatible               Limited backward compatible commands for testing
                           only.

$ 
```

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
