### PR TITLE
Better representation of minting values in the code

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -13,8 +13,8 @@ repository cardano-haskell-packages
 -- See CONTRIBUTING for information about these, including some Nix commands
 -- you need to run if you change them
 index-state:
-  , hackage.haskell.org 2025-03-03T01:12:46Z
-  , cardano-haskell-packages 2025-03-04T03:28:33Z
+  , hackage.haskell.org 2025-03-18T07:42:38Z
+  , cardano-haskell-packages 2025-03-19T18:08:29Z
 
 
 packages:

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -235,7 +235,7 @@ library
     binary,
     bytestring,
     canonical-json,
-    cardano-api ^>=10.10,
+    cardano-api ^>=10.11.1,
     cardano-binary,
     cardano-crypto,
     cardano-crypto-class ^>=2.1.2,

--- a/cardano-cli/src/Cardano/CLI/EraBased/Transaction/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Transaction/Command.hs
@@ -24,6 +24,7 @@ where
 
 import Cardano.Api.Experimental qualified as Exp
 import Cardano.Api.Ledger (Coin)
+import Cardano.Api.Ledger qualified as L
 import Cardano.Api.Shelley
 
 import Cardano.CLI.EraBased.Script.Certificate.Type (CliCertificateScriptRequirements)
@@ -70,8 +71,8 @@ data TransactionBuildRawCmdArgs era = TransactionBuildRawCmdArgs
   , requiredSigners :: ![RequiredSigner]
   -- ^ Required signers
   , txouts :: ![TxOutAnyEra]
-  , mValue :: !(Maybe (Value, [CliMintScriptRequirements]))
-  -- ^ Multi-Asset value with script witness
+  , mMintedAssets :: !(Maybe (L.MultiAsset L.StandardCrypto, [CliMintScriptRequirements]))
+  -- ^ Multi-Asset minted value with script witness
   , mValidityLowerBound :: !(Maybe SlotNo)
   -- ^ Transaction validity lower bound
   , mValidityUpperBound :: !(TxValidityUpperBound era)
@@ -118,8 +119,8 @@ data TransactionBuildCmdArgs era = TransactionBuildCmdArgs
   -- ^ Normal outputs
   , changeAddresses :: !TxOutChangeAddress
   -- ^ A change output
-  , mValue :: !(Maybe (Value, [CliMintScriptRequirements]))
-  -- ^ Multi-Asset value with script witness
+  , mMintedAssets :: !(Maybe (L.MultiAsset L.StandardCrypto, [CliMintScriptRequirements]))
+  -- ^ Multi-Asset minted value with script witness
   , mValidityLowerBound :: !(Maybe SlotNo)
   -- ^ Transaction validity lower bound
   , mValidityUpperBound :: !(TxValidityUpperBound era)
@@ -164,7 +165,7 @@ data TransactionBuildEstimateCmdArgs era = TransactionBuildEstimateCmdArgs
   -- ^ Normal outputs
   , changeAddress :: !TxOutChangeAddress
   -- ^ A change output
-  , mValue :: !(Maybe (Value, [CliMintScriptRequirements]))
+  , mMintedAssets :: !(Maybe (L.MultiAsset L.StandardCrypto, [CliMintScriptRequirements]))
   -- ^ Multi-Asset value with script witness
   , mValidityLowerBound :: !(Maybe SlotNo)
   -- ^ Transaction validity lower bound

--- a/cardano-cli/src/Cardano/CLI/EraBased/Transaction/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Transaction/Option.hs
@@ -18,6 +18,7 @@ import Cardano.CLI.EraBased.Transaction.Command
 import Cardano.CLI.Parser
 import Cardano.CLI.Type.Common
 
+import Control.Monad
 import Data.Foldable
 import Options.Applicative hiding (help, str)
 import Options.Applicative qualified as Opt
@@ -188,7 +189,7 @@ pTransactionBuildCmd sbe envCli = do
         <*> optional pTotalCollateral
         <*> many pTxOut
         <*> pChangeAddress
-        <*> optional (pMintMultiAsset sbe AutoBalance)
+        <*> (fmap join . optional $ pMintMultiAsset sbe AutoBalance)
         <*> optional pInvalidBefore
         <*> pInvalidHereafter sbe
         <*> many (pCertificateFile AutoBalance)
