### PR TITLE
Remove use of script witness files in withdrawal scripts

### DIFF
--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -129,6 +129,8 @@ library
     Cardano.CLI.EraBased.Script.Types
     Cardano.CLI.EraBased.Script.Vote.Read
     Cardano.CLI.EraBased.Script.Vote.Types
+    Cardano.CLI.EraBased.Script.Withdrawal.Read
+    Cardano.CLI.EraBased.Script.Withdrawal.Types
     Cardano.CLI.EraBased.Transaction.HashCheck
     Cardano.CLI.Helpers
     Cardano.CLI.IO.Lazy

--- a/cardano-cli/src/Cardano/CLI/EraBased/Commands/Transaction.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Commands/Transaction.hs
@@ -30,6 +30,7 @@ import           Cardano.CLI.EraBased.Script.Mint.Types
 import           Cardano.CLI.EraBased.Script.Proposal.Types (CliProposalScriptRequirements)
 import           Cardano.CLI.EraBased.Script.Spend.Types (CliSpendScriptRequirements)
 import           Cardano.CLI.EraBased.Script.Vote.Types
+import           Cardano.CLI.EraBased.Script.Withdrawal.Types
 import           Cardano.CLI.Orphans ()
 import           Cardano.CLI.Types.Common
 import           Cardano.CLI.Types.Governance
@@ -77,7 +78,7 @@ data TransactionBuildRawCmdArgs era = TransactionBuildRawCmdArgs
   -- ^ Transaction fee
   , certificates :: ![(CertificateFile, Maybe CliCertificateScriptRequirements)]
   -- ^ Certificates with potential script witness
-  , withdrawals :: ![(StakeAddress, Coin, Maybe (ScriptWitnessFiles WitCtxStake))]
+  , withdrawals :: ![(StakeAddress, Coin, Maybe CliWithdrawalScriptRequirements)]
   , metadataSchema :: !TxMetadataJsonSchema
   , scriptFiles :: ![ScriptFile]
   -- ^ Auxiliary scripts
@@ -123,7 +124,7 @@ data TransactionBuildCmdArgs era = TransactionBuildCmdArgs
   -- ^ Transaction validity upper bound
   , certificates :: ![(CertificateFile, Maybe CliCertificateScriptRequirements)]
   -- ^ Certificates with potential script witness
-  , withdrawals :: ![(StakeAddress, Coin, Maybe (ScriptWitnessFiles WitCtxStake))]
+  , withdrawals :: ![(StakeAddress, Coin, Maybe CliWithdrawalScriptRequirements)]
   -- ^ Withdrawals with potential script witness
   , metadataSchema :: !TxMetadataJsonSchema
   , scriptFiles :: ![ScriptFile]
@@ -169,7 +170,7 @@ data TransactionBuildEstimateCmdArgs era = TransactionBuildEstimateCmdArgs
   -- ^ Transaction validity upper bound
   , certificates :: ![(CertificateFile, Maybe CliCertificateScriptRequirements)]
   -- ^ Certificates with potential script witness
-  , withdrawals :: ![(StakeAddress, Coin, Maybe (ScriptWitnessFiles WitCtxStake))]
+  , withdrawals :: ![(StakeAddress, Coin, Maybe CliWithdrawalScriptRequirements)]
   -- ^ Withdrawals with potential script witness
   , plutusCollateral :: !(Maybe Coin)
   -- ^ Total collateral

