### PR TITLE
Add pool operator extended key support

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -14,7 +14,7 @@ repository cardano-haskell-packages
 -- you need to run if you change them
 index-state:
   , hackage.haskell.org 2025-04-16T18:30:40Z
-  , cardano-haskell-packages 2025-04-18T06:38:47Z
+  , cardano-haskell-packages 2025-04-25T15:50:18Z
 
 packages:
   cardano-cli

--- a/cabal.project
+++ b/cabal.project
@@ -16,6 +16,7 @@ index-state:
   , hackage.haskell.org 2025-04-16T18:30:40Z
   , cardano-haskell-packages 2025-04-25T15:50:18Z
 
+
 packages:
   cardano-cli
 

--- a/cardano-cli/cardano-cli.cabal
+++ b/cardano-cli/cardano-cli.cabal
@@ -238,7 +238,7 @@ library
     binary,
     bytestring,
     canonical-json,
-    cardano-api ^>=10.14,
+    cardano-api ^>=10.15,
     cardano-binary,
     cardano-crypto,
     cardano-crypto-class ^>=2.2,

--- a/cardano-cli/src/Cardano/CLI/Compatible/StakeAddress/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/Compatible/StakeAddress/Command.hs
@@ -26,7 +26,7 @@ data CompatibleStakeAddressCmds era
   | CompatibleStakeAddressStakeDelegationCertificateCmd
       (ShelleyBasedEra era)
       StakeIdentifier
-      (VerificationKeyOrHashOrFile StakePoolKey)
+      StakePoolKeyHashSource
       (File () Out)
   deriving Show
 

--- a/cardano-cli/src/Cardano/CLI/Compatible/StakePool/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/Compatible/StakePool/Command.hs
@@ -19,16 +19,16 @@ import Prelude
 
 import Data.Text (Text)
 
-data CompatibleStakePoolCmds era
+newtype CompatibleStakePoolCmds era
   = CompatibleStakePoolRegistrationCertificateCmd
-      !(CompatibleStakePoolRegistrationCertificateCmdArgs era)
+      (CompatibleStakePoolRegistrationCertificateCmdArgs era)
   deriving Show
 
 data CompatibleStakePoolRegistrationCertificateCmdArgs era
   = CompatibleStakePoolRegistrationCertificateCmdArgs
   { sbe :: !(ShelleyBasedEra era)
   -- ^ Era in which to register the stake pool.
-  , poolVerificationKeyOrFile :: !(VerificationKeyOrFile StakePoolKey)
+  , poolVerificationKeyOrFile :: !StakePoolVerificationKeySource
   -- ^ Stake pool verification key.
   , vrfVerificationKeyOrFile :: !(VerificationKeyOrFile VrfKey)
   -- ^ VRF Verification key.

--- a/cardano-cli/src/Cardano/CLI/Compatible/StakePool/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/Compatible/StakePool/Run.hs
@@ -14,6 +14,9 @@ import Cardano.Api.Shelley
 import Cardano.CLI.Compatible.Exception
 import Cardano.CLI.Compatible.StakePool.Command
 import Cardano.CLI.EraBased.StakePool.Internal.Metadata
+import Cardano.CLI.Read
+  ( getVerificationKeyFromStakePoolVerificationKeySource
+  )
 import Cardano.CLI.Type.Common
 import Cardano.CLI.Type.Error.StakePoolCmdError
 import Cardano.CLI.Type.Key (readVerificationKeyOrFile)
@@ -48,11 +51,8 @@ runStakePoolRegistrationCertificateCmd
     } =
     shelleyBasedEraConstraints sbe $ do
       -- Pool verification key
-      stakePoolVerKey <-
-        fromExceptTCli $
-          firstExceptT StakePoolCmdReadKeyFileError $
-            readVerificationKeyOrFile AsStakePoolKey poolVerificationKeyOrFile
-      let stakePoolId' = verificationKeyHash stakePoolVerKey
+      stakePoolVerKey <- getVerificationKeyFromStakePoolVerificationKeySource poolVerificationKeyOrFile
+      let stakePoolId' = anyStakePoolVerificationKeyHash stakePoolVerKey
 
       -- VRF verification key
       vrfVerKey <-

--- a/cardano-cli/src/Cardano/CLI/EraBased/Genesis/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Genesis/Option.hs
@@ -247,8 +247,8 @@ pGenesisCreateTestNetData era envCli =
       <*> pNumGenesisKeys
       <*> pNumPools
       <*> pNumStakeDelegs
-      <*> (case era of Exp.BabbageEra -> pure 0; Exp.ConwayEra -> pNumCommittee) -- Committee doesn't exist in babbage
-      <*> (case era of Exp.BabbageEra -> pure $ DRepCredentials OnDisk 0; Exp.ConwayEra -> pNumDReps) -- DReps don't exist in babbage
+      <*> (case era of Exp.ConwayEra -> pNumCommittee) -- Committee doesn't exist in babbage
+      <*> (case era of Exp.ConwayEra -> pNumDReps) -- DReps don't exist in babbage
       <*> pNumStuffedUtxoCount
       <*> pNumUtxoKeys
       <*> pSupply

--- a/cardano-cli/src/Cardano/CLI/EraBased/Genesis/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Genesis/Run.hs
@@ -341,7 +341,8 @@ generateShelleyNodeSecrets shelleyDelegateKeys shelleyGenesisvkeys = do
     createOpCert (kesKey, delegateKey) = either (error . show) id eResult
      where
       eResult = issueOperationalCertificate kesKey (Right delegateKey) (KESPeriod 0) counter
-      counter = OperationalCertificateIssueCounter 0 (convertFun . getVerificationKey $ delegateKey)
+      counter =
+        OperationalCertificateIssueCounter 0 (convertFun . getVerificationKey $ delegateKey)
       convertFun
         :: VerificationKey GenesisDelegateExtendedKey
         -> VerificationKey StakePoolKey

--- a/cardano-cli/src/Cardano/CLI/EraBased/Governance/Vote/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Governance/Vote/Run.hs
@@ -21,6 +21,7 @@ import Cardano.Api.Shelley
 import Cardano.CLI.EraBased.Governance.Vote.Command qualified as Cmd
 import Cardano.CLI.EraBased.Script.Vote.Read
 import Cardano.CLI.EraIndependent.Hash.Internal.Common (carryHashChecks)
+import Cardano.CLI.Read (getHashFromStakePoolKeyHashSource)
 import Cardano.CLI.Type.Common
 import Cardano.CLI.Type.Error.CmdError
 import Cardano.CLI.Type.Error.GovernanceVoteCmdError
@@ -85,7 +86,8 @@ runGovernanceVoteCreateCmd
           drepCred <- readVerificationKeyOrHashOrFileOrScriptHash AsDRepKey unDRepKeyHash stake
           pure $ L.DRepVoter drepCred
         AnyStakePoolVerificationKeyOrHashOrFile stake -> do
-          StakePoolKeyHash h <- readVerificationKeyOrHashOrTextEnvFile AsStakePoolKey stake
+          StakePoolKeyHash h <-
+            liftIO $ getHashFromStakePoolKeyHashSource stake
           pure $ L.StakePoolVoter h
         AnyCommitteeHotVerificationKeyOrHashOrFileOrScriptHash stake -> do
           hotCred <- readVerificationKeyOrHashOrFileOrScriptHash AsCommitteeHotKey unCommitteeHotKeyHash stake