@@ -201,7 +202,7 @@ pTransactionBuildCmd sbe envCli = do
               "Filepath of auxiliary script(s)"
           )
         <*> many pMetadataFile
-        <*> pFeatured (toCardanoEra sbe) (optional pUpdateProposalFile)
+        <*> pFeatured era' (optional pUpdateProposalFile)
         <*> pVoteFiles sbe AutoBalance
         <*> pProposalFiles sbe AutoBalance
         <*> pTreasuryDonation sbe
@@ -248,7 +249,7 @@ pTransactionBuildEstimateCmd eon' _envCli = do
         <*> optional pReturnCollateral
         <*> many pTxOut
         <*> pChangeAddress
-        <*> optional (pMintMultiAsset sbe ManualBalance)
+        <*> (fmap join . optional $ pMintMultiAsset sbe ManualBalance)
         <*> optional pInvalidBefore
         <*> pInvalidHereafter sbe
         <*> many (pCertificateFile ManualBalance)
@@ -291,7 +292,7 @@ pTransactionBuildRaw era' =
       <*> optional pTotalCollateral
       <*> many pRequiredSigner
       <*> many pTxOut
-      <*> optional (pMintMultiAsset era' ManualBalance)
+      <*> (fmap join . optional $ pMintMultiAsset era' ManualBalance)
       <*> optional pInvalidBefore
       <*> pInvalidHereafter era'
       <*> pTxFee

--- a/cardano-cli/src/Cardano/CLI/EraIndependent/Key/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraIndependent/Key/Run.hs
@@ -25,6 +25,7 @@ module Cardano.CLI.EraIndependent.Key.Run
   , genesisVkeyDesc
   , genesisVkeyDelegateDesc
   , stakeVkeyDesc
+  , stakePoolDesc
   , paymentVkeyDesc
 
     -- * Exports for testing
@@ -36,6 +37,7 @@ import Cardano.Api
 import Cardano.Api.Byron qualified as ByronApi
 import Cardano.Api.Crypto.Ed25519Bip32 (xPrvFromBytes)
 import Cardano.Api.Ledger qualified as L
+import Cardano.Api.Shelley (StakePoolKey)
 
 import Cardano.CLI.Byron.Key qualified as Byron
 import Cardano.CLI.EraIndependent.Key.Command qualified as Cmd
@@ -102,6 +104,9 @@ paymentVkeyDesc = "Payment Verification Key"
 
 stakeVkeyDesc :: TextEnvelopeDescr
 stakeVkeyDesc = "Stake Verification Key"
+
+stakePoolDesc :: TextEnvelopeDescr
+stakePoolDesc = "Stake Pool Operator Verification Key"
 
 runKeyCmds
   :: ()
@@ -171,6 +176,8 @@ runNonExtendedKeyCmd
           writeToDisk vkf (Just ccHotVkeyDesc) (castVerificationKey vk :: VerificationKey CommitteeHotKey)
         AStakeExtendedVerificationKey vk ->
           writeToDisk vkf (Just stakeVkeyDesc) (castVerificationKey vk :: VerificationKey StakeKey)
+        AStakePoolExtendedVerificationKey vk ->
+          writeToDisk vkf (Just stakeVkeyDesc) (castVerificationKey vk :: VerificationKey StakePoolKey)
         AGenesisExtendedVerificationKey vk ->
           writeToDisk vkf (Just genesisVkeyDesc) (castVerificationKey vk :: VerificationKey GenesisKey)
         AGenesisDelegateExtendedVerificationKey vk ->
@@ -185,6 +192,7 @@ runNonExtendedKeyCmd
         vk@AKesVerificationKey{} -> goFail vk
         vk@AVrfVerificationKey{} -> goFail vk
         vk@AStakeVerificationKey{} -> goFail vk
+        vk@AStakePoolVerificationKey{} -> goFail vk
         vk@ADRepVerificationKey{} -> goFail vk
         vk@ACommitteeColdVerificationKey{} -> goFail vk
         vk@ACommitteeHotVerificationKey{} -> goFail vk
@@ -219,6 +227,7 @@ readExtendedVerificationKeyFile evkfile = do
     k@AStakeExtendedVerificationKey{} -> return k
     k@AGenesisExtendedVerificationKey{} -> return k
     k@AGenesisDelegateExtendedVerificationKey{} -> return k
+    k@AStakePoolExtendedVerificationKey{} -> return k
     -- Non-extended keys are below and cause failure.
     k@AByronVerificationKey{} -> goFail k
     k@APaymentVerificationKey{} -> goFail k
@@ -226,6 +235,7 @@ readExtendedVerificationKeyFile evkfile = do
     k@AKesVerificationKey{} -> goFail k
     k@AVrfVerificationKey{} -> goFail k
     k@AStakeVerificationKey{} -> goFail k
+    k@AStakePoolVerificationKey{} -> goFail k
     k@ADRepVerificationKey{} -> goFail k
     k@ACommitteeColdVerificationKey{} -> goFail k
     k@ACommitteeHotVerificationKey{} -> goFail k

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -1879,27 +1879,6 @@ Usage: cardano-cli shelley transaction build-raw
                                                      | --tx-out-inline-datum-value JSON_VALUE
                                                      ]
                                                      [--tx-out-reference-script-file FILEPATH]]
