### PR TITLE
Add canonical CBOR toggle for transaction building and signing commands

### DIFF
--- a/cardano-cli/src/Cardano/CLI/EraBased/Common/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Common/Option.hs
@@ -3443,6 +3443,7 @@ parseTxOutShelleyBasedEra = do
   val <- parseTxOutMultiAssetValue -- UTxO role works for transaction output
   return (TxOutShelleyBasedEra addr val)
 
+-- TODO: replace with parseAddressAny from cardano-api
 parseShelleyAddress :: Parsec.Parser (Address ShelleyAddr)
 parseShelleyAddress = do
   str <- lexPlausibleAddressString

--- a/cardano-cli/src/Cardano/CLI/EraBased/Transaction/Command.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Transaction/Command.hs
@@ -5,6 +5,7 @@
 module Cardano.CLI.EraBased.Transaction.Command
   ( TransactionCmds (..)
   , TransactionBuildRawCmdArgs (..)
+  , TxCborFormat (..)
   , TransactionBuildCmdArgs (..)
   , TransactionBuildEstimateCmdArgs (..)
   , TransactionSignCmdArgs (..)
@@ -92,9 +93,19 @@ data TransactionBuildRawCmdArgs era = TransactionBuildRawCmdArgs
   , voteFiles :: ![(VoteFile In, Maybe CliVoteScriptRequirements)]
   , proposalFiles :: ![(ProposalFile In, Maybe CliProposalScriptRequirements)]
   , currentTreasuryValueAndDonation :: !(Maybe (TxCurrentTreasuryValue, TxTreasuryDonation))
+  , isCborOutCanonical :: !TxCborFormat
   , txBodyOutFile :: !(TxBodyFile Out)
   }
   deriving Show
+
+-- | Whether output transaction is in CBOR canonical format according to RFC7049 section 3.9.
+--
+-- 1. https://datatracker.ietf.org/doc/html/rfc7049#section-3.9
+-- 2. https://github.com/cardano-foundation/CIPs/blob/master/CIP-0021/README.md#canonical-cbor-serialization-format
+data TxCborFormat
+  = TxCborCanonical
+  | TxCborNotCanonical
+  deriving (Eq, Show)
 
 -- | Like 'TransactionBuildRaw' but without the fee, and with a change output.
 data TransactionBuildCmdArgs era = TransactionBuildCmdArgs
@@ -138,6 +149,7 @@ data TransactionBuildCmdArgs era = TransactionBuildCmdArgs
   , voteFiles :: ![(VoteFile In, Maybe CliVoteScriptRequirements)]
   , proposalFiles :: ![(ProposalFile In, Maybe CliProposalScriptRequirements)]
   , treasuryDonation :: !(Maybe TxTreasuryDonation)
+  , isCborOutCanonical :: !TxCborFormat
   , buildOutputOptions :: !TxBuildOutputOptions
   }
   deriving Show
@@ -188,6 +200,7 @@ data TransactionBuildEstimateCmdArgs era = TransactionBuildEstimateCmdArgs
   , voteFiles :: ![(VoteFile In, Maybe CliVoteScriptRequirements)]
   , proposalFiles :: ![(ProposalFile In, Maybe CliProposalScriptRequirements)]
   , currentTreasuryValueAndDonation :: !(Maybe (TxCurrentTreasuryValue, TxTreasuryDonation))
+  , isCborOutCanonical :: !TxCborFormat
   , txBodyOutFile :: !(TxBodyFile Out)
   }
 
@@ -195,6 +208,7 @@ data TransactionSignCmdArgs = TransactionSignCmdArgs
   { txOrTxBodyFile :: !InputTxBodyOrTxFile
   , witnessSigningData :: ![WitnessSigningData]
   , mNetworkId :: !(Maybe NetworkId)
+  , isCborOutCanonical :: !TxCborFormat
   , outTxFile :: !(TxFile Out)
   }
   deriving Show
@@ -210,6 +224,7 @@ data TransactionWitnessCmdArgs = TransactionWitnessCmdArgs
 data TransactionSignWitnessCmdArgs = TransactionSignWitnessCmdArgs
   { txBodyFile :: !(TxBodyFile In)
   , witnessFiles :: ![WitnessFile]
+  , isCborOutCanonical :: !TxCborFormat
   , outFile :: !(File () Out)
   }
   deriving Show

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help.cli
@@ -2697,6 +2697,7 @@ Usage: cardano-cli conway transaction build-raw
                                                     ]]
                                                   [--current-treasury-value LOVELACE
                                                     --treasury-donation LOVELACE]