--- a/cardano-cli/src/Cardano/CLI/EraBased/Query/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Query/Command.hs
@@ -92,7 +92,7 @@ data QueryCommons = QueryCommons
 data QueryLeadershipScheduleCmdArgs = QueryLeadershipScheduleCmdArgs
   { commons :: !QueryCommons
   , genesisFp :: !GenesisFile
-  , poolColdVerKeyFile :: !(VerificationKeyOrHashOrFile StakePoolKey)
+  , poolColdVerKeyFile :: !StakePoolKeyHashSource
   , vrkSkeyFp :: !(SigningKeyFile In)
   , whichSchedule :: !EpochLeadershipSchedule
   , format :: !(Vary [FormatJson, FormatText])

--- a/cardano-cli/src/Cardano/CLI/EraBased/StakeAddress/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/StakeAddress/Command.hs
@@ -38,12 +38,12 @@ data StakeAddressCmds era
   | StakeAddressStakeDelegationCertificateCmd
       (ShelleyBasedEra era)
       StakeIdentifier
-      (VerificationKeyOrHashOrFile StakePoolKey)
+      StakePoolKeyHashSource
       (File () Out)
   | StakeAddressStakeAndVoteDelegationCertificateCmd
       (ConwayEraOnwards era)
       StakeIdentifier
-      (VerificationKeyOrHashOrFile StakePoolKey)
+      StakePoolKeyHashSource
       VoteDelegationTarget
       (File () Out)
   | StakeAddressVoteDelegationCertificateCmd
@@ -59,7 +59,7 @@ data StakeAddressCmds era
   | StakeAddressRegistrationAndDelegationCertificateCmd
       (ConwayEraOnwards era)
       StakeIdentifier
-      (VerificationKeyOrHashOrFile StakePoolKey)
+      StakePoolKeyHashSource
       Coin
       (File () Out)
   | StakeAddressRegistrationAndVoteDelegationCertificateCmd
@@ -71,7 +71,7 @@ data StakeAddressCmds era
   | StakeAddressRegistrationStakeAndVoteDelegationCertificateCmd
       (ConwayEraOnwards era)
       StakeIdentifier
-      (VerificationKeyOrHashOrFile StakePoolKey)
+      StakePoolKeyHashSource
       VoteDelegationTarget
       Coin
       (File () Out)

--- a/cardano-cli/src/Cardano/CLI/EraBased/StakeAddress/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/StakeAddress/Run.hs
@@ -222,16 +222,14 @@ runStakeAddressStakeDelegationCertificateCmd
   => ShelleyBasedEra era
   -> StakeIdentifier
   -- ^ Delegator stake verification key, verification key file or script file.
-  -> VerificationKeyOrHashOrFile StakePoolKey
+  -> StakePoolKeyHashSource
   -- ^ Delegatee stake pool verification key or verification key file or
   -- verification key hash.
   -> File () Out
   -> ExceptT StakeAddressCmdError IO ()
 runStakeAddressStakeDelegationCertificateCmd sbe stakeVerifier poolVKeyOrHashOrFile outFp =
   shelleyBasedEraConstraints sbe $ do
-    poolStakeVKeyHash <-
-      modifyError StakeAddressCmdReadKeyFileError $
-        readVerificationKeyOrHashOrFile AsStakePoolKey poolVKeyOrHashOrFile
+    poolStakeVKeyHash <- getHashFromStakePoolKeyHashSource poolVKeyOrHashOrFile
 
     stakeCred <-
       getStakeCredentialFromIdentifier stakeVerifier
@@ -249,7 +247,7 @@ runStakeAddressStakeAndVoteDelegationCertificateCmd
   => ConwayEraOnwards era
   -> StakeIdentifier
   -- ^ Delegator stake verification key, verification key file or script file.
-  -> VerificationKeyOrHashOrFile StakePoolKey
+  -> StakePoolKeyHashSource
   -- ^ Delegatee stake pool verification key or verification key file or
   -> VoteDelegationTarget
   -- verification key hash.
@@ -257,9 +255,7 @@ runStakeAddressStakeAndVoteDelegationCertificateCmd
   -> ExceptT StakeAddressCmdError IO ()
 runStakeAddressStakeAndVoteDelegationCertificateCmd w stakeVerifier poolVKeyOrHashOrFile voteDelegationTarget outFp =
   conwayEraOnwardsConstraints w $ do
-    StakePoolKeyHash poolStakeVKeyHash <-
-      modifyError StakeAddressCmdReadKeyFileError $
-        readVerificationKeyOrHashOrFile AsStakePoolKey poolVKeyOrHashOrFile
+    StakePoolKeyHash poolStakeVKeyHash <- getHashFromStakePoolKeyHashSource poolVKeyOrHashOrFile
 
     stakeCredential <-
       modifyError StakeAddressCmdStakeCredentialError $
@@ -363,16 +359,14 @@ runStakeAddressRegistrationAndDelegationCertificateCmd
   :: ()
   => ConwayEraOnwards era
   -> StakeIdentifier
-  -> VerificationKeyOrHashOrFile StakePoolKey
+  -> StakePoolKeyHashSource
   -- ^ Delegatee stake pool verification key or verification key file or id
   -> Lovelace
   -> File () Out
   -> ExceptT StakeAddressCmdError IO ()
 runStakeAddressRegistrationAndDelegationCertificateCmd w stakeVerifier poolVKeyOrHashOrFile deposit outFp =
   conwayEraOnwardsConstraints w $ do
-    StakePoolKeyHash poolStakeVKeyHash <-
-      modifyError StakeAddressCmdReadKeyFileError $
-        readVerificationKeyOrHashOrFile AsStakePoolKey poolVKeyOrHashOrFile
+    StakePoolKeyHash poolStakeVKeyHash <- getHashFromStakePoolKeyHashSource poolVKeyOrHashOrFile
 
     stakeCred <-
       getStakeCredentialFromIdentifier stakeVerifier
@@ -422,16 +416,14 @@ runStakeAddressRegistrationStakeAndVoteDelegationCertificateCmd
   :: ()
   => ConwayEraOnwards era
   -> StakeIdentifier
-  -> VerificationKeyOrHashOrFile StakePoolKey
+  -> StakePoolKeyHashSource
   -> VoteDelegationTarget
   -> Lovelace
   -> File () Out
   -> ExceptT StakeAddressCmdError IO ()
 runStakeAddressRegistrationStakeAndVoteDelegationCertificateCmd w stakeVerifier poolVKeyOrHashOrFile voteDelegationTarget keydeposit outFp =
   conwayEraOnwardsConstraints w $ do
-    StakePoolKeyHash poolStakeVKeyHash <-
-      modifyError StakeAddressCmdReadKeyFileError $
-        readVerificationKeyOrHashOrFile AsStakePoolKey poolVKeyOrHashOrFile
+    StakePoolKeyHash poolStakeVKeyHash <- getHashFromStakePoolKeyHashSource poolVKeyOrHashOrFile
 
     stakeCred <-
       getStakeCredentialFromIdentifier stakeVerifier

--- a/cardano-cli/src/Cardano/CLI/EraBased/StakePool/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/StakePool/Command.hs
@@ -35,7 +35,7 @@ data StakePoolCmds era
 data StakePoolDeregistrationCertificateCmdArgs era
   = StakePoolDeregistrationCertificateCmdArgs
   { sbe :: !(ShelleyBasedEra era)
-  , poolVerificationKeyOrFile :: !(VerificationKeyOrFile StakePoolKey)
+  , poolVerificationKeyOrFile :: !StakePoolVerificationKeySource
   , retireEpoch :: !EpochNo
   , outFile :: !(File () Out)
   }
@@ -43,7 +43,7 @@ data StakePoolDeregistrationCertificateCmdArgs era
 
 data StakePoolIdCmdArgs era
   = StakePoolIdCmdArgs
-  { poolVerificationKeyOrFile :: !(VerificationKeyOrFile StakePoolKey)
+  { poolVerificationKeyOrFile :: !StakePoolVerificationKeySource
   , outputFormat :: !IdOutputFormat
   , mOutFile :: !(Maybe (File () Out))
   }
@@ -65,7 +65,7 @@ data StakePoolRegistrationCertificateCmdArgs era
   = StakePoolRegistrationCertificateCmdArgs
   { sbe :: !(ShelleyBasedEra era)
   -- ^ Era in which to register the stake pool.
-  , poolVerificationKeyOrFile :: !(VerificationKeyOrFile StakePoolKey)
+  , poolVerificationKeyOrFile :: !StakePoolVerificationKeySource
   -- ^ Stake pool verification key.
   , vrfVerificationKeyOrFile :: !(VerificationKeyOrFile VrfKey)
   -- ^ VRF Verification key.

--- a/cardano-cli/src/Cardano/CLI/EraBased/Transaction/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Transaction/Run.hs
@@ -1672,7 +1672,7 @@ runTransactionCalculateMinValueCmd
     pp <- firstExceptT TxCmdProtocolParamsError (readProtocolParameters eon protocolParamsFile)
     out <- toTxOutInShelleyBasedEra eon txOut
 
-    let minValue = calculateMinimumUTxO eon out pp
+    let minValue = calculateMinimumUTxO eon pp out
     liftIO . IO.print $ minValue
 
 runTransactionCalculatePlutusScriptCostCmd

--- a/cardano-cli/src/Cardano/CLI/EraIndependent/Key/Run.hs
+++ b/cardano-cli/src/Cardano/CLI/EraIndependent/Key/Run.hs
@@ -23,8 +23,10 @@ module Cardano.CLI.EraIndependent.Key.Run
   , genesisVkeyDesc
   , genesisVkeyDelegateDesc
   , stakeVkeyDesc
-  , stakePoolDesc
+  , stakePoolVKeyDesc
   , paymentVkeyDesc
+  , stakePoolExtendedSKeyDesc
+  , stakePoolExtendedVKeyDesc
 
     -- * Exports for testing
   , decodeBech32
@@ -104,8 +106,14 @@ paymentVkeyDesc = "Payment Verification Key"
 stakeVkeyDesc :: TextEnvelopeDescr
 stakeVkeyDesc = "Stake Verification Key"
 
-stakePoolDesc :: TextEnvelopeDescr
-stakePoolDesc = "Stake Pool Operator Verification Key"
+stakePoolVKeyDesc :: TextEnvelopeDescr
+stakePoolVKeyDesc = "Stake Pool Operator Verification Key"
+
+stakePoolExtendedSKeyDesc :: TextEnvelopeDescr
+stakePoolExtendedSKeyDesc = "Stake Pool Operator Signing Key"
+
+stakePoolExtendedVKeyDesc :: TextEnvelopeDescr
+stakePoolExtendedVKeyDesc = "Stake Pool Operator Verification Key"
 
 runKeyCmds
   :: ()
@@ -180,7 +188,10 @@ runNonExtendedKeyCmd
         AStakeExtendedVerificationKey vk ->
           writeToDisk vkf (Just stakeVkeyDesc) (castVerificationKey vk :: VerificationKey StakeKey)
         AStakePoolExtendedVerificationKey vk ->
-          writeToDisk vkf (Just stakeVkeyDesc) (castVerificationKey vk :: VerificationKey StakePoolKey)
+          writeToDisk
+            vkf
+            (Just stakePoolVKeyDesc)
+            (castVerificationKey vk :: VerificationKey StakePoolKey)
         AGenesisExtendedVerificationKey vk ->
           writeToDisk vkf (Just genesisVkeyDesc) (castVerificationKey vk :: VerificationKey GenesisKey)
         AGenesisDelegateExtendedVerificationKey vk ->

--- a/cardano-cli/src/Cardano/CLI/Type/Governance.hs
+++ b/cardano-cli/src/Cardano/CLI/Type/Governance.hs
@@ -4,11 +4,10 @@
 module Cardano.CLI.Type.Governance where
 
 import Cardano.Api
-import Cardano.Api.Shelley
 
 import Cardano.CLI.Type.Key
   ( DRepHashSource
-  , VerificationKeyOrHashOrFile
+  , StakePoolKeyHashSource
   , VerificationKeyOrHashOrFileOrScriptHash
   )
 
@@ -26,7 +25,7 @@ data VType
 -- | Possible credentials for creating a vote
 data AnyVotingStakeVerificationKeyOrHashOrFile
   = AnyDRepVerificationKeyOrHashOrFileOrScriptHash (VerificationKeyOrHashOrFileOrScriptHash DRepKey)
-  | AnyStakePoolVerificationKeyOrHashOrFile (VerificationKeyOrHashOrFile StakePoolKey)
+  | AnyStakePoolVerificationKeyOrHashOrFile StakePoolKeyHashSource
   | AnyCommitteeHotVerificationKeyOrHashOrFileOrScriptHash
       (VerificationKeyOrHashOrFileOrScriptHash CommitteeHotKey)
 

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/StakePool/RegistrationCertificate.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/StakePool/RegistrationCertificate.hs
@@ -50,3 +50,42 @@ hprop_golden_shelley_stake_pool_registration_certificate = propertyOnce . H.modu
   goldenFile <- H.note "test/cardano-cli-golden/files/golden/shelley/reg-certificate.json"
 
   H.diffFileVsGoldenFile registrationCertFile goldenFile
+
+hprop_golden_conway_stake_pool_registration_certificate_extended_cold_key :: Property
+hprop_golden_conway_stake_pool_registration_certificate_extended_cold_key = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  operatorVerificationKeyFile <-
+    noteInputFile "test/cardano-cli-golden/files/input/shelley/node-pool/extended-operator.vkey"
+  vrfVerificationKeyFile <-
+    noteInputFile "test/cardano-cli-golden/files/input/shelley/node-pool/vrf.vkey"
+  ownerVerificationKeyFile <-
+    noteInputFile "test/cardano-cli-golden/files/input/shelley/node-pool/owner.vkey"
+  registrationCertFile <- noteTempFile tempDir "registration.cert"
+
+  void $
+    execCardanoCLI
+      [ "conway"
+      , "stake-pool"
+      , "registration-certificate"
+      , "--testnet-magic"
+      , "42"
+      , "--pool-pledge"
+      , "0"
+      , "--pool-cost"
+      , "0"
+      , "--pool-margin"
+      , "0"
+      , "--cold-verification-key-file"
+      , operatorVerificationKeyFile
+      , "--vrf-verification-key-file"
+      , vrfVerificationKeyFile
+      , "--pool-reward-account-verification-key-file"
+      , ownerVerificationKeyFile
+      , "--pool-owner-stake-verification-key-file"
+      , ownerVerificationKeyFile
+      , "--out-file"
+      , registrationCertFile
+      ]
+
+  goldenFile <- H.note "test/cardano-cli-golden/files/golden/shelley/reg-certificate-extended.json"
+
+  H.diffFileVsGoldenFile registrationCertFile goldenFile

--- a/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/StakePool/RegistrationCertificate.hs
+++ b/cardano-cli/test/cardano-cli-golden/Test/Golden/Shelley/StakePool/RegistrationCertificate.hs
@@ -2,11 +2,21 @@
 
 module Test.Golden.Shelley.StakePool.RegistrationCertificate where
 
+import Cardano.Api
+  ( AsType (AsStakePoolExtendedKey, AsVerificationKey)
+  , File (File)
+  , liftIO
+  , readFileTextEnvelope
+  , serialiseToBech32
+  )
+
 import Control.Monad (void)
+import Data.Text qualified as Text
 
 import Test.Cardano.CLI.Util
 
 import Hedgehog (Property)
+import Hedgehog qualified as H
 import Hedgehog.Extras.Test.Base qualified as H
 import Hedgehog.Extras.Test.Golden qualified as H
 
@@ -76,6 +86,50 @@ hprop_golden_conway_stake_pool_registration_certificate_extended_cold_key = prop
       , "0"
       , "--cold-verification-key-file"
       , operatorVerificationKeyFile
+      , "--vrf-verification-key-file"
+      , vrfVerificationKeyFile
+      , "--pool-reward-account-verification-key-file"
+      , ownerVerificationKeyFile
+      , "--pool-owner-stake-verification-key-file"
+      , ownerVerificationKeyFile
+      , "--out-file"
+      , registrationCertFile
+      ]
+
+  goldenFile <- H.note "test/cardano-cli-golden/files/golden/shelley/reg-certificate-extended.json"
+
+  H.diffFileVsGoldenFile registrationCertFile goldenFile
+
+hprop_golden_conway_stake_pool_registration_certificate_extended_literal_cold_key :: Property
+hprop_golden_conway_stake_pool_registration_certificate_extended_literal_cold_key = propertyOnce . H.moduleWorkspace "tmp" $ \tempDir -> do
+  operatorVerificationKeyFile <-
+    noteInputFile "test/cardano-cli-golden/files/input/shelley/node-pool/extended-operator.vkey"
+  vrfVerificationKeyFile <-
+    noteInputFile "test/cardano-cli-golden/files/input/shelley/node-pool/vrf.vkey"
+  ownerVerificationKeyFile <-
+    noteInputFile "test/cardano-cli-golden/files/input/shelley/node-pool/owner.vkey"
+  registrationCertFile <- noteTempFile tempDir "registration.cert"
+
+  stakePoolExtendedKey <-
+    H.evalEitherM $
+      liftIO $
+        readFileTextEnvelope (AsVerificationKey AsStakePoolExtendedKey) (File operatorVerificationKeyFile)
+
+  void $
+    execCardanoCLI
+      [ "conway"
+      , "stake-pool"
+      , "registration-certificate"
+      , "--testnet-magic"
+      , "42"
+      , "--pool-pledge"
+      , "0"
+      , "--pool-cost"
+      , "0"
+      , "--pool-margin"
+      , "0"
+      , "--stake-pool-verification-extended-key"
+      , Text.unpack $ serialiseToBech32 stakePoolExtendedKey
       , "--vrf-verification-key-file"
       , vrfVerificationKeyFile
       , "--pool-reward-account-verification-key-file"

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -201,6 +201,7 @@ Usage: cardano-cli node key-hash-VRF
 
 Usage: cardano-cli node new-counter 
                                       ( --stake-pool-verification-key STRING
+                                      | --stake-pool-verification-extended-key STRING
                                       | --genesis-delegate-verification-key STRING
                                       | --cold-verification-key-file FILEPATH
                                       )
@@ -401,6 +402,7 @@ Usage: cardano-cli query leadership-schedule
                                                ]
                                                --genesis FILEPATH
                                                ( --stake-pool-verification-key STRING
+                                               | --stake-pool-verification-extended-key STRING
                                                | --cold-verification-key-file FILEPATH
                                                | --stake-pool-id STAKE_POOL_ID
                                                )
@@ -1698,6 +1700,7 @@ Usage: cardano-cli conway governance vote create (--yes | --no | --abstain)
                                                    | --drep-key-hash HASH
                                                    | --drep-script-hash HASH
                                                    | --stake-pool-verification-key STRING
+                                                   | --stake-pool-verification-extended-key STRING
                                                    | --cold-verification-key-file FILEPATH
                                                    | --stake-pool-id STAKE_POOL_ID
                                                    | --cc-hot-verification-key STRING
@@ -1759,6 +1762,7 @@ Usage: cardano-cli conway node key-hash-VRF
 
 Usage: cardano-cli conway node new-counter 
                                              ( --stake-pool-verification-key STRING
+                                             | --stake-pool-verification-extended-key STRING
                                              | --genesis-delegate-verification-key STRING
                                              | --cold-verification-key-file FILEPATH
                                              )
@@ -1966,6 +1970,7 @@ Usage: cardano-cli conway query leadership-schedule
                                                       ]
                                                       --genesis FILEPATH
                                                       ( --stake-pool-verification-key STRING
+                                                      | --stake-pool-verification-extended-key STRING
                                                       | --cold-verification-key-file FILEPATH
                                                       | --stake-pool-id STAKE_POOL_ID
                                                       )
@@ -2360,6 +2365,7 @@ Usage: cardano-cli conway stake-address stake-delegation-certificate
                                                                        | --stake-address ADDRESS
                                                                        )
                                                                        ( --stake-pool-verification-key STRING
+                                                                       | --stake-pool-verification-extended-key STRING
                                                                        | --cold-verification-key-file FILEPATH
                                                                        | --stake-pool-id STAKE_POOL_ID
                                                                        )
