### PR TITLE
Remove semaphores and disable parallel test execution for GHA

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -142,6 +142,8 @@ jobs:
         TMP: ${{ runner.temp }}
         KEEP_WORKSPACE: 1
         CREATE_GOLDEN_FILES: 1
+      # We disable parallel execution of tests because there is a race condition
+      # that appears only in CI when the golden files are removed and then recreated
       run: cabal test all --enable-tests --test-show-details=direct --ghc-options="-threaded -rtsopts \"-with-rtsopts=-N1 -T\""
 
     # We want this check to run first because $(git ls-files -m) (see below) returns both

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -77,7 +77,7 @@ jobs:
     - name: Cabal update
       run: cabal update
 
-    # A dry run `build all` operation does *NOT* downlaod anything, it just looks at the package
+    # A dry run `build all` operation does *NOT* download anything, it just looks at the package
     # indices to generate an install plan.
     - name: Build dry run
       run: cabal build all --enable-tests --dry-run --minimize-conflict-set
@@ -142,7 +142,7 @@ jobs:
         TMP: ${{ runner.temp }}
         KEEP_WORKSPACE: 1
         CREATE_GOLDEN_FILES: 1
-      run: cabal test all --enable-tests --test-show-details=direct
+      run: cabal test all --enable-tests --test-show-details=direct --ghc-options="-threaded -rtsopts \"-with-rtsopts=-N1 -T\""
 
     # We want this check to run first because $(git ls-files -m) (see below) returns both
     # modified files *and* deleted files. So we want to fail on deleted files first.

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -307,7 +307,6 @@ library cardano-cli-test-lib
     process,
     resourcet,
     text,
-    transformers-base,
     utf8-string,
     vector,
     wai,

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/CreateTestnetData.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/CreateTestnetData.hs
@@ -19,7 +19,7 @@ import           System.Directory.Extra (listDirectories)
 import           System.FilePath
 
 import           Test.Cardano.CLI.Aeson
-import           Test.Cardano.CLI.Util (FileSem, bracketSem, execCardanoCLI, newFileSem)
+import           Test.Cardano.CLI.Util (execCardanoCLI)
 
 import           Hedgehog (Property)
 import qualified Hedgehog as H
@@ -96,10 +96,8 @@ hprop_golden_create_testnet_data_with_template =
   golden_create_testnet_data $
     Just "test/cardano-cli-golden/files/input/shelley/genesis/genesis.spec.json"
 