-                                                   [--mint VALUE
-                                                     ( --mint-script-file FILEPATH
-                                                       [
-                                                         ( --mint-redeemer-cbor-file CBOR_FILE
-                                                         | --mint-redeemer-file JSON_FILE
-                                                         | --mint-redeemer-value JSON_VALUE
-                                                         )
-                                                         --mint-execution-units (INT, INT)]
-                                                     | --simple-minting-script-tx-in-reference TX-IN
-                                                       --policy-id HASH
-                                                     | --mint-tx-in-reference TX-IN
-                                                       ( --mint-plutus-script-v2
-                                                       | --mint-plutus-script-v3
-                                                       )
-                                                       ( --mint-reference-tx-in-redeemer-cbor-file CBOR_FILE
-                                                       | --mint-reference-tx-in-redeemer-file JSON_FILE
-                                                       | --mint-reference-tx-in-redeemer-value JSON_VALUE
-                                                       )
-                                                       --mint-reference-tx-in-execution-units (INT, INT)
-                                                       --policy-id HASH
-                                                     )]
                                                    [--invalid-before SLOT]
                                                    [--invalid-hereafter SLOT]
                                                    --fee LOVELACE
@@ -2975,27 +2954,6 @@ Usage: cardano-cli allegra transaction build-raw
                                                      | --tx-out-inline-datum-value JSON_VALUE
                                                      ]
                                                      [--tx-out-reference-script-file FILEPATH]]
-                                                   [--mint VALUE
-                                                     ( --mint-script-file FILEPATH
-                                                       [
-                                                         ( --mint-redeemer-cbor-file CBOR_FILE
-                                                         | --mint-redeemer-file JSON_FILE
-                                                         | --mint-redeemer-value JSON_VALUE
-                                                         )
-                                                         --mint-execution-units (INT, INT)]
-                                                     | --simple-minting-script-tx-in-reference TX-IN
-                                                       --policy-id HASH
-                                                     | --mint-tx-in-reference TX-IN
-                                                       ( --mint-plutus-script-v2
-                                                       | --mint-plutus-script-v3
-                                                       )
-                                                       ( --mint-reference-tx-in-redeemer-cbor-file CBOR_FILE
-                                                       | --mint-reference-tx-in-redeemer-file JSON_FILE
-                                                       | --mint-reference-tx-in-redeemer-value JSON_VALUE
-                                                       )
-                                                       --mint-reference-tx-in-execution-units (INT, INT)
-                                                       --policy-id HASH
-                                                     )]
                                                    [--invalid-before SLOT]
                                                    [--invalid-hereafter SLOT]
                                                    --fee LOVELACE

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_transaction_build-raw.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/allegra_transaction_build-raw.cli
@@ -51,27 +51,6 @@ Usage: cardano-cli allegra transaction build-raw
                                                      | --tx-out-inline-datum-value JSON_VALUE
                                                      ]
                                                      [--tx-out-reference-script-file FILEPATH]]
