### PR TITLE
cardano-cli-golden: protect shared file by a semaphore

### DIFF
--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/StakeAddress/RegistrationCertificate.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/StakeAddress/RegistrationCertificate.hs
@@ -12,6 +12,11 @@ import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.Golden as H
 import qualified Hedgehog.Extras.Test.Process as H
 
+-- | Semaphore protecting against locked file error, when running properties concurrently.
+regCertificate2Sem :: FileSem
+regCertificate2Sem = newFileSem "test/cardano-cli-golden/files/golden/shelley/stake-address/reg-certificate-2.json"
+{-# NOINLINE regCertificate2Sem #-}
+
 {- HLINT ignore "Use camelCase" -}
 
 hprop_golden_shelley_stake_address_registration_certificate :: Property
@@ -77,7 +82,7 @@ hprop_golden_shelley_stake_address_registration_certificate_with_build_raw = pro
 
   goldenFile1 <-
     H.note "test/cardano-cli-golden/files/golden/shelley/stake-address/reg-certificate-2.json"
-  H.diffFileVsGoldenFile registrationCertFile goldenFile1
+  bracketSem regCertificate2Sem $ H.diffFileVsGoldenFile goldenFile1
 
   void $
     execCardanoCLI

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/Shelley/Transaction/Compatible/Build.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/Shelley/Transaction/Compatible/Build.hs
@@ -17,6 +17,7 @@ import           Test.Cardano.CLI.Util
 
 import           Hedgehog
 import qualified Hedgehog.Extras as H
+import           Test.Golden.Shelley.StakeAddress.RegistrationCertificate (regCertificate2Sem)
 
 inputDir :: FilePath
 inputDir = "test/cardano-cli-test/files/input/shelley/transaction"
@@ -36,8 +37,6 @@ hprop_compatible_conway_transaction_build_one_voter_many_votes = propertyOnce $ 
         , "addr_test1vpfwv0ezc5g8a4mkku8hhy3y3vp92t7s3ul8g778g5yegsgalc6gc+24910487859"
         , "--fee"
         , "178569"
-        , "--certificate-file"
-        , "test/cardano-cli-golden/files/golden/shelley/stake-address/reg-certificate-2.json"
         , "--certificate-script-file"
         , "test/cardano-cli-golden/files/input/AlwaysSucceeds.plutus"
         , "--certificate-redeemer-value"
@@ -47,19 +46,21 @@ hprop_compatible_conway_transaction_build_one_voter_many_votes = propertyOnce $ 
         ]
 
   -- reference transaction
-  _ <-
+  _ <- bracketSem regCertificate2Sem $ \regFile ->
     execCardanoCLI $
       [ eraName
       , "transaction"
       , "build-raw"
       ]
         <> args
-        <> [ "--out-file"
+        <> [ "--certificate-file"
+           , regFile
+           , "--out-file"
            , refOutFile
            ]
 
   -- tested compatible transaction
-  _ <-
+  _ <- bracketSem regCertificate2Sem $ \regFile ->
     execCardanoCLI $
       [ "compatible"
       , eraName
@@ -67,7 +68,9 @@ hprop_compatible_conway_transaction_build_one_voter_many_votes = propertyOnce $ 
       , "signed-transaction"
       ]
         <> args
-        <> [ "--out-file"
+        <> [ "--certificate-file"
+           , regFile
+           , "--out-file"
            , outFile
            ]
 


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    cardano-cli-golden: protect shared file by a semaphore, to avoid spurious failures
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

`test/cardano-cli-golden/files/golden/shelley/stake-address/reg-certificate-2.json` is being used by two tests and I think this has been creating flakiness in the CI, as visible here (failure happened on https://github.com/IntersectMBO/cardano-cli/pull/1036, see [here](https://github.com/IntersectMBO/cardano-cli/actions/runs/13137919343/job/36657661186?pr=1036) and also [here](https://github.com/IntersectMBO/cardano-cli/actions/runs/13138676288/job/36660183869?pr=1038) on #1038):

![image](https://github.com/user-attachments/assets/297f6a04-9372-4370-868f-0355c3b14023)

# How to trust this PR

* Tests pass
* Locking looks good

# Checklist

- [X] Commit sequence broadly makes sense and commits have useful messages
- [X] Self-reviewed the diff