@@ -2376,6 +2382,7 @@ Usage: cardano-cli conway stake-address stake-and-vote-delegation-certificate
                                                                                 | --stake-address ADDRESS
                                                                                 )
                                                                                 ( --stake-pool-verification-key STRING
+                                                                                | --stake-pool-verification-extended-key STRING
                                                                                 | --cold-verification-key-file FILEPATH
                                                                                 | --stake-pool-id STAKE_POOL_ID
                                                                                 )
@@ -2418,6 +2425,7 @@ Usage: cardano-cli conway stake-address registration-and-delegation-certificate
                                                                                   | --stake-address ADDRESS
                                                                                   )
                                                                                   ( --stake-pool-verification-key STRING
+                                                                                  | --stake-pool-verification-extended-key STRING
                                                                                   | --cold-verification-key-file FILEPATH
                                                                                   | --stake-pool-id STAKE_POOL_ID
                                                                                   )
@@ -2457,6 +2465,7 @@ Usage: cardano-cli conway stake-address registration-stake-and-vote-delegation-c
                                                                                              | --stake-address ADDRESS
                                                                                              )
                                                                                              ( --stake-pool-verification-key STRING
+                                                                                             | --stake-pool-verification-extended-key STRING
                                                                                              | --cold-verification-key-file FILEPATH
                                                                                              | --stake-pool-id STAKE_POOL_ID
                                                                                              )
@@ -2486,6 +2495,7 @@ Usage: cardano-cli conway stake-pool
 
 Usage: cardano-cli conway stake-pool registration-certificate 
                                                                 ( --stake-pool-verification-key STRING
+                                                                | --stake-pool-verification-extended-key STRING
                                                                 | --cold-verification-key-file FILEPATH
                                                                 )
                                                                 ( --vrf-verification-key STRING
@@ -2519,6 +2529,7 @@ Usage: cardano-cli conway stake-pool registration-certificate
 
 Usage: cardano-cli conway stake-pool deregistration-certificate 
                                                                   ( --stake-pool-verification-key STRING
+                                                                  | --stake-pool-verification-extended-key STRING
                                                                   | --cold-verification-key-file FILEPATH
                                                                   )
                                                                   --epoch NATURAL
@@ -2528,6 +2539,7 @@ Usage: cardano-cli conway stake-pool deregistration-certificate
 
 Usage: cardano-cli conway stake-pool id 
                                           ( --stake-pool-verification-key STRING
+                                          | --stake-pool-verification-extended-key STRING
                                           | --cold-verification-key-file FILEPATH
                                           )
                                           [--output-format STRING]
@@ -3889,6 +3901,7 @@ Usage: cardano-cli latest governance vote create (--yes | --no | --abstain)
                                                    | --drep-key-hash HASH
                                                    | --drep-script-hash HASH
                                                    | --stake-pool-verification-key STRING
+                                                   | --stake-pool-verification-extended-key STRING
                                                    | --cold-verification-key-file FILEPATH
                                                    | --stake-pool-id STAKE_POOL_ID
                                                    | --cc-hot-verification-key STRING
@@ -3950,6 +3963,7 @@ Usage: cardano-cli latest node key-hash-VRF
 
 Usage: cardano-cli latest node new-counter 
                                              ( --stake-pool-verification-key STRING
+                                             | --stake-pool-verification-extended-key STRING
                                              | --genesis-delegate-verification-key STRING
                                              | --cold-verification-key-file FILEPATH
                                              )
@@ -4157,6 +4171,7 @@ Usage: cardano-cli latest query leadership-schedule
                                                       ]
                                                       --genesis FILEPATH
                                                       ( --stake-pool-verification-key STRING
+                                                      | --stake-pool-verification-extended-key STRING
                                                       | --cold-verification-key-file FILEPATH
                                                       | --stake-pool-id STAKE_POOL_ID
                                                       )
@@ -4551,6 +4566,7 @@ Usage: cardano-cli latest stake-address stake-delegation-certificate
                                                                        | --stake-address ADDRESS
                                                                        )
                                                                        ( --stake-pool-verification-key STRING
+                                                                       | --stake-pool-verification-extended-key STRING
                                                                        | --cold-verification-key-file FILEPATH
                                                                        | --stake-pool-id STAKE_POOL_ID
                                                                        )