+                                                  [--out-canonical-cbor]
                                                   --out-file FILEPATH
 
   Build a transaction (low-level, inconvenient)
@@ -2846,6 +2847,7 @@ Usage: cardano-cli conway transaction build
                                                   )
                                                 ]]
                                               [--treasury-donation LOVELACE]
+                                              [--out-canonical-cbor]
                                               ( --out-file FILEPATH
                                               | --calculate-plutus-script-cost FILEPATH
                                               )
@@ -3014,6 +3016,7 @@ Usage: cardano-cli conway transaction build-estimate
                                                          ]]
                                                        [--current-treasury-value LOVELACE
                                                          --treasury-donation LOVELACE]
+                                                       [--out-canonical-cbor]
                                                        --out-file FILEPATH
 
   Build a balanced transaction without access to a live node (automatically estimates fees)
@@ -3029,6 +3032,7 @@ Usage: cardano-cli conway transaction sign
                                              [ --mainnet
                                              | --testnet-magic NATURAL
                                              ]
+                                             [--out-canonical-cbor]
                                              --out-file FILEPATH
 
   Sign a transaction
@@ -3045,12 +3049,14 @@ Usage: cardano-cli conway transaction witness --tx-body-file FILEPATH
 
 Usage: cardano-cli conway transaction assemble --tx-body-file FILEPATH
                                                  [--witness-file FILEPATH]
+                                                 [--out-canonical-cbor]
                                                  --out-file FILEPATH
 
   Assemble a tx body and witness(es) to form a transaction
 
 Usage: cardano-cli conway transaction sign-witness --tx-body-file FILEPATH
                                                      [--witness-file FILEPATH]
+                                                     [--out-canonical-cbor]
                                                      --out-file FILEPATH
 
   Assemble a tx body and witness(es) to form a transaction
@@ -4841,6 +4847,7 @@ Usage: cardano-cli latest transaction build-raw
                                                     ]]
                                                   [--current-treasury-value LOVELACE
                                                     --treasury-donation LOVELACE]
+                                                  [--out-canonical-cbor]
                                                   --out-file FILEPATH
 
   Build a transaction (low-level, inconvenient)
@@ -4990,6 +4997,7 @@ Usage: cardano-cli latest transaction build
                                                   )
                                                 ]]
                                               [--treasury-donation LOVELACE]
+                                              [--out-canonical-cbor]
                                               ( --out-file FILEPATH
                                               | --calculate-plutus-script-cost FILEPATH
                                               )
@@ -5158,6 +5166,7 @@ Usage: cardano-cli latest transaction build-estimate
                                                          ]]
                                                        [--current-treasury-value LOVELACE
                                                          --treasury-donation LOVELACE]
+                                                       [--out-canonical-cbor]
                                                        --out-file FILEPATH
 
   Build a balanced transaction without access to a live node (automatically estimates fees)
@@ -5173,6 +5182,7 @@ Usage: cardano-cli latest transaction sign
                                              [ --mainnet
                                              | --testnet-magic NATURAL
                                              ]
+                                             [--out-canonical-cbor]
                                              --out-file FILEPATH
 
   Sign a transaction
@@ -5189,12 +5199,14 @@ Usage: cardano-cli latest transaction witness --tx-body-file FILEPATH
 
 Usage: cardano-cli latest transaction assemble --tx-body-file FILEPATH
                                                  [--witness-file FILEPATH]
+                                                 [--out-canonical-cbor]
                                                  --out-file FILEPATH
 
   Assemble a tx body and witness(es) to form a transaction
 
 Usage: cardano-cli latest transaction sign-witness --tx-body-file FILEPATH
                                                      [--witness-file FILEPATH]
+                                                     [--out-canonical-cbor]
                                                      --out-file FILEPATH
 
   Assemble a tx body and witness(es) to form a transaction

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_assemble.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_assemble.cli
@@ -1,5 +1,6 @@
 Usage: cardano-cli conway transaction assemble --tx-body-file FILEPATH
                                                  [--witness-file FILEPATH]
+                                                 [--out-canonical-cbor]
                                                  --out-file FILEPATH
 
   Assemble a tx body and witness(es) to form a transaction
@@ -7,5 +8,7 @@ Usage: cardano-cli conway transaction assemble --tx-body-file FILEPATH
 Available options:
   --tx-body-file FILEPATH  Input filepath of the JSON TxBody.
   --witness-file FILEPATH  Filepath of the witness
