### PR TITLE
Default to hex for binary query utxo output

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Options/Common.hs
@@ -1787,7 +1787,7 @@ pAllOutputFormats kind =
   asum
     [ make' FormatJson "JSON" "json" (Just " Default format when writing to a file") kind
     , make' FormatText "TEXT" "text" (Just " Default format when writing to stdout") kind
-    , make' FormatCBOR "CBOR" "cbor" Nothing kind
+    , make' FormatCBOR "BASE16 CBOR" "cbor" Nothing kind
     ]
 
 -- | @pTxIdOutputFormatJsonOrText kind@ is a parser to specify in which format

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Query.hs
@@ -67,6 +67,7 @@ import Data.Aeson as Aeson
 import Data.Aeson qualified as A
 import Data.Aeson.Encode.Pretty (encodePretty)
 import Data.Bifunctor (Bifunctor (..))
+import Data.ByteString.Base16 qualified as Base16
 import Data.ByteString.Lazy qualified as BS
 import Data.ByteString.Lazy.Char8 qualified as LBS
 import Data.Coerce (coerce)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Run/Query.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Run/Query.hs
@@ -1185,7 +1185,7 @@ writeFilteredUTxOs sbe format mOutFile utxo =
     $ case allOutputFormats format mOutFile of
       FormatJson -> encodePretty utxo
       FormatText -> strictTextToLazyBytestring $ filteredUTxOsToText sbe utxo
-      FormatCBOR -> CBOR.serialize $ toLedgerUTxO sbe utxo
+      FormatCBOR -> LBS.fromStrict . Base16.encode . CBOR.serialize' $ toLedgerUTxO sbe utxo
 
 filteredUTxOsToText :: Api.ShelleyBasedEra era -> UTxO era -> Text
 filteredUTxOsToText sbe (UTxO utxo) = do

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_utxo.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_query_utxo.cli
@@ -35,6 +35,6 @@ Available options:
                            writing to a file
   --output-text            Format utxo query output to TEXT. Default format when
                            writing to stdout
-  --output-cbor            Format utxo query output to CBOR.
+  --output-cbor            Format utxo query output to BASE16 CBOR.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_utxo.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/alonzo_query_utxo.cli
@@ -35,6 +35,6 @@ Available options:
                            writing to a file
   --output-text            Format utxo query output to TEXT. Default format when
                            writing to stdout
-  --output-cbor            Format utxo query output to CBOR.
+  --output-cbor            Format utxo query output to BASE16 CBOR.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_utxo.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/babbage_query_utxo.cli
@@ -35,6 +35,6 @@ Available options:
                            writing to a file
   --output-text            Format utxo query output to TEXT. Default format when
                            writing to stdout
-  --output-cbor            Format utxo query output to CBOR.
+  --output-cbor            Format utxo query output to BASE16 CBOR.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_utxo.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_utxo.cli
@@ -39,6 +39,6 @@ Available options:
                            writing to a file
   --output-text            Format utxo query output to TEXT. Default format when
                            writing to stdout
-  --output-cbor            Format utxo query output to CBOR.
+  --output-cbor            Format utxo query output to BASE16 CBOR.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_utxo.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_utxo.cli
@@ -39,6 +39,6 @@ Available options:
                            writing to a file
   --output-text            Format utxo query output to TEXT. Default format when
                            writing to stdout
-  --output-cbor            Format utxo query output to CBOR.
+  --output-cbor            Format utxo query output to BASE16 CBOR.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_utxo.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/mary_query_utxo.cli
@@ -35,6 +35,6 @@ Available options:
                            writing to a file
   --output-text            Format utxo query output to TEXT. Default format when
                            writing to stdout
-  --output-cbor            Format utxo query output to CBOR.
+  --output-cbor            Format utxo query output to BASE16 CBOR.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/query_utxo.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/query_utxo.cli
@@ -36,6 +36,6 @@ Available options:
                            writing to a file
   --output-text            Format utxo query output to TEXT. Default format when
                            writing to stdout
-  --output-cbor            Format utxo query output to CBOR.
+  --output-cbor            Format utxo query output to BASE16 CBOR.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_utxo.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_query_utxo.cli
@@ -35,6 +35,6 @@ Available options:
                            writing to a file
   --output-text            Format utxo query output to TEXT. Default format when
                            writing to stdout
-  --output-cbor            Format utxo query output to CBOR.
+  --output-cbor            Format utxo query output to BASE16 CBOR.
   --out-file FILEPATH      Optional output file. Default is to write to stdout.
   -h,--help                Show this help text


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Default to hex for binary query utxo output

  type:
  - feature        # introduces a new feature
  - breaking       # the API has changed in a breaking way
```

# Context

Additional context for the PR goes here. If the PR fixes a particular issue please provide a [link](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword=) to the issue.

# How to trust this PR

Highlight important bits of the PR that will make the review faster. If there are commands the reviewer can run to observe the new behavior, describe them.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