@@ -4567,6 +4583,7 @@ Usage: cardano-cli latest stake-address stake-and-vote-delegation-certificate
                                                                                 | --stake-address ADDRESS
                                                                                 )
                                                                                 ( --stake-pool-verification-key STRING
+                                                                                | --stake-pool-verification-extended-key STRING
                                                                                 | --cold-verification-key-file FILEPATH
                                                                                 | --stake-pool-id STAKE_POOL_ID
                                                                                 )
@@ -4609,6 +4626,7 @@ Usage: cardano-cli latest stake-address registration-and-delegation-certificate
                                                                                   | --stake-address ADDRESS
                                                                                   )
                                                                                   ( --stake-pool-verification-key STRING
+                                                                                  | --stake-pool-verification-extended-key STRING
                                                                                   | --cold-verification-key-file FILEPATH
                                                                                   | --stake-pool-id STAKE_POOL_ID
                                                                                   )
@@ -4648,6 +4666,7 @@ Usage: cardano-cli latest stake-address registration-stake-and-vote-delegation-c
                                                                                              | --stake-address ADDRESS
                                                                                              )
                                                                                              ( --stake-pool-verification-key STRING
+                                                                                             | --stake-pool-verification-extended-key STRING
                                                                                              | --cold-verification-key-file FILEPATH
                                                                                              | --stake-pool-id STAKE_POOL_ID
                                                                                              )
@@ -4677,6 +4696,7 @@ Usage: cardano-cli latest stake-pool
 
 Usage: cardano-cli latest stake-pool registration-certificate 
                                                                 ( --stake-pool-verification-key STRING
+                                                                | --stake-pool-verification-extended-key STRING
                                                                 | --cold-verification-key-file FILEPATH
                                                                 )
                                                                 ( --vrf-verification-key STRING
@@ -4710,6 +4730,7 @@ Usage: cardano-cli latest stake-pool registration-certificate
 
 Usage: cardano-cli latest stake-pool deregistration-certificate 
                                                                   ( --stake-pool-verification-key STRING
+                                                                  | --stake-pool-verification-extended-key STRING
                                                                   | --cold-verification-key-file FILEPATH
                                                                   )
                                                                   --epoch NATURAL
@@ -4719,6 +4740,7 @@ Usage: cardano-cli latest stake-pool deregistration-certificate
 
 Usage: cardano-cli latest stake-pool id 
                                           ( --stake-pool-verification-key STRING
+                                          | --stake-pool-verification-extended-key STRING
                                           | --cold-verification-key-file FILEPATH
                                           )
                                           [--output-format STRING]
@@ -5726,6 +5748,7 @@ Usage: cardano-cli compatible shelley stake-address stake-delegation-certificate
                                                                                    | --stake-address ADDRESS
                                                                                    )
                                                                                    ( --stake-pool-verification-key STRING
+                                                                                   | --stake-pool-verification-extended-key STRING
                                                                                    | --cold-verification-key-file FILEPATH
                                                                                    | --stake-pool-id STAKE_POOL_ID
                                                                                    )
@@ -5740,6 +5763,7 @@ Usage: cardano-cli compatible shelley stake-pool registration-certificate
 
 Usage: cardano-cli compatible shelley stake-pool registration-certificate 
                                                                             ( --stake-pool-verification-key STRING
+                                                                            | --stake-pool-verification-extended-key STRING
                                                                             | --cold-verification-key-file FILEPATH
                                                                             )
                                                                             ( --vrf-verification-key STRING
@@ -5935,6 +5959,7 @@ Usage: cardano-cli compatible allegra stake-address stake-delegation-certificate
                                                                                    | --stake-address ADDRESS
                                                                                    )
                                                                                    ( --stake-pool-verification-key STRING
+                                                                                   | --stake-pool-verification-extended-key STRING
                                                                                    | --cold-verification-key-file FILEPATH
                                                                                    | --stake-pool-id STAKE_POOL_ID
                                                                                    )
@@ -5949,6 +5974,7 @@ Usage: cardano-cli compatible allegra stake-pool registration-certificate
 
 Usage: cardano-cli compatible allegra stake-pool registration-certificate 
                                                                             ( --stake-pool-verification-key STRING
+                                                                            | --stake-pool-verification-extended-key STRING
                                                                             | --cold-verification-key-file FILEPATH
                                                                             )
                                                                             ( --vrf-verification-key STRING
@@ -6144,6 +6170,7 @@ Usage: cardano-cli compatible mary stake-address stake-delegation-certificate
                                                                                 | --stake-address ADDRESS
                                                                                 )
                                                                                 ( --stake-pool-verification-key STRING
+                                                                                | --stake-pool-verification-extended-key STRING
                                                                                 | --cold-verification-key-file FILEPATH
                                                                                 | --stake-pool-id STAKE_POOL_ID
                                                                                 )
@@ -6158,6 +6185,7 @@ Usage: cardano-cli compatible mary stake-pool registration-certificate
 
 Usage: cardano-cli compatible mary stake-pool registration-certificate 
                                                                          ( --stake-pool-verification-key STRING
+                                                                         | --stake-pool-verification-extended-key STRING
                                                                          | --cold-verification-key-file FILEPATH
                                                                          )
                                                                          ( --vrf-verification-key STRING
@@ -6368,6 +6396,7 @@ Usage: cardano-cli compatible alonzo stake-address stake-delegation-certificate
                                                                                   | --stake-address ADDRESS
                                                                                   )
                                                                                   ( --stake-pool-verification-key STRING
+                                                                                  | --stake-pool-verification-extended-key STRING
                                                                                   | --cold-verification-key-file FILEPATH
                                                                                   | --stake-pool-id STAKE_POOL_ID
                                                                                   )
@@ -6382,6 +6411,7 @@ Usage: cardano-cli compatible alonzo stake-pool registration-certificate
 
 Usage: cardano-cli compatible alonzo stake-pool registration-certificate 
                                                                            ( --stake-pool-verification-key STRING
+                                                                           | --stake-pool-verification-extended-key STRING
                                                                            | --cold-verification-key-file FILEPATH
                                                                            )
                                                                            ( --vrf-verification-key STRING
@@ -6614,6 +6644,7 @@ Usage: cardano-cli compatible babbage stake-address stake-delegation-certificate
                                                                                    | --stake-address ADDRESS
                                                                                    )
                                                                                    ( --stake-pool-verification-key STRING
+                                                                                   | --stake-pool-verification-extended-key STRING
                                                                                    | --cold-verification-key-file FILEPATH
                                                                                    | --stake-pool-id STAKE_POOL_ID
                                                                                    )
@@ -6628,6 +6659,7 @@ Usage: cardano-cli compatible babbage stake-pool registration-certificate
 
 Usage: cardano-cli compatible babbage stake-pool registration-certificate 
                                                                             ( --stake-pool-verification-key STRING
+                                                                            | --stake-pool-verification-extended-key STRING
                                                                             | --cold-verification-key-file FILEPATH
                                                                             )
                                                                             ( --vrf-verification-key STRING
@@ -7139,6 +7171,7 @@ Usage: cardano-cli compatible conway governance vote create
                                                               | --drep-key-hash HASH
                                                               | --drep-script-hash HASH
                                                               | --stake-pool-verification-key STRING
+                                                              | --stake-pool-verification-extended-key STRING
                                                               | --cold-verification-key-file FILEPATH
                                                               | --stake-pool-id STAKE_POOL_ID
                                                               | --cc-hot-verification-key STRING
@@ -7189,6 +7222,7 @@ Usage: cardano-cli compatible conway stake-address stake-delegation-certificate
                                                                                   | --stake-address ADDRESS
                                                                                   )
                                                                                   ( --stake-pool-verification-key STRING
+                                                                                  | --stake-pool-verification-extended-key STRING
                                                                                   | --cold-verification-key-file FILEPATH
                                                                                   | --stake-pool-id STAKE_POOL_ID
                                                                                   )
@@ -7203,6 +7237,7 @@ Usage: cardano-cli compatible conway stake-pool registration-certificate
 
 Usage: cardano-cli compatible conway stake-pool registration-certificate 
                                                                            ( --stake-pool-verification-key STRING
+                                                                           | --stake-pool-verification-extended-key STRING
                                                                            | --cold-verification-key-file FILEPATH
                                                                            )
                                                                            ( --vrf-verification-key STRING

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_allegra_stake-address_stake-delegation-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_allegra_stake-address_stake-delegation-certificate.cli
@@ -6,6 +6,7 @@ Usage: cardano-cli compatible allegra stake-address stake-delegation-certificate
                                                                                    | --stake-address ADDRESS
                                                                                    )
                                                                                    ( --stake-pool-verification-key STRING
+                                                                                   | --stake-pool-verification-extended-key STRING
                                                                                    | --cold-verification-key-file FILEPATH
                                                                                    | --stake-pool-id STAKE_POOL_ID
                                                                                    )
@@ -25,6 +26,9 @@ Available options:
   --stake-address ADDRESS  Target stake address (bech32 format).
   --stake-pool-verification-key STRING
                            Stake pool verification key (Bech32 or hex-encoded).
+  --stake-pool-verification-extended-key STRING
+                           Stake pool verification extended key (Bech32 or
+                           hex-encoded).
   --cold-verification-key-file FILEPATH
                            Filepath of the stake pool verification key.
   --stake-pool-id STAKE_POOL_ID

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_allegra_stake-pool_registration-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_allegra_stake-pool_registration-certificate.cli
@@ -1,5 +1,6 @@
 Usage: cardano-cli compatible allegra stake-pool registration-certificate 
                                                                             ( --stake-pool-verification-key STRING
+                                                                            | --stake-pool-verification-extended-key STRING
                                                                             | --cold-verification-key-file FILEPATH
                                                                             )
                                                                             ( --vrf-verification-key STRING
@@ -34,6 +35,9 @@ Usage: cardano-cli compatible allegra stake-pool registration-certificate
 Available options:
   --stake-pool-verification-key STRING
                            Stake pool verification key (Bech32 or hex-encoded).
+  --stake-pool-verification-extended-key STRING
+                           Stake pool verification extended key (Bech32 or
+                           hex-encoded).
   --cold-verification-key-file FILEPATH
                            Filepath of the stake pool verification key.
   --vrf-verification-key STRING

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_alonzo_stake-address_stake-delegation-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_alonzo_stake-address_stake-delegation-certificate.cli
@@ -6,6 +6,7 @@ Usage: cardano-cli compatible alonzo stake-address stake-delegation-certificate
                                                                                   | --stake-address ADDRESS
                                                                                   )
                                                                                   ( --stake-pool-verification-key STRING
+                                                                                  | --stake-pool-verification-extended-key STRING
                                                                                   | --cold-verification-key-file FILEPATH
                                                                                   | --stake-pool-id STAKE_POOL_ID
                                                                                   )