--- | Semaphore protecting against locked file error, when running properties concurrently.
-createTestnetDataOutSem :: FileSem
-createTestnetDataOutSem = newFileSem "test/cardano-cli-golden/files/golden/conway/create-testnet-data.out"
-{-# NOINLINE createTestnetDataOutSem #-}
+createTestnetDataOutGoldenFile :: FilePath
+createTestnetDataOutGoldenFile = "test/cardano-cli-golden/files/golden/conway/create-testnet-data.out"
 
 -- | This test tests the non-transient case, i.e. it maximizes the files
 -- that can be written to disk.
@@ -130,8 +128,7 @@ golden_create_testnet_data mShelleyTemplate =
         generated'' = map (\c -> if c == '\\' then '/' else c) generated'
     void $ H.note generated''
 
-    bracketSem createTestnetDataOutSem $
-      H.diffVsGoldenFile generated''
+    H.diffVsGoldenFile generated'' createTestnetDataOutGoldenFile
 
     shelleyGenesis :: ShelleyGenesis StandardCrypto <-
       H.readJsonFileOk $ outputDir </> "shelley-genesis.json"

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Governance/DRep.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Governance/DRep.hs
@@ -29,11 +29,9 @@ import qualified Hedgehog.Extras.Test.Base as H
 import qualified Hedgehog.Extras.Test.File as H
 import qualified Hedgehog.Extras.Test.Golden as H
 
--- | Semaphore protecting against locked file error, when running properties concurrently.
 drepRetirementCertFile :: FilePath
 drepRetirementCertFile = "test/cardano-cli-golden/files/golden/governance/drep/drep_retirement_cert"
 
--- | Semaphore protecting against locked file error, when running properties concurrently.
 drepRegistrationCertFile :: FilePath
 drepRegistrationCertFile = "test/cardano-cli-golden/files/golden/governance/drep/drep_registration_certificate.json"
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Governance/DRep.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Governance/DRep.hs
@@ -20,8 +20,8 @@ import           System.Posix.Files (fileMode, getFileStatus)
 import           GHC.IO.Exception (ExitCode (ExitFailure))
 import           Test.Cardano.CLI.Hash (exampleAnchorDataHash, exampleAnchorDataIpfsHash,
                    exampleAnchorDataPathGolden, serveFilesWhile, tamperBase16Hash)
-import           Test.Cardano.CLI.Util (FileSem, bracketSem, execCardanoCLI, execDetailCardanoCLI,
-                   newFileSem, noteInputFile, noteTempFile, propertyOnce)
+import           Test.Cardano.CLI.Util (execCardanoCLI, execDetailCardanoCLI,
+                   noteInputFile, noteTempFile, propertyOnce)
 
 import           Hedgehog
 import qualified Hedgehog as H
@@ -30,15 +30,12 @@ import qualified Hedgehog.Extras.Test.File as H
 import qualified Hedgehog.Extras.Test.Golden as H
 
 -- | Semaphore protecting against locked file error, when running properties concurrently.
-drepRetirementCertSem :: FileSem
-drepRetirementCertSem = newFileSem "test/cardano-cli-golden/files/golden/governance/drep/drep_retirement_cert"
-{-# NOINLINE drepRetirementCertSem #-}
+drepRetirementCertFile :: FilePath
+drepRetirementCertFile = "test/cardano-cli-golden/files/golden/governance/drep/drep_retirement_cert"
 
 -- | Semaphore protecting against locked file error, when running properties concurrently.
-drepRegistrationCertSem :: FileSem
-drepRegistrationCertSem =
-  newFileSem "test/cardano-cli-golden/files/golden/governance/drep/drep_registration_certificate.json"
-{-# NOINLINE drepRegistrationCertSem #-}
+drepRegistrationCertFile :: FilePath
+drepRegistrationCertFile = "test/cardano-cli-golden/files/golden/governance/drep/drep_registration_certificate.json"
 
 hprop_golden_governanceDRepKeyGen :: Property
 hprop_golden_governanceDRepKeyGen =
@@ -174,7 +171,7 @@ hprop_golden_governance_drep_retirement_certificate_vkey_file =
   propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     drepVKeyFile <- noteInputFile "test/cardano-cli-golden/files/input/drep.vkey"
     certFile <- H.noteTempFile tempDir "drep.retirement.cert"
-    H.noteShow_ drepRetirementCertSem
+    H.noteShow_ drepRetirementCertFile
 
     void $
       execCardanoCLI
@@ -190,14 +187,13 @@ hprop_golden_governance_drep_retirement_certificate_vkey_file =
         , certFile
         ]
 
-    bracketSem drepRetirementCertSem $
-      H.diffFileVsGoldenFile certFile
+    H.diffFileVsGoldenFile certFile drepRetirementCertFile
 
 hprop_golden_governance_drep_retirement_certificate_id_hex :: Property
 hprop_golden_governance_drep_retirement_certificate_id_hex =
   propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     certFile <- H.noteTempFile tempDir "drep.retirement.cert"
-    H.noteShow_ drepRetirementCertSem
+    H.noteShow_ drepRetirementCertFile
 
     idFile <- H.readFile "test/cardano-cli-golden/files/input/drep.id.hex"
 
@@ -215,14 +211,13 @@ hprop_golden_governance_drep_retirement_certificate_id_hex =
         , certFile
         ]
 
-    bracketSem drepRetirementCertSem $
-      H.diffFileVsGoldenFile certFile
+    H.diffFileVsGoldenFile certFile drepRetirementCertFile
 
 hprop_golden_governance_drep_retirement_certificate_id_bech32 :: Property
 hprop_golden_governance_drep_retirement_certificate_id_bech32 =
   propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     certFile <- H.noteTempFile tempDir "drep.retirement.cert"
-    H.noteShow_ drepRetirementCertSem
+    H.noteShow_ drepRetirementCertFile
 
     idFile <- H.readFile "test/cardano-cli-golden/files/input/drep.id.bech32"
 
@@ -240,8 +235,7 @@ hprop_golden_governance_drep_retirement_certificate_id_bech32 =
         , certFile
         ]
 
-    bracketSem drepRetirementCertSem $
-      H.diffFileVsGoldenFile certFile
+    H.diffFileVsGoldenFile certFile drepRetirementCertFile
 
 hprop_golden_governance_drep_metadata_hash :: Property
 hprop_golden_governance_drep_metadata_hash = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
@@ -297,7 +291,7 @@ hprop_golden_governance_drep_metadata_hash_cip119 = propertyOnce . H.moduleWorks
 hprop_golden_governance_drep_registration_certificate_vkey_file :: Property
 hprop_golden_governance_drep_registration_certificate_vkey_file = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
   drepVKeyFile <- noteInputFile "test/cardano-cli-golden/files/input/drep.vkey"
