### PR TITLE
Inline `subParser`

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -32,7 +32,7 @@ jobs:
 
     env:
       # Modify this value to "invalidate" the cabal cache.
-      CABAL_CACHE_VERSION: "2024-09-30"
+      CABAL_CACHE_VERSION: "2025-03-25"
       # these two are msys2 env vars, they have no effect on non-msys2 installs.
       MSYS2_PATH_TYPE: inherit
       MSYSTEM: MINGW64

--- a/cardano-cli/src/Cardano/CLI/Byron/Parser.hs
+++ b/cardano-cli/src/Cardano/CLI/Byron/Parser.hs
@@ -36,6 +36,7 @@ import Cardano.CLI.Byron.Key
 import Cardano.CLI.Byron.Tx
 import Cardano.CLI.Environment (EnvCli (..))
 import Cardano.CLI.EraBased.Common.Option hiding (parseLovelace, parseTxIn)
+import Cardano.CLI.Parser (commandWithMetavar)
 import Cardano.CLI.Run (ClientCommand (ByronCommand))
 import Cardano.CLI.Type.Common
 import Cardano.Crypto (RequiresNetworkMagic (..))
@@ -115,7 +116,7 @@ parseByronCommands envCli =
     ]
  where
   subParser' :: String -> ParserInfo ByronCommand -> Parser ByronCommand
-  subParser' name pInfo = Opt.subparser $ Opt.command name pInfo <> Opt.metavar name
+  subParser' name pInfo = Opt.subparser $ commandWithMetavar name pInfo
 
 pNodeCmdBackwardCompatible :: EnvCli -> Parser NodeCmds
 pNodeCmdBackwardCompatible envCli = Opt.subparser $ pNodeCmds envCli <> Opt.internal

--- a/cardano-cli/src/Cardano/CLI/Compatible/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/Compatible/Option.hs
@@ -30,24 +30,30 @@ pAnyCompatibleCommand :: EnvCli -> Parser AnyCompatibleCommand
 pAnyCompatibleCommand envCli =
   asum
     [ -- Note, byron is ommitted because there is already a legacy command group for it.
-      subParser "shelley" $
-        Opt.info (AnyCompatibleCommand <$> pCompatibleCommand ShelleyBasedEraShelley envCli) $
-          Opt.progDesc "Shelley era commands"
-    , subParser "allegra" $
-        Opt.info (AnyCompatibleCommand <$> pCompatibleCommand ShelleyBasedEraAllegra envCli) $
-          Opt.progDesc "Allegra era commands"
-    , subParser "mary" $
-        Opt.info (AnyCompatibleCommand <$> pCompatibleCommand ShelleyBasedEraMary envCli) $
-          Opt.progDesc "Mary era commands"
-    , subParser "alonzo" $
-        Opt.info (AnyCompatibleCommand <$> pCompatibleCommand ShelleyBasedEraAlonzo envCli) $
-          Opt.progDesc "Alonzo era commands"
-    , subParser "babbage" $
-        Opt.info (AnyCompatibleCommand <$> pCompatibleCommand ShelleyBasedEraBabbage envCli) $
-          Opt.progDesc "Babbage era commands"
-    , subParser "conway" $
-        Opt.info (AnyCompatibleCommand <$> pCompatibleCommand ShelleyBasedEraConway envCli) $
-          Opt.progDesc "Conway era commands"
+      Opt.hsubparser $
+        commandWithMetavar "shelley" $
+          Opt.info (AnyCompatibleCommand <$> pCompatibleCommand ShelleyBasedEraShelley envCli) $
+            Opt.progDesc "Shelley era commands"
+    , Opt.hsubparser $
+        commandWithMetavar "allegra" $
+          Opt.info (AnyCompatibleCommand <$> pCompatibleCommand ShelleyBasedEraAllegra envCli) $
+            Opt.progDesc "Allegra era commands"
+    , Opt.hsubparser $
+        commandWithMetavar "mary" $
+          Opt.info (AnyCompatibleCommand <$> pCompatibleCommand ShelleyBasedEraMary envCli) $
+            Opt.progDesc "Mary era commands"
+    , Opt.hsubparser $
+        commandWithMetavar "alonzo" $
+          Opt.info (AnyCompatibleCommand <$> pCompatibleCommand ShelleyBasedEraAlonzo envCli) $
+            Opt.progDesc "Alonzo era commands"
+    , Opt.hsubparser $
+        commandWithMetavar "babbage" $
+          Opt.info (AnyCompatibleCommand <$> pCompatibleCommand ShelleyBasedEraBabbage envCli) $
+            Opt.progDesc "Babbage era commands"
+    , Opt.hsubparser $
+        commandWithMetavar "conway" $
+          Opt.info (AnyCompatibleCommand <$> pCompatibleCommand ShelleyBasedEraConway envCli) $
+            Opt.progDesc "Conway era commands"
     ]
 
 pCompatibleCommand :: ShelleyBasedEra era -> EnvCli -> Parser (CompatibleCommand era)

--- a/cardano-cli/src/Cardano/CLI/Compatible/StakeAddress/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/Compatible/StakeAddress/Option.hs
@@ -36,14 +36,15 @@ pStakeAddressRegistrationCertificateCmd
   => ShelleyBasedEra era
   -> Parser (CompatibleStakeAddressCmds era)
 pStakeAddressRegistrationCertificateCmd sbe = do
-  subParser "registration-certificate" $
-    Opt.info
-      ( CompatibleStakeAddressRegistrationCertificateCmd sbe
-          <$> pStakeIdentifier Nothing
-          <*> pFeatured (toCardanoEra sbe) pKeyRegistDeposit
-          <*> pOutputFile
-      )
-      desc
+  Opt.hsubparser $
+    commandWithMetavar "registration-certificate" $
+      Opt.info
+        ( CompatibleStakeAddressRegistrationCertificateCmd sbe
+            <$> pStakeIdentifier Nothing
+            <*> pFeatured (toCardanoEra sbe) pKeyRegistDeposit
+            <*> pOutputFile
+        )
+        desc
  where
   desc = Opt.progDesc "Create a stake address registration certificate"
 
@@ -52,7 +53,8 @@ pStakeAddressStakeDelegationCertificateCmd
   => ShelleyBasedEra era
   -> Parser (CompatibleStakeAddressCmds era)
 pStakeAddressStakeDelegationCertificateCmd sbe = do
-  subParser "stake-delegation-certificate"
+  Opt.hsubparser
+    $ commandWithMetavar "stake-delegation-certificate"
     $ Opt.info
       ( CompatibleStakeAddressStakeDelegationCertificateCmd sbe
           <$> pStakeIdentifier Nothing

--- a/cardano-cli/src/Cardano/CLI/Compatible/StakePool/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/Compatible/StakePool/Option.hs
@@ -42,7 +42,8 @@ pCompatibleStakePoolRegistrationCertificateCmd
 pCompatibleStakePoolRegistrationCertificateCmd era envCli = do
   w <- forShelleyBasedEraMaybeEon era
   pure
-    $ subParser "registration-certificate"
+    $ Opt.hsubparser
+    $ commandWithMetavar "registration-certificate"
     $ Opt.info
       ( fmap CompatibleStakePoolRegistrationCertificateCmd $
           CompatibleStakePoolRegistrationCertificateCmdArgs w

--- a/cardano-cli/src/Cardano/CLI/Compatible/Transaction/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/Compatible/Transaction/Option.hs
@@ -29,16 +29,18 @@ pAllCompatibleTransactionCommands envCli sbe =
         asum
           [ pCompatibleSignedTransactionCommand envCli sbe
           ]
-   in subParser "transaction" $
-        Opt.info allCommannds $
-          Opt.progDesc "Transaction commands."
+   in Opt.hsubparser $
+        commandWithMetavar "transaction" $
+          Opt.info allCommannds $
+            Opt.progDesc "Transaction commands."
 
 pCompatibleSignedTransactionCommand
   :: EnvCli -> ShelleyBasedEra era -> Parser (CompatibleTransactionCmds era)
 pCompatibleSignedTransactionCommand envCli sbe =
-  subParser "signed-transaction" $
-    Opt.info (pCompatibleSignedTransaction envCli sbe) $
-      Opt.progDesc "Create a simple signed transaction."
+  Opt.hsubparser $
+    commandWithMetavar "signed-transaction" $
+      Opt.info (pCompatibleSignedTransaction envCli sbe) $
+        Opt.progDesc "Create a simple signed transaction."
 
 pCompatibleSignedTransaction
   :: EnvCli -> ShelleyBasedEra era -> Parser (CompatibleTransactionCmds era)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Common/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Common/Option.hs
@@ -3798,7 +3798,3 @@ pFeatured peon p = do
   case mw of
     Nothing -> pure Nothing
     Just eon' -> Just . Featured eon' <$> p
-
-hiddenSubParser :: String -> ParserInfo a -> Parser a
-hiddenSubParser availableCommand pInfo =
-  Opt.hsubparser $ Opt.command availableCommand pInfo <> Opt.metavar availableCommand <> Opt.hidden

--- a/cardano-cli/src/Cardano/CLI/EraBased/Common/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Common/Option.hs
@@ -373,7 +373,11 @@ pStakeVerificationKeyFile prefix =
 subInfoParser :: String -> InfoMod a -> [Maybe (Parser a)] -> Maybe (Parser a)
 subInfoParser name i mps = case catMaybes mps of
   [] -> Nothing
-  parsers -> Just $ subParser name $ Opt.info (asum parsers) i
+  parsers ->
+    Just $
+      Opt.hsubparser $
+        commandWithMetavar name $
+          Opt.info (asum parsers) i
 
 pAnyShelleyBasedEra :: EnvCli -> Parser (EraInEon ShelleyBasedEra)
 pAnyShelleyBasedEra envCli =

--- a/cardano-cli/src/Cardano/CLI/EraBased/Genesis/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Genesis/Option.hs
@@ -39,77 +39,89 @@ pGenesisCmds era envCli =
           ]
     )
     [ Just $
-        subParser "key-gen-genesis" $
-          Opt.info pGenesisKeyGen $
-            Opt.progDesc "Create a Shelley genesis key pair"
+        Opt.hsubparser $
+          commandWithMetavar "key-gen-genesis" $
+            Opt.info pGenesisKeyGen $
+              Opt.progDesc "Create a Shelley genesis key pair"
     , Just $
-        subParser "key-gen-delegate" $
-          Opt.info pGenesisDelegateKeyGen $
-            Opt.progDesc "Create a Shelley genesis delegate key pair"
+        Opt.hsubparser $
+          commandWithMetavar "key-gen-delegate" $
+            Opt.info pGenesisDelegateKeyGen $
+              Opt.progDesc "Create a Shelley genesis delegate key pair"
     , Just $
-        subParser "key-gen-utxo" $
-          Opt.info pGenesisUTxOKeyGen $
-            Opt.progDesc "Create a Shelley genesis UTxO key pair"
+        Opt.hsubparser $
+          commandWithMetavar "key-gen-utxo" $
+            Opt.info pGenesisUTxOKeyGen $
+              Opt.progDesc "Create a Shelley genesis UTxO key pair"
     , Just $
-        subParser "key-hash" $
-          Opt.info pGenesisKeyHash $
-            Opt.progDesc "Print the identifier (hash) of a public key"
+        Opt.hsubparser $
+          commandWithMetavar "key-hash" $
+            Opt.info pGenesisKeyHash $
+              Opt.progDesc "Print the identifier (hash) of a public key"
     , Just $
-        subParser "get-ver-key" $
-          Opt.info pGenesisVerKey $
-            Opt.progDesc "Derive the verification key from a signing key"
+        Opt.hsubparser $
+          commandWithMetavar "get-ver-key" $
+            Opt.info pGenesisVerKey $
+              Opt.progDesc "Derive the verification key from a signing key"
     , Just $
-        subParser "initial-addr" $
-          Opt.info (pGenesisAddr envCli) $
-            Opt.progDesc "Get the address for an initial UTxO based on the verification key"
+        Opt.hsubparser $
+          commandWithMetavar "initial-addr" $
+            Opt.info (pGenesisAddr envCli) $
+              Opt.progDesc "Get the address for an initial UTxO based on the verification key"
     , Just $
-        subParser "initial-txin" $
-          Opt.info (pGenesisTxIn envCli) $
-            Opt.progDesc "Get the TxIn for an initial UTxO based on the verification key"
+        Opt.hsubparser $
+          commandWithMetavar "initial-txin" $
+            Opt.info (pGenesisTxIn envCli) $
+              Opt.progDesc "Get the TxIn for an initial UTxO based on the verification key"
     , forShelleyBasedEraInEonMaybe
         era
         ( \sbe ->
-            subParser "create-cardano" $
-              Opt.info (pGenesisCreateCardano sbe envCli) $
-                Opt.progDesc $
-                  mconcat
-                    [ "Create a Byron and Shelley genesis file from a genesis "
-                    , "template and genesis/delegation/spending keys."
-                    ]
+            Opt.hsubparser $
+              commandWithMetavar "create-cardano" $
+                Opt.info (pGenesisCreateCardano sbe envCli) $
+                  Opt.progDesc $
+                    mconcat
+                      [ "Create a Byron and Shelley genesis file from a genesis "
+                      , "template and genesis/delegation/spending keys."
+                      ]
         )
     , forShelleyBasedEraInEonMaybe era $ \sbe ->
-        subParser "create" $
-          Opt.info (pGenesisCreate sbe envCli) $
-            Opt.progDesc $
-              mconcat
-                [ "Create a Shelley genesis file from a genesis "
-                , "template and genesis/delegation/spending keys."
-                ]
+        Opt.hsubparser $
+          commandWithMetavar "create" $
+            Opt.info (pGenesisCreate sbe envCli) $
+              Opt.progDesc $
+                mconcat
+                  [ "Create a Shelley genesis file from a genesis "
+                  , "template and genesis/delegation/spending keys."
+                  ]
     , forShelleyBasedEraInEonMaybe era $ \sbe ->
-        subParser "create-staked" $
-          Opt.info (pGenesisCreateStaked sbe envCli) $
-            Opt.progDesc $
-              mconcat
-                [ "Create a staked Shelley genesis file from a genesis "
-                , "template and genesis/delegation/spending keys."
-                ]
+        Opt.hsubparser $
+          commandWithMetavar "create-staked" $
+            Opt.info (pGenesisCreateStaked sbe envCli) $
+              Opt.progDesc $
+                mconcat
+                  [ "Create a staked Shelley genesis file from a genesis "
+                  , "template and genesis/delegation/spending keys."
+                  ]
     , forShelleyBasedEraInEonMaybe era $ \sbe ->
-        subParser "create-testnet-data" $
-          Opt.info (pGenesisCreateTestNetData sbe envCli) $
-            Opt.progDesc $
-              mconcat
-                [ "Create data to use for starting a testnet."
-                ]
+        Opt.hsubparser $
+          commandWithMetavar "create-testnet-data" $
+            Opt.info (pGenesisCreateTestNetData sbe envCli) $
+              Opt.progDesc $
+                mconcat
+                  [ "Create data to use for starting a testnet."
+                  ]
     , Just $
-        subParser "hash" $
-          Opt.info pGenesisHash $
-            Opt.progDesc $
-              mconcat
-                [ "DEPRECATION WARNING! This command is deprecated and will be "
-                , "removed in a future release. Please use hash genesis-file "
-                , "instead. "
-                , "Compute the hash of a genesis file."
-                ]
+        Opt.hsubparser $
+          commandWithMetavar "hash" $
+            Opt.info pGenesisHash $
+              Opt.progDesc $
+                mconcat
+                  [ "DEPRECATION WARNING! This command is deprecated and will be "
+                  , "removed in a future release. Please use hash genesis-file "
+                  , "instead. "
+                  , "Compute the hash of a genesis file."
+                  ]
     ]
 
 pGenesisKeyGen :: Parser (GenesisCmds era)