@@ -25,6 +26,9 @@ Available options:
   --stake-address ADDRESS  Target stake address (bech32 format).
   --stake-pool-verification-key STRING
                            Stake pool verification key (Bech32 or hex-encoded).
+  --stake-pool-verification-extended-key STRING
+                           Stake pool verification extended key (Bech32 or
+                           hex-encoded).
   --cold-verification-key-file FILEPATH
                            Filepath of the stake pool verification key.
   --stake-pool-id STAKE_POOL_ID

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_alonzo_stake-pool_registration-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_alonzo_stake-pool_registration-certificate.cli
@@ -1,5 +1,6 @@
 Usage: cardano-cli compatible alonzo stake-pool registration-certificate 
                                                                            ( --stake-pool-verification-key STRING
+                                                                           | --stake-pool-verification-extended-key STRING
                                                                            | --cold-verification-key-file FILEPATH
                                                                            )
                                                                            ( --vrf-verification-key STRING
@@ -34,6 +35,9 @@ Usage: cardano-cli compatible alonzo stake-pool registration-certificate
 Available options:
   --stake-pool-verification-key STRING
                            Stake pool verification key (Bech32 or hex-encoded).
+  --stake-pool-verification-extended-key STRING
+                           Stake pool verification extended key (Bech32 or
+                           hex-encoded).
   --cold-verification-key-file FILEPATH
                            Filepath of the stake pool verification key.
   --vrf-verification-key STRING

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_babbage_stake-address_stake-delegation-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_babbage_stake-address_stake-delegation-certificate.cli
@@ -6,6 +6,7 @@ Usage: cardano-cli compatible babbage stake-address stake-delegation-certificate
                                                                                    | --stake-address ADDRESS
                                                                                    )
                                                                                    ( --stake-pool-verification-key STRING
+                                                                                   | --stake-pool-verification-extended-key STRING
                                                                                    | --cold-verification-key-file FILEPATH
                                                                                    | --stake-pool-id STAKE_POOL_ID
                                                                                    )
@@ -25,6 +26,9 @@ Available options:
   --stake-address ADDRESS  Target stake address (bech32 format).
   --stake-pool-verification-key STRING
                            Stake pool verification key (Bech32 or hex-encoded).
+  --stake-pool-verification-extended-key STRING
+                           Stake pool verification extended key (Bech32 or
+                           hex-encoded).
   --cold-verification-key-file FILEPATH
                            Filepath of the stake pool verification key.
   --stake-pool-id STAKE_POOL_ID

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_babbage_stake-pool_registration-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_babbage_stake-pool_registration-certificate.cli
@@ -1,5 +1,6 @@
 Usage: cardano-cli compatible babbage stake-pool registration-certificate 
                                                                             ( --stake-pool-verification-key STRING
+                                                                            | --stake-pool-verification-extended-key STRING
                                                                             | --cold-verification-key-file FILEPATH
                                                                             )
                                                                             ( --vrf-verification-key STRING
@@ -34,6 +35,9 @@ Usage: cardano-cli compatible babbage stake-pool registration-certificate
 Available options:
   --stake-pool-verification-key STRING
                            Stake pool verification key (Bech32 or hex-encoded).
+  --stake-pool-verification-extended-key STRING
+                           Stake pool verification extended key (Bech32 or
+                           hex-encoded).
   --cold-verification-key-file FILEPATH
                            Filepath of the stake pool verification key.
   --vrf-verification-key STRING

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_governance_vote_create.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_governance_vote_create.cli
@@ -10,6 +10,7 @@ Usage: cardano-cli compatible conway governance vote create
                                                               | --drep-key-hash HASH
                                                               | --drep-script-hash HASH
                                                               | --stake-pool-verification-key STRING
+                                                              | --stake-pool-verification-extended-key STRING
                                                               | --cold-verification-key-file FILEPATH
                                                               | --stake-pool-id STAKE_POOL_ID
                                                               | --cc-hot-verification-key STRING
@@ -39,6 +40,9 @@ Available options:
                            Obtain it with "cardano-cli hash script ...".
   --stake-pool-verification-key STRING
                            Stake pool verification key (Bech32 or hex-encoded).
+  --stake-pool-verification-extended-key STRING
+                           Stake pool verification extended key (Bech32 or
+                           hex-encoded).
   --cold-verification-key-file FILEPATH
                            Filepath of the stake pool verification key.
   --stake-pool-id STAKE_POOL_ID

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_stake-address_stake-delegation-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_stake-address_stake-delegation-certificate.cli
@@ -6,6 +6,7 @@ Usage: cardano-cli compatible conway stake-address stake-delegation-certificate
                                                                                   | --stake-address ADDRESS
                                                                                   )
                                                                                   ( --stake-pool-verification-key STRING
+                                                                                  | --stake-pool-verification-extended-key STRING
                                                                                   | --cold-verification-key-file FILEPATH
                                                                                   | --stake-pool-id STAKE_POOL_ID
                                                                                   )
@@ -25,6 +26,9 @@ Available options:
   --stake-address ADDRESS  Target stake address (bech32 format).
   --stake-pool-verification-key STRING
                            Stake pool verification key (Bech32 or hex-encoded).
+  --stake-pool-verification-extended-key STRING
+                           Stake pool verification extended key (Bech32 or
+                           hex-encoded).
   --cold-verification-key-file FILEPATH
                            Filepath of the stake pool verification key.
   --stake-pool-id STAKE_POOL_ID

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_stake-pool_registration-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_conway_stake-pool_registration-certificate.cli
@@ -1,5 +1,6 @@
 Usage: cardano-cli compatible conway stake-pool registration-certificate 
                                                                            ( --stake-pool-verification-key STRING
+                                                                           | --stake-pool-verification-extended-key STRING
                                                                            | --cold-verification-key-file FILEPATH
                                                                            )
                                                                            ( --vrf-verification-key STRING
@@ -34,6 +35,9 @@ Usage: cardano-cli compatible conway stake-pool registration-certificate
 Available options:
   --stake-pool-verification-key STRING
                            Stake pool verification key (Bech32 or hex-encoded).
+  --stake-pool-verification-extended-key STRING
+                           Stake pool verification extended key (Bech32 or
+                           hex-encoded).
   --cold-verification-key-file FILEPATH
                            Filepath of the stake pool verification key.
   --vrf-verification-key STRING

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_mary_stake-address_stake-delegation-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_mary_stake-address_stake-delegation-certificate.cli
@@ -6,6 +6,7 @@ Usage: cardano-cli compatible mary stake-address stake-delegation-certificate
                                                                                 | --stake-address ADDRESS
                                                                                 )
                                                                                 ( --stake-pool-verification-key STRING
+                                                                                | --stake-pool-verification-extended-key STRING
                                                                                 | --cold-verification-key-file FILEPATH
                                                                                 | --stake-pool-id STAKE_POOL_ID
                                                                                 )
@@ -25,6 +26,9 @@ Available options:
   --stake-address ADDRESS  Target stake address (bech32 format).
   --stake-pool-verification-key STRING
                            Stake pool verification key (Bech32 or hex-encoded).
+  --stake-pool-verification-extended-key STRING
+                           Stake pool verification extended key (Bech32 or
+                           hex-encoded).
   --cold-verification-key-file FILEPATH
                            Filepath of the stake pool verification key.
   --stake-pool-id STAKE_POOL_ID

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_mary_stake-pool_registration-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_mary_stake-pool_registration-certificate.cli
@@ -1,5 +1,6 @@
 Usage: cardano-cli compatible mary stake-pool registration-certificate 
                                                                          ( --stake-pool-verification-key STRING
+                                                                         | --stake-pool-verification-extended-key STRING
                                                                          | --cold-verification-key-file FILEPATH
                                                                          )
                                                                          ( --vrf-verification-key STRING
@@ -34,6 +35,9 @@ Usage: cardano-cli compatible mary stake-pool registration-certificate
 Available options:
   --stake-pool-verification-key STRING
                            Stake pool verification key (Bech32 or hex-encoded).
+  --stake-pool-verification-extended-key STRING
+                           Stake pool verification extended key (Bech32 or
+                           hex-encoded).
   --cold-verification-key-file FILEPATH
                            Filepath of the stake pool verification key.
   --vrf-verification-key STRING

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_shelley_stake-address_stake-delegation-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_shelley_stake-address_stake-delegation-certificate.cli
@@ -6,6 +6,7 @@ Usage: cardano-cli compatible shelley stake-address stake-delegation-certificate
                                                                                    | --stake-address ADDRESS
                                                                                    )
                                                                                    ( --stake-pool-verification-key STRING
+                                                                                   | --stake-pool-verification-extended-key STRING
                                                                                    | --cold-verification-key-file FILEPATH
                                                                                    | --stake-pool-id STAKE_POOL_ID
                                                                                    )
@@ -25,6 +26,9 @@ Available options:
   --stake-address ADDRESS  Target stake address (bech32 format).
   --stake-pool-verification-key STRING
                            Stake pool verification key (Bech32 or hex-encoded).