-                                                   [--mint VALUE
-                                                     ( --mint-script-file FILEPATH
-                                                       [
-                                                         ( --mint-redeemer-cbor-file CBOR_FILE
-                                                         | --mint-redeemer-file JSON_FILE
-                                                         | --mint-redeemer-value JSON_VALUE
-                                                         )
-                                                         --mint-execution-units (INT, INT)]
-                                                     | --simple-minting-script-tx-in-reference TX-IN
-                                                       --policy-id HASH
-                                                     | --mint-tx-in-reference TX-IN
-                                                       ( --mint-plutus-script-v2
-                                                       | --mint-plutus-script-v3
-                                                       )
-                                                       ( --mint-reference-tx-in-redeemer-cbor-file CBOR_FILE
-                                                       | --mint-reference-tx-in-redeemer-file JSON_FILE
-                                                       | --mint-reference-tx-in-redeemer-value JSON_VALUE
-                                                       )
-                                                       --mint-reference-tx-in-execution-units (INT, INT)
-                                                       --policy-id HASH
-                                                     )]
                                                    [--invalid-before SLOT]
                                                    [--invalid-hereafter SLOT]
                                                    --fee LOVELACE
@@ -262,45 +241,6 @@ Available options:
                            top-level strings and numbers.
   --tx-out-reference-script-file FILEPATH
                            Reference script input file.
-  --mint VALUE             Mint multi-asset value(s) with the multi-asset cli
-                           syntax. You must specify a script witness.
-  --mint-script-file FILEPATH
-                           The file containing the script to witness the minting
-                           of assets for a particular policy Id.
-  --mint-redeemer-cbor-file CBOR_FILE
-                           The script redeemer file. The file has to be in CBOR
-                           format.
-  --mint-redeemer-file JSON_FILE
-                           The script redeemer file. The file must follow the
-                           detailed JSON schema for script data.
-  --mint-redeemer-value JSON_VALUE
-                           The script redeemer value. There is no schema:
-                           (almost) any JSON value is supported, including
-                           top-level strings and numbers.
-  --mint-execution-units (INT, INT)
-                           The time and space units needed by the script.
-  --simple-minting-script-tx-in-reference TX-IN
-                           TxId#TxIx - Specify a reference input. The reference
-                           input must have a simple reference script attached.
-  --policy-id HASH         Policy id of minting script.
-  --mint-tx-in-reference TX-IN
-                           TxId#TxIx - Specify a reference input. The reference
-                           input must have a plutus reference script attached.
-  --mint-plutus-script-v2  Specify a plutus script v2 reference script.
-  --mint-plutus-script-v3  Specify a plutus script v3 reference script.
-  --mint-reference-tx-in-redeemer-cbor-file CBOR_FILE
-                           The script redeemer file. The file has to be in CBOR
-                           format.
-  --mint-reference-tx-in-redeemer-file JSON_FILE
-                           The script redeemer file. The file must follow the
-                           detailed JSON schema for script data.
-  --mint-reference-tx-in-redeemer-value JSON_VALUE
-                           The script redeemer value. There is no schema:
-                           (almost) any JSON value is supported, including
-                           top-level strings and numbers.
-  --mint-reference-tx-in-execution-units (INT, INT)
-                           The time and space units needed by the script.
-  --policy-id HASH         Policy id of minting script.
   --invalid-before SLOT    Time that transaction is valid from (in slots).
   --invalid-hereafter SLOT Time that transaction is valid until (in slots).
   --fee LOVELACE           The fee amount in Lovelace.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_transaction_build-raw.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/shelley_transaction_build-raw.cli
@@ -51,27 +51,6 @@ Usage: cardano-cli shelley transaction build-raw
                                                      | --tx-out-inline-datum-value JSON_VALUE
                                                      ]
                                                      [--tx-out-reference-script-file FILEPATH]]
-                                                   [--mint VALUE
-                                                     ( --mint-script-file FILEPATH
-                                                       [
-                                                         ( --mint-redeemer-cbor-file CBOR_FILE
-                                                         | --mint-redeemer-file JSON_FILE
-                                                         | --mint-redeemer-value JSON_VALUE
-                                                         )
-                                                         --mint-execution-units (INT, INT)]
-                                                     | --simple-minting-script-tx-in-reference TX-IN
-                                                       --policy-id HASH
-                                                     | --mint-tx-in-reference TX-IN
-                                                       ( --mint-plutus-script-v2
-                                                       | --mint-plutus-script-v3
-                                                       )
-                                                       ( --mint-reference-tx-in-redeemer-cbor-file CBOR_FILE
-                                                       | --mint-reference-tx-in-redeemer-file JSON_FILE
-                                                       | --mint-reference-tx-in-redeemer-value JSON_VALUE
-                                                       )
-                                                       --mint-reference-tx-in-execution-units (INT, INT)
-                                                       --policy-id HASH
-                                                     )]
                                                    [--invalid-before SLOT]
                                                    [--invalid-hereafter SLOT]
                                                    --fee LOVELACE