-  H.noteShow_ drepRegistrationCertSem
+  H.noteShow_ drepRegistrationCertFile
 
   outFile <- H.noteTempFile tempDir "drep-reg-cert.txt"
 
@@ -319,13 +313,12 @@ hprop_golden_governance_drep_registration_certificate_vkey_file = propertyOnce .
       , outFile
       ]
 
-  bracketSem drepRegistrationCertSem $
-    H.diffFileVsGoldenFile outFile
+  H.diffFileVsGoldenFile outFile drepRegistrationCertFile
 
 hprop_golden_governance_drep_registration_certificate_id_hex :: Property
 hprop_golden_governance_drep_registration_certificate_id_hex = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
   idFile <- H.readFile "test/cardano-cli-golden/files/input/drep.id.hex"
-  H.noteShow_ drepRegistrationCertSem
+  H.noteShow_ drepRegistrationCertFile
 
   outFile <- H.noteTempFile tempDir "drep-reg-cert.txt"
 
@@ -347,13 +340,12 @@ hprop_golden_governance_drep_registration_certificate_id_hex = propertyOnce . H.
       , outFile
       ]
 
-  bracketSem drepRegistrationCertSem $
-    H.diffFileVsGoldenFile outFile
+  H.diffFileVsGoldenFile outFile drepRegistrationCertFile
 
 hprop_golden_governance_drep_registration_certificate_id_bech32 :: Property
 hprop_golden_governance_drep_registration_certificate_id_bech32 = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
   idFile <- H.readFile "test/cardano-cli-golden/files/input/drep.id.bech32"
-  H.noteShow_ drepRegistrationCertSem
+  H.noteShow_ drepRegistrationCertFile
 
   outFile <- H.noteTempFile tempDir "drep-reg-cert.txt"
 
@@ -375,8 +367,7 @@ hprop_golden_governance_drep_registration_certificate_id_bech32 = propertyOnce .
       , outFile
       ]
 
-  bracketSem drepRegistrationCertSem $
-    H.diffFileVsGoldenFile outFile
+  H.diffFileVsGoldenFile outFile drepRegistrationCertFile
 
 hprop_golden_governance_drep_registration_certificate_script_hash :: Property
 hprop_golden_governance_drep_registration_certificate_script_hash = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Governance/Vote.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Governance/Vote.hs
@@ -9,8 +9,8 @@ import qualified System.Environment as IO
 
 import           Test.Cardano.CLI.Hash (exampleAnchorDataHash, exampleAnchorDataIpfsHash,
                    exampleAnchorDataPathGolden, serveFilesWhile, tamperBase16Hash)
-import           Test.Cardano.CLI.Util (FileSem, bracketSem, execCardanoCLI,
-                   execDetailConfigCardanoCLI, newFileSem, noteInputFile, propertyOnce)
+import           Test.Cardano.CLI.Util (execCardanoCLI, execDetailConfigCardanoCLI, noteInputFile,
+                   propertyOnce)
 
 import           Hedgehog (Property, (===))
 import qualified Hedgehog as H
@@ -47,15 +47,14 @@ hprop_golden_governance_governance_vote_create =
 
     H.diffFileVsGoldenFile voteFile voteGold
 