+  --stake-pool-verification-extended-key STRING
+                           Stake pool verification extended key (Bech32 or
+                           hex-encoded).
   --cold-verification-key-file FILEPATH
                            Filepath of the stake pool verification key.
   --stake-pool-id STAKE_POOL_ID

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_shelley_stake-pool_registration-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/compatible_shelley_stake-pool_registration-certificate.cli
@@ -1,5 +1,6 @@
 Usage: cardano-cli compatible shelley stake-pool registration-certificate 
                                                                             ( --stake-pool-verification-key STRING
+                                                                            | --stake-pool-verification-extended-key STRING
                                                                             | --cold-verification-key-file FILEPATH
                                                                             )
                                                                             ( --vrf-verification-key STRING
@@ -34,6 +35,9 @@ Usage: cardano-cli compatible shelley stake-pool registration-certificate
 Available options:
   --stake-pool-verification-key STRING
                            Stake pool verification key (Bech32 or hex-encoded).
+  --stake-pool-verification-extended-key STRING
+                           Stake pool verification extended key (Bech32 or
+                           hex-encoded).
   --cold-verification-key-file FILEPATH
                            Filepath of the stake pool verification key.
   --vrf-verification-key STRING

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_vote_create.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_governance_vote_create.cli
@@ -6,6 +6,7 @@ Usage: cardano-cli conway governance vote create (--yes | --no | --abstain)
                                                    | --drep-key-hash HASH
                                                    | --drep-script-hash HASH
                                                    | --stake-pool-verification-key STRING
+                                                   | --stake-pool-verification-extended-key STRING
                                                    | --cold-verification-key-file FILEPATH
                                                    | --stake-pool-id STAKE_POOL_ID
                                                    | --cc-hot-verification-key STRING
@@ -35,6 +36,9 @@ Available options:
                            Obtain it with "cardano-cli hash script ...".
   --stake-pool-verification-key STRING
                            Stake pool verification key (Bech32 or hex-encoded).
+  --stake-pool-verification-extended-key STRING
+                           Stake pool verification extended key (Bech32 or
+                           hex-encoded).
   --cold-verification-key-file FILEPATH
                            Filepath of the stake pool verification key.
   --stake-pool-id STAKE_POOL_ID

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_node_new-counter.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_node_new-counter.cli
@@ -1,5 +1,6 @@
 Usage: cardano-cli conway node new-counter 
                                              ( --stake-pool-verification-key STRING
+                                             | --stake-pool-verification-extended-key STRING
                                              | --genesis-delegate-verification-key STRING
                                              | --cold-verification-key-file FILEPATH
                                              )
@@ -11,6 +12,9 @@ Usage: cardano-cli conway node new-counter
 Available options:
   --stake-pool-verification-key STRING
                            Stake pool verification key (Bech32 or hex-encoded).
+  --stake-pool-verification-extended-key STRING
+                           Stake pool verification extended key (Bech32 or
+                           hex-encoded).
   --genesis-delegate-verification-key STRING
                            Genesis delegate verification key (hex-encoded).
   --cold-verification-key-file FILEPATH

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_leadership-schedule.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_query_leadership-schedule.cli
@@ -10,6 +10,7 @@ Usage: cardano-cli conway query leadership-schedule
                                                       ]
                                                       --genesis FILEPATH
                                                       ( --stake-pool-verification-key STRING
+                                                      | --stake-pool-verification-extended-key STRING
                                                       | --cold-verification-key-file FILEPATH
                                                       | --stake-pool-id STAKE_POOL_ID
                                                       )
@@ -42,6 +43,9 @@ Available options:
   --genesis FILEPATH       Shelley genesis filepath
   --stake-pool-verification-key STRING
                            Stake pool verification key (Bech32 or hex-encoded).
+  --stake-pool-verification-extended-key STRING
+                           Stake pool verification extended key (Bech32 or
+                           hex-encoded).
   --cold-verification-key-file FILEPATH
                            Filepath of the stake pool verification key.
   --stake-pool-id STAKE_POOL_ID

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_stake-address_registration-and-delegation-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_stake-address_registration-and-delegation-certificate.cli
@@ -6,6 +6,7 @@ Usage: cardano-cli conway stake-address registration-and-delegation-certificate
                                                                                   | --stake-address ADDRESS
                                                                                   )
                                                                                   ( --stake-pool-verification-key STRING
+                                                                                  | --stake-pool-verification-extended-key STRING
                                                                                   | --cold-verification-key-file FILEPATH
                                                                                   | --stake-pool-id STAKE_POOL_ID
                                                                                   )
@@ -27,6 +28,9 @@ Available options:
   --stake-address ADDRESS  Target stake address (bech32 format).
   --stake-pool-verification-key STRING
                            Stake pool verification key (Bech32 or hex-encoded).
+  --stake-pool-verification-extended-key STRING
+                           Stake pool verification extended key (Bech32 or
+                           hex-encoded).
   --cold-verification-key-file FILEPATH
                            Filepath of the stake pool verification key.
   --stake-pool-id STAKE_POOL_ID

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_stake-address_registration-stake-and-vote-delegation-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_stake-address_registration-stake-and-vote-delegation-certificate.cli
@@ -6,6 +6,7 @@ Usage: cardano-cli conway stake-address registration-stake-and-vote-delegation-c
                                                                                              | --stake-address ADDRESS
                                                                                              )
                                                                                              ( --stake-pool-verification-key STRING
+                                                                                             | --stake-pool-verification-extended-key STRING
                                                                                              | --cold-verification-key-file FILEPATH
                                                                                              | --stake-pool-id STAKE_POOL_ID
                                                                                              )
@@ -35,6 +36,9 @@ Available options:
   --stake-address ADDRESS  Target stake address (bech32 format).
   --stake-pool-verification-key STRING
                            Stake pool verification key (Bech32 or hex-encoded).
+  --stake-pool-verification-extended-key STRING
+                           Stake pool verification extended key (Bech32 or
+                           hex-encoded).
   --cold-verification-key-file FILEPATH
                            Filepath of the stake pool verification key.
   --stake-pool-id STAKE_POOL_ID

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_stake-address_stake-and-vote-delegation-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_stake-address_stake-and-vote-delegation-certificate.cli
@@ -6,6 +6,7 @@ Usage: cardano-cli conway stake-address stake-and-vote-delegation-certificate
                                                                                 | --stake-address ADDRESS
                                                                                 )
                                                                                 ( --stake-pool-verification-key STRING
+                                                                                | --stake-pool-verification-extended-key STRING
                                                                                 | --cold-verification-key-file FILEPATH
                                                                                 | --stake-pool-id STAKE_POOL_ID
                                                                                 )
@@ -32,6 +33,9 @@ Available options:
   --stake-address ADDRESS  Target stake address (bech32 format).
   --stake-pool-verification-key STRING
                            Stake pool verification key (Bech32 or hex-encoded).
+  --stake-pool-verification-extended-key STRING
+                           Stake pool verification extended key (Bech32 or
+                           hex-encoded).
   --cold-verification-key-file FILEPATH
                            Filepath of the stake pool verification key.
   --stake-pool-id STAKE_POOL_ID

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_stake-address_stake-delegation-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_stake-address_stake-delegation-certificate.cli
@@ -6,6 +6,7 @@ Usage: cardano-cli conway stake-address stake-delegation-certificate
                                                                        | --stake-address ADDRESS
                                                                        )
                                                                        ( --stake-pool-verification-key STRING
+                                                                       | --stake-pool-verification-extended-key STRING
                                                                        | --cold-verification-key-file FILEPATH
                                                                        | --stake-pool-id STAKE_POOL_ID
                                                                        )
@@ -25,6 +26,9 @@ Available options:
   --stake-address ADDRESS  Target stake address (bech32 format).
   --stake-pool-verification-key STRING
                            Stake pool verification key (Bech32 or hex-encoded).
+  --stake-pool-verification-extended-key STRING
+                           Stake pool verification extended key (Bech32 or
+                           hex-encoded).
   --cold-verification-key-file FILEPATH
                            Filepath of the stake pool verification key.
   --stake-pool-id STAKE_POOL_ID

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_stake-pool_deregistration-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_stake-pool_deregistration-certificate.cli
@@ -1,5 +1,6 @@
 Usage: cardano-cli conway stake-pool deregistration-certificate 
                                                                   ( --stake-pool-verification-key STRING
+                                                                  | --stake-pool-verification-extended-key STRING
                                                                   | --cold-verification-key-file FILEPATH
                                                                   )
                                                                   --epoch NATURAL
@@ -10,6 +11,9 @@ Usage: cardano-cli conway stake-pool deregistration-certificate
 Available options:
   --stake-pool-verification-key STRING
                            Stake pool verification key (Bech32 or hex-encoded).
+  --stake-pool-verification-extended-key STRING
+                           Stake pool verification extended key (Bech32 or
+                           hex-encoded).
   --cold-verification-key-file FILEPATH
                            Filepath of the stake pool verification key.
   --epoch NATURAL          The epoch number.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_stake-pool_id.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_stake-pool_id.cli
@@ -1,5 +1,6 @@
 Usage: cardano-cli conway stake-pool id 
                                           ( --stake-pool-verification-key STRING
+                                          | --stake-pool-verification-extended-key STRING
                                           | --cold-verification-key-file FILEPATH
                                           )
                                           [--output-format STRING]
@@ -10,6 +11,9 @@ Usage: cardano-cli conway stake-pool id
 Available options:
   --stake-pool-verification-key STRING
                            Stake pool verification key (Bech32 or hex-encoded).
+  --stake-pool-verification-extended-key STRING
+                           Stake pool verification extended key (Bech32 or
+                           hex-encoded).
   --cold-verification-key-file FILEPATH
                            Filepath of the stake pool verification key.
   --output-format STRING   Optional pool id output format. Accepted output

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_stake-pool_registration-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_stake-pool_registration-certificate.cli
@@ -1,5 +1,6 @@
 Usage: cardano-cli conway stake-pool registration-certificate 
                                                                 ( --stake-pool-verification-key STRING
+                                                                | --stake-pool-verification-extended-key STRING
                                                                 | --cold-verification-key-file FILEPATH
                                                                 )
                                                                 ( --vrf-verification-key STRING
@@ -34,6 +35,9 @@ Usage: cardano-cli conway stake-pool registration-certificate
 Available options:
   --stake-pool-verification-key STRING
                            Stake pool verification key (Bech32 or hex-encoded).
+  --stake-pool-verification-extended-key STRING
+                           Stake pool verification extended key (Bech32 or
+                           hex-encoded).
   --cold-verification-key-file FILEPATH
                            Filepath of the stake pool verification key.
   --vrf-verification-key STRING

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_governance_vote_create.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_governance_vote_create.cli
@@ -6,6 +6,7 @@ Usage: cardano-cli latest governance vote create (--yes | --no | --abstain)
                                                    | --drep-key-hash HASH
                                                    | --drep-script-hash HASH
                                                    | --stake-pool-verification-key STRING
+                                                   | --stake-pool-verification-extended-key STRING
                                                    | --cold-verification-key-file FILEPATH
                                                    | --stake-pool-id STAKE_POOL_ID
                                                    | --cc-hot-verification-key STRING
@@ -35,6 +36,9 @@ Available options:
                            Obtain it with "cardano-cli hash script ...".
   --stake-pool-verification-key STRING
                            Stake pool verification key (Bech32 or hex-encoded).
+  --stake-pool-verification-extended-key STRING
+                           Stake pool verification extended key (Bech32 or
+                           hex-encoded).
   --cold-verification-key-file FILEPATH
                            Filepath of the stake pool verification key.
   --stake-pool-id STAKE_POOL_ID

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_node_new-counter.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_node_new-counter.cli
@@ -1,5 +1,6 @@
 Usage: cardano-cli latest node new-counter 
                                              ( --stake-pool-verification-key STRING
+                                             | --stake-pool-verification-extended-key STRING
                                              | --genesis-delegate-verification-key STRING
                                              | --cold-verification-key-file FILEPATH
                                              )
@@ -11,6 +12,9 @@ Usage: cardano-cli latest node new-counter
 Available options:
   --stake-pool-verification-key STRING
                            Stake pool verification key (Bech32 or hex-encoded).
+  --stake-pool-verification-extended-key STRING
+                           Stake pool verification extended key (Bech32 or
+                           hex-encoded).
   --genesis-delegate-verification-key STRING
                            Genesis delegate verification key (hex-encoded).
   --cold-verification-key-file FILEPATH

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_leadership-schedule.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_query_leadership-schedule.cli
@@ -10,6 +10,7 @@ Usage: cardano-cli latest query leadership-schedule
                                                       ]
                                                       --genesis FILEPATH
                                                       ( --stake-pool-verification-key STRING
+                                                      | --stake-pool-verification-extended-key STRING
                                                       | --cold-verification-key-file FILEPATH
                                                       | --stake-pool-id STAKE_POOL_ID
                                                       )