+  --out-canonical-cbor     Produce transaction in canonical CBOR according to
+                           RFC7049. Only this part of CIP-21 is implemented.
   --out-file FILEPATH      The output file.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_build-estimate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_build-estimate.cli
@@ -158,6 +158,7 @@ Usage: cardano-cli conway transaction build-estimate
                                                          ]]
                                                        [--current-treasury-value LOVELACE
                                                          --treasury-donation LOVELACE]
+                                                       [--out-canonical-cbor]
                                                        --out-file FILEPATH
 
   Build a balanced transaction without access to a live node (automatically estimates fees)
@@ -511,5 +512,7 @@ Available options:
                            The current treasury value.
   --treasury-donation LOVELACE
                            The donation to the treasury to perform.
+  --out-canonical-cbor     Produce transaction in canonical CBOR according to
+                           RFC7049. Only this part of CIP-21 is implemented.
   --out-file FILEPATH      Output filepath of the JSON TxBody.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_build-raw.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_build-raw.cli
@@ -153,6 +153,7 @@ Usage: cardano-cli conway transaction build-raw
                                                     ]]
                                                   [--current-treasury-value LOVELACE
                                                     --treasury-donation LOVELACE]
+                                                  [--out-canonical-cbor]
                                                   --out-file FILEPATH
 
   Build a transaction (low-level, inconvenient)
@@ -495,5 +496,7 @@ Available options:
                            The current treasury value.
   --treasury-donation LOVELACE
                            The donation to the treasury to perform.
+  --out-canonical-cbor     Produce transaction in canonical CBOR according to
+                           RFC7049. Only this part of CIP-21 is implemented.
   --out-file FILEPATH      Output filepath of the JSON TxBody.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_build.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_build.cli
@@ -141,6 +141,7 @@ Usage: cardano-cli conway transaction build
                                                   )
                                                 ]]
                                               [--treasury-donation LOVELACE]
+                                              [--out-canonical-cbor]
                                               ( --out-file FILEPATH
                                               | --calculate-plutus-script-cost FILEPATH
                                               )
@@ -472,6 +473,8 @@ Available options:
                            top-level strings and numbers.
   --treasury-donation LOVELACE
                            The donation to the treasury to perform.
+  --out-canonical-cbor     Produce transaction in canonical CBOR according to
+                           RFC7049. Only this part of CIP-21 is implemented.
   --out-file FILEPATH      Output filepath of the JSON TxBody.
   --calculate-plutus-script-cost FILEPATH
                            Where to write the script cost information.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_sign-witness.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_sign-witness.cli
@@ -1,5 +1,6 @@
 Usage: cardano-cli conway transaction sign-witness --tx-body-file FILEPATH
                                                      [--witness-file FILEPATH]
+                                                     [--out-canonical-cbor]
                                                      --out-file FILEPATH
 
   Assemble a tx body and witness(es) to form a transaction
@@ -7,4 +8,6 @@ Usage: cardano-cli conway transaction sign-witness --tx-body-file FILEPATH
 Available options:
   --tx-body-file FILEPATH  Input filepath of the JSON TxBody.
   --witness-file FILEPATH  Filepath of the witness
+  --out-canonical-cbor     Produce transaction in canonical CBOR according to
+                           RFC7049. Only this part of CIP-21 is implemented.
   --out-file FILEPATH      The output file.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_sign.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/conway_transaction_sign.cli
@@ -7,6 +7,7 @@ Usage: cardano-cli conway transaction sign
                                              [ --mainnet
                                              | --testnet-magic NATURAL
                                              ]
+                                             [--out-canonical-cbor]
                                              --out-file FILEPATH
 
   Sign a transaction
@@ -21,5 +22,7 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --out-canonical-cbor     Produce transaction in canonical CBOR according to
+                           RFC7049. Only this part of CIP-21 is implemented.
   --out-file FILEPATH      Output filepath of the JSON Tx.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_transaction_assemble.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_transaction_assemble.cli
@@ -1,5 +1,6 @@
 Usage: cardano-cli latest transaction assemble --tx-body-file FILEPATH
                                                  [--witness-file FILEPATH]
+                                                 [--out-canonical-cbor]
                                                  --out-file FILEPATH
 
   Assemble a tx body and witness(es) to form a transaction
@@ -7,5 +8,7 @@ Usage: cardano-cli latest transaction assemble --tx-body-file FILEPATH
 Available options:
   --tx-body-file FILEPATH  Input filepath of the JSON TxBody.
   --witness-file FILEPATH  Filepath of the witness
+  --out-canonical-cbor     Produce transaction in canonical CBOR according to
+                           RFC7049. Only this part of CIP-21 is implemented.
   --out-file FILEPATH      The output file.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_transaction_build-estimate.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_transaction_build-estimate.cli