-voteViewJsonSem :: FileSem
-voteViewJsonSem = newFileSem "test/cardano-cli-golden/files/golden/governance/vote/voteViewJSON"
-{-# NOINLINE voteViewJsonSem #-}
+voteViewJsonFile :: FilePath
+voteViewJsonFile = "test/cardano-cli-golden/files/golden/governance/vote/voteViewJSON"
 
 hprop_golden_governance_governance_vote_view_json_stdout :: Property
 hprop_golden_governance_governance_vote_view_json_stdout =
   propertyOnce $ do
     voteFile <- noteInputFile "test/cardano-cli-golden/files/input/governance/vote/vote"
-    H.noteShow_ voteViewJsonSem
+    H.noteShow_ voteViewJsonFile
     voteView <-
       execCardanoCLI
         [ "conway"
@@ -66,15 +65,14 @@ hprop_golden_governance_governance_vote_view_json_stdout =
         , voteFile
         ]
 
-    bracketSem voteViewJsonSem $
-      H.diffVsGoldenFile voteView
+    H.diffVsGoldenFile voteView voteViewJsonFile
 
 hprop_golden_governance_governance_vote_view_json_outfile :: Property
 hprop_golden_governance_governance_vote_view_json_outfile =
   propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
     voteFile <- noteInputFile "test/cardano-cli-golden/files/input/governance/vote/vote"
     voteViewFile <- H.noteTempFile tempDir "voteView"
-    H.noteShow_ voteViewJsonSem
+    H.noteShow_ voteViewJsonFile
     void $
       execCardanoCLI
         [ "conway"
@@ -87,8 +85,7 @@ hprop_golden_governance_governance_vote_view_json_outfile =
         , voteViewFile
         ]
 
-    bracketSem voteViewJsonSem $
-      H.diffFileVsGoldenFile voteViewFile
+    H.diffFileVsGoldenFile voteViewFile voteViewJsonFile
 
 hprop_golden_governance_governance_vote_view_yaml :: Property
 hprop_golden_governance_governance_vote_view_yaml =

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/CheckNodeConfiguration.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/CheckNodeConfiguration.hs
@@ -24,7 +24,6 @@ import qualified Hedgehog as H
 import           Hedgehog.Extras (propertyOnce)
 import qualified Hedgehog.Extras as H
 
--- | Semaphore protecting against locked file error, when running properties concurrently.
 nodeConfigFile :: FilePath
 nodeConfigFile = "test/cardano-cli-test/files/input/check-node-configuration/node-config.json"
 

--- a/cardano-cli/test/cardano-cli-test/Test/Cli/CheckNodeConfiguration.hs
+++ b/cardano-cli/test/cardano-cli-test/Test/Cli/CheckNodeConfiguration.hs
@@ -17,8 +17,7 @@ import qualified Data.Yaml as Yaml
 import           GHC.IO.Exception (ExitCode (..))
 import           System.FilePath ((</>))
 
-import           Test.Cardano.CLI.Util (FileSem, bracketSem, execCardanoCLI, execDetailCardanoCLI,
-                   newFileSem)
+import           Test.Cardano.CLI.Util (execCardanoCLI, execDetailCardanoCLI)
 
 import           Hedgehog (Property)
 import qualified Hedgehog as H
@@ -26,25 +25,21 @@ import           Hedgehog.Extras (propertyOnce)
 import qualified Hedgehog.Extras as H
 
 -- | Semaphore protecting against locked file error, when running properties concurrently.
-nodeConfigSem :: FileSem
-nodeConfigSem = newFileSem "test/cardano-cli-test/files/input/check-node-configuration/node-config.json"
-{-# NOINLINE nodeConfigSem #-}
+nodeConfigFile :: FilePath
+nodeConfigFile = "test/cardano-cli-test/files/input/check-node-configuration/node-config.json"
 
 -- Execute this test with:
 -- @cabal test cardano-cli-test --test-options '-p "/check node configuration success/"'@
 hprop_check_node_configuration_success :: Property
 hprop_check_node_configuration_success =
   propertyOnce $ do
-    -- We test that the command doesn't crash, because otherwise
-    -- execCardanoCLI would fail.
-    bracketSem nodeConfigSem $ \nodeConfigFile -> do
-      H.noteM_ $
-        execCardanoCLI
-          [ "debug"
-          , "check-node-configuration"
-          , "--node-configuration-file"
-          , nodeConfigFile
-          ]
+    H.noteM_ $
+      execCardanoCLI
+        [ "debug"
+        , "check-node-configuration"
+        , "--node-configuration-file"
+        , nodeConfigFile
+        ]
 
 data FiddleKind
   = FiddleByron
@@ -64,58 +59,57 @@ hprop_check_node_configuration_failure = do
         , fiddleKind <- [minBound .. maxBound]
         ]
 
-  propertyOnce $ forM_ supplyValues $ \(nodeConfigPath, fiddleKind) -> H.moduleWorkspace "tmp" $ \tempDir ->
-    bracketSem nodeConfigSem $ \_ -> do
-      let finalInputConfig = tempDir </> "node-config-changed.json"
-          -- TODO why is that writing to "AlonzoGenesisHash" writes one more 0 than specified here? (and hence the need for this hack)
-          wrongHash = Text.pack $ replicate (case fiddleKind of FiddleByron -> 65; FiddleNonByron -> 64) '0'
+  propertyOnce $ forM_ supplyValues $ \(nodeConfigPath, fiddleKind) -> H.moduleWorkspace "tmp" $ \tempDir -> do
+    let finalInputConfig = tempDir </> "node-config-changed.json"
+        -- TODO why is that writing to "AlonzoGenesisHash" writes one more 0 than specified here? (and hence the need for this hack)
+        wrongHash = Text.pack $ replicate (case fiddleKind of FiddleByron -> 65; FiddleNonByron -> 64) '0'
 
-      -- Install the genesis files in the sandbox
-      forM_
-        [AnyCardanoEra ByronEra, AnyCardanoEra AlonzoEra, AnyCardanoEra ConwayEra, AnyCardanoEra ShelleyEra]
-        $ \(AnyCardanoEra era) -> do
-          let filename = Text.unpack $ "genesis." <> Text.toLower (eraToStringKey era) <> ".spec.json"
-              genesisFile = "test/cardano-cli-test/files/input/check-node-configuration" </> filename
-          H.copyFile genesisFile (tempDir </> filename)
+    -- Install the genesis files in the sandbox
+    forM_
+      [AnyCardanoEra ByronEra, AnyCardanoEra AlonzoEra, AnyCardanoEra ConwayEra, AnyCardanoEra ShelleyEra]
+      $ \(AnyCardanoEra era) -> do
+        let filename = Text.unpack $ "genesis." <> Text.toLower (eraToStringKey era) <> ".spec.json"
+            genesisFile = "test/cardano-cli-test/files/input/check-node-configuration" </> filename
+        H.copyFile genesisFile (tempDir </> filename)
 
-      -- We make a hash value incorrect, and check that
-      -- check-node-configuration fails.
+    -- We make a hash value incorrect, and check that
+    -- check-node-configuration fails.
 
-      nodeConfigValue :: Aeson.Value <- Yaml.decodeFileThrow nodeConfigPath
-      nodeConfigObject :: Aeson.Object <-
-        case nodeConfigValue of
-          Aeson.Object obj -> pure obj
-          _ ->
-            do
-              H.note_ "Expected an Object, but got something else"
-              H.failure
+    nodeConfigValue :: Aeson.Value <- Yaml.decodeFileThrow nodeConfigPath
+    nodeConfigObject :: Aeson.Object <-
+      case nodeConfigValue of
+        Aeson.Object obj -> pure obj
+        _ ->
+          do
+            H.note_ "Expected an Object, but got something else"
+            H.failure
 
-      -- We make a hash value incorrect, and check that
-      -- check-node-configuration finds the mistake.
+    -- We make a hash value incorrect, and check that
+    -- check-node-configuration finds the mistake.
 
-      -- Prepare file with incorrect hash
+    -- Prepare file with incorrect hash
 
-      let fiddledEraKey =
-            Aeson.fromText $ eraToGenesisHashKey $ case fiddleKind of
-              FiddleByron -> AnyCardanoEra ByronEra
-              FiddleNonByron -> AnyCardanoEra AlonzoEra
-          finalConfigObject =
-            Aeson.Object $ Aeson.insert fiddledEraKey (Aeson.String wrongHash) nodeConfigObject
+    let fiddledEraKey =
+          Aeson.fromText $ eraToGenesisHashKey $ case fiddleKind of
+            FiddleByron -> AnyCardanoEra ByronEra
+            FiddleNonByron -> AnyCardanoEra AlonzoEra
+        finalConfigObject =
+          Aeson.Object $ Aeson.insert fiddledEraKey (Aeson.String wrongHash) nodeConfigObject
 
-      -- Write file with incorrect hash
-      liftIO $ LBS.writeFile finalInputConfig $ Aeson.encodePretty finalConfigObject
+    -- Write file with incorrect hash
+    liftIO $ LBS.writeFile finalInputConfig $ Aeson.encodePretty finalConfigObject
 
-      (exitCode, _stdout, stderr) <-
-        H.noteShowM $
-          execDetailCardanoCLI
-            [ "debug"
-            , "check-node-configuration"
-            , "--node-configuration-file"
-            , finalInputConfig
-            ]
+    (exitCode, _stdout, stderr) <-
+      H.noteShowM $
+        execDetailCardanoCLI
+          [ "debug"
+          , "check-node-configuration"
+          , "--node-configuration-file"
+          , finalInputConfig
+          ]
 
-      H.assertWith exitCode (ExitSuccess /=)
-      H.assertWith stderr ("Wrong genesis hash" `isInfixOf`)
+    H.assertWith exitCode (ExitSuccess /=)
+    H.assertWith stderr ("Wrong genesis hash" `isInfixOf`)
 
 -- | The JSON key of the genesis hash for the given era.
 eraToGenesisHashKey :: AnyCardanoEra -> Text.Text


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Removed semaphores and disable parallel test execution for GHA
  type:
  - maintenance
```

# Context

Semaphores complicate code, and they seem to only be needed for GHA. At the same time parallel test execution saves very little time. So this PR disables parallel test execution for GHA, and it removes all usages of semaphores in tests.

# How to trust this PR

Check parallel test execution is properly disabled in GHA, that it doesn't need disabling anywhere else. And that modifications didn't break anything.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