@@ -42,6 +43,9 @@ Available options:
   --genesis FILEPATH       Shelley genesis filepath
   --stake-pool-verification-key STRING
                            Stake pool verification key (Bech32 or hex-encoded).
+  --stake-pool-verification-extended-key STRING
+                           Stake pool verification extended key (Bech32 or
+                           hex-encoded).
   --cold-verification-key-file FILEPATH
                            Filepath of the stake pool verification key.
   --stake-pool-id STAKE_POOL_ID

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_stake-address_registration-and-delegation-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_stake-address_registration-and-delegation-certificate.cli
@@ -6,6 +6,7 @@ Usage: cardano-cli latest stake-address registration-and-delegation-certificate
                                                                                   | --stake-address ADDRESS
                                                                                   )
                                                                                   ( --stake-pool-verification-key STRING
+                                                                                  | --stake-pool-verification-extended-key STRING
                                                                                   | --cold-verification-key-file FILEPATH
                                                                                   | --stake-pool-id STAKE_POOL_ID
                                                                                   )
@@ -27,6 +28,9 @@ Available options:
   --stake-address ADDRESS  Target stake address (bech32 format).
   --stake-pool-verification-key STRING
                            Stake pool verification key (Bech32 or hex-encoded).
+  --stake-pool-verification-extended-key STRING
+                           Stake pool verification extended key (Bech32 or
+                           hex-encoded).
   --cold-verification-key-file FILEPATH
                            Filepath of the stake pool verification key.
   --stake-pool-id STAKE_POOL_ID

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_stake-address_registration-stake-and-vote-delegation-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_stake-address_registration-stake-and-vote-delegation-certificate.cli
@@ -6,6 +6,7 @@ Usage: cardano-cli latest stake-address registration-stake-and-vote-delegation-c
                                                                                              | --stake-address ADDRESS
                                                                                              )
                                                                                              ( --stake-pool-verification-key STRING
+                                                                                             | --stake-pool-verification-extended-key STRING
                                                                                              | --cold-verification-key-file FILEPATH
                                                                                              | --stake-pool-id STAKE_POOL_ID
                                                                                              )
@@ -35,6 +36,9 @@ Available options:
   --stake-address ADDRESS  Target stake address (bech32 format).
   --stake-pool-verification-key STRING
                            Stake pool verification key (Bech32 or hex-encoded).
+  --stake-pool-verification-extended-key STRING
+                           Stake pool verification extended key (Bech32 or
+                           hex-encoded).
   --cold-verification-key-file FILEPATH
                            Filepath of the stake pool verification key.
   --stake-pool-id STAKE_POOL_ID

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_stake-address_stake-and-vote-delegation-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_stake-address_stake-and-vote-delegation-certificate.cli
@@ -6,6 +6,7 @@ Usage: cardano-cli latest stake-address stake-and-vote-delegation-certificate
                                                                                 | --stake-address ADDRESS
                                                                                 )
                                                                                 ( --stake-pool-verification-key STRING
+                                                                                | --stake-pool-verification-extended-key STRING
                                                                                 | --cold-verification-key-file FILEPATH
                                                                                 | --stake-pool-id STAKE_POOL_ID
                                                                                 )
@@ -32,6 +33,9 @@ Available options:
   --stake-address ADDRESS  Target stake address (bech32 format).
   --stake-pool-verification-key STRING
                            Stake pool verification key (Bech32 or hex-encoded).
+  --stake-pool-verification-extended-key STRING
+                           Stake pool verification extended key (Bech32 or
+                           hex-encoded).
   --cold-verification-key-file FILEPATH
                            Filepath of the stake pool verification key.
   --stake-pool-id STAKE_POOL_ID

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_stake-address_stake-delegation-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_stake-address_stake-delegation-certificate.cli
@@ -6,6 +6,7 @@ Usage: cardano-cli latest stake-address stake-delegation-certificate
                                                                        | --stake-address ADDRESS
                                                                        )
                                                                        ( --stake-pool-verification-key STRING
+                                                                       | --stake-pool-verification-extended-key STRING
                                                                        | --cold-verification-key-file FILEPATH
                                                                        | --stake-pool-id STAKE_POOL_ID
                                                                        )
@@ -25,6 +26,9 @@ Available options:
   --stake-address ADDRESS  Target stake address (bech32 format).
   --stake-pool-verification-key STRING
                            Stake pool verification key (Bech32 or hex-encoded).
+  --stake-pool-verification-extended-key STRING
+                           Stake pool verification extended key (Bech32 or
+                           hex-encoded).
   --cold-verification-key-file FILEPATH
                            Filepath of the stake pool verification key.
   --stake-pool-id STAKE_POOL_ID

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_stake-pool_deregistration-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_stake-pool_deregistration-certificate.cli
@@ -1,5 +1,6 @@
 Usage: cardano-cli latest stake-pool deregistration-certificate 
                                                                   ( --stake-pool-verification-key STRING
+                                                                  | --stake-pool-verification-extended-key STRING
                                                                   | --cold-verification-key-file FILEPATH
                                                                   )
                                                                   --epoch NATURAL
@@ -10,6 +11,9 @@ Usage: cardano-cli latest stake-pool deregistration-certificate
 Available options:
   --stake-pool-verification-key STRING
                            Stake pool verification key (Bech32 or hex-encoded).
+  --stake-pool-verification-extended-key STRING
+                           Stake pool verification extended key (Bech32 or
+                           hex-encoded).
   --cold-verification-key-file FILEPATH
                            Filepath of the stake pool verification key.
   --epoch NATURAL          The epoch number.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_stake-pool_id.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_stake-pool_id.cli
@@ -1,5 +1,6 @@
 Usage: cardano-cli latest stake-pool id 
                                           ( --stake-pool-verification-key STRING
+                                          | --stake-pool-verification-extended-key STRING
                                           | --cold-verification-key-file FILEPATH
                                           )
                                           [--output-format STRING]
@@ -10,6 +11,9 @@ Usage: cardano-cli latest stake-pool id
 Available options:
   --stake-pool-verification-key STRING
                            Stake pool verification key (Bech32 or hex-encoded).
+  --stake-pool-verification-extended-key STRING
+                           Stake pool verification extended key (Bech32 or
+                           hex-encoded).
   --cold-verification-key-file FILEPATH
                            Filepath of the stake pool verification key.
   --output-format STRING   Optional pool id output format. Accepted output

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_stake-pool_registration-certificate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_stake-pool_registration-certificate.cli
@@ -1,5 +1,6 @@
 Usage: cardano-cli latest stake-pool registration-certificate 
                                                                 ( --stake-pool-verification-key STRING
+                                                                | --stake-pool-verification-extended-key STRING
                                                                 | --cold-verification-key-file FILEPATH
                                                                 )
                                                                 ( --vrf-verification-key STRING
@@ -34,6 +35,9 @@ Usage: cardano-cli latest stake-pool registration-certificate
 Available options:
   --stake-pool-verification-key STRING
                            Stake pool verification key (Bech32 or hex-encoded).
+  --stake-pool-verification-extended-key STRING
+                           Stake pool verification extended key (Bech32 or
+                           hex-encoded).
   --cold-verification-key-file FILEPATH
                            Filepath of the stake pool verification key.
   --vrf-verification-key STRING

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/node_new-counter.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/node_new-counter.cli
@@ -1,5 +1,6 @@
 Usage: cardano-cli node new-counter 
                                       ( --stake-pool-verification-key STRING
+                                      | --stake-pool-verification-extended-key STRING
                                       | --genesis-delegate-verification-key STRING
                                       | --cold-verification-key-file FILEPATH
                                       )
@@ -11,6 +12,9 @@ Usage: cardano-cli node new-counter
 Available options:
   --stake-pool-verification-key STRING
                            Stake pool verification key (Bech32 or hex-encoded).
+  --stake-pool-verification-extended-key STRING
+                           Stake pool verification extended key (Bech32 or
+                           hex-encoded).
   --genesis-delegate-verification-key STRING
                            Genesis delegate verification key (hex-encoded).
   --cold-verification-key-file FILEPATH

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/query_leadership-schedule.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/query_leadership-schedule.cli
@@ -10,6 +10,7 @@ Usage: cardano-cli query leadership-schedule
                                                ]
                                                --genesis FILEPATH
                                                ( --stake-pool-verification-key STRING
+                                               | --stake-pool-verification-extended-key STRING
                                                | --cold-verification-key-file FILEPATH
                                                | --stake-pool-id STAKE_POOL_ID
                                                )
@@ -40,6 +41,9 @@ Available options:
   --genesis FILEPATH       Shelley genesis filepath
   --stake-pool-verification-key STRING
                            Stake pool verification key (Bech32 or hex-encoded).
+  --stake-pool-verification-extended-key STRING
+                           Stake pool verification extended key (Bech32 or
+                           hex-encoded).
   --cold-verification-key-file FILEPATH
                            Filepath of the stake pool verification key.
   --stake-pool-id STAKE_POOL_ID

--- a/cardano-cli/test/cardano-cli-golden/files/golden/shelley/reg-certificate-extended.json
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/shelley/reg-certificate-extended.json
@@ -1,0 +1,5 @@
+{
+    "type": "CertificateConway",
+    "description": "Stake Pool Registration Certificate",
+    "cborHex": "8a03581c1ae194ffedb008b77bfb8ec39b1514dbeb99ceccd66448181295142258206aa5f600f54659d456dc2628997df23d98f8f85681edd3e6f4a9340cb06b8db70000d81e820001581de0749440f878a5ba2ac3ab03dbdec6ae3ad5c89f06fc9c031611947803d9010281581c749440f878a5ba2ac3ab03dbdec6ae3ad5c89f06fc9c03161194780380f6"
+}