--- a/cardano-cli/src/Cardano/CLI/EraBased/Governance/Actions/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Governance/Actions/Option.hs
@@ -49,7 +49,8 @@ pGovernanceActionViewCmd
 pGovernanceActionViewCmd era = do
   eon <- forShelleyBasedEraMaybeEon era
   return
-    $ subParser "view"
+    $ Opt.hsubparser
+    $ commandWithMetavar "view"
     $ Opt.info
       ( fmap Cmd.GovernanceActionViewCmd $
           Cmd.GovernanceActionViewCmdArgs eon
@@ -65,7 +66,8 @@ pGovernanceActionNewInfoCmd
 pGovernanceActionNewInfoCmd era = do
   eon <- forShelleyBasedEraMaybeEon era
   pure
-    $ subParser "create-info"
+    $ Opt.hsubparser
+    $ commandWithMetavar "create-info"
     $ Opt.info
       ( fmap Cmd.GovernanceActionInfoCmd $
           Cmd.GovernanceActionInfoCmdArgs eon
@@ -85,7 +87,8 @@ pGovernanceActionNewConstitutionCmd
 pGovernanceActionNewConstitutionCmd era = do
   eon <- forShelleyBasedEraMaybeEon era
   pure
-    $ subParser "create-constitution"
+    $ Opt.hsubparser
+    $ commandWithMetavar "create-constitution"
     $ Opt.info
       ( fmap Cmd.GovernanceActionCreateConstitutionCmd $
           Cmd.GovernanceActionCreateConstitutionCmdArgs eon
@@ -110,7 +113,8 @@ pGovernanceActionUpdateCommitteeCmd
 pGovernanceActionUpdateCommitteeCmd era = do
   eon <- forShelleyBasedEraMaybeEon era
   pure
-    $ subParser "update-committee"
+    $ Opt.hsubparser
+    $ commandWithMetavar "update-committee"
     $ Opt.info
       ( Cmd.GovernanceActionUpdateCommitteeCmd
           <$> pUpdateCommitteeCmd eon
@@ -145,7 +149,8 @@ pGovernanceActionNoConfidenceCmd
 pGovernanceActionNoConfidenceCmd era = do
   eon <- forShelleyBasedEraMaybeEon era
   pure
-    $ subParser "create-no-confidence"
+    $ Opt.hsubparser
+    $ commandWithMetavar "create-no-confidence"
     $ Opt.info
       ( fmap Cmd.GovernanceActionCreateNoConfidenceCmd $
           Cmd.GovernanceActionCreateNoConfidenceCmdArgs eon
@@ -186,7 +191,8 @@ pUpdateProtocolParametersCmd =
   caseShelleyToBabbageOrConwayEraOnwards
     ( \shelleyToBab ->
         let sbe = convert shelleyToBab
-         in subParser "create-protocol-parameters-update"
+         in Opt.hsubparser
+              $ commandWithMetavar "create-protocol-parameters-update"
               $ Opt.info
                 ( Cmd.GovernanceActionProtocolParametersUpdateCmdArgs
                     (convert shelleyToBab)
@@ -200,7 +206,8 @@ pUpdateProtocolParametersCmd =
     )
     ( \conwayOnwards ->
         let sbe = convert conwayOnwards
-         in subParser "create-protocol-parameters-update"
+         in Opt.hsubparser
+              $ commandWithMetavar "create-protocol-parameters-update"
               $ Opt.info
                 ( Cmd.GovernanceActionProtocolParametersUpdateCmdArgs
                     (convert conwayOnwards)
@@ -375,7 +382,8 @@ pGovernanceActionTreasuryWithdrawalCmd
 pGovernanceActionTreasuryWithdrawalCmd era = do
   eon <- forShelleyBasedEraMaybeEon era
   pure
-    $ subParser "create-treasury-withdrawal"
+    $ Opt.hsubparser
+    $ commandWithMetavar "create-treasury-withdrawal"
     $ Opt.info
       ( fmap Cmd.GovernanceActionTreasuryWithdrawalCmd $
           Cmd.GovernanceActionTreasuryWithdrawalCmdArgs eon
@@ -418,7 +426,8 @@ pGovernanceActionHardforkInitCmd
 pGovernanceActionHardforkInitCmd era = do
   eon <- forShelleyBasedEraMaybeEon era
   pure
-    $ subParser "create-hardfork"
+    $ Opt.hsubparser
+    $ commandWithMetavar "create-hardfork"
     $ Opt.info
       ( fmap Cmd.GovernanceActionHardforkInitCmd $
           Cmd.GovernanceActionHardforkInitCmdArgs eon

--- a/cardano-cli/src/Cardano/CLI/EraBased/Governance/Committee/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Governance/Committee/Option.hs
@@ -45,12 +45,13 @@ pGovernanceCommitteeKeyGenColdCmd
 pGovernanceCommitteeKeyGenColdCmd era = do
   w <- forShelleyBasedEraMaybeEon era
   pure $
-    subParser "key-gen-cold" $
-      Opt.info (pCmd w) $
-        Opt.progDesc $
-          mconcat
-            [ "Create a cold key pair for a Constitutional Committee Member"
-            ]
+    Opt.hsubparser $
+      commandWithMetavar "key-gen-cold" $
+        Opt.info (pCmd w) $
+          Opt.progDesc $
+            mconcat
+              [ "Create a cold key pair for a Constitutional Committee Member"
+              ]
  where
   pCmd
     :: ()
@@ -69,12 +70,13 @@ pGovernanceCommitteeKeyGenHotCmd
 pGovernanceCommitteeKeyGenHotCmd era = do
   w <- forShelleyBasedEraMaybeEon era
   pure $
-    subParser "key-gen-hot" $
-      Opt.info (pCmd w) $
-        Opt.progDesc $
-          mconcat
-            [ "Create a hot key pair for a Constitutional Committee Member"
-            ]
+    Opt.hsubparser $
+      commandWithMetavar "key-gen-hot" $
+        Opt.info (pCmd w) $
+          Opt.progDesc $
+            mconcat
+              [ "Create a hot key pair for a Constitutional Committee Member"
+              ]
  where
   pCmd
     :: ()
@@ -93,7 +95,8 @@ pGovernanceCommitteeKeyHashCmd
 pGovernanceCommitteeKeyHashCmd era = do
   w <- forShelleyBasedEraMaybeEon era
   pure
-    $ subParser "key-hash"
+    $ Opt.hsubparser
+    $ commandWithMetavar "key-hash"
     $ Opt.info
       ( fmap GovernanceCommitteeKeyHashCmd $
           GovernanceCommitteeKeyHashCmdArgs w
@@ -111,7 +114,8 @@ pGovernanceCommitteeCreateHotKeyAuthorizationCertificateCmd
 pGovernanceCommitteeCreateHotKeyAuthorizationCertificateCmd era = do
   w <- forShelleyBasedEraMaybeEon era
   pure
-    $ subParser "create-hot-key-authorization-certificate"
+    $ Opt.hsubparser
+    $ commandWithMetavar "create-hot-key-authorization-certificate"
     $ Opt.info
       ( fmap GovernanceCommitteeCreateHotKeyAuthorizationCertificateCmd $
           GovernanceCommitteeCreateHotKeyAuthorizationCertificateCmdArgs w
@@ -131,12 +135,13 @@ pGovernanceCommitteeCreateColdKeyResignationCertificateCmd
 pGovernanceCommitteeCreateColdKeyResignationCertificateCmd era = do
   w <- forShelleyBasedEraMaybeEon era
   pure $
-    subParser "create-cold-key-resignation-certificate" $
-      Opt.info (conwayEraOnwardsConstraints w $ mkParser w) $
-        Opt.progDesc $
-          mconcat
-            [ "Create cold key resignation certificate for a Constitutional Committee Member"
-            ]
+    Opt.hsubparser $
+      commandWithMetavar "create-cold-key-resignation-certificate" $
+        Opt.info (conwayEraOnwardsConstraints w $ mkParser w) $
+          Opt.progDesc $
+            mconcat
+              [ "Create cold key resignation certificate for a Constitutional Committee Member"
+              ]
  where
   mkParser w =
     GovernanceCommitteeCreateColdKeyResignationCertificateCmd

--- a/cardano-cli/src/Cardano/CLI/EraBased/Governance/DRep/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Governance/DRep/Option.hs
@@ -50,7 +50,8 @@ pGovernanceDRepKeyGenCmd
 pGovernanceDRepKeyGenCmd era = do
   w <- forShelleyBasedEraMaybeEon era
   pure
-    $ subParser "key-gen"
+    $ Opt.hsubparser
+    $ commandWithMetavar "key-gen"
     $ Opt.info
       ( fmap GovernanceDRepKeyGenCmd $
           GovernanceDRepKeyGenCmdArgs w
@@ -66,7 +67,8 @@ pGovernanceDRepKeyIdCmd
 pGovernanceDRepKeyIdCmd era = do
   w <- forShelleyBasedEraMaybeEon era
   pure
-    $ subParser "id"
+    $ Opt.hsubparser
+    $ commandWithMetavar "id"
     $ Opt.info
       ( fmap GovernanceDRepIdCmd $
           GovernanceDRepIdCmdArgs w
@@ -101,9 +103,10 @@ pRegistrationCertificateCmd
 pRegistrationCertificateCmd era = do
   w <- forShelleyBasedEraMaybeEon era
   pure $
-    subParser "registration-certificate" $
-      Opt.info (conwayEraOnwardsConstraints w $ mkParser w) $
-        Opt.progDesc "Create a registration certificate."
+    Opt.hsubparser $
+      commandWithMetavar "registration-certificate" $
+        Opt.info (conwayEraOnwardsConstraints w $ mkParser w) $
+          Opt.progDesc "Create a registration certificate."
  where
   mkParser w =
     fmap GovernanceDRepRegistrationCertificateCmd $
@@ -148,7 +151,8 @@ pRetirementCertificateCmd
 pRetirementCertificateCmd era = do
   w <- forShelleyBasedEraMaybeEon era
   pure
-    $ subParser "retirement-certificate"
+    $ Opt.hsubparser
+    $ commandWithMetavar "retirement-certificate"
     $ Opt.info
       ( fmap GovernanceDRepRetirementCertificateCmd $
           GovernanceDRepRetirementCertificateCmdArgs w
@@ -165,7 +169,8 @@ pUpdateCertificateCmd
 pUpdateCertificateCmd era = do
   w <- forShelleyBasedEraMaybeEon era
   pure
-    $ subParser "update-certificate"
+    $ Opt.hsubparser
+    $ commandWithMetavar "update-certificate"
     $ Opt.info
       ( fmap GovernanceDRepUpdateCertificateCmd $
           conwayEraOnwardsConstraints w $
@@ -187,7 +192,8 @@ pGovernanceDrepMetadataHashCmd
 pGovernanceDrepMetadataHashCmd era = do
   w <- forShelleyBasedEraMaybeEon era
   pure
-    $ subParser "metadata-hash"
+    $ Opt.hsubparser
+    $ commandWithMetavar "metadata-hash"
     $ Opt.info
       ( fmap GovernanceDRepMetadataHashCmd $
           GovernanceDRepMetadataHashCmdArgs w

--- a/cardano-cli/src/Cardano/CLI/EraBased/Governance/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Governance/Option.hs
@@ -51,9 +51,10 @@ pCreateMirCertificatesCmds :: ShelleyBasedEra era -> Maybe (Parser (GovernanceCm
 pCreateMirCertificatesCmds era = do
   w <- forShelleyBasedEraMaybeEon era
   pure $
-    subParser "create-mir-certificate" $
-      Opt.info (pMIRPayStakeAddresses w <|> mirCertParsers w) $
-        Opt.progDesc "Create an MIR (Move Instantaneous Rewards) certificate"
+    Opt.hsubparser $
+      commandWithMetavar "create-mir-certificate" $
+        Opt.info (pMIRPayStakeAddresses w <|> mirCertParsers w) $
+          Opt.progDesc "Create an MIR (Move Instantaneous Rewards) certificate"
 
 mirCertParsers
   :: ()
@@ -61,15 +62,18 @@ mirCertParsers
   -> Parser (GovernanceCmds era)
 mirCertParsers w =
   asum
-    [ subParser "stake-addresses" $
-        Opt.info (pMIRPayStakeAddresses w) $
-          Opt.progDesc "Create an MIR certificate to pay stake addresses"
-    , subParser "transfer-to-treasury" $
-        Opt.info (pGovernanceCreateMirCertificateTransferToTreasuryCmd w) $
-          Opt.progDesc "Create an MIR certificate to transfer from the reserves pot to the treasury pot"
-    , subParser "transfer-to-rewards" $
-        Opt.info (pGovernanceCreateMirCertificateTransferToReservesCmd w) $
-          Opt.progDesc "Create an MIR certificate to transfer from the treasury pot to the reserves pot"
+    [ Opt.hsubparser $
+        commandWithMetavar "stake-addresses" $
+          Opt.info (pMIRPayStakeAddresses w) $
+            Opt.progDesc "Create an MIR certificate to pay stake addresses"
+    , Opt.hsubparser $
+        commandWithMetavar "transfer-to-treasury" $
+          Opt.info (pGovernanceCreateMirCertificateTransferToTreasuryCmd w) $
+            Opt.progDesc "Create an MIR certificate to transfer from the reserves pot to the treasury pot"
+    , Opt.hsubparser $
+        commandWithMetavar "transfer-to-rewards" $
+          Opt.info (pGovernanceCreateMirCertificateTransferToReservesCmd w) $
+            Opt.progDesc "Create an MIR certificate to transfer from the treasury pot to the reserves pot"
     ]
 
 pMIRPayStakeAddresses
@@ -108,9 +112,10 @@ pGovernanceGenesisKeyDelegationCertificate
 pGovernanceGenesisKeyDelegationCertificate era = do
   w <- forShelleyBasedEraMaybeEon era
   pure $
-    subParser "create-genesis-key-delegation-certificate" $
-      Opt.info (parser w) $
-        Opt.progDesc "Create a genesis key delegation certificate"
+    Opt.hsubparser $
+      commandWithMetavar "create-genesis-key-delegation-certificate" $
+        Opt.info (parser w) $
+          Opt.progDesc "Create a genesis key delegation certificate"
  where
   parser w =
     GovernanceGenesisKeyDelegationCertificate w

--- a/cardano-cli/src/Cardano/CLI/EraBased/Governance/Poll/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Governance/Poll/Option.hs
@@ -26,17 +26,17 @@ pGovernancePollCmds era =
  where
   parsers =
     catMaybes
-      [ subParser "create-poll"
+      [ Opt.hsubparser . commandWithMetavar "create-poll"
           <$> ( Opt.info
                   <$> pGovernanceCreatePoll era
                   <*> pure (Opt.progDesc "Create an SPO poll")
               )
-      , subParser "answer-poll"
+      , Opt.hsubparser . commandWithMetavar "answer-poll"
           <$> ( Opt.info
                   <$> pGovernanceAnswerPoll era
                   <*> pure (Opt.progDesc "Answer an SPO poll")
               )
-      , subParser "verify-poll"
+      , Opt.hsubparser . commandWithMetavar "verify-poll"
           <$> ( Opt.info
                   <$> pGovernanceVerifyPoll era
                   <*> pure (Opt.progDesc "Verify an answer to a given SPO poll")

--- a/cardano-cli/src/Cardano/CLI/EraBased/Governance/Vote/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Governance/Vote/Option.hs
@@ -41,7 +41,8 @@ pGovernanceVoteCreateCmd
 pGovernanceVoteCreateCmd era = do
   w <- forShelleyBasedEraMaybeEon era
   pure
-    $ subParser "create"
+    $ Opt.hsubparser
+    $ commandWithMetavar "create"
     $ Opt.info
       ( GovernanceVoteCreateCmd
           <$> pGovernanceVoteCreateCmdArgs w
@@ -79,7 +80,8 @@ pGovernanceVoteViewCmd
 pGovernanceVoteViewCmd era = do
   w <- forShelleyBasedEraMaybeEon era
   pure
-    $ subParser "view"
+    $ Opt.hsubparser
+    $ commandWithMetavar "view"
     $ Opt.info
       (GovernanceVoteViewCmd <$> pGovernanceVoteViewCmdArgs w)
     $ Opt.progDesc "Vote viewing."

--- a/cardano-cli/src/Cardano/CLI/EraBased/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Option.hs
@@ -47,25 +47,32 @@ pAnyEraCommand envCli =
   asum
     [ -- Note, byron is ommitted because there is already a legacy command group for it.
 
-      subParser "shelley" $
-        Opt.info (AnyEraCommandOf ShelleyBasedEraShelley <$> pCmds ShelleyBasedEraShelley envCli) $
-          Opt.progDesc ("Shelley era commands" <> deprecationText)
-    , subParser "allegra" $
-        Opt.info (AnyEraCommandOf ShelleyBasedEraAllegra <$> pCmds ShelleyBasedEraAllegra envCli) $
-          Opt.progDesc ("Allegra era commands" <> deprecationText)
-    , subParser "mary" $
-        Opt.info (AnyEraCommandOf ShelleyBasedEraMary <$> pCmds ShelleyBasedEraMary envCli) $
-          Opt.progDesc ("Mary era commands" <> deprecationText)
-    , subParser "alonzo" $
-        Opt.info (AnyEraCommandOf ShelleyBasedEraAlonzo <$> pCmds ShelleyBasedEraAlonzo envCli) $
-          Opt.progDesc ("Alonzo era commands" <> deprecationText)
-    , subParser "babbage" $
-        Opt.info (AnyEraCommandOf ShelleyBasedEraBabbage <$> pCmds ShelleyBasedEraBabbage envCli) $
-          Opt.progDesc ("Babbage era commands" <> deprecationText)
-    , subParser "conway" $
-        Opt.info (AnyEraCommandOf ShelleyBasedEraConway <$> pCmds ShelleyBasedEraConway envCli) $
-          Opt.progDesc "Conway era commands"
-    , subParser "latest" $
-        Opt.info (AnyEraCommandOf ShelleyBasedEraConway <$> pCmds ShelleyBasedEraConway envCli) $
-          Opt.progDesc "Latest era commands (Conway)"
+      Opt.hsubparser $
+        commandWithMetavar "shelley" $
+          Opt.info (AnyEraCommandOf ShelleyBasedEraShelley <$> pCmds ShelleyBasedEraShelley envCli) $
+            Opt.progDesc ("Shelley era commands" <> deprecationText)
+    , Opt.hsubparser $
+        commandWithMetavar "allegra" $
+          Opt.info (AnyEraCommandOf ShelleyBasedEraAllegra <$> pCmds ShelleyBasedEraAllegra envCli) $
+            Opt.progDesc ("Allegra era commands" <> deprecationText)
+    , Opt.hsubparser $
+        commandWithMetavar "mary" $
+          Opt.info (AnyEraCommandOf ShelleyBasedEraMary <$> pCmds ShelleyBasedEraMary envCli) $
+            Opt.progDesc ("Mary era commands" <> deprecationText)
+    , Opt.hsubparser $
+        commandWithMetavar "alonzo" $
+          Opt.info (AnyEraCommandOf ShelleyBasedEraAlonzo <$> pCmds ShelleyBasedEraAlonzo envCli) $
+            Opt.progDesc ("Alonzo era commands" <> deprecationText)
+    , Opt.hsubparser $
+        commandWithMetavar "babbage" $
+          Opt.info (AnyEraCommandOf ShelleyBasedEraBabbage <$> pCmds ShelleyBasedEraBabbage envCli) $
+            Opt.progDesc ("Babbage era commands" <> deprecationText)
+    , Opt.hsubparser $
+        commandWithMetavar "conway" $
+          Opt.info (AnyEraCommandOf ShelleyBasedEraConway <$> pCmds ShelleyBasedEraConway envCli) $
+            Opt.progDesc "Conway era commands"
+    , Opt.hsubparser $
+        commandWithMetavar "latest" $
+          Opt.info (AnyEraCommandOf ShelleyBasedEraConway <$> pCmds ShelleyBasedEraConway envCli) $
+            Opt.progDesc "Latest era commands (Conway)"
     ]

--- a/cardano-cli/src/Cardano/CLI/EraBased/Query/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Query/Option.hs
@@ -138,13 +138,17 @@ pStakeSnapshot envCli =
 
 pPoolParams :: EnvCli -> Parser (QueryCmds ConwayEra)
 pPoolParams envCli =
-  hiddenSubParser "pool-params" $
-    Opt.info (pQueryPoolStateCmd ShelleyBasedEraConway envCli) $
-      Opt.progDesc $
-        mconcat
-          [ "DEPRECATED.  Use query pool-state instead.  Dump the pool parameters "
-          , "(Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced command)"
-          ]
+  Opt.hsubparser $
+    mconcat
+      [ Opt.hidden
+      , commandWithMetavar "pool-params" $
+          Opt.info (pQueryPoolStateCmd ShelleyBasedEraConway envCli) $
+            Opt.progDesc $
+              mconcat
+                [ "DEPRECATED.  Use query pool-state instead.  Dump the pool parameters "
+                , "(Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced command)"
+                ]
+      ]
 
 pLeadershipSchedule :: EnvCli -> Parser (QueryCmds ConwayEra)
 pLeadershipSchedule envCli =
@@ -283,13 +287,17 @@ pQueryCmds era envCli =
                   [ "Obtain the three stake snapshots for a pool, plus the total active stake (advanced command)"
                   ]
     , Just $
-        hiddenSubParser "pool-params" $
-          Opt.info (pQueryPoolStateCmd era envCli) $
-            Opt.progDesc $
-              mconcat
-                [ "DEPRECATED.  Use query pool-state instead.  Dump the pool parameters "
-                , "(Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced command)"
-                ]
+        Opt.hsubparser $
+          mconcat
+            [ Opt.hidden
+            , commandWithMetavar "pool-params" $
+                Opt.info (pQueryPoolStateCmd era envCli) $
+                  Opt.progDesc $
+                    mconcat
+                      [ "DEPRECATED.  Use query pool-state instead.  Dump the pool parameters "
+                      , "(Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced command)"
+                      ]
+            ]
     , Just $
         Opt.hsubparser $
           commandWithMetavar "leadership-schedule" $

--- a/cardano-cli/src/Cardano/CLI/EraBased/Query/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Query/Option.hs
@@ -54,76 +54,87 @@ pQueryCmdsTopLevel envCli =
             [ "Node query commands. Will query the local node whose Unix domain socket is "
             , "obtained from the CARDANO_NODE_SOCKET_PATH environment variable."
             ]
-   in subParser "query" $ Opt.info (asum parsers) i
+   in Opt.hsubparser $
+        commandWithMetavar "query" $
+          Opt.info (asum parsers) i
 
 pProtocolParams :: EnvCli -> Parser (QueryCmds era)
 pProtocolParams envCli =
-  subParser "protocol-parameters" $
-    Opt.info (pQueryProtocolParametersCmd envCli) $
-      Opt.progDesc "Get the node's current protocol parameters"
+  Opt.hsubparser $
+    commandWithMetavar "protocol-parameters" $
+      Opt.info (pQueryProtocolParametersCmd envCli) $
+        Opt.progDesc "Get the node's current protocol parameters"
 
 pTip :: EnvCli -> Parser (QueryCmds ConwayEra)
 pTip envCli =
-  subParser "tip" $
-    Opt.info (pQueryTipCmd ShelleyBasedEraConway envCli) $
-      Opt.progDesc "Get the node's current tip (slot no, hash, block no)"
+  Opt.hsubparser $
+    commandWithMetavar "tip" $
+      Opt.info (pQueryTipCmd ShelleyBasedEraConway envCli) $
+        Opt.progDesc "Get the node's current tip (slot no, hash, block no)"
 
 pStakePools :: EnvCli -> Parser (QueryCmds ConwayEra)
 pStakePools envCli =
-  subParser "stake-pools" $
-    Opt.info (pQueryStakePoolsCmd ShelleyBasedEraConway envCli) $
-      Opt.progDesc "Get the node's current set of stake pool ids"
+  Opt.hsubparser $
+    commandWithMetavar "stake-pools" $
+      Opt.info (pQueryStakePoolsCmd ShelleyBasedEraConway envCli) $
+        Opt.progDesc "Get the node's current set of stake pool ids"
 
 pStakeDistribution :: EnvCli -> Parser (QueryCmds ConwayEra)
 pStakeDistribution envCli =
-  subParser "stake-distribution" $
-    Opt.info (pQueryStakeDistributionCmd ShelleyBasedEraConway envCli) $
-      Opt.progDesc "Get the node's current aggregated stake distribution"
+  Opt.hsubparser $
+    commandWithMetavar "stake-distribution" $
+      Opt.info (pQueryStakeDistributionCmd ShelleyBasedEraConway envCli) $
+        Opt.progDesc "Get the node's current aggregated stake distribution"
 
 pStakeAddressInfo :: EnvCli -> Parser (QueryCmds ConwayEra)
 pStakeAddressInfo envCli =
-  subParser "stake-address-info" $
-    Opt.info (pQueryStakeAddressInfoCmd ShelleyBasedEraConway envCli) $
-      Opt.progDesc $
-        mconcat
-          [ "Get the current delegations and reward accounts filtered by stake address."
-          ]
+  Opt.hsubparser $
+    commandWithMetavar "stake-address-info" $
+      Opt.info (pQueryStakeAddressInfoCmd ShelleyBasedEraConway envCli) $
+        Opt.progDesc $
+          mconcat
+            [ "Get the current delegations and reward accounts filtered by stake address."
+            ]
 
 pUTxO :: EnvCli -> Parser (QueryCmds ConwayEra)
 pUTxO envCli =
-  subParser "utxo" $
-    Opt.info (pQueryUTxOCmd ShelleyBasedEraConway envCli) $
-      Opt.progDesc $
-        mconcat
-          [ "Get a portion of the current UTxO: by tx in, by address or the whole."
-          ]
+  Opt.hsubparser $
+    commandWithMetavar "utxo" $
+      Opt.info (pQueryUTxOCmd ShelleyBasedEraConway envCli) $
+        Opt.progDesc $
+          mconcat
+            [ "Get a portion of the current UTxO: by tx in, by address or the whole."
+            ]
 
 pLedgerState :: EnvCli -> Parser (QueryCmds ConwayEra)
 pLedgerState envCli =
-  subParser "ledger-state" $
-    Opt.info (pQueryLedgerStateCmd ShelleyBasedEraConway envCli) $
-      Opt.progDesc $
-        mconcat
-          [ "Dump the current ledger state of the node (Ledger.NewEpochState -- advanced command)"
-          ]
+  Opt.hsubparser $
+    commandWithMetavar "ledger-state" $
+      Opt.info (pQueryLedgerStateCmd ShelleyBasedEraConway envCli) $
+        Opt.progDesc $
+          mconcat
+            [ "Dump the current ledger state of the node (Ledger.NewEpochState -- advanced command)"
+            ]
 
 pProtocolState :: EnvCli -> Parser (QueryCmds ConwayEra)
 pProtocolState envCli =
-  subParser "protocol-state" $
-    Opt.info (pQueryProtocolStateCmd ShelleyBasedEraConway envCli) $
-      Opt.progDesc $
-        mconcat
-          [ "Dump the current protocol state of the node (Ledger.ChainDepState -- advanced command)"
-          ]
+  Opt.hsubparser $
+    commandWithMetavar "protocol-state" $
+      Opt.info (pQueryProtocolStateCmd ShelleyBasedEraConway envCli) $
+        Opt.progDesc $
+          mconcat
+            [ "Dump the current protocol state of the node (Ledger.ChainDepState -- advanced command)"
+            ]
 
 pStakeSnapshot :: EnvCli -> Parser (QueryCmds ConwayEra)
 pStakeSnapshot envCli =
-  subParser "stake-snapshot" $
-    Opt.info (pQueryStakeSnapshotCmd ShelleyBasedEraConway envCli) $
-      Opt.progDesc $
-        mconcat
-          [ "Obtain the three stake snapshots for a pool, plus the total active stake (advanced command)"
-          ]
+  Opt.hsubparser $
+    commandWithMetavar "stake-snapshot" $
+      Opt.info (pQueryStakeSnapshotCmd ShelleyBasedEraConway envCli) $
+        Opt.progDesc $
+          mconcat
+            [ "Obtain the three stake snapshots for a pool, plus the total active stake (advanced command)"
+            ]
 
 pPoolParams :: EnvCli -> Parser (QueryCmds ConwayEra)
 pPoolParams envCli =
@@ -137,44 +148,50 @@ pPoolParams envCli =
 
 pLeadershipSchedule :: EnvCli -> Parser (QueryCmds ConwayEra)
 pLeadershipSchedule envCli =
-  subParser "leadership-schedule" $
-    Opt.info (pLeadershipScheduleCmd ShelleyBasedEraConway envCli) $
-      Opt.progDesc "Get the slots the node is expected to mint a block in (advanced command)"
+  Opt.hsubparser $
+    commandWithMetavar "leadership-schedule" $
+      Opt.info (pLeadershipScheduleCmd ShelleyBasedEraConway envCli) $
+        Opt.progDesc "Get the slots the node is expected to mint a block in (advanced command)"
 
 pKesPeriodInfo :: EnvCli -> Parser (QueryCmds ConwayEra)
 pKesPeriodInfo envCli =
-  subParser "kes-period-info" $
-    Opt.info (pKesPeriodInfoCmd ShelleyBasedEraConway envCli) $
-      Opt.progDesc "Get information about the current KES period and your node's operational certificate."
+  Opt.hsubparser $
+    commandWithMetavar "kes-period-info" $
+      Opt.info (pKesPeriodInfoCmd ShelleyBasedEraConway envCli) $
+        Opt.progDesc "Get information about the current KES period and your node's operational certificate."
 
 pPoolState :: EnvCli -> Parser (QueryCmds ConwayEra)
 pPoolState envCli =
-  subParser "pool-state" $
-    Opt.info (pQueryPoolStateCmd ShelleyBasedEraConway envCli) $
-      Opt.progDesc "Dump the pool state"
+  Opt.hsubparser $
+    commandWithMetavar "pool-state" $
+      Opt.info (pQueryPoolStateCmd ShelleyBasedEraConway envCli) $
+        Opt.progDesc "Dump the pool state"
 
 pTxMempool :: EnvCli -> Parser (QueryCmds era)
 pTxMempool envCli =
-  subParser "tx-mempool" $
-    Opt.info (pQueryTxMempoolCmd envCli) $
-      Opt.progDesc "Local Mempool info"
+  Opt.hsubparser $
+    commandWithMetavar "tx-mempool" $
+      Opt.info (pQueryTxMempoolCmd envCli) $
+        Opt.progDesc "Local Mempool info"
 
 pSlotNumber :: EnvCli -> Parser (QueryCmds ConwayEra)
 pSlotNumber envCli =
-  subParser "slot-number" $
-    Opt.info (pQuerySlotNumberCmd ShelleyBasedEraConway envCli) $
-      Opt.progDesc "Query slot number for UTC timestamp"
+  Opt.hsubparser $
+    commandWithMetavar "slot-number" $
+      Opt.info (pQuerySlotNumberCmd ShelleyBasedEraConway envCli) $
+        Opt.progDesc "Query slot number for UTC timestamp"
 
 pQueryLedgerPeerSnapshot :: EnvCli -> Parser (QueryCmds ConwayEra)
 pQueryLedgerPeerSnapshot envCli =
-  subParser "ledger-peer-snapshot" $
-    Opt.info (pQueryLedgerPeerSnapshotCmd ShelleyBasedEraConway envCli) $
-      Opt.progDesc $
-        mconcat
-          [ "Dump the current snapshot of big ledger peers. "
-          , "These are the largest pools that cumulatively hold "
-          , "90% of total stake."
-          ]
+  Opt.hsubparser $
+    commandWithMetavar "ledger-peer-snapshot" $
+      Opt.info (pQueryLedgerPeerSnapshotCmd ShelleyBasedEraConway envCli) $
+        Opt.progDesc $
+          mconcat
+            [ "Dump the current snapshot of big ledger peers. "
+            , "These are the largest pools that cumulatively hold "
+            , "90% of total stake."
+            ]
 
 -- \^ TODO use bigLedgerPeerQuota from Ouroboros.Network.PeerSelection.LedgerPeers.Utils
 -- which must be re-exposed thru cardano-api
@@ -194,67 +211,77 @@ pQueryCmds era envCli =
           ]
     )
     [ Just $
-        subParser "protocol-parameters" $
-          Opt.info (pQueryProtocolParametersCmd envCli) $
-            Opt.progDesc "Get the node's current protocol parameters"
+        Opt.hsubparser $
+          commandWithMetavar "protocol-parameters" $
+            Opt.info (pQueryProtocolParametersCmd envCli) $
+              Opt.progDesc "Get the node's current protocol parameters"
     , Just $
-        subParser "tip" $
-          Opt.info (pQueryTipCmd era envCli) $
-            Opt.progDesc "Get the node's current tip (slot no, hash, block no)"
+        Opt.hsubparser $
+          commandWithMetavar "tip" $
+            Opt.info (pQueryTipCmd era envCli) $
+              Opt.progDesc "Get the node's current tip (slot no, hash, block no)"
     , Just $
-        subParser "stake-pools" $
-          Opt.info (pQueryStakePoolsCmd era envCli) $
-            Opt.progDesc "Get the node's current set of stake pool ids"
+        Opt.hsubparser $
+          commandWithMetavar "stake-pools" $
+            Opt.info (pQueryStakePoolsCmd era envCli) $
+              Opt.progDesc "Get the node's current set of stake pool ids"
     , Just $
-        subParser "stake-distribution" $
-          Opt.info (pQueryStakeDistributionCmd era envCli) $
-            Opt.progDesc "Get the node's current aggregated stake distribution"
+        Opt.hsubparser $
+          commandWithMetavar "stake-distribution" $
+            Opt.info (pQueryStakeDistributionCmd era envCli) $
+              Opt.progDesc "Get the node's current aggregated stake distribution"
     , Just $
-        subParser "stake-address-info" $
-          Opt.info (pQueryStakeAddressInfoCmd era envCli) $
-            Opt.progDesc $
-              mconcat
-                [ "Get the current delegations and reward accounts filtered by stake address."
-                ]
+        Opt.hsubparser $
+          commandWithMetavar "stake-address-info" $
+            Opt.info (pQueryStakeAddressInfoCmd era envCli) $
+              Opt.progDesc $
+                mconcat
+                  [ "Get the current delegations and reward accounts filtered by stake address."
+                  ]
     , Just $
-        subParser "utxo" $
-          Opt.info (pQueryUTxOCmd era envCli) $
-            Opt.progDesc $
-              mconcat
-                [ "Get a portion of the current UTxO: by tx in, by address or the whole."
-                ]
+        Opt.hsubparser $
+          commandWithMetavar "utxo" $
+            Opt.info (pQueryUTxOCmd era envCli) $
+              Opt.progDesc $
+                mconcat
+                  [ "Get a portion of the current UTxO: by tx in, by address or the whole."
+                  ]
     , Just $
-        subParser "ledger-state" $
-          Opt.info (pQueryLedgerStateCmd era envCli) $
-            Opt.progDesc $
-              mconcat
-                [ "Dump the current ledger state of the node (Ledger.NewEpochState -- advanced command)"
-                ]
+        Opt.hsubparser $
+          commandWithMetavar "ledger-state" $
+            Opt.info (pQueryLedgerStateCmd era envCli) $
+              Opt.progDesc $
+                mconcat
+                  [ "Dump the current ledger state of the node (Ledger.NewEpochState -- advanced command)"
+                  ]
     , Just $
-        subParser "ledger-peer-snapshot" $
-          Opt.info (pQueryLedgerPeerSnapshotCmd era envCli) $
-            Opt.progDesc $
-              mconcat
-                [ "Dump the current snapshot of ledger peers."
-                , "These are the largest pools that cumulatively hold "
-                , "90% of total stake."
-                ]
+        Opt.hsubparser $
+          commandWithMetavar "ledger-peer-snapshot" $
+            Opt.info (pQueryLedgerPeerSnapshotCmd era envCli) $
+              Opt.progDesc $
+                mconcat
+                  [ "Dump the current snapshot of ledger peers."
+                  , "These are the largest pools that cumulatively hold "
+                  , "90% of total stake."
+                  ]
     , -- \^ TODO use bigLedgerPeerQuota from Ouroboros.Network.PeerSelection.LedgerPeers.Utils
       -- which must be re-exposed thru cardano-api
       Just $
-        subParser "protocol-state" $
-          Opt.info (pQueryProtocolStateCmd era envCli) $
-            Opt.progDesc $
-              mconcat
-                [ "Dump the current protocol state of the node (Ledger.ChainDepState -- advanced command)"
-                ]
+        Opt.hsubparser $
+          commandWithMetavar "protocol-state" $
+            Opt.info (pQueryProtocolStateCmd era envCli) $
+              Opt.progDesc $
+                mconcat
+                  [ "Dump the current protocol state of the node (Ledger.ChainDepState -- advanced command)"
+                  ]
     , Just $
-        subParser "stake-snapshot" $
-          Opt.info (pQueryStakeSnapshotCmd era envCli) $
-            Opt.progDesc $
-              mconcat
-                [ "Obtain the three stake snapshots for a pool, plus the total active stake (advanced command)"
-                ]
+        Opt.hsubparser $
+          commandWithMetavar "stake-snapshot" $
+            Opt.info (pQueryStakeSnapshotCmd era envCli) $
+              Opt.progDesc $
+                mconcat
+                  [ "Obtain the three stake snapshots for a pool, plus the total active stake (advanced command)"
+                  ]
     , Just $
         hiddenSubParser "pool-params" $
           Opt.info (pQueryPoolStateCmd era envCli) $
@@ -264,27 +291,33 @@ pQueryCmds era envCli =
                 , "(Ledger.NewEpochState.esLState._delegationState._pState._pParams -- advanced command)"
                 ]
     , Just $
-        subParser "leadership-schedule" $
-          Opt.info (pLeadershipScheduleCmd era envCli) $
-            Opt.progDesc "Get the slots the node is expected to mint a block in (advanced command)"
+        Opt.hsubparser $
+          commandWithMetavar "leadership-schedule" $
+            Opt.info (pLeadershipScheduleCmd era envCli) $
+              Opt.progDesc "Get the slots the node is expected to mint a block in (advanced command)"
     , Just $
-        subParser "kes-period-info" $
-          Opt.info (pKesPeriodInfoCmd era envCli) $
-            Opt.progDesc "Get information about the current KES period and your node's operational certificate."
+        Opt.hsubparser $
+          commandWithMetavar "kes-period-info" $
+            Opt.info (pKesPeriodInfoCmd era envCli) $
+              Opt.progDesc "Get information about the current KES period and your node's operational certificate."
     , Just $
-        subParser "pool-state" $
-          Opt.info (pQueryPoolStateCmd era envCli) $
-            Opt.progDesc "Dump the pool state"
+        Opt.hsubparser $
+          commandWithMetavar "pool-state" $
+            Opt.info (pQueryPoolStateCmd era envCli) $
+              Opt.progDesc "Dump the pool state"
     , Just $
-        subParser "tx-mempool" $
-          Opt.info (pQueryTxMempoolCmd envCli) $
-            Opt.progDesc "Local Mempool info"
+        Opt.hsubparser $
+          commandWithMetavar "tx-mempool" $
+            Opt.info (pQueryTxMempoolCmd envCli) $
+              Opt.progDesc "Local Mempool info"
     , Just $
-        subParser "slot-number" $
-          Opt.info (pQuerySlotNumberCmd era envCli) $
-            Opt.progDesc "Query slot number for UTC timestamp"
+        Opt.hsubparser $
+          commandWithMetavar "slot-number" $
+            Opt.info (pQuerySlotNumberCmd era envCli) $
+              Opt.progDesc "Query slot number for UTC timestamp"
     , Just
-        . subParser "ref-script-size"
+        . Opt.hsubparser
+        . commandWithMetavar "ref-script-size"
         . Opt.info (pQueryRefScriptSizeCmd era envCli)
         $ Opt.progDesc "Calculate the reference input scripts size in bytes for provided transaction inputs."
     , pQueryGetConstitutionCmd era envCli
@@ -415,15 +448,18 @@ pQueryTxMempoolCmd envCli =
   pTxMempoolQuery :: Parser TxMempoolQuery
   pTxMempoolQuery =
     asum
-      [ subParser "info" $
-          Opt.info (pure TxMempoolQueryInfo) $
-            Opt.progDesc "Ask the node about the current mempool's capacity and sizes"
-      , subParser "next-tx" $
-          Opt.info (pure TxMempoolQueryNextTx) $
-            Opt.progDesc "Requests the next transaction from the mempool's current list"
-      , subParser "tx-exists" $
-          Opt.info (TxMempoolQueryTxExists <$> argument Opt.str (metavar "TX_ID")) $
-            Opt.progDesc "Query if a particular transaction exists in the mempool"
+      [ Opt.hsubparser $
+          commandWithMetavar "info" $
+            Opt.info (pure TxMempoolQueryInfo) $
+              Opt.progDesc "Ask the node about the current mempool's capacity and sizes"
+      , Opt.hsubparser $
+          commandWithMetavar "next-tx" $
+            Opt.info (pure TxMempoolQueryNextTx) $
+              Opt.progDesc "Requests the next transaction from the mempool's current list"
+      , Opt.hsubparser $
+          commandWithMetavar "tx-exists" $
+            Opt.info (TxMempoolQueryTxExists <$> argument Opt.str (metavar "TX_ID")) $
+              Opt.progDesc "Query if a particular transaction exists in the mempool"
       ]
 
 pLeadershipScheduleCmd :: ShelleyBasedEra era -> EnvCli -> Parser (QueryCmds era)
@@ -486,9 +522,10 @@ pQueryGetConstitutionCmd
 pQueryGetConstitutionCmd era envCli = do
   w <- forShelleyBasedEraMaybeEon era
   pure $
-    subParser "constitution" $
-      Opt.info (QueryConstitutionCmd <$> pQueryNoArgCmdArgs w envCli) $
-        Opt.progDesc "Get the constitution"
+    Opt.hsubparser $
+      commandWithMetavar "constitution" $
+        Opt.info (QueryConstitutionCmd <$> pQueryNoArgCmdArgs w envCli) $
+          Opt.progDesc "Get the constitution"
 
 pQueryGetGovStateCmd
   :: ()
@@ -498,9 +535,10 @@ pQueryGetGovStateCmd
 pQueryGetGovStateCmd era envCli = do
   w <- forShelleyBasedEraMaybeEon era
   pure $
-    subParser "gov-state" $
-      Opt.info (QueryGovStateCmd <$> pQueryNoArgCmdArgs w envCli) $
-        Opt.progDesc "Get the governance state"
+    Opt.hsubparser $
+      commandWithMetavar "gov-state" $
+        Opt.info (QueryGovStateCmd <$> pQueryNoArgCmdArgs w envCli) $
+          Opt.progDesc "Get the governance state"
 
 pQueryGetRatifyStateCmd
   :: ()
@@ -510,9 +548,10 @@ pQueryGetRatifyStateCmd
 pQueryGetRatifyStateCmd era envCli = do
   w <- forShelleyBasedEraMaybeEon era
   pure $
-    subParser "ratify-state" $
-      Opt.info (QueryRatifyStateCmd <$> pQueryNoArgCmdArgs w envCli) $
-        Opt.progDesc "Get the ratification state"
+    Opt.hsubparser $
+      commandWithMetavar "ratify-state" $
+        Opt.info (QueryRatifyStateCmd <$> pQueryNoArgCmdArgs w envCli) $
+          Opt.progDesc "Get the ratification state"
 
 pQueryFuturePParamsCmd
   :: ()
@@ -522,9 +561,10 @@ pQueryFuturePParamsCmd
 pQueryFuturePParamsCmd era envCli = do
   w <- forShelleyBasedEraMaybeEon era
   pure $
-    subParser "future-pparams" $
-      Opt.info (QueryFuturePParamsCmd <$> pQueryNoArgCmdArgs w envCli) $
-        Opt.progDesc "Get the protocol parameters that will apply at the next epoch"
+    Opt.hsubparser $
+      commandWithMetavar "future-pparams" $
+        Opt.info (QueryFuturePParamsCmd <$> pQueryNoArgCmdArgs w envCli) $
+          Opt.progDesc "Get the protocol parameters that will apply at the next epoch"
 
 -- TODO Conway: DRep State and DRep Stake Distribution parsers use DRep keys to obtain DRep credentials. This only
 -- makes use of 'KeyHashObj' constructor of 'Credential kr c'. Should we also support here 'ScriptHashObj'?
@@ -539,9 +579,10 @@ pQueryDRepStateCmd
 pQueryDRepStateCmd era envCli = do
   w <- forShelleyBasedEraMaybeEon era
   pure $
-    subParser "drep-state" $
-      Opt.info (QueryDRepStateCmd <$> pQueryDRepStateCmdArgs w) $
-        Opt.progDesc "Get the DRep state."
+    Opt.hsubparser $
+      commandWithMetavar "drep-state" $
+        Opt.info (QueryDRepStateCmd <$> pQueryDRepStateCmdArgs w) $
+          Opt.progDesc "Get the DRep state."
  where
   pQueryDRepStateCmdArgs :: ConwayEraOnwards era -> Parser (QueryDRepStateCmdArgs era)
   pQueryDRepStateCmdArgs w =
@@ -572,9 +613,10 @@ pQueryDRepStakeDistributionCmd
 pQueryDRepStakeDistributionCmd era envCli = do
   w <- forShelleyBasedEraMaybeEon era
   pure $
-    subParser "drep-stake-distribution" $
-      Opt.info (QueryDRepStakeDistributionCmd <$> pQueryDRepStakeDistributionCmdArgs w) $
-        Opt.progDesc "Get the DRep stake distribution."
+    Opt.hsubparser $
+      commandWithMetavar "drep-stake-distribution" $
+        Opt.info (QueryDRepStakeDistributionCmd <$> pQueryDRepStakeDistributionCmdArgs w) $
+          Opt.progDesc "Get the DRep stake distribution."
  where
   pQueryDRepStakeDistributionCmdArgs
     :: ConwayEraOnwards era -> Parser (QueryDRepStakeDistributionCmdArgs era)
@@ -592,13 +634,14 @@ pQueryProposalsCmd
 pQueryProposalsCmd era envCli = do
   w <- forShelleyBasedEraMaybeEon era
   pure $
-    subParser "proposals" $
-      Opt.info (QueryProposalsCmd <$> pQueryProposalsCmdArgs w) $
-        Opt.progDesc $
-          mconcat
-            [ "Get the governance proposals that are eligible for ratification. "
-            , "Proposals submitted during the current epoch are excluded, as they cannot be ratified until the next epoch. "
-            ]
+    Opt.hsubparser $
+      commandWithMetavar "proposals" $
+        Opt.info (QueryProposalsCmd <$> pQueryProposalsCmdArgs w) $
+          Opt.progDesc $
+            mconcat
+              [ "Get the governance proposals that are eligible for ratification. "
+              , "Proposals submitted during the current epoch are excluded, as they cannot be ratified until the next epoch. "
+              ]
  where
   pQueryProposalsCmdArgs :: ConwayEraOnwards era -> Parser (QueryProposalsCmdArgs era)
   pQueryProposalsCmdArgs w =
@@ -615,9 +658,10 @@ pQuerySPOStakeDistributionCmd
 pQuerySPOStakeDistributionCmd era envCli = do
   w <- forShelleyBasedEraMaybeEon era
   pure $
-    subParser "spo-stake-distribution" $
-      Opt.info (QuerySPOStakeDistributionCmd <$> pQuerySPOStakeDistributionCmdArgs w) $
-        Opt.progDesc "Get the SPO stake distribution."
+    Opt.hsubparser $
+      commandWithMetavar "spo-stake-distribution" $
+        Opt.info (QuerySPOStakeDistributionCmd <$> pQuerySPOStakeDistributionCmdArgs w) $
+          Opt.progDesc "Get the SPO stake distribution."
  where
   pQuerySPOStakeDistributionCmdArgs
     :: ConwayEraOnwards era -> Parser (QuerySPOStakeDistributionCmdArgs era)
@@ -635,9 +679,10 @@ pQueryGetCommitteeStateCmd
 pQueryGetCommitteeStateCmd era envCli = do
   w <- forShelleyBasedEraMaybeEon era
   pure $
-    subParser "committee-state" $
-      Opt.info (QueryCommitteeMembersStateCmd <$> pQueryCommitteeMembersStateArgs w) $
-        Opt.progDesc "Get the committee state"
+    Opt.hsubparser $
+      commandWithMetavar "committee-state" $
+        Opt.info (QueryCommitteeMembersStateCmd <$> pQueryCommitteeMembersStateArgs w) $
+          Opt.progDesc "Get the committee state"
  where
   pQueryCommitteeMembersStateArgs
     :: ConwayEraOnwards era -> Parser (QueryCommitteeMembersStateCmdArgs era)
@@ -699,9 +744,10 @@ pQueryTreasuryValueCmd
 pQueryTreasuryValueCmd era envCli = do
   w <- forShelleyBasedEraMaybeEon era
   pure $
-    subParser "treasury" $
-      Opt.info (QueryTreasuryValueCmd <$> pQueryTreasuryValueArgs w) $
-        Opt.progDesc "Get the treasury value"
+    Opt.hsubparser $
+      commandWithMetavar "treasury" $
+        Opt.info (QueryTreasuryValueCmd <$> pQueryTreasuryValueArgs w) $
+          Opt.progDesc "Get the treasury value"
  where
   pQueryTreasuryValueArgs
     :: ConwayEraOnwards era -> Parser (QueryTreasuryValueCmdArgs era)

--- a/cardano-cli/src/Cardano/CLI/EraBased/StakeAddress/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/StakeAddress/Option.hs
@@ -46,7 +46,8 @@ pStakeAddressKeyGenCmd
   :: ()
   => Parser (StakeAddressCmds era)
 pStakeAddressKeyGenCmd = do
-  subParser "key-gen"
+  Opt.hsubparser
+    $ commandWithMetavar "key-gen"
     $ Opt.info
       ( StakeAddressKeyGenCmd
           <$> pKeyOutputFormat
@@ -59,8 +60,8 @@ pStakeAddressKeyHashCmd
   :: ()
   => Parser (StakeAddressCmds era)
 pStakeAddressKeyHashCmd =
-  do
-    subParser "key-hash"
+  Opt.hsubparser
+    $ commandWithMetavar "key-hash"
     $ Opt.info
       ( StakeAddressKeyHashCmd
           <$> pStakeVerificationKeyOrFile Nothing
@@ -73,7 +74,8 @@ pStakeAddressBuildCmd
   => EnvCli
   -> Parser (StakeAddressCmds era)
 pStakeAddressBuildCmd envCli = do
-  subParser "build"
+  Opt.hsubparser
+    $ commandWithMetavar "build"
     $ Opt.info
       ( StakeAddressBuildCmd
           <$> pStakeVerifier Nothing
@@ -87,14 +89,15 @@ pStakeAddressRegistrationCertificateCmd
   => ShelleyBasedEra era
   -> Parser (StakeAddressCmds era)
 pStakeAddressRegistrationCertificateCmd sbe = do
-  subParser "registration-certificate" $
-    Opt.info
-      ( StakeAddressRegistrationCertificateCmd sbe
-          <$> pStakeIdentifier Nothing
-          <*> pFeatured (toCardanoEra sbe) pKeyRegistDeposit
-          <*> pOutputFile
-      )
-      desc
+  Opt.hsubparser $
+    commandWithMetavar "registration-certificate" $
+      Opt.info
+        ( StakeAddressRegistrationCertificateCmd sbe
+            <$> pStakeIdentifier Nothing
+            <*> pFeatured (toCardanoEra sbe) pKeyRegistDeposit
+            <*> pOutputFile
+        )
+        desc
  where
   desc = Opt.progDesc "Create a stake address registration certificate"
 
@@ -103,7 +106,8 @@ pStakeAddressDeregistrationCertificateCmd
   => ShelleyBasedEra era
   -> Parser (StakeAddressCmds era)
 pStakeAddressDeregistrationCertificateCmd sbe =
-  subParser "deregistration-certificate"
+  Opt.hsubparser
+    $ commandWithMetavar "deregistration-certificate"
     $ Opt.info
       ( StakeAddressDeregistrationCertificateCmd sbe
           <$> pStakeIdentifier Nothing
@@ -117,7 +121,8 @@ pStakeAddressStakeDelegationCertificateCmd
   => ShelleyBasedEra era
   -> Parser (StakeAddressCmds era)
 pStakeAddressStakeDelegationCertificateCmd sbe = do
-  subParser "stake-delegation-certificate"
+  Opt.hsubparser
+    $ commandWithMetavar "stake-delegation-certificate"
     $ Opt.info
       ( StakeAddressStakeDelegationCertificateCmd sbe
           <$> pStakeIdentifier Nothing
@@ -137,7 +142,8 @@ pStakeAddressStakeAndVoteDelegationCertificateCmd
 pStakeAddressStakeAndVoteDelegationCertificateCmd era = do
   w <- forShelleyBasedEraMaybeEon era
   pure
-    $ subParser "stake-and-vote-delegation-certificate"
+    $ Opt.hsubparser
+    $ commandWithMetavar "stake-and-vote-delegation-certificate"
     $ Opt.info
       ( StakeAddressStakeAndVoteDelegationCertificateCmd w
           <$> pStakeIdentifier Nothing
@@ -158,7 +164,8 @@ pStakeAddressVoteDelegationCertificateCmd
 pStakeAddressVoteDelegationCertificateCmd era = do
   w <- forShelleyBasedEraMaybeEon era
   pure
-    $ subParser "vote-delegation-certificate"
+    $ Opt.hsubparser
+    $ commandWithMetavar "vote-delegation-certificate"
     $ Opt.info
       ( StakeAddressVoteDelegationCertificateCmd w
           <$> pStakeIdentifier Nothing
@@ -178,7 +185,8 @@ pStakeAddressRegistrationAndDelegationCertificateCmd
 pStakeAddressRegistrationAndDelegationCertificateCmd era = do
   w <- forShelleyBasedEraMaybeEon era
   pure
-    $ subParser "registration-and-delegation-certificate"
+    $ Opt.hsubparser
+    $ commandWithMetavar "registration-and-delegation-certificate"
     $ Opt.info
       ( StakeAddressRegistrationAndDelegationCertificateCmd w
           <$> pStakeIdentifier Nothing
@@ -199,7 +207,8 @@ pStakeAddressRegistrationAndVoteDelegationCertificateCmd
 pStakeAddressRegistrationAndVoteDelegationCertificateCmd era = do
   w <- forShelleyBasedEraMaybeEon era
   pure
-    $ subParser "registration-and-vote-delegation-certificate"
+    $ Opt.hsubparser
+    $ commandWithMetavar "registration-and-vote-delegation-certificate"
     $ Opt.info
       ( StakeAddressRegistrationAndVoteDelegationCertificateCmd w
           <$> pStakeIdentifier Nothing
@@ -220,7 +229,8 @@ pStakeAddressRegistrationStakeAndVoteDelegationCertificateCmd
 pStakeAddressRegistrationStakeAndVoteDelegationCertificateCmd era = do
   w <- forShelleyBasedEraMaybeEon era
   pure
-    $ subParser "registration-stake-and-vote-delegation-certificate"
+    $ Opt.hsubparser
+    $ commandWithMetavar "registration-stake-and-vote-delegation-certificate"
     $ Opt.info
       ( StakeAddressRegistrationStakeAndVoteDelegationCertificateCmd w
           <$> pStakeIdentifier Nothing

--- a/cardano-cli/src/Cardano/CLI/EraBased/StakePool/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/StakePool/Option.hs
@@ -41,16 +41,19 @@ pStakePoolCmds era envCli =
     [ pStakePoolRegistrationCertificateCmd era envCli
     , pStakePoolDeregistrationCertificateCmd era
     , Just $
-        subParser "id" $
-          Opt.info pStakePoolId $
-            Opt.progDesc "Build pool id from the offline key"
+        Opt.hsubparser $
+          commandWithMetavar "id" $
+            Opt.info pStakePoolId $
+              Opt.progDesc "Build pool id from the offline key"
     , Just $
-        subParser "metadata-hash" $
-          Opt.info pStakePoolMetadataHashCmd $
-            Opt.progDesc
-              ( "Calculate the hash of a stake pool metadata file,"
-                  <> " optionally checking the obtained hash against an expected value."
-              )
+        Opt.hsubparser $
+          commandWithMetavar "metadata-hash" $
+            Opt.info pStakePoolMetadataHashCmd $
+              Opt.progDesc $
+                mconcat
+                  [ "Calculate the hash of a stake pool metadata file,"
+                  , " optionally checking the obtained hash against an expected value."
+                  ]
     ]
 
 pStakePoolId
@@ -100,7 +103,8 @@ pStakePoolRegistrationCertificateCmd
 pStakePoolRegistrationCertificateCmd era envCli = do
   w <- forShelleyBasedEraMaybeEon era
   pure
-    $ subParser "registration-certificate"
+    $ Opt.hsubparser
+    $ commandWithMetavar "registration-certificate"
     $ Opt.info
       ( fmap Cmd.StakePoolRegistrationCertificateCmd $
           Cmd.StakePoolRegistrationCertificateCmdArgs w
@@ -129,7 +133,8 @@ pStakePoolDeregistrationCertificateCmd
 pStakePoolDeregistrationCertificateCmd era = do
   w <- forShelleyBasedEraMaybeEon era
   pure
-    $ subParser "deregistration-certificate"
+    $ Opt.hsubparser
+    $ commandWithMetavar "deregistration-certificate"
     $ Opt.info
       ( fmap Cmd.StakePoolDeregistrationCertificateCmd $
           Cmd.StakePoolDeregistrationCertificateCmdArgs w

--- a/cardano-cli/src/Cardano/CLI/EraBased/TextView/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/TextView/Option.hs
@@ -29,7 +29,8 @@ pTextViewCmds =
           ]
     )
     [ Just $
-        subParser "decode-cbor" $
-          Opt.info (TextViewInfo <$> pCBORInFile <*> pMaybeOutputFile) $
-            Opt.progDesc "Print a TextView file as decoded CBOR."
+        Opt.hsubparser $
+          commandWithMetavar "decode-cbor" $
+            Opt.info (TextViewInfo <$> pCBORInFile <*> pMaybeOutputFile) $
+              Opt.progDesc "Print a TextView file as decoded CBOR."
     ]

--- a/cardano-cli/src/Cardano/CLI/EraBased/Transaction/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraBased/Transaction/Option.hs
@@ -42,70 +42,81 @@ pTransactionCmds era' envCli =
           ]
     )
     [ Just $
-        subParser "build-raw" $
-          Opt.info (pTransactionBuildRaw era') $
-            Opt.progDescDoc $
-              Just $
-                mconcat
-                  [ pretty @String "Build a transaction (low-level, inconvenient)"
-                  , line
-                  , line
-                  , H.yellow $
-                      mconcat
-                        [ "Please note "
-                        , H.underline "the order"
-                        , " of some cmd options is crucial. If used incorrectly may produce "
-                        , "undesired tx body. See nested [] notation above for details."
-                        ]
-                  ]
+        Opt.hsubparser $
+          commandWithMetavar "build-raw" $
+            Opt.info (pTransactionBuildRaw era') $
+              Opt.progDescDoc $
+                Just $
+                  mconcat
+                    [ pretty @String "Build a transaction (low-level, inconvenient)"
+                    , line
+                    , line
+                    , H.yellow $
+                        mconcat
+                          [ "Please note "
+                          , H.underline "the order"
+                          , " of some cmd options is crucial. If used incorrectly may produce "
+                          , "undesired tx body. See nested [] notation above for details."
+                          ]
+                    ]
     , pTransactionBuildCmd era' envCli
     , forShelleyBasedEraInEon era' Nothing (`pTransactionBuildEstimateCmd` envCli)
     , Just $
-        subParser "sign" $
-          Opt.info (pTransactionSign envCli) $
-            Opt.progDesc "Sign a transaction"
+        Opt.hsubparser $
+          commandWithMetavar "sign" $
+            Opt.info (pTransactionSign envCli) $
+              Opt.progDesc "Sign a transaction"
     , Just $
-        subParser "witness" $
-          Opt.info (pTransactionCreateWitness envCli) $
-            Opt.progDesc "Create a transaction witness"
+        Opt.hsubparser $
+          commandWithMetavar "witness" $
+            Opt.info (pTransactionCreateWitness envCli) $
+              Opt.progDesc "Create a transaction witness"
     , Just $
-        subParser "assemble" $
-          Opt.info pTransactionAssembleTxBodyWit $
-            Opt.progDesc "Assemble a tx body and witness(es) to form a transaction"
+        Opt.hsubparser $
+          commandWithMetavar "assemble" $
+            Opt.info pTransactionAssembleTxBodyWit $
+              Opt.progDesc "Assemble a tx body and witness(es) to form a transaction"
     , Just pSignWitnessBackwardCompatible
     , Just $
-        subParser "submit" $
-          Opt.info (pTransactionSubmit envCli) $
-            Opt.progDesc $
-              mconcat
-                [ "Submit a transaction to the local node whose Unix domain socket "
-                , "is obtained from the CARDANO_NODE_SOCKET_PATH environment variable."
-                ]
+        Opt.hsubparser $
+          commandWithMetavar "submit" $
+            Opt.info (pTransactionSubmit envCli) $
+              Opt.progDesc $
+                mconcat
+                  [ "Submit a transaction to the local node whose Unix domain socket "
+                  , "is obtained from the CARDANO_NODE_SOCKET_PATH environment variable."
+                  ]
     , Just $
-        subParser "policyid" $
-          Opt.info pTransactionPolicyId $
-            Opt.progDesc "Calculate the PolicyId from the monetary policy script."
+        Opt.hsubparser $
+          commandWithMetavar "policyid" $
+            Opt.info pTransactionPolicyId $
+              Opt.progDesc "Calculate the PolicyId from the monetary policy script."
     , Just $
-        subParser "calculate-min-fee" $
-          Opt.info pTransactionCalculateMinFee $
-            Opt.progDesc "Calculate the minimum fee for a transaction."
+        Opt.hsubparser $
+          commandWithMetavar "calculate-min-fee" $
+            Opt.info pTransactionCalculateMinFee $
+              Opt.progDesc "Calculate the minimum fee for a transaction."
     , Just $
-        subParser "calculate-min-required-utxo" $
-          Opt.info (pTransactionCalculateMinReqUTxO era') $
-            Opt.progDesc "Calculate the minimum required UTxO for a transaction output."
+        Opt.hsubparser $
+          commandWithMetavar "calculate-min-required-utxo" $
+            Opt.info (pTransactionCalculateMinReqUTxO era') $
+              Opt.progDesc "Calculate the minimum required UTxO for a transaction output."
     , Just $
-        subParser "calculate-plutus-script-cost" $
-          Opt.info (pTransactionCalculatePlutusScriptCost envCli) $
-            Opt.progDesc "Calculate the costs of the Plutus scripts of a given transaction."
+        Opt.hsubparser $
+          commandWithMetavar "calculate-plutus-script-cost" $
+            Opt.info (pTransactionCalculatePlutusScriptCost envCli) $
+              Opt.progDesc "Calculate the costs of the Plutus scripts of a given transaction."
     , Just $ pCalculateMinRequiredUtxoBackwardCompatible era'
     , Just $
-        subParser "hash-script-data" $
-          Opt.info pTxHashScriptData $
-            Opt.progDesc "Calculate the hash of script data."
+        Opt.hsubparser $
+          commandWithMetavar "hash-script-data" $
+            Opt.info pTxHashScriptData $
+              Opt.progDesc "Calculate the hash of script data."
     , Just $
-        subParser "txid" $
-          Opt.info pTransactionId $
-            Opt.progDesc "Print a transaction identifier."
+        Opt.hsubparser $
+          commandWithMetavar "txid" $
+            Opt.info pTransactionId $
+              Opt.progDesc "Print a transaction identifier."
     ]
 
 -- Backwards compatible parsers
@@ -154,22 +165,23 @@ pTransactionBuildCmd
 pTransactionBuildCmd sbe envCli = do
   era' <- forEraMaybeEon (toCardanoEra sbe)
   pure $
-    subParser "build" $
-      Opt.info (pCmd era') $
-        Opt.progDescDoc $
-          Just $
-            mconcat
-              [ pretty @String "Build a balanced transaction (automatically calculates fees)"
-              , line
-              , line
-              , H.yellow $
-                  mconcat
-                    [ "Please note "
-                    , H.underline "the order"
-                    , " of some cmd options is crucial. If used incorrectly may produce "
-                    , "undesired tx body. See nested [] notation above for details."
-                    ]
-              ]
+    Opt.hsubparser $
+      commandWithMetavar "build" $
+        Opt.info (pCmd era') $
+          Opt.progDescDoc $
+            Just $
+              mconcat
+                [ pretty @String "Build a balanced transaction (automatically calculates fees)"
+                , line
+                , line
+                , H.yellow $
+                    mconcat
+                      [ "Please note "
+                      , H.underline "the order"
+                      , " of some cmd options is crucial. If used incorrectly may produce "
+                      , "undesired tx body. See nested [] notation above for details."
+                      ]
+                ]
  where
   pCmd era' = do
     fmap TransactionBuildCmd $
@@ -214,23 +226,24 @@ pTransactionBuildEstimateCmd
 pTransactionBuildEstimateCmd eon' _envCli = do
   era' <- forEraMaybeEon (toCardanoEra eon')
   pure $
-    subParser "build-estimate" $
-      Opt.info (pCmd era') $
-        Opt.progDescDoc $
-          Just $
-            mconcat
-              [ pretty @String
-                  "Build a balanced transaction without access to a live node (automatically estimates fees)"
-              , line
-              , line
-              , H.yellow $
-                  mconcat
-                    [ "Please note "
-                    , H.underline "the order"
-                    , " of some cmd options is crucial. If used incorrectly may produce "
-                    , "undesired tx body. See nested [] notation above for details."
-                    ]
-              ]
+    Opt.hsubparser $
+      commandWithMetavar "build-estimate" $
+        Opt.info (pCmd era') $
+          Opt.progDescDoc $
+            Just $
+              mconcat
+                [ pretty @String
+                    "Build a balanced transaction without access to a live node (automatically estimates fees)"
+                , line
+                , line
+                , H.yellow $
+                    mconcat
+                      [ "Please note "
+                      , H.underline "the order"
+                      , " of some cmd options is crucial. If used incorrectly may produce "
+                      , "undesired tx body. See nested [] notation above for details."
+                      ]
+                ]
  where
   pCmd :: Exp.Era era -> Parser (TransactionCmds era)
   pCmd era' = do

--- a/cardano-cli/src/Cardano/CLI/EraIndependent/Address/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraIndependent/Address/Option.hs
@@ -24,28 +24,30 @@ pAddressCmds
 pAddressCmds envCli =
   let addressParsers =
         asum
-          [ subParser "key-gen" $
-              Opt.info pAddressKeyGen $
-                Opt.progDesc "Create an address key pair."
-          , subParser "key-hash" $
-              Opt.info pAddressKeyHash $
-                Opt.progDesc "Print the hash of an address key."
-          , subParser "build" $
-              Opt.info (pAddressBuild envCli) $
-                Opt.progDesc "Build a Shelley payment address, with optional delegation to a stake address."
-          , subParser "info" $
-              Opt.info pAddressInfo $
-                Opt.progDesc "Print information about an address."
+          [ Opt.hsubparser $
+              commandWithMetavar "key-gen" $
+                Opt.info pAddressKeyGen $
+                  Opt.progDesc "Create an address key pair."
+          , Opt.hsubparser $
+              commandWithMetavar "key-hash" $
+                Opt.info pAddressKeyHash $
+                  Opt.progDesc "Print the hash of an address key."
+          , Opt.hsubparser $
+              commandWithMetavar "build" $
+                Opt.info (pAddressBuild envCli) $
+                  Opt.progDesc "Build a Shelley payment address, with optional delegation to a stake address."
+          , Opt.hsubparser $
+              commandWithMetavar "info" $
+                Opt.info pAddressInfo $
+                  Opt.progDesc "Print information about an address."
           ]
-   in subParser
-        "address"
-        $ Opt.info
-          addressParsers
-          ( Opt.progDesc $
+   in Opt.hsubparser $
+        commandWithMetavar "address" $
+          Opt.info addressParsers $
+            Opt.progDesc $
               mconcat
                 [ "Payment address commands."
                 ]
-          )
 
 pAddressKeyGen :: Parser AddressCmds
 pAddressKeyGen =

--- a/cardano-cli/src/Cardano/CLI/EraIndependent/Debug/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraIndependent/Debug/Option.hs
@@ -39,26 +39,32 @@ parseDebugCmds envCli =
 pDebugCmds :: EnvCli -> Parser DebugCmds
 pDebugCmds envCli =
   asum
-    [ subParser "log-epoch-state" $
-        Opt.info pLogEpochStateCmdArgs $
-          Opt.progDesc $
-            mconcat
-              [ "Log epoch state of a running node."
-              , " This command will connect to a local node and log the epoch state to a file."
-              , " The log file format is line delimited JSON."
-              , " The command will not terminate."
-              ]
-    , subParser "check-node-configuration" $
-        Opt.info pCheckNodeConfigurationCmdArgs $
-          Opt.progDesc
-            "Check hashes and paths of genesis files in the given node configuration file."
-    , subParser "transaction" $
-        Opt.info
-          ( asum
-              [ subParser "view" (Opt.info pTransactionView $ Opt.progDesc "Print a transaction.")
-              ]
-          )
-          (Opt.progDesc "Transaction commands")
+    [ Opt.hsubparser $
+        commandWithMetavar "log-epoch-state" $
+          Opt.info pLogEpochStateCmdArgs $
+            Opt.progDesc $
+              mconcat
+                [ "Log epoch state of a running node."
+                , " This command will connect to a local node and log the epoch state to a file."
+                , " The log file format is line delimited JSON."
+                , " The command will not terminate."
+                ]
+    , Opt.hsubparser $
+        commandWithMetavar "check-node-configuration" $
+          Opt.info pCheckNodeConfigurationCmdArgs $
+            Opt.progDesc
+              "Check hashes and paths of genesis files in the given node configuration file."
+    , Opt.hsubparser $
+        commandWithMetavar "transaction" $
+          Opt.info
+            ( asum
+                [ Opt.hsubparser $
+                    commandWithMetavar "view" $
+                      Opt.info pTransactionView $
+                        Opt.progDesc "Print a transaction."
+                ]
+            )
+            (Opt.progDesc "Transaction commands")
     ]
  where
   pLogEpochStateCmdArgs :: Parser DebugCmds

--- a/cardano-cli/src/Cardano/CLI/EraIndependent/Hash/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraIndependent/Hash/Option.hs
@@ -18,18 +18,18 @@ import Options.Applicative qualified as Opt
 
 pHashCmds :: Parser Cmd.HashCmds
 pHashCmds =
-  subParser "hash" $
-    Opt.info
-      (asum [pHashAnchorDataCmd, pHashScriptCmd, pHashGenesisHashCmd])
-      ( Opt.progDesc $
+  Opt.hsubparser $
+    commandWithMetavar "hash" $
+      Opt.info (asum [pHashAnchorDataCmd, pHashScriptCmd, pHashGenesisHashCmd]) $
+        Opt.progDesc $
           mconcat
             [ "Compute the hash to pass to the various --*-hash arguments of commands."
             ]
-      )
 
 pHashAnchorDataCmd :: Parser Cmd.HashCmds
 pHashAnchorDataCmd = do
-  subParser "anchor-data"
+  Opt.hsubparser
+    $ commandWithMetavar "anchor-data"
     $ Opt.info
       ( fmap
           Cmd.HashAnchorDataCmd
@@ -69,7 +69,8 @@ pAnchorDataHashSource =
 
 pHashScriptCmd :: Parser Cmd.HashCmds
 pHashScriptCmd = do
-  subParser "script"
+  Opt.hsubparser
+    $ commandWithMetavar "script"
     $ Opt.info
       ( fmap
           Cmd.HashScriptCmd
@@ -82,9 +83,10 @@ pHashScriptCmd = do
 
 pHashGenesisHashCmd :: Parser Cmd.HashCmds
 pHashGenesisHashCmd =
-  subParser "genesis-file" $
-    Opt.info pGenesisHash $
-      Opt.progDesc "Compute the hash of a genesis file."
+  Opt.hsubparser $
+    commandWithMetavar "genesis-file" $
+      Opt.info pGenesisHash $
+        Opt.progDesc "Compute the hash of a genesis file."
 
 pGenesisHash :: Parser Cmd.HashCmds
 pGenesisHash =

--- a/cardano-cli/src/Cardano/CLI/EraIndependent/Key/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraIndependent/Key/Option.hs
@@ -30,95 +30,102 @@ pKeyCmds :: Parser KeyCmds
 pKeyCmds =
   let keyCmdParsers =
         asum
-          [ subParser "verification-key" $
-              Opt.info pKeyVerificationKeyCmd $
-                Opt.progDesc $
-                  mconcat
-                    [ "Get a verification key from a signing key. This "
-                    , " supports all key types."
-                    ]
-          , subParser "non-extended-key" $
-              Opt.info pKeyNonExtendedKeyCmd $
-                Opt.progDesc $
-                  mconcat
-                    [ "Get a non-extended verification key from an "
-                    , "extended verification key. This supports all "
-                    , "extended key types."
-                    ]
-          , subParser "generate-mnemonic" $
-              Opt.info pKeyGenerateMnemonicCmd $
-                Opt.progDesc $
-                  mconcat
-                    [ "Generate a mnemonic sentence that can be used "
-                    , "for key derivation."
-                    ]
-          , subParser "derive-from-mnemonic" $
-              Opt.info pKeyExtendedSigningKeyFromMnemonicCmd $
-                Opt.progDesc $
-                  mconcat
-                    [ "Derive an extended signing key from a mnemonic "
-                    , "sentence. "
-                    , "To ensure the safety of the mnemonic phrase, "
-                    , "we recommend that key derivation is performed "
-                    , "in an air-gapped environment."
-                    ]
-          , subParser "convert-byron-key" $
-              Opt.info pKeyConvertByronKeyCmd $
-                Opt.progDesc $
-                  mconcat
-                    [ "Convert a Byron payment, genesis or genesis "
-                    , "delegate key (signing or verification) to a "
-                    , "corresponding Shelley-format key."
-                    ]
-          , subParser "convert-byron-genesis-vkey" $
-              Opt.info pKeyConvertByronGenesisKeyCmd $
-                Opt.progDesc $
-                  mconcat
-                    [ "Convert a Base64-encoded Byron genesis "
-                    , "verification key to a Shelley genesis "
-                    , "verification key"
-                    ]
-          , subParser "convert-itn-key" $
-              Opt.info pKeyConvertITNKeyCmd $
-                Opt.progDesc $
-                  mconcat
-                    [ "Convert an Incentivized Testnet (ITN) non-extended "
-                    , "(Ed25519) signing or verification key to a "
-                    , "corresponding Shelley stake key"
-                    ]
-          , subParser "convert-itn-extended-key" $
-              Opt.info pKeyConvertITNExtendedKeyCmd $
-                Opt.progDesc $
-                  mconcat
-                    [ "Convert an Incentivized Testnet (ITN) extended "
-                    , "(Ed25519Extended) signing key to a corresponding "
-                    , "Shelley stake signing key"
-                    ]
-          , subParser "convert-itn-bip32-key" $
-              Opt.info pKeyConvertITNBip32KeyCmd $
-                Opt.progDesc $
-                  mconcat
-                    [ "Convert an Incentivized Testnet (ITN) BIP32 "
-                    , "(Ed25519Bip32) signing key to a corresponding "
-                    , "Shelley stake signing key"
-                    ]
-          , subParser "convert-cardano-address-key" $
-              Opt.info pKeyConvertCardanoAddressKeyCmd $
-                Opt.progDesc $
-                  mconcat
-                    [ "Convert a cardano-address extended signing key "
-                    , "to a corresponding Shelley-format key."
-                    ]
+          [ Opt.hsubparser $
+              commandWithMetavar "verification-key" $
+                Opt.info pKeyVerificationKeyCmd $
+                  Opt.progDesc $
+                    mconcat
+                      [ "Get a verification key from a signing key. This "
+                      , " supports all key types."
+                      ]
+          , Opt.hsubparser $
+              commandWithMetavar "non-extended-key" $
+                Opt.info pKeyNonExtendedKeyCmd $
+                  Opt.progDesc $
+                    mconcat
+                      [ "Get a non-extended verification key from an "
+                      , "extended verification key. This supports all "
+                      , "extended key types."
+                      ]
+          , Opt.hsubparser $
+              commandWithMetavar "generate-mnemonic" $
+                Opt.info pKeyGenerateMnemonicCmd $
+                  Opt.progDesc $
+                    mconcat
+                      [ "Generate a mnemonic sentence that can be used "
+                      , "for key derivation."
+                      ]
+          , Opt.hsubparser $
+              commandWithMetavar "derive-from-mnemonic" $
+                Opt.info pKeyExtendedSigningKeyFromMnemonicCmd $
+                  Opt.progDesc $
+                    mconcat
+                      [ "Derive an extended signing key from a mnemonic sentence. "
+                      , "To ensure the safety of the mnemonic phrase, "
+                      , "we recommend that key derivation is performed "
+                      , "in an air-gapped environment."
+                      ]
+          , Opt.hsubparser $
+              commandWithMetavar "convert-byron-key" $
+                Opt.info pKeyConvertByronKeyCmd $
+                  Opt.progDesc $
+                    mconcat
+                      [ "Convert a Byron payment, genesis or genesis "
+                      , "delegate key (signing or verification) to a "
+                      , "corresponding Shelley-format key."
+                      ]
+          , Opt.hsubparser $
+              commandWithMetavar "convert-byron-genesis-vkey" $
+                Opt.info pKeyConvertByronGenesisKeyCmd $
+                  Opt.progDesc $
+                    mconcat
+                      [ "Convert a Base64-encoded Byron genesis "
+                      , "verification key to a Shelley genesis "
+                      , "verification key"
+                      ]
+          , Opt.hsubparser $
+              commandWithMetavar "convert-itn-key" $
+                Opt.info pKeyConvertITNKeyCmd $
+                  Opt.progDesc $
+                    mconcat
+                      [ "Convert an Incentivized Testnet (ITN) non-extended "
+                      , "(Ed25519) signing or verification key to a "
+                      , "corresponding Shelley stake key"
+                      ]
+          , Opt.hsubparser $
+              commandWithMetavar "convert-itn-extended-key" $
+                Opt.info pKeyConvertITNExtendedKeyCmd $
+                  Opt.progDesc $
+                    mconcat
+                      [ "Convert an Incentivized Testnet (ITN) extended "
+                      , "(Ed25519Extended) signing key to a corresponding "
+                      , "Shelley stake signing key"
+                      ]
+          , Opt.hsubparser $
+              commandWithMetavar "convert-itn-bip32-key" $
+                Opt.info pKeyConvertITNBip32KeyCmd $
+                  Opt.progDesc $
+                    mconcat
+                      [ "Convert an Incentivized Testnet (ITN) BIP32 "
+                      , "(Ed25519Bip32) signing key to a corresponding "
+                      , "Shelley stake signing key"
+                      ]
+          , Opt.hsubparser $
+              commandWithMetavar "convert-cardano-address-key" $
+                Opt.info pKeyConvertCardanoAddressKeyCmd $
+                  Opt.progDesc $
+                    mconcat
+                      [ "Convert a cardano-address extended signing key "
+                      , "to a corresponding Shelley-format key."
+                      ]
           ]
-   in subParser
-        "key"
-        $ Opt.info
-          keyCmdParsers
-          ( Opt.progDesc $
+   in Opt.hsubparser $
+        commandWithMetavar "key" $
+          Opt.info keyCmdParsers $
+            Opt.progDesc $
               mconcat
                 [ "Key utility commands."
                 ]
-          )
 
 pKeyVerificationKeyCmd :: Parser KeyCmds
 pKeyVerificationKeyCmd =

--- a/cardano-cli/src/Cardano/CLI/EraIndependent/Node/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/EraIndependent/Node/Option.hs
@@ -26,52 +26,56 @@ pNodeCmds :: Parser NodeCmds
 pNodeCmds =
   let nodeCmdParsers =
         asum
-          [ subParser "key-gen" $
-              Opt.info pKeyGenOperator $
+          [ Opt.hsubparser $
+              commandWithMetavar "key-gen" $
+                Opt.info pKeyGenOperator $
+                  Opt.progDesc $
+                    mconcat
+                      [ "Create a key pair for a node operator's offline "
+                      , "key and a new certificate issue counter"
+                      ]
+          , Opt.hsubparser $
+              commandWithMetavar "key-gen-KES" $
+                Opt.info pKeyGenKES $
+                  Opt.progDesc $
+                    mconcat
+                      [ "Create a key pair for a node KES operational key"
+                      ]
+          , Opt.hsubparser $
+              commandWithMetavar "key-gen-VRF" $
+                Opt.info pKeyGenVRF $
+                  Opt.progDesc $
+                    mconcat
+                      [ "Create a key pair for a node VRF operational key"
+                      ]
+          , Opt.hsubparser $
+              commandWithMetavar "key-hash-VRF" . Opt.info pKeyHashVRF $
                 Opt.progDesc $
                   mconcat
-                    [ "Create a key pair for a node operator's offline "
-                    , "key and a new certificate issue counter"
+                    [ "Print hash of a node's operational VRF key."
                     ]
-          , subParser "key-gen-KES" $
-              Opt.info pKeyGenKES $
-                Opt.progDesc $
-                  mconcat
-                    [ "Create a key pair for a node KES operational key"
-                    ]
-          , subParser "key-gen-VRF" $
-              Opt.info pKeyGenVRF $
-                Opt.progDesc $
-                  mconcat
-                    [ "Create a key pair for a node VRF operational key"
-                    ]
-          , subParser "key-hash-VRF" . Opt.info pKeyHashVRF $
-              Opt.progDesc $
-                mconcat
-                  [ "Print hash of a node's operational VRF key."
-                  ]
-          , subParser "new-counter" $
-              Opt.info pNewCounter $
-                Opt.progDesc $
-                  mconcat
-                    [ "Create a new certificate issue counter"
-                    ]
-          , subParser "issue-op-cert" $
-              Opt.info pIssueOpCert $
-                Opt.progDesc $
-                  mconcat
-                    [ "Issue a node operational certificate"
-                    ]
+          , Opt.hsubparser $
+              commandWithMetavar "new-counter" $
+                Opt.info pNewCounter $
+                  Opt.progDesc $
+                    mconcat
+                      [ "Create a new certificate issue counter"
+                      ]
+          , Opt.hsubparser $
+              commandWithMetavar "issue-op-cert" $
+                Opt.info pIssueOpCert $
+                  Opt.progDesc $
+                    mconcat
+                      [ "Issue a node operational certificate"
+                      ]
           ]
-   in subParser
-        "node"
-        $ Opt.info
-          nodeCmdParsers
-          ( Opt.progDesc $
+   in Opt.hsubparser $
+        commandWithMetavar "node" $
+          Opt.info nodeCmdParsers $
+            Opt.progDesc $
               mconcat
                 [ "Node operation commands."
                 ]
-          )
 
 pKeyGenOperator :: Parser NodeCmds
 pKeyGenOperator =

--- a/cardano-cli/src/Cardano/CLI/Legacy/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/Legacy/Option.hs
@@ -60,29 +60,35 @@ parseLegacyCmds envCli =
 pGovernanceCmds :: EnvCli -> Parser LegacyGovernanceCmds
 pGovernanceCmds envCli =
   asum
-    [ subParser "create-mir-certificate" $
-        Opt.info (pLegacyMIRPayStakeAddresses <|> mirCertParsers) $
-          Opt.progDesc "Create an MIR (Move Instantaneous Rewards) certificate"
-    , subParser "create-genesis-key-delegation-certificate" $
-        Opt.info pGovernanceGenesisKeyDelegationCertificate $
-          Opt.progDesc "Create a genesis key delegation certificate"
-    , subParser "create-update-proposal" $
-        Opt.info pUpdateProposal $
-          Opt.progDesc "Create an update proposal"
+    [ Opt.hsubparser $
+        commandWithMetavar "create-mir-certificate" $
+          Opt.info (pLegacyMIRPayStakeAddresses <|> mirCertParsers) $
+            Opt.progDesc "Create an MIR (Move Instantaneous Rewards) certificate"
+    , Opt.hsubparser $
+        commandWithMetavar "create-genesis-key-delegation-certificate" $
+          Opt.info pGovernanceGenesisKeyDelegationCertificate $
+            Opt.progDesc "Create a genesis key delegation certificate"
+    , Opt.hsubparser $
+        commandWithMetavar "create-update-proposal" $
+          Opt.info pUpdateProposal $
+            Opt.progDesc "Create an update proposal"
     ]
  where
   mirCertParsers :: Parser LegacyGovernanceCmds
   mirCertParsers =
     asum
-      [ subParser "stake-addresses" $
-          Opt.info pLegacyMIRPayStakeAddresses $
-            Opt.progDesc "Create an MIR certificate to pay stake addresses"
-      , subParser "transfer-to-treasury" $
-          Opt.info pLegacyMIRTransferToTreasury $
-            Opt.progDesc "Create an MIR certificate to transfer from the reserves pot to the treasury pot"
-      , subParser "transfer-to-rewards" $
-          Opt.info pLegacyMIRTransferToReserves $
-            Opt.progDesc "Create an MIR certificate to transfer from the treasury pot to the reserves pot"
+      [ Opt.hsubparser $
+          commandWithMetavar "stake-addresses" $
+            Opt.info pLegacyMIRPayStakeAddresses $
+              Opt.progDesc "Create an MIR certificate to pay stake addresses"
+      , Opt.hsubparser $
+          commandWithMetavar "transfer-to-treasury" $
+            Opt.info pLegacyMIRTransferToTreasury $
+              Opt.progDesc "Create an MIR certificate to transfer from the reserves pot to the treasury pot"
+      , Opt.hsubparser $
+          commandWithMetavar "transfer-to-rewards" $
+            Opt.info pLegacyMIRTransferToReserves $
+              Opt.progDesc "Create an MIR certificate to transfer from the treasury pot to the reserves pot"
       ]
 
   pLegacyMIRPayStakeAddresses :: Parser LegacyGovernanceCmds
@@ -129,57 +135,68 @@ pGovernanceCmds envCli =
 pGenesisCmds :: EnvCli -> Parser LegacyGenesisCmds
 pGenesisCmds envCli =
   asum
-    [ subParser "key-gen-genesis" $
-        Opt.info pGenesisKeyGen $
-          Opt.progDesc "Create a Shelley genesis key pair"
-    , subParser "key-gen-delegate" $
-        Opt.info pGenesisDelegateKeyGen $
-          Opt.progDesc "Create a Shelley genesis delegate key pair"
-    , subParser "key-gen-utxo" $
-        Opt.info pGenesisUTxOKeyGen $
-          Opt.progDesc "Create a Shelley genesis UTxO key pair"
-    , subParser "key-hash" $
-        Opt.info pGenesisKeyHash $
-          Opt.progDesc "Print the identifier (hash) of a public key"
-    , subParser "get-ver-key" $
-        Opt.info pGenesisVerKey $
-          Opt.progDesc "Derive the verification key from a signing key"
-    , subParser "initial-addr" $
-        Opt.info pGenesisAddr $
-          Opt.progDesc "Get the address for an initial UTxO based on the verification key"
-    , subParser "initial-txin" $
-        Opt.info pGenesisTxIn $
-          Opt.progDesc "Get the TxIn for an initial UTxO based on the verification key"
-    , subParser "create-cardano" $
-        Opt.info pGenesisCreateCardano $
-          Opt.progDesc $
-            mconcat
-              [ "Create a Byron and Shelley genesis file from a genesis "
-              , "template and genesis/delegation/spending keys."
-              ]
-    , subParser "create" $
-        Opt.info pGenesisCreate $
-          Opt.progDesc $
-            mconcat
-              [ "Create a Shelley genesis file from a genesis "
-              , "template and genesis/delegation/spending keys."
-              ]
-    , subParser "create-staked" $
-        Opt.info pGenesisCreateStaked $
-          Opt.progDesc $
-            mconcat
-              [ "Create a staked Shelley genesis file from a genesis "
-              , "template and genesis/delegation/spending keys."
-              ]
-    , subParser "hash" $
-        Opt.info pGenesisHash $
-          Opt.progDesc $
-            unlines
-              [ "DEPRECATION WARNING! This command is deprecated and will be "
-              , "removed in a future release. Please use hash genesis-file "
-              , "instead. "
-              , "Compute the hash of a genesis file."
-              ]
+    [ Opt.hsubparser $
+        commandWithMetavar "key-gen-genesis" $
+          Opt.info pGenesisKeyGen $
+            Opt.progDesc "Create a Shelley genesis key pair"
+    , Opt.hsubparser $
+        commandWithMetavar "key-gen-delegate" $
+          Opt.info pGenesisDelegateKeyGen $
+            Opt.progDesc "Create a Shelley genesis delegate key pair"
+    , Opt.hsubparser $
+        commandWithMetavar "key-gen-utxo" $
+          Opt.info pGenesisUTxOKeyGen $
+            Opt.progDesc "Create a Shelley genesis UTxO key pair"
+    , Opt.hsubparser $
+        commandWithMetavar "key-hash" $
+          Opt.info pGenesisKeyHash $
+            Opt.progDesc "Print the identifier (hash) of a public key"
+    , Opt.hsubparser $
+        commandWithMetavar "get-ver-key" $
+          Opt.info pGenesisVerKey $
+            Opt.progDesc "Derive the verification key from a signing key"
+    , Opt.hsubparser $
+        commandWithMetavar "initial-addr" $
+          Opt.info pGenesisAddr $
+            Opt.progDesc "Get the address for an initial UTxO based on the verification key"
+    , Opt.hsubparser $
+        commandWithMetavar "initial-txin" $
+          Opt.info pGenesisTxIn $
+            Opt.progDesc "Get the TxIn for an initial UTxO based on the verification key"
+    , Opt.hsubparser $
+        commandWithMetavar "create-cardano" $
+          Opt.info pGenesisCreateCardano $
+            Opt.progDesc $
+              mconcat
+                [ "Create a Byron and Shelley genesis file from a genesis "
+                , "template and genesis/delegation/spending keys."
+                ]
+    , Opt.hsubparser $
+        commandWithMetavar "create" $
+          Opt.info pGenesisCreate $
+            Opt.progDesc $
+              mconcat
+                [ "Create a Shelley genesis file from a genesis "
+                , "template and genesis/delegation/spending keys."
+                ]
+    , Opt.hsubparser $
+        commandWithMetavar "create-staked" $
+          Opt.info pGenesisCreateStaked $
+            Opt.progDesc $
+              mconcat
+                [ "Create a staked Shelley genesis file from a genesis "
+                , "template and genesis/delegation/spending keys."
+                ]
+    , Opt.hsubparser $
+        commandWithMetavar "hash" $
+          Opt.info pGenesisHash $
+            Opt.progDesc $
+              unlines
+                [ "DEPRECATION WARNING! This command is deprecated and will be "
+                , "removed in a future release. Please use hash genesis-file "
+                , "instead. "
+                , "Compute the hash of a genesis file."
+                ]
     ]
  where
   pGenesisKeyGen :: Parser LegacyGenesisCmds

--- a/cardano-cli/src/Cardano/CLI/Option.hs
+++ b/cardano-cli/src/Cardano/CLI/Option.hs
@@ -106,9 +106,10 @@ parseHash = HashCmds <$> pHashCmds
 
 parseCompatibilityCommands :: EnvCli -> Parser ClientCommand
 parseCompatibilityCommands envCli =
-  subParser "compatible" $
-    Opt.info (CompatibleCommands <$> pAnyCompatibleCommand envCli) $
-      Opt.progDesc "Limited backward compatible commands for testing only."
+  Opt.hsubparser $
+    commandWithMetavar "compatible" $
+      Opt.info (CompatibleCommands <$> pAnyCompatibleCommand envCli) $
+        Opt.progDesc "Limited backward compatible commands for testing only."
 
 parseDebug :: EnvCli -> Parser ClientCommand
 parseDebug envCli = CliDebugCmds <$> parseDebugCmds envCli
@@ -118,9 +119,10 @@ parseAnyEra envCli = AnyEraCommand <$> pAnyEraCommand envCli
 
 parseLegacy :: EnvCli -> Parser ClientCommand
 parseLegacy envCli =
-  subParser "legacy" $
-    Opt.info (LegacyCmds <$> parseLegacyCmds envCli) $
-      Opt.progDesc "Legacy commands"
+  Opt.hsubparser $
+    commandWithMetavar "legacy" $
+      Opt.info (LegacyCmds <$> parseLegacyCmds envCli) $
+        Opt.progDesc "Legacy commands"
 
 -- | Parse Legacy commands at the top level of the CLI.
 -- Yes! A --version flag or version command. Either guess is right!

--- a/cardano-cli/src/Cardano/CLI/Parser.hs
+++ b/cardano-cli/src/Cardano/CLI/Parser.hs
@@ -13,7 +13,6 @@ module Cardano.CLI.Parser
   , readViewOutputFormat
   , readURIOfMaxLength
   , commandWithMetavar
-  , subParser
   , eDNSName
   , stringToAnchorScheme
   )
@@ -126,10 +125,6 @@ readerFromAttoParser p =
 
 commandWithMetavar :: String -> Opt.ParserInfo a -> Opt.Mod Opt.CommandFields a
 commandWithMetavar cmdName pInfo = Opt.command cmdName pInfo <> Opt.metavar cmdName
-
-subParser :: String -> Opt.ParserInfo a -> Opt.Parser a
-subParser cmdName pInfo =
-  Opt.hsubparser $ commandWithMetavar cmdName pInfo
 
 -- | Converts a string to an 'AnchorScheme' if it is a valid scheme and is in the
 -- 'SupportedScheme' list, otherwise it returns 'Left'.

--- a/cardano-cli/src/Cardano/CLI/Parser.hs
+++ b/cardano-cli/src/Cardano/CLI/Parser.hs
@@ -12,6 +12,7 @@ module Cardano.CLI.Parser
   , readStringOfMaxLength
   , readViewOutputFormat
   , readURIOfMaxLength
+  , commandWithMetavar
   , subParser
   , eDNSName
   , stringToAnchorScheme
@@ -123,9 +124,12 @@ readerFromAttoParser :: Atto.Parser a -> Opt.ReadM a
 readerFromAttoParser p =
   Opt.eitherReader (Atto.parseOnly (p <* Atto.endOfInput) . BSC.pack)
 
+commandWithMetavar :: String -> Opt.ParserInfo a -> Opt.Mod Opt.CommandFields a
+commandWithMetavar cmdName pInfo = Opt.command cmdName pInfo <> Opt.metavar cmdName
+
 subParser :: String -> Opt.ParserInfo a -> Opt.Parser a
-subParser availableCommand pInfo =
-  Opt.hsubparser $ Opt.command availableCommand pInfo <> Opt.metavar availableCommand
+subParser cmdName pInfo =
+  Opt.hsubparser $ commandWithMetavar cmdName pInfo
 
 -- | Converts a string to an 'AnchorScheme' if it is a valid scheme and is in the
 -- 'SupportedScheme' list, otherwise it returns 'Left'.


### PR DESCRIPTION
# Changelog

```yaml
- description: |
    Inline `subParser`, `subParser'` and `hiddenSubParser` for more fine-grained control.
# uncomment types applicable to the change:
  type:
  # - feature        # introduces a new feature
  # - breaking       # the API has changed in a breaking way
  # - compatible     # the API has changed but is non-breaking
  # - optimisation   # measurable performance improvements
  - refactoring    # QoL changes
  # - bugfix         # fixes a defect
  # - test           # fixes/modifies tests
  # - maintenance    # not directly related to the code
  # - release        # related to a new release preparation
  # - documentation  # change in code docs, haddocks...
```

# Context

We currently use `subParser`, `subParser'` and `hiddenSubParser` for convenience.

The wrappers may be convenient, but they do not allow us to use to use available `optparse-applicative` combinators to control the rendering of CLI help easily.

Not using them affords us that flexibility.

# How to trust this PR

This PR is purely refactoring and produces no change in behaviour.  This is evidenced by no changes to the CLI help golden files.

# Checklist

- [ ] Commit sequence broadly makes sense and commits have useful messages
- [ ] New tests are added if needed and existing tests are updated. See [Running tests](https://github.com/input-output-hk/cardano-node-wiki/wiki/Running-tests) for more details
- [ ] Self-reviewed the diff

<!--
### Note on CI ###
If your PR is from a fork, the necessary CI jobs won't trigger automatically for security reasons.
You will need to get someone with write privileges. Please contact IOG node developers to do this
for you.
-->