@@ -158,6 +158,7 @@ Usage: cardano-cli latest transaction build-estimate
                                                          ]]
                                                        [--current-treasury-value LOVELACE
                                                          --treasury-donation LOVELACE]
+                                                       [--out-canonical-cbor]
                                                        --out-file FILEPATH
 
   Build a balanced transaction without access to a live node (automatically estimates fees)
@@ -511,5 +512,7 @@ Available options:
                            The current treasury value.
   --treasury-donation LOVELACE
                            The donation to the treasury to perform.
+  --out-canonical-cbor     Produce transaction in canonical CBOR according to
+                           RFC7049. Only this part of CIP-21 is implemented.
   --out-file FILEPATH      Output filepath of the JSON TxBody.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_transaction_build-raw.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_transaction_build-raw.cli
@@ -153,6 +153,7 @@ Usage: cardano-cli latest transaction build-raw
                                                     ]]
                                                   [--current-treasury-value LOVELACE
                                                     --treasury-donation LOVELACE]
+                                                  [--out-canonical-cbor]
                                                   --out-file FILEPATH
 
   Build a transaction (low-level, inconvenient)
@@ -495,5 +496,7 @@ Available options:
                            The current treasury value.
   --treasury-donation LOVELACE
                            The donation to the treasury to perform.
+  --out-canonical-cbor     Produce transaction in canonical CBOR according to
+                           RFC7049. Only this part of CIP-21 is implemented.
   --out-file FILEPATH      Output filepath of the JSON TxBody.
   -h,--help                Show this help text

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_transaction_build.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_transaction_build.cli
@@ -141,6 +141,7 @@ Usage: cardano-cli latest transaction build
                                                   )
                                                 ]]
                                               [--treasury-donation LOVELACE]
+                                              [--out-canonical-cbor]
                                               ( --out-file FILEPATH
                                               | --calculate-plutus-script-cost FILEPATH
                                               )
@@ -472,6 +473,8 @@ Available options:
                            top-level strings and numbers.
   --treasury-donation LOVELACE
                            The donation to the treasury to perform.
+  --out-canonical-cbor     Produce transaction in canonical CBOR according to
+                           RFC7049. Only this part of CIP-21 is implemented.
   --out-file FILEPATH      Output filepath of the JSON TxBody.
   --calculate-plutus-script-cost FILEPATH
                            Where to write the script cost information.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_transaction_sign-witness.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_transaction_sign-witness.cli
@@ -1,5 +1,6 @@
 Usage: cardano-cli latest transaction sign-witness --tx-body-file FILEPATH
                                                      [--witness-file FILEPATH]
+                                                     [--out-canonical-cbor]
                                                      --out-file FILEPATH
 
   Assemble a tx body and witness(es) to form a transaction
@@ -7,4 +8,6 @@ Usage: cardano-cli latest transaction sign-witness --tx-body-file FILEPATH
 Available options:
   --tx-body-file FILEPATH  Input filepath of the JSON TxBody.
   --witness-file FILEPATH  Filepath of the witness
+  --out-canonical-cbor     Produce transaction in canonical CBOR according to
+                           RFC7049. Only this part of CIP-21 is implemented.
   --out-file FILEPATH      The output file.

--- a/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_transaction_sign.cli
+++ b/cardano-cli/test/cardano-cli-golden/files/golden/help/latest_transaction_sign.cli
@@ -7,6 +7,7 @@ Usage: cardano-cli latest transaction sign
                                              [ --mainnet
                                              | --testnet-magic NATURAL
                                              ]
+                                             [--out-canonical-cbor]
                                              --out-file FILEPATH
 
   Sign a transaction
@@ -21,5 +22,7 @@ Available options:
                            CARDANO_NODE_NETWORK_ID environment variable
   --testnet-magic NATURAL  Specify a testnet magic id. This overrides the
                            CARDANO_NODE_NETWORK_ID environment variable
+  --out-canonical-cbor     Produce transaction in canonical CBOR according to
+                           RFC7049. Only this part of CIP-21 is implemented.
   --out-file FILEPATH      Output filepath of the JSON Tx.
   -h,--help                Show this help text


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Add canonical CBOR output toggle for transaction building and signing commands
# uncomment types applicable to the change:
  type:
   - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
   - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  # - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

Requires:
- https://github.com/IntersectMBO/cardano-api/pull/785

Implements:
- https://github.com/IntersectMBO/cardano-cli/issues/1086

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