--- a/cardano-cli/test/cardano-cli-golden/files/input/shelley/node-pool/extended-operator.vkey
+++ b/cardano-cli/test/cardano-cli-golden/files/input/shelley/node-pool/extended-operator.vkey
@@ -1,0 +1,5 @@
+{
+      "type": "StakePoolExtendedVerificationKey_ed25519_bip32",
+      "description": "Stake Pool Operator Verification Key",
+      "cborHex": "58405474de0dd906dae02e33cad45bb24a21f1ade6af57457b6ea171985412cd35d070a3adf6f2ecd799fa127e536d2c93c2c1946d11fb92c5608dfb3acef8eb72f1"
+}

--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1744959461,
-        "narHash": "sha256-rPOr9nXAYOOgv+uJ5nP2UCPKLi4y/xCVjdoa5+l9tF4=",
+        "lastModified": 1745606874,
+        "narHash": "sha256-BKunBedqSA09I8HaXenDsQpZ2u5mZQFeafkAxZ02fxE=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "bdb90651c5f9c236068965945fd2d0b03ef40891",
+        "rev": "0f473eb9b6830d100ff6e6d6b9250f553e0f71cd",
         "type": "github"
       },
       "original": {
@@ -170,23 +170,6 @@
         "type": "github"
       }
     },
-    "hackage-for-stackage": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1744935886,
-        "narHash": "sha256-51sNWB+CsVaq24DC7gYLuDmTX73AMIpfpW0HvOyCi/8=",
-        "owner": "input-output-hk",
-        "repo": "hackage.nix",
-        "rev": "4e36dca00cbcf1db7afea37c5196b7394ccc53ea",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "ref": "for-stackage",
-        "repo": "hackage.nix",
-        "type": "github"
-      }
-    },
     "hackageNix": {
       "flake": false,
       "locked": {
@@ -216,7 +199,6 @@
         "hackage": [
           "hackageNix"
         ],
-        "hackage-for-stackage": "hackage-for-stackage",
         "hls-1.10": "hls-1.10",
         "hls-2.0": "hls-2.0",
         "hls-2.2": "hls-2.2",
@@ -228,25 +210,30 @@
         "hls-2.8": "hls-2.8",
         "hls-2.9": "hls-2.9",
         "hpc-coveralls": "hpc-coveralls",
+        "hydra": "hydra",
         "iserv-proxy": "iserv-proxy",
         "nixpkgs": [
           "haskellNix",
           "nixpkgs-unstable"
         ],
+        "nixpkgs-2003": "nixpkgs-2003",
+        "nixpkgs-2105": "nixpkgs-2105",
+        "nixpkgs-2111": "nixpkgs-2111",
+        "nixpkgs-2205": "nixpkgs-2205",
+        "nixpkgs-2211": "nixpkgs-2211",
         "nixpkgs-2305": "nixpkgs-2305",
         "nixpkgs-2311": "nixpkgs-2311",
         "nixpkgs-2405": "nixpkgs-2405",
-        "nixpkgs-2411": "nixpkgs-2411",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "old-ghc-nix": "old-ghc-nix",
         "stackage": "stackage"
       },
       "locked": {
-        "lastModified": 1741061330,
-        "narHash": "sha256-wweNm8nqb/lnR9uyM7qOPARZs/QdXlIsMyRagIqfjGM=",
+        "lastModified": 1726275037,
+        "narHash": "sha256-q0+NlcOGV1eQRN1FjLpt5li6iyPQPeky37hwP5JLqVU=",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "7e4a6c27899c457ef5a2ba3d89624c622572b4e5",
+        "rev": "a93d40302777a9ce268b3bc57caae3f7fdae1ce1",
         "type": "github"
       },
       "original": {
@@ -412,16 +399,16 @@
     "hls-2.9": {
       "flake": false,
       "locked": {
-        "lastModified": 1719993701,
-        "narHash": "sha256-wy348++MiMm/xwtI9M3vVpqj2qfGgnDcZIGXw8sF1sA=",
+        "lastModified": 1718469202,
+        "narHash": "sha256-THXSz+iwB1yQQsr/PY151+2GvtoJnTIB2pIQ4OzfjD4=",
         "owner": "haskell",
         "repo": "haskell-language-server",
-        "rev": "90319a7e62ab93ab65a95f8f2bcf537e34dae76a",
+        "rev": "40891bccb235ebacce020b598b083eab9dda80f1",
         "type": "github"
       },
       "original": {
         "owner": "haskell",
-        "ref": "2.9.0.1",
+        "ref": "2.9.0.0",
         "repo": "haskell-language-server",
         "type": "github"
       }
@@ -440,6 +427,29 @@
         "owner": "sevanspowell",
         "repo": "hpc-coveralls",
         "type": "github"
+      }
+    },
+    "hydra": {
+      "inputs": {
+        "nix": "nix",
+        "nixpkgs": [
+          "haskellNix",
+          "hydra",
+          "nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1671755331,
+        "narHash": "sha256-hXsgJj0Cy0ZiCiYdW2OdBz5WmFyOMKuw4zyxKpgUKm4=",
+        "owner": "NixOS",
+        "repo": "hydra",
+        "rev": "f48f00ee6d5727ae3e488cbf9ce157460853fea8",
+        "type": "github"
+      },
+      "original": {
+        "id": "hydra",
+        "type": "indirect"
       }
     },
     "incl": {
@@ -463,7 +473,7 @@
     "iohkNix": {
       "inputs": {
         "blst": "blst",
-        "nixpkgs": "nixpkgs",
+        "nixpkgs": "nixpkgs_2",
         "secp256k1": "secp256k1",
         "sodium": "sodium"
       },
@@ -498,6 +508,43 @@
         "type": "github"
       }
     },
+    "lowdown-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1633514407,
+        "narHash": "sha256-Dw32tiMjdK9t3ETl5fzGrutQTzh2rufgZV4A/BbxuD4=",
+        "owner": "kristapsdz",
+        "repo": "lowdown",
+        "rev": "d2c2b44ff6c27b936ec27358a2653caaef8f73b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "kristapsdz",
+        "repo": "lowdown",
+        "type": "github"
+      }
+    },
+    "nix": {
+      "inputs": {
+        "lowdown-src": "lowdown-src",
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-regression": "nixpkgs-regression"
+      },
+      "locked": {
+        "lastModified": 1661606874,
+        "narHash": "sha256-9+rpYzI+SmxJn+EbYxjGv68Ucp22bdFUSy/4LkHkkDQ=",
+        "owner": "NixOS",
+        "repo": "nix",
+        "rev": "11e45768b34fdafdcf019ddbd337afa16127ff0f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "2.11.0",
+        "repo": "nix",
+        "type": "github"
+      }
+    },
     "nixlib": {
       "locked": {
         "lastModified": 1667696192,
@@ -515,16 +562,96 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1684171562,
-        "narHash": "sha256-BMUWjVWAUdyMWKk0ATMC9H0Bv4qAV/TXwwPUvTiC5IQ=",
-        "owner": "nixos",
+        "lastModified": 1657693803,
+        "narHash": "sha256-G++2CJ9u0E7NNTAi9n5G8TdDmGJXcIjkJ3NF8cetQB8=",
+        "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "55af203d468a6f5032a519cba4f41acf5a74b638",
+        "rev": "365e1b3a859281cf11b94f87231adeabbdd878a2",
         "type": "github"
       },
       "original": {
-        "owner": "nixos",
-        "ref": "release-22.11",
+        "owner": "NixOS",
+        "ref": "nixos-22.05-small",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2003": {
+      "locked": {
+        "lastModified": 1620055814,
+        "narHash": "sha256-8LEHoYSJiL901bTMVatq+rf8y7QtWuZhwwpKE2fyaRY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1db42b7fe3878f3f5f7a4f2dc210772fd080e205",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-20.03-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2105": {
+      "locked": {
+        "lastModified": 1659914493,
+        "narHash": "sha256-lkA5X3VNMKirvA+SUzvEhfA7XquWLci+CGi505YFAIs=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "022caabb5f2265ad4006c1fa5b1ebe69fb0c3faf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-21.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2111": {
+      "locked": {
+        "lastModified": 1659446231,
+        "narHash": "sha256-hekabNdTdgR/iLsgce5TGWmfIDZ86qjPhxDg/8TlzhE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "eabc38219184cc3e04a974fe31857d8e0eac098d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-21.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2205": {
+      "locked": {
+        "lastModified": 1685573264,
+        "narHash": "sha256-Zffu01pONhs/pqH07cjlF10NnMDLok8ix5Uk4rhOnZQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "380be19fbd2d9079f677978361792cb25e8a3635",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-22.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2211": {
+      "locked": {
+        "lastModified": 1688392541,
+        "narHash": "sha256-lHrKvEkCPTUO+7tPfjIcb7Trk6k31rz18vkyqmkeJfY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ea4c80b39be4c09702b0cb3b42eab59e2ba4f24b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-22.11-darwin",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -577,19 +704,19 @@
         "type": "github"
       }
     },
-    "nixpkgs-2411": {
+    "nixpkgs-regression": {
       "locked": {
-        "lastModified": 1744492897,
-        "narHash": "sha256-qqKO4FOo/vPmNIaRPcLqwfudUlQ29iNdI1IbCZfjmxs=",
+        "lastModified": 1643052045,
+        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "86484f6076aac9141df2bfcddbf7dcfce5e0c6bb",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixpkgs-24.11-darwin",
         "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
         "type": "github"
       }
     },
@@ -605,6 +732,22 @@
       "original": {
         "owner": "NixOS",
         "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1684171562,
+        "narHash": "sha256-BMUWjVWAUdyMWKk0ATMC9H0Bv4qAV/TXwwPUvTiC5IQ=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "55af203d468a6f5032a519cba4f41acf5a74b638",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "release-22.11",
         "repo": "nixpkgs",
         "type": "github"
       }


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Added support for stake pool extended keys
  type:
  - feature
```

# Context

Tries to address https://github.com/IntersectMBO/cardano-cli/issues/1076.

Check together with: https://github.com/IntersectMBO/cardano-api/pull/781

# How to trust this PR

Look at the test for creating stake pool registration certificate using an extended cold key. Make sure the refactorings preserve the logic of the code and that the extensions make sense. Check the code structure is good and documentation is appropriate.

# Checklist

- [x] Commit sequence broadly makes sense and commits have useful messages
- [x] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [x] Self-reviewed the diff