--- a/cardano-cli/src/Cardano/CLI/EraBased/Script/Read/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Script/Read/Common.hs
@@ -5,7 +5,6 @@
 module Cardano.CLI.EraBased.Script.Read.Common
   ( -- * Plutus Script Related
     readScriptDataOrFile
-  , readScriptDatumOrFile
   , readScriptRedeemerOrFile
   , readFilePlutusScript
 
@@ -129,17 +128,6 @@ readScriptDataOrFile (ScriptDataCborFile fp) = do
       validateScriptData $
         getScriptData hSd
   return hSd
-
-readScriptDatumOrFile
-  :: ScriptDatumOrFile witctx
-  -> ExceptT ScriptDataError IO (ScriptDatum witctx)
-readScriptDatumOrFile (ScriptDatumOrFileForTxIn Nothing) = pure $ ScriptDatumForTxIn Nothing
-readScriptDatumOrFile (ScriptDatumOrFileForTxIn (Just df)) =
-  ScriptDatumForTxIn . Just
-    <$> readScriptDataOrFile df
-readScriptDatumOrFile InlineDatumPresentAtTxIn = pure InlineScriptDatum
-readScriptDatumOrFile NoScriptDatumOrFileForMint = pure NoScriptDatumForMint
-readScriptDatumOrFile NoScriptDatumOrFileForStake = pure NoScriptDatumForStake
 
 readScriptRedeemerOrFile
   :: ScriptRedeemerOrFile

--- a/cardano-cli/src/Cardano/CLI/EraBased/Script/Withdrawal/Read.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Script/Withdrawal/Read.hs
@@ -8,8 +8,8 @@ module Cardano.CLI.EraBased.Script.Withdrawal.Read
 where
 
 import           Cardano.Api
-import           Cardano.Api.Shelley
 import           Cardano.Api.Ledger
+import           Cardano.Api.Shelley
 
 import           Cardano.CLI.EraBased.Script.Read.Common
 import           Cardano.CLI.EraBased.Script.Types
@@ -32,7 +32,8 @@ readWithdrawalScriptWitness sbe (stakeAddr, withdrawalAmt, Just certScriptReq) =
       case s of
         SimpleScript ss -> do
           return
-            (stakeAddr, withdrawalAmt
+            ( stakeAddr
+            , withdrawalAmt
             , Just $
                 WithdrawalScriptWitness
                   ( SimpleScriptWitness (sbeToSimpleScriptLanguageInEra sbe) $
@@ -60,7 +61,8 @@ readWithdrawalScriptWitness sbe (stakeAddr, withdrawalAmt, Just certScriptReq) =
               $ scriptLanguageSupportedInEra sbe
               $ PlutusScriptLanguage lang
           return
-            (stakeAddr, withdrawalAmt
+            ( stakeAddr
+            , withdrawalAmt
             , Just $
                 WithdrawalScriptWitness $
                   PlutusScriptWitness
@@ -96,7 +98,8 @@ readWithdrawalScriptWitness sbe (stakeAddr, withdrawalAmt, Just certScriptReq) =
               $ PlutusScriptLanguage lang
 
           return
-            (stakeAddr, withdrawalAmt
+            ( stakeAddr
+            , withdrawalAmt
             , Just $
                 WithdrawalScriptWitness $
                   PlutusScriptWitness

--- a/cardano-cli/src/Cardano/CLI/EraBased/Script/Withdrawal/Read.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Script/Withdrawal/Read.hs
@@ -1,0 +1,109 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+
+module Cardano.CLI.EraBased.Script.Withdrawal.Read
+  ( readWithdrawalScriptWitness
+  )
+where
+
+import           Cardano.Api
+import           Cardano.Api.Shelley
+import           Cardano.Api.Ledger
+
+import           Cardano.CLI.EraBased.Script.Read.Common
+import           Cardano.CLI.EraBased.Script.Types
+import           Cardano.CLI.EraBased.Script.Withdrawal.Types
+
+readWithdrawalScriptWitness
+  :: MonadIOTransError (FileError CliScriptWitnessError) t m
+  => ShelleyBasedEra era
+  -> (StakeAddress, Coin, Maybe CliWithdrawalScriptRequirements)
+  -> t m (StakeAddress, Coin, Maybe (WithdrawalScriptWitness era))
+readWithdrawalScriptWitness _ (stakeAddr, withdrawalAmt, Nothing) =
+  return (stakeAddr, withdrawalAmt, Nothing)
+readWithdrawalScriptWitness sbe (stakeAddr, withdrawalAmt, Just certScriptReq) = do
+  case certScriptReq of
+    OnDiskSimpleScript scriptFp -> do
+      let sFp = unFile scriptFp
+      s <-
+        modifyError (fmap SimpleScriptWitnessDecodeError) $
+          readFileSimpleScript sFp
+      case s of
+        SimpleScript ss -> do
+          return
+            (stakeAddr, withdrawalAmt
+            , Just $
+                WithdrawalScriptWitness
+                  ( SimpleScriptWitness (sbeToSimpleScriptLanguageInEra sbe) $
+                      SScript ss
+                  )
+            )
+    OnDiskPlutusScript (OnDiskPlutusScriptCliArgs scriptFp redeemerFile execUnits) -> do
+      let plutusScriptFp = unFile scriptFp
+      plutusScript <-
+        modifyError (fmap PlutusScriptWitnessDecodeError) $
+          readFilePlutusScript plutusScriptFp
+      redeemer <-
+        modifyError (FileError plutusScriptFp . PlutusScriptWitnessRedeemerError) $
+          readScriptDataOrFile redeemerFile
+      case plutusScript of
+        AnyPlutusScript lang script -> do
+          let pScript = PScript script
+          sLangSupported <-
+            modifyError (FileError plutusScriptFp)
+              $ hoistMaybe
+                ( PlutusScriptWitnessLanguageNotSupportedInEra
+                    (AnyPlutusScriptVersion lang)
+                    (shelleyBasedEraConstraints sbe $ AnyShelleyBasedEra sbe)
+                )
+              $ scriptLanguageSupportedInEra sbe
+              $ PlutusScriptLanguage lang
+          return
+            (stakeAddr, withdrawalAmt
+            , Just $
+                WithdrawalScriptWitness $
+                  PlutusScriptWitness
+                    sLangSupported
+                    lang
+                    pScript
+                    NoScriptDatumForStake
+                    redeemer
+                    execUnits
+            )
+    OnDiskPlutusRefScript (PlutusRefScriptCliArgs refTxIn anyPlutusScriptVersion redeemerFile execUnits) -> do
+      case anyPlutusScriptVersion of
+        AnyPlutusScriptVersion lang -> do
+          let pScript = PReferenceScript refTxIn
+          redeemer <-
+            -- TODO: Implement a new error type to capture this. FileError is not representative of cases
+            -- where we do not have access to the script.
+            modifyError
+              ( FileError "Reference script filepath not available"
+                  . PlutusScriptWitnessRedeemerError
+              )
+              $ readScriptDataOrFile redeemerFile
+          sLangSupported <-
+            -- TODO: Implement a new error type to capture this. FileError is not representative of cases
+            -- where we do not have access to the script.
+            modifyError (FileError "Reference script filepath not available")
+              $ hoistMaybe
+                ( PlutusScriptWitnessLanguageNotSupportedInEra
+                    (AnyPlutusScriptVersion lang)
+                    (shelleyBasedEraConstraints sbe $ AnyShelleyBasedEra sbe)
+                )
+              $ scriptLanguageSupportedInEra sbe
+              $ PlutusScriptLanguage lang
+
+          return
+            (stakeAddr, withdrawalAmt
+            , Just $
+                WithdrawalScriptWitness $
+                  PlutusScriptWitness
+                    sLangSupported
+                    lang
+                    pScript
+                    NoScriptDatumForStake
+                    redeemer
+                    execUnits
+            )

--- a/cardano-cli/src/Cardano/CLI/EraBased/Script/Withdrawal/Types.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Script/Withdrawal/Types.hs
@@ -1,0 +1,63 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE GADTs #-}
+
+module Cardano.CLI.EraBased.Script.Withdrawal.Types
+  ( CliWithdrawalScriptRequirements (..)
+  , PlutusRefScriptCliArgs (..)
+  , PlutusScriptCliArgs (..)
+  , WithdrawalScriptWitness (..)
+  , createSimpleOrPlutusScriptFromCliArgs
+  , createPlutusReferenceScriptFromCliArgs
+  )
+where
+
+import           Cardano.Api
+
+import           Cardano.CLI.Types.Common (ScriptDataOrFile)
+
+newtype WithdrawalScriptWitness era
+  = WithdrawalScriptWitness {wswScriptWitness :: ScriptWitness WitCtxStake era}
+  deriving Show
+
+data CliWithdrawalScriptRequirements
+  = OnDiskPlutusScript PlutusScriptCliArgs
+  | OnDiskSimpleScript (File ScriptInAnyLang In)
+  | OnDiskPlutusRefScript PlutusRefScriptCliArgs
+  deriving Show
+
+data PlutusScriptCliArgs
+  = OnDiskPlutusScriptCliArgs
+      (File ScriptInAnyLang In)
+      ScriptDataOrFile
+      -- ^ Redeemer
+      ExecutionUnits
+  deriving Show
+
+createSimpleOrPlutusScriptFromCliArgs
+  :: File ScriptInAnyLang In
+  -> Maybe (ScriptDataOrFile, ExecutionUnits)
+  -> CliWithdrawalScriptRequirements
+createSimpleOrPlutusScriptFromCliArgs scriptFp (Just (redeemer, execUnits)) =
+  OnDiskPlutusScript $ OnDiskPlutusScriptCliArgs scriptFp redeemer execUnits
+createSimpleOrPlutusScriptFromCliArgs scriptFp Nothing =
+  OnDiskSimpleScript scriptFp
+
+data PlutusRefScriptCliArgs
+  = PlutusRefScriptCliArgs
+      TxIn
+      -- ^ TxIn with reference script
+      AnyPlutusScriptVersion
+      ScriptDataOrFile
+      -- ^ Redeemer
+      ExecutionUnits
+  deriving Show
+
+createPlutusReferenceScriptFromCliArgs
+  :: TxIn
+  -> AnyPlutusScriptVersion
+  -> ScriptDataOrFile
+  -> ExecutionUnits
+  -> CliWithdrawalScriptRequirements
+createPlutusReferenceScriptFromCliArgs txIn version redeemer execUnits =
+  OnDiskPlutusRefScript $ PlutusRefScriptCliArgs txIn version redeemer execUnits

--- a/cardano-cli/src/Cardano/CLI/Types/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Common.hs
@@ -58,7 +58,6 @@ module Cardano.CLI.Types.Common
   , ReferenceScriptSize (..)
   , RequiredSigner (..)
   , ScriptDataOrFile (..)
-  , ScriptDatumOrFile (..)
   , ScriptFile
   , ScriptRedeemerOrFile
   , SigningKeyFile
@@ -403,16 +402,6 @@ data ScriptDataOrFile
   deriving (Eq, Show)
 
 type ScriptRedeemerOrFile = ScriptDataOrFile
-
-data ScriptDatumOrFile witctx where
-  ScriptDatumOrFileForTxIn
-    :: Maybe ScriptDataOrFile -- CIP-0069 - Spending datums optional in Conway era onwards
-    -> ScriptDatumOrFile WitCtxTxIn
-  InlineDatumPresentAtTxIn :: ScriptDatumOrFile WitCtxTxIn
-  NoScriptDatumOrFileForMint :: ScriptDatumOrFile WitCtxMint
-  NoScriptDatumOrFileForStake :: ScriptDatumOrFile WitCtxStake
-
-deriving instance Show (ScriptDatumOrFile witctx)
 
 newtype SlotsTillKesKeyExpiry = SlotsTillKesKeyExpiry {unSlotsTillKesKeyExpiry :: SlotNo}
   deriving (Eq, Show)

--- a/cardano-cli/src/Cardano/CLI/Types/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Common.hs
@@ -61,7 +61,6 @@ module Cardano.CLI.Types.Common
   , ScriptDatumOrFile (..)
   , ScriptFile
   , ScriptRedeemerOrFile
-  , ScriptWitnessFiles (..)
   , SigningKeyFile
   , SlotsTillKesKeyExpiry (..)
   , SomeKeyFile (..)
@@ -404,54 +403,6 @@ data ScriptDataOrFile
   deriving (Eq, Show)
 
 type ScriptRedeemerOrFile = ScriptDataOrFile
-
--- | This type is like 'ScriptWitness', but the file paths from which to load
--- the script witness data representation.
---
--- It is era-independent, but witness context-dependent.
--- NB: This is in the process of being deprecated because it is difficult
--- to accomodate for changes for specific plutus script purposes. As an
--- example when minting a multi-asset with a plutus script we need the policy
--- id of the said script. This is fine when we have access to the plutus script however
--- in the case of a reference script we demand the user provides the policy id.
--- Enshrining that change in the 'ScriptWitnessFiles' is difficult because only
--- minting scripts require this but not the other kinds of plutus scripts (spending, certifying etc.)
--- Another example is CIP-69 where datums are no longer required for spending scripts. This is
--- further complicated by the fact at the parsing level we make user facing simplifications e.g `--mint-script-file`
--- which says nothing about the script type (simple vs plutus) or script version.
--- As a result need to separate the different script purposes into
--- their own separate data definitions where we can make changes specific to that script purpose
--- more easily without affecting the rest of the api.
-data ScriptWitnessFiles witctx where
-  SimpleScriptWitnessFile
-    :: ScriptFile
-    -> ScriptWitnessFiles witctx
-  PlutusScriptWitnessFiles
-    :: ScriptFile
-    -> ScriptDatumOrFile witctx
-    -> ScriptRedeemerOrFile
-    -> ExecutionUnits
-    -> ScriptWitnessFiles witctx
-  -- | This no longer is used for minting or spending
-  -- scripts.
-  -- Use MintScriptWitnessWithPolicyId or SpendScriptWitness instead
-  PlutusReferenceScriptWitnessFiles
-    :: TxIn
-    -> AnyPlutusScriptVersion
-    -> ScriptDatumOrFile witctx
-    -> ScriptRedeemerOrFile
-    -> ExecutionUnits
-    -- ^ For minting reference scripts
-    -> ScriptWitnessFiles witctx
-  -- | This no longer is used for minting or spending
-  -- scripts
-  -- Use MintScriptWitnessWithPolicyId or SpendScriptWitness instead
-  SimpleReferenceScriptWitnessFiles
-    :: TxIn
-    -> AnyScriptLanguage
-    -> ScriptWitnessFiles witctx
-
-deriving instance Show (ScriptWitnessFiles witctx)
 
 data ScriptDatumOrFile witctx where
   ScriptDatumOrFileForTxIn

--- a/cardano-cli/src/Cardano/CLI/Types/Errors/TxCmdError.hs
+++ b/cardano-cli/src/Cardano/CLI/Types/Errors/TxCmdError.hs
@@ -49,7 +49,6 @@ data TxCmdError
   | TxCmdVoteError VoteError
   | TxCmdConstitutionError ConstitutionError
   | TxCmdProposalError ProposalError
-  | TxCmdScriptWitnessError ScriptWitnessError
   | TxCmdProtocolParamsError ProtocolParamsError
   | TxCmdScriptFileError (FileError ScriptDecodeError)
   | TxCmdCliScriptWitnessError !(FileError CliScriptWitnessError)
@@ -212,8 +211,6 @@ renderTxCmdError = \case
     "Protocol parameters were not found in transaction body"
   TxCmdMetadataError e ->
     renderMetadataError e
-  TxCmdScriptWitnessError e ->
-    renderScriptWitnessError e
   TxCmdScriptDataError e ->
     renderScriptDataError e
   TxCmdProtocolParamsError e ->


### PR DESCRIPTION
Depends on #1047 

# Changelog

```yaml
- description: |
    Remove use of script witness files in withdrawal scripts
  type:
  - refactoring    # QoL changes
```

# Context

Additional context for the PR goes here. If the PR fixes a particular issue please provide a [link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=) to the issue.

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