@@ -262,45 +241,6 @@ Available options:
                            top-level strings and numbers.
   --tx-out-reference-script-file FILEPATH
                            Reference script input file.
-  --mint VALUE             Mint multi-asset value(s) with the multi-asset cli
-                           syntax. You must specify a script witness.
-  --mint-script-file FILEPATH
-                           The file containing the script to witness the minting
-                           of assets for a particular policy Id.
-  --mint-redeemer-cbor-file CBOR_FILE
-                           The script redeemer file. The file has to be in CBOR
-                           format.
-  --mint-redeemer-file JSON_FILE
-                           The script redeemer file. The file must follow the
-                           detailed JSON schema for script data.
-  --mint-redeemer-value JSON_VALUE
-                           The script redeemer value. There is no schema:
-                           (almost) any JSON value is supported, including
-                           top-level strings and numbers.
-  --mint-execution-units (INT, INT)
-                           The time and space units needed by the script.
-  --simple-minting-script-tx-in-reference TX-IN
-                           TxId#TxIx - Specify a reference input. The reference
-                           input must have a simple reference script attached.
-  --policy-id HASH         Policy id of minting script.
-  --mint-tx-in-reference TX-IN
-                           TxId#TxIx - Specify a reference input. The reference
-                           input must have a plutus reference script attached.
-  --mint-plutus-script-v2  Specify a plutus script v2 reference script.
-  --mint-plutus-script-v3  Specify a plutus script v3 reference script.
-  --mint-reference-tx-in-redeemer-cbor-file CBOR_FILE
-                           The script redeemer file. The file has to be in CBOR
-                           format.
-  --mint-reference-tx-in-redeemer-file JSON_FILE
-                           The script redeemer file. The file must follow the
-                           detailed JSON schema for script data.
-  --mint-reference-tx-in-redeemer-value JSON_VALUE
-                           The script redeemer value. There is no schema:
-                           (almost) any JSON value is supported, including
-                           top-level strings and numbers.
-  --mint-reference-tx-in-execution-units (INT, INT)
-                           The time and space units needed by the script.
-  --policy-id HASH         Policy id of minting script.
   --invalid-before SLOT    Time that transaction is valid from (in slots).
   --invalid-hereafter SLOT Time that transaction is valid until (in slots).
   --fee LOVELACE           The fee amount in Lovelace.

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1741062432,
-        "narHash": "sha256-yX7+jlT+RoIvElEr7k8Gnzu+ghsDffjPzCWqML8yIJo=",
+        "lastModified": 1742409857,
+        "narHash": "sha256-lXe20bT2RfoTKMlfD+79FoQyoMlVe8MaMRAWMtZEr/w=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "c42eaba9517d6bb4457a903724920a214a36e9d9",
+        "rev": "770c349e947776325209a6286938741f9a24dd53",
         "type": "github"
       },
       "original": {
@@ -173,11 +173,11 @@
     "hackageNix": {
       "flake": false,
       "locked": {
-        "lastModified": 1741047855,
-        "narHash": "sha256-maKGmHkR0jztEQcy1Ya6T66v9ZzmtqCDyANy3pWuIko=",
+        "lastModified": 1742257465,
+        "narHash": "sha256-+TFf3A0YGCp84ySQtOyf7NnFUhygbYDg+xrZDw/OQ8g=",
         "owner": "input-output-hk",
         "repo": "hackage.nix",
-        "rev": "c486dfef773c7ed0d983b2b9fbd54c2233317963",
+        "rev": "d64feaae2cc7d84e3886fdb0901986606f9aa2a2",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Remove minting capabilities in eras prior to Mary.
    Change minted assets representation to `L.MultiAsset` instead of `Value`.
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
   - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

The minted amount was represented as `Value` which includes ADA. It was only guarded against "minting ada" in parser, not in the type. This PR changes the type to use ledger's `L.MultiAsset`, which contains only non-ADA assets.

Also the minting options are removed from eras before Mary.

Requires changes from to build successfully:
- https://github.com/IntersectMBO/cardano-api/pull/782/
- https://github.com/IntersectMBO/cardano-api/pull/776

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